### PR TITLE
Update fiveguys spider parsing of json

### DIFF
--- a/locations/spiders/fiveguys.py
+++ b/locations/spiders/fiveguys.py
@@ -16,9 +16,7 @@ class FiveguysSpider(scrapy.Spider):
     def parse(self, response):
         results = json.loads(response.body_as_unicode())
 
-        for data in results:
-            store_data = data['Store']
-
+        for store_data in results:
             properties = {
                 'phone': store_data['PhoneNumber'],
                 'addr_full': store_data['AddressLine1'],


### PR DESCRIPTION
This is currently returning zero locations. Looks like the data is the same, just one less level of indirection in the json.

```
2020-05-15 18:31:13 [scrapy.core.scraper] DEBUG: Scraped from <200 https://www.fiveguys.com/5gapi/stores/ByDistance?lat=45.0&lng=-90.0&distance=25000&secondaryDistance=250&lang=en&lat=45.0&lng=-90.0&dista
nce=25000&secondaryDistance=250&lang=en>
{'addr_full': 'Unit #01-32/33/34C/35',
 'brand': 'Five Guys',
 'brand_wikidata': 'Q1131810',
 'city': 'Singapore',
 'country': 'SG',
 'extras': {'@spider': 'fiveguys'},
 'lat': 1.2997339963912964,
 'lon': 103.84444427490234,
 'name': 'Plaza Singapura',
 'phone': '69764385',
 'postcode': '238839',
 'ref': '3039',
 'state': 'Singapore'}
2020-05-15 18:31:13 [scrapy.core.engine] INFO: Closing spider (finished)
2020-05-15 18:31:13 [scrapy.extensions.feedexport] INFO: Stored geojson feed (1620 items) in: output/output/fiveguys.geojson
2020-05-15 18:31:13 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 744,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 317834,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 1.226198,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2020, 5, 16, 1, 31, 13, 177068),
 'item_dropped_count': 6,
 'item_dropped_reasons_count/DropItem': 6,
 'item_scraped_count': 1620,
 'log_count/DEBUG': 1622,
 'log_count/INFO': 9,
 'log_count/WARNING': 6,
 'memusage/max': 68005888,
 'memusage/startup': 68005888,
 'response_received_count': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2020, 5, 16, 1, 31, 11, 950870)}
2020-05-15 18:31:13 [scrapy.core.engine] INFO: Spider closed (finished)
```