### PR TITLE
Add Foschini Spider

### DIFF
--- a/locations/spiders/foschini.py
+++ b/locations/spiders/foschini.py
@@ -1,0 +1,40 @@
+import html
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, day_range, sanitise_day
+
+
+class FoschiniSpider(Spider):
+    name = "foschini"
+    item_attributes = {"brand": "Foschini", "brand_wikidata": "Q116391780"}
+    start_urls = [f"https://www.foschini.co.za/browse/storeLocatorSearch.jsp?searchText={letter}" for letter in "aeiou"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["items"]:
+            location["street_address"] = html.unescape(
+                ", ".join(
+                    filter(
+                        None,
+                        [location.pop("address_line1"), location.pop("address_line2"), location.pop("address_line3")],
+                    )
+                )
+            )
+            location["phoneNumber"] = location["phoneNumber"].replace(",", ";")
+
+            item = DictParser.parse(location)
+
+            item["ref"] = location.pop("branch_number")
+            item["name"] = location.pop("branch_name")
+
+            item["opening_hours"] = OpeningHours()
+            for rule in location["normalOpeningHours"]:
+                if "-" in rule["description"]:
+                    start_day, end_day = rule["description"].split(" - ")
+                else:
+                    start_day = end_day = rule["description"]
+                for day in day_range(sanitise_day(start_day), sanitise_day(end_day)):
+                    item["opening_hours"].add_range(day, rule["openTime"], rule["closeTime"])
+
+            yield item

--- a/locations/spiders/tops_at_spar.py
+++ b/locations/spiders/tops_at_spar.py
@@ -6,7 +6,7 @@ from locations.spiders.vapestore_gb import clean_address
 
 
 class TopsSpider(Spider):
-    name = "tops"
+    name = "tops_at_spar"
     item_attributes = {"brand": "Tops", "brand_wikidata": "Q116377563"}
     skip_auto_cc = True
 


### PR DESCRIPTION
```python
{'atp/brand/Foschini': 352,
 'atp/brand_wikidata/Q116391780': 352,
 'atp/category/missing': 352,
 'atp/field/country/from_reverse_geocoding': 352,
 'atp/field/email/missing': 352,
 'atp/field/image/missing': 352,
 'atp/field/lat/invalid': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/phone/invalid': 54,
 'atp/field/phone/missing': 25,
 'atp/field/state/missing': 352,
 'atp/field/twitter/missing': 352,
 'atp/field/website/missing': 352,
 'atp/nsi/brand_missing': 352,
 'downloader/request_bytes': 3391,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 142202,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 6,
 'downloader/response_status_count/302': 2,
 'elapsed_time_seconds': 12.076063,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 24, 22, 38, 42, 896436),
 'httpcache/hit': 8,
 'httpcompression/response_bytes': 1827839,
 'httpcompression/response_count': 6,
 'item_dropped_count': 1323,
 'item_dropped_reasons_count/DropItem': 1323,
 'item_scraped_count': 352,
 'log_count/DEBUG': 370,
 'log_count/INFO': 9,
 'log_count/WARNING': 1323,
 'memusage/max': 125595648,
 'memusage/startup': 125595648,
 'response_received_count': 6,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2023, 1, 24, 22, 38, 30, 820373)}
```
https://github.com/osmlab/name-suggestion-index/pull/7690