### PR TITLE
Add spider for First Cash

### DIFF
--- a/locations/spiders/first_cash.py
+++ b/locations/spiders/first_cash.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import json
+import re
+
+import scrapy
+
+from locations.items import GeojsonPointItem
+from locations.hours import OpeningHours
+
+
+class FirstCashSpider(scrapy.Spider):
+    name = "first_cash"
+    allowed_domains = ['find.cashamerica.us']
+
+    def start_requests(self):
+        base_url = "http://find.cashamerica.us/api/stores?p=1&s=100&lat={lat}&lng={lng}&d=2019-10-14T17:43:05.914Z&key=D21BFED01A40402BADC9B931165432CD"
+
+        with open('./locations/searchable_points/us_centroids_100mile_radius.csv') as points:
+            next(points)
+            for point in points:
+                _, lat, lon = point.strip().split(',')
+                url = base_url.format(lat=lat, lng=lon)
+                yield scrapy.Request(url=url, callback=self.parse)
+
+    def parse(self, response):
+        data = json.loads(response.body_as_unicode())
+
+        for place in data:
+            properties = {
+                'ref': place["storeNumber"],
+                'name': place["shortName"],
+                'addr_full': place["address"]["address1"],
+                'city': place["address"]["city"],
+                'state': place["address"]["state"],
+                'postcode': place["address"]["zipCode"],
+                'country': 'US',
+                'lat': place["latitude"],
+                'lon': place["longitude"],
+                'phone': place["phone"],
+                'extras': {
+                    'brand': place["brand"]
+                }
+            }
+
+            yield GeojsonPointItem(**properties)


### PR DESCRIPTION
I had to use the searchable points for this scraper which got all the stores in the US.  But 60% of first cash stores are in latin america, so this spider will need to be updated once we have searchable points for that region of the world.