### PR TITLE
fix: iter_nsi

### DIFF
--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -76,6 +76,8 @@ class NSI(metaclass=Singleton):
                     yield item
                 elif wikidata_code == item["tags"].get("brand:wikidata"):
                     yield item
+                elif wikidata_code == item["tags"].get("operator:wikidata"):
+                    yield item
 
     @staticmethod
     def normalise(s):


### PR DESCRIPTION
Apple -> Q312

Current version: 
```
nsi.iter_nsi("Q312")
empty
```

Fix:
```
nsi.iter_nsi("Q312")
[
    {
        "displayName": "Apple Inc.",
        "id": "appleinc-918717",
        "locationSet": {
            "include": [
                "001"
            ]
        },
        "tags": {
            "operator": "Apple Inc.",
            "operator:wikidata": "Q312",
            "telecom": "data_center"
        }
    }
]
```
