### PR TITLE
Implement the "continue" part of "there is a microdata error; continue".

### DIFF
--- a/locations/microdata_parser.py
+++ b/locations/microdata_parser.py
@@ -7,10 +7,6 @@ import lxml
 import parsel
 
 
-class MicrodataError(Exception):
-    pass
-
-
 def token_split(val):
     return re.findall(r"\S+", val, flags=re.ASCII)
 
@@ -129,7 +125,8 @@ def item_props(scope: lxml.html.HtmlElement):
         # 5. 2. If current is already in memory, there is a microdata error;
         # continue.
         if current in memory:
-            raise MicrodataError
+            # FIXME show a warning?
+            continue
 
         # 5. 3. Add current to memory.
         memory.append(current)

--- a/tests/test_microdata_parser.py
+++ b/tests/test_microdata_parser.py
@@ -1,0 +1,43 @@
+from parsel.selector import Selector
+
+from locations.microdata_parser import MicrodataParser
+
+
+def test_itemref():
+    src = """
+<main itemscope itemtype="http://schema.org/GroceryStore">
+    <article itemref="schema-location" itemprop="event" itemscope itemtype="http://schema.org/Event">
+        <div id="schema-location" itemprop="location" itemscope itemtype="http://schema.org/Place"></div>
+    </article>
+</main>
+    """
+    doc = Selector(text=src)
+    items = MicrodataParser.extract_microdata(doc)
+    assert items == {
+        "items": [
+            {
+                "type": ["http://schema.org/GroceryStore"],
+                "properties": {
+                    "event": [
+                        {
+                            "type": ["http://schema.org/Event"],
+                            "properties": {
+                                "location": [
+                                    {
+                                        "type": ["http://schema.org/Place"],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    ld = MicrodataParser.convert_to_graph(items)
+    assert ld == {
+        "@context": "https://schema.org",
+        "@type": "GroceryStore",
+        "event": {"@type": "Event", "location": {"@type": "Place"}},
+    }


### PR DESCRIPTION
Add a test case that was triggering this and a reasonable enough parse.

(Observation: The validator.schema.org parser creates an event with the same location property twice.)