### PR TITLE
Remove the state column from subway spider

### DIFF
--- a/locations/spiders/subway.py
+++ b/locations/spiders/subway.py
@@ -32,7 +32,7 @@ class SubwaySpider(scrapy.Spider):
 
             next(points)  # Ignore the header
             for point in points:
-                _, lat, lon, state = point.strip().split(',')
+                _, lat, lon = point.strip().split(',')
                 options = {
                     "InputText": "",
                     "Geocode": {


### PR DESCRIPTION
Looks like the underlying file changed and removed a field. The state
column wasn't used in this spider, so dropping is a no-op.