### PR TITLE
some doc about spider naming convention

### DIFF
--- a/docs/SPIDER_NAMING.md
+++ b/docs/SPIDER_NAMING.md
@@ -13,7 +13,6 @@ If your Python file is `great_name.py` then your spider
 should look something like:
 
 ```python
-# -*- coding: utf-8 -*-
 import scrapy
 
 class GreatNameSpider(scrapy.Spider):
@@ -30,7 +29,6 @@ South Africa, then spider file `great_name_za.py` should look
 something like:
 
 ```python
-# -*- coding: utf-8 -*-
 import scrapy
 
 class GreatNameZASpider(scrapy.Spider):

--- a/docs/SPIDER_NAMING.md
+++ b/docs/SPIDER_NAMING.md
@@ -1,0 +1,64 @@
+## Naming your spider
+
+With so many spider files it is important that we maintain
+a high level of naming consistency.
+
+At the time of writing there is a
+[single directory](../locations/spiders)
+containing all of our spiders.
+
+The file and the spider within it should share the same name.
+The name should reflect the brand or company name that the
+spider is for.
+Lower case characters must be used.
+If your Python file is `great_name.py` then your spider
+should look something like:
+
+    ```python
+    # -*- coding: utf-8 -*-
+    import scrapy
+
+    class GreatNameSpider(scrapy.Spider):
+        name = "great_name"
+    ```
+
+The camel case approach illustrated for the class name
+is further recommended. If you know the company / brand
+that you are spidering only has outlets in one country then it
+is helpful to suffix your name with the
+[ISO alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+for that country. For example,  if `great_name` only had outlets in
+South Africa, then spider file `great_name_za.py` should look
+something like:
+
+    ```python
+    # -*- coding: utf-8 -*-
+    import scrapy
+
+    class GreatNameZASpider(scrapy.Spider):
+        name = "great_name_za"
+    ```
+
+If a brand / company is present in multiple territories, and
+the spider is able
+to access all of these using a common approach / API, then do not
+qualify the spider name with a country code.
+An example of this would be the
+[Decathlon spider](../locations/spiders/decathlon.py)
+
+Sometimes things get a little complex. There is a primary
+[mcdonalds.py](../locations/spiders/mcdonalds.py) which
+is able to spider many major countries with a common API.
+There are country specific spiders, e.g.
+[mcdonalds_pt.py](../locations/spiders/mcdonalds_pt.py),
+which do a single territory.
+There are also some McDonald's spiders which cover
+a small number of countries with the same approach,
+e.g. [mcdonalds_baltics.py](../locations/spiders/mcdonalds_baltics.py).
+
+It is quite important that you only add a two character
+suffix to the spider name if you are sure that all POIs generated
+by the spider are in the same country. The reason for this
+is that [ATP pipeline code](../locations/pipelines.py) will add
+this country suffix as the country code to scraped POIs if it
+has not been set by the spider itself.

--- a/docs/SPIDER_NAMING.md
+++ b/docs/SPIDER_NAMING.md
@@ -2,25 +2,23 @@
 
 With so many spider files it is important that we maintain
 a high level of naming consistency.
-
 At the time of writing there is a
 [single directory](../locations/spiders)
 containing all of our spiders.
 
 The file and the spider within it should share the same name.
 The name should reflect the brand or company name that the
-spider is for.
-Lower case characters must be used.
+spider is for. Lower case characters must be used.
 If your Python file is `great_name.py` then your spider
 should look something like:
 
-    ```python
-    # -*- coding: utf-8 -*-
-    import scrapy
+```python
+# -*- coding: utf-8 -*-
+import scrapy
 
-    class GreatNameSpider(scrapy.Spider):
-        name = "great_name"
-    ```
+class GreatNameSpider(scrapy.Spider):
+    name = "great_name"
+```
 
 The camel case approach illustrated for the class name
 is further recommended. If you know the company / brand
@@ -31,27 +29,27 @@ for that country. For example,  if `great_name` only had outlets in
 South Africa, then spider file `great_name_za.py` should look
 something like:
 
-    ```python
-    # -*- coding: utf-8 -*-
-    import scrapy
+```python
+# -*- coding: utf-8 -*-
+import scrapy
 
-    class GreatNameZASpider(scrapy.Spider):
-        name = "great_name_za"
-    ```
+class GreatNameZASpider(scrapy.Spider):
+    name = "great_name_za"
+```
 
 If a brand / company is present in multiple territories, and
 the spider is able
 to access all of these using a common approach / API, then do not
 qualify the spider name with a country code.
 An example of this would be the
-[Decathlon spider](../locations/spiders/decathlon.py)
+[Decathlon spider](../locations/spiders/decathlon.py).
 
 Sometimes things get a little complex. There is a primary
-[mcdonalds.py](../locations/spiders/mcdonalds.py) which
-is able to spider many major countries with a common API.
+[mcdonalds.py](../locations/spiders/mcdonalds.py) spider which
+is able to process many major countries with a common API.
 There are country specific spiders, e.g.
 [mcdonalds_pt.py](../locations/spiders/mcdonalds_pt.py),
-which do a single territory.
+which cover a single territory.
 There are also some McDonald's spiders which cover
 a small number of countries with the same approach,
 e.g. [mcdonalds_baltics.py](../locations/spiders/mcdonalds_baltics.py).


### PR DESCRIPTION
The top level README will get too unwieldy for some of the things we should be saying (we have quite a few things to say). I think we should break things down into little vignettes that we can tie together in the main README or wherever.

The files will serve as reference but also single links that can be pasted into a PR to help the reviewer get a point across in a particular area. Who likes typing? :-)