### PR TITLE
Add a Microdata parser.

### DIFF
--- a/locations/microdata_parser.py
+++ b/locations/microdata_parser.py
@@ -1,0 +1,305 @@
+import json
+import re
+from typing import Union
+from urllib.parse import urljoin
+
+import lxml
+import parsel
+
+
+class MicrodataError(Exception):
+    pass
+
+
+def token_split(val):
+    return re.findall("\S+", val, flags=re.ASCII)
+
+
+def top_level_items(selector: parsel.Selector):
+    yield from selector.xpath("//*[@itemscope][not(@itemprop)]")
+
+
+def property_value(element: lxml.html.HtmlElement):
+    # 5.2.4 Values
+
+    # The property value of a name-value pair added by an element with an
+    # itemprop attribute is as given for the first matching case in the
+    # following list:
+
+    # If the element also has an itemscope attribute
+    if "itemscope" in element.attrib:
+        # The value is the item created by the element.
+        return element
+    # If the element is a meta element
+    elif element.tag == "meta":
+        # The value is the value of the element's content attribute, if any, or
+        # the empty string if there is no such attribute.
+        value = element.attrib.get("content", "")
+        return value
+    # If the element is an audio, embed, iframe, img, source, track, or video
+    # element
+    elif element.tag in ["audio", "embed", "iframe", "img", "source", "track", "video"]:
+        # The value is the resulting URL string that results from parsing the
+        # value of the element's src attribute relative to the node document of
+        # the element at the time the attribute is set, or the empty string if
+        # there is no such attribute or if parsing it results in an error.
+        value = element.attrib.get("src", "")
+        value = urljoin(element.base_url, value)
+        return value
+    # If the element is an a, area, or link element
+    elif element.tag in ["a", "area", "link"]:
+        # The value is the resulting URL string that results from parsing the
+        # value of the element's href attribute relative to the node document
+        # of the element at the time the attribute is set, or the empty string
+        # if there is no such attribute or if parsing it results in an error.
+        value = element.attrib.get("href", "")
+        value = urljoin(element.base_url, value)
+        return value
+    # If the element is an object element
+    elif element.tag == "object":
+        # The value is the resulting URL string that results from parsing the
+        # value of the element's data attribute relative to the node document
+        # of the element at the time the attribute is set, or the empty string
+        # if there is no such attribute or if parsing it results in an error.
+        value = element.attrib.get("data", "")
+        value = urljoin(element.base_url, value)
+        return value
+    # If the element is a data element
+    # If the element is a meter element
+    elif element.tag in ["data", "meter"]:
+        # The value is the value of the element's value attribute, if it has one,
+        # or the empty string otherwise.
+        value = element.attrib.get("value", "")
+        return value
+    # If the element is a time element
+    elif element.tag == "time":
+        # The value is the element's datetime value.
+        # The datetime value of a time element is the value of the element's
+        # datetime content attribute, if it has one, otherwise the child text
+        # content of the time element.
+        if "datetime" in element.attrib:
+            value = element.attrib["datetime", ""]
+        else:
+            value = element.text_content()
+        return value
+    # https://github.com/w3c/microdata-rdf/issues/26
+    # https://github.com/w3c/microdata/issues/20
+    # Allow @content on any element
+    elif "content" in element.attrib:
+        value = element.attrib["content"]
+        return value
+    # Otherwise
+    else:
+        # The value is the element's descendant text content.
+        value = element.text_content()
+        return value
+
+
+def item_props(scope: lxml.html.HtmlElement):
+    assert "itemscope" in scope.attrib
+    # 5.2.5 Associating names with items
+
+    # 1. Let results, memory, and pending be empty lists of elements.
+    results = []
+    memory = []
+    pending = []
+
+    # 2. Add the element root to memory.
+    memory.append(scope)
+
+    # 3. Add the child elements of root, if any, to pending.
+    pending.extend(scope.getchildren())
+
+    # 4. If root has an itemref attribute, split the value of that itemref
+    # attribute on ASCII whitespace. For each resulting token ID, if there is
+    # an element in the tree of root with the ID ID, then add the first such
+    # element to pending.
+    id_tokens = token_split(scope.attrib.get("itemref", ""))
+    docroot = scope.getroottree().getroot()
+    for token in id_tokens:
+        try:
+            ele = docroot.get_element_by_id(token)
+            pending.append(ele)
+        except KeyError:
+            pass
+    # 5. While pending is not empty:
+    while pending:
+        # 5. 1. Remove an element from pending and let current be that element.
+        current = pending.pop()
+        # 5. 2. If current is already in memory, there is a microdata error;
+        # continue.
+        if current in memory:
+            raise MicrodataError
+
+        # 5. 3. Add current to memory.
+        memory.append(current)
+
+        # 5. 4. If current does not have an itemscope attribute, then: add all
+        # the child elements of current to pending.
+        if "itemscope" not in current.attrib:
+            pending.extend(current.getchildren())
+
+        # 5. 5. If current has an itemprop attribute specified and has one or
+        # more property names, then add current to results.
+        prop_tokens = token_split(current.attrib.get("itemprop", ""))
+        if prop_tokens:
+            results.append(current)
+
+    # 6. Sort results in tree order.
+
+    # 7. Return results.
+    return results
+
+
+def get_object(item: lxml.html.HtmlElement, memory=None):
+    # 1. Let result be an empty object.
+    result = {}
+    # 2. If no memory was passed to the algorithm, let memory be an empty list.
+    if memory is None:
+        memory = []
+    # 3. Add item to memory.
+    memory.append(item)
+
+    # 4. If the item has any item types, add an entry to result called "type"
+    # whose value is an array listing the item types of item, in the order they
+    # were specified on the itemtype attribute.
+    if item_type := token_split(item.attrib.get("itemtype", "")):
+        result["type"] = item_type
+
+    # 5. If the item has a global identifier, add an entry to result called
+    # "id" whose value is the global identifier of item.
+    if itemid := item.attrib.get("itemid"):
+        value = urljoin(item.base_url, itemid)
+        result["id"] = value
+
+    # 6. Let properties be an empty object.
+    properties = {}
+
+    # 7. For each element element that has one or more property names and is
+    # one of the properties of the item item, in the order those elements are
+    # given by the algorithm that returns the properties of an item, run the
+    # following substeps:
+    for element in item_props(item):
+
+        # 7.1. Let value be the property value of element.
+        value = property_value(element)
+
+        # 7.2. If value is an item, then: If value is in memory, then let value
+        # be the string "ERROR". Otherwise, get the object for value, passing a
+        # copy of memory, and then replace value with the object returned from
+        # those steps.
+        if isinstance(value, lxml.html.HtmlElement):
+            if value in memory:
+                value = "ERROR"
+            else:
+                value = get_object(value, memory[:])
+
+        # 7.3. For each name name in element's property names, run the
+        # following substeps:
+        for name in token_split(element.attrib.get("itemprop", "")):
+            # 7.3.1. If there is no entry named name in properties, then add an
+            # entry named name to properties whose value is an empty array.
+            if name not in properties:
+                properties[name] = []
+
+            # 7.3.2. Append value to the entry named name in properties.
+            properties[name] += [value]
+
+    # 8. Add an entry to result called "properties" whose value is the object
+    # properties.
+    result["properties"] = properties
+
+    # 9. Return result.
+    return result
+
+
+# Python cowardly refuses to hash a dict
+# Otherwise, this would be: list(dict.fromkeys(lst))
+# Treat unhashable objects as distinct
+def hash_obj(val):
+    try:
+        return hash(val)
+    except TypeError:
+        return id(val)
+
+
+def remove_duplicates(lst):
+    # Return a new list without duplicates
+    seen = set()
+    result = []
+    for v in lst:
+        if (h := hash_obj(v)) not in seen:
+            result.append(v)
+            seen.add(h)
+    return result
+
+
+def convert_item(item):
+    ld = {}
+    for itemtype in item.get("type", []):
+        schema_type = itemtype.removeprefix("http://schema.org/").removeprefix("https://schema.org/")
+        if schema_type != itemtype:
+            # Did we identify the URI prefix?
+            ld["@type"] = schema_type
+    if "@type" not in ld:
+        return
+    # Convert literal values as-is; convert objects recursively
+    # Properties is a list; if its length is 1 then flatten, else don't.
+    if itemid := item.get("id"):
+        ld["@id"] = itemid
+    for k, v in item["properties"].items():
+        ld[k] = [convert_item(val) if isinstance(val, dict) else val for val in v]
+        ld[k] = remove_duplicates(ld[k])
+        if len(ld[k]) == 1:
+            ld[k] = ld[k][0]
+    return ld
+
+
+def gen_json_ld(result):
+    for item in result["items"]:
+        obj = convert_item(item)
+        if obj is not None:
+            yield obj
+
+
+class MicrodataParser:
+    @staticmethod
+    def convert_to_graph(result):
+        graph = list(gen_json_ld(result))
+        if len(graph) == 1:
+            result = {"@context": "https://schema.org", **graph[0]}
+        else:
+            result = {"@context": "https://schema.org", "@graph": graph}
+        return result
+
+    @staticmethod
+    def extract_microdata(doc: parsel.Selector):
+        # 1. Let result be an empty object.
+        result = {}
+        # 2. Let items be an empty array.
+        items = []
+        # 3. For each node in nodes, check if the element is a top-level microdata
+        # item, and if it is then get the object for that element and add it to
+        # items.
+        for item in top_level_items(doc):
+            items.append(get_object(item.root))
+
+        # 4. Add an entry to result called "items" whose value is the array items.
+        result["items"] = items
+
+        # 5. Return the result of serializing result to JSON in the shortest
+        # possible way (meaning no whitespace between tokens, no unnecessary zero
+        # digits in numbers, and only using Unicode escapes in strings for
+        # characters that do not have a dedicated escape sequence), and with a
+        # lowercase "e" used, when appropriate, in the representation of any
+        # numbers. [JSON]
+        return result
+
+    @staticmethod
+    def convert_to_json_ld(response: Union['parsel.Selector', 'scrapy.http.Response']):
+        selector = getattr(response, "selector", response)
+        obj = MicrodataParser.extract_microdata(selector)
+        ld = MicrodataParser.convert_to_graph(obj)
+        script = selector.root.makeelement("script", {"type": "application/ld+json"})
+        script.text = json.dumps(ld, indent=2)
+        selector.root.append(script)

