### PR TITLE
add opening hours to the Home Depot scraper

### DIFF
--- a/locations/google_url.py
+++ b/locations/google_url.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlsplit
 
 
 def url_to_coords(url: str) -> (float, float):
@@ -28,5 +28,10 @@ def url_to_coords(url: str) -> (float, float):
     elif url.startswith("https://www.google.com/maps/dir/"):
         lat, lon = url.split("/")[6].split(",")
         return float(lat.strip()), float(lon.strip())
+    elif url.startswith("https://dev.virtualearth.net/REST/v1/Imagery/"):
+        mapurl = urlsplit(url)
+        lat_lon = next(p for p in mapurl.path.split("/") if "," in p)
+        lat, lon = lat_lon.split(",")
+        return float(lat), float(lon)
 
     return None

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -90,7 +90,7 @@ class OpeningHours(object):
             "Thur": "Th",
             "Fri": "Fr",
             "Sat": "Sa",
-            "Sun": "Su"
+            "Sun": "Su",
         }
         if linked_data.get("openingHoursSpecification"):
             for rule in linked_data["openingHoursSpecification"]:

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -83,6 +83,15 @@ class OpeningHours(object):
         return opening_hours
 
     def from_linked_data(self, linked_data, time_format="%H:%M"):
+        DAY_MAPPING = {
+            "Mon": "Mo",
+            "Tue": "Tu",
+            "Wed": "We",
+            "Thur": "Th",
+            "Fri": "Fr",
+            "Sat": "Sa",
+            "Sun": "Su"
+        }
         if linked_data.get("openingHoursSpecification"):
             for rule in linked_data["openingHoursSpecification"]:
                 if (
@@ -133,10 +142,16 @@ class OpeningHours(object):
 
                     if "-" in days:
                         start_day, end_day = days.split("-")
+                        if start_day in DAY_MAPPING:
+                            start_day = DAY_MAPPING[start_day]
+                        if end_day in DAY_MAPPING:
+                            end_day = DAY_MAPPING[end_day]
                         for i in range(DAYS.index(start_day), DAYS.index(end_day) + 1):
                             self.add_range(DAYS[i], start_time, end_time, time_format)
                     else:
                         for day in days.split(","):
+                            if day in DAY_MAPPING:
+                                day = DAY_MAPPING[day]
                             self.add_range(
                                 day.strip(), start_time, end_time, time_format
                             )

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -83,15 +83,6 @@ class OpeningHours(object):
         return opening_hours
 
     def from_linked_data(self, linked_data, time_format="%H:%M"):
-        DAY_MAPPING = {
-            "Mon": "Mo",
-            "Tue": "Tu",
-            "Wed": "We",
-            "Thur": "Th",
-            "Fri": "Fr",
-            "Sat": "Sa",
-            "Sun": "Su",
-        }
         if linked_data.get("openingHoursSpecification"):
             for rule in linked_data["openingHoursSpecification"]:
                 if (
@@ -142,16 +133,12 @@ class OpeningHours(object):
 
                     if "-" in days:
                         start_day, end_day = days.split("-")
-                        if start_day in DAY_MAPPING:
-                            start_day = DAY_MAPPING[start_day]
-                        if end_day in DAY_MAPPING:
-                            end_day = DAY_MAPPING[end_day]
-                        for i in range(DAYS.index(start_day), DAYS.index(end_day) + 1):
+                        for i in range(
+                            DAYS.index(start_day[:2]), DAYS.index(end_day[:2]) + 1
+                        ):
                             self.add_range(DAYS[i], start_time, end_time, time_format)
                     else:
                         for day in days.split(","):
-                            if day in DAY_MAPPING:
-                                day = DAY_MAPPING[day]
                             self.add_range(
-                                day.strip(), start_time, end_time, time_format
+                                day.strip()[:2], start_time, end_time, time_format
                             )

--- a/locations/spiders/homedepot.py
+++ b/locations/spiders/homedepot.py
@@ -17,11 +17,7 @@ class HomeDepotSpider(SitemapSpider):
     ]
 
     def parse_store(self, response):
-        json_ld = json.loads(
-            response.xpath(
-                '//script[@id="thd-helmet__script--storeDetailStructuredLocalBusinessData"]/text()'
-            ).extract_first()
-        )
+        json_ld = LinkedDataParser.find_linked_data(response, "LocalBusiness")
         item = LinkedDataParser.parse_ld(json_ld)
         item["ref"] = item["website"].split("/")[-1]
         mapurl = urllib.parse.urlsplit(

--- a/locations/spiders/homedepot.py
+++ b/locations/spiders/homedepot.py
@@ -4,6 +4,7 @@ import json
 from scrapy.spiders import SitemapSpider
 from locations.linked_data_parser import LinkedDataParser
 from locations.hours import OpeningHours
+from locations.google_url import url_to_coords
 
 
 class HomeDepotSpider(SitemapSpider):
@@ -20,13 +21,9 @@ class HomeDepotSpider(SitemapSpider):
         json_ld = LinkedDataParser.find_linked_data(response, "LocalBusiness")
         item = LinkedDataParser.parse_ld(json_ld)
         item["ref"] = item["website"].split("/")[-1]
-        mapurl = urllib.parse.urlsplit(
+        item["lat"], item["lon"] = url_to_coords(
             response.css('img[alt="map preview"]').attrib["src"]
         )
-        lat_lon = next(p for p in mapurl.path.split("/") if "," in p)
-        lat, lon = lat_lon.split(",")
-        item["lat"] = lat
-        item["lon"] = lon
         oh = OpeningHours()
         oh.from_linked_data({"openingHours": json_ld["openingHours"]}, "%I:%M %p")
         item["opening_hours"] = oh.as_opening_hours()

--- a/locations/spiders/homedepot.py
+++ b/locations/spiders/homedepot.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import urllib.parse
+import json
 from scrapy.spiders import SitemapSpider
 from locations.linked_data_parser import LinkedDataParser
 from locations.hours import OpeningHours
-import json
 
 
 class HomeDepotSpider(SitemapSpider):

--- a/tests/test_google_url.py
+++ b/tests/test_google_url.py
@@ -33,3 +33,12 @@ def test_directions():
         51.4063062,
         -0.02920658,
     )
+
+
+def test_bing_virtualearth_url():
+    assert url_to_coords(
+        "https://dev.virtualearth.net/REST/v1/Imagery/Map/Road/38.59966,-90.487672/13?mapSize=60,60&amp;key=AoKTFnu3hdkRgVWl45fcxdz0WSDP6hroMDcPKXE4ZkQql3hPt3PtkCDwtNRCYgYA"
+    ) == (
+        38.59966,
+        -90.487672,
+    )

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -171,6 +171,33 @@ def test_ld_parse_openingHours_array_with_commas():
     )
     assert o.as_opening_hours() == "Mo-Su 00:00-01:00,04:00-24:00"
 
+def test_ld_parse_openingHours_extended_day_format():
+    o = OpeningHours()
+    o.from_linked_data(
+        json.loads(
+            """
+            {
+                "@context": "https://schema.org",
+                "@type": "LocalBusiness",
+                "address": {
+                    "@type": "PostalAddress",
+                    "addressLocality": "Ballwin",
+                    "addressRegion": "MO",
+                    "postalCode": "63011",
+                    "streetAddress": "13929 Manchester Rd"
+                },
+                "name": "Manchester Road",
+                "openingHours": [
+                    "Mon-Sat 6:00 am - 10:00 pm",
+                    "Sun 7:00 am - 8:00 pm"
+                ],
+                "telephone": "(636)207-8875",
+                "url": "https://www.homedepot.com/l/Manchester-Road/MO/Ballwin/63011/3004"
+            }
+            """
+        ),"%I:%M %p"
+    )
+    assert o.as_opening_hours() == "Mo-Sa 06:00-22:00; Su 07:00-20:00"
 
 def test_ld_parse_time_format():
     o = OpeningHours()

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -171,6 +171,7 @@ def test_ld_parse_openingHours_array_with_commas():
     )
     assert o.as_opening_hours() == "Mo-Su 00:00-01:00,04:00-24:00"
 
