### PR TITLE
Fix Goodstart spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -83,6 +83,7 @@ class Categories(Enum):
     BUREAU_DE_CHANGE = {"amenity": "bureau_de_change"}
     CAFE = {"amenity": "cafe"}
     CHARGING_STATION = {"amenity": "charging_station"}
+    CHILD_CARE = {"amenity": "childcare"}
     CLINIC_URGENT = {"amenity": "clinic", "healthcare": "clinic", "urgent_care": "yes"}
     COFFEE_SHOP = {"amenity": "cafe", "cuisine": "coffee_shop"}
     COMPRESSED_AIR = {"amenity": "compressed_air"}

--- a/locations/spiders/goodstart.py
+++ b/locations/spiders/goodstart.py
@@ -25,6 +25,7 @@ class GoodstartSpider(scrapy.Spider):
             item["image"] = "https://www.goodstart.org.au" + i["imageUrl"]
             item["addr_full"] = i["fullAddress"]
             item["street_address"] = i["address"]
+            item["city"] = i["suburb"]
 
             oh = OpeningHours()
             (hour_range, days_range) = i["hours"].split(", ")

--- a/locations/spiders/goodstart.py
+++ b/locations/spiders/goodstart.py
@@ -1,6 +1,8 @@
 import scrapy
 
-from locations.items import Feature
+from locations.categories import apply_category, Categories
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, day_range, DAYS_EN
 
 
 class GoodstartSpider(scrapy.Spider):
@@ -11,21 +13,26 @@ class GoodstartSpider(scrapy.Spider):
     }
     allowed_domains = ["goodstart.org.au"]
     start_urls = [
-        "https://www.goodstart.org.au/extApi/CentreAPI/",
+        "https://www.goodstart.org.au/find-centre/api/get-centres/-35.0004451/138.3309724/10000/",
     ]
 
     def parse(self, response):
         data = response.json()
 
-        for i in data["centres"]:
-            properties = {
-                "ref": i["NodeAliasPath"],
-                "name": i["Name"],
-                "addr_full": i["Address"],
-                "country": "AU",
-                "phone": i["Phone"],
-                "lat": i["Latitude"],
-                "lon": i["Longitude"],
-            }
+        for i in data:
+            item = DictParser.parse(i)
+            item["website"] = "https://www.goodstart.org.au" + item.pop("website")
+            item["image"] = "https://www.goodstart.org.au" + i["imageUrl"]
+            item["addr_full"] = i["fullAddress"]
+            item["street_address"] = i["address"]
 
-            yield Feature(**properties)
+            oh = OpeningHours()
+            (hour_range, days_range) = i["hours"].split(", ")
+            (from_time, close_time) = hour_range.split(" to ")
+            (start_day, end_day) = days_range.split(" to ")
+            for day in day_range(DAYS_EN[start_day], DAYS_EN[end_day]):
+                oh.add_range(day, from_time, close_time, time_format="%I:%M%p")
+            item["opening_hours"] = oh.as_opening_hours()
+
+            apply_category(Categories.CHILD_CARE, item)
+            yield item

--- a/locations/spiders/goodstart.py
+++ b/locations/spiders/goodstart.py
@@ -1,8 +1,8 @@
 import scrapy
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, day_range, DAYS_EN
+from locations.hours import DAYS_EN, OpeningHours, day_range
 
 
 class GoodstartSpider(scrapy.Spider):


### PR DESCRIPTION
Fixing the Goodstart spider.

Some remarks: 

- The changes to the website removed the original ref. The new version has an `id` field that is taken by the `DictParser`, but it's different compared to older scraped results from https://data.alltheplaces.xyz/runs/2022-12-10-13-32-28/output/goodstart.geojson. Does it make sense to try to recreate them?
- The JSON result contains a suburb, but not a city. PR #4615 seems to state that suburb is not used in our model. What should I do with this?
- A center can have different services: kindergarten-preschool, nursery, toddler, ... I used the `amenity=childcare` since I can find this the most on OSM. It might make sense to go more granular, but I guess I can't add multiple amenities to a single place.