### PR TITLE
Fix Vue Spider

### DIFF
--- a/locations/google_url.py
+++ b/locations/google_url.py
@@ -14,6 +14,9 @@ def extract_google_position(item, response):
     for link in response.xpath("//a[contains(@href, 'google')][contains(@href, 'maps')]/@href").getall():
         item["lat"], item["lon"] = url_to_coords(link)
         return
+    for link in response.xpath("//a[contains(@href, 'maps.apple.com')]/@href").getall():
+        item["lat"], item["lon"] = url_to_coords(link)
+        return
 
 
 def url_to_coords(url: str) -> (float, float):  # noqa: C901
@@ -79,6 +82,11 @@ def url_to_coords(url: str) -> (float, float):  # noqa: C901
             daddr = daddr.split(",")
             if len(daddr) == 2:
                 return float(daddr[0]), float(daddr[1])
+    elif "maps.apple.com" in url:
+        for q in get_query_param(url, "q"):
+            coords = q.split(",")
+            if len(coords) == 2:
+                return float(coords[0]), float(coords[1])
 
     if "/maps.google.com/" in url:
         for ll in get_query_param(url, "ll"):

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -145,6 +145,12 @@ class ExtractGBPostcodePipeline:
                     postcode = re.search(r"(\w{1,2}\d{1,2}\w?) O(\w{2})", item["addr_full"].upper())
                     if postcode:
                         item["postcode"] = postcode.group(1) + " 0" + postcode.group(2)
+        elif item.get("country") == "IE":
+            if item.get("addr_full") and not item.get("postcode"):
+                if postcode := re.search(
+                    r"([AC-FHKNPRTV-Y][0-9]{2}|D6W)[ -]?([0-9AC-FHKNPRTV-Y]{4})", item["addr_full"].upper()
+                ):
+                    item["postcode"] = "{} {}".format(postcode.group(1), postcode.group(2))
 
         return item
 

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -215,6 +215,8 @@ class CheckItemPropertiesPipeline:
                 lat = None
                 spider.crawler.stats.inc_value("atp/field/lat/invalid")
             item["lat"] = lat
+        else:
+            spider.crawler.stats.inc_value("atp/field/lat/missing")
         if lon := item.get("lon"):
             try:
                 lon = float(lon)
@@ -226,6 +228,8 @@ class CheckItemPropertiesPipeline:
                 lon = None
                 spider.crawler.stats.inc_value("atp/field/lon/invalid")
             item["lon"] = lon
+        else:
+            spider.crawler.stats.inc_value("atp/field/lon/missing")
 
         if twitter := item.get("twitter"):
             if not isinstance(twitter, str):

--- a/locations/spiders/vue_cinemas.py
+++ b/locations/spiders/vue_cinemas.py
@@ -22,7 +22,7 @@ class VueCinemasSpider(SitemapSpider):
         address_parts = cinema.xpath('.//img[@alt="location-pin"]/../text()').getall()
         if not address_parts:
             address_parts = cinema.xpath(
-                f'.//div[contains(@data-page-url, "/getting-here")]/following-sibling::div//div[@class="container container--scroll"]/div/p/text()'
+                './/div[contains(@data-page-url, "/getting-here")]/following-sibling::div//div[@class="container container--scroll"]/div/p/text()'
             ).getall()
 
         item["addr_full"] = clean_address(address_parts)

--- a/locations/spiders/vue_cinemas.py
+++ b/locations/spiders/vue_cinemas.py
@@ -1,46 +1,32 @@
-from urllib import parse
+from scrapy.spiders import SitemapSpider
 
-import scrapy
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
 
-from locations.items import GeojsonPointItem
 
-
-class VueCinemasSpider(scrapy.Spider):
+class VueCinemasSpider(SitemapSpider):
     name = "vue_cinemas"
-    item_attributes = {"brand": "Vue Cinemas", "brand_wikidata": "Q2535134"}
-    start_urls = ("https://www.myvue.com/data/locations/",)
+    item_attributes = {"brand": "Vue", "brand_wikidata": "Q2535134"}
+    sitemap_urls = ["https://www.myvue.com/sitemap.xml"]
+    sitemap_rules = [(r"/getting-here$", "parse")]
 
-    def parse(self, response):
-        data = response.json()
-        for letter in data["venues"]:
-            for cinema in letter["cinemas"]:
-                yield response.follow(
-                    f"https://www.myvue.com/cinema/{cinema['link_name']}/getting-here",
-                    self.parse_cinema,
-                )
+    def parse(self, response, **kwargs):
+        item = Feature()
+        item["ref"] = response.xpath("//@data-selected-locationid").get()
+        item["name"] = response.xpath("//@data-selected-locationname").get()
+        item["website"] = response.url.replace("/getting-here", "")
 
