### PR TITLE
fixed name attribute for pizza_hut

### DIFF
--- a/locations/spiders/pizza_hut.py
+++ b/locations/spiders/pizza_hut.py
@@ -38,7 +38,7 @@ class PizzaHutSpider(scrapy.Spider):
         ref = re.findall(r".com/(.+?)/(.+?)/(.+)", response.url)[0]
         ref = "_".join(ref)
         properties = {
-            'name': response.xpath('//span[@class="LocationName-geo"]/text()').extract_first(),
+            'name': response.xpath('//span[@class="c-address-street-1"]/text()').extract_first(),
             'addr_full': response.xpath('//span[@class="c-address-street-1"]/text()').extract_first(),
             'phone': response.xpath('//span[@itemprop="telephone"]/text()').extract_first(),
             'city': response.xpath('//span[@class="c-address-city"]/text()').extract_first(),


### PR DESCRIPTION
Previous name attribute was grabbing the information from the 'nearby locations' at the bottom of the branch page instead of from the top.