### PR TITLE
Rename FeatureCollection properties to dataset_attributes

### DIFF
--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -174,7 +174,7 @@ class GeoJsonExporter(JsonItemExporter):
 
     def write_geojson_header(self):
         header = io.StringIO()
-        header.write('{"type":"FeatureCollection","properties":')
+        header.write('{"type":"FeatureCollection","dataset_attributes":')
         json.dump(
             get_dataset_attributes(self.spider_name), header, ensure_ascii=False, separators=(",", ":"), sort_keys=True
         )


### PR DESCRIPTION
geojson.io complains when using a "properties" field on a FeatureCollection. The spec is a bit hard to parse but I think geojson.io is right. The GeoJSONL exporter already uses "dataset_attributes", so this unifies them.