### PR TITLE
Fix Pilot Flying J parser: rewrite using CSV export, add fuel tags

### DIFF
--- a/locations/spiders/pilot_flyingj.py
+++ b/locations/spiders/pilot_flyingj.py
@@ -1,4 +1,4 @@
-import json
+import csv
 
 import scrapy
 from locations.items import GeojsonPointItem
@@ -6,76 +6,51 @@ from locations.items import GeojsonPointItem
 
 class PilotFlyingJSpider(scrapy.Spider):
     name = "pilot_flyingj"
-    item_attributes = { 'brand': "Pilot Flying J", 'brand_wikidata': "Q1434601" }
+    item_attributes = {'brand': "Pilot Flying J", 'brand_wikidata': "Q1434601"}
     download_delay = 0.3
     allowed_domains = [
         "pilotflyingj.com",
     ]
-    headers = {'Content-Type': 'application/json'}
 
-    def start_requests(self):
-        payload = {
-                "PageNumber": 1,
-                "PageSize": 50,
-                "States": [],
-                "Countries": [],
-                "Concepts": []
-            }
-        return [scrapy.Request("https://pilotflyingj.com/umbraco/surface/storelocations/search",
-                               method='POST',
-                               body=json.dumps(payload),
-                               headers=self.headers,
-                               callback=self.parse)]
-
-    def parse_store(self, response):
-        properties = response.meta["properties"]
-
-        lat = response.xpath('//ul[@id="places-in-map"]/@data-lat').extract()
-        long = response.xpath('//ul[@id="places-in-map"]/@data-long').extract()
-
-        properties.update({
-            'name': response.xpath('//h1[@class="store-name"]/text()').extract_first().strip(),
-            'website': response.url,
-            'lat':  float(lat[0]),
-            'lon':  float(long[0]),
-            'extras': {
-                'number': properties["ref"]
-            }
-        })
-
-        yield GeojsonPointItem(**properties)
+    start_urls = [
+        'https://pilotflyingj.com/umbraco/surface/storelocations/download?Format=csv&PageSize=1000&PageNumber=1'
+    ]
 
     def parse(self, response):
+        for store in csv.DictReader(response.body_as_unicode().splitlines()):
+            yield GeojsonPointItem(
+                lat=store['Latitude'],
+                lon=store['Longitude'],
+                name=store['Name'],
+                addr_full=store['Address'],
+                city=store['City'],
+                state=store['State/Province'],
+                postcode=store['Zip'],
+                country=store['Country'],
+                phone=store['Phone'],
+                ref=store['Store#'],
+                extras={
+                    'amenity:fuel': True,
+                    'fax': store['Fax'],
+                    'fuel:diesel': True,
+                    'fuel:HGV_diesel': True,
+                    'hgv': True,
+                },
+                **self.brand_info(store['Name'])
+            )
 
-        data = json.loads(response.body_as_unicode())
-        current_page_number = data["PageNumber"]
-        total_pages = data["TotalPages"]
-
-        stores = data.get("Locations", [])
-
-        if current_page_number <= total_pages:
-            for store in stores:
-                properties = {
-                    'addr_full': store["StreetAddress"].strip(),
-                    'city': store['City'].strip(),
-                    'state': store['State'].strip(),
-                    'postcode': store['ZipCode'].strip(),
-                    'phone': store["PhoneNumber"].strip(),
-                    'ref': store['StoreNumber'],
-                }
-                yield scrapy.Request('https://pilotflyingj.com/stores/{}/'.format(store["Id"]),
-                                     callback=self.parse_store,
-                                     meta={'properties': properties})
-
-            payload = {
-                "PageNumber": current_page_number + 1,
-                "PageSize": 50,
-                "States": [],
-                "Countries": [],
-                "Concepts": []
+    def brand_info(self, name):
+        if 'Pilot' in name:
+            return {
+                'brand': 'Pilot',
+                'brand_wikidata': 'Q7194412'
             }
-            yield scrapy.Request("https://pilotflyingj.com/umbraco/surface/storelocations/search",
-                                 method='POST',
-                                 body=json.dumps(payload),
-                                 headers=self.headers,
-                                 callback=self.parse)
+        elif 'Flying J' in name:
+            return {
+                'brand': 'Flying J',
+                'brand_wikidata': 'Q16974822'
+            }
+        else:
+            return {
+                'brand': name
+            }


### PR DESCRIPTION
The existing parser was failing on the individual store pages. This rewrites it using a CSV export available on their site. It takes quite a while to resolve the CSV download, but once it does we get all the records at once.

This also adds differentiation between the Pilot and Flying J brands for individual stations.

Alternatively, I found that appending `.json` to the end of any store page returns a nice JSON payload: https://locations.pilotflyingj.com/us/pa/mill-hall/5868-nittany-valley-drive.json