### PR TITLE
Add a spider attribute to skip auto cc extraction

### DIFF
--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -63,6 +63,8 @@ class CountryCodeCleanUpPipeline:
             if clean_country := self.country_utils.to_iso_alpha2_country_code(country):
                 item["country"] = clean_country
         else:
+            if hasattr(spider, "skip_auto_cc") and getattr(spider, "skip_auto_cc"):
+                return item
 
             # No country set, see if it can be cleanly deduced from the spider name
             if country := self.country_utils.country_code_from_spider_name(spider.name):

--- a/locations/spiders/designer_shoe_warehouse.py
+++ b/locations/spiders/designer_shoe_warehouse.py
@@ -81,4 +81,9 @@ class DesignerShoeWarehouseSpider(SitemapSpider):
             ).extract_first(),
             "opening_hours": oh.as_opening_hours(),
         }
+        if "stores.dsw.com" in response.url:
+            properties["country"] = "US"
+        elif "stores.dsw.ca" in response.url:
+            properties["country"] = "CA"
+
         yield GeojsonPointItem(**properties)

--- a/locations/spiders/erieinsurance.py
+++ b/locations/spiders/erieinsurance.py
@@ -11,7 +11,11 @@ am_pm = lambda s: re.sub(r" ?([ap])\.*m\.*", lambda x: x[1] + "m", s)
 
 class ErieInsuranceSpider(SitemapSpider):
     name = "erieinsurance"
-    item_attributes = {"brand": "Erie Insurance", "brand_wikidata": "Q5388314"}
+    item_attributes = {
+        "brand": "Erie Insurance",
+        "brand_wikidata": "Q5388314",
+        "country": "US",
+    }
     allowed_domains = ["www.erieinsurance.com"]
     sitemap_urls = ["https://www.erieinsurance.com/robots.txt"]
     sitemap_rules = [(r"^https://www.erieinsurance.com/agencies/.", "parse")]

--- a/locations/spiders/erieinsurance.py
+++ b/locations/spiders/erieinsurance.py
@@ -24,6 +24,8 @@ class ErieInsuranceSpider(SitemapSpider):
         script = response.xpath(
             '//script/text()[contains(.,"agencyInformation")]'
         ).get()
+        if not script:
+            return
         data = json.decoder.JSONDecoder().raw_decode(
             script, script.index("{", script.index("agencyInformation ="))
         )[0]

--- a/locations/spiders/footlocker.py
+++ b/locations/spiders/footlocker.py
@@ -42,4 +42,9 @@ class FootLockerSpider(scrapy.spiders.SitemapSpider):
         item = LinkedDataParser.parse(response, "ShoeStore")
         if item:
             item["ref"] = response.url
+
+            if "stores.footlocker.com" in response.url:
+                item["country"] = "US"
+                # Other countries are handled by the TLD in pipeline code
+
             yield item

--- a/locations/spiders/homebase_gb_ie.py
+++ b/locations/spiders/homebase_gb_ie.py
@@ -3,11 +3,11 @@ from scrapy.spiders import SitemapSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class Homebase(SitemapSpider, StructuredDataSpider):
-    name = "homebase"
+class HomebaseGBIESpider(SitemapSpider, StructuredDataSpider):
+    name = "homebase_gb_ie"
     item_attributes = {"brand": "Homebase", "brand_wikidata": "Q9293447"}
     sitemap_urls = ["https://store.homebase.co.uk/robots.txt"]
     sitemap_rules = [
         (r"https:\/\/store\.homebase\.co\.uk\/[-\w]+\/[-.\w]+$", "parse_sd")
     ]
-    wanted_types = ["HardwareStore"]
+    skip_auto_cc = True

--- a/locations/spiders/jll.py
+++ b/locations/spiders/jll.py
@@ -27,11 +27,13 @@ class JllSpider(scrapy.Spider):
                 "city": place["city"],
                 "state": place["stateProvince"],
                 "postcode": place["postalCode"],
-                "country": place["country"],
                 "lat": place["latitude"],
                 "lon": place["longitude"],
                 "phone": place["telephoneNumber"],
                 "website": place["cityPageLink"],
             }
+
+            if "https://www.us.jll.com/en/locations" in properties["website"]:
+                properties["country"] = "US"
 
             yield GeojsonPointItem(**properties)

--- a/locations/spiders/nandos.py
+++ b/locations/spiders/nandos.py
@@ -25,6 +25,7 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
         ("nandos.ca/find/", "parse_json1"),
     ]
     download_delay = 0.5
+    skip_auto_cc = True
 
     @staticmethod
     def country_from_url(response):

--- a/locations/spiders/northern_california_breweries.py
+++ b/locations/spiders/northern_california_breweries.py
@@ -31,8 +31,9 @@ class NorthernCaliforniaBreweriesSpider(scrapy.Spider):
                 ref=item.get("Brewery"),
                 lat=latitude,
                 lon=longitude,
-                addr_full=item.get("Address"),
+                street_address=item.get("Address"),
                 city=item.get("City"),
                 state="CA",
+                country="US",
                 website=item.get("Website"),
             )


### PR DESCRIPTION
A couple issues, with the auto extraction. We could have a spider in 2 regions, called "homebase_gb_ie", we shouldn't guess in pipeline. And an issue where multiple countries of POI are served from one tld, eg where GB and IE use the same ".co.uk" domain. Erroneously applying GB to IE POIs.

My solution is `skip_auto_cc = True` on the spider.

We also have a little issue because ".com" isn't mapped to "US", I agree with this decision, we'd have loads of false positives if we did, but we have to handle it in spider sometimes. After this PR I think everything is working as expected.

```bash
$ ./check_stats.sh 2022-11-12-13-31-47 atp/field/country/from_website_url
2022-11-12-13-31-47/bestbuy-ca.json: 164
2022-11-12-13-31-47/casino.json: 419
2022-11-12-13-31-47/dsw.json: 25
2022-11-12-13-31-47/erieinsurance.json: 9
2022-11-12-13-31-47/footlocker.json: 1524
2022-11-12-13-31-47/homebase.json: 172
2022-11-12-13-31-47/jll.json: 80
2022-11-12-13-31-47/mcdonalds_baltics.json: 40
2022-11-12-13-31-47/nandos.json: 468
2022-11-12-13-31-47/netto_salling.json: 1524
2022-11-12-13-31-47/northern_california_breweries.json: 1
2022-11-12-13-31-47/sparkasse.json: 8818
Spider Count: 12
Item Count: 13244
```