### PR TITLE
Fix bug in Wal-mart spider

### DIFF
--- a/locations/spiders/walmart.py
+++ b/locations/spiders/walmart.py
@@ -55,7 +55,7 @@ class WalmartSpider(scrapy.Spider):
                 yield scrapy.Request(u.strip(), callback=self.parse_store)
 
     def parse_store(self, response):
-        script = response.xpath("//script[contains(.,'WML_REDUX_INITIAL_STATE')]").extract_first()
+        script = response.xpath("//script[contains(.,'__WML_REDUX_INITIAL_STATE__ = ')]").extract_first()
         # In rare cases will hit page before script tag loads with content
         if script is None:
             if self.retries.get(response.url, 0) <= 2:


### PR DESCRIPTION
This small fix addresses an issue whereby the original XPath query was pulling the wrong `<script>`
tag to look for location data. The minor adjustment makes the XPath query roughly equivalent to
the actual data extraction regular expression.

The result of the fix is around ~4300 locations found, and is visualized below (via the preview page):

![Screenshot from 2020-05-12 17-37-24](https://user-images.githubusercontent.com/745427/81758707-739e6180-9477-11ea-9fc0-bb40da813a41.png)
