### PR TITLE
Add base Woosmap Spider

### DIFF
--- a/locations/spiders/e_leclerc.py
+++ b/locations/spiders/e_leclerc.py
@@ -1,85 +1,17 @@
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import GeojsonPointItem
+from locations.storefinders.woosmap import WoosmapSpider
 
 
-class ELeclercSpider(scrapy.Spider):
+class ELeclercSpider(WoosmapSpider):
     name = "e_leclerc"
     item_attributes = {"brand": "E.Leclerc", "brand_wikidata": "Q1273376"}
-    allowed_domains = ["e-leclerc.com", "api.woosmap.com"]
-
     key = "woos-6256d36f-af9b-3b64-a84f-22b2342121ba"
-    headers = {
-        "origin": "https://www.e.leclerc",
-    }
+    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.e.leclerc"}}
 
-    day_range = {
-        1: "Mo",
-        2: "Tu",
-        3: "We",
-        4: "Th",
-        5: "Fr",
-        6: "Sa",
-        7: "Su",
-    }
-
-    def start_requests(self):
-        yield scrapy.Request(
-            url=f"https://api.woosmap.com/stores/search?key={self.key}&lat=48.860245&lng=2.378051&stores_by_page=300&limit=300&page=1",
-            method="GET",
-            callback=self.parse,
-            headers=self.headers,
-        )
-
-    def parse(self, response):
-        json_obj = response.json()
-        pagination = json_obj.get("pagination")
-        for store in json_obj["features"]:
-            store_properties = store.get("properties")
-            contact = store_properties.get("contact")
-            address = store_properties.get("address")
-            user_properties = store_properties.get("user_properties")
-            coords = store.get("geometry").get("coordinates")
-            email = contact.get("email")
-            opening_hours = OpeningHours()
-            usual_oh = store_properties.get("opening_hours").get("usual")
-            for day_count in usual_oh if usual_oh else []:
-                if len(usual_oh.get(day_count)) >= 1:
-                    dates = usual_oh.get(day_count)[0]
-                    if dates["start"] != "":
-                        opening_hours.add_range(
-                            self.day_range.get(int(day_count)),
-                            dates["start"],
-                            dates["end"],
-                        )
-
-            properties = {
-                "name": f"E.Leclerc {store_properties.get('name')}",
-                "ref": store_properties.get("store_id"),
-                "street_address": address.get("lines")[0],
-                "city": address.get("city"),
-                "postcode": address.get("zipcode"),
-                "country": address.get("country_code"),
-                "phone": contact.get("phone"),
-                "website": user_properties.get("urlStore"),
-                "opening_hours": opening_hours.as_opening_hours(),
-                "lat": coords[1],
-                "lon": coords[0],
-                "email": email,
-                "extras": {
-                    "store_type": user_properties.get("commercialActivity").get("label")
-                    if user_properties.get("commercialActivity")
-                    else ""
-                },
-            }
-
-            yield GeojsonPointItem(**properties)
-
-        if pagination.get("page") != pagination.get("pageCount"):
-            next_page = pagination.get("page") + 1
-            yield scrapy.Request(
-                f"https://api.woosmap.com/stores/search?key={self.key}&lat=48.860245&lng=2.378051&stores_by_page=300&limit=300&page={next_page}",
-                callback=self.parse,
-                headers=self.headers,
-            )
+    def parse_item(self, item, feature, **kwargs):
+        item["website"] = feature["properties"]["user_properties"].get("urlStore")
+        item["extras"] = {
+            "store_type": feature["properties"]["user_properties"]
+            .get("commercialActivity", {})
+            .get("label")
+        }
+        yield item

--- a/locations/spiders/mcdonalds_fr.py
+++ b/locations/spiders/mcdonalds_fr.py
@@ -1,89 +1,17 @@
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import GeojsonPointItem
 from locations.spiders.mcdonalds import McDonaldsSpider
+from locations.storefinders.woosmap import WoosmapSpider
 
 
-class McDonaldsFRSpider(scrapy.Spider):
+class McDonaldsFRSpider(WoosmapSpider):
     name = "mcdonalds_fr"
     item_attributes = McDonaldsSpider.item_attributes
-    allowed_domains = ["www.mcdonalds.fr", "api.woosmap.com", "ws.mcdonalds.fr"]
-
-    start_urls = [
-        "https://api.woosmap.com/project/config?key=woos-77bec2e5-8f40-35ba-b483-67df0d5401be"
-    ]
-    headers = {
-        "origin": "https://www.mcdonalds.fr",
+    key = "woos-77bec2e5-8f40-35ba-b483-67df0d5401be"
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.mcdonalds.fr"}
     }
 
