### PR TITLE
Panera Bread - Fix parsing of cities with multiple locations

### DIFF
--- a/locations/spiders/panera_bread.py
+++ b/locations/spiders/panera_bread.py
@@ -86,7 +86,7 @@ class PaneraBread(scrapy.Spider):
         return GeojsonPointItem(**props)
 
     def parse_city(self, city_page):
-        locations = city_page.xpath('//h2[@class="c-location-grid-item-title"]').extract()
+        locations = city_page.xpath('//h2[@class="c-location-grid-item-title"]//a[@data-ya-track="businessname"]/@href').extract()
         if len(locations) > 0:
             for loc in locations:
                 yield scrapy.Request(city_page.urljoin(loc), callback=self.parse_location)


### PR DESCRIPTION
I noticed some Panera Bread locations in my area were missing from the alltheplaces data. I investigated it a bit and it turned out that for cities that had more than one location, it wasn't crawling the right pages (404 error) so it just wasn't getting added to the output geojson. I wrote a small fix and tested it, I was able to get it to produce the locations in Tucson, AZ; Fort Wayne, IN; Evansville, IN, which all have more than one location. This should add around 888 new locations if the total number of locations [here](https://locations.panerabread.com/index.html) is right.