### PR TITLE
fix: mcdonalds usa scraper didn't use the correct order lat/long

### DIFF
--- a/locations/spiders/mcdonalds_ca.py
+++ b/locations/spiders/mcdonalds_ca.py
@@ -99,8 +99,8 @@ class McDonaldsCASpider(scrapy.Spider):
                     "country": store_info["addressLine4"],
                     "postcode": store_info["postcode"],
                     "phone": store_info.get("telephone"),
-                    "lon": store["geometry"]["coordinates"][0],
-                    "lat": store["geometry"]["coordinates"][1],
+                    "lon": store["geometry"]["coordinates"][1],
+                    "lat": store["geometry"]["coordinates"][0],
                 }
 
             hours = store_info.get("restauranthours")

--- a/locations/spiders/mcdonalds_us.py
+++ b/locations/spiders/mcdonalds_us.py
@@ -86,8 +86,8 @@ class McDonaldsUSSpider(scrapy.Spider):
                     "country": store_info["addressLine4"],
                     "postcode": store_info["postcode"],
                     "phone": store_info.get("telephone"),
-                    "lon": store["geometry"]["coordinates"][0],
-                    "lat": store["geometry"]["coordinates"][1],
+                    "lon": store["geometry"]["coordinates"][1],
+                    "lat": store["geometry"]["coordinates"][0],
                     "extras": {
                         "number": store_info[
                             "identifierValue"


### PR DESCRIPTION
`"coordinates": [-157.708106, 21.28524]}},`
First coordinate should be latitude


<img width="964" alt="Capture d’écran 2022-06-28 à 18 19 10" src="https://user-images.githubusercontent.com/92714362/176230191-7d0f7b5b-6d18-48b7-a3b5-68c0bb2327ba.png">

