### PR TITLE
Let setup-python do pipenv caching

### DIFF
--- a/.github/workflows/spider-pr.yaml
+++ b/.github/workflows/spider-pr.yaml
@@ -16,18 +16,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@master
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
+        cache: 'pipenv'
     - name: Install pipenv
       run: |
         pip --quiet install pipenv
-    # https://github.com/actions/cache/blob/main/examples.md#python---pipenv
-    - uses: actions/cache@v3
-      with:
-        path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies
       run: |
         pipenv --bare install --system --deploy


### PR DESCRIPTION
Don't use the `actions/cache` workflow, let `actions/setup-python` do it.