--- a/locations/microdata_parser.py
+++ b/locations/microdata_parser.py
@@ -237,7 +237,9 @@ def remove_duplicates(lst):
 def convert_item(item):
     ld = {}
     for itemtype in item.get("type", []):
-        schema_type = itemtype.removeprefix("http://schema.org/").removeprefix("https://schema.org/")
+        schema_type = itemtype.removeprefix("http://schema.org/").removeprefix(
+            "https://schema.org/"
+        )
         if schema_type != itemtype:
             # Did we identify the URI prefix?
             ld["@type"] = schema_type
@@ -296,7 +298,7 @@ class MicrodataParser:
         return result
 
     @staticmethod
-    def convert_to_json_ld(response: Union['parsel.Selector', 'scrapy.http.Response']):
+    def convert_to_json_ld(response: Union["parsel.Selector", "scrapy.http.Response"]):
         selector = getattr(response, "selector", response)
         obj = MicrodataParser.extract_microdata(selector)
         ld = MicrodataParser.convert_to_graph(obj)

--- a/locations/spiders/fifththirdbank.py
+++ b/locations/spiders/fifththirdbank.py
@@ -1,95 +1,30 @@
+# -*- coding: utf-8 -*-
 import scrapy
-import re
 
-from locations.items import GeojsonPointItem
-from locations.hours import OpeningHours
+from locations.microdata_parser import MicrodataParser
+from locations.linked_data_parser import LinkedDataParser
 
 
-class FifthThirdBankSpider(scrapy.Spider):
-
+class FifthThirdBankSpider(scrapy.spiders.SitemapSpider):
     name = "fifththirdbank"