+
 def test_ld_parse_openingHours_extended_day_format():
     o = OpeningHours()
     o.from_linked_data(
@@ -195,9 +196,11 @@ def test_ld_parse_openingHours_extended_day_format():
                 "url": "https://www.homedepot.com/l/Manchester-Road/MO/Ballwin/63011/3004"
             }
             """
-        ),"%I:%M %p"
+        ),
+        "%I:%M %p",
     )
     assert o.as_opening_hours() == "Mo-Sa 06:00-22:00; Su 07:00-20:00"
+
 
 def test_ld_parse_time_format():
     o = OpeningHours()


### PR DESCRIPTION
No hard feelings if you want to edit my changes or reject this PR, I am still pretty rusty in Python. 

### Changes
- added support for extended day abbreviations (such as "Mon", "Thur") to locations/hours.py
  - Note:  I don't think my implementation is very robust, I believe the other parsing functions won't support this format.
- added a new test to tests/test_opening_hours.py to cover this use case
  - Note: the `test_ld_lowercase_attributes` and `test_ld_parse_openingHours_array_with_commas` tests were already failing when I started. 
- modified the Home Depot scraper to support the time format they use
  - Note: I couldn't figure out how to specify a custom time format with `LinkedDataParser.parse()` so I copied the approach from 071a1b86a2b7c5f2851dff8e790c603aef5aef06
