### PR TITLE
Added spider for enterprise.com

### DIFF
--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import scrapy
+import json
+import logging
+from locations.items import GeojsonPointItem
+
+class EnterpriseSpider(scrapy.Spider):
+    name = "enterprise"
+    allowed_domains = ["enterprise.com"]
+    start_urls = (
+        'https://www.enterprise.com/en/car-rental/locations.html',
+    )
+
+    def parse(self, response):
+        data = response.xpath('//script[@type="application/ld+json"]/text()').extract_first()
+        if data:
+            data = json.loads(data)
+            address = data.get('address', {})
+            properties = {
+                'name': data.get('name'),
+                'phone': data.get('telephone'),
+                'website': response.url,
+                'addr_full': address.get('streetAddress'),
+                'city': address.get('addressLocality'),
+                'state': address.get('addressRegion'),
+                'postcode': address.get('postalCode'),
+                'country': address.get('addressCountry'),
+            }
+            lat = data.get('geo', {}).get('latitude')
+            lon = data.get('geo', {}).get('longitude')
+            if lat: lat = float(lat)
+            if lon: lon = float(lon)
+            properties['lat'] = lat
+            properties['lon'] = lon
+            properties['ref'] = response.url
+            yield GeojsonPointItem(**properties)
+        else:
+            for url in response.xpath('//section[contains(@class, "region-list") or contains(@class, "location-band")]//ul/li/a/@href').extract():
+                yield scrapy.Request(
+                    response.urljoin(url),
+                    callback=self.parse,
+                )
+

--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -34,10 +34,9 @@ class EnterpriseSpider(scrapy.Spider):
             properties['lon'] = lon
             properties['ref'] = response.url
             yield GeojsonPointItem(**properties)
-        else:
-            for url in response.xpath('//section[contains(@class, "region-list") or contains(@class, "location-band")]//ul/li/a/@href').extract():
-                yield scrapy.Request(
-                    response.urljoin(url),
-                    callback=self.parse,
-                )
+        for url in response.xpath('//a/@href').re('/en/car-rental/locations/.+'):
+            yield scrapy.Request(
+                response.urljoin(url),
+                callback=self.parse,
+            )
 


### PR DESCRIPTION
Fixes #523.

Scrapes 3776 locations, although Wikipedia says they have more than 5400 locations. This spider accesses all of the locations in their site's location hierarchy (based on my own spot checks), and therefore this is likely due in part to not all of them not being listed in the location pages on their website.