-    item_attributes = {"brand": "Fifth Third Bank"}
-    download_delay = 0.5
+    item_attributes = {"brand": "Fifth Third Bank", "brand_wikidata": "Q1411810"}
     allowed_domains = [
         "53.com",
     ]
-    start_urls = ("https://locations.53.com/index.html",)
-
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        for hour in hours:
-            day, hours = re.search(r"([a-z]{2})\s(.*)", hour, re.IGNORECASE).groups()
-            if hours == "Closed":
-                continue
-            open_time, close_time = hours.split("-")
-            opening_hours.add_range(day, open_time=open_time, close_time=close_time)
-
-        return opening_hours.as_opening_hours()
-
-    def parse_branch(self, response):
-        ref = re.findall(r".com/(.+?)/(.+?)/(.+?).html", response.url)[0]
-        ref = "_".join(ref)
-
-        name = response.xpath(
-            'normalize-space(//h1[@class="c-location-title"]/span[@class="name"]/text())'
-        ).extract_first()
-        branch = response.xpath(
-            'normalize-space(//h1[@class="c-location-title"]/span[@class="geomodifier"]/text())'
-        ).extract_first()
-
-        properties = {
-            "name": " ".join([name, branch]),
-            "addr_full": response.xpath(
-                'normalize-space(//span[@itemprop="streetAddress"]/text())'
-            ).extract_first(),
-            "city": response.xpath(
-                'normalize-space(//span[@itemprop="addressLocality"]/text())'
-            ).extract_first(),
-            "state": response.xpath(
-                'normalize-space(//span[@itemprop="addressRegion"]/text())'
-            ).extract_first(),
-            "postcode": response.xpath(
-                'normalize-space(//span[@itemprop="postalCode"]/text())'
-            ).extract_first(),
-            "phone": response.xpath(
-                'normalize-space(//span[@itemprop="telephone"]/text())'
-            ).extract_first(),
-            "ref": ref,
-            "website": response.url,
-            "lat": float(
-                response.xpath(
-                    'normalize-space(//meta[@itemprop="latitude"]/@content)'
-                ).extract_first()
-            ),
-            "lon": float(
-                response.xpath(
-                    'normalize-space(//meta[@itemprop="longitude"]/@content)'
-                ).extract_first()
-            ),
-        }
-        hours = response.xpath('//tr[@itemprop="openingHours"]/@content').extract()
-        if hours:
-            properties["opening_hours"] = self.parse_hours(hours)
-        yield GeojsonPointItem(**properties)
+    sitemap_urls = [
+        "https://locations.53.com/robots.txt",
+    ]
 
     def parse(self, response):
