### PR TITLE
Fix Costco spider

### DIFF
--- a/locations/spiders/costco.py
+++ b/locations/spiders/costco.py
@@ -2,11 +2,13 @@
 import scrapy
 import json
 import re
+from urllib.parse import urlencode
 
 from locations.items import GeojsonPointItem
 
 DAYS_NAME = {
     'm': 'Mo',
+    'mon': 'Mo',
     't': 'Tu',
     'w': 'We',
     's': 'Th',
@@ -21,13 +23,41 @@ DAYS_NAME = {
 class CostcoSpider(scrapy.Spider):
     name = "costco"
     allowed_domains = ['www.costco.com']
-    start_urls = (
-        'https://www.costco.com/WarehouseLocatorBrowseView',
-    )
+
     download_delay = 0.5
     custom_settings = {
         'USER_AGENT': 'Mozilla/5.0',
     }
+
+    def start_requests(self):
+        url = 'https://www.costco.com/AjaxWarehouseBrowseLookupView?'
+
+        params = {
+            "langId": "-1",
+            # "storeId": "10301",
+            "numOfWarehouses": "50", # max allowed
+            "hasGas": "false",
+            "hasTires": "false",
+            "hasFood": "false",
+            "hasHearing": "false",
+            "hasPharmacy": "false",
+            "hasOptical": "false",
+            "hasBusiness": "false",
+            "hasPhotoCenter": "false",
+            "tiresCheckout": "0",
+            "isTransferWarehouse": "false",
+            "populateWarehouseDetails": "true",
+            "warehousePickupCheckout": "false",
+            "countryCode": "US",
+        }
+
+        with open('./locations/searchable_points/us_centroids_100mile_radius.csv') as points:
+            next(points)
+            for point in points:
+                _, lat, lon = point.split(',')
+                params.update({"latitude": lat, "longitude": lon})
+                yield scrapy.Request(url=url + urlencode(params))
+
 
     def store_hours(self, store_hours):
         opening_hours = []
@@ -39,7 +69,7 @@ class CostcoSpider(scrapy.Spider):
             if day_info.lower().find('close') > -1:
                 continue
 
-            match = re.match(r'^(\w+)-?\.?([A-Za-z]*)\.? *(\d{1,2}):(\d{2}) ?(am|pm|) *- +(\d{1,2}):(\d{2}) ?(am|pm|hrs\.)$', day_info)
+            match = re.match(r'^(\w+)-?[\.:]?([A-Za-z]*)\.? *(\d{1,2}):(\d{2}) ?(am|pm|) *- +(\d{1,2}):(\d{2}) ?(am|pm|hrs\.)$', day_info)
             if not match:
                 self.logger.warn("Couldn't match hours: %s", day_info)
 
@@ -69,34 +99,40 @@ class CostcoSpider(scrapy.Spider):
 
         return '; '.join(opening_hours)
 
-    def parse(self, response):
-        container_ids = response.xpath('//div[@class="form-item statePanel"]/select/option/@value').extract()
-        for container_id in container_ids:
-            yield scrapy.Request(
-                'https://www.costco.com/AjaxWarehouseBrowseLookupView?catalogId=10701&parentGeoNode=' + container_id,
-                callback=self.parse_stores
-            )
-
-    def parse_stores(self, response):
-        stores = json.loads(response.body_as_unicode())
-
-        for store in stores:
-            props = {
-                'lat': store.get('latitude'),
-                'lon': store.get('longitude'),
-                'ref': store.get('identifier'),
-                'phone': self._clean_text(store.get('phone')),
-                'name': store.get('displayName'),
-                'addr_full': store.get('address1'),
-                'city': store.get('city'),
-                'state': store.get('state'),
-                'postcode': store.get('zipCode'),
-                'country': store.get('country'),
-                'website': 'https://www.costco.com/warehouse-locations/store-{}.html'.format(store.get('identifier')),
-                'opening_hours': self.store_hours(store.get('warehouseHours')),
-            }
-
-            yield GeojsonPointItem(**props)
-
     def _clean_text(sel, text):
         return re.sub("[\r\n\t]", "", text).strip()
+
+    def parse(self, response):
+        body = json.loads(response.body_as_unicode())
+
+
+        for store in body[1:]:
+            if store["distance"] < 110:
+                # only process stores that are within 110 miles of query point
+                # (to reduce processing a ton of duplicates)
+                ref = store['identifier']
+                properties = {
+                    'lat': store.get('latitude'),
+                    'lon': store.get('longitude'),
+                    'ref': ref,
+                    'phone': self._clean_text(store.get('phone')),
+                    'name': store['locationName'],
+                    'addr_full': store['address1'],
+                    'city': store['city'],
+                    'state': store['state'],
+                    'postcode': store.get('zipCode'),
+                    'country': store.get('country'),
+                    'website': 'https://www.costco.com/warehouse-locations/store-{}.html'.format(ref),
+                    'extras': {
+                        'number': store["displayName"]
+                    }
+                }
+
+                hours = store.get('warehouseHours')
+                if hours:
+                    try:
+                        properties["opening_hours"] = self.store_hours(hours)
+                    except:
+                        pass
+
+                yield GeojsonPointItem(**properties)


### PR DESCRIPTION
Costco removed its list of warehouses and they are now only available via lat/long searches.

Scrapes 538/538 stores in the US.