### PR TITLE
Slightly extend, and add tests for NSI client

### DIFF
--- a/locations/commands/insights.py
+++ b/locations/commands/insights.py
@@ -1,7 +1,6 @@
 import json
 import geonamescache
 import os
-import requests
 from collections import Counter
 from locations.name_suggestion_index import NSI
 from scrapy.commands import ScrapyCommand
@@ -120,7 +119,7 @@ class InsightsCommand(ScrapyCommand):
             brand_wikidata = feature["properties"].get("brand:wikidata")
             if not brand_wikidata:
                 spider_empty_counter[spider_name] += 1
-            elif not nsi.lookup_wikidata_code(brand_wikidata):
+            elif not nsi.lookup_wikidata(brand_wikidata):
                 spider_nsi_missing_counter[spider_name + "/" + brand_wikidata] += 1
             else:
                 # TODO: query wikidata to see if Q-code remotely sensible?

--- a/locations/commands/nsi.py
+++ b/locations/commands/nsi.py
@@ -45,12 +45,14 @@ class NameSuggestionIndexCommand(ScrapyCommand):
             self.lookup_code(args)
 
     def lookup_name(self, args):
-        for k, v in self.nsi.lookup_label(args[0]):
+        for k, v in self.nsi.iter_wikidata(args[0]):
             NameSuggestionIndexCommand.show(k, v)
 
     def lookup_code(self, args):
-        if v := self.nsi.lookup_wikidata_code(args[0]):
+        if v := self.nsi.lookup_wikidata(args[0]):
             NameSuggestionIndexCommand.show(args[0], v)
+            for item in self.nsi.iter_nsi(args[0]):
+                print("       -> " + str(item))
 
     @staticmethod
     def show(code, data):

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -1,48 +1,77 @@
 import requests
 
 
-class NSI(object):
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+# This is a lazy initialised singleton as it pulls (over the network) quite a lot of data into memory.
+class NSI(object, metaclass=Singleton):
     """
-    Interact with Name Suggestion Index (NSI). The NSI distribution is a GIT sub-module of this
-    project. As part of their GIT repo the NSI people publish a JSON version of their database
+    Interact with Name Suggestion Index (NSI). The NSI people publish a JSON version of their database
     which is used by the OSM editor to do rather useful brand suggestions when editing POIs.
-    It is possible that we move to dynamic API (HTTP) access to the NSI in the future.
     """
 
     def __init__(self):
-        self.nsi_wikidata = None
+        self.loaded = False
+        self.wikidata_json = None
+        self.nsi_json = None
+
+    @staticmethod
+    def _request_file(file):
+        resp = requests.get(
+            "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/" + file
+        )
+        if not resp.status_code == 200:
+            raise Exception("NSI load failure")
+        return resp.json()
 
     def _ensure_loaded(self):
-        if self.nsi_wikidata is None:
-            resp = requests.get(
-                "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/wikidata.min.json"
-            )
-            self.nsi_wikidata = resp.json()["wikidata"]
+        if not self.loaded:
+            self.wikidata_json = self._request_file("wikidata.min.json")["wikidata"]
+            self.nsi_json = self._request_file("nsi.min.json")["nsi"]
+            self.loaded = True
 
-            if not self.nsi_wikidata:
-                self.nsi_wikidata = {}
-
-    def lookup_wikidata_code(self, brand_wikidata):
+    def lookup_wikidata(self, wikidata_code):
         """
         Lookup wikidata code in the NSI.
-        :param brand_wikidata: wikidata code to lookup in the NSI
+        :param wikidata_code: wikidata code to lookup in the NSI
         :return: NSI wikidata.json entry if present
         """
         self._ensure_loaded()
-        return self.nsi_wikidata.get(brand_wikidata)
+        return self.wikidata_json.get(wikidata_code)
 
-    def lookup_label(self, s):
+    def iter_wikidata(self, fuzzy_label):
         """
         Lookup by fuzzy label match in the NSI.
-        :param s: string to fuzzy match
+        :param fuzzy_label: string to fuzzy match
         :return: iterator of matching NSI wikidata.json entries
         """
         self._ensure_loaded()
-        s = NSI.normalise(s)
-        for k, v in self.nsi_wikidata.items():
+        s = NSI.normalise(fuzzy_label)
+        for k, v in self.wikidata_json.items():
             if label := v.get("label"):
                 if s in NSI.normalise(label):
                     yield k, v
