### PR TITLE
Fix history.json

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -155,7 +155,7 @@ aws s3 cp \
     "s3://${S3_BUCKET}/runs/history.json" \
     history.json
 
-if [ ! -f history.json ]; then
+if [ ! -s history.json ]; then
     echo '[]' > history.json
 fi
 


### PR DESCRIPTION
If the file was empty then the jq expression wouldn't work. Correctly initialize the file.

e.g.

```
¶ </dev/null jq '. += [1]' 
¶ <<<'[]' jq -c '. += [1]' 
[1]
¶ 
```