### PR TITLE
Fix Walmart Spider

### DIFF
--- a/locations/spiders/walmart.py
+++ b/locations/spiders/walmart.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
-import re
 
-from locations.items import GeojsonPointItem
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
@@ -28,70 +29,56 @@ class WalmartSpider(CrawlSpider):
         ),
     ]
 
-    def store_hours(self, store_hours):
-        if store_hours.get("operationalHours").get("open24Hours") is True:
+    def store_hours(self, store):
+        if store.get("open24Hours") is True:
             return "24/7"
-        elif not store_hours.get("operationalHoursCombined"):
-            return None
-        else:
-            op_hours = store_hours.get("operationalHoursCombined")
-            open_hours = []
-            for op_hour in op_hours:
-                if op_hour.get("dailyHours").get("closed") is True:
+        elif rules := store.get("operationalHours"):
+            oh = OpeningHours()
+            for rule in rules:
+                if rule.get("closed") is True:
                     continue
 
-                if op_hour.get("dailyHours").get("openFullDay") is True:
-                    start_hr = "00:00"
-                    end_hr = "24:00"
-                else:
-                    start_hr = op_hour.get("dailyHours").get("startHr")
-                    end_hr = op_hour.get("dailyHours").get("endHr")
+                oh.add_range(rule.get("day")[:2], rule.get("start"), rule.get("end"))
 
-                start_day = op_hour.get("startDayName")[:2]
-                end_day = op_hour.get("endDayName")[:2]
-
-                if end_day is None:
-                    end_day = ""
-
-                hours = start_day + "-" + end_day + " " + start_hr + "-" + end_hr
-                open_hours.append(hours)
-
-            hours_combined = "; ".join(open_hours)
-
-            return hours_combined
+            return oh.as_opening_hours()
 
     def parse_store(self, response):
-        script = response.xpath(
-            "//script[contains(.,'__WML_REDUX_INITIAL_STATE__ = ')]"
-        ).extract_first()
+        script = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
 
-        script_content = re.search(
-            r"window.__WML_REDUX_INITIAL_STATE__ = (.*);</script>",
-            script,
-            flags=re.IGNORECASE | re.DOTALL,
-        ).group(1)
+        if script is None:
+            return
 
-        store_data = json.loads(script_content).get("store")
-        services = store_data["primaryServices"] + store_data["secondaryServices"]
+        data = json.loads(script)
 
-        yield GeojsonPointItem(
-            lat=store_data.get("geoPoint").get("latitude"),
-            lon=store_data.get("geoPoint").get("longitude"),
-            ref=store_data.get("id"),
-            phone=store_data.get("phone"),
-            name=store_data.get("displayName"),
-            opening_hours=self.store_hours(store_data),
-            street_address=store_data.get("address").get("streetAddress"),
-            city=store_data.get("address").get("city"),
-            state=store_data.get("address").get("state"),
-            postcode=store_data.get("address").get("postalCode"),
-            website=response.url,
-            extras={
-                "amenity:fuel": any(
-                    s["name"] == "GAS_STATION" and s["active"] for s in services
-                ),
-                "shop": "department_store"
-                if store_data["storeType"]["id"] == 2
-                else "supermarket",
-            },
+        if data is None:
+            return
+
+        store = data["props"]["pageProps"]["initialData"]["initialDataNodeDetail"][
+            "data"
+        ]["nodeDetail"]
+
+        item = DictParser.parse(store)
+
+        item["phone"] = store.get("phoneNumber")
+        item["name"] = store.get("displayName")
+        item["opening_hours"] = self.store_hours(store)
+
+        if addr := store.get("address"):
+            item["street_address"] = ", ".join(
+                filter(
+                    None,
+                    [
+                        addr.get("addressLineOne"),
+                        addr.get("addressLineTwo"),
+                    ],
+                )
+            )
+        item["website"] = response.url
+
+        item["extras"] = {}
+        item["extras"]["type"] = store.get("type")
+        item["extras"]["amenity:fuel"] = any(
+            s["name"] == "GAS_STATION" for s in store["services"]
         )
+
+        return item

--- a/locations/spiders/walmart.py
+++ b/locations/spiders/walmart.py
@@ -12,7 +12,7 @@ class WalmartSpider(CrawlSpider):
     name = "walmart"
     item_attributes = {"brand": "Walmart", "brand_wikidata": "Q483551", "country": "US"}
     allowed_domains = ["walmart.com"]
-    download_delay = 3
+    download_delay = 5
     start_urls = ["https://www.walmart.com/store/directory"]
     rules = [
         Rule(
@@ -56,6 +56,9 @@ class WalmartSpider(CrawlSpider):
         store = data["props"]["pageProps"]["initialData"]["initialDataNodeDetail"][
             "data"
         ]["nodeDetail"]
+
+        if store is None:
+            return
 
         item = DictParser.parse(store)
 


### PR DESCRIPTION
This moves the Walmart Spider to `__NEXT_DATA__` data since the old `window.__WML_REDUX_INITIAL_STATE__` is gone.

GH will fail because CrawlSpider will crawl the directory before doing the store pages. I've not ran it against the whole of the US, but it works on Alabama.