### PR TITLE
Ignore Robots.txt on WordPress API spiders

### DIFF
--- a/locations/spiders/bayshore_healthcare.py
+++ b/locations/spiders/bayshore_healthcare.py
@@ -12,6 +12,7 @@ class BayshoreHealthcareSpider(scrapy.Spider):
     name = "bayshore_healthcare"
     item_attributes = {"brand": "Bayshore Healthcare"}
     allowed_domains = ["bayshore.ca"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         url = "https://www.bayshore.ca/wp-admin/admin-ajax.php?action=location_finder&language=en"

--- a/locations/spiders/bc_pizza.py
+++ b/locations/spiders/bc_pizza.py
@@ -17,6 +17,7 @@ class BcpizzaSpider(scrapy.Spider):
     start_urls = [
         "https://bc.pizza/wp-admin/admin-ajax.php?action=store_search&lat=42.331427&lng=-83.0457538&max_results=100&search_radius=1000&_=1515354445197"
     ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def convert_hours(self, hours):
         hours = [x.strip() for x in hours]

--- a/locations/spiders/beacon_bridge_market.py
+++ b/locations/spiders/beacon_bridge_market.py
@@ -17,10 +17,10 @@ HEADERS = {
 
 
 class BeaconAndBridgeSpider(scrapy.Spider):
-
     name = "beacon_and_bridge"
     item_attributes = {"brand": "Beacon Bridge Market"}
-    allowed_domains = ["www.beaconandbridge.com/"]
+    allowed_domains = ["www.beaconandbridge.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         form_data = {

--- a/locations/spiders/boston_market.py
+++ b/locations/spiders/boston_market.py
@@ -71,6 +71,7 @@ class BostonMarketSpider(scrapy.Spider):
     item_attributes = {"brand": "Boston Market"}
     allowed_domains = ["www.bostonmarket.com"]
     base_url = "https://www.bostonmarket.com"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         for state in STATES:

--- a/locations/spiders/buc-ees.py
+++ b/locations/spiders/buc-ees.py
@@ -9,6 +9,7 @@ class BuceesSpider(scrapy.Spider):
     name = "buc-ees"
     item_attributes = {"brand": "Buc-ee's", "brand_wikidata": "Q4982335"}
     allowed_domains = ["buc-ees.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     start_urls = [
         "https://buc-ees.com/wp-admin/admin-ajax.php?action=store_search&lat=30.26715&lng=-97.74306&autoload=1"

--- a/locations/spiders/busy_beaver.py
+++ b/locations/spiders/busy_beaver.py
@@ -12,6 +12,7 @@ class BusyBeaverSpider(scrapy.Spider):
     name = "busy_beaver"
     item_attributes = {"brand": "Busy Beaver", "brand_wikidata": "Q108394482"}
     allowed_domains = ["busybeaver.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "https://busybeaver.com/wp-admin/admin-ajax.php?action=store_search&lat=40&lng=-79&max_results=5000&search_radius=5000&autoload=1",
     )

--- a/locations/spiders/cell-only.py
+++ b/locations/spiders/cell-only.py
@@ -35,6 +35,7 @@ class CellOnlySpider(scrapy.Spider):
     name = "cellonly"
     item_attributes = {"brand": "CellOnly"}
     allowed_domains = ["cell-only.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def process_hours(self, hours):
         if not hours:

--- a/locations/spiders/coastal.py
+++ b/locations/spiders/coastal.py
@@ -8,6 +8,7 @@ class CoastalFarmSpider(scrapy.Spider):
     name = "coastalfarm"
     item_attributes = {"brand": "Coastal"}
     allowed_domains = ["www.coastalfarm.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "https://www.coastalfarm.com/wp-admin/admin-ajax.php?action=store_search&lat=45.523062&lng=-122.67648199999996&max_results=25&search_radius=50",
     )

--- a/locations/spiders/cookout.py
+++ b/locations/spiders/cookout.py
@@ -11,6 +11,7 @@ class CookoutSpider(scrapy.Spider):
     name = "cookout"
     item_attributes = {"brand": "Cookout", "brand_wikidata": "Q5166992"}
     allowed_domains = ["cookout.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         base_url = "https://cookout.com/wp-admin/admin-ajax.php?action=store_search&lat={lat}&lng={lng}&max_results=300&search_radius=500"

--- a/locations/spiders/dunhams_sports.py
+++ b/locations/spiders/dunhams_sports.py
@@ -7,6 +7,7 @@ class DunhamsSportsSpiders(scrapy.Spider):
     name = "dunhams_sports"
     item_attributes = {"brand": "Dunham's Sports"}
     allowed_domains = ["http://www.dunhamssports.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "http://www.dunhamssports.com/wp-admin/admin-ajax.php?action=simloc_get_locations&lat=32.7258378&lng=-116.95580669999998&radius=200000",
     )

--- a/locations/spiders/gattispizza.py
+++ b/locations/spiders/gattispizza.py
@@ -21,6 +21,7 @@ class GattispizzaSpider(scrapy.Spider):
     name = "gattispizza"
     item_attributes = {"brand": "Gatti's Pizza", "brand_wikidata": "Q5527509"}
     allowed_domains = ["gattispizza.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         form_data = {"action": "udfd_update_locations", "data": "3211"}

--- a/locations/spiders/heronfoods.py
+++ b/locations/spiders/heronfoods.py
@@ -8,6 +8,7 @@ class HeronFoodsSpider(scrapy.Spider):
     name = "heron_foods"
     item_attributes = {"brand": "Heron Foods", "brand_wikidata": "Q5743472"}
     allowed_domains = ["heronfoods.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         yield scrapy.FormRequest(

--- a/locations/spiders/kbp_foods.py
+++ b/locations/spiders/kbp_foods.py
@@ -18,6 +18,7 @@ class KBPFoodsSpider(scrapy.Spider):
     allowed_domains = ["kbp-foods.com"]
     item_attributes = {"brand": "KBP Foods"}
     download_delay = 0.3
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         # Fetch brand data first

--- a/locations/spiders/krystal.py
+++ b/locations/spiders/krystal.py
@@ -59,12 +59,12 @@ STATES = [
 
 
 class KrystalSpider(scrapy.Spider):
-
     name = "krystal"
     item_attributes = {"brand": "Krystal"}
     allowed_domains = ["krystal.com"]
     download_delay = 1.5
     start_urls = ("http://krystal.com/wp-admin/admin-ajax.php",)
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse_hours(self, hours):
         hours = json.loads(hours)

--- a/locations/spiders/kum_and_go.py
+++ b/locations/spiders/kum_and_go.py
@@ -11,6 +11,7 @@ class KumAndGoSpider(scrapy.Spider):
     name = "kum_and_go"
     item_attributes = {"brand": "Kum & Go", "brand_wikidata": "Q6443340"}
     allowed_domains = ["kumandgo.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         with open(

--- a/locations/spiders/mcdonalds_gt.py
+++ b/locations/spiders/mcdonalds_gt.py
@@ -7,6 +7,7 @@ class McDonaldsGTSpider(scrapy.Spider):
     name = "mcdonalds_gt"
     item_attributes = {"brand": "McDonald's"}
     allowed_domains = ["mcdonalds.com.gt"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         url = "https://mcdonalds.com.gt/wp-admin/admin-ajax.php"

--- a/locations/spiders/mcdonalds_sg.py
+++ b/locations/spiders/mcdonalds_sg.py
@@ -7,6 +7,7 @@ class McDonaldsSGSpider(scrapy.Spider):
     name = "mcdonalds_sg"
     item_attributes = {"brand": "McDonald's"}
     allowed_domains = ["www.mcdonalds.com.sg"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     start_urls = (
         "https://www.mcdonalds.com.sg/wp/wp-admin/admin-ajax.php?action=store_locator_locations",

--- a/locations/spiders/mobilelink.py
+++ b/locations/spiders/mobilelink.py
@@ -11,6 +11,7 @@ class MobilelinkSpider(scrapy.Spider):
     name = "mobilelink"
     item_attributes = {"brand": "Mobilelink"}
     allowed_domains = ["mobilelinkusa.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = [
         "https://mobilelinkusa.com/wp-admin/admin-ajax.php?action=store_search&lat=29.760427&lng=-95.36980299999999&max_results=1000&search_radius=10000&autoload=1",
     ]

--- a/locations/spiders/premierurgentcare.py
+++ b/locations/spiders/premierurgentcare.py
@@ -12,6 +12,7 @@ class PremierurgentcareSpider(scrapy.Spider):
     name = "premierurgentcare"
     item_attributes = {"brand": "Premier Urgent Care"}
     allowed_domains = ["premierimc.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "http://www.premierimc.com/wp-admin/admin-ajax.php?action=store_search&lat=40.030628&lng=-75.36398400000002&max_results=50&search_radius=10&autoload=1",
     )

--- a/locations/spiders/smilebrands.py
+++ b/locations/spiders/smilebrands.py
@@ -12,6 +12,7 @@ class SmilebrandsSpider(scrapy.Spider):
     name = "smilebrands"
     item_attributes = {"brand": "Smile Brands Inc."}
     allowed_domains = ["smilebrands.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = [
         "https://smilebrands.com/wp-admin/admin-ajax.php?action=store_search&lat=39.11553&lng=-94.62679&max_results=100000&search_radius=100&autoload=1",
     ]

--- a/locations/spiders/speedee.py
+++ b/locations/spiders/speedee.py
@@ -73,6 +73,7 @@ class SpeeDeeSpider(scrapy.Spider):
     name = "speedee_oil"
     item_attributes = {"brand": "SpeeDee Oil Change and Auto Service"}
     allowed_domains = ["speedeeoil.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = [
         "https://www.speedeeoil.com/wp-admin/admin-ajax.php?action=asl_load_stores&nonce=207e81f157&load_all=1&layout=1",
     ]

--- a/locations/spiders/steak_n_shake.py
+++ b/locations/spiders/steak_n_shake.py
@@ -10,6 +10,7 @@ class SteakNShakeSpider(scrapy.Spider):
     name = "steak_n_shake"
     item_attributes = {"brand": "Steak N Shake", "brand_wikidata": "Q7605233"}
     allowed_domains = ["www.steaknshake.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = ("https://www.steaknshake.com/locations/",)
 
     def start_requests(self):

--- a/locations/spiders/superamerica.py
+++ b/locations/spiders/superamerica.py
@@ -9,6 +9,7 @@ class SuperAmericaSpider(scrapy.Spider):
     name = "superamerica"
     item_attributes = {"brand": "SuperAmerica"}
     allowed_domains = ["superamerica.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "http://superamerica.com/wp-admin/admin-ajax.php?action=store_search&lat=45.0&lng=-90.0&max_results=0&search_radius=500",
     )

--- a/locations/spiders/sweet_tomatoes.py
+++ b/locations/spiders/sweet_tomatoes.py
@@ -6,10 +6,10 @@ from locations.items import GeojsonPointItem
 
 
 class SweetTomatoesSpider(scrapy.Spider):
-
     name = "sweet_tomatoes"
     item_attributes = {"brand": "Sweet Tomatoes"}
     allowed_domains = ["sweettomatoes.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = (
         "https://sweettomatoes.com/wp-admin/admin-ajax.php?action=store_search&lat=37.09024&lng=-95.71289100000001&max_results=9990&search_radius=1500&autoload=1",
     )

--- a/locations/spiders/viva_chicken.py
+++ b/locations/spiders/viva_chicken.py
@@ -23,6 +23,7 @@ class VivaChickenSpider(scrapy.Spider):
     name = "viva_chicken"
     item_attributes = {"brand": "Viva Chicken"}
     allowed_domains = ["www.vivachicken.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         params = {


### PR DESCRIPTION
Untested edit of any spiders accessing "wp-admin/admin-ajax.php" to ignore robots.txt as WordPress blocks them.