### PR TITLE
Always populate extras

### DIFF
--- a/locations/items.py
+++ b/locations/items.py
@@ -39,5 +39,10 @@ class GeojsonPointItem(scrapy.Item):
     nsi_id = scrapy.Field()
     extras = scrapy.Field()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self._values.get("extras"):
+            self.__setitem__("extras", {})
+
 
 Feature = GeojsonPointItem

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -12,6 +12,7 @@ from scrapy.exceptions import DropItem
 
 from locations.categories import get_category_tags
 from locations.country_utils import CountryUtils
+from locations.hours import OpeningHours
 from locations.name_suggestion_index import NSI
 
 
@@ -238,7 +239,9 @@ class CheckItemPropertiesPipeline:
             spider.crawler.stats.inc_value("atp/field/twitter/missing")
 
         if opening_hours := item.get("opening_hours"):
-            if not isinstance(opening_hours, str):
+            if isinstance(opening_hours, OpeningHours):
+                item["opening_hours"] = opening_hours.as_opening_hours()
+            elif not isinstance(opening_hours, str):
                 spider.crawler.stats.inc_value("atp/field/opening_hours/wrong_type")
             elif not self.opening_hours_regex.match(opening_hours) and opening_hours != "24/7":
                 spider.crawler.stats.inc_value("atp/field/opening_hours/invalid")


### PR DESCRIPTION
As mentioned in https://github.com/alltheplaces/alltheplaces/pull/4548#discussion_r1060390390 always having extras will make some things simpler, and remove us having to do the check every time.

I've also added a check in `CheckItemPropertiesPipeline` for `OpeningHours` and convert it the OSM string, and skipped the format check since the output of `as_opening_hours` should always be valid. I think we could prepopulate this too, like `extras`, but I've not checked to see if it'd backfire anywhere.