### PR TITLE
Add GBFS Spider

### DIFF
--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -1,0 +1,62 @@
+from scrapy.http import JsonRequest
+from scrapy.spiders import CSVFeedSpider
+
+from locations.dict_parser import DictParser
+
+# General Bikeshare Feed Specification
+# https://gbfs.mobilitydata.org/
+
+# GBFS is a standardized API for operators of bicycles, scooters, moped, and car rental service providers. This
+# spider stats at https://github.com/MobilityData/gbfs which offers a centralised catalog of networks or "systems".
+# It then processes each system and collects the docks or "stations" from it. Not every system has stations as some
+# are dockless.
+
+
+class GBFSSpider(CSVFeedSpider):
+    name = "gbfs"
+    start_urls = ["https://github.com/MobilityData/gbfs/raw/master/systems.csv"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse_row(self, response, row):
+        yield JsonRequest(
+            url=row["Auto-Discovery URL"], cb_kwargs=row, callback=self.parse_gbfs
+        )
+
+    def parse_gbfs(self, response, **kwargs):
+        try:
+            data = response.json()
+        except:
+            return
+
+        for feed in DictParser.get_nested_key(data, "feeds") or []:
+            if feed["name"] == "station_information":
+                yield JsonRequest(
+                    url=feed["url"], cb_kwargs=kwargs, callback=self.parse_stations
+                )
+
+    def parse_stations(self, response, **kwargs):
+        try:
+            data = response.json()
+        except:
+            return
+
+        for station in DictParser.get_nested_key(data, "stations") or []:
+
+            station["id"] = kwargs["System ID"] + "-" + str(station["station_id"])
+            if station.get("address"):
+                station["street_address"] = station.pop("address")
+            station["country"] = kwargs["Country Code"]
+
+            item = DictParser.parse(station)
+
+            item["brand"] = kwargs["Name"]  # Closer to OSM operator or network?
+            item["extras"] = {"capacity": station.get("capacity")}
+            # This URL isn't POI specific, but it is Network specific
+            item["website"] = kwargs["URL"]
+
+            # TODO: we could do with the vehicles types, then add OSM tags
+            # eg amenity=bicycle_rental, amenity=kick-scooter_rental, amenity=motorcycle_rental, amenity=car_rental
+            # but until then, we can do a white lie and call it public transit
+            item["extras"]["public_transport"] = "stop_position"
+
+            yield item


### PR DESCRIPTION
```python
{'atp/field/brand_wikidata/missing': 78059,
 'atp/field/city/missing': 78059,
 'atp/field/email/missing': 78059,
 'atp/field/image/missing': 78059,
 'atp/field/lat/invalid': 1,
 'atp/field/opening_hours/missing': 78059,
 'atp/field/phone/missing': 78059,
 'atp/field/postcode/missing': 73370,
 'atp/field/state/missing': 78059,
 'atp/field/street_address/missing': 52605,
 'atp/field/twitter/missing': 78059,
 'atp/field/website/invalid': 37,
 'downloader/request_bytes': 649027,
 'downloader/request_count': 1410,
 'downloader/request_method_count/GET': 1410,
 'downloader/response_bytes': 7527562,
 'downloader/response_count': 1410,
 'downloader/response_status_count/200': 1322,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/302': 2,
 'downloader/response_status_count/307': 1,
 'downloader/response_status_count/404': 18,
 'downloader/response_status_count/429': 54,
 'downloader/response_status_count/502': 12,
 'dupefilter/filtered': 17,
 'elapsed_time_seconds': 730.498402,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2022, 11, 18, 10, 41, 30, 255379),
 'httpcache/firsthand': 1366,
 'httpcache/hit': 44,
 'httpcache/miss': 1366,
 'httpcache/store': 1366,
 'httpcompression/response_bytes': 26183259,
 'httpcompression/response_count': 1041,
 'httperror/response_ignored_count': 40,
 'httperror/response_ignored_status_count/404': 18,
 'httperror/response_ignored_status_count/429': 18,
 'httperror/response_ignored_status_count/502': 4,
 'item_dropped_count': 1719,
 'item_dropped_reasons_count/DropItem': 1719,
 'item_scraped_count': 78059,
 'log_count/DEBUG': 79476,
 'log_count/ERROR': 22,
 'log_count/INFO': 61,
 'log_count/WARNING': 1720,
 'memusage/max': 128847872,
 'memusage/startup': 82305024,
 'request_depth_max': 2,
 'response_received_count': 1362,
 'retry/count': 44,
 'retry/max_reached': 22,
 'retry/reason_count/429 Unknown Status': 36,
 'retry/reason_count/502 Bad Gateway': 8,
 'scheduler/dequeued': 1410,
 'scheduler/dequeued/memory': 1410,
 'scheduler/enqueued': 1410,
 'scheduler/enqueued/memory': 1410,
 'start_time': datetime.datetime(2022, 11, 18, 10, 29, 19, 756977)}
```

Related to #4216