### PR TITLE
Add Joules Spider

### DIFF
--- a/locations/spiders/joules.py
+++ b/locations/spiders/joules.py
@@ -1,0 +1,14 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class JoulesSpider(SitemapSpider, StructuredDataSpider):
+    name = "joules"
+    item_attributes = {"brand": "Joules", "brand_wikidata": "Q25351738"}
+    sitemap_urls = ["https://www.joules.com/sitemap.xml"]
+    sitemap_follow = ["Store-en-GBP"]
+    sitemap_rules = [("/store-locator/store/", "parse_sd")]
+
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data["url"] = None


### PR DESCRIPTION
```python
{'atp/field/city/missing': 82,
 'atp/field/country/from_reverse_geocoding': 133,
 'atp/field/email/missing': 133,
 'atp/field/image/missing': 33,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 133,
 'atp/nsi/perfect_match': 133,
 'downloader/request_bytes': 164929,
 'downloader/request_count': 171,
 'downloader/request_method_count/GET': 171,
 'downloader/response_bytes': 7886121,
 'downloader/response_count': 171,
 'downloader/response_status_count/200': 136,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 34,
 'dupefilter/filtered': 7,
 'elapsed_time_seconds': 9.800239,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2022, 12, 8, 16, 36, 10, 297169),
 'httpcache/hit': 171,
 'httpcompression/response_bytes': 47279144,
 'httpcompression/response_count': 136,
 'httperror/response_ignored_count': 34,
 'httperror/response_ignored_status_count/404': 34,
 'item_scraped_count': 133,
 'log_count/DEBUG': 315,
 'log_count/INFO': 43,
 'log_count/WARNING': 1,
 'memusage/max': 128315392,
 'memusage/startup': 128315392,
 'request_depth_max': 2,
 'response_received_count': 170,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 169,
 'scheduler/dequeued/memory': 169,
 'scheduler/enqueued': 169,
 'scheduler/enqueued/memory': 169,
 'start_time': datetime.datetime(2022, 12, 8, 16, 36, 0, 496930)}
```