### PR TITLE
Fix DictParser key variations

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -128,7 +128,8 @@ class DictParser(object):
 
     @staticmethod
     def get_variations(key):
-        results = set(key)
+        results = set()
+        results.add(key)
 
         lower = key.lower()
         results.add(lower)


### PR DESCRIPTION
So `set(key)` was adding treating key as a char array, adding each letter on there own. We want it as a string.