### PR TITLE
Fixed broken spider for Sephora

### DIFF
--- a/locations/spiders/sephora.py
+++ b/locations/spiders/sephora.py
@@ -1,84 +1,88 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import datetime
 import json
 
-from locations.items import GeojsonPointItem
 
+from locations.items import GeojsonPointItem
+from locations.hours import OpeningHours
+
+
+DAY_MAPPING = {
+    "fridayHours": "Fr",
+    "mondayHours": "Mo",
+    "saturdayHours": "Sa",
+    "sundayHours": "Su",
+    "thursdayHours": "Th",
+    "tuesdayHours": "Tu",
+    "wednesdayHours": "We"}
 
 class SephoraSpider(scrapy.Spider):
     name = "sephora"
     allowed_domains = ["www.sephora.com"]
-    download_delay = 1.5
+    download_delay = 0.2
     start_urls = (
         'https://www.sephora.com/storelist',
     )
 
-    def store_hours(self, store_hours):
-        day_groups = []
-        this_day_group = None
-        for day in ('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'):
-            day_open = store_hours[day]['open'].zfill(5)
-            day_close = store_hours[day]['close'].zfill(5)
+    def store_hours(self, response):
+        opening_hours = OpeningHours()
+        weekdays = response
 
-            hours = day_open + "-" + day_close
-
-            if hours == '00:00-00:00':
-                # They're closed on this day
+        for day, hrs in weekdays.items():
+            if 'closedDays' in day or 'textColor' in day or 'timeZone' in day:
                 continue
+            elif 'CLOSED' in hrs:
+                    continue
+            else:
+                try:
+                    open, close = hrs.split('-')
+                    open = open.strip()
+                    close = close.strip()
+                    if ':' in open:
+                        open_time = datetime.datetime.strptime(open, '%I:%M%p').strftime('%H:%M')
+                    else:
+                        open_time = datetime.datetime.strptime(open, '%I%p').strftime('%H:%M')
 
-            day_short = day.title()[:2]
+                    if ':' in close:
+                        close_time = datetime.datetime.strptime(close, '%I:%M%p').strftime('%H:%M')
+                    else:
+                        close_time = datetime.datetime.strptime(close, '%I%p').strftime('%H:%M')
+                except ValueError:
+                    continue
+                opening_hours.add_range(DAY_MAPPING[day],
+                                        open_time=open_time,
+                                        close_time=close_time,
+                                        time_format='%H:%M')
 
-            if not this_day_group:
-                this_day_group = dict(from_day=day_short, to_day=day_short, hours=hours)
-            elif this_day_group['hours'] == hours:
-                this_day_group['to_day'] = day_short
-            elif this_day_group['hours'] != hours:
-                day_groups.append(this_day_group)
-                this_day_group = dict(from_day=day_short, to_day=day_short, hours=hours)
-        day_groups.append(this_day_group)
-
-        if not day_groups:
-            return None
-
-        if len(day_groups) == 1:
-            opening_hours = day_groups[0]['hours']
-            if opening_hours == '07:00-07:00':
-                opening_hours = '24/7'
-        else:
-            opening_hours = ''
-            for day_group in day_groups:
-                if day_group['from_day'] == day_group['to_day']:
-                    opening_hours += '{from_day} {hours}; '.format(**day_group)
-                else:
-                    opening_hours += '{from_day}-{to_day} {hours}; '.format(**day_group)
-            opening_hours = opening_hours[:-2]
-
-        return opening_hours
+        return opening_hours.as_opening_hours()
 
     def parse(self, response):
-        for path in response.xpath('//a[@class="u-hoverRed u-p1 u-db"]/@href'):
-            yield scrapy.Request(
-                response.urljoin(path.extract()),
-                callback=self.parse_store,
-            )
+        urls = response.xpath('//a[@class="css-j9u336 "]/@href').extract()
+
+        for url in urls:
+            yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
 
     def parse_store(self, response):
-        data = json.loads(response.xpath('//script[@type="application/ld+json"]/text()').extract_first())
+            jsondata = json.loads(response.xpath('//script[@id="linkJSON"]/text()').extract_first())
+            data = jsondata[2]['props']
+            properties = {
+                'website': response.urljoin(data['storeInfo']['seoCanonicalUrl']),
+                'ref': data['storeInfo']['storeId'],
+                'name': data['storeInfo']['displayName'],
+                'phone': data['storeInfo']['address']['phone'],
+                'addr_full': data['storeInfo']['address']['address1'],
+                'city': data['storeInfo']['address']['city'],
+                'state': data['storeInfo']['address']['state'],
+                'postcode': data['storeInfo']['address']['postalCode'],
+                'country': data['storeInfo']['address']['country'],
+                'lon': float(data['storeInfo']['longitude']),
+                'lat': float(data['storeInfo']['latitude'])
 
-        properties = {
-            'website': data['url'],
-            'phone': data['address']['telephone'],
-            'addr_full': data['address']['streetAddress'],
-            'postcode': data['address']['postalCode'],
-            'state': data['address']['addressRegion'],
-            'city': data['address']['addressLocality'],
-            'ref': data['url'],
-            'lon': float(response.xpath('//div[@class="storehq-detail"]/@data-lng').extract_first()),
-            'lat': float(response.xpath('//div[@class="storehq-detail"]/@data-lat').extract_first()),
-        }
+            }
+            opening_hours = self.store_hours(data['storeInfo']['storeHours'])
 
-        opening_hours = data.get('openingHours')
-        if opening_hours:
-            properties['opening_hours'] = '; '.join(opening_hours)
+            if opening_hours:
+                properties['opening_hours'] = opening_hours
 
-        yield GeojsonPointItem(**properties)
+            yield GeojsonPointItem(**properties)


### PR DESCRIPTION
One store, https://www.sephora.com/happening/stores/new-york-5th-avenue does not have store properties in the same format as all the other stores, 1 error for this.