### PR TITLE
Add Footgear ZA spider

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -81,7 +81,7 @@ class DictParser:
         "yext-display-lng",
     ]
 
-    website_keys = ["url", "website"]
+    website_keys = ["url", "website", "permalink"]
 
     @staticmethod
     def parse(obj) -> Feature:

--- a/locations/spiders/footgear_za.py
+++ b/locations/spiders/footgear_za.py
@@ -1,0 +1,26 @@
+from scrapy import Selector, Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class FootgearZASpider(Spider):
+    name = "footgear_za"
+    item_attributes = {"brand": "Footgear", "brand_wikidata": "Q116290280"}
+    start_urls = ["https://www.footgear.co.za/wp-admin/admin-ajax.php?action=store_search&autoload=1"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            location["street_address"] = ", ".join(filter(None, [location.pop("address2"), location.pop("address")]))
+            location["name"] = location.pop("store")
+
+            item = DictParser.parse(location)
+
+            item["opening_hours"] = OpeningHours()
+            hours = Selector(text=location["hours"] or "")
+            for rule in hours.xpath("//tr"):
+                day = rule.xpath("./td/text()").get()
+                start_time, end_time = rule.xpath("./td/time/text()").get().split(" - ")
+                item["opening_hours"].add_range(day, start_time, end_time)
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Footgear': 221,
 'atp/brand_wikidata/Q116290280': 221,
 'atp/category/missing': 221,
 'atp/field/email/missing': 221,
 'atp/field/image/missing': 221,
 'atp/field/phone/invalid': 5,
 'atp/field/postcode/missing': 73,
 'atp/field/state/missing': 27,
 'atp/field/twitter/missing': 221,
 'atp/nsi/brand_missing': 221,
 'downloader/request_bytes': 660,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 19477,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.551088,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 23, 10, 8, 37, 739683),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 203239,
 'httpcompression/response_count': 2,
 'item_scraped_count': 221,
 'log_count/DEBUG': 233,
 'log_count/INFO': 8,
 'memusage/max': 118419456,
 'memusage/startup': 118419456,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 1, 23, 10, 8, 33, 188595)}
```

Category will come after the next NSI release