### PR TITLE
Fix taco bell missing some locations

### DIFF
--- a/locations/spiders/tacobell.py
+++ b/locations/spiders/tacobell.py
@@ -93,6 +93,13 @@ class TacobellSpider(scrapy.Spider):
 
     def parse(self, response):
         states = response.xpath('//li[@class="Directory-listItem"]/a/@href').extract()
+        # The web site currently special-cases DC by linking directly to the
+        # page for the one store therein, bypassing the state index page.
+        # (This spider will call parse_state on the store page and fail.)
+        # Un-special case this by inserting a link to the state index page
+        # which does in fact exist. Hopefully this is bulletproof if the
+        # web site changes.
+        states.append('dc.html')
 
         for state in states:
             yield scrapy.Request(


### PR DESCRIPTION
The taco bell crawler had various issues preventing it from finding all the locations:

- Don't fail if opening hours are missing (189 seem to be missing hours)
- Don't bail out early if a page is both a restaurant and a list of nearby locations (logic error that was causing the spider to skip about a third of the pages)
- Correctly handle the unusual link to the washington, dc store

This now crawls all 7241 locations on the site (up from 4294).