### PR TITLE
Fix ApplyNSICategoriesPipeline crash

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -8,6 +8,7 @@ class Categories(Enum):
     BUS_STOP = {"highway": "bus_stop", "public_transport": "platform"}
     BUS_STATION = {"amenity": "bus_station", "public_transport": "station"}
 
+    SHOP_CLOTHES = {"shop": "clothes"}
     SHOP_BOOKS = {"shop": "books"}
     SHOP_CONVENIENCE = {"shop": "convenience"}
     SHOP_SUPERMARKET = {"shop": "supermarket"}

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -289,6 +289,8 @@ class ApplyNSICategoriesPipeline:
                 continue
 
             include = match["locationSet"].get("include", [])
+            # Ignore non string such as: {"include":[[-122.835,45.5,2]]}
+            include = filter(lambda i: isinstance(i, str), include)
             # "gb-eng" -> "gb"
             include = [i.split("-")[0] for i in include]
             if cc in include:

--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -2,13 +2,14 @@ import datetime
 
 import scrapy
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
 class NikeSpider(scrapy.Spider):
     name = "nike"
-    item_attributes = {"brand": "Nike", "brand_wikidata": "Q483915"}
+    item_attributes = {"brand": "Nike", "brand_wikidata": "Q483915", "extras": Categories.SHOP_CLOTHES.value}
     start_urls = ["https://storeviews-cdn.risedomain-prod.nikecloud.com/store-locations-static.json"]
 
     def parse(self, response):

--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -15,7 +15,6 @@ class NikeSpider(scrapy.Spider):
     def parse(self, response):
         all_stores = response.json()["stores"]
         for store in all_stores.values():
-            store.update(store.get("coordinates"))
             item = DictParser.parse(store)
 
             days = DictParser.get_nested_key(store, "regularHours")
@@ -47,5 +46,13 @@ class NikeSpider(scrapy.Spider):
             item["opening_hours"] = opening_hours.as_opening_hours()
             item["website"] = "https://www.nike.com/retail/s/" + store["slug"]
             item["image"] = store["imageURL"]
-            item["extras"] = {"store_type": store.get("facilityType")}
+            item["extras"] = {"owner:type": store["facilityType"]}
+            if store["businessConcept"] == "FACTORY":
+                item["brand"] = "Nike Factory Store"
+            elif store["businessConcept"] == "CLEARANCE":
+                item["brand"] = "Nike Clearance Store"
+            elif store["businessConcept"] == "COMMUNITY":
+                item["brand"] = "Nike Community Store"
+            else:
+                item["extras"]["type"] = store["businessConcept"]
             yield item


### PR DESCRIPTION
My change last week crashes when `include` isn't a string array. Nike was the only spider effected.