### PR TITLE
Fix WHSmith Spider

### DIFF
--- a/locations/spiders/whsmith_gb.py
+++ b/locations/spiders/whsmith_gb.py
@@ -25,6 +25,8 @@ class WHSmithGBSpider(scrapy.Spider):
 
             item = DictParser.parse(store)
 
+            item["city"] = item["city"].strip()
+
             item["street_address"] = ", ".join(filter(None, [store.get("address1"), store.get("address2")]))
 
             oh = OpeningHours()

--- a/locations/spiders/whsmith_gb.py
+++ b/locations/spiders/whsmith_gb.py
@@ -5,13 +5,9 @@ from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 
 
-class WHSmithGB(scrapy.Spider):
-    name = "whsmith_uk"
-    item_attributes = {
-        "brand": "WHSmith",
-        "brand_wikidata": "Q1548712",
-        "extras": Categories.SHOP_NEWSAGENT.value,
-    }
+class WHSmithGBSpider(scrapy.Spider):
+    name = "whsmith_gb"
+    item_attributes = {"brand": "WHSmith", "brand_wikidata": "Q1548712", "extras": Categories.SHOP_NEWSAGENT.value}
     allowed_domains = ["whsmith.co.uk"]
     start_urls = [
         "https://www.whsmith.co.uk/mobify/proxy/api/s/whsmith/dw/shop/v21_3/stores?latitude=57.28687230000001&longitude=-2.3815684&distance_unit=mi&max_distance=20000&count=200"
@@ -36,7 +32,7 @@ class WHSmithGB(scrapy.Spider):
                 if not store.get("c_openingTimes" + day):
                     continue
 
-                if store["c_openingTimes" + day].lower() == "closed":
+                if "closed" in store["c_openingTimes" + day].lower():
                     continue
 
                 start_time, end_time = store["c_openingTimes" + day].split("-")
@@ -44,6 +40,10 @@ class WHSmithGB(scrapy.Spider):
                     start_time = "00:00"
                 if end_time == "24hr":
                     end_time = "24:00"
+                if ":" not in start_time:
+                    start_time += ":00"
+                if ":" not in end_time:
+                    end_time += ":00"
                 oh.add_range(day, start_time, end_time)
 
             item["opening_hours"] = oh.as_opening_hours()


### PR DESCRIPTION
```python
{'atp/category/shop/newsagent': 760,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 760,
 'atp/field/image/missing': 760,
 'atp/field/lon/invalid': 7,
 'atp/field/opening_hours/missing': 28,
 'atp/field/phone/invalid': 2,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 760,
 'atp/nsi/category_match': 760,
 'downloader/request_bytes': 2631,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 70629,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 2.990674,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 3, 15, 26, 19, 268701),
 'httpcache/hit': 6,
 'httpcompression/response_bytes': 632793,
 'httpcompression/response_count': 5,
 'item_scraped_count': 760,
 'log_count/DEBUG': 772,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 137097216,
 'memusage/startup': 137097216,
 'request_depth_max': 3,
 'response_received_count': 6,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2023, 1, 3, 15, 26, 16, 278027)}
```