### PR TITLE
Fix: IKEA

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -17,6 +17,8 @@ class OpeningHours(object):
             return
         if close_time.lower() == "closed":
             return
+        if close_time == "24:00":
+            close_time = "23:59"
         if not isinstance(open_time, time.struct_time):
             open_time = time.strptime(open_time, time_format)
         if not isinstance(close_time, time.struct_time):

--- a/locations/spiders/ikea.py
+++ b/locations/spiders/ikea.py
@@ -62,8 +62,6 @@ class IkeaSpider(scrapy.Spider):
     def parse(self, response):
         data = response.json()
         for store in data:
-            if "storePageUrl" not in store:
-                continue
             opening_hours = OpeningHours()
             for day in store["hours"]["normal"]:
                 if day["open"] != "":
@@ -72,6 +70,8 @@ class IkeaSpider(scrapy.Spider):
                         day["open"],
                         day["close"],
                     )
+            split_url = response.url.split("/")
+            country_path = f"{split_url[3]}/{split_url[4]}"
             properties = {
                 "lat": store["lat"],
                 "lon": store["lng"],
@@ -80,7 +80,9 @@ class IkeaSpider(scrapy.Spider):
                 "city": store["address"].get("city"),
                 "postcode": store["address"].get("zipCode"),
                 "country": response.request.url[21:23].upper(),
-                "website": store["storePageUrl"],
+                "website": store["storePageUrl"]
+                if "storePageUrl" in store
+                else f"https://www.ikea.com/{country_path}/stores/",
                 "ref": store["id"],
                 "opening_hours": opening_hours.as_opening_hours(),
                 "extras": {

--- a/locations/spiders/ikea.py
+++ b/locations/spiders/ikea.py
@@ -66,7 +66,7 @@ class IkeaSpider(scrapy.Spider):
             for day in store["hours"]["normal"] if "hours" in store else []:
                 if day["open"] != "":
                     opening_hours.add_range(
-                        day["day"][0:1].upper() + day["day"][1:2].lower(),
+                        day["day"].title()[0:1].upper() + day["day"].title()[1:2].lower(),
                         day["open"],
                         day["close"],
                     )

--- a/locations/spiders/ikea.py
+++ b/locations/spiders/ikea.py
@@ -63,7 +63,7 @@ class IkeaSpider(scrapy.Spider):
         data = response.json()
         for store in data:
             opening_hours = OpeningHours()
-            for day in store["hours"]["normal"]:
+            for day in store["hours"]["normal"] if "hours" in store else []:
                 if day["open"] != "":
                     opening_hours.add_range(
                         day["day"][0:1].upper() + day["day"][1:2].lower(),

--- a/locations/spiders/ikea.py
+++ b/locations/spiders/ikea.py
@@ -66,7 +66,7 @@ class IkeaSpider(scrapy.Spider):
             for day in store["hours"]["normal"] if "hours" in store else []:
                 if day["open"] != "":
                     opening_hours.add_range(
-                        day["day"].title()[0:1].upper() + day["day"].title()[1:2].lower(),
+                        day["day"].title()[:2],
                         day["open"],
                         day["close"],
                     )


### PR DESCRIPTION
After some investigation on IKEA store locators (more specifically the ones in the France https://www.ikea.com/fr/fr/meta-data/navigation/stores-detailed.json) I noticed that there was missing data in the GeoJson. Issue was that some countries don't specify the key `storePageUrl` (1 out of 36 for France). 

So instead not ingesting them, we ingest them and link it to the main store page url for that given country.