### PR TITLE
Fix Dunelm spider crash (closes #4632)

### DIFF
--- a/locations/spiders/dunelm_gb.py
+++ b/locations/spiders/dunelm_gb.py
@@ -37,7 +37,6 @@ class DunelmGB(Spider):
 
             item["opening_hours"] = oh.as_opening_hours()
 
-            item["email"] = store["email"]
             item["extras"] = {"storeType": store.get("storeType")}
 
             yield item


### PR DESCRIPTION
Missing email address in source data causes store["email"] to give an error. Email addresses already captured by DictParser.parse(store) so we can remove that line anyway.