### PR TITLE
a command to poke a website robots.txt / sitemap.xml

### DIFF
--- a/locations/commands/sitemap.py
+++ b/locations/commands/sitemap.py
@@ -1,0 +1,85 @@
+import scrapy
+from scrapy.commands import BaseRunSpiderCommand
+from scrapy.exceptions import UsageError
+from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
+from scrapy.spiders.sitemap import iterloc
+from urllib.parse import urlparse
+from locations.user_agents import BROSWER_DEFAULT
+
+
+class MySitemapSpider(scrapy.spiders.SitemapSpider):
+    name = "my_sitemap_spider"
+    user_agent = BROSWER_DEFAULT
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    pages = False
+    download_delay = 0.5
+
+    def _parse_sitemap(self, response):
+        if response.url.endswith("/robots.txt"):
+            for url in sitemap_urls_from_robots(response.text, base_url=response.url):
+                if not self.pages:
+                    print(url)
+                yield scrapy.Request(url, callback=self._parse_sitemap)
+        else:
+            body = self._get_sitemap_body(response)
+            if body is None:
+                print("invalid sitemap response: " + response.url)
+                return
+
+            s = Sitemap(body)
+            it = self.sitemap_filter(s)
+
+            if s.type == "sitemapindex":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    if any(x.search(loc) for x in self._follow):
+                        if not self.pages:
+                            print(loc)
+                        yield scrapy.Request(loc, callback=self._parse_sitemap)
+            elif s.type == "urlset":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    if self.pages:
+                        print(loc)
+
+
+class SitemapCommand(BaseRunSpiderCommand):
+    requires_project = True
+    default_settings = {"LOG_ENABLED": False}
+
+    def syntax(self):
+        return "[options] <root URL | robots.txt URL | sitemap URL>"
+
+    def short_desc(self):
+        return "Probe website robots.txt / sitemap.xml for spider development insights"
+
+    def add_options(self, parser):
+        super().add_options(parser)
+        parser.add_argument(
+            "--pages",
+            action="store_true",
+            help="print HTTP page links rather than sitemap XML links, helps identify POI pages",
+        )
+        parser.add_argument(
+            "--stats",
+            action="store_true",
+            help="show crawler stats",
+        )
+
+    def run(self, args, opts):
+        if len(args) != 1:
+            raise UsageError("Please specify a URL for the SitemapSpider")
+
+        url = args[0]
+        parsed = urlparse(url)
+        if parsed.path.replace("/", "") == "":
+            # If URL has no path data then take a chance on robots.txt being there to help.
+            url = parsed.scheme + "://" + parsed.netloc + "/robots.txt"
+        MySitemapSpider.sitemap_urls = [url]
+
+        MySitemapSpider.pages = opts.pages
+
+        crawler = self.crawler_process.create_crawler(MySitemapSpider, **opts.spargs)
+        self.crawler_process.crawl(crawler)
+        self.crawler_process.start()
+        if opts.stats:
+            for k, v in crawler.stats.get_stats().items():
+                print(k + ": " + str(v))


### PR DESCRIPTION
A complementary twin to the "sd" command. A quick command to see if scrapy can read any sitemap index support that may be present e.g.

$ pipenv run scrapy sitemap https://smashburger.com https://smashburger.com/sitemap_index.xml
https://smashburger.com/post-sitemap.xml
https://smashburger.com/page-sitemap.xml
https://smashburger.com/store-sitemap.xml
https://smashburger.com/give_forms-sitemap.xml
https://smashburger.com/promo-sitemap.xml
https://smashburger.com/item_type-sitemap.xml

can be followed with:

$ pipenv run scrapy sitemap https://smashburger.com/store-sitemap.xml --pages https://smashburger.com/locations/us/co/glendale/1120-s-colorado-blvd/ https://smashburger.com/locations/us/co/lafayette/2755-dagny-way/ https://smashburger.com/locations/us/co/wheatridge/3356-youngfield-st/ https://smashburger.com/locations/us/co/fort-collins/2550-e-harmony-rd/ https://smashburger.com/locations/us/tx/houston/7811-s-main-street/ https://smashburger.com/locations/us/co/denver/7305-e-35th-avenue/ ......

can be followed with:

$ pipenv run scrapy sd https://smashburger.com/locations/us/co/denver/7305-e-35th-avenue/