### PR TITLE
Implement addr:suburb for Australian addresses

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -31,6 +31,7 @@ Each GeoJSON feature will have a `properties` object with the following keys:
 | `addr:housenumber`    | No  | The house number part of the address.
 | `addr:street`         | No  | The street name.
 | `addr:street_address` | No  | The street address, including street name and house number and/or name.
+| `addr:suburb`         | No  | The suburb part of the address.
 | `addr:city`           | No  | The city part of the address.
 | `addr:state`          | No  | The state or province part of the address.
 | `addr:postcode`       | No  | The postcode part of the address.

--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -17,6 +17,10 @@ class DictParser:
         "address-line-one",
     ]
 
+    suburb_keys = [
+        "suburb",
+    ]
+
     city_keys = [
         "address-locality",
         "city",
@@ -108,6 +112,7 @@ class DictParser:
         item["housenumber"] = DictParser.get_first_key(address, DictParser.house_number_keys)
         item["street"] = DictParser.get_first_key(address, ["street", "streetName"])
         item["street_address"] = DictParser.get_first_key(address, DictParser.street_address_keys)
+        item["suburb"] = DictParser.get_first_key(address, DictParser.suburb_keys)
         item["city"] = DictParser.get_first_key(address, DictParser.city_keys)
         item["state"] = DictParser.get_first_key(address, DictParser.region_keys)
         item["postcode"] = DictParser.get_first_key(address, DictParser.postcode_keys)

--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -17,6 +17,7 @@ mapping = (
     ("housenumber", "addr:housenumber"),
     ("street", "addr:street"),
     ("street_address", "addr:street_address"),
+    ("suburb", "addr:suburb"),
     ("city", "addr:city"),
     ("state", "addr:state"),
     ("postcode", "addr:postcode"),

--- a/locations/items.py
+++ b/locations/items.py
@@ -15,6 +15,7 @@ class Feature(scrapy.Item):
     housenumber = scrapy.Field()
     street = scrapy.Field()
     street_address = scrapy.Field()
+    suburb = scrapy.Field()
     city = scrapy.Field()
     state = scrapy.Field()
     postcode = scrapy.Field()

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -102,6 +102,13 @@ class LinkedDataParser:
                     # Common mistake to put "telephone" in "address"
                     item["phone"] = LinkedDataParser.get_clean(addr, "telephone")
 
+        # Australia uses addr:suburb not addr:city
+        # Refer to https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Australian_features#Addresses
+        # Refer to https://en.wikipedia.org/wiki/Suburbs_and_localities_(Australia)
+        if "country" in item and "city" in item:
+            if item["country"] in {"AU", "Australia"}:
+                item["suburb"] = item.pop("city")
+
         if item.get("phone") is None:
             item["phone"] = LinkedDataParser.get_clean(ld, "telephone")
 

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -209,6 +209,7 @@ class CheckItemPropertiesPipeline:
         check_field(item, spider, "email", (str,), self.email_regex)
         check_field(item, spider, "phone", (str,))
         check_field(item, spider, "street_address", (str,))
+        check_field(item, spider, "suburb", (str,))
         check_field(item, spider, "city", (str,))
         check_field(item, spider, "state", (str,))
         check_field(item, spider, "postcode", (str,))

--- a/locations/spiders/calvin_klein_au.py
+++ b/locations/spiders/calvin_klein_au.py
@@ -22,7 +22,7 @@ class CalvinKleinAUSpider(Spider):
             item["name"] = location["n"]
             item["addr_full"] = clean_address(location.get("a"))
             item["street_address"] = location["a"][0]
-            item["city"] = location["a"][1]
+            item["suburb"] = location["a"][1]
             item["state"] = location["a"][2]
             item["postcode"] = location["a"][3]
             item["website"] = f'https://www.calvinklein.com.au{location["u"]}'

--- a/locations/spiders/coles_au.py
+++ b/locations/spiders/coles_au.py
@@ -33,7 +33,7 @@ class ColesAUSpider(scrapy.Spider):
                 "ref": i["storeId"],
                 "name": i["brandName"],
                 "addr_full": i["address"],
-                "city": i["suburb"],
+                "suburb": i["suburb"],
                 "state": i["state"],
                 "postcode": i["postcode"],
                 "country": "AU",

--- a/locations/spiders/hungryjacks.py
+++ b/locations/spiders/hungryjacks.py
@@ -19,7 +19,7 @@ class HungryJacksSpider(scrapy.Spider):
                 "ref": i["store_id"],
                 "name": i["name"],
                 "addr_full": i["location"]["address"],
-                "city": i["location"]["suburb"],
+                "suburb": i["location"]["suburb"],
                 "state": i["location"]["state"],
                 "postcode": i["location"]["postcode"],
                 "country": "AU",

--- a/locations/spiders/jbhifi.py
+++ b/locations/spiders/jbhifi.py
@@ -45,7 +45,7 @@ class JbHifiSpider(scrapy.Spider):
                         ],
                     )
                 ),
