### PR TITLE
Fix target_au

### DIFF
--- a/locations/spiders/target_au.py
+++ b/locations/spiders/target_au.py
@@ -12,7 +12,9 @@ class TargetAUSpider(scrapy.Spider):
     allowed_domains = ["target.com.au"]
     start_urls = ["https://www.target.com.au/store-finder"]
     headers = {
-        "User-Agent": "Mozilla/5.0 (X11; CrOS aarch64 14324.72.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.91 Safari/537.36"
+        "Accept": "*/*",
+        "Accept-Language": "en-US,en;q=0.9",
+        "User-Agent": "Mozilla/5.0 (X11; CrOS aarch64 14324.72.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.91 Safari/537.36",
     }
     custom_settings = {
         "DEFAULT_REQUEST_HEADERS": headers,

--- a/locations/spiders/target_au.py
+++ b/locations/spiders/target_au.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 import scrapy
+import json
 
 from locations.hours import OpeningHours
 from locations.items import GeojsonPointItem
@@ -6,76 +8,46 @@ from locations.items import GeojsonPointItem
 
 class TargetAUSpider(scrapy.Spider):
     name = "target_au"
-    item_attributes = { 'brand': "Target", 'brand_wikidata': "Q7685854" }
+    item_attributes = {"brand": "Target", "brand_wikidata": "Q7685854"}
     allowed_domains = ["target.com.au"]
-    states = ["nsw","vic","qld","nt", "act", "sa", "tas", "wa"]
-    headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101 Firefox/81.0",
-                "Referer": "https://www.target.com.au/store-finder"}
-
-    custom_settings = {'DOWNLOAD_DELAY' : 0.5,}
-
-    def start_requests(self):
-        url = "https://www.target.com.au/store-finder/state/{}"
-        for state in self.states:
-            yield scrapy.Request(url.format(state),headers=self.headers, callback=self.parse)
-
+    start_urls = ["https://www.target.com.au/store-finder"]
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; CrOS aarch64 14324.72.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.91 Safari/537.36"
+    }
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": headers,
+        "DOWNLOAD_HANDLERS": {
+            "https": "scrapy.core.downloader.handlers.http2.H2DownloadHandler"
+        },
+    }
 
     def parse(self, response):
-        store_links = response.xpath('//a[@class="table-tap-canonical"]/@href').getall()
-        for link in store_links:
-            yield scrapy.Request(response.urljoin(link), callback=self.parse_store, headers=self.headers)
+        for href in response.xpath('//*[@class="store-states"]//@href').extract():
+            url = response.urljoin(href)
+            yield scrapy.Request(url, callback=self.parse_state)
 
-    def _parse_hour_str(self, hour_string):
-        if hour_string == "Midnight":
-            return self._parse_hour_str("12:00 AM")
-        time_, am_pm = tuple(hour_string.split(" "))
-        hour, min = tuple(time_.split(":"))
-        hour = int(hour)
-        if am_pm == "PM":
-            hour += 12
-        return f"{hour}:{min}"
-
-    def parse_hours(self, hours_node):
-        opening_hours = OpeningHours()
-        days = hours_node.xpath(".//dt/text()").getall()
-        hours = hours_node.xpath(".//dd/text()").getall()
-        for idx, day in enumerate(days):
-            store_hours = hours[idx]
-            if "–" not in store_hours or ":" not in store_hours:
-                continue
-            parts = store_hours.strip().split(" – ")
-            open_time = self._parse_hour_str(parts[0])
-            close_time = self._parse_hour_str(parts[1])
-            opening_hours.add_range(day[0:2], open_time, close_time)
-        
-        return opening_hours.as_opening_hours()
-
-
-
-    def parse_store(self, response):
-        store_name = response.xpath("//h4/text()").get().replace("Target – ","")
-        address_header = response.xpath("//span[@itemprop='streetAddress']/strong/text()").get()
-        address = " ".join(response.xpath("//span[@itemprop='streetAddress']/text()").getall()).strip()
-        if address_header:
-            address = address_header + " " + address
-        locality = response.xpath("//span[@itemprop='addressLocality']/text()").get()
-        region = response.xpath("//span[@itemprop='addressRegion']/text()").get()
-        post_code = response.xpath("//span[@itemprop='postalCode']/text()").get()
-        phone_number = response.xpath("//span[@itemprop='telephone']/text()").get()
-        hours_section = response.xpath("(//dl)[1]")[0]
-        opening_hours = self.parse_hours(hours_section)
-        lat = response.xpath("//div[@data-embedded-json='store-content-data']//@data-lat").get()
-        lon = response.xpath("//div[@data-embedded-json='store-content-data']//@data-lng").get()
-
-        yield GeojsonPointItem(lat=lat,
-                                lon=lon,
-                                name=store_name,
-                                addr_full=address,
-                                city=locality,
-                                state=region,
-                                postcode=post_code,
-                                country="AU",
-                                phone=phone_number,
-                                website=response.url,
-                                opening_hours=opening_hours,
-                                ref=response.url.split("/")[-1])  
+    def parse_state(self, response):
+        data = json.loads(
+            response.xpath('//script[@id="store-json-data"]/text()').get()
+        )
+        for row in data["locations"]:
+            body = scrapy.Selector(text=row["content"])
+            href = body.xpath("//@href").get()
+            properties = {
+                "ref": href.rsplit("/", 1)[-1],
+                "name": row["name"],
+                "lat": row["lat"],
+                "lon": row["lng"],
+                "addr_full": " ".join(
+                    s.strip()
+                    for s in body.xpath(
+                        '//*[@itemprop="streetAddress"]//text()'
+                    ).extract()
+                ),
+                "city": body.xpath('//*[@itemprop="addressLocality"]/text()').get(),
+                "state": body.xpath('//*[@itemprop="addressRegion"]/text()').get(),
+                "postcode": body.xpath('//*[@itemprop="postalCode"]/text()').get(),
+                "phone": body.xpath("//p[last()-1]/text()").get(),
+                "website": response.urljoin(href),
+            }
+            yield GeojsonPointItem(**properties)


### PR DESCRIPTION
It appears that Akamai Ghost is happy to talk given:

1. A browser user-agent (and certain accept-* headers)
2. Over HTTP/2

Note that [HTTP/2 support in Scrapy is experimental][1].

[1]: https://docs.scrapy.org/en/latest/topics/settings.html?highlight=http2#download-handlers-base

I tested this successfully from GCP and AWS.