### PR TITLE
Allow spiders to not set refs

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -4,7 +4,9 @@ The output of the periodic run of all spiders posted on https://www.alltheplaces
 
 ## Identifier
 
-Each GeoJSON feature has an `id` field. The ID is a hash based on the `ref` and `@spider` fields and should be consistent between builds. You might use this to determine if new objects show up or disappear between builds. Occasionally, the authors of spiders will change the spider name or the website we spider will change the identifiers used for the store. In these cases, the ID field in our output will change dramatically. At this time, we don't make an attempt to link the old and new IDs.
+Each GeoJSON feature will have an `id` field. The ID is a hash based on the `ref` and `@spider` fields and should be consistent between builds.
+
+Data consumers might use the `id` field to determine if new objects show up or disappear between builds. Occasionally, the authors of spiders will change the spider name or the website we spider will change the identifiers used for the store. In these cases, the ID field in our output will change dramatically. At this time, we don't make an attempt to link the old and new IDs. Also, in some cases a spider author is unable to find a stable identifier for an item and each run will get a unique identifier.
 
 ## Geometry
 

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import logging
+import uuid
 
 from scrapy.exporters import JsonItemExporter, JsonLinesItemExporter
 from scrapy.utils.python import to_bytes
@@ -33,8 +34,9 @@ mapping = (
 def item_to_properties(item):
     props = {}
 
-    # Ref is required
-    props["ref"] = str(item["ref"])
+    # Ref is required, unless `no_refs = True` is set in spider
+    if ref := item.get("ref"):
+        props["ref"] = str(ref)
 
     # Add in the extra bits
     extras = item.get("extras")
@@ -51,7 +53,7 @@ def item_to_properties(item):
 
 
 def compute_hash(item):
-    ref = str(item.get("ref") or "").encode("utf8")
+    ref = str(item.get("ref") or uuid.uuid1()).encode("utf8")
     sha1 = hashlib.sha1(ref)
 
     spider_name = item.get("extras", {}).get("@spider")

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -16,6 +16,9 @@ class DuplicatesPipeline:
         self.ids_seen = set()
 
     def process_item(self, item, spider):
+        if hasattr(spider, "no_refs") and getattr(spider, "no_refs"):
+            return item
+
         ref = (spider.name, item["ref"])
         if ref in self.ids_seen:
             raise DropItem("Duplicate item found: %s" % item)


### PR DESCRIPTION
Some spiders are currently setting ref as hashes, random or even index order (eg BunningsSpider). Lets just embrace that some sources don't provide ids. `no_refs = True` on the spider allow it and skip de dup for them.