### PR TITLE
Add longitude key for Sears hometown stores

### DIFF
--- a/locations/spiders/sears.py
+++ b/locations/spiders/sears.py
@@ -119,7 +119,7 @@ class SearsSpider(scrapy.Spider):
             'phone': store_data.get('custrecord_loc_det_phone'),
             'website': store_data.get('custrecord_loc_det_store_url'),
             'lat': store_data.get('custrecord_sho_latitude'),
-            'lon': store_data.get('custrecord_sho_longitude'),
+            'lon': store_data.get('custrecord_sho_lbi_longitude'),
         }
 
         yield GeojsonPointItem(**properties)


### PR DESCRIPTION
Looks like the longitude key for the home town stores is slightly different than the latitude key. Should now include latlons for the home town stores as well. 