-    def parse_cinema(self, response):
-        cinema_name = response.xpath('//h2[@class="article-title gradient-fill"]/text()').extract_first()
+        cinema = response.xpath('//div[@data-scroll-id="cinema-details"]')
 
-        address_parts = response.xpath('//img[@alt="location-pin"]/../text()').extract()
+        address_parts = cinema.xpath('.//img[@alt="location-pin"]/../text()').getall()
         if not address_parts:
-            address_parts = response.xpath(
-                f'//div[@class="collapse__heading" and @data-page-url="{parse.urlparse(response.url).path}"]/following-sibling::div//div[@class="container container--scroll"]/div/p/text()'
-            ).extract()
-        address_parts = [a.strip() for a in address_parts if a.strip()]
+            address_parts = cinema.xpath(
+                f'.//div[contains(@data-page-url, "/getting-here")]/following-sibling::div//div[@class="container container--scroll"]/div/p/text()'
+            ).getall()
 
-        maps_link = response.xpath('//a[text()="Get directions"]/@href').extract_first()
-        query_string = parse.urlparse(maps_link).query
-        query_dict = parse.parse_qs(query_string)
-        coords = query_dict["q"][0].split(",")
+        item["addr_full"] = clean_address(address_parts)
 
-        properties = {
-            "ref": response.url.split("/")[4],
-            "name": cinema_name,
-            "addr_full": ", ".join(address_parts),
-            "postcode": address_parts[-1],
-            "lat": float(coords[0]),
-            "lon": float(coords[1]),
-            "website": response.url.replace("/getting-here", ""),
-        }
-        yield GeojsonPointItem(**properties)
+        extract_google_position(item, cinema)
+
+        yield item

--- a/tests/test_google_url.py
+++ b/tests/test_google_url.py
@@ -84,3 +84,8 @@ def test_search():
         55.0046686,
         -1.6200268,
     )
+
+
+def test_apple_maps():
+    assert url_to_coords("http://maps.apple.com/?q=53.26471,-2.88613") == (53.26471, -2.88613)
+    assert url_to_coords("https://maps.apple.com/?q=53.26471,-2.88613") == (53.26471, -2.88613)

--- a/tests/test_pipeline_extract_gb_postcode.py
+++ b/tests/test_pipeline_extract_gb_postcode.py
@@ -22,3 +22,14 @@ def test_badformat_o():
     pl.process_item(item, None)
 
     assert item["postcode"] == "HU17 0XL"
+
+
+def test_ie():
+    item = Feature()
+    item["country"] = "IE"
+    item["addr_full"] = "7-9 Ennis Road Retail Park, Ennis Road, Limerick, V94 K240"
+
+    pl = ExtractGBPostcodePipeline()
+    pl.process_item(item, None)
+
+    assert item["postcode"] == "V94 K240"


### PR DESCRIPTION
```python
{'atp/category/amenity/cinema': 91,
 'atp/field/city/missing': 91,
 'atp/field/country/from_reverse_geocoding': 90,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 91,
 'atp/field/image/missing': 91,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 91,
 'atp/field/phone/missing': 91,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 91,
 'atp/field/street_address/missing': 91,
 'atp/field/twitter/missing': 91,
 'atp/nsi/perfect_match': 91,
 'downloader/request_bytes': 93473,
 'downloader/request_count': 93,
 'downloader/request_method_count/GET': 93,
 'downloader/response_bytes': 1704503,
 'downloader/response_count': 93,
 'downloader/response_status_count/200': 93,
 'elapsed_time_seconds': 2.576302,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 4, 12, 30, 49, 730417),
 'httpcache/hit': 93,
 'httpcompression/response_bytes': 8453696,
 'httpcompression/response_count': 93,
 'item_scraped_count': 91,
 'log_count/DEBUG': 195,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 137175040,
 'memusage/startup': 137175040,
 'request_depth_max': 1,
 'response_received_count': 93,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 92,
 'scheduler/dequeued/memory': 92,
 'scheduler/enqueued': 92,
 'scheduler/enqueued/memory': 92,
 'start_time': datetime.datetime(2023, 1, 4, 12, 30, 47, 154115)}
```

I assume `atp/field/lat/missing` and `atp/field/lon/missing` were removed by mistake in #4309? I've re added them.