### PR TITLE
fix: First Cash brand names

### DIFF
--- a/locations/spiders/first_cash.py
+++ b/locations/spiders/first_cash.py
@@ -39,7 +39,9 @@ class FirstCashSpider(scrapy.Spider):
                 "lat": place["latitude"],
                 "lon": place["longitude"],
                 "phone": place["phone"],
-                "brand": place["brand"],
+                "brand": "First Cash Pawn"
+                if "First Cash Pawn" in place["brand"]
+                else "First Cash",
             }
 
             yield GeojsonPointItem(**properties)

--- a/locations/spiders/first_cash.py
+++ b/locations/spiders/first_cash.py
@@ -39,9 +39,7 @@ class FirstCashSpider(scrapy.Spider):
                 "lat": place["latitude"],
                 "lon": place["longitude"],
                 "phone": place["phone"],
-                "brand": "First Cash Pawn"
-                if "First Cash Pawn" in place["brand"]
-                else "First Cash",
+                "brand": place["brand"].split(" #")[0],
             }
 
             yield GeojsonPointItem(**properties)


### PR DESCRIPTION
<img width="207" alt="Capture d’écran 2022-09-28 à 16 39 41" src="https://user-images.githubusercontent.com/92714362/192808667-89afcb13-e07a-449b-90b8-2e9bafaa4d0a.png">

The spider was using the `brand` field which wasn't normalized. Each brand had the store ID attached to the brand which in my opinion shouldn't be the case.