### PR TITLE
Have du report in bytes instead of kb

### DIFF
--- a/ci/restore_history.py
+++ b/ci/restore_history.py
@@ -74,7 +74,6 @@ if __name__ == "__main__":
 
         run_data = {
             "run_id": run_id,
-            "output_url": f"https://data.alltheplaces.xyz/runs/{run_id}/output.tar.gz",
         }
 
         stats_suffix = f"runs/{run_id}/stats/_results.json"
@@ -100,6 +99,7 @@ if __name__ == "__main__":
         output_suffix = f"runs/{run_id}/output.tar.gz"
         if size_bytes := object_size(client, bucket_name, output_suffix):
             run_data["size_bytes"] = size_bytes
+            run_data["output_url"] = f"https://data.alltheplaces.xyz/{output_suffix}"
         else:
             output_suffix = f"runs/{run_id}/output.zip"
             if size_bytes := object_size(client, bucket_name, output_suffix):

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -127,12 +127,12 @@ if [ ! $retval -eq 0 ]; then
 fi
 
 (>&2 echo "Saving embed to https://data.alltheplaces.xyz/runs/latest/info_embed.html")
-OUTPUT_FILESIZE=$(du "${SPIDER_RUN_DIR}/output.zip"  | awk '{ print $1 }')
-OUTPUT_FILESIZE_PRETTY=$(echo "$OUTPUT_FILESIZE" | awk '{printf "%0.1f", $1/1024}')
+OUTPUT_FILESIZE=$(du -b "${SPIDER_RUN_DIR}/output.zip"  | awk '{ print $1 }')
+OUTPUT_FILESIZE_PRETTY=$(echo "$OUTPUT_FILESIZE" | numfmt --to=si --format=%0.1f)
 cat > "${SPIDER_RUN_DIR}/info_embed.html" << EOF
 <html><body>
 <a href="${RUN_URL_PREFIX}/output.zip">Download</a>
-(${OUTPUT_FILESIZE_PRETTY} MB)<br/><small>$(printf "%'d" "${OUTPUT_LINECOUNT}") rows from
+(${OUTPUT_FILESIZE_PRETTY})<br/><small>$(printf "%'d" "${OUTPUT_LINECOUNT}") rows from
 ${SPIDER_COUNT} spiders, updated $(date)</small>
 </body></html>
 EOF


### PR DESCRIPTION
The history.json file is getting the wrong size for the output because `du` is reporting in blocks of kilobytes. Switch that to bytes to report apparent size.