### PR TITLE
Pipeline fixes

### DIFF
--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -207,12 +207,6 @@ class CheckItemPropertiesPipeline:
         else:
             spider.crawler.stats.inc_value("atp/field/city/missing")
 
-        if state := item.get("state"):
-            if not isinstance(state, str):
-                spider.crawler.stats.inc_value("atp/field/state/wrong_type")
-        else:
-            spider.crawler.stats.inc_value("atp/field/state/missing")
-
         if postcode := item.get("postcode"):
             if not isinstance(postcode, str):
                 spider.crawler.stats.inc_value("atp/field/postcode/wrong_type")

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -41,7 +41,7 @@ class ApplySpiderLevelAttributesPipeline:
         item_attributes = spider.item_attributes
 
         for (key, value) in item_attributes.items():
-            if key is "extras":
+            if key == "extras":
                 extras = item.get("extras", {})
                 for k, v in value.items():
                     if extras.get(k) is None:


### PR DESCRIPTION
I added `if key is "extras":` which adds a warning at the start of every spider run.

state checks were duplicated when street_address checks were added.