### PR TITLE
Add costcutter_gb (1472 stores)

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -90,15 +90,6 @@ class LinkedDataParser(object):
         if item["ref"] is None:
             item["ref"] = ld.get("@id")
 
-        if ld.get("brand"):
-            if isinstance(ld["brand"], str):
-                item["brand"] = ld["brand"]
-            elif (
-                ld["brand"].get("@type") == "Brand"
-                or ld["brand"].get("@type") == "Organization"
-            ):
-                item["brand"] = ld["brand"].get("name")
-
         return item
 
     @staticmethod

--- a/locations/spiders/costcutter_gb.py
+++ b/locations/spiders/costcutter_gb.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import scrapy
+from locations.linked_data_parser import LinkedDataParser
+
+
+class CostcutterGBSpider(scrapy.spiders.SitemapSpider):
+    name = "costcutter_gb"
+    item_attributes = {
+        "brand": "Costcutter",
+        "brand_wikidata": "Q5175072",
+    }
+    allowed_domains = ["costcutter.co.uk"]
+    sitemap_urls = ["https://store-locator.costcutter.co.uk/sitemap.xml"]
+    sitemap_rules = [("/costcutter-*", "parse_store")]
+
+    def parse_store(self, response):
+        ld = LinkedDataParser.find_linked_data(response, "ConvenienceStore")
+        if ld:
+            ld["brand"] = None
+            return LinkedDataParser.parse_ld(ld)

--- a/locations/spiders/costcutter_gb.py
+++ b/locations/spiders/costcutter_gb.py
@@ -8,13 +8,13 @@ class CostcutterGBSpider(scrapy.spiders.SitemapSpider):
     item_attributes = {
         "brand": "Costcutter",
         "brand_wikidata": "Q5175072",
+        "country": "GB",
     }
     allowed_domains = ["costcutter.co.uk"]
     sitemap_urls = ["https://store-locator.costcutter.co.uk/sitemap.xml"]
     sitemap_rules = [("/costcutter-*", "parse_store")]
 
     def parse_store(self, response):
-        ld = LinkedDataParser.find_linked_data(response, "ConvenienceStore")
-        if ld:
-            ld["brand"] = None
-            return LinkedDataParser.parse_ld(ld)
+        item = LinkedDataParser.parse(response, "ConvenienceStore")
+        if item and "closed" not in item["name"].lower():
+            return item

--- a/tests/test_ld_parser.py
+++ b/tests/test_ld_parser.py
@@ -31,11 +31,7 @@ def test_ld():
                 "priceRange": "$$",
                 "servesCuisine": ["Middle Eastern", "Mediterranean"],
                 "telephone": "(408) 714-1489",
-                "url": "http://www.greatfood.com",
-                "brand": {
-                    "@type": "Brand",
-                    "name": "GreatFood"
-                }
+                "url": "http://www.greatfood.com"
             }
             """
         )
@@ -53,7 +49,6 @@ def test_ld():
     assert i["phone"] == "(408) 714-1489"
     assert i["website"] == "http://www.greatfood.com"
     assert i["ref"] is None
-    assert i["brand"] == "GreatFood"
 
 
 def test_ld_lowercase_attributes():
@@ -93,7 +88,6 @@ def test_ld_lowercase_attributes():
     assert i["phone"] == "(308) 234-3062"
     assert i["website"] is None
     assert i["ref"] is None
-    assert i.get("brand") is None
     assert i["lat"] == "40.6862"
     assert i["lon"] == "-99.08411"
 
@@ -128,8 +122,7 @@ def test_flat_properties():
                 "@context": "https://schema.org",
                 "@type": "Place",
                 "address": "a, b, c",
-                "image": "https://example.org/image",
-                "brand": "Example"
+                "image": "https://example.org/image"
             }
             """
         )
@@ -137,4 +130,3 @@ def test_flat_properties():
 
     assert i["addr_full"] == "a, b, c"
     assert i["image"] == "https://example.org/image"
-    assert i["brand"] == "Example"


### PR DESCRIPTION
So costcutter_gb uses ld+json but lists all the brands it stocks rather than itself, it does so in a way causing the library parser to error (exception). You see how I have subverted this is the spider code.

However, @Cj-Malone it does beg the question as to why we would decode the brand data? The wikidata code / brand name that by convention we put in the spider is likely the correct brand reference. My reading of the code paths is that picking up the brand from ld+json will stop it being copied from the spider "item_attributes".