### PR TITLE
Fix and improve US 7-Eleven spider

### DIFF
--- a/locations/spiders/7_11.py
+++ b/locations/spiders/7_11.py
@@ -4,60 +4,91 @@ import json
 import re
 
 from locations.items import GeojsonPointItem
-from locations.hours import OpeningHours
+
+# When the 7-eleven site loads, it makes a reqest to fetch an anon
+# OAuth bearer token from the API using this client ID / secret.
+#
+# If this key rotates in the future, load the site in a private window,
+# look for a POST request to https://api.7-eleven.com/auth/token, and extract
+# the JSON from the outgoing request body.
+ANON_CLIENT_CREDENTIALS = {
+    'client_id': 'sl3rgdU5c5ZvsYj95FGIuexau5Nt7J5OTf7VRPfV',
+    'client_secret': '11BBlWqIeLenwAmPOKqz8WN5NIZRCCSBSEcBtp9DikLh90WL217OlaCvghuDJucGP5wG12VW2vQ7FRAzUMcYtOOrLtcd4eMqShsOJJKZnJOL5snAnih0uyUN8ZEURXPh',
+    'grant_type': 'client_credentials'
+}
+
+
+HEADERS = {
+    # This seems to be a base64-encoded hash generated from a combination of data
+    # in the above headers. Changing the trip ID or any of the other headers will
+    # cause the API requests to fail validation.
+    #
+    # I'm not sure if this hash uses any time-based components to cause it to expire
+    # over time or if it only maintain ingegrety between the other headers.
+    #
+    # These values were pulled from the token request in a private window (see above)
+    'X-SEI-TRIP-ID': 'OWMwYTY1NjE4OGExZWMwZDM2MDEzMDYwZGYzNWQ4OGM=',
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15',
+    'X-SEI-TZ': '-07:00',
+    'X-SEI-VERSION': '3.6.0',
+    'X-SEI-PLATFORM': 'us_web'
+}
 
 
 class SevenElevenSpider(scrapy.Spider):
     name = "seven_eleven"
-    item_attributes = { 'brand': "7-Eleven", 'brand_wikidata': "Q259340" }
-    allowed_domains = [
-                        "www.7-eleven.com",
-                        "api.7-eleven.com"
-                        ]
-    start_urls = (
-        'https://www.7-eleven.com/locations',
-    )
+    allowed_domains = ["7-eleven.com"]
 
-    def parse_hours(self, hours):
-        if hours.xpath('./div/text()').extract_first() == "Open 24/7":
-            return '24/7'
-        else:
-            opening_hours = OpeningHours()
-            hours = hours.xpath('./meta[@itemprop="openingHours"]/@content').extract()
-            for hour in hours:
-                try:
-                    day, open_time, close_time = re.search(r'([A-Za-z]{2})\s([\d:]+)\s-\s([\d:]+)', hour).groups()
-                except:
-                    continue
-                opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format='%H:%M')
+    def start_requests(self):
+        yield scrapy.http.JsonRequest(
+            'https://api.7-eleven.com/auth/token',
+            method='POST',
+            headers=HEADERS,
+            data=ANON_CLIENT_CREDENTIALS,
+            callback=self.fetch_stores
+        )
 
-            return opening_hours.as_opening_hours()
+    def fetch_stores(self, response):
+        auth = json.loads(response.body_as_unicode())
+        HEADERS.update(
+            {'Authorization': 'Bearer cvrL4po6pXlnjzd7lrQRQ3iAbzDf9L'})
 
-    def parse_store(self, response):
-        properties = {
-            'ref': "_".join(re.search(r".+/(.+?)/(.+?)/(.+?)/?(?:\.html|$)", response.url).groups()),
-            'addr_full': response.xpath('normalize-space(//span[@itemprop="streetAddress"]//text())').extract_first().upper(),
-            'city': response.xpath('normalize-space(//span[@itemprop="addressLocality"]//text())').extract_first(),
-            'state': response.xpath('normalize-space(//abbr[@itemprop="addressRegion"]//text())').extract_first(),
-            'postcode': response.xpath('normalize-space(//span[@itemprop="postalCode"]//text())').extract_first(),
-            'country': response.xpath('normalize-space(//meta[@itemprop="addressCountry"]/@content)').extract_first(),
-            'phone': response.xpath('normalize-space(//*[@itemprop="telephone"]//text())').extract_first(),
-            'website': response.url,
-            'lat': response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first(),
-            'lon': response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first(),
-        }
-
-        properties['opening_hours'] = self.parse_hours(response.xpath('//div[@id="se-local-store-hours"]'))
-
-        yield GeojsonPointItem(**properties)
+        yield scrapy.Request(
+            'https://api.7-eleven.com/v4/stores/?lat=40.72786721004897&lon=-73.96717732880859&features=&radius=100000&limit=500&curr_lat=40.72786721004897&curr_lon=-73.96717732880859',
+            headers=HEADERS)
 
     def parse(self, response):
-        urls = response.xpath('//div[contains(@class, "locations-specifics")]//li/a/@href').extract()
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url))
+        data = json.loads(response.body_as_unicode())
 
-        if not urls:
-            stores = response.xpath('//div[@class="location"]')
-            for store in stores:
-                url = store.xpath('.//a[contains(@class, "se-local-store")]/@href').extract_first()
-                yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
+        for store in data['results']:
+            features = store['features']
+
+            properties = {
+                'ref': store['id'],
+                'name': store['name'],
+                'opening_hours': '24/7' if store['open_time'] == '24h' else None,
+                'addr_full': store['address'],
+                'city': store['city'],
+                'state': store['state'],
+                'postcode': store['zip'],
+                'country': store['country'],
+                'lon': float(store['lon']),
+                'lat': float(store['lat']),
+                'phone': store['phone'],
+                'website': store['seo_web_url'],
+                'extras': {
+                    'shop': 'convenience',
+                    'amenity:fuel': 'gas' in features,
+                    'atm': 'atm' in features,
+                    'car_wash': 'carwash' in features,
+                    'fuel:diesel': 'diesel' in features,
+                    'fuel:propane': 'propane' in features
+                }
+            }
+
+            yield GeojsonPointItem(**properties)
+
+        next_url = data['next']
+        if next_url is not None:
+            next_url = response.urljoin(next_url)
+            yield scrapy.Request(url=next_url, headers=HEADERS, callback=self.parse)


### PR DESCRIPTION
The most recent change to this spider switched from hitting an API endpoint to scraping data from the HTML directly. Enough things had broken in the HTML structure since then that I switched it back to hitting the API.

The API endpoint seems to be protected in two ways:

1. It requires an OAuth Bearer token to access
For anonymous sessions, this token is fetched using a static set of client credentials before first use. It's possible that this client ID / secret is rotated regularly with website deploys, but I haven't seen any evidence of that in a few days of testing.

2. It requires a set of `X-SEI-*` headers on every request.
These headers seem to be used in tandem to validate the request. The X-SEI-TRIP-ID appears to be a base64-encoded hash of info from the user agent, time zone, platform, and version. From skimming the minified JS code that generates it, there doesn't appear to be any obvious time-based component that would case it to expire, so the static credentials here are likely good unless the algorithm changes or old versions get locked out.