### PR TITLE
Fix wsp spider

### DIFF
--- a/locations/spiders/wsp.py
+++ b/locations/spiders/wsp.py
@@ -24,10 +24,10 @@ class wsp(scrapy.Spider):
             self.parse_store,
             method='POST',
             formdata=formdata,
-            )
+        )
 
     def parse_store(self, response):
-        office_data = json.loads(response.body_as_unicode())
+        office_data = json.loads(response.text)
 
         for office in office_data:
             try:
@@ -37,7 +37,7 @@ class wsp(scrapy.Spider):
                     'lat': office["Location"].split(",")[0],
                     'lon': office["Location"].split(",")[1],
                     'name': office["Name"],
-                    'website': office["MapPointURL"]
+                    'website': response.urljoin(office["MapPointURL"]),
                 }
             except IndexError:
                 continue


### PR DESCRIPTION
Missing '/' in the start URL is leading to incorrect URL constructions. Fixed this. See attached logs in comments for #3298

Fixes #3298
Fixes #2797 