### PR TITLE
Enhance StructuredDataSpider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ There is usually a few ways to find locations:
 
 ### Structured Data
 
-Some websites may already be publishing there data in a [standard way](https://schema.org/). We can parse these with our [StructuredDataSpider](https://github.com/alltheplaces/alltheplaces/blob/master/locations/structured_data_spider.py), use a `SitemapSpider` or `CrawlSpider` to obtain the pages and pass them to `parse_sd` it will parse any Microdata or Linked Data with a type defined in `wanted_types`, you can then clean up the item, or add extra attributes with `inspect_item`.
+Some websites may already be publishing there data in a [standard way](https://schema.org/). We can parse these with our [StructuredDataSpider](https://github.com/alltheplaces/alltheplaces/blob/master/locations/structured_data_spider.py), use a `SitemapSpider` or `CrawlSpider` to obtain the pages and pass them to `parse_sd` it will parse any Microdata or Linked Data with a type defined in `wanted_types`, you can clean up source data with `pre_process_data` and clean up the item, or add extra attributes with `post_process_item`.
 
 [validator.schema.org](https://validator.schema.org/) can be really helpful when making spiders to see what structured data is available.
 

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -35,8 +35,22 @@ class LinkedDataParser(object):
             if not isinstance(types, list):
                 types = [types]
 
-            for t in types:
-                if LinkedDataParser.check_type(t, wanted_type, default=False):
+            types = [LinkedDataParser.clean_type(t) for t in types]
+
+            if isinstance(wanted_type, list):
+                wanted_types = wanted_type
+            else:
+                wanted_types = [wanted_type]
+
+            wanted_types = [LinkedDataParser.clean_type(t) for t in wanted_types]
+
+            for wanted_type in wanted_types:
+                valid_type = True
+                for t in types:
+                    if not t in wanted_types:
+                        valid_type = False
+
+                if valid_type:
                     return ld_obj
 
     @staticmethod
@@ -173,10 +187,13 @@ class LinkedDataParser(object):
         if default and type is None:
             return True
 
+        return LinkedDataParser.clean_type(type) == wanted_type.lower()
+
+    @staticmethod
+    def clean_type(type: str) -> str:
         return (
             type.lower()
             .replace("http://", "")
             .replace("https://", "")
             .replace("schema.org/", "")
-            == wanted_type.lower()
         )

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -96,11 +96,11 @@ class StructuredDataSpider(Spider):
 
                 yield from self.post_process_item(item, response, ld_item)
 
-    def pre_process_data(self, ld_data):
+    def pre_process_data(self, ld_data, **kwargs):
         """Override with any pre-processing on the item."""
         pass
 
-    def post_process_item(self, item, response, ld_data):
+    def post_process_item(self, item, response, ld_data, **kwargs):
         """Override with any post-processing on the item."""
         yield from self.inspect_item(item, response)
 

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -38,7 +38,19 @@ def extract_image(item, response):
 
 class StructuredDataSpider(Spider):
 
-    wanted_types = []
+    wanted_types = [
+        "LocalBusiness",
+        "Store",
+        "Restaurant",
+        "BankOrCreditUnion",
+        "GroceryStore",
+        "FastFoodRestaurant",
+        "Hotel",
+        "Place",
+        "ClothingStore",
+        "DepartmentStore",
+        "HardwareStore",
+    ]
     search_for_email = True
     search_for_phone = True
     search_for_twitter = True

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -59,7 +59,10 @@ class StructuredDataSpider(Spider):
     def parse_sd(self, response):
         MicrodataParser.convert_to_json_ld(response)
         for wanted_type in self.wanted_types:
-            if item := LinkedDataParser.parse(response, wanted_type):
+            if ld_item := LinkedDataParser.find_linked_data(response, wanted_type):
+                self.pre_process_data(ld_item)
+
+                item = LinkedDataParser.parse_ld(ld_item)
 
                 if item["ref"] is None:
                     if hasattr(self, "rules"):
@@ -91,8 +94,16 @@ class StructuredDataSpider(Spider):
                 if self.search_for_image and item.get("image") is None:
                     extract_image(item, response)
 
-                yield from self.inspect_item(item, response)
+                yield from self.post_process_item(item, response, ld_item)
+
+    def pre_process_data(self, ld_data):
+        """Override with any pre-processing on the item."""
+        pass
+
+    def post_process_item(self, item, response, ld_data):
+        """Override with any post-processing on the item."""
+        yield from self.inspect_item(item, response)
 
     def inspect_item(self, item, response):
-        """Override with any additional processing on the item."""
+        """Deprecated, please use post_process_item(self, item, response, ld_data):"""
         yield item

--- a/tests/test_ld_parser.py
+++ b/tests/test_ld_parser.py
@@ -1,5 +1,7 @@
 import json
 
+from scrapy.http import HtmlResponse
+
 from locations.linked_data_parser import LinkedDataParser
 
 
@@ -232,3 +234,27 @@ def test_check_type():
         is True
     )
     assert LinkedDataParser.check_type("postalAddress", "GeoCoordinates") is False
+
+
+def test_multiple_types():
+    response = HtmlResponse(
+        url="",
+        encoding="utf-8",
+        body="""<script type="application/ld+json">
+                {
+                    "@context": "https://schema.org",
+                    "@type": ["http://schema.org/Place", "Thing"],
+                    "name": "test 1"
+                }
+            </script>
+            <script type="application/ld+json">
+                {
+                    "@context": "https://schema.org",
+                    "@type": "http://schema.org/Place",
+                    "name": "test 2"
+                }
+            </script>""",
+    )
+
+    assert LinkedDataParser.find_linked_data(response, ["Place", "Thing"])["name"] == "test 1"
+    assert LinkedDataParser.find_linked_data(response, "Place")["name"] == "test 2"

--- a/tests/test_ld_parser.py
+++ b/tests/test_ld_parser.py
@@ -256,5 +256,8 @@ def test_multiple_types():
             </script>""",
     )
 
-    assert LinkedDataParser.find_linked_data(response, ["Place", "Thing"])["name"] == "test 1"
+    assert (
+        LinkedDataParser.find_linked_data(response, ["Place", "Thing"])["name"]
+        == "test 1"
+    )
     assert LinkedDataParser.find_linked_data(response, "Place")["name"] == "test 2"


### PR DESCRIPTION
Fixes #4062

I couldn't expand `inspect_item` to take an extra argument without breaking existing spiders, so I renamed it to `post_process_item(self, item, response, ld_data, **kwargs)` the `**kwargs` will hopefully allow us to add new arguments in the future.

I've also added `pre_process_data(self, ld_data, **kwargs)` where we can clean up source data before it's passed to the LinkedDataParser.

If wanted `wanted_types` contains an array, it will require all of them to be considered a match.

Default `wanted_types` have also been added. Obviously it can still be overridden in spider.