### PR TITLE
Repairs Nike spider

### DIFF
--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -1,33 +1,44 @@
 import scrapy
 import re
+import json
 from locations.items import GeojsonPointItem
 
+
 class NikeSpider(scrapy.Spider):
-
     name = "nike"
-    item_attributes = { 'brand': "Nike" }
-    allowed_domains = ["www.nike.com"]
-    download_delay = 1.5
-    start_urls = (
-        'https://www.nike.com/us/en_us/retail/en/directory',
-    )
+    item_attributes = {'brand': "Nike"}
+    allowed_domains = ["nike.bricksoftware.com"]
+    download_delay = 0.3
 
-    def parse_stores(self, response):
-        properties = {
-            'name': response.xpath('normalize-space(//meta[@itemprop="name"]/@content)').extract_first(),
-            'addr_full': response.xpath('normalize-space(//meta[@itemprop="streetAddress"]/@content)').extract_first(),
-            'phone': response.xpath('normalize-space(//meta[@itemprop="telephone"]/@content)').extract_first(),
-            'city': response.xpath('normalize-space(//meta[@itemprop="addressLocality"]/@content)').extract_first(),
-            'state': response.xpath('normalize-space(//meta[@itemprop="addressRegion"]/@content)').extract_first(),
-            'postcode': response.xpath('normalize-space(//meta[@itemprop="postalCode"]/@content)').extract_first(),
-            'ref': re.findall(r"[^\/]+$" ,response.url)[0],
-            'website': response.url,
-            'lat': float(response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first()),
-            'lon': float(response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first()),
-        }
-        yield GeojsonPointItem(**properties)
+    def start_requests(self):
+        url = 'https://nike.brickworksoftware.com/api/v3/stores.json'
+
+        yield scrapy.Request(url=url, callback=self.parse)
 
     def parse(self, response):
-        urls = response.xpath('//div[@class="bwt-directory-store-wrapper bwt-hide-on-mobile"]/a/@href').extract()
-        for path in urls:
-            yield scrapy.Request(response.urljoin(path), callback=self.parse_stores)
+        data = json.loads(response.body_as_unicode())
+        stores = data["stores"]
+
+        for store in stores:
+            addr_1 = store["address_1"]
+            addr_2 = store["address_2"]
+            addr_3 = store["address_3"]
+
+            properties = {
+                'name': store["name"],
+                'ref': store["id"],
+                'addr_full': re.sub(' +', ' ', ' '.join(filter(None, [addr_1, addr_2, addr_3])).strip()),
+                'city': store["city"],
+                'state': store["state"],
+                'postcode': store["postal_code"],
+                'country': store["country_code"],
+                'phone': store.get("phone_number"),
+                'website': response.url,
+                'lat': float(store["latitude"]),
+                'lon': float(store["longitude"]),
+                'extras': {
+                    'store_type': store["type"],
+                },
+            }
+
+            yield GeojsonPointItem(**properties)


### PR DESCRIPTION
Nike spider was previously returning zero results, now scrapes 1495 Nike locations internationally.