### PR TITLE
Fix AT&T Spider

### DIFF
--- a/locations/spiders/att.py
+++ b/locations/spiders/att.py
@@ -1,77 +1,22 @@
-import json
-import re
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import Feature
-
-DAY_MAPPING = {
-    "MONDAY": "Mo",
-    "TUESDAY": "Tu",
-    "WEDNESDAY": "We",
-    "THURSDAY": "Th",
-    "FRIDAY": "Fr",
-    "SATURDAY": "Sa",
-    "SUNDAY": "Su",
-}
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ATTSpider(scrapy.Spider):
+class ATTSpider(SitemapSpider, StructuredDataSpider):
     name = "att"
-    item_attributes = {"brand": "AT&T", "brand_wikidata": "Q35476"}
+    item_attributes = {"brand": "AT&T", "brand_wikidata": "Q298594"}
     allowed_domains = ["www.att.com"]
-    start_urls = ("https://www.att.com/stores/us",)
-    download_delay = 0.2
+    sitemap_urls = ["https://www.att.com/stores/sitemap.xml"]
+    sitemap_rules = [(r"/\d+$", "parse_sd")]
+    wanted_types = ["MobilePhoneStore"]
 
-    def parse_hours(self, store_hours):
-        opening_hours = OpeningHours()
-        store_data = json.loads(store_hours)
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        name = ""
+        for part in item["name"].strip().split("\n"):
+            if name:
+                name += " "
+            name += part.strip()
+        item["name"] = name
 
-        for store_day in store_data:
-            if len(store_day["intervals"]) < 1:
-                continue
-            day = DAY_MAPPING[store_day["day"]]
-            open_time = str(store_day["intervals"][0]["start"])
-            if open_time == "0":
-                open_time = "0000"
-            close_time = str(store_day["intervals"][0]["end"])
-            if close_time == "0":
-                close_time = "2359"
-            opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H%M")
-
-        return opening_hours.as_opening_hours()
-
-    def parse(self, response):
-        urls = response.xpath('//a[@class="Directory-listLink"]/@href').extract()
-        is_store_list = response.xpath('//a[@class="Teaser-titleLink"]/@href').extract()
-
-        if not urls and is_store_list:
-            urls = response.xpath('//a[@class="Teaser-titleLink"]/@href').extract()
-        for url in urls:
-            if url.count("/") >= 2:
-                yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
-            else:
-                yield scrapy.Request(response.urljoin(url))
-
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-
-        properties = {
-            "ref": ref,
-            "name": response.xpath('normalize-space(//span[@class="LocationName-brand"]/text())').extract_first(),
-            "addr_full": response.xpath('normalize-space(//meta[@itemprop="streetAddress"]/@content)').extract_first(),
-            "city": response.xpath('normalize-space(//meta[@itemprop="addressLocality"]/@content)').extract_first(),
-            "state": response.xpath('normalize-space(//abbr[@itemprop="addressRegion"]/text())').extract_first(),
-            "postcode": response.xpath('normalize-space(//span[@itemprop="postalCode"]/text())').extract_first(),
-            "country": response.xpath('normalize-space(//abbr[@itemprop="addressCountry"]/text())').extract_first(),
-            "phone": response.xpath('normalize-space(//span[@itemprop="telephone"]//text())').extract_first(),
-            "website": response.url,
-            "lat": response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first(),
-            "lon": response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first(),
-        }
-
-        hours = response.xpath('//span[@class="c-hours-today js-hours-today"]/@data-days').extract_first()
-        properties["opening_hours"] = self.parse_hours(hours)
-
-        yield Feature(**properties)
+        yield item


### PR DESCRIPTION
```python
{'atp/category/shop/mobile_phone': 259,
 'atp/field/email/missing': 259,
 'atp/field/opening_hours/missing': 259,
 'atp/field/twitter/missing': 259,
 'atp/nsi/perfect_match': 259,
 'downloader/request_bytes': 304021,
 'downloader/request_count': 263,
 'downloader/request_method_count/GET': 263,
 'downloader/response_bytes': 29939897,
 'downloader/response_count': 263,
 'downloader/response_status_count/200': 263,
 'elapsed_time_seconds': 64.083954,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2023, 1, 17, 17, 38, 28, 349369),
 'httpcache/firsthand': 40,
 'httpcache/hit': 223,
 'httpcache/miss': 40,
 'httpcache/store': 40,
 'httpcompression/response_bytes': 431070350,
 'httpcompression/response_count': 263,
 'item_scraped_count': 259,
 'log_count/DEBUG': 532,
 'log_count/INFO': 10,
 'memusage/max': 914382848,
 'memusage/startup': 118923264,
 'request_depth_max': 2,
 'response_received_count': 263,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 262,
 'scheduler/dequeued/memory': 262,
 'scheduler/enqueued': 1287,
 'scheduler/enqueued/memory': 1287,
 'start_time': datetime.datetime(2023, 1, 17, 17, 37, 24, 265415)}
```

I didn't run this to completion, we should expect ~5400 POIs like before it broke.