-    day_range = {
-        1: "Mo",
-        2: "Tu",
-        3: "We",
-        4: "Th",
-        5: "Fr",
-        6: "Sa",
-        7: "Su",
-    }
-
-    def start_requests(self):
-        yield scrapy.Request(
-            url="https://api.woosmap.com/project/config?key=woos-77bec2e5-8f40-35ba-b483-67df0d5401be",
-            method="GET",
-            callback=self.parse_store_grid,
-            headers=self.headers,
-        )
-
-    def parse_store_grid(self, response):
-        config_id = str(response.json().get("updated")).split(".", maxsplit=1)[0]
-
-        # Scan the entire France map with zoom level 10. https://www.mcdonalds.fr/restaurants
-        for lat in range(495, 540):
-            for long in range(340, 379):
-                yield scrapy.Request(
-                    url=f"https://api.woosmap.com/tiles/10-{str(lat)}-{str(long)}.grid.json?key=woos-77bec2e5-8f40-35ba-b483-67df0d5401be&_={config_id}",
-                    method="GET",
-                    callback=self.get_store_ids,
-                    headers=self.headers,
-                )
-
-    def get_store_ids(self, response):
-        json_obj = response.json()
-        for store in json_obj["data"]:
-            store_id = json_obj["data"].get(store)["store_id"]
-            yield scrapy.Request(
-                url=f"https://ws.mcdonalds.fr/api/restaurant/{store_id}/?responseGroups=RG.RESTAURANT.FACILITIES",
-                method="GET",
-                callback=self.parse_all_stores,
-                headers=self.headers,
-            )
-
-    def parse_all_stores(self, response):
-        store_json = response.json()
-        address_info = store_json["restaurantAddress"][0]
-        coords = store_json["coordinates"]
-        store_oh = store_json.get("openingHours")
-        opening_hours = OpeningHours()
-        for day in store_oh if len(store_json.get("openingHours")) > 0 else []:
-            if day["beginHour"] != "":
-                opening_hours.add_range(
-                    self.day_range.get(day.get("day")),
-                    day["beginHour"],
-                    day["endHour"],
-                )
-        properties = {
-            "name": f"McDonalds {store_json['name']}",
-            "ref": address_info.get("id"),
-            "addr_full": address_info.get("address1"),
-            "city": address_info.get("city"),
-            "postcode": address_info.get("zipCode"),
-            "country": address_info.get("country"),
-            "phone": store_json.get("phone"),
-            "state": store_json.get("region"),
-            "opening_hours": opening_hours.as_opening_hours(),
-            "lat": coords.get("latitude"),
-            "lon": coords.get("longitude"),
-        }
-
-        yield GeojsonPointItem(**properties)
+    def parse_item(self, item, feature, **kwargs):
+        item[
+            "website"
+        ] = f'https://www.mcdonalds.fr/restaurants{feature["properties"]["contact"]["website"]}/{feature["properties"]["store_id"]}'
+        yield item

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -1,0 +1,50 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class WoosmapSpider(Spider):
+    key = ""
+
+    def start_requests(self):
+        yield JsonRequest(url=f"https://api.woosmap.com/stores?key={self.key}&page=1")
+
+    def parse(self, response, **kwargs):
+        if features := response.json()["features"]:
+            for feature in features:
+                item = DictParser.parse(feature["properties"])
+
+                item["street_address"] = ", ".join(
+                    filter(None, feature["properties"]["address"]["lines"])
+                )
+                item["lon"], item["lat"] = feature["geometry"]["coordinates"]
+
+                oh = OpeningHours()
+                for day, rules in (
+                    feature["properties"]
+                    .get("opening_hours", {})
+                    .get("usual", {})
+                    .items()
+                ):
+                    for hours in rules:
+                        if hours.get("all-day"):
+                            start = "00:00"
+                            end = "23:59"
+                        else:
+                            start = hours["start"]
+                            end = hours["end"]
+                        oh.add_range(DAYS[int(day) - 1], start, end)
+                item["opening_hours"] = oh.as_opening_hours()
+
+                yield from self.parse_item(item, feature)
+
+        if pagination := response.json()["pagination"]:
+            if pagination["page"] < pagination["pageCount"]:
+                yield JsonRequest(
+                    url=f'https://api.woosmap.com/stores?key={self.key}&page={pagination["page"]+1}'
+                )
+
+    def parse_item(self, item, feature, **kwargs):
+        yield item


### PR DESCRIPTION
I started the day off thinking that Woosmap was third party data. But it's not, it's first party data on a hosted store finder. And I found a better end point that we don't have to mess around with lat/lons or grids.

I want everyones opinions on some kind of base spiders, specifically for third party store finders. @jleedev @iandees @mjoe999 You can checkout the specific implementation, but I just rushed it, it's the idea that really want your opinions on.
