### PR TITLE
Fix Jumbo Argentina spider

### DIFF
--- a/locations/spiders/jumbo_ar.py
+++ b/locations/spiders/jumbo_ar.py
@@ -5,9 +5,8 @@ from locations.dict_parser import DictParser
 
 
 class JumboARSpider(scrapy.Spider):
-    name = "jumbo_argentina"
-    item_attributes = {"brand": "Jumbo", "brand_wikidata": "Q116259940"}
-    allowed_domains = ["www.jumbo.com.ar"]
+    name = "jumbo_ar"
+    item_attributes = {"brand": "Jumbo", "brand_wikidata": "Q6310864"}
 
     def start_requests(self):
         url = "https://www.jumbo.com.ar/api/dataentities/NT/search?_fields=name,grouping,image_maps,geocoordinates,SellerName,id,country,city,neighborhood,number,postalCode,state,street,schedule,services,paymentMethods,opening,hasPickup,hasDelivery,address,url_image,phone&an=jumboargentina"

--- a/locations/spiders/jumbo_ar.py
+++ b/locations/spiders/jumbo_ar.py
@@ -1,8 +1,7 @@
-import json
-
 import scrapy
 
-from locations.items import Feature
+from locations.categories import apply_category, Categories
+from locations.dict_parser import DictParser
 
 
 class JumboARSpider(scrapy.Spider):
@@ -11,36 +10,23 @@ class JumboARSpider(scrapy.Spider):
     allowed_domains = ["www.jumbo.com.ar"]
 
     def start_requests(self):
-        url = "https://www.jumbo.com.ar/Login/PreHomeService.aspx/TraerLocales"
+        url = "https://www.jumbo.com.ar/api/dataentities/NT/search?_fields=name,grouping,image_maps,geocoordinates,SellerName,id,country,city,neighborhood,number,postalCode,state,street,schedule,services,paymentMethods,opening,hasPickup,hasDelivery,address,url_image,phone&an=jumboargentina"
         headers = {
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "rest-range": "resources=0-999"
         }
-        form_data = {}
 
-        yield scrapy.http.FormRequest(
-            url=url,
-            method="POST",
-            formdata=form_data,
-            headers=headers,
-            callback=self.parse,
-        )
+        yield scrapy.Request(url=url, headers=headers, callback=self.parse)
 
     def parse(self, response):
-        result = response.text.replace("\\", "")
-        result = result[:5] + result[6:-2] + result[-1:]
-        data = json.loads(result)
-        ref = 0
-        for store in data["d"]["Locales"]:
-            properties = {
-                "ref": ref,
-                "name": store["Local"]["Nombre"].strip(),
-                "addr_full": store["Local"]["Direccion"].strip(),
-                "city": store["Local"]["Localidad"].strip(),
-                "state": store["Local"]["Provincia"].strip(),
-                "postcode": store["Local"]["CodigoPostal"].strip(),
-                "lat": float(store["Local"]["Latitud"].strip()),
-                "lon": float(store["Local"]["Longitud"].strip()),
-                "phone": store["Local"]["Telefono"].strip(),
-            }
-            ref += 1
-            yield Feature(**properties)
+        for data in response.json():
+            item = DictParser.parse(data)
+
+            (lat, lon) = data["geocoordinates"].split(',')
+            item["lat"] = lat
+            item["lon"] = lon
+
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+
+            yield item

--- a/locations/spiders/jumbo_ar.py
+++ b/locations/spiders/jumbo_ar.py
@@ -1,6 +1,6 @@
 import scrapy
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -11,11 +11,7 @@ class JumboARSpider(scrapy.Spider):
 
     def start_requests(self):
         url = "https://www.jumbo.com.ar/api/dataentities/NT/search?_fields=name,grouping,image_maps,geocoordinates,SellerName,id,country,city,neighborhood,number,postalCode,state,street,schedule,services,paymentMethods,opening,hasPickup,hasDelivery,address,url_image,phone&an=jumboargentina"
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "rest-range": "resources=0-999"
-        }
+        headers = {"Content-Type": "application/json", "Accept": "application/json", "rest-range": "resources=0-999"}
 
         yield scrapy.Request(url=url, headers=headers, callback=self.parse)
 
@@ -23,7 +19,7 @@ class JumboARSpider(scrapy.Spider):
         for data in response.json():
             item = DictParser.parse(data)
 
-            (lat, lon) = data["geocoordinates"].split(',')
+            (lat, lon) = data["geocoordinates"].split(",")
             item["lat"] = lat
             item["lon"] = lon
 

--- a/locations/spiders/jumbo_ar.py
+++ b/locations/spiders/jumbo_ar.py
@@ -6,7 +6,7 @@ from locations.dict_parser import DictParser
 
 class JumboARSpider(scrapy.Spider):
     name = "jumbo_argentina"
-    item_attributes = {"brand": "Jumbo"}
+    item_attributes = {"brand": "Jumbo", "brand_wikidata": "Q116259940"}
     allowed_domains = ["www.jumbo.com.ar"]
 
     def start_requests(self):


### PR DESCRIPTION
There's no wikidata entry. Jumbo Argentina is, in fact, a brand from [Cencosud](https://www.wikidata.org/wiki/Q1053372) and not from the Dutch supermarket chain [Jumbo](https://www.wikidata.org/wiki/Q2262314). However, that's not present in Wikidata. Should this be added to Wikidata and NSI?