### PR TITLE
Add La Halle FR Spider

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -34,6 +34,11 @@ class LinkedDataParser:
 
     @staticmethod
     def find_linked_data(response, wanted_type, json_parser="json") -> {}:
+        if isinstance(wanted_type, list):
+            wanted_types = [LinkedDataParser.clean_type(t) for t in wanted_type]
+        else:
+            wanted_types = [LinkedDataParser.clean_type(wanted_type)]
+
         for ld_obj in LinkedDataParser.iter_linked_data(response, json_parser=json_parser):
             if not ld_obj.get("@type"):
                 continue
@@ -45,21 +50,8 @@ class LinkedDataParser:
 
             types = [LinkedDataParser.clean_type(t) for t in types]
 
-            if isinstance(wanted_type, list):
-                wanted_types = wanted_type
-            else:
-                wanted_types = [wanted_type]
-
-            wanted_types = [LinkedDataParser.clean_type(t) for t in wanted_types]
-
-            for wanted_type in wanted_types:
-                valid_type = True
-                for t in types:
-                    if t not in wanted_types:
-                        valid_type = False
-
-                if valid_type:
-                    return ld_obj
+            if all(wanted in types for wanted in wanted_types):
+                return ld_obj
 
     @staticmethod
     def parse_ld(ld) -> Feature:  # noqa: C901

--- a/locations/spiders/la_halle_fr.py
+++ b/locations/spiders/la_halle_fr.py
@@ -1,0 +1,25 @@
+import re
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LaHalleFRSpider(CrawlSpider, StructuredDataSpider):
+    name = "la_halle_fr"
+    item_attributes = {"brand": "La Halle", "brand_wikidata": "Q100728296"}
+    start_urls = ["https://www.lahalle.com/magasins"]
+    rules = [
+        Rule(LinkExtractor(restrict_xpaths='//div[@id="store-locator-home-departements"]')),
+        Rule(LinkExtractor(restrict_xpaths='//a[@class="store-details-link"]'), callback="parse_sd"),
+    ]
+    wanted_types = [["LocalBusiness", "ClothingStore"]]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if script := response.xpath('//script[contains(text(), "env_template")]/text()').get():
+            if lat := re.search(r'\\"store_latitude\\":\\"(-?\d+\.\d+)\\",', script):
+                item["lat"] = lat.group(1)
+            if lon := re.search(r'\\"store_longitude\\":\\"(-?\d+\.\d+)\\",', script):
+                item["lon"] = lon.group(1)
+        yield item

--- a/tests/test_ld_parser.py
+++ b/tests/test_ld_parser.py
@@ -238,8 +238,14 @@ def test_multiple_types():
                     "@type": ["http://schema.org/Place", "Thing"],
                     "name": "test 1"
                 }
-            </script>
-            <script type="application/ld+json">
+            </script>""",
+    )
+    assert LinkedDataParser.find_linked_data(response, ["Place", "Thing"])["name"] == "test 1"
+
+    response = HtmlResponse(
+        url="",
+        encoding="utf-8",
+        body="""<script type="application/ld+json">
                 {
                     "@context": "https://schema.org",
                     "@type": "http://schema.org/Place",
@@ -247,6 +253,47 @@ def test_multiple_types():
                 }
             </script>""",
     )
-
-    assert LinkedDataParser.find_linked_data(response, ["Place", "Thing"])["name"] == "test 1"
     assert LinkedDataParser.find_linked_data(response, "Place")["name"] == "test 2"
+
+    response = HtmlResponse(
+        url="",
+        encoding="utf-8",
+        body="""<script type="application/ld+json">
+                {
+                    "@context": "https://schema.org",
+                    "@graph": [
+                        {
+                            "@context": "http://schema.org",
+                            "@type": "BreadcrumbList",
+                            "itemListElement": [
+                                {
+                                    "@type": "ListItem",
+                                    "position": 1,
+                                    "item": {"@id": "https://www.lahalle.com/", "name": "La Halle"}
+                                },
+                                {
+                                    "@type": "ListItem",
+                                    "position": 2,
+                                    "item": {"@id": "https://www.lahalle.com/magasins", "name": "Magasin Vêtements et chaussures"}
+                                },
+                                {
+                                    "@type": "ListItem",
+                                    "position": 3,
+                                    "item": {"@id": "https://www.lahalle.com/magasins-paris-75.htm", "name": "75 Paris"}
+                                },
+                                {
+                                    "@type": "ListItem",
+                                    "position": 4,
+                                    "item": {
+                                        "@id": "https://www.lahalle.com/magasins-paris-75-paris-flandre-168.html",
+                                        "name": "PARIS FLANDRE"
+                                    }
+                                }
+                            ]
+                        },
+                        {"@context": "https://schema.org", "@type": ["LocalBusiness", "ClothingStore"], "name": "test 3"}
+                    ]
+                }
+            </script>""",
+    )
+    assert LinkedDataParser.find_linked_data(response, ["LocalBusiness", "ClothingStore"])["name"] == "test 3"


### PR DESCRIPTION
Didn't run to completion, but:
```python
{'atp/brand/La Halle': 74,
 'atp/brand_wikidata/Q100728296': 74,
 'atp/category/shop/clothes': 74,
 'atp/field/city/missing': 74,
 'atp/field/email/missing': 74,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 74,
 'atp/nsi/perfect_match': 74,
 'downloader/request_bytes': 73388,
 'downloader/request_count': 94,
 'downloader/request_method_count/GET': 94,
 'downloader/response_bytes': 2864543,
 'downloader/response_count': 94,
 'downloader/response_status_count/200': 94,
 'elapsed_time_seconds': 25.190468,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2023, 1, 24, 19, 44, 25, 303478),
 'httpcache/firsthand': 19,
 'httpcache/hit': 75,
 'httpcache/miss': 19,
 'httpcache/store': 19,
 'httpcompression/response_bytes': 20745984,
 'httpcompression/response_count': 94,
 'item_scraped_count': 74,
 'log_count/DEBUG': 178,
 'log_count/INFO': 9,
 'memusage/max': 118497280,
 'memusage/startup': 118497280,
 'request_depth_max': 2,
 'response_received_count': 94,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 93,
 'scheduler/dequeued/memory': 93,
 'scheduler/enqueued': 170,
 'scheduler/enqueued/memory': 170,
 'start_time': datetime.datetime(2023, 1, 24, 19, 44, 0, 113010)}
```