### PR TITLE
Improve opening_hours regex to allow for multiple time ranges

### DIFF
--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -195,7 +195,7 @@ class CheckItemPropertiesPipeline:
         r"^Q[0-9]+$",
     )
     opening_hours_regex = re.compile(
-        r"^(?:(?:Mo|Tu|We|Th|Fr|Sa|Su)(?:-(?:Mo|Tu|We|Th|Fr|Sa|Su))? [0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}(?:; )?)+$"
+        r"^(?:(?:Mo|Tu|We|Th|Fr|Sa|Su)(?:-(?:Mo|Tu|We|Th|Fr|Sa|Su))? (?:,?[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2})+(?:; )?)+$"
     )
     min_lat = -90.0
     max_lat = 90.0


### PR DESCRIPTION
eg "Mo 08:00-12:00,13:00-17:30"

Then after the next weekly we should get better stats on `atp/field/opening_hours/invalid` so we know which ones need fixing.