### PR TITLE
Add street_address field

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -16,26 +16,27 @@ Although it's not supported at the time of this writing, we hope to include a ge
 
 Each GeoJSON feature will have a `properties` object with the following keys:
 
-| Name | Required? | Description |
-|---|---|---|
-| `ref`              | Yes | A unique identifier for this feature inside this spider. The code that generates the output will remove duplicates based on the value of this key.
-| `@spider`          | Yes | The name of the spider that produced this feature. It is [specified in each spider](https://github.com/alltheplaces/alltheplaces/blob/11d9be56515ef0f6419e001b1950f69d28d4f400/locations/spiders/apple.py#L9), so it doesn't necessarily related to the file name of the spider.
-| `name`             | No  | The name of the feature. This is usually extracted from the venue's page, so it will probably be different per feature. This is often the location specific part of a chain location's name, like the name of the mall it's in, without the chain name included.
-| **Brand**          |     | _Information about the brand that operates or owns the venue_
-| `brand`            | No  | The brand or chain name of the feature. This will generally be the same for most features outputted by a scraper. Some scrapers will output for companies that own multiple brands, like Duane Reade and Walgreens for the Walgreens scraper.
-| `brand:wikidata`   | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand of the feature. This is a machine-readible identifier counterpart for the human-readible `brand` above.
-| **Address**        |     | _Information about the address of the venue_
-| `addr:full`        | No  | The full address for the venue in one line of text. Usually this follows the format of street, city, province, postcode address. This field might exist instead of the other address-related fields, especially if the spider can't reliably extract the individual parts of the address.
-| `addr:housenumber` | No  | The house number part of the address.
-| `addr:street`      | No  | The street name.
-| `addr:city`        | No  | The city part of the address.
-| `addr:state`       | No  | The state or province part of the address.
-| `addr:postcode`    | No  | The postcode part of the address.
-| `addr:country`     | No  | The country part of the address.
-| **Contact**        |     | _Contact information for the venue_
-| `phone`            | No  | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
-| `website`          | No  | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
-| `opening_hours`    | No  | The opening hours for the venue. When we can, the format for this field follows [OpenStreetMap's `opening_hours` format](https://wiki.openstreetmap.org/wiki/Key:opening_hours#Examples).
+| Name                 | Required? | Description |
+|----------------------|---|---|
+| `ref`                | Yes | A unique identifier for this feature inside this spider. The code that generates the output will remove duplicates based on the value of this key.
+| `@spider`            | Yes | The name of the spider that produced this feature. It is [specified in each spider](https://github.com/alltheplaces/alltheplaces/blob/11d9be56515ef0f6419e001b1950f69d28d4f400/locations/spiders/apple.py#L9), so it doesn't necessarily related to the file name of the spider.
+| `name`               | No  | The name of the feature. This is usually extracted from the venue's page, so it will probably be different per feature. This is often the location specific part of a chain location's name, like the name of the mall it's in, without the chain name included.
+| **Brand**            |     | _Information about the brand that operates or owns the venue_
+| `brand`              | No  | The brand or chain name of the feature. This will generally be the same for most features outputted by a scraper. Some scrapers will output for companies that own multiple brands, like Duane Reade and Walgreens for the Walgreens scraper.
+| `brand:wikidata`     | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand of the feature. This is a machine-readible identifier counterpart for the human-readible `brand` above.
+| **Address**          |     | _Information about the address of the venue_
+| `addr:full`          | No  | The full address for the venue in one line of text. Usually this follows the format of street, city, province, postcode address. This field might exist instead of the other address-related fields, especially if the spider can't reliably extract the individual parts of the address.
+| `addr:housenumber`   | No  | The house number part of the address.
+| `addr:street`        | No  | The street name.
+| `addr:streetAddress` | No  | The street address, including street name and house number and/or name.
+| `addr:city`          | No  | The city part of the address.
+| `addr:state`         | No  | The state or province part of the address.
+| `addr:postcode`      | No  | The postcode part of the address.
+| `addr:country`       | No  | The country part of the address.
+| **Contact**          |     | _Contact information for the venue_
+| `phone`              | No  | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
+| `website`            | No  | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
+| `opening_hours`      | No  | The opening hours for the venue. When we can, the format for this field follows [OpenStreetMap's `opening_hours` format](https://wiki.openstreetmap.org/wiki/Key:opening_hours#Examples).
 
 
 

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -16,27 +16,27 @@ Although it's not supported at the time of this writing, we hope to include a ge
 
 Each GeoJSON feature will have a `properties` object with the following keys:
 
-| Name                 | Required? | Description |
-|----------------------|---|---|
-| `ref`                | Yes | A unique identifier for this feature inside this spider. The code that generates the output will remove duplicates based on the value of this key.
-| `@spider`            | Yes | The name of the spider that produced this feature. It is [specified in each spider](https://github.com/alltheplaces/alltheplaces/blob/11d9be56515ef0f6419e001b1950f69d28d4f400/locations/spiders/apple.py#L9), so it doesn't necessarily related to the file name of the spider.
-| `name`               | No  | The name of the feature. This is usually extracted from the venue's page, so it will probably be different per feature. This is often the location specific part of a chain location's name, like the name of the mall it's in, without the chain name included.
-| **Brand**            |     | _Information about the brand that operates or owns the venue_
-| `brand`              | No  | The brand or chain name of the feature. This will generally be the same for most features outputted by a scraper. Some scrapers will output for companies that own multiple brands, like Duane Reade and Walgreens for the Walgreens scraper.
-| `brand:wikidata`     | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand of the feature. This is a machine-readible identifier counterpart for the human-readible `brand` above.
-| **Address**          |     | _Information about the address of the venue_
-| `addr:full`          | No  | The full address for the venue in one line of text. Usually this follows the format of street, city, province, postcode address. This field might exist instead of the other address-related fields, especially if the spider can't reliably extract the individual parts of the address.
-| `addr:housenumber`   | No  | The house number part of the address.
-| `addr:street`        | No  | The street name.
-| `addr:streetAddress` | No  | The street address, including street name and house number and/or name.
-| `addr:city`          | No  | The city part of the address.
-| `addr:state`         | No  | The state or province part of the address.
-| `addr:postcode`      | No  | The postcode part of the address.
-| `addr:country`       | No  | The country part of the address.
-| **Contact**          |     | _Contact information for the venue_
-| `phone`              | No  | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
-| `website`            | No  | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
-| `opening_hours`      | No  | The opening hours for the venue. When we can, the format for this field follows [OpenStreetMap's `opening_hours` format](https://wiki.openstreetmap.org/wiki/Key:opening_hours#Examples).
+| Name                  | Required? | Description |
+|-----------------------|---|---|
+| `ref`                 | Yes | A unique identifier for this feature inside this spider. The code that generates the output will remove duplicates based on the value of this key.
+| `@spider`             | Yes | The name of the spider that produced this feature. It is [specified in each spider](https://github.com/alltheplaces/alltheplaces/blob/11d9be56515ef0f6419e001b1950f69d28d4f400/locations/spiders/apple.py#L9), so it doesn't necessarily related to the file name of the spider.
+| `name`                | No  | The name of the feature. This is usually extracted from the venue's page, so it will probably be different per feature. This is often the location specific part of a chain location's name, like the name of the mall it's in, without the chain name included.
+| **Brand**             |     | _Information about the brand that operates or owns the venue_
+| `brand`               | No  | The brand or chain name of the feature. This will generally be the same for most features outputted by a scraper. Some scrapers will output for companies that own multiple brands, like Duane Reade and Walgreens for the Walgreens scraper.
+| `brand:wikidata`      | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand of the feature. This is a machine-readible identifier counterpart for the human-readible `brand` above.
+| **Address**           |     | _Information about the address of the venue_
+| `addr:full`           | No  | The full address for the venue in one line of text. Usually this follows the format of street, city, province, postcode address. This field might exist instead of the other address-related fields, especially if the spider can't reliably extract the individual parts of the address.
+| `addr:housenumber`    | No  | The house number part of the address.
+| `addr:street`         | No  | The street name.
+| `addr:street_address` | No  | The street address, including street name and house number and/or name.
+| `addr:city`           | No  | The city part of the address.
+| `addr:state`          | No  | The state or province part of the address.
+| `addr:postcode`       | No  | The postcode part of the address.
+| `addr:country`        | No  | The country part of the address.
+| **Contact**           |     | _Contact information for the venue_
+| `phone`               | No  | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
+| `website`             | No  | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
+| `opening_hours`       | No  | The opening hours for the venue. When we can, the format for this field follows [OpenStreetMap's `opening_hours` format](https://wiki.openstreetmap.org/wiki/Key:opening_hours#Examples).
 
 
 

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -9,7 +9,7 @@ mapping = (
     ("addr_full", "addr:full"),
     ("housenumber", "addr:housenumber"),
     ("street", "addr:street"),
-    ("street_address", "addr:streetAddress"),
+    ("street_address", "addr:street_address"),
     ("city", "addr:city"),
     ("state", "addr:state"),
     ("postcode", "addr:postcode"),

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -9,6 +9,7 @@ mapping = (
     ("addr_full", "addr:full"),
     ("housenumber", "addr:housenumber"),
     ("street", "addr:street"),
+    ("street_address", "addr:streetAddress"),
     ("city", "addr:city"),
     ("state", "addr:state"),
     ("postcode", "addr:postcode"),

--- a/locations/items.py
+++ b/locations/items.py
@@ -15,6 +15,7 @@ class GeojsonPointItem(scrapy.Item):
     addr_full = scrapy.Field()
     housenumber = scrapy.Field()
     street = scrapy.Field()
+    street_address = scrapy.Field()
     city = scrapy.Field()
     state = scrapy.Field()
     postcode = scrapy.Field()


### PR DESCRIPTION
As discussed in #3579 add `street_address` which gets outputted to `addr:streetAddress`.

I've not deprecated `addr:housenumber`and `addr:street` as they are useful if the spider can reliably separate them, but for most the data I've looked at, that isn't being done.