### PR TITLE
Add a default download delay

### DIFF
--- a/locations/settings.py
+++ b/locations/settings.py
@@ -41,7 +41,7 @@ FEED_EXPORTERS = {
 # Configure a delay for requests for the same website (default: 0)
 # See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
-# DOWNLOAD_DELAY = 3
+DOWNLOAD_DELAY = 1
 # The download delay setting will honor only one of:
 # CONCURRENT_REQUESTS_PER_DOMAIN = 16
 # CONCURRENT_REQUESTS_PER_IP = 16

--- a/locations/spiders/western_union.py
+++ b/locations/spiders/western_union.py
@@ -13,6 +13,7 @@ class WesternUnionSpider(SitemapSpider):
     # Use plural, singular responds with a redirect confusing to scrapy?
     sitemap_urls = ["https://locations.westernunion.com/robots.txt"]
     sitemap_rules = [(r"westernunion\.com/.*/.*", "parse")]
+    download_delay = 0
 
     def sitemap_filter(self, entries):
         for entry in entries:


### PR DESCRIPTION
Just to be polite to the servers, can still be lowered in spiders, or increased if needed.

Western Union is already hitting the 8 hour limit, so I've explicitly lowered it's limit. Other spiders that are at or near the 8 hour limit already have delays.