### PR TITLE
Add stats for NSI matching

### DIFF
--- a/ci/fetch_all_stats.sh
+++ b/ci/fetch_all_stats.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+BUILD_ID=$1
+
+if [ -z "${BUILD_ID}" ]; then
+    (>&2 echo "Missing BUILD_ID")
+    (>&2 echo "Try '$0 2022-10-08-13-31-39'")
+    exit 1
+fi
+
+mkdir -p "${BUILD_ID}"
+
+SPIDERS=$(curl "https://data.alltheplaces.xyz/runs/${BUILD_ID}/stats/_results.json" | jq -r ".results[].spider")
+for SPIDER in $SPIDERS
+do
+  curl "https://data.alltheplaces.xyz/runs/${BUILD_ID}/stats/${SPIDER}.json" -o "${BUILD_ID}/${SPIDER}.json"
+done

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -204,6 +204,8 @@ class ApplyNSICategoriesPipeline(object):
 
     important_keys = ["amenity", "leisure", "shop", "tourism"]
 
+    wikidata_cache = {}
+
     def process_item(self, item, spider):
         code = item.get("brand_wikidata")
         if not code:
@@ -217,7 +219,11 @@ class ApplyNSICategoriesPipeline(object):
             if value := extras.get(key):
                 current_keys[key] = value
 
-        matches = list(self.nsi.iter_nsi(code))
+        if not self.wikidata_cache.get(code):
+            self.wikidata_cache[code] = list(self.nsi.iter_nsi(code))
+
+        matches = self.wikidata_cache.get(code)
+
         match = None
 
         if len(matches) == 0:

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -262,7 +262,13 @@ class ApplyNSICategoriesPipeline(object):
         extras["nsi_id"] = match["id"]
 
         for (key, value) in match["tags"].items():
-            if key in self.important_keys:
+            if key == "brand:wikidata":
+                key = "brand_wikidata"
+
+            if key in item.fields:
+                if item.get(key) is None:
+                    item[key] = value
+            else:
                 if extras.get(key) is None:
                     extras[key] = value
 

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -214,11 +214,6 @@ class ApplyNSICategoriesPipeline(object):
         brand = item.get("brand", "").lower().replace(" ", "")
         extras = item.get("extras", {}).copy()
 
-        current_keys = {}
-        for key in self.important_keys:
-            if value := extras.get(key):
-                current_keys[key] = value
-
         if not self.wikidata_cache.get(code):
             self.wikidata_cache[code] = list(self.nsi.iter_nsi(code))
 
@@ -233,6 +228,11 @@ class ApplyNSICategoriesPipeline(object):
             spider.crawler.stats.inc_value("atp/nsi/perfect_match")
             match = matches[0]
         else:
+            current_keys = {}
+            for key in self.important_keys:
+                if value := extras.get(key):
+                    current_keys[key] = value
+
             type_possible_matches = []
             for possible_match in matches:
                 match_names = [possible_match["displayName"]]

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -205,17 +205,17 @@ class ApplyNSICategoriesPipeline(object):
     important_keys = ["amenity", "leisure", "shop", "tourism"]
 
     def process_item(self, item, spider):
-        brand = item.get("brand", "").lower().replace(" ", "")
         code = item.get("brand_wikidata")
+        if not code:
+            return item
+
+        brand = item.get("brand", "").lower().replace(" ", "")
         extras = item.get("extras", {})
 
         current_keys = {}
         for key in self.important_keys:
             if value := extras.get(key):
                 current_keys[key] = value
-
-        if not code:
-            return item
 
         matches = list(self.nsi.iter_nsi(code))
         match = None

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -237,8 +237,12 @@ class ApplyNSICategoriesPipeline(object):
             # Loop through the NSI Qcode matches and exclude any that don't match
             possible_type_matches = []
             for possible_match in matches:
-                match_names = [possible_match["displayName"]]
+                match_names = [
+                    possible_match["displayName"],
+                    possible_match["tags"].get("brand"),
+                ]
                 match_names += possible_match.get("matchNames", [])
