### PR TITLE
Fix safeway hours parsing, name, and ref

### DIFF
--- a/locations/spiders/safeway.py
+++ b/locations/spiders/safeway.py
@@ -8,7 +8,7 @@ from locations.items import GeojsonPointItem
 
 class SafewaySpider(scrapy.Spider):
     name = "safeway"
-    item_attributes = { 'brand': "Safeway" }
+    item_attributes = { 'brand': "Safeway", 'brand_wikidata': "Q1508234" }
     allowed_domains = ['safeway.com']
     start_urls = (
         'https://local.safeway.com/sitemap.xml',
@@ -80,12 +80,10 @@ class SafewaySpider(scrapy.Spider):
                 )
 
     def parse_store(self, response):
-        ref = re.search(r'.+/(.+?)/?(?:\.html|$)', response.url).group(1)
-
         properties = {
-            'name': response.xpath('//span[@class="LocationName-geo"]/text()').extract_first(),
+            'name': response.xpath('//meta[@itemprop="name"]/@content').extract_first(),
             'website': response.url,
-            'ref': ref,
+            'ref': response.url,
             'addr_full': response.xpath('//meta[@itemprop="streetAddress"]/@content').extract_first(),
             'city': response.xpath('//meta[@itemprop="addressLocality"]/@content').extract_first(),
             'state': response.xpath('//abbr[@itemprop="addressRegion"]/text()').extract_first(),
@@ -94,7 +92,7 @@ class SafewaySpider(scrapy.Spider):
             'lon': float(response.xpath('//meta[@itemprop="longitude"]/@content').extract_first()),
         }
 
-        hours = json.loads(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]/@data-days').extract_first())
+        hours = json.loads(response.xpath('//div[@class="c-hours-details-wrapper js-hours-table"]/@data-days').extract_first())
         opening_hours = self.store_hours(hours) if hours else None
         if opening_hours:
             properties['opening_hours'] = opening_hours


### PR DESCRIPTION
- Doesn't look like the ref was unique anymore, so was dropping items
- Pulls name from meta itemprop (many were None)
- Adds wikidata

```
2020-04-07 14:52:05 [scrapy.core.scraper] ERROR: Spider error processing <GET https://local.safeway.com/safeway/ca/saint-helena/1026-hunt-ave.html> (referer: https://local.safeway.com/sitemap.xml)
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/scrapy/utils/defer.py", line 102, in iter_errback
    yield next(it)
  File "/usr/lib/python3/dist-packages/scrapy/core/spidermw.py", line 84, in evaluate_iterable
    for r in iterable:
  File "/usr/lib/python3/dist-packages/scrapy/spidermiddlewares/offsite.py", line 29, in process_spider_output
    for x in result:
  File "/usr/lib/python3/dist-packages/scrapy/core/spidermw.py", line 84, in evaluate_iterable
    for r in iterable:
  File "/usr/lib/python3/dist-packages/scrapy/spidermiddlewares/referer.py", line 339, in <genexpr>
    return (_set_referer(r) for r in result or ())
  File "/usr/lib/python3/dist-packages/scrapy/core/spidermw.py", line 84, in evaluate_iterable
    for r in iterable:
  File "/usr/lib/python3/dist-packages/scrapy/spidermiddlewares/urllength.py", line 37, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/usr/lib/python3/dist-packages/scrapy/core/spidermw.py", line 84, in evaluate_iterable
    for r in iterable:
  File "/usr/lib/python3/dist-packages/scrapy/spidermiddlewares/depth.py", line 58, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/home/tgarner/projects/third_party/github.com/thomas536/alltheplaces/locations/spiders/safeway.py", line 97, in parse_store
    hours = json.loads(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]/@data-days').extract_first())
  File "/usr/lib/python3.7/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```