### PR TITLE
Update whataburger spider to directory url, city handling

### DIFF
--- a/locations/spiders/whataburger.py
+++ b/locations/spiders/whataburger.py
@@ -66,6 +66,7 @@ class WhataburgerSpider(scrapy.Spider):
 
     def parse(self, response):
         urls = response.xpath('//a[@class="Directory-listLink"]/@href').extract()
+        urls.extend(response.xpath('//a[@class="Teaser-titleLink"]/@href').extract())
         for path in urls:
             if len(path.split('/')) > 2:
                 # If there's only one store, the URL will be longer than <state code>.html

--- a/locations/spiders/whataburger.py
+++ b/locations/spiders/whataburger.py
@@ -10,7 +10,7 @@ class WhataburgerSpider(scrapy.Spider):
     item_attributes = { 'brand': "Whataburger", 'brand_wikidata': "Q376627" }
     allowed_domains = ["locations.whataburger.com"]
     start_urls = (
-        'https://locations.whataburger.com/',
+        'https://locations.whataburger.com/directory.html',
     )
 
     def store_hours(self, store_hours):


### PR DESCRIPTION
This is outputting zero locations currently.

```
2020-05-15 13:23:00 [scrapy.core.scraper] DEBUG: Scraped from <200 https://locations.whataburger.com/al/birmingham/5931-trussville-crossings-pkwy.html>
{'addr_full': '5931 Trussville Crossings Pkwy',
 'brand': 'Whataburger',
 'brand_wikidata': 'Q376627',
 'city': 'Birmingham', 
 'extras': {'@spider': 'whataburger'},
 'lat': 33.64291205352172,
 'lon': -86.62591406508915,
 'opening_hours': '24/7',
 'phone': '(205) 655-4513',
 'postcode': '35235',  
 'ref': 'https://locations.whataburger.com/al/birmingham/5931-trussville-crossings-pkwy.html',
 'state': 'AL',
 'website': 'https://locations.whataburger.com/al/birmingham/5931-trussville-crossings-pkwy.html'}
2020-05-15 13:23:00 [scrapy.core.engine] INFO: Closing spider (finished)
2020-05-15 13:23:00 [scrapy.extensions.feedexport] INFO: Stored geojson feed (833 items) in: output/output/whataburger.geojson
2020-05-15 13:23:00 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 396960,
 'downloader/request_count': 958,
 'downloader/request_method_count/GET': 958,
 'downloader/response_bytes': 11139763,
 'downloader/response_count': 958,
 'downloader/response_status_count/200': 958,
 'elapsed_time_seconds': 29.308051,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2020, 5, 15, 20, 23, 0, 703909),
 'item_scraped_count': 833,
 'log_count/DEBUG': 1791,
 'log_count/INFO': 9,
 'memusage/max': 68157440,
 'memusage/startup': 68157440,
 'request_depth_max': 3,
 'response_received_count': 958,
 'scheduler/dequeued': 958,
 'scheduler/dequeued/memory': 958,
 'scheduler/enqueued': 958,
 'scheduler/enqueued/memory': 958,
 'start_time': datetime.datetime(2020, 5, 15, 20, 22, 31, 395858)}
2020-05-15 13:23:00 [scrapy.core.engine] INFO: Spider closed (finished)
```