### PR TITLE
Filter potental NSI matches by categories

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -1,6 +1,8 @@
 import logging
 from enum import Enum
 
+from locations.items import GeojsonPointItem
+
 
 class Categories(Enum):
     BUS_STOP = {"highway": "bus_stop", "public_transport": "platform"}
@@ -24,6 +26,8 @@ class Categories(Enum):
     FUEL_STATION = {"amenity": "fuel"}
     BANK = {"amenity": "bank"}
     ATM = {"amenity": "atm"}
+    POST_OFFICE = {"amenity": "post_office"}
+    POST_BOX = {"amenity": "post_box"}
 
 
 def apply_category(category, item):
@@ -38,3 +42,31 @@ def apply_category(category, item):
     if not item.get("extras"):
         item["extras"] = {}
     item["extras"].update(tags)
+
+
+top_level_tags = [
+    "amenity",
+    "emergency",
+    "healthcare",
+    "highway",
+    "leisure",
+    "office",
+    "public_transport",
+    "shop",
+    "tourism",
+]
+
+
+def get_category_tags(source) -> {}:
+    if isinstance(source, GeojsonPointItem):
+        tags = source.get("extras", {})
+    elif isinstance(source, Enum):
+        tags = source.value
+    elif isinstance(source, dict):
+        tags = source
+
+    categories = {}
+    for top_level_tag in top_level_tags:
+        if v := tags.get(top_level_tag):
+            categories[top_level_tag] = v
+    return categories or None

--- a/locations/spiders/bank_of_scotland_gb.py
+++ b/locations/spiders/bank_of_scotland_gb.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -8,7 +9,7 @@ class BankOfScotlandGB(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Bank of Scotland",
         "brand_wikidata": "Q627381",
-        "extras": {"amenity": "bank"},
+        "extras": Categories.BANK.value,
     }
     sitemap_urls = ["https://branches.bankofscotland.co.uk/sitemap.xml"]
     sitemap_rules = [
@@ -17,4 +18,3 @@ class BankOfScotlandGB(SitemapSpider, StructuredDataSpider):
             "parse_sd",
         )
     ]
-    wanted_types = ["BankOrCreditUnion"]

--- a/locations/spiders/lidl_de.py
+++ b/locations/spiders/lidl_de.py
@@ -2,6 +2,7 @@ import scrapy
 
 from locations.hours import OpeningHours
 from locations.items import GeojsonPointItem
