### PR TITLE
Update texas_roadhouse spider to use some embedded json

### DIFF
--- a/locations/spiders/texas_roadhouse.py
+++ b/locations/spiders/texas_roadhouse.py
@@ -42,6 +42,7 @@ class TexasRoadhouseSpider(scrapy.Spider):
                 'lat': store['gps_lat'],
                 'lon': store['gps_lon'],
                 'ref': store['url'],
+                'name': store['name'],
                 'addr_full': store['address1'],
                 'city': store['city'],
                 'state': store['state'],


### PR DESCRIPTION
This is currently returning zero locations.

```
2020-05-15 18:13:23 [scrapy.core.scraper] DEBUG: Scraped from <200 https://www.texasroadhouse.com/locations>
{'addr_full': '365 Zane Street',
 'brand': 'Texas Roadhouse',
 'brand_wikidata': 'Q7707945',
 'city': 'Zanesville',
 'country': 'USA',
 'extras': {'@spider': 'texas_roadhouse', 'amenity:toilets': True},
 'lat': 0,
 'lon': 0,
 'opening_hours': '',
 'phone': '740-562-6551',
 'postcode': '43701',
 'ref': '/locations/ohio/',
 'state': 'OH',
 'website': 'https://www.texasroadhouse.com/locations/ohio/'}
2020-05-15 18:13:23 [scrapy.core.engine] INFO: Closing spider (finished)
2020-05-15 18:13:23 [scrapy.extensions.feedexport] INFO: Stored geojson feed (594 items) in: output/output/texas_roadhouse.geojson
2020-05-15 18:13:23 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 268,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 103682,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.396058,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2020, 5, 16, 1, 13, 23, 365664),
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 594,
 'log_count/DEBUG': 595,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 67923968,
 'memusage/startup': 67923968,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2020, 5, 16, 1, 13, 21, 969606)}
2020-05-15 18:13:23 [scrapy.core.engine] INFO: Spider closed (finished)
```