### PR TITLE
extend country code clean up pipeline

### DIFF
--- a/locations/commands/insights.py
+++ b/locations/commands/insights.py
@@ -1,9 +1,9 @@
 import json
-import geonamescache
 import os
 import requests
 from collections import Counter
 from locations.name_suggestion_index import NSI
+from locations.country_utils import CountryUtils
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 
@@ -208,50 +208,3 @@ class InsightsCommand(ScrapyCommand):
         for_datatables = {"data": list(wikidata_dict.values())}
         with open(outfile, "w") as f:
             json.dump(for_datatables, f)
-
-
-class CountryUtils(object):
-    def __init__(self):
-        self.gc = geonamescache.GeonamesCache()
-
-    # All keys in this dict should be lower case. The idea is also that we
-    # only place totally non contentious common mappings here.
-    UNHANDLED_COUNTRY_MAPPINGS = {
-        "espana": "ES",
-        "great britain": "GB",
-        "norge": "NO",
-        "uk": "GB",
-        "united states of america": "US",
-    }
-
-    def to_iso_alpha2_country_code(self, country_str):
-        """
-        Map country string to an ISO alpha-2 country string. This method understands
-        ISO alpha-3 to ISO alpha-2 mapping. It also copes with a few common non
-        contentious mappings such as "UK" -> "GB", "United Kingdom." -> "GB"
-        :param country_str: the string to map to an ISO alpha-2 country code
-        :return: ISO alpha-2 country code or None if no clean mapping
-        """
-        if not country_str:
-            return None
-        # Clean up some common appendages we see on country strings.
-        country_str = country_str.strip().replace(".", "")
-        if len(country_str) < 2:
-            return None
-        if len(country_str) == 2:
-            # Check for the clean/fast path, spider has given us a 2-alpha iso country code.
-            if self.gc.get_countries().get(country_str.upper()):
-                return country_str.upper()
-        if len(country_str) == 3:
-            # Check for a 3-alpha code, this is done by iteration.
-            country_str = country_str.upper()
-            for country in self.gc.get_countries().values():
-                if country["iso3"] == country_str:
-                    return country["iso"]
-        # Failed so far, now let's try a match by name.
-        country_name = country_str.lower()
-        for country in self.gc.get_countries().values():
-            if country["name"].lower() == country_name:
-                return country["iso"]
-        # Finally let's go digging in the random country string collection!
-        return self.UNHANDLED_COUNTRY_MAPPINGS.get(country_name)

--- a/locations/country_utils.py
+++ b/locations/country_utils.py
@@ -1,0 +1,72 @@
+import geonamescache
+from urllib.parse import urlparse
+
+
+class CountryUtils(object):
+    def __init__(self):
+        self.gc = geonamescache.GeonamesCache()
+
+    # All keys in this dict should be lower case. The idea is also that we
+    # only place totally non contentious common mappings here.
+    UNHANDLED_COUNTRY_MAPPINGS = {
+        "espana": "ES",
+        "great britain": "GB",
+        "england": "GB",
+        "scotland": "GB",
+        "wales": "GB",
+        "northern ireland": "GB",
+        "uk": "GB",
+        "norge": "NO",
+        "united states of america": "US",
+    }
+
+    def to_iso_alpha2_country_code(self, country_str):
+        """
+        Map country string to an ISO alpha-2 country string. This method understands
+        ISO alpha-3 to ISO alpha-2 mapping. It also copes with a few common non
+        contentious mappings such as "UK" -> "GB", "United Kingdom." -> "GB"
+        :param country_str: the string to map to an ISO alpha-2 country code
+        :return: ISO alpha-2 country code or None if no clean mapping
+        """
+        if not country_str:
+            return None
+        # Clean up some common appendages we see on country strings.
+        country_str = country_str.strip().replace(".", "")
+        if len(country_str) < 2:
+            return None
+        if len(country_str) == 2:
+            # Check for the clean/fast path, spider has given us a 2-alpha iso country code.
+            if self.gc.get_countries().get(country_str.upper()):
+                return country_str.upper()
+        if len(country_str) == 3:
+            # Check for a 3-alpha code, this is done by iteration.
+            country_str = country_str.upper()
+            for country in self.gc.get_countries().values():
+                if country["iso3"] == country_str:
+                    return country["iso"]
+        # Failed so far, now let's try a match by name.
+        country_name = country_str.lower()
+        for country in self.gc.get_countries().values():
+            if country["name"].lower() == country_name:
+                return country["iso"]
+        # Finally let's go digging in the random country string collection!
+        return self.UNHANDLED_COUNTRY_MAPPINGS.get(country_name)
+
+    def _convert_to_iso2_country_code(self, splits):
+        if len(splits) > 1 and len(splits[-1]) == 2:
+            candidate = splits[-1].upper()
+            if self.gc.get_countries().get(candidate):
+                return candidate
+            if candidate == "UK":
+                return "GB"
+        return None
+
+    def country_code_from_spider_name(self, spider_name):
+        if isinstance(spider_name, str):
+            return self._convert_to_iso2_country_code(spider_name.split("_"))
+        return None
+
+    def country_code_from_url(self, url):
+        if isinstance(url, str):
+            return self._convert_to_iso2_country_code(urlparse(url).netloc.split("."))
+        return None

