### PR TITLE
Add RSG Spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -18,6 +18,8 @@ class Categories(Enum):
     BUS_STOP = {"highway": "bus_stop", "public_transport": "platform"}
     BUS_STATION = {"amenity": "bus_station", "public_transport": "station"}
 
+    GYM = {"leisure": "fitness_centre"}
+
     HIGHWAY_RESIDENTIAL = {"highway": "residential"}
 
     SHOP_ALCOHOL = {"shop": "alcohol"}

--- a/locations/spiders/goldsgym.py
+++ b/locations/spiders/goldsgym.py
@@ -1,83 +1,15 @@
-import json
-import re
-from urllib.parse import urlparse
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-from scrapy.selector import Selector
-
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class GoldsGymSpider(scrapy.Spider):
+class GoldsGymSpider(SitemapSpider, StructuredDataSpider):
     name = "goldsgym"
     item_attributes = {"brand": "Gold's Gym", "brand_wikidata": "Q1536234"}
-    allowed_domains = ["goldsgym.com"]
+    sitemap_urls = ["https://www.goldsgym.com/gym_index-sitemap.xml"]
+    wanted_types = ["ExerciseGym"]
 
-    start_urls = [
-        "https://www.goldsgym.com/gym_index-sitemap.xml",
-    ]
-
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        for group in hours:
-            days, open_time, close_time = re.search(r"([a-zA-Z,]+)\s([\d:]+)-([\d:]+)", group).groups()
-            days = days.split(",")
-            for day in days:
-                opening_hours.add_range(
-                    day=day,
-                    open_time=open_time,
-                    close_time=close_time,
-                    time_format="%H:%M",
-                )
-
-        return opening_hours.as_opening_hours()
-
-    def parse_hotel(self, response):
-        if "locate-a-gym" in response.url or "/markets/" in response.url:
-            return  # closed gym, redirects
-
-        data = response.xpath('//script[@type="application/ld+json"]/text()').extract_first()
-        if data:
-            data = json.loads(data)
-        else:
-            return  # closed gym
-
-        if data.get("@graph"):
-            found = False
-            for obj in data["@graph"]:
-                if obj["@type"] == "ExerciseGym":
-                    data = obj
-                    found = True
-                    break
-            if not found:
-                return
-
-        properties = {
-            "ref": "_".join([x for x in response.url.split("/")[-2:] if x]),
-            "name": data["name"],
-            "addr_full": data["address"]["streetAddress"].strip(),
-            "city": data["address"]["addressLocality"].strip(),
-            "state": data["address"]["addressRegion"],
-            "postcode": data["address"]["postalCode"],
-            "country": data["address"]["addressCountry"],
-            "phone": data.get("telephone", None),
-            "lat": float(data["geo"]["latitude"]),
-            "lon": float(data["geo"]["longitude"]),
-            "website": response.url,
-        }
-
-        hours = self.parse_hours(data["openingHours"])
-        if hours:
-            properties["opening_hours"] = hours
-
-        yield Feature(**properties)
-
-    def parse(self, response):
-        xml = Selector(response)
-        xml.remove_namespaces()
-
-        urls = xml.xpath("//loc/text()").extract()
-        for url in urls:
-            path = "/".join(urlparse(url).path.split("/")[:-1])
-            yield scrapy.Request(response.urljoin(path) + "/", callback=self.parse_hotel)
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            entry["loc"] = entry["loc"].replace("sitemap_index.xml", "")
+            yield entry

--- a/locations/spiders/rsg_group.py
+++ b/locations/spiders/rsg_group.py
@@ -1,0 +1,36 @@
+from locations.categories import Categories
+from locations.storefinders.woosmap import WoosmapSpider
+
+
+class RSGGroupSpider(WoosmapSpider):
+    name = "rsg_group"
+    key = "woos-3cb8caa3-ad4d-3e7b-b7d6-221a7b72398d&stores_by_page=300"
+    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.mcfit.com"}}
+    item_attributes = {"extras": Categories.GYM.value}
+
+    JOHN_REED = {"brand": "JOHN REED Fitness", "brand_wikidata": "Q106434148"}
+    MC_FIT = {"brand": "McFit", "brand_wikidata": "Q871302"}
+    HIGH_5 = {"brand": "High5", "brand_wikidata": "Q116183459"}
+
+    BRANDS = {
+        "JR": JOHN_REED,
+        "JOHN REED Fitness": JOHN_REED,
+        "McFIT": MC_FIT,
+        "Palestra McFIT": MC_FIT,
+        "H5": HIGH_5,
+    }
+
+    def parse_item(self, item, feature, **kwargs):
+        if feature["properties"]["user_properties"].get("closed", False):
+            return
+        if item["ref"] == "5814289014024709637":
+            return  # Head Office
+
+        brand_id = feature["properties"]["types"][0]
+        if brand_id in ["GG", "franchise"]:
+            return  # GoldsGymSpider
+
+        if brand := self.BRANDS.get(brand_id):
+            item.update(brand)
+
+        yield item

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -17,7 +17,7 @@ class WoosmapSpider(Spider):
                 item = DictParser.parse(feature["properties"])
 
                 item["street_address"] = ", ".join(filter(None, feature["properties"]["address"]["lines"]))
-                item["lon"], item["lat"] = feature["geometry"]["coordinates"]
+                item["geometry"] = feature["geometry"]
 
                 oh = OpeningHours()
                 for day, rules in feature["properties"].get("opening_hours", {}).get("usual", {}).items():
@@ -31,7 +31,7 @@ class WoosmapSpider(Spider):
                         oh.add_range(DAYS[int(day) - 1], start, end)
                 item["opening_hours"] = oh.as_opening_hours()
 
-                yield from self.parse_item(item, feature)
+                yield from self.parse_item(item, feature) or []
 
         if pagination := response.json()["pagination"]:
             if pagination["page"] < pagination["pageCount"]:


### PR DESCRIPTION
```python
{'atp/category/leisure/fitness_centre': 344,
 'atp/field/brand/missing': 9,
 'atp/field/brand_wikidata/missing': 9,
 'atp/field/country/missing': 4,
 'atp/field/email/missing': 344,
 'atp/field/image/missing': 344,
 'atp/field/lat/missing': 344,
 'atp/field/lon/missing': 344,
 'atp/field/opening_hours/missing': 7,
 'atp/field/phone/missing': 45,
 'atp/field/state/missing': 344,
 'atp/field/twitter/missing': 344,
 'atp/field/website/missing': 5,
 'atp/nsi/brand_missing': 59,
 'atp/nsi/perfect_match': 276,
 'downloader/request_bytes': 1662,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 254777,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.182928,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 12, 15, 59, 49, 189895),
 'httpcache/hit': 4,
 'httpcompression/response_bytes': 4919507,
 'httpcompression/response_count': 3,
 'item_scraped_count': 344,
 'log_count/DEBUG': 354,
 'log_count/INFO': 9,
 'memusage/max': 118484992,
 'memusage/startup': 118484992,
 'request_depth_max': 2,
 'response_received_count': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2023, 1, 12, 15, 59, 46, 6967)}
```