-        branch_urls = response.xpath(
-            '//div[@class="location"]//a[@class="location-name-link"]/@href'
-        ).extract()
-        if branch_urls:
-            for url in branch_urls:
-                yield scrapy.Request(response.urljoin(url), callback=self.parse_branch)
-
+        MicrodataParser.convert_to_json_ld(response.selector)
+        for obj in LinkedDataParser.iter_linked_data(response):
+            # Page includes nearby locations; find the one that's the subject
+            # of this page. We're going to crawl all the pages anyway, so take
+            # the one that also includes the yext itemid.
+            if obj["@type"] == "BankOrCreditUnion" and "@id" in obj:
+                break
         else:
-            urls = response.xpath(
-                '//div[@class="c-directory-list"]//li/a/@href'
-            ).extract()
-
-            for url in urls:
-                if len(url.split("/")) == 3:
-                    # if there's only one branch in a city then the url is directly to that branch page
-                    yield scrapy.Request(
-                        response.urljoin(url), callback=self.parse_branch
-                    )
-                else:
-                    yield scrapy.Request(response.urljoin(url))
+            return
+        if obj:
+            item = LinkedDataParser.parse_ld(obj)
+            yield item

--- a/locations/spiders/greatclips.py
+++ b/locations/spiders/greatclips.py
@@ -1,59 +1,25 @@
 # -*- coding: utf-8 -*-
 import scrapy
