### PR TITLE
Remove unused BaseSpider imports

### DIFF
--- a/locations/spiders/supercuts.py
+++ b/locations/spiders/supercuts.py
@@ -1,5 +1,4 @@
 import scrapy
-from scrapy.spiders import BaseSpider
 from locations.items import GeojsonPointItem
 import json
 import re

--- a/locations/spiders/toysrus.py
+++ b/locations/spiders/toysrus.py
@@ -1,5 +1,4 @@
 import scrapy
-from scrapy.spiders import BaseSpider
 from locations.items import GeojsonPointItem
 import json
 import re


### PR DESCRIPTION
`pipenv run scrapy check` works with v1.7.1 after removing these BaseSpider imports (they were both unused)