+
+    def iter_nsi(self, wikidata_code=None):
+        """
+        Iterate NSI for all items in nsi.json with a matching wikidata code
+        :param wikidata_code: wikidata code to match, if None then all entries
+        :return: iterator of matching NSI nsi.json item entries
+        """
+        self._ensure_loaded()
+        for v in self.nsi_json.values():
+            for item in v["items"]:
+                if not wikidata_code:
+                    yield item
+                elif wikidata_code == item["tags"].get("brand:wikidata"):
+                    yield item
 
     @staticmethod
     def normalise(s):

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -25,7 +25,8 @@ class NSI(object, metaclass=Singleton):
     @staticmethod
     def _request_file(file):
         resp = requests.get(
-            "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/" + file
+            "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/dist/"
+            + file
         )
         if not resp.status_code == 200:
             raise Exception("NSI load failure")

--- a/tests/test_name_suggestion_index.py
+++ b/tests/test_name_suggestion_index.py
@@ -1,0 +1,29 @@
+from locations.name_suggestion_index import NSI
+
+
+def test_nsi_lookup_wikidata():
+    nsi = NSI()
+    data = nsi.lookup_wikidata("Q38076")
+    assert data["identities"]["facebook"] == "mcdonalds"
+
+
+def test_iter_wikidata():
+    nsi = NSI()
+    found = False
+    for k, v in nsi.iter_wikidata("mcdonalds"):
+        if k == "Q38076":
+            found = True
+    assert found
+
+
+def test_iter_nsi():
+    nsi = NSI()
+    # McDonald's has identities in a number of locationSet's (countries)
+    matches = list(nsi.iter_nsi("Q38076"))
+    assert len(matches) > 4
+    # Greggs is present only in the UK, only one match then
+    matches = list(nsi.iter_nsi("Q3403981"))
+    assert len(matches) == 1
+    i = matches[0]
+    assert i["displayName"] == "Greggs"
+    assert i["tags"]["amenity"] == "fast_food"


### PR DESCRIPTION
Add tests. Make NSI into a lazy loaded singleton. nsi scrapy command will now output any matching NSI data gainst a successful Q-code query i.e. loactions sets and suggested tags.

For example, Greggs in the UK:
$ pipenv run scrapy nsi --code Q3403981
"Greggs", "Q3403981"
       -> https://www.wikidata.org/wiki/Q3403981
       -> https://www.wikidata.org/wiki/Special:EntityData/Q3403981.json
       -> bakery chain in the United Kingdom
       -> https://www.greggs.co.uk/
       -> item_attributes = {"brand": "Greggs", "brand_wikidata": "Q3403981"}
       **-> {'displayName': 'Greggs', 'id': 'greggs-45095e', 'locationSet': {'include': ['gb']}, 'tags': {'amenity': 'fast_food', 'brand': 'Greggs', 'brand:wikidata': 'Q3403981', 'cuisine': 'sandwich;bakery', 'name': 'Greggs', 'takeaway': 'yes'}}**

