### PR TITLE
Change format of weekly dump files to `*.zip` instead of `*.tar.gz`

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -97,11 +97,11 @@ do
 done
 (>&2 echo "Wrote out summary JSON")
 
-(>&2 echo "Concatenating and compressing output files")
-tar -czf "${SPIDER_RUN_DIR}/output.tar.gz" -C "${SPIDER_RUN_DIR}" ./output
+(>&2 echo "Compressing output files")
+(cd "${SPIDER_RUN_DIR}" && zip -r output.zip output)
 
-(>&2 echo "Concatenating and compressing log files")
-tar -czf "${SPIDER_RUN_DIR}/logs.tar.gz" -C "${SPIDER_RUN_DIR}" ./logs
+(>&2 echo "Compressing log files")
+(cd "${SPIDER_RUN_DIR}" && zip -r logs.zip logs)
 
 (>&2 echo "Saving log and output files to ${RUN_S3_PREFIX}")
 aws s3 sync \
@@ -116,11 +116,11 @@ if [ ! $retval -eq 0 ]; then
 fi
 
 (>&2 echo "Saving embed to https://data.alltheplaces.xyz/runs/latest/info_embed.html")
-OUTPUT_FILESIZE=$(du "${SPIDER_RUN_DIR}/output.tar.gz"  | awk '{ print $1 }')
+OUTPUT_FILESIZE=$(du "${SPIDER_RUN_DIR}/output.zip"  | awk '{ print $1 }')
 OUTPUT_FILESIZE_PRETTY=$(echo "$OUTPUT_FILESIZE" | awk '{printf "%0.1f", $1/1024}')
 cat > "${SPIDER_RUN_DIR}/info_embed.html" << EOF
 <html><body>
-<a href="${RUN_URL_PREFIX}/output.tar.gz">Download</a>
+<a href="${RUN_URL_PREFIX}/output.zip">Download</a>
 (${OUTPUT_FILESIZE_PRETTY} MB)<br/><small>$(printf "%'d" "${OUTPUT_LINECOUNT}") rows from
 ${SPIDER_COUNT} spiders, updated $(date)</small>
 </body></html>
@@ -140,7 +140,7 @@ fi
 
 jq -n --compact-output \
     --arg run_id "${RUN_TIMESTAMP}" \
-    --arg run_output_url "${RUN_URL_PREFIX}/output.tar.gz" \
+    --arg run_output_url "${RUN_URL_PREFIX}/output.zip" \
     --arg run_stats_url "${RUN_URL_PREFIX}/stats/_results.json" \
     --arg run_insights_url "${RUN_URL_PREFIX}/stats/_insights.json" \
     --arg run_start_time "${RUN_START}" \

--- a/docs/WEEKLY_RUN.md
+++ b/docs/WEEKLY_RUN.md
@@ -11,7 +11,7 @@ to no longer function.
 For all these reasons we try (at the time of writing) to perform a weekly run of
 all the spiders. The output is published on our
 website: [alltheplaces.xyz](https://www.alltheplaces.xyz/).
-This data set is available as a compressed tar file. Each entry in the tar file
+This data set is available as a compressed zip file. Each entry in the zip file
 is the [GeoJSON](https://geojson.org/) output from a spider. Some of the fields, which
 may be in the GeoJSON, are described in our [data format document](../DATA_FORMAT.md).
 For those with knowledge of OpenStreetMap POI tags these will be somewhat familiar.


### PR DESCRIPTION
The size of the compressed dump is about the same: 146M vs. 147M with the current dump, which isn’t surprising given that both formats use the same compression algorithm. But other than with tar, the files in a ZIP archive can be accessed separately without having to read the entire stream. This property of ZIP allows processing the weekly dump files in parallel with multiple threads/processes/machines.

Closes https://github.com/alltheplaces/alltheplaces/issues/4227.