-import re
 
-from locations.items import GeojsonPointItem
+from locations.microdata_parser import MicrodataParser
+from locations.linked_data_parser import LinkedDataParser
 
 
-class GreatclipsSpider(scrapy.Spider):
+class GreatclipsSpider(scrapy.spiders.SitemapSpider):
     name = "greatclips"
     item_attributes = {"brand": "Great Clips", "brand_wikidata": "Q5598967"}
-    allowed_domains = ["greatclips.com", "stylewaretouch.net"]
-    start_urls = (
-        "https://www.stylewaretouch.net/checkin/wa/jsonMarkers?client=locator&lat=-34&lng=85&tzoffset=200&callback=onSuccess&failureCallback=onFailure&stores=",
-    )
+    allowed_domains = ["greatclips.com"]
+    sitemap_urls = [
+        "https://salons.greatclips.com/robots.txt",
+    ]
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            if entry["loc"].endswith("/salon-services"):
+                entry["loc"] = entry["loc"].removesuffix("/salon-services")
+                yield entry
 
     def parse(self, response):
-        # creating storeid's
-        for i in range(1, 10000):
-            yield scrapy.Request(
-                self.start_urls[0] + str(i),
-                callback=self.parse_url,
-            )
-
-    def parse_url(self, response):
-        # passing storeid's to find a valid response
-        if response.text.find("onFailure('An unknown error occurred')") != -1:
-            return
-        else:
-            store = re.search(r".+/?stores=(.+)", response.url).group(1)
-            store_url = "https://www.greatclips.com/salons/" + store
-
-            yield scrapy.Request(store_url, callback=self.parse_location)
-
-    def parse_location(self, response):
-        ref = re.search(r".+/(.+)", response.url).group(1)
-
-        properties = {
-            "ref": ref.strip("/"),
-            "name": response.xpath(
-                'normalize-space(//span[@itemprop="name"]/text())'
-            ).extract_first(),
-            "addr_full": response.xpath(
-                'normalize-space(//div[@itemprop="streetAddress"]/div/text())'
-            ).extract_first(),
-            "city": response.xpath(
-                'normalize-space(//span[@itemprop="addressLocality"]/text())'
-            ).extract_first(),
-            "state": response.xpath(
-                'normalize-space(//span[@itemprop="addressRegion"]/text())'
-            ).extract_first(),
-            "postcode": response.xpath(
-                'normalize-space(//span[@itemprop="postalCode"]/text())'
-            ).extract_first(),
-            "phone": response.xpath(
-                'normalize-space(//span[@itemprop="telephone"]/@content)'
-            ).extract_first(),
-            "website": response.url,
-        }
-        yield GeojsonPointItem(**properties)
+        MicrodataParser.convert_to_json_ld(response)
+        item = LinkedDataParser.parse(response, "HealthAndBeautyBusiness")
+        yield item

