### PR TITLE
Improve Nationwide spider

### DIFF
--- a/locations/spiders/nationwide_gb.py
+++ b/locations/spiders/nationwide_gb.py
@@ -1,12 +1,17 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class NationwideGB(CrawlSpider, StructuredDataSpider):
     name = "nationwide_gb"
-    item_attributes = {"brand": "Nationwide", "brand_wikidata": "Q846735"}
+    item_attributes = {
+        "brand": "Nationwide",
+        "brand_wikidata": "Q846735",
+        "extras": Categories.BANK.value,
+    }
     start_urls = ["https://www.nationwide.co.uk/branches/index.html"]
     rules = [Rule(LinkExtractor(allow=r"/branches/"), callback="parse_sd", follow=True)]
 

--- a/locations/spiders/nationwide_gb.py
+++ b/locations/spiders/nationwide_gb.py
@@ -8,17 +8,8 @@ class NationwideGB(CrawlSpider, StructuredDataSpider):
     name = "nationwide_gb"
     item_attributes = {"brand": "Nationwide", "brand_wikidata": "Q846735"}
     start_urls = ["https://www.nationwide.co.uk/branches/index.html"]
-    rules = [
-        Rule(
-            LinkExtractor(
-                allow=r"https:\/\/www\.nationwide\.co\.uk\/branches\/[-()\w]+\/[-\w]+$"
-            ),
-            callback="parse_sd",
-        ),
-        Rule(
-            LinkExtractor(
-                allow=r"https:\/\/www\.nationwide\.co\.uk\/branches\/[-()\w]+$"
-            )
-        ),
-    ]
-    wanted_types = ["BankOrCreditUnion"]
+    rules = [Rule(LinkExtractor(allow=r"/branches/"), callback="parse_sd", follow=True)]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "permanently closed" not in item["name"].lower():
+            yield item


### PR DESCRIPTION
Fixes #4283
Kinda fixes #4282

```python
{'atp/field/email/missing': 607,
 'atp/field/lon/invalid': 4,
 'atp/field/opening_hours/missing': 3,
 'atp/field/state/missing': 607,
 'atp/field/twitter/missing': 607,
 'atp/nsi/category_match': 607,
 'downloader/request_bytes': 473888,
 'downloader/request_count': 1202,
 'downloader/request_method_count/GET': 1202,
 'downloader/response_bytes': 36243710,
 'downloader/response_count': 1202,
 'downloader/response_status_count/200': 1202,
 'dupefilter/filtered': 7873,
 'elapsed_time_seconds': 42.093066,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2022, 12, 6, 18, 29, 38, 807869),
 'httpcache/hit': 1202,
 'httpcompression/response_bytes': 235722408,
 'httpcompression/response_count': 1201,
 'item_scraped_count': 607,
 'log_count/DEBUG': 1820,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 120160256,
 'memusage/startup': 120160256,
 'request_depth_max': 7,
 'response_received_count': 1202,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1201,
 'scheduler/dequeued/memory': 1201,
 'scheduler/enqueued': 1201,
 'scheduler/enqueued/memory': 1201,
 'start_time': datetime.datetime(2022, 12, 6, 18, 28, 56, 714803)}
```