### PR TITLE
Add "sd" command to decode a web page or file for structured data

### DIFF
--- a/locations/commands/sd.py
+++ b/locations/commands/sd.py
@@ -1,0 +1,86 @@
+import os
+import pathlib
+import scrapy
+from scrapy.commands import BaseRunSpiderCommand
+from scrapy.exceptions import UsageError
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROSWER_DEFAULT
+
+
+class MySpider(StructuredDataSpider):
+    name = "my_spider"
+    my_url = None
+    item_attributes = {}
+    user_agent = BROSWER_DEFAULT
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self):
+        yield scrapy.Request(self.my_url, callback=self.parse_sd)
+
+    def inspect_item(self, item, response):
+        print(item)
+        yield item
+
+
+# See what ATP libraries can do with a given web site / web page.
+class SdCommand(BaseRunSpiderCommand):
+    requires_project = True
+    default_settings = {"LOG_ENABLED": False}
+
+    def syntax(self):
+        return "[options] <file or URL to decode>"
+
+    def short_desc(self):
+        return "Decode a web page or file for structured data with ATP scrapy library code"
+
+    def add_options(self, parser):
+        super().add_options(parser)
+        parser.add_argument(
+            "--wanted-types",
+            dest="wanted_types",
+            help="wanted place type(s), many times not required as defaults cope with most",
+        )
+        parser.add_argument(
+            "--wikidata",
+            dest="wikidata",
+            help="wikidata Q-code, see if brand name and NSI category data pulled in",
+        )
+        parser.add_argument(
+            "--spider-name",
+            dest="spider_name",
+            help="specify spider name, possibly to see result of pipeline country inference",
+        )
+        parser.add_argument(
+            "--stats",
+            action="store_true",
+            help="show crawl counters",
+        )
+
+    def run(self, args, opts):
+        if len(args) != 1:
+            raise UsageError("Please specify single file or URL to load")
+
+        if args[0].startswith("http"):
+            MySpider.my_url = args[0]
+        else:
+            path = os.path.abspath(args[0])
+            MySpider.my_url = pathlib.Path(path).as_uri()
+
+        if opts.wikidata:
+            MySpider.item_attributes["brand_wikidata"] = opts.wikidata
+
+        if opts.spider_name:
+            MySpider.name = opts.spider_name
+
+        if opts.wanted_types:
+            MySpider.wanted_types = opts.wanted_types.split(",")
+
+        crawler = self.crawler_process.create_crawler(MySpider, **opts.spargs)
+        self.crawler_process.crawl(crawler)
+        self.crawler_process.start()
+        stats_dict = crawler.stats.get_stats()
+        if stats_dict.get("item_scraped_count", 0) == 0:
+            print("failed to decode structured data")
+        if opts.stats:
+            for k, v in stats_dict.items():
+                print(k + ": " + str(v))

--- a/locations/commands/sd.py
+++ b/locations/commands/sd.py
@@ -31,7 +31,9 @@ class SdCommand(BaseRunSpiderCommand):
         return "[options] <file or URL to decode>"
 
     def short_desc(self):
-        return "Decode a web page or file for structured data with ATP scrapy library code"
+        return (
+            "Decode a web page or file for structured data with ATP scrapy library code"
+        )
 
     def add_options(self, parser):
         super().add_options(parser)


### PR DESCRIPTION
Quickly run a minimum structured data spider against a web page or file.
    
    **$ pipenv run scrapy sd https://www.nisalocally.co.uk/stores/city-of-edinburgh/edinburgh/77-warrender-park-rd**
    {'city': 'Edinburgh',
     'country': 'GB',
     'email': None,
     'image': 'https://www.nisalocally.co.uk/stores/permanent-b0b701/assets/images/nisa-logo-blue.88689a6b.svg',
     'lat': '55.938520097370755',
     'lon': '-3.1976409867417033',
     'name': 'Margiotta Ltd 77 Warrender Park Rd',
     'opening_hours': 'Mo-Su 07:00-23:00',
     'phone': '0131 229 8228',
     'postcode': 'EH9 1ES',
     'ref': 'https://www.nisalocally.co.uk/stores/#13429806',
     'state': None,
     'street_address': '77 Warrender Park Rd Midlothian',
     'website': 'https://www.nisalocally.co.uk/stores/city-of-edinburgh/edinburgh/77-warrender-park-rd'}
 
Has a few more options like supplying a wikidata code, giving the spider a name, dumping stats. Developed when trying to "fix" auto_zone spider on which I failed.