--- a/tests/test_country_utils.py
+++ b/tests/test_country_utils.py
@@ -37,4 +37,6 @@ def test_country_code_from_spider_name():
     assert "ES" == country_utils.country_code_from_spider_name("spider_es")
     assert "GB" == country_utils.country_code_from_spider_name("spider_UK")
     assert "GB" == country_utils.country_code_from_spider_name("spider_GB")
-    assert "GB" == country_utils.country_code_from_spider_name("spider_with_more_words_GB")
+    assert "GB" == country_utils.country_code_from_spider_name(
+        "spider_with_more_words_GB"
+    )

--- a/tests/test_country_utils.py
+++ b/tests/test_country_utils.py
@@ -1,4 +1,4 @@
-from locations.commands.insights import CountryUtils
+from locations.country_utils import CountryUtils
 
 
 def test_country_fix():
@@ -13,3 +13,28 @@ def test_country_fix():
     assert "GB" == country_utils.to_iso_alpha2_country_code("United Kingdom. ")
     assert "GB" == country_utils.to_iso_alpha2_country_code("GBR")
     assert "GB" == country_utils.to_iso_alpha2_country_code(" UK ")
+
+
+def test_country_code_from_url():
+    country_utils = CountryUtils()
+    assert not country_utils.country_code_from_url(None)
+    assert not country_utils.country_code_from_url([1, 2, 3])
+    assert not country_utils.country_code_from_url("https://site.com/path")
+    assert not country_utils.country_code_from_url("https://site.co.xx/path")
+    assert not country_utils.country_code_from_url("https://site.co.gbr/path")
+    assert "ES" == country_utils.country_code_from_url("https://site.co.es/path")
+    assert "GB" == country_utils.country_code_from_url("https://site.co.uk/path")
+    assert "GB" == country_utils.country_code_from_url("https://site.co.UK/path")
+
+
+def test_country_code_from_spider_name():
+    country_utils = CountryUtils()
+    assert not country_utils.country_code_from_spider_name(None)
+    assert not country_utils.country_code_from_spider_name([1, 2, 3])
+    assert not country_utils.country_code_from_spider_name("fails")
+    assert not country_utils.country_code_from_spider_name("fails_xx")
+    assert not country_utils.country_code_from_spider_name("fails_gbr")
+    assert "ES" == country_utils.country_code_from_spider_name("spider_es")
+    assert "GB" == country_utils.country_code_from_spider_name("spider_UK")
+    assert "GB" == country_utils.country_code_from_spider_name("spider_GB")
+    assert "GB" == country_utils.country_code_from_spider_name("spider_with_more_words_GB")

--- a/tests/test_pipeline_country_code_cleanup.py
+++ b/tests/test_pipeline_country_code_cleanup.py
@@ -1,0 +1,35 @@
+from scrapy.crawler import Crawler
+from locations.items import GeojsonPointItem
+from locations.pipelines import CountryCodeCleanUpPipeline
+from locations.spiders.greggs_gb import GreggsGBSpider
+
+
+def get_objects(spider_name):
+    class Spider(object):
+        pass
+
+    spider = Spider()
+    spider.name = spider_name
+    spider.crawler = Crawler(GreggsGBSpider)
+    return GeojsonPointItem(), CountryCodeCleanUpPipeline(), spider
+
+
+def test_handle_empty():
+    item, pipeline, spider = get_objects("meaningless")
+    pipeline.process_item(item, spider)
+    assert not item.get("country")
+
+
+def test_country_from_spider_name():
+    item, pipeline, spider = get_objects("greggs_gb")
+    pipeline.process_item(item, spider)
+    assert "GB" == item.get("country")
+    assert 1 == spider.crawler.stats.get_value("atp/field/country/from_spider_name")
+
+
+def test_country_from_website_url():
+    item, pipeline, spider = get_objects("greggs")
+    item["website"] = "https://www.greggs.co.uk/index.html"
+    pipeline.process_item(item, spider)
+    assert "GB" == item.get("country")
+    assert 1 == spider.crawler.stats.get_value("atp/field/country/from_website_url")


### PR DESCRIPTION
CJ's recent commit to try and standardise country code fields to ISO2 alpha as best we can has been extended further with code that will set the country code from our spider naming convention if appropriate and also as a final resort the item website URL.

As part of this CountryUtils has been pulled out of the insights.py command file and put in "core" ATP library code where it should be.

This means we will get more POIs with country codes which means that the NSI categorisation pipeline code should pick up more items.

Also means that going forward people in many cases will not need to set the country code field "by hand" in the spider.