### PR TITLE
Add Shurgard Spider

### DIFF
--- a/locations/spiders/shurgard.py
+++ b/locations/spiders/shurgard.py
@@ -1,0 +1,11 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ShurgardSpider(SitemapSpider, StructuredDataSpider):
+    name = "shurgard"
+    item_attributes = {"brand": "Shurgard", "brand_wikidata": "Q3482670"}
+    sitemap_urls = ["https://www.shurgard.com/sitemap.xml"]
+    sitemap_rules = [(r"/en-(?:\w\w/self-storage-[-\w]+|be/self-storage)/[-\w]+/[-\w]+$", "parse_sd")]
+    wanted_types = ["SelfStorage"]


### PR DESCRIPTION
```python
{'atp/brand/Shurgard': 257,
 'atp/brand_wikidata/Q3482670': 257,
 'atp/category/missing': 257,
 'atp/field/city/missing': 216,
 'atp/field/country/from_reverse_geocoding': 257,
 'atp/field/email/missing': 257,
 'atp/field/image/missing': 257,
 'atp/field/lon/invalid': 1,
 'atp/field/opening_hours/missing': 257,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 257,
 'atp/field/twitter/missing': 257,
 'atp/nsi/brand_missing': 257,
 'downloader/request_bytes': 437734,
 'downloader/request_count': 342,
 'downloader/request_method_count/GET': 342,
 'downloader/response_bytes': 16345343,
 'downloader/response_count': 342,
 'downloader/response_status_count/200': 342,
 'elapsed_time_seconds': 14.327777,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 20, 10, 27, 27, 395072),
 'httpcache/hit': 342,
 'httpcompression/response_bytes': 60828761,
 'httpcompression/response_count': 342,
 'item_scraped_count': 257,
 'log_count/DEBUG': 609,
 'log_count/INFO': 8,
 'memusage/max': 119111680,
 'memusage/startup': 119111680,
 'request_depth_max': 1,
 'response_received_count': 342,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 341,
 'scheduler/dequeued/memory': 341,
 'scheduler/enqueued': 341,
 'scheduler/enqueued/memory': 341,
 'start_time': datetime.datetime(2023, 1, 20, 10, 27, 13, 67295)}
```