### PR TITLE
Remove 'Scrapy' from user agent string

### DIFF
--- a/locations/settings.py
+++ b/locations/settings.py
@@ -19,7 +19,7 @@ NEWSPIDER_MODULE = "locations.spiders"
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) Scrapy/{scrapy.__version__} {BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces)"
+USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) {BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; framework {scrapy.__version__})"
 
 ROBOTSTXT_USER_AGENT = BOT_NAME
 


### PR DESCRIPTION
Several sites seem to respond to generic terms like curl, Python-urllib,
Scrapy with 403 errors, apparently as a cheap "I've written a robot!"
deterrent.

Still identify ourselves clearly by default and include the version
number of scrapy. We can of course use a generic user-agent for sites
which require it.

Appears to fix walmart, at least.