### PR TITLE
Fix M&S Spider

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -33,7 +33,7 @@ class OpeningHours(object):
                 "%s-%s"
                 % (
                     time.strftime("%H:%M", h[0]),
-                    time.strftime("%H:%M", h[1]),
+                    time.strftime("%H:%M", h[1]).replace("23:59", "24:00"),
                 )
                 for h in self.day_hours[day]
             )
@@ -50,7 +50,7 @@ class OpeningHours(object):
 
         opening_hours = ""
         if len(day_groups) == 1 and day_groups[0]["hours"] in (
-            "00:00-23:59",
+            "00:00-24:00",
             "00:00-00:00",
         ):
             opening_hours = "24/7"

--- a/locations/spiders/marks_and_spencer.py
+++ b/locations/spiders/marks_and_spencer.py
@@ -7,7 +7,7 @@ from locations.items import GeojsonPointItem
 
 class MarksAndSpencerSpider(scrapy.Spider):
     name = "marks_and_spencer"
-    item_attributes = {"brand": "Marks and Spencer"}
+    item_attributes = {"brand": "Marks and Spencer", "brand_wikidata": "Q714491"}
     start_urls = (
         "https://www.marksandspencer.com/webapp/wcs/stores/servlet/MSResStoreFinderConfigCmd?storeId=10151&langId=-24",
     )
@@ -40,6 +40,8 @@ class MarksAndSpencerSpider(scrapy.Spider):
         o = OpeningHours()
         for day in store["coreOpeningHours"]:
             o.add_range(
-                day["day"][:2], day["open"], day["close"].replace("24:00", "23:59")
+                day["day"][:2],
+                day["open"].replace("24:00", "00:00"),
+                day["close"].replace("24:00", "23:59"),
             )
         return o.as_opening_hours()


### PR DESCRIPTION
So, M&S returns "24:00" sometimes, Python doesn't like it so I'm changing it to "00:00", or "23:59". However "24:00" is allowed in [OSM opening_hours](https://wiki.openstreetmap.org/wiki/Key:opening_hours), so I'm converting it back when we turn convert it.