### PR TITLE
Sort same-day opening hours

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -199,7 +199,7 @@ class OpeningHours:
                     time.strftime("%H:%M", h[0]),
                     time.strftime("%H:%M", h[1]).replace("23:59", "24:00"),
                 )
-                for h in self.day_hours[day]
+                for h in sorted(self.day_hours[day])
             )
 
             if not this_day_group:

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -99,6 +99,11 @@ def test_multiple_times():
     o.add_range("Mo", "13:00", "17:30")
     assert o.as_opening_hours() == "Mo 08:00-12:00,13:00-17:30"
 
+    o2 = OpeningHours()
+    o2.add_range("Tu", "09:00", "12:00")
+    o2.add_range("Tu", "15:00", "17:00")
+    assert o2.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
+
 
 def test_sanitise_days():
     assert sanitise_day("Mo") == "Mo"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -104,6 +104,11 @@ def test_multiple_times():
     o2.add_range("Tu", "15:00", "17:00")
     assert o2.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
 
+    o3 = OpeningHours()
+    o3.add_range("Tu", "15:00", "17:00")
+    o3.add_range("Tu", "09:00", "12:00")
+    assert o3.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
+
 
 def test_sanitise_days():
     assert sanitise_day("Mo") == "Mo"


### PR DESCRIPTION
There had already been a unit test for sorting multiple opening hours on the same day, but the implementation had not actually sorted the hours. Before this change, the results thus got formatted in pseudo-random order depending on the value of Python’s built-in hash function. Accidentally, the existing test case happened to give the expected sorting order.