McDonald's is a bit more fun:
$ pipenv run scrapy nsi --code Q38076
"McDonald’s", "Q38076"
       -> https://www.wikidata.org/wiki/Q38076
       -> https://www.wikidata.org/wiki/Special:EntityData/Q38076.json
       -> American fast food restaurant chain
       -> https://www.mcdonalds.com/
       -> item_attributes = {"brand": "McDonald’s", "brand_wikidata": "Q38076"}
       **-> {'displayName': "McDonald's", 'id': 'mcdonalds-0ddedb', 'locationSet': {'include': ['001'], 'exclude': ['ae', 'bh', 'by', 'cn', 'eg', 'fr', 'hk', 'iq', 'jo', 'jp', 'kr', 'kw', 'kz', 'lb', 'ma', 'mo', 'no', 'om', 'qa', 'ru', 'sa', 'sg', 'sy', 'tn', 'tw', 'ua']}, 'tags': {'amenity': 'fast_food', 'brand': "McDonald's", 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': "McDonald's", 'takeaway': 'yes'}}
       -> {'displayName': "McDonald's (France)", 'id': 'mcdonalds-e4dee6', 'locationSet': {'include': ['fr']}, 'preserveTags': ['^name'], 'tags': {'amenity': 'fast_food', 'brand': "McDonald's", 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': "McDonald's", 'takeaway': 'yes'}}
       -> {'displayName': "McDonald's (Norge)", 'id': 'mcdonalds-86f814', 'locationSet': {'include': ['no']}, 'preserveTags': ['^name'], 'tags': {'amenity': 'fast_food', 'brand': "McDonald's", 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': "McDonald's", 'takeaway': 'yes'}}
       -> {'displayName': 'Макдоналдс', 'id': 'mcdonalds-bac877', 'locationSet': {'include': ['by', 'kz']}, 'tags': {'amenity': 'fast_food', 'brand': 'Макдоналдс', 'brand:en': "McDonald's", 'brand:ru': 'Макдоналдс', 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': 'Макдоналдс', 'name:en': "McDonald's", 'name:ru': 'Макдоналдс', 'takeaway': 'yes'}}
       -> {'displayName': 'МакДональдз', 'id': 'mcdonalds-50e0ae', 'locationSet': {'include': ['ua']}, 'tags': {'amenity': 'fast_food', 'brand': "McDonald's", 'brand:en': "McDonald's", 'brand:ru': 'МакДоналдс', 'brand:uk': 'МакДональдз', 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': "McDonald's", 'name:en': "McDonald's", 'name:ru': 'МакДоналдс', 'name:uk': 'МакДональдз', 'takeaway': 'yes'}}
       -> {'displayName': 'ماكدونالدز', 'id': 'mcdonalds-19c993', 'locationSet': {'include': ['ae', 'bh', 'eg', 'iq', 'jo', 'kw', 'lb', 'ma', 'om', 'qa', 'sa', 'sy', 'tn']}, 'tags': {'amenity': 'fast_food', 'brand': 'ماكدونالدز', 'brand:ar': 'ماكدونالدز', 'brand:en': "McDonald's", 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': 'ماكدونالدز', 'name:ar': 'ماكدونالدز', 'name:en': "McDonald's", 'takeaway': 'yes'}}
       -> {'displayName': '맥도날드', 'id': 'mcdonalds-c56583', 'locationSet': {'include': ['kr']}, 'tags': {'amenity': 'fast_food', 'brand': '맥도날드', 'brand:en': "McDonald's", 'brand:ko': '맥도날드', 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': '맥도날드', 'name:en': "McDonald's", 'name:ko': '맥도날드', 'takeaway': 'yes'}}
       -> {'displayName': 'マクドナルド', 'id': 'mcdonalds-3e7699', 'locationSet': {'include': ['jp']}, 'tags': {'amenity': 'fast_food', 'brand': 'マクドナルド', 'brand:en': "McDonald's", 'brand:ja': 'マクドナルド', 'brand:wikidata': 'Q38076', 'cuisine': 'burger', 'name': 'マクドナルド', 'name:en': "McDonald's", 'name:ja': 'マクドナルド', 'takeaway': 'yes'}}
       -> {'displayName': '麥當勞', 'id': 'mcdonalds-60a4d5', 'locationSet': {'include': ['tw']}, 'tags': {'amenity': 'fast_food', 'brand': '麥當勞', 'brand:en': "McDonald's", 'brand:wikidata': 'Q38076', 'brand:zh': '麥當勞', 'brand:zh-Hant': '麥當勞', 'cuisine': 'burger', 'name': '麥當勞', 'name:en': "McDonald's", 'name:zh': '麥當勞', 'name:zh-Hant': '麥當勞', 'takeaway': 'yes'}}
       -> {'displayName': "麥當勞 McDonald's", 'id': 'mcdonalds-17dd9a', 'locationSet': {'include': ['hk', 'mo']}, 'matchNames': ['m記', '麥記'], 'tags': {'amenity': 'fast_food', 'brand': "麥當勞 McDonald's", 'brand:en': "McDonald's", 'brand:wikidata': 'Q38076', 'brand:zh': '麥當勞', 'brand:zh-Hans': '麦当劳', 'brand:zh-Hant': '麥當勞', 'cuisine': 'burger', 'name': "麥當勞 McDonald's", 'name:en': "McDonald's", 'name:zh': '麥當勞', 'name:zh-Hans': '麦当劳', 'name:zh-Hant': '麥當勞', 'takeaway': 'yes'}}
       -> {'displayName': '麦当劳', 'id': 'mcdonalds-0711fa', 'locationSet': {'include': ['cn', 'sg'], 'exclude': ['hk', 'mo']}, 'tags': {'amenity': 'fast_food', 'brand': '麦当劳', 'brand:en': "McDonald's", 'brand:wikidata': 'Q38076', 'brand:zh': '麦当劳', 'brand:zh-Hans': '麦当劳', 'cuisine': 'burger', 'name': '麦当劳', 'name:en': "McDonald's", 'name:zh': '麦当劳', 'name:zh-Hans': '麦当劳', 'takeaway': 'yes'}}
       -> {'displayName': "McDonald's PlayPlace", 'id': 'mcdonaldsplayplace-bacb55', 'locationSet': {'include': ['001']}, 'tags': {'access': 'customers', 'brand': "McDonald's", 'brand:wikidata': 'Q38076', 'leisure': 'playground', 'name': "McDonald's PlayPlace"}}**
