### PR TITLE
fix: AutoNation brand incorrect

### DIFF
--- a/locations/spiders/autonation.py
+++ b/locations/spiders/autonation.py
@@ -60,6 +60,7 @@ class AutoNationSpider(scrapy.Spider):
                 "phone": store["Phone"],
                 "website": "https://www.autonation.com/dealers/"
                 + store["StoreDetailsUrl"],
+                "extra": {"sells": store["Makes"]},
             }
 
             hours = self.parse_hours(store["StoreDetailedHours"])

--- a/locations/spiders/autonation.py
+++ b/locations/spiders/autonation.py
@@ -60,7 +60,7 @@ class AutoNationSpider(scrapy.Spider):
                 "phone": store["Phone"],
                 "website": "https://www.autonation.com/dealers/"
                 + store["StoreDetailsUrl"],
-                "extra": {"sells": store["Makes"]},
+                "extras": {"sells": store["Makes"]},
             }
 
             hours = self.parse_hours(store["StoreDetailedHours"])

--- a/locations/spiders/autonation.py
+++ b/locations/spiders/autonation.py
@@ -12,6 +12,7 @@ DAY_MAPPING = {0: "Mo", 1: "Tu", 2: "We", 3: "Th", 4: "Fr", 5: "Sa", 6: "Su"}
 class AutoNationSpider(scrapy.Spider):
     name = "auto_nation"
     allowed_domains = ["autonation.com"]
+    item_attributes = {"brand": "Auto Nation", "brand_wikidata": "Q784804"}
     start_urls = [
         "https://www.autonation.com/StoreDetails/Get/?lat=30.218908309936523&long=-97.8546142578125&radius=5000\
         &zipcode=78749&d=1602263009819",
@@ -57,7 +58,6 @@ class AutoNationSpider(scrapy.Spider):
                 "lat": store["Latitude"],
                 "lon": store["Longitude"],
                 "phone": store["Phone"],
-                "brand": store["Makes"],
                 "website": "https://www.autonation.com/dealers/"
                 + store["StoreDetailsUrl"],
             }


### PR DESCRIPTION
<img width="515" alt="Capture d’écran 2022-09-28 à 16 43 51" src="https://user-images.githubusercontent.com/92714362/192809679-64bf8143-a40f-4fd1-98f7-370d9d252444.png">

Auto Nation scraper was setting as a brand what brands the dealership was selling, which isn't the brand of the store locator.