### PR TITLE
Add issue filing to run_all_spiders.sh

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -11,6 +11,13 @@ if [ -z "${GITHUB_WORKSPACE}" ]; then
     exit 1
 fi
 
+if [ -z "${GITHUB_TOKEN}" ]; then
+    (>&2 echo "Please set GITHUB_TOKEN environment variable")
+    exit 1
+fi
+
+GITHUB_AUTH="scraperbot:${GITHUB_TOKEN}"
+
 RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 RUN_TIMESTAMP=$(date -u +%F-%H-%M-%S)
 RUN_S3_KEY_PREFIX="runs/${RUN_TIMESTAMP}"
@@ -26,7 +33,7 @@ mkdir -p "${SPIDER_RUN_DIR}"
 (>&2 echo "Write out a file with scrapy commands to parallelize")
 for spider in $(scrapy list)
 do
-    echo "--output ${SPIDER_RUN_DIR}/output/${spider}.geojson --output-format geojson --logfile ${SPIDER_RUN_DIR}/logs/${spider}.log --loglevel ERROR --set TELNETCONSOLE_ENABLED=0 --set CLOSESPIDER_TIMEOUT=${SPIDER_TIMEOUT} --set LOGSTATS_FILE=${SPIDER_RUN_DIR}/stats/${spider}.json ${spider}" >> ${SPIDER_RUN_DIR}/commands.txt
+    echo "--output ${SPIDER_RUN_DIR}/output/${spider}.geojson:geojson --logfile ${SPIDER_RUN_DIR}/logs/${spider}.log --loglevel ERROR --set TELNETCONSOLE_ENABLED=0 --set CLOSESPIDER_TIMEOUT=${SPIDER_TIMEOUT} --set LOGSTATS_FILE=${SPIDER_RUN_DIR}/stats/${spider}.json ${spider}" >> ${SPIDER_RUN_DIR}/commands.txt
 done
 
 mkdir -p ${SPIDER_RUN_DIR}/logs
@@ -51,13 +58,101 @@ for spider in $(scrapy list)
 do
     spider_out_geojson="${SPIDER_RUN_DIR}/output/${spider}.geojson"
     spider_out_log="${SPIDER_RUN_DIR}/logs/${spider}.log"
+    statistics_json="${SPIDER_RUN_DIR}/stats/${spider}.json"
+
+    feature_count=$(jq --raw-output '.item_scraped_count' ${statistics_json})
+
+    if [ "${feature_count}" == "null" ]; then
+        feature_count="0"
+    fi
+
+    error_count=$(jq --raw-output '."log_count/ERROR"' ${statistics_json})
+
+    if [ "${error_count}" == "null" ]; then
+        error_count="0"
+    fi
+
+    echo "Spider ${spider} has ${feature_count} features, ${error_count} errors"
+
+    # use JQ to create an overall results JSON
     cat ${SPIDER_RUN_DIR}/output/results.json | \
         jq --compact-output \
             --arg spider_name ${spider} \
-            --arg spider_feature_count $(wc -l < ${spider_out_geojson}) \
-            --arg spider_error_count $(grep ' ERROR: ' ${spider_out_log} | wc -l | tr -d ' ') \
+            --arg spider_feature_count ${feature_count} \
+            --arg spider_error_count ${error_count} \
             '.results += [{"spider": $spider_name, "errors": $spider_error_count | tonumber, "features": $spider_feature_count | tonumber}]' \
         > ${SPIDER_RUN_DIR}/output/results.json