+from locations.spiders.lidl_gb import LidlGBSpider
 
 DAY_MAPPING = {
     "Mo": "Mo",
@@ -16,7 +17,7 @@ DAY_MAPPING = {
 
 class LidlDESpider(scrapy.Spider):
     name = "lidl_de"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954", "country": "DE"}
+    item_attributes = LidlGBSpider.item_attributes
     allowed_domains = ["lidl.de"]
     handle_httpstatus_list = [404]
     start_urls = ["https://www.lidl.de/f/"]

--- a/locations/spiders/lidl_fr.py
+++ b/locations/spiders/lidl_fr.py
@@ -1,11 +1,12 @@
 import scrapy
 
 from locations.items import GeojsonPointItem
+from locations.spiders.lidl_gb import LidlGBSpider
 
 
 class LidlFRSpider(scrapy.Spider):
     name = "lidl_fr"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954"}
+    item_attributes = LidlGBSpider.item_attributes
     allowed_domains = ["virtualearth.net"]
     base_url = (
         "https://spatial.virtualearth.net/REST/v1/data/717c7792c09a4aa4a53bb789c6bb94ee/Filialdaten-FR/Filialdaten-FR"

--- a/locations/spiders/lidl_gb.py
+++ b/locations/spiders/lidl_gb.py
@@ -2,13 +2,18 @@ import re
 
 import scrapy
 
+from locations.categories import Categories
 from locations.hours import OpeningHours, day_range, sanitise_day
 from locations.items import GeojsonPointItem
 
 
 class LidlGBSpider(scrapy.Spider):
     name = "lidl_gb"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954"}
+    item_attributes = {
+        "brand": "Lidl",
+        "brand_wikidata": "Q151954",
+        "extras": Categories.SHOP_SUPERMARKET.value,
+    }
     allowed_domains = ["virtualearth.net"]
     base_url = (
         "https://spatial.virtualearth.net/REST/v1/data/588775718a4b4312842f6dffb4428cff/Filialdaten-UK/Filialdaten-UK"

--- a/locations/spiders/lidl_ie.py
+++ b/locations/spiders/lidl_ie.py
@@ -4,11 +4,12 @@ import scrapy
 
 from locations.hours import OpeningHours, day_range, sanitise_day
 from locations.items import GeojsonPointItem
+from locations.spiders.lidl_gb import LidlGBSpider
 
 
 class LidlIESpider(scrapy.Spider):
     name = "lidl_ie"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954"}
+    item_attributes = LidlGBSpider.item_attributes
     allowed_domains = ["virtualearth.net"]
     base_url = (
         "https://spatial.virtualearth.net/REST/v1/data/94c7e19092854548b3be21b155af58a1/Filialdaten-RIE/Filialdaten-RIE"

--- a/locations/spiders/lidl_ni.py
+++ b/locations/spiders/lidl_ni.py
@@ -4,11 +4,12 @@ import scrapy
 
 from locations.hours import OpeningHours, day_range, sanitise_day
 from locations.items import GeojsonPointItem
+from locations.spiders.lidl_gb import LidlGBSpider
 
 
 class LidlNISpider(scrapy.Spider):
     name = "lidl_ni"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954"}
+    item_attributes = LidlGBSpider.item_attributes
     allowed_domains = ["virtualearth.net"]
     base_url = (
         "https://spatial.virtualearth.net/REST/v1/data/91bdba818b3c4f5e8b109f223ac4a9f0/Filialdaten-NIE/Filialdaten-NIE"

--- a/locations/spiders/lidl_us.py
+++ b/locations/spiders/lidl_us.py
@@ -1,11 +1,12 @@
 import scrapy
 
 from locations.items import GeojsonPointItem
+from locations.spiders.lidl_gb import LidlGBSpider
 
 
 class LidlUSSpider(scrapy.Spider):
     name = "lidl_us"
-    item_attributes = {"brand": "Lidl", "brand_wikidata": "Q151954"}
+    item_attributes = LidlGBSpider.item_attributes
     allowed_domains = ["lidl.com"]
     start_urls = [
         "https://mobileapi.lidl.com/v1/stores",

--- a/locations/spiders/usps.py
+++ b/locations/spiders/usps.py
@@ -2,6 +2,7 @@ import json
 
 import scrapy
 
+from locations.categories import Categories
 from locations.hours import OpeningHours
 from locations.items import GeojsonPointItem
 
@@ -18,7 +19,11 @@ DAYS_NAME = {
 
 class UspsSpider(scrapy.Spider):
     name = "usps"
-    item_attributes = {"brand": "USPS", "brand_wikidata": "Q668687"}
+    item_attributes = {
+        "brand": "United States Postal Service",
+        "brand_wikidata": "Q668687",
+        "extras": Categories.POST_OFFICE.value,
+    }
     allowed_domains = ["usps.com"]
 
     def start_requests(self):

--- a/locations/spiders/usps_collection_boxes.py
+++ b/locations/spiders/usps_collection_boxes.py
@@ -2,6 +2,7 @@ import json
 
 import scrapy
 
+from locations.categories import Categories
 from locations.geo import MILES_TO_KILOMETERS, vincenty_distance
 from locations.items import GeojsonPointItem
 
@@ -24,7 +25,11 @@ USPS_HEADERS = {
 
 class UspsCollectionBoxesSpider(scrapy.Spider):
     name = "usps_collection_boxes"
-    item_attributes = {"brand": "USPS", "brand_wikidata": "Q668687"}
+    item_attributes = {
+        "brand": "United States Postal Service",
+        "brand_wikidata": "Q668687",
+        "extras": Categories.POST_BOX.value,
+    }
     allowed_domains = ["usps.com"]
     download_delay = 0.1
 

--- a/tests/test_pipeline_nsi_categories.py
+++ b/tests/test_pipeline_nsi_categories.py
@@ -1,0 +1,101 @@
+from scrapy.crawler import Crawler
+
+from locations.categories import Categories, apply_category, get_category_tags
+from locations.items import GeojsonPointItem
+from locations.pipelines import ApplyNSICategoriesPipeline
+from locations.spiders.greggs_gb import GreggsGBSpider
+
+
+def get_objects():
+    class Spider(object):
+        pass
+
+    spider = Spider()
+    spider.crawler = Crawler(GreggsGBSpider)
+    return GeojsonPointItem(), ApplyNSICategoriesPipeline(), spider
+
+
+def test_no_categories():
+    item, pipeline, _ = get_objects()
+
+    assert get_category_tags(item) == None
+
+
+def test_categories_apply():
+    item, pipeline, _ = get_objects()
+    apply_category(Categories.BUS_STOP, item)
+
+    assert item["extras"]["highway"] == "bus_stop"
+    assert item["extras"]["public_transport"] == "platform"
+
+
+def test_categories_extract():
+    item, pipeline, _ = get_objects()
+    apply_category(Categories.BUS_STOP, item)
+
+    assert get_category_tags(item) == Categories.BUS_STOP.value
+    assert get_category_tags(Categories.BUS_STOP) == Categories.BUS_STOP.value
+    assert get_category_tags(Categories.BUS_STOP.value) == Categories.BUS_STOP.value
+
+
+def test_categories_filter():
+    item, pipeline, _ = get_objects()
+    apply_category(Categories.BUS_STOP, item)
+
+    filtered = pipeline.filter_categories(
+        [
+            {
+                "displayName": "test",
+                "id": "test_bus_stop",
+                "locationSet": {"include": ["001"]},
+                "tags": {
+                    "highway": "bus_stop",
+                    "public_transport": "platform",
+                },
+            },
+            {
+                "displayName": "test",
+                "id": "test_bus_stop",
+                "locationSet": {"include": ["001"]},
+                "tags": {
+                    "highway": "bus_station",
+                    "public_transport": "station",
+                },
+            },
+        ],
+        item["extras"],
+    )
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "test_bus_stop"
+
+
+def test_cc_filter():
+    _, pipeline, _ = get_objects()
+    matches = [
+        {
+            "displayName": "test",
+            "id": "test_us",
+            "locationSet": {"include": ["US"]},
+            "tags": {
+                "highway": "bus_stop",
+                "public_transport": "platform",
+            },
+        },
+        {
+            "displayName": "test",
+            "id": "test_global",
+            "locationSet": {"include": ["001"]},
+            "tags": {
+                "highway": "bus_station",
+                "public_transport": "station",
+            },
+        },
+    ]
+
+    filtered = pipeline.filter_cc(matches, "US")
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "test_us"
+
+    filtered = pipeline.filter_cc(matches, "GB")
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "test_global"


### PR DESCRIPTION
Bank of Scotland is a perfect example of how this can help, the pipeline doesn't know which [NSI entry](https://nsi.guide/?t=brands&tt=Q627381) to pick, but we know when making the spider it's banks, not ATMs.

With #4213 we now look through NSI entries with `operator:wikidata`, this unfortunately made some of the matching worse, Lidl now matches against a [supermarket](https://nsi.guide/?t=brands&tt=Q151954), and [car chargers](https://nsi.guide/index.html?t=operators&tt=Q151954). Instead of rethinking ATP and operators, I'm kicking the can and categorising them as supermarkets in the spiders.

However it also helped us as we can now match against operators like [USPS](https://nsi.guide/index.html?t=operators&tt=Q668687) for free.