### PR TITLE
Add StructuredDataSpider

### DIFF
--- a/locations/spiders/welcome.py
+++ b/locations/spiders/welcome.py
@@ -1,27 +1,16 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class WelcomeSpider(SitemapSpider):
+class WelcomeGB(SitemapSpider, StructuredDataSpider):
     name = "welcome"
     item_attributes = {"brand": "Welcome"}
     sitemap_urls = ["https://stores.welcome-stores.co.uk/sitemap.xml"]
     sitemap_rules = [
         (
             "https:\/\/stores\.welcome-stores\.co\.uk\/[-\w]+\/[-\w]+\/[-\w]+\.html$",
-            "parse_item",
+            "parse_sd",
         )
     ]
-
-    def parse_item(self, response):
-        MicrodataParser.convert_to_json_ld(response)
-        item = LinkedDataParser.parse(response, "GroceryStore")
-
-        if item is None:
-            return
-
-        item["ref"] = item["website"]
-
-        return item
+    wanted_types = ["GroceryStore"]

--- a/locations/spiders/wickes_gb.py
+++ b/locations/spiders/wickes_gb.py
@@ -12,7 +12,7 @@ class WickesGB(SitemapSpider, StructuredDataSpider):
         "country": "GB",
     }
     sitemap_urls = ["https://www.wickes.co.uk/sitemap.xml"]
-    sitemap_rules = [("/store/", "parse_sd")]
+    sitemap_rules = [(r"https:\/\/www\.wickes\.co\.uk\/store\/(\d+)$", "parse_sd")]
     wanted_types = ["Place"]
 
     def inspect_item(self, item, response):

--- a/locations/spiders/wickes_gb.py
+++ b/locations/spiders/wickes_gb.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import scrapy
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
+
+from scrapy.spiders import SitemapSpider
 
 
-class WickesGBSpider(scrapy.spiders.SitemapSpider):
+class WickesGB(SitemapSpider, StructuredDataSpider):
     name = "wickes_gb"
     item_attributes = {
         "brand": "Wickes",
@@ -11,11 +12,11 @@ class WickesGBSpider(scrapy.spiders.SitemapSpider):
         "country": "GB",
     }
     sitemap_urls = ["https://www.wickes.co.uk/sitemap.xml"]
-    sitemap_rules = [("/store/", "parse_store")]
+    sitemap_rules = [("/store/", "parse_sd")]
+    wanted_types = ["Place"]
 
-    def parse_store(self, response):
-        item = LinkedDataParser.parse(response, "Place")
-        if item:
-            item["lat"] = response.xpath("//@data-latitude").get()
-            item["lon"] = response.xpath("//@data-longitude").get()
-            return item
+    def inspect_item(self, item, response):
+        item["lat"] = response.xpath("//@data-latitude").get()
+        item["lon"] = response.xpath("//@data-longitude").get()
+
+        yield item

--- a/locations/spiders/wrenkitchens_gb.py
+++ b/locations/spiders/wrenkitchens_gb.py
@@ -16,7 +16,13 @@ class WrenKitchensGB(CrawlSpider, StructuredDataSpider):
     allowed_domains = ["wrenkitchens.com"]
     start_urls = ["https://www.wrenkitchens.com/showrooms/"]
     rules = [
-        Rule(LinkExtractor(allow="/showrooms/"), callback="parse_sd", follow=False)
+        Rule(
+            LinkExtractor(
+                allow=r"https:\/\/www\.wrenkitchens\.com\/showrooms\/([_\w]+)$"
+            ),
+            callback="parse_sd",
+            follow=False,
+        )
     ]
     download_delay = 0.5
     wanted_types = ["HomeAndConstructionBusiness"]

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -1,0 +1,24 @@
+from scrapy import Spider
+
+from locations.linked_data_parser import LinkedDataParser
+from locations.microdata_parser import MicrodataParser
+
+
+class StructuredDataSpider(Spider):
+
+    wanted_types = []
+
+    def parse_sd(self, response):
+        MicrodataParser.convert_to_json_ld(response)
+        for wanted_type in self.wanted_types:
+            if item := LinkedDataParser.parse(response, wanted_type):
+
+                if item["ref"] is None:
+                    item["ref"] = response.url
+
+                self.inspect_item(item, response)
+
+                yield item
+
+    def inspect_item(self, item, response):
+        yield item

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -21,7 +21,7 @@ class StructuredDataSpider(Spider):
                 if self.search_for_email:
                     self.email_search(item, response)
 
-                if self.search_for_phone:
+                if self.search_for_phone and item["phone"] is None:
                     self.phone_search(item, response)
 
                 for i in self.inspect_item(item, response):

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -8,6 +8,7 @@ class StructuredDataSpider(Spider):
 
     wanted_types = []
     search_for_email = True
+    search_for_phone = True
 
     def parse_sd(self, response):
         MicrodataParser.convert_to_json_ld(response)
@@ -20,6 +21,9 @@ class StructuredDataSpider(Spider):
                 if self.search_for_email:
                     self.email_search(item, response)
 
+                if self.search_for_phone:
+                    self.phone_search(item, response)
+
                 self.inspect_item(item, response)
 
                 yield item
@@ -28,11 +32,19 @@ class StructuredDataSpider(Spider):
         yield item
 
     def email_search(self, item, response):
-        for link in response.xpath("//a[contains(@href, 'mailto')]").getall():
+        for link in response.xpath("//a[contains(@href, 'mailto')]/@href").getall():
             link = link.strip()
             if link.startswith("mailto:"):
                 if not item.get("extras"):
                     item["extras"] = {}
 
                 item["extras"]["email"] = link.replace("mailto:", "")
+                return
+
+    def phone_search(self, item, response):
+        for link in response.xpath("//a[contains(@href, 'tel')]/@href").getall():
+            link = link.strip()
+            if link.startswith("tel:"):
+
+                item["phone"] = link.replace("tel:", "")
                 return

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -24,9 +24,8 @@ class StructuredDataSpider(Spider):
                 if self.search_for_phone:
                     self.phone_search(item, response)
 
-                self.inspect_item(item, response)
-
-                yield item
+                for i in self.inspect_item(item, response):
+                    yield i
 
     def inspect_item(self, item, response):
         yield item


### PR DESCRIPTION
`StructuredDataSpider` can be inherited by any spider, including `SitemapSpider` and `CrawlSpider`s.

It gives us `parse_sd` which does the normal Microdata/LinkedData stuff, using a `wanted_types` attribute. It also does some smarts with getting refs from the url (only when none is set from source), it will try to grab a regex group from `rules` or `sitemap_rules`. If not it falls back to the full url. It can also try to pull phone and email addresses from the response.

There is also `inspect_item` callback where we can do clean up in spider.