### PR TITLE
Repairs Verizon spider

### DIFF
--- a/locations/spiders/verizon.py
+++ b/locations/spiders/verizon.py
@@ -4,56 +4,91 @@ import json
 import re
 
 from locations.items import GeojsonPointItem
+from locations.hours import OpeningHours
+
 
 class VerizonSpider(scrapy.Spider):
-
     name = "verizon"
     allowed_domains = ["www.verizonwireless.com"]
     start_urls = (
-        'https://www.verizonwireless.com/stores/',
+        'https://www.verizonwireless.com/sitemap_storelocator.xml',
     )
+    custom_settings = {
+        'USER_AGENT': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36',
+    }
 
-    # Once per city, parse stores
-    def parse_city(self, city):
-        city_stores = city.xpath('//div[@class="col-xs-3 cityListView products store-list-product list-view"]//address')
-        city_locations = city.xpath('//script[text()[contains(.,"resultsList")]]/text()').extract_first()
-        city_json = json.loads(city_locations.split('resultsList=')[-1].strip())
-        if len(city_stores) > 0:
-            for index, city_store in enumerate(city_stores):
-                phone = city_store.xpath('.//span/text()').extract()[-1]
-                city_name = city_json[index]['city']
-                state = city_json[index]['state']
-                zip_code = city_json[index]['zip']
-                web = city_store.xpath('.//span/a/@href').extract_first()
-                props = {
-                    'addr_full': '{}, {}, {} {}'.format(city_json[index]['address'], city_name, state, zip_code),
-                    'city': city_name,
-                    'state': state,
-                    'postcode': zip_code,
-                    'phone': phone,
-                    'ref': web,
-                    'website': city.urljoin(web),
-                    'name': city_store.xpath('.//span/a/text()').extract_first()
-                }
-                if city_json[index]['lat'] != 'null' and city_json[index]['lng'] != 'null':
-                    props['lat'] = float(city_json[index]['lat'])
-                    props['lon'] = float(city_json[index]['lng'])
-                yield GeojsonPointItem(**props)
-    
-    # Once per state, gets cities.
-    def parse_state(self, state):
-        cities = state.xpath('//div[@id="cityStateLinks"]/ul[@id="cityList"]/li/a/@href').extract()
-        for city in cities:
-            yield scrapy.Request(
-                state.urljoin(city),
-                callback=self.parse_city
-            )
-    
-    # Initial request, gets states.
+    def parse_hours(self, store_hours):
+        opening_hours = OpeningHours()
+        for store_day in store_hours['dayOfWeek']:
+            if store_day.lower() == 'closed':
+                continue
+            else:
+                day, open_close = store_day.split('-')
+                day = day.strip()[:2]
+                open_time = ' '.join(open_close.strip().split(' ', 2)[0:2])
+                if open_time.split(' ')[0].lower() == 'closed':
+                    continue
+                elif open_time.split(' ')[0].lower() == 'null':
+                    continue
+                else:
+                    if open_close.strip().count(' ') == 1:
+                        open_time, close_time = open_time.split(' ')
+                        opening_hours.add_range(day=day,
+                                                open_time=open_time,
+                                                close_time=close_time,
+                                                time_format='%I:%M%p'
+                                                )
+                    elif open_close.strip().count(' ') == 2:
+                        open_time = open_close.strip().split(' ')[0]
+                        close_time = ''.join(open_close.strip().split(' ')[1:3])
+                        opening_hours.add_range(day=day,
+                                                open_time=open_time,
+                                                close_time=close_time,
+                                                time_format='%I:%M%p'
+                                                )
+                    else:
+                        close_time = open_close.strip().split(' ', 2)[2]
+                        opening_hours.add_range(day=day,
+                                                open_time=open_time,
+                                                close_time=close_time,
+                                                time_format='%I:%M %p'
+                                                )
+
+        return opening_hours.as_opening_hours()
+
     def parse(self, response):
-        states = response.xpath('//div[@id="cityStateLinks"]//ul/li/a/@href').extract()
-        for state in states:
-            yield scrapy.Request(
-                response.urljoin(state), 
-                callback=self.parse_state
-            )
+        response.selector.remove_namespaces()
+        urls = response.xpath('//url/loc/text()').extract()
+
+        for url in urls:
+            yield scrapy.Request(url, callback=self.parse_store)
+
+    def parse_store(self, response):
+        script = response.xpath('//script[contains(text(), "storeJSON")]/text()').extract_first()
+        store_data = json.loads(re.search(r'var storeJSON = (.*);', script).group(1))
+
+        properties = {
+                'name': store_data["storeName"],
+                'ref': store_data["storeNumber"],
+                'addr_full': store_data["address"]["streetAddress"],
+                'city': store_data["address"]["addressLocality"],
+                'state': store_data["address"]["addressRegion"],
+                'postcode': store_data["address"]["postalCode"],
+                'country': store_data["address"]["addressCountry"],
+                'phone': store_data.get("telephone"),
+                'website': store_data.get("url") or response.url,
+                'lat': store_data["geo"].get("latitude"),
+                'lon': store_data["geo"].get("longitude"),
+                'extras': {
+                    'business_name': store_data.get('posStoreDetail').get('businessName'),
+                    'retail_id': store_data.get('retailId'),
+                    'store_type': store_data.get('posStoreDetail').get('storeType'),
+                    'store_type_note': store_data.get('typeOfStore')
+                }
+            }
+
+        hours = self.parse_hours(store_data.get("openingHoursSpecification"))
+        if hours:
+            properties["opening_hours"] = hours
+
+        yield GeojsonPointItem(**properties)


### PR DESCRIPTION
Previously returned 0 results. Now scrapes 5,620 verizon locations. I added extra attributes to include the business name and store type incase anyone wants to filter out 3rd party sellers.