### PR TITLE
Convert JDSports GB Spider StructuredDataSpider

### DIFF
--- a/locations/spiders/jdsports_gb.py
+++ b/locations/spiders/jdsports_gb.py
@@ -11,3 +11,4 @@ class JDSportsGBSpider(CrawlSpider, StructuredDataSpider):
     rules = [
         Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")
     ]
+    requires_proxy = True

--- a/locations/spiders/jdsports_gb.py
+++ b/locations/spiders/jdsports_gb.py
@@ -1,28 +1,13 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class JDSportsGBSpider(CrawlSpider):
+class JDSportsGBSpider(CrawlSpider, StructuredDataSpider):
     name = "jdsports_gb"
-    item_attributes = {
-        "brand": "JD Sports",
-        "brand_wikidata": "Q6108019",
-    }
+    item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.co.uk/store-locator/all-stores/"]
     rules = [
-        Rule(
-            LinkExtractor(allow="store-locator/"), callback="parse_store", follow=False
-        )
+        Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")
     ]
-    download_delay = 0.2
-
-    def parse_store(self, response):
-        if "-soon" in response.url:
-            self.logger.warning("ignoring store opening soon %s", response.url)
-        else:
-            item = LinkedDataParser.parse(response, "Store")
-            if item:
-                item["ref"] = response.url.strip("/").split("/")[-1]
-                yield item


### PR DESCRIPTION
It's broken in the weekly, but worked fine locally, presumably they block AWS ips. `download_delay` increased to the default 1 seconds, but still don't really expect this to work in the weeklies.