+                match_names = filter(None, match_names)
                 match_names = [m.lower().replace(" ", "") for m in match_names]
 
                 # Exclude based on name

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -233,8 +233,6 @@ class ApplyNSICategoriesPipeline(object):
         if match is None:
             return item
 
-        return item  # TODO: evaluate stats from next weekly run before modifying the output
-
         extras = item.get("extras", {})
         extras["nsi_id"] = match["id"]
 

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -212,7 +212,7 @@ class ApplyNSICategoriesPipeline(object):
             return item
 
         brand = item.get("brand", "").lower().replace(" ", "")
-        extras = item.get("extras", {})
+        extras = item.get("extras", {}).copy()
 
         current_keys = {}
         for key in self.important_keys:
@@ -266,6 +266,7 @@ class ApplyNSICategoriesPipeline(object):
                 if extras.get(key) is None:
                     extras[key] = value
 
-        item["extras"] = extras
+        # TODO: evaluate stats from next weekly run
+        # item["extras"] = extras
 
         return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -84,8 +84,8 @@ EXTENSIONS = {
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
     "locations.pipelines.DuplicatesPipeline": 200,
-    "locations.pipelines.ApplySpiderNamePipeline": 250,
     "locations.pipelines.ApplySpiderLevelAttributesPipeline": 300,
+    "locations.pipelines.ApplySpiderNamePipeline": 350,
     "locations.pipelines.ExtractGBPostcodePipeline": 400,
     "locations.pipelines.AssertURLSchemePipeline": 500,
     "locations.pipelines.CheckItemPropertiesPipeline": 600,

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -89,6 +89,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.ExtractGBPostcodePipeline": 400,
     "locations.pipelines.AssertURLSchemePipeline": 500,
     "locations.pipelines.CheckItemPropertiesPipeline": 600,
+    "locations.pipelines.ApplyNSICategoriesPipeline": 700,
 }
 
 

--- a/locations/spiders/bank_of_scotland_gb.py
+++ b/locations/spiders/bank_of_scotland_gb.py
@@ -5,7 +5,11 @@ from scrapy.spiders import SitemapSpider
 
 class BankOfScotlandGB(SitemapSpider, StructuredDataSpider):
     name = "bank_of_scotland_gb"
-    item_attributes = {"brand": "Bank of Scotland", "brand_wikidata": "Q627381"}
+    item_attributes = {
+        "brand": "Bank of Scotland",
+        "brand_wikidata": "Q627381",
+        "extras": {"amenity": "bank"},
+    }
     sitemap_urls = ["https://branches.bankofscotland.co.uk/sitemap.xml"]
     sitemap_rules = [
         (

--- a/locations/spiders/chase.py
+++ b/locations/spiders/chase.py
@@ -79,6 +79,7 @@ class ChaseSpider(scrapy.Spider):
             "lon": float(
                 response.xpath('//meta[@itemprop="longitude"]/@content').extract_first()
             ),
+            "extras": {"amenity": "atm" if atm_only else "bank"},
         }
 
         hours = response.xpath('//tr[@itemprop="openingHours"]/@content').extract()[


### PR DESCRIPTION
So this started out as me trying to add categories from NSI, and hopefully we'll end up there. But I think we need some stats first.

- `atp/nsi/brand_missing` for times when NSI is missing an entry with the Wikidata ID
- `atp/nsi/perfect_match` for when there is a single NSI match for the Wikidata ID
- `atp/nsi/multiple_hits` for when there are multiple NSI matches with the Wikidata ID

You can see the commit log for some ideas I've had to filter the multiple NSI matches, but ultimately I want to see the stats and identify the specific spiders before I go to far there. This is the TODO on line 229.

Removing line 236 would apply the NSI tags to the output, not overriding any tags set by the spider, applied to the item or extras depending. I'd be happy for us to start doing this right away, but I'm also happy to wait until after the weekly run so we can see the stats and discus it properly.