-                "city": store["storeAddress"]["Suburb"],
+                "suburb": store["storeAddress"]["Suburb"],
                 "state": store["storeAddress"]["State"],
                 "postcode": store["storeAddress"]["Postcode"],
                 "country": "AU",

--- a/locations/spiders/redrooster.py
+++ b/locations/spiders/redrooster.py
@@ -18,7 +18,7 @@ class RedRoosterSpider(scrapy.Spider):
                 "ref": i["storeNumber"],
                 "name": i["title"],
                 "street_address": i["address"],
-                "city": i["suburb"],
+                "suburb": i["suburb"],
                 "state": i.get("state"),
                 "postcode": i["postcode"],
                 "country": "AU",

--- a/locations/spiders/target_au.py
+++ b/locations/spiders/target_au.py
@@ -38,7 +38,7 @@ class TargetAUSpider(scrapy.Spider):
                 "addr_full": " ".join(
                     s.strip() for s in body.xpath('//*[@itemprop="streetAddress"]//text()').extract()
                 ),
-                "city": body.xpath('//*[@itemprop="addressLocality"]/text()').get(),
+                "suburb": body.xpath('//*[@itemprop="addressLocality"]/text()').get(),
                 "state": body.xpath('//*[@itemprop="addressRegion"]/text()').get(),
                 "postcode": body.xpath('//*[@itemprop="postalCode"]/text()').get(),
                 "phone": body.xpath("//p[last()-1]/text()").get(),

--- a/locations/spiders/woolworths_au.py
+++ b/locations/spiders/woolworths_au.py
@@ -21,13 +21,13 @@ class WoolworthsAUSpider(scrapy.Spider):
 
             i["street_address"] = ", ".join(filter(None, [i["AddressLine1"], i["AddressLine2"]]))
             i["ref"] = i.pop("StoreNo")
-            i["city"] = i.pop("Suburb")
+            i["suburb"] = i.pop("Suburb")
 
             item = DictParser.parse(i)
 
             item["website"] = (
                 "https://www.woolworths.com.au/shop/storelocator/"
-                + "-".join([item["state"], item["city"], item["ref"], i["Division"]]).lower()
+                + "-".join([item["state"], item["suburb"], item["ref"], i["Division"]]).lower()
             )
 
             # TODO: types needs some work, NSI seems out of date too


### PR DESCRIPTION
Refer to https://en.wikipedia.org/wiki/Suburbs_and_localities_(Australia) for a description of how places in Australia have a "Suburb" subdivision below "City".
    
For example, in the state of Victoria (1st level), a town named Omeo (2nd level) exists. There are no suburbs of Omeo.
    
For example, in the state of Victoria (1st level), a city named Melbourne (2nd level) exists. Within Melbourne, a suburb named Carlton (3rd level) exists.
    
From the description of https://schema.org/addressLocality and Australian tagging guidelines at https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Australian_features#Addresses it is more likely that addr:suburb would be the corresponding OpenStreetMap key for addressLocality.
    
Per Australian tagging guidelines at https://wiki.openstreetmap.org/wiki/Australian_Tagging_Guidelines/Australian_features#Addresses, addr:city is not used within Australia. iD editor does not ask users to enter addr:city but rather asks users to enter addr:suburb for Australian addresses.