### PR TITLE
Update spider-pr to use actions/cache@v3

### DIFF
--- a/.github/workflows/spider-pr.yaml
+++ b/.github/workflows/spider-pr.yaml
@@ -23,12 +23,11 @@ jobs:
     - name: Install pipenv
       run: |
         pip --quiet install pipenv
-    - uses: actions/cache@v2
+    # https://github.com/actions/cache/blob/main/examples.md#python---pipenv
+    - uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        path: ~/.local/share/virtualenvs
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies
       run: |
         pipenv --bare install --system --deploy


### PR DESCRIPTION
See https://github.com/alltheplaces/alltheplaces/issues/4269 for the problem this is trying to fix. To test this change, probably the easiest way will be to merge this PR, then send a dummy PR on a spider, and check if the caching works as expected without generating warnings.