### PR TITLE
GeoJSON exporter improvements

### DIFF
--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 from scrapy.exporters import JsonLinesItemExporter, JsonItemExporter
 from scrapy.utils.python import to_bytes
 
@@ -37,11 +39,18 @@ def item_to_properties(item):
     return props
 
 
+def compute_hash(item):
+    sha1 = hashlib.sha1(item['extras']['@spider'])
+    sha1.update(item['ref'])
+    return base64.urlsafe_b64encode(sha1.digest())
+
+
 class LineDelimitedGeoJsonExporter(JsonLinesItemExporter):
 
     def _get_serialized_fields(self, item, default_value=None, include_empty=None):
         feature = []
         feature.append(('type', 'Feature'))
+        feature.append(('id', compute_hash(item)))
         feature.append(('properties', item_to_properties(item)))
 
         if item.get('lon'):
@@ -61,6 +70,7 @@ class GeoJsonExporter(JsonItemExporter):
     def _get_serialized_fields(self, item, default_value=None, include_empty=None):
         feature = []
         feature.append(('type', 'Feature'))
+        feature.append(('id', compute_hash(item)))
         feature.append(('properties', item_to_properties(item)))
 
         if item.get('lon'):

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -57,8 +57,8 @@ class LineDelimitedGeoJsonExporter(JsonLinesItemExporter):
             feature.append(('geometry', {
                 'type': 'Point',
                 'coordinates': [
-                    item['lon'],
-                    item['lat']
+                    float(item['lon']),
+                    float(item['lat'])
                 ],
             }))
 
@@ -77,8 +77,8 @@ class GeoJsonExporter(JsonItemExporter):
             feature.append(('geometry', {
                 'type': 'Point',
                 'coordinates': [
-                    item['lon'],
-                    item['lat']
+                    float(item['lon']),
+                    float(item['lat'])
                 ],
             }))
 


### PR DESCRIPTION
- Add an `id` property on the GeoJSON feature that is a base64 encoded SHA1 hash of the spider name and the item's `ref` field
- This also always casts that lat and lon to float so the spiders don't have to do it.