--- a/locations/spiders/northwest_bank.py
+++ b/locations/spiders/northwest_bank.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import scrapy
+
+from locations.linked_data_parser import LinkedDataParser
+from locations.microdata_parser import MicrodataParser
+
+
+class NorthwestBankSpider(scrapy.spiders.SitemapSpider):
+    name = "northwest_bank"
+    item_attributes = {"brand": "Northwest Bank", "brand_wikidata": "Q7060191"}
+    allowed_domains = ["northwest.bank"]
+    sitemap_urls = ["https://locations.northwest.bank/robots.txt"]
+
+    def parse(self, response):
+        # Contains branch hours and and drive thru hours undifferentiated;
+        # inject a scope to keep them from collapsing
+        for div in response.xpath('(//h2/..)[.//*[@itemprop="openingHours"]]'):
+            div.root.set("itemscope")
+            div.root.set("itemprop", "department")
+            div.root.set("itemtype", "http://schema.org/Department")
+            h2 = div.xpath("./h2")[0]
+            h2.root.set("itemprop", "name")
+        for city in response.css('[itemprop="address"] .Address-city'):
+            city.root.set("itemprop", "addressLocality")
+        MicrodataParser.convert_to_json_ld(response.selector)
+        item = LinkedDataParser.parse(response, "BankOrCreditUnion")
+        yield item


### PR DESCRIPTION
To address:

- [ ] Handle more of the w3c test suite, an itemprop can be absolute and itemtype can be empty. Not sure if anything needs this.
- [ ] Ensure we're sufficiently sensible in the face of itemref.
- [ ] "find the properties of the item" can produce a "microdata error", while "get the object for an item" can produce the string "ERROR". Is there a difference? `<test0085>` produces the latter. The w3c test suite doesn't seem to produce the former.
- [ ] It's probably fine to leave all values untyped?

Converts the HTML5 Microdata directly to JSON-LD in a similar format to (nearly) all of the JSON-LD seen in the wild.

Steps of this process:

1. Run the algorithm to extract the microdata given at <https://html.spec.whatwg.org/multipage/microdata.html>, _not_ the one at <https://www.w3.org/TR/microdata-rdf/>. [Note]

2. Convert the HTML Microdata JSON output to a JSON-LD format.

   While the algorithm to extract the microdata is implemented more or less to spec, this is entirely ad-hoc. If the root item seems to be in the schema.org namespace, produce a correct-looking output.
   Flatten lists of property values if there is only one element.
   Duplicated string values are removed; this is a side effect of what would happen if you actually ran this through an RDF processor.

3. Take the JSON-LD produced and hang it off of the document, then invoke the Linked Data parser as usual. Has the advantage that the special cases here can be reused, such as "phone a property of address", or "multiple addresses for some reason", and so on.

The default entry point I expect will be this one:

    MicrodataParser.convert_to_json_ld(response)
    LinkedDataParser.parse(response, "LocalBusiness")
    # etc.

but the class exposes methods to stop at either of the steps, whether to do more preprocessing, or if that's desired for the output.

Include three spiders to illustrate some possible usage patterns:

- Fix fifththirdbank
- Fix sunglasshut (address and geo are included twice; the
  LinkedDataParser already knows to just look at the first address.)
- Add spider for northwest_bank (insert a hack in the markup to recover
  two different types of openingHours mixed together)

[Note]

Why? Microdata to RDF refers to the HTML Microdata specification _anyway_, for instance when getting the properties of the item, so I found it less reliable as a specification. I think in particular it was unclear when to recursively produce an item when an itemprop has an itemscope. And the output includes typed values and triples, both of which are unnecessary here: Typing all values as strings is sufficient, and the tree structure produced by the HTML Microdata algorithm is exactly what we need, not the graph.

If you want to invoke an RDF library, dear reader, then you need to correctly distinguish between strings and IRI's, be prepared to prevent the library from crawling arbitrary JSON-LD context documents it finds referenced somewhere, and you need to learn how to write a JSON-LD frame in order to produce a JSON-LD document that looks generally familiar. And distinguish between string values with and without a language code. Maybe you could wire up the rest of the application to the rdflib Python API, or write everything in SPARQL. Let me know if you find that fun.