### PR TITLE
Fix Deichmann Spider

### DIFF
--- a/locations/spiders/deichmann.py
+++ b/locations/spiders/deichmann.py
@@ -1,66 +1,41 @@
-import json
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.items import GeojsonPointItem
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class DeichmannSpider(scrapy.Spider):
+class DeichmannSpider(SitemapSpider, StructuredDataSpider):
     name = "deichmann"
-    item_attributes = {"brand": "Deichmann", "brand_wikidata": "Q664543"}
-    allowed_domains = ["stores.deichmann.com", "stores.dosenbach.ch"]
-    start_urls = ("https://stores.deichmann.com/index.html",)
+    DEICHMANN = {"brand": "Deichmann", "brand_wikidata": "Q664543"}
+    DOSENBACH = {"brand": "Dosenbach", "brand_wikidata": "Q2677329"}
+    item_attributes = DEICHMANN
+    sitemap_urls = [
+        "https://stores.deichmann.com/sitemap.xml",
+        "https://stores.dosenbach.ch/sitemap.xml",
+    ]
+    sitemap_rules = [
+        (
+            r"https://stores\.dosenbach\.ch/[-\w]+/[-\w]+/[-\w]+\.html",
+            "parse_sd",
+        ),  # CH
+        (
+            r"https://stores\.deichmann\.com/[-\w]+/[-\w]+/[-\w]+\.html",
+            "parse_sd",
+        ),  # DE
+        (
+            r"https://stores\.deichmann\.com/\w\w-\w\w/[-\w]+/[-\w]+/[-\w]+\.html",
+            "parse_sd",
+        ),  # All the others
+    ]
+    wanted_types = ["ShoeStore"]
 
-    def parse(self, response):
-        # base url of all countries
-        countries = response.xpath(
-            '//ul[@class="countrydropdown"]/li/a/@href'
-        ).extract()
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            # Filter out excessive matches
+            if not entry["loc"].endswith("index.html"):
+                yield entry
 
-        for country in countries:
-            yield scrapy.Request(country, callback=self.parse_country)
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "dosenbach.ch" in response.url:
+            item.update(self.DOSENBACH)
 
-    def parse_country(self, response):
-        # parse country per region
-        cities = response.xpath('//a[@class="region-list__link"]/@href').extract()
-
-        for city in cities:
-            yield scrapy.Request(response.urljoin(city), callback=self.parse_city)
-
-    def parse_city(self, response):
-        # parse cities in region
-        stores = response.xpath('//a[@class="button-link"]/@href').extract()
-
-        for store in stores:
-            yield scrapy.Request(response.urljoin(store), callback=self.parse_locations)
-
-    def parse_locations(self, response):
-        # get json which provides all data
-        data = response.xpath(
-            '//script[@type="application/ld+json"]/text()'
-        ).extract_first()
-
-        try:
-            if data:
-                data = json.loads(data)
-
-                geo_data = data.get("geo", {})
-                address_data = data.get("address", {})
-                contact_data = data.get("ContactPoint", {})
-
-                properties = {
-                    "ref": data.get("@id", None),
-                    "name": data.get("name", None),
-                    "lat": geo_data.get("latitude", None),
-                    "lon": geo_data.get("longitude", None),
-                    "phone": contact_data[0].get("telephone", None),
-                    "addr_full": address_data.get("streetAddress", None),
-                    "country": address_data.get("addressCountry", None),
-                    "postcode": address_data.get("postalCode", None),
-                    "city": address_data.get("addressLocality", None),
-                    "opening_hours": data.get("openingHours", None),
-                }
-
-                yield GeojsonPointItem(**properties)
-        except Exception as e:
-            self.logger.warn("----------------- Error -----------------: {}".format(e))
+        yield item


### PR DESCRIPTION
```python
{'atp/field/brand_wikidata/missing': 2799,
 'atp/field/lat/invalid': 1,
 'atp/field/lon/invalid': 2,
 'atp/field/opening_hours/invalid': 3,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 7,
 'atp/field/state/missing': 2799,
 'atp/field/twitter/missing': 2799,
 'downloader/request_bytes': 1126498,
 'downloader/request_count': 2803,
 'downloader/request_method_count/GET': 2803,
 'downloader/response_bytes': 31939535,
 'downloader/response_count': 2803,
 'downloader/response_status_count/200': 2801,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 40.609692,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2022, 12, 5, 16, 21, 2, 172588),
 'httpcache/hit': 2803,
 'httpcompression/response_bytes': 362757521,
 'httpcompression/response_count': 2803,
 'item_scraped_count': 2799,
 'log_count/DEBUG': 5714,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 134062080,
 'memusage/startup': 134062080,
 'request_depth_max': 1,
 'response_received_count': 2803,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 2801,
 'scheduler/dequeued/memory': 2801,
 'scheduler/enqueued': 2801,
 'scheduler/enqueued/memory': 2801,
 'start_time': datetime.datetime(2022, 12, 5, 16, 20, 21, 562896)}
```