### PR TITLE
Fixed spider for Albertsons

### DIFF
--- a/locations/spiders/albertsons.py
+++ b/locations/spiders/albertsons.py
@@ -19,11 +19,39 @@ class AlbertsonsSpider(scrapy.Spider):
     download_delay = 0.5
     allowed_domains = [
         "local.albertsons.com",
+        "local.acmemarkets.com",
+        "local.albertsonsmarket.com",
+        "local.amigosunited.com",
+        "local.andronicos.com",
+        "local.carrsqc.com",
         "local.jewelosco.com",
+        "local.luckylowprices.com",
+        "local.marketstreetunited.com",
+        "local.pavilions.com",
+        "local.randalls.com",
+        "local.shaws.com",
+        "local.starmarket.com",
+        "local.tomthumb.com",
+        "local.unitedsupermarkets.com",
+        "local.vons.com"
     ]
     start_urls = (
+        'https://local.acmemarkets.com/index.html',
         'https://local.albertsons.com/index.html',
+        'https://local.albertsonsmarket.com/index.html',
+        'https://local.amigosunited.com/index.html',
+        'https://local.andronicos.com/index.html',
+        'https://local.carrsqc.com/index.html',
         'https://local.jewelosco.com/index.html',
+        'https://local.luckylowprices.com/index.html',
+        'https://local.marketstreetunited.com/index.html',
+        'https://local.pavilions.com/index.html',
+        'https://local.randalls.com/index.html',
+        'https://local.shaws.com/index.html',
+        'https://local.starmarket.com/index.html',
+        'https://local.tomthumb.com/index.html',
+        'https://local.unitedsupermarkets.com/index.html',
+        'https://local.vons.com/index.html'
     )
 
     def parse_stores(self, response):
@@ -33,15 +61,19 @@ class AlbertsonsSpider(scrapy.Spider):
         if(len(ref)>0):
             ref = ref[0].split('.')[0]
         properties = {
-            'addr_full': response.xpath('normalize-space(//span[@itemprop="streetAddress"]/span/text())').extract_first(),
+            'addr_full': response.xpath('normalize-space(//meta[@itemprop="streetAddress"]/@content)').extract_first(),
             'phone': response.xpath('normalize-space(//span[@itemprop="telephone"]/text())').extract_first(),
-            'city': response.xpath('normalize-space(//span[@itemprop="addressLocality"]/text())').extract_first(),
+            'city': response.xpath('normalize-space(//meta[@itemprop="addressLocality"]/@content)').extract_first(),
             'state': response.xpath('normalize-space(//abbr[@itemprop="addressRegion"]/text())').extract_first(),
             'postcode': response.xpath('normalize-space(//span[@itemprop="postalCode"]/text())').extract_first(),
+            'name': response.xpath('normalize-space(//span[@class="LocationName-geo"]/text())').extract_first(),
             'ref': ref,
             'website': response.url,
             'lat':  float(map_json['locs'][0]['latitude']),
             'lon':  float(map_json['locs'][0]['longitude']),
+            'extras' : {
+                'brand' : response.xpath('normalize-space(//span[@class="LocationName-brand"]/text())').extract_first()
+            }
         }
         hours = response.xpath('//div[@class="LocationInfo-right"]/div[1]/div[@class="LocationInfo-hoursTable"]/div[@class="c-location-hours-details-wrapper js-location-hours"]/table/tbody/tr/@content').extract()
         if hours:


### PR DESCRIPTION
Fixed spider to capture street address and locality.
Also updated spider to capture Albertsons subsidiaries:

-         acme markets
-         albertsons market.
-         amigos united
-         andronicos
-         carrs
-         jewel osco
-         lucky low prices
-         market street united
-         pavilions
-         randalls
-         shaws
-         star market
-         tom thumb.com
-         united super markets
-         vons