### PR TITLE
Fix Brueggers Bagels spider; add rest of brands under Coffee & Bagel empire

### DIFF
--- a/locations/spiders/manhattanbagels.py
+++ b/locations/spiders/manhattanbagels.py
@@ -16,12 +16,12 @@ DAY_MAPPING = {
     'Sunday': 'Su'
 }
 
-class BrueggersSpider(scrapy.Spider):
+class ManhattanBagelSpider(scrapy.Spider):
     """Copy of Einstein Bros. Bagels - all brands of the same parent company Coffee & Bagels"""
-    name = "brueggers"
-    allowed_domains = ["brueggers.com"]
+    name = "manhattanbagels"
+    allowed_domains = ["manhattanbagel.com"]
     start_urls = (
-        'https://locations.brueggers.com/us',
+        'https://locations.manhattanbagel.com/us',
     )
 
     def parse_hours(self, elements):

--- a/locations/spiders/noahsnybagels.py
+++ b/locations/spiders/noahsnybagels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import datetime
 import re
 
 from locations.items import GeojsonPointItem
@@ -16,12 +17,12 @@ DAY_MAPPING = {
     'Sunday': 'Su'
 }
 
-class BrueggersSpider(scrapy.Spider):
+class NoahsNYBagelsSpider(scrapy.Spider):
     """Copy of Einstein Bros. Bagels - all brands of the same parent company Coffee & Bagels"""
-    name = "brueggers"
-    allowed_domains = ["brueggers.com"]
+    name = "noahsnybagels"
+    allowed_domains = ["noahs.com"]
     start_urls = (
-        'https://locations.brueggers.com/us',
+        'https://locations.noahs.com/us',
     )
 
     def parse_hours(self, elements):


### PR DESCRIPTION
Fix Bruegger's Bagels scraper (was scraping 0 items).  Also add the two remaining bagel chains under the Coffee & Bagel parent company, which all use the same store listing format.

Closes #1014
Closes #1013