### PR TITLE
Document nsi_id and skip ApplyNSICategoriesPipeline when it's set

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -44,5 +44,6 @@ Each GeoJSON feature will have a `properties` object with the following keys:
 | `image`               | No  | A URL of an image for the venue. We try to make this specific to the venue and not generic for the brand that is operating the venue.
 | `located_in`          | No  | The name of the feature that this feature is located in.
 | `located_in:wikidata` | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand or chain of the feature that this feature is located in. This is a machine-readible identifier counterpart for the human-readible `located_in` above.
+| `nsi_id`              | No  | The [NSI ID](https://nsi.guide/) for the feature. NSI IDs aren't stable, so you may require [old NSI data](https://github.com/osmlab/name-suggestion-index/tree/main/dist) if you are working with old ATP data.                                                                         |
 
 Spiders can also include extra fields that will show up but aren't necessarily documented outside their spider source code. If enough spiders find interesting things to include in an extra property, it might be included here in the documentation in the future.

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -44,6 +44,6 @@ Each GeoJSON feature will have a `properties` object with the following keys:
 | `image`               | No  | A URL of an image for the venue. We try to make this specific to the venue and not generic for the brand that is operating the venue.
 | `located_in`          | No  | The name of the feature that this feature is located in.
 | `located_in:wikidata` | No  | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand or chain of the feature that this feature is located in. This is a machine-readible identifier counterpart for the human-readible `located_in` above.
-| `nsi_id`              | No  | The [NSI ID](https://nsi.guide/) for the feature. NSI IDs aren't stable, so you may require [old NSI data](https://github.com/osmlab/name-suggestion-index/tree/main/dist) if you are working with old ATP data.                                                                         |
+| `nsi_id`              | No  | The [Name Suggestion Index](https://nsi.guide/) (NSI) ID for the feature. NSI IDs aren't stable, so you may require [old NSI data](https://github.com/osmlab/name-suggestion-index/tree/main/dist) if you are working with old ATP data.                                                                         |
 
 Spiders can also include extra fields that will show up but aren't necessarily documented outside their spider source code. If enough spiders find interesting things to include in an extra property, it might be included here in the documentation in the future.

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -1,9 +1,9 @@
 import base64
 import hashlib
 import logging
-from scrapy.exporters import JsonLinesItemExporter, JsonItemExporter
-from scrapy.utils.python import to_bytes
 
+from scrapy.exporters import JsonItemExporter, JsonLinesItemExporter
+from scrapy.utils.python import to_bytes
 
 mapping = (
     ("addr_full", "addr:full"),
@@ -26,6 +26,7 @@ mapping = (
     ("brand_wikidata", "brand:wikidata"),
     ("located_in", "located_in"),
     ("located_in_wikidata", "located_in:wikidata"),
+    ("nsi_id", "nsi_id"),
 )
 
 
@@ -84,7 +85,6 @@ class LineDelimitedGeoJsonExporter(JsonLinesItemExporter):
                 logging.warning(
                     "Couldn't convert lat (%s) and lon (%s) to string", lat, lon
                 )
-                pass
 
         return feature
 
@@ -113,7 +113,6 @@ class GeoJsonExporter(JsonItemExporter):
                 logging.warning(
                     "Couldn't convert lat (%s) and lon (%s) to string", lat, lon
                 )
-                pass
 
         return feature
 

--- a/locations/items.py
+++ b/locations/items.py
@@ -32,4 +32,5 @@ class GeojsonPointItem(scrapy.Item):
     brand_wikidata = scrapy.Field()
     located_in = scrapy.Field()
     located_in_wikidata = scrapy.Field()
+    nsi_id = scrapy.Field()
     extras = scrapy.Field()

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -240,6 +240,9 @@ class ApplyNSICategoriesPipeline(object):
     wikidata_cache = {}
 
     def process_item(self, item, spider):
+        if item.get("nsi_id"):
+            return item
+
         code = item.get("brand_wikidata")
         if not code:
             return item
@@ -287,7 +290,7 @@ class ApplyNSICategoriesPipeline(object):
 
     def apply_tags(self, match, item):
         extras = item.get("extras", {})
-        extras["nsi_id"] = match["id"]
+        item["nsi_id"] = match["id"]
 
         # Apply NSI tags to item
         for (key, value) in match["tags"].items():


### PR DESCRIPTION
I can't really envision us setting the `nsi_id` in spider to a real value, but we we'll have the option. However I can foresee us wanting to skip `ApplyNSICategoriesPipeline`, now we can `nsi_id=0` and it'll be skipped.