### PR TITLE
Lunds & Byerlys edits

### DIFF
--- a/locations/spiders/lundsandbyerlys.py
+++ b/locations/spiders/lundsandbyerlys.py
@@ -9,7 +9,7 @@ class LundsAndByerlysSpider(scrapy.Spider):
     item_attributes = {"brand": "Lunds & Byerlys", "brand_wikidata": "Q19903424"}
     allowed_domains = ["lundsandbyerlys.com"]
     start_urls = [
-        "https://lundsandbyerlys.com/wp-admin/admin-ajax.php?action=store_search&lat=44.983654&lng=-93.269357&max_results=NaN&radius=10&store_options=&autoload=1",
+        "https://lundsandbyerlys.com/wp-admin/admin-ajax.php?action=store_search&autoload=1",
     ]
 
     def parse_hours(self, hours):
@@ -21,6 +21,8 @@ class LundsAndByerlysSpider(scrapy.Spider):
         from_time, to_time = hours.split(" - ")
         from_time = datetime.datetime.strptime(from_time, "%I:%M %p").strftime("%H:%M")
         to_time = datetime.datetime.strptime(to_time, "%I:%M %p").strftime("%H:%M")
+        if to_time == "00:00":
+            to_time = "24:00"
 
         return f"Mo-Su {from_time}-{to_time}"
 
@@ -28,7 +30,10 @@ class LundsAndByerlysSpider(scrapy.Spider):
         for store in response.json():
             item = DictParser.parse(store)
 
-            item["street_address"] = store["address"]
+            item["street_address"] = ", ".join(
+                filter(None, [store["address"], store["address2"]])
+            )
+            item["addr_full"] = None
             item["website"] = response.urljoin(store["url"])
             item["name"] = store["store"]
             item["opening_hours"] = self.parse_hours(store["hours"])


### PR DESCRIPTION
Set `addr_full` to null because DictParser sets it with the street address in this case.

Trim unused attributes from URL.

Convert close of "00:00" to "24:00".