### PR TITLE
Update Wikidata ids

### DIFF
--- a/locations/spiders/albertsons.py
+++ b/locations/spiders/albertsons.py
@@ -10,7 +10,7 @@ from locations.hours import OpeningHours
 class AlbertsonsSpider(scrapy.Spider):
 
     name = "albertsons"
-    item_attributes = {"brand": "Albertsons", "brand_wikidata": "Q4712282"}
+    item_attributes = {"brand": "Albertsons", "brand_wikidata": "Q2831861"}
     download_delay = 0.5
 
     allowed_domains = [

--- a/locations/spiders/exxonmobil.py
+++ b/locations/spiders/exxonmobil.py
@@ -210,7 +210,7 @@ class ExxonMobilSpider(scrapy.Spider):
         elif "esso" in location["BrandingImage"]:
             return {"brand": "Esso", "brand_wikidata": "Q867662"}
         elif "exxon" in location["BrandingImage"]:
-            return {"brand": "Exxon", "brand_wikidata": "Q4781944"}
+            return {"brand": "Exxon", "brand_wikidata": "Q109675651"}
         else:
             return {}
 

--- a/locations/spiders/exxonmobil.py
+++ b/locations/spiders/exxonmobil.py
@@ -154,6 +154,9 @@ class ExxonMobilSpider(scrapy.Spider):
     crawled_locations = set()
     allowed_domains = ["exxon.com"]
     start_urls = CreateStartURLs().get_urls()
+    custom_settings = {
+        "USER_AGENT": "Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0"
+    }
 
     def parse(self, response):
         json_data = json.loads(response.text)

--- a/locations/spiders/phillips_66_conoco_76.py
+++ b/locations/spiders/phillips_66_conoco_76.py
@@ -8,7 +8,7 @@ HEADERS = {"Content-Type": "application/json"}
 
 BRANDS = {"U76": "76", "P66": "Phillips 66", "CON": "Conoco"}
 
-WIKIBRANDS = {"U76": "Q1658320", "P66": "Q1656230", "CON": "Q1126518"}
+WIKIBRANDS = {"U76": "Q1658320", "P66": "Q1656230", "CON": "Q214763"}
 
 
 class Phillips66Spider(scrapy.Spider):


### PR DESCRIPTION
[Q4712282](https://www.wikidata.org/wiki/Q4712282) -> [Q2831861](https://www.wikidata.org/wiki/Q2831861) is a pure redirect
[Q4781944](https://www.wikidata.org/wiki/Q4781944) -> [Q109675651](https://www.wikidata.org/wiki/Q109675651) is former Exxon to current Exxon by ExxonMobil
[Q1126518](https://www.wikidata.org/wiki/Q1126518) -> [Q214763](https://www.wikidata.org/wiki/Q214763) I'm not 100% on this one but its Conoco Inc. to ConocoPhillips