### PR TITLE
Add Heronfoods spider

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -13,6 +13,10 @@ class OpeningHours(object):
         if day not in DAYS:
             raise ValueError("day must be one of " + ", ".join(DAYS))
 
+        if open_time.lower() == "closed":
+            return
+        if close_time.lower() == "closed":
+            return
         if not isinstance(open_time, time.struct_time):
             open_time = time.strptime(open_time, time_format)
         if not isinstance(close_time, time.struct_time):

--- a/locations/spiders/heronfoods.py
+++ b/locations/spiders/heronfoods.py
@@ -1,0 +1,57 @@
+import scrapy
+
+from locations.hours import OpeningHours
+from locations.items import GeojsonPointItem
+
+
+class HeronFoodsSpider(scrapy.Spider):
+    name = "heron_foods"
+    item_attributes = {"brand": "Heron Foods", "brand_wikidata": "Q5743472"}
+    allowed_domains = ["heronfoods.com"]
+
+    def start_requests(self):
+        yield scrapy.FormRequest(
+            url="https://heronfoods.com/wp-admin/admin-ajax.php",
+            formdata={
+                "action": "get_stores",
+                "lat": "51.5072178",
+                "lng": "-0.1275862",
+                "radius": "600",
+            },
+            callback=self.parse,
+        )
+
+    def parse(self, response):
+        stores = response.json()
+        for i in range(0, len(stores)):
+            store = stores[str(i)]
+
+            oh = OpeningHours()
+            oh.add_range("Mo", store["op"]["0"], store["op"]["1"])
+            oh.add_range("Tu", store["op"]["2"], store["op"]["3"])
+            oh.add_range("We", store["op"]["4"], store["op"]["5"])
+            oh.add_range(
+                "Th", store["op"]["6"], store["op"]["7"].replace("17:20:00", "17:20")
+            )
+            oh.add_range("Fr", store["op"]["8"], store["op"]["9"])
+            oh.add_range("Sa", store["op"]["10"], store["op"]["11"])
+            oh.add_range("Su", store["op"]["12"], store["op"]["13"])
+
+            properties = {
+                "lat": store["lat"],
+                "lon": store["lng"],
+                "name": store["na"],
+                "street_address": store["st"].strip(" ,"),
+                "city": store["ct"].strip(),
+                "postcode": store["zp"].strip(),
+                "country": "GB",
+                "website": store["gu"],
+                "opening_hours": oh.as_opening_hours(),
+                "ref": store["ID"],
+            }
+            if properties["name"].endswith(" (B&M Express)"):
+                properties["name"] = properties["name"].replace(" (B&M Express)", "")
+                properties["brand"] = "B&M Express"
+                properties["brand_wikidata"] = "Q99640578"
+
+            yield GeojsonPointItem(**properties)


### PR DESCRIPTION
It can currently be done with one request, that may need to change at some point but it works fine for now.

I've also changed `add_range` from `OpeningHours` to silently reject "closed", technically OSM opening hours can be outputted as "off" instead of a time range, but I don't know enough Python to support this.