### PR TITLE
Fixes: #3259: Spider alnatura_de is broken

### DIFF
--- a/locations/spiders/alnatura_de.py
+++ b/locations/spiders/alnatura_de.py
@@ -28,8 +28,8 @@ class AlnaturaSpider(scrapy.Spider):
         if match:
             from_day = match.group(1).strip()
             to_day = match.group(2).strip()
-            from_time = match.group(3).strip()
-            to_time = match.group(4).strip()
+            from_time = match.group(3).strip().replace(':','.')
+            to_time = match.group(4).strip().replace(':','.')
 
             fhours = int(float(from_time))
             fminutes = (float(from_time) * 60) % 60
@@ -38,13 +38,13 @@ class AlnaturaSpider(scrapy.Spider):
             tminutes = (float(to_time) * 60) % 60
             fmt_to_time = "%d:%02d" % (thours, tminutes)
 
-        for day in range(DAY_MAPPING[from_day], DAY_MAPPING[to_day] + 1):
-            opening_hours.add_range(
-                day=DAY_MAPPING[day],
-                open_time=fmt_from_time,
-                close_time=fmt_to_time,
-                time_format='%H:%M'
-            )
+            for day in range(DAY_MAPPING[from_day], DAY_MAPPING[to_day] + 1):
+                opening_hours.add_range(
+                    day=DAY_MAPPING[day],
+                    open_time=fmt_from_time,
+                    close_time=fmt_to_time,
+                    time_format='%H:%M'
+                )
 
         return opening_hours.as_opening_hours()
 


### PR DESCRIPTION
Fixes #3259
Fixes #3191
Fixes #3137
Fixes #3055
Fixes #2978
Fixes #2880
Fixes #2817
Fixes #2707
Fixes #2651

**There were two issues:**
1.`UnboundLocalError: local variable 'from_day' referenced before assignment` This happened because `match` was not initialized. Due to this, `from_day` didn't initalize and later it was referenced. Moving `for` inside the same condition resolved this.
2. `ValueError: could not convert string to float: '06:30'` When this time was tried to convert to float it gave error. This is happening because date is not correctly formatted in some rows. Fixed this by replacing ':' by '.'