### PR TITLE
Repairs Microsoft stores spider

### DIFF
--- a/locations/spiders/microsoft.py
+++ b/locations/spiders/microsoft.py
@@ -2,10 +2,10 @@ import scrapy
 import re
 from locations.items import GeojsonPointItem
 
-class MicrosoftSpider(scrapy.Spider):
 
+class MicrosoftSpider(scrapy.Spider):
     name = "microsoft"
-    item_attributes = { 'brand': "Microsoft" }
+    item_attributes = {'brand': "Microsoft"}
     allowed_domains = ["www.microsoft.com"]
     download_delay = 0.5
     start_urls = (
@@ -13,20 +13,20 @@ class MicrosoftSpider(scrapy.Spider):
     )
 
     def parse_stores(self, response):
+
         properties = {
+            'name': response.xpath('normalize-space(//h1/strong/text())').extract_first(),
             'addr_full': response.xpath('normalize-space(//div[@itemprop="streetAddress"]/span/text())').extract_first(),
             'phone': response.xpath('normalize-space(//div[@itemprop="telephone"]/span/text())').extract_first(),
             'city': response.xpath('normalize-space(//span[@itemprop="addressLocality"]/text())').extract_first(),
             'state': response.xpath('normalize-space(//span[@itemprop="addressRegion"]/text())').extract_first(),
             'postcode': response.xpath('normalize-space(//span[@itemprop="postalCode"]/text())').extract_first().replace(u'\xa0',''),
-            'ref': re.findall(r"[^\/]+$" ,response.url)[0],
+            'country': re.search(r"^(?:[^\/]*\/){3}([^\/]*)", response.url).group(1).lstrip('en-').upper(),
+            'ref': re.search(r"\/store-([0-9]+)", response.url).group(1),
             'website': response.url,
-            'lat': float(response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first()),
-            'lon': float(response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first()),
         }
 
         yield GeojsonPointItem(**properties)
-
 
     def parse(self, response):
         urls = response.xpath('//ul[@instancename="Cities list"]/li/a/@href').extract()


### PR DESCRIPTION
Repairs the Microsoft store spider. Looks like they no longer include coordinates on their pages unfortunately which was causing the spider to error out. Added `name` and `country` properties. 