### PR TITLE
Add additional Decathlon hosts

### DIFF
--- a/locations/spiders/decathlon.py
+++ b/locations/spiders/decathlon.py
@@ -20,7 +20,6 @@ class Decathlon(CrawlSpider):
         "https://www.decathlon.it/store-locator",
         "https://www.decathlon.fr/store-locator",
         "https://www.decathlon.hu/store-locator",
-        "https://www.decathlon.nl/store-locator",
         "https://www.decathlon.pl/store-locator",
         "https://www.decathlon.pt/store-locator",
         "https://www.decathlon.ro/store-locator",

--- a/locations/spiders/decathlon.py
+++ b/locations/spiders/decathlon.py
@@ -10,14 +10,21 @@ class Decathlon(CrawlSpider):
     name = "decathlon"
     item_attributes = {"brand": "Decathlon", "brand_wikidata": "Q509349"}
     start_urls = [
+        "https://www.decathlon.be/nl/store-locator",
+        "https://www.decathlon.ch/fr/store-locator",
+        "https://www.decathlon.cz/store-locator",
         "https://www.decathlon.co.uk/store-locator",
         "https://www.decathlon.de/store-locator",
         "https://www.decathlon.es/es/store-locator",
+        "https://www.decathlon.com.hk/en/store-locator",
         "https://www.decathlon.it/store-locator",
         "https://www.decathlon.fr/store-locator",
         "https://www.decathlon.hu/store-locator",
+        "https://www.decathlon.nl/store-locator",
         "https://www.decathlon.pl/store-locator",
         "https://www.decathlon.pt/store-locator",
+        "https://www.decathlon.ro/store-locator",
+        "https://www.decathlon.com.tr/store-locator",
         # TODO: more domains no doubt
     ]
     rules = [Rule(LinkExtractor(allow="/store-view/"), callback="parse", follow=False)]


### PR DESCRIPTION
Add additional hosts for Decathlon. The added hosts follow the same contract as those already present.

There are more hosts (e.g. sk, se, cn), but they use a different mechanism to locate the store. So, I didn't include those since required code changes are much more substantial.