+
+    # look for an existing issue for this spider
+    lookup_response=$(curl -s -u ${GITHUB_AUTH} -s https://api.github.com/search/issues\?q=is:issue+label:bug+repo:alltheplaces/alltheplaces+\"Spider+${spider}+is+broken\" | jq '{count: .total_count, url: .items[0].url, state: .items[0].state}')
+
+    if [ "${feature_count}" -eq "0" ] || [ "${error_count}" -gt "0" ]; then
+        # if there are errors or zero features, post an issue about it
+        issue_body="During the global build at ${RUN_TIMESTAMP}, spider **$spider** failed with **${feature_count} features** and **${error_count} errors**.\n\nHere's [the log](${RUN_URL_PREFIX}/logs/${spider}.log) and [the output](${RUN_URL_PREFIX}/output/${spider}.geojson) ([on a map](https://data.alltheplaces.xyz/map.html?show=${RUN_URL_PREFIX}/output/${spider}.geojson))"
+
+        if [ "$(echo $lookup_response | jq --raw-output '.count')" -eq 0 ]; then
+            # no existing issue found, so create a new one
+
+            curl -s -u $GITHUB_AUTH -XPOST -d "{\"title\": \"Spider ${spider} is broken\", \"labels\": [\"bug\"], \"body\": \"${issue_body}\"}" https://api.github.com/repos/alltheplaces/alltheplaces/issues | jq --raw-output --compact-output .
+
+            if [ ! $? -eq 0 ]; then
+                (>&2 echo "Couldn't create new issue for spider ${spider}")
+            else
+                (>&2 echo "Created new issue for ${spider}")
+            fi
+        else
+            # existing issue found, so add a comment to it
+            issue_url=$(echo $lookup_response | jq --raw-output '.url')
+
+            if [ "$(echo $lookup_response | jq --raw-output '.state')" -eq "closed" ]; then
+                # ... but first reopen the issue if it's closed
+                curl -s -u $GITHUB_AUTH -XPATCH -d '{"state": "open"}' $issue_url | jq --raw-output --compact-output .
+
+                if [ ! $? -eq 0 ]; then
+                    (>&2 echo "Couldn't reopen issue ${issue_url} for spider ${spider}")
+                else
+                    (>&2 echo "Reopened ${issue_url} for spider ${spider}")
+                fi
+            fi
+
+            curl -s -u $GITHUB_AUTH -XPOST -d "{\"body\": \"${issue_body}\"}" ${issue_url}/comments | jq --raw-output --compact-output .
+
+            if [ ! $? -eq 0 ]; then
+                (>&2 echo "Couldn't leave comment on issue ${issue_url} for spider ${spider}")
+            else
+                (>&2 echo "Left comment on ${issue_url} for spider ${spider}")
+            fi
+        fi
+    else
+        issue_body="During the global build at ${RUN_TIMESTAMP}, spider **$spider** succeeded with **${feature_count} features** and **${error_count} errors**.\n\nHere's [the log](${RUN_URL_PREFIX}/logs/${spider}.log) and [the output](${RUN_URL_PREFIX}/output/${spider}.geojson) ([on a map](https://data.alltheplaces.xyz/map.html?show=${RUN_URL_PREFIX}/output/${spider}.geojson))"
+
+        if [ "$(echo $lookup_response | jq --raw-output '.count')" -eq 0 ]; then
+            # no existing issue found, and output was as expected, so continue
+            continue
+        else
+            # existing issue found. post a comment about success.
+            issue_url=$(echo $lookup_response | jq --raw-output '.url')
+
+            if [ "$(echo $lookup_response | jq --raw-output '.state')" -eq "open" ]; then
+                # ... but first close the issue if it's open
+                curl -s -u $GITHUB_AUTH -XPATCH -d '{"state": "closed"}' $issue_url | jq --raw-output --compact-output .
+
+                if [ ! $? -eq 0 ]; then
+                    (>&2 echo "Couldn't close issue ${issue_url} for spider ${spider}")
+                else
+                    (>&2 echo "Closed ${issue_url} for spider ${spider}")
+                fi
+            fi
+
+            curl -s -u $GITHUB_AUTH -XPOST -d "{\"body\": \"${issue_body}\"}" ${issue_url}/comments | jq --raw-output --compact-output .
+
+            if [ ! $? -eq 0 ]; then
+                (>&2 echo "Couldn't leave comment on issue ${issue_url} for spider ${spider}")
+            else
+                (>&2 echo "Left comment on ${issue_url} for spider ${spider}")
+            fi
+        fi
+    fi
 done
 (>&2 echo "Wrote out summary JSON")
 
@@ -78,7 +173,7 @@ if [ ! $? -eq 0 ]; then
     exit 1
 fi
 
-(>&2 echo "Saving embed to https://s3.amazonaws.com/${S3_BUCKET}/runs/latest/info_embed.html")
+(>&2 echo "Saving embed to https://data.alltheplaces.xyz/runs/latest/info_embed.html")
 OUTPUT_FILESIZE=$(du ${SPIDER_RUN_DIR}/output.tar.gz | awk '{printf "%0.1f", $1/1024}')
 cat > "${SPIDER_RUN_DIR}/info_embed.html" << EOF
 <html><body>


### PR DESCRIPTION
This adds a bit to the run_all_spiders.sh script that gets run weekly to create new issues when a spider returns errors or zero results.

- It looks for an existing github issue in this repo with the label "bug" and with the title "Spider <spider name> is broken"
- If this spider run resulted in >0 errors or =0 scraped results
    - If there is an existing ticket
        - If the ticket is closed, reopen it
        - Post a comment that says the spider is still broken
    - If there is not an existing ticket
        - Create a new ticket that says the spider is broken
- Else (==0 errors and >0 scraped results)
    - If there is an existing ticket
        - If the ticket is open, close it
        - Post a comment saying the spider is fixed
    - If there is not an existing ticket
        - Do nothing
