### PR TITLE
Readd US_TERRITORIES to xfinity spider

### DIFF
--- a/locations/spiders/us_army_national_guard.py
+++ b/locations/spiders/us_army_national_guard.py
@@ -15,9 +15,7 @@ class USArmyNationalGuardSpider(scrapy.Spider):
     allowed_domains = ["www.nationalguard.com"]
 
     def start_requests(self):
-        for state in GeonamesCache().get_us_states():
-            yield scrapy.Request(url="https://www.nationalguard.com/api/state/" + state)
-        for state in ["USPR", "USGU", "USVI"]:
+        for state in GeonamesCache().get_us_states().keys() | ["USPR", "USGU", "USVI"]:
             yield scrapy.Request(url="https://www.nationalguard.com/api/state/" + state)
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/xfinity.py
+++ b/locations/spiders/xfinity.py
@@ -7,6 +7,17 @@ from geonamescache import GeonamesCache
 
 from locations.items import GeojsonPointItem
 
+US_TERRITORIES = {
+    "AS": {"code": "AS", "name": "American Samoa"},
+    "FM": {"code": "FM", "name": "Micronesia"},
+    "GU": {"code": "GU", "name": "Guam"},
+    "MH": {"code": "MH", "name": "Marshall Islands"},
+    "MP": {"code": "MP", "name": "Northern Mariana Islands"},
+    "PW": {"code": "PW", "name": "Palau"},
+    "PR": {"code": "PR", "name": "Puerto Rico"},
+    "VI": {"code": "VI", "name": "U.S. Virgin Islands"},
+}
+
 
 class XfinitySpider(scrapy.Spider):
     name = "xfinity"
@@ -14,7 +25,7 @@ class XfinitySpider(scrapy.Spider):
     allowed_domains = ["www.xfinity.com"]
 
     def start_requests(self):
-        for state in GeonamesCache().get_us_states():
+        for state in GeonamesCache().get_us_states() | US_TERRITORIES:
             yield scrapy.http.Request(
                 url=f"https://api-support.xfinity.com/servicecenters?location={state}"
             )


### PR DESCRIPTION
As discussed in #4146, US territories aren't included in `GeonamesCache().get_us_states()`. This fixes the xfinity spider that I degraded with the last PR, hopefully in future people will use this `US_TERRITORIES`, and not define a new list.