### PR TITLE
Add OTR Spider

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -23,6 +23,7 @@ class DictParser:
         "address-city",
         "town",
         "locality",
+        "suburb",
     ]
 
     region_keys = [

--- a/locations/spiders/otr_au.py
+++ b/locations/spiders/otr_au.py
@@ -1,0 +1,40 @@
+from scrapy import FormRequest, Spider
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class OTRAUSpider(Spider):
+    name = "otr_au"
+    item_attributes = {"brand": "OTR", "brand_wikidata": "Q116394019"}
+
+    def start_requests(self):
+        yield FormRequest(url="https://www.otr.com.au/wp-admin/admin-ajax.php", formdata={"action": "LocationsSearch"})
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["response"]:
+            if location["site_closed"] != "0" or location["site_wpid"] == 0:
+                continue
+
+            clean_location = {}
+            for key, value in location.items():
+                clean_location[key.replace("site_", "")] = value
+            location = clean_location
+
+            location[
+                "url"
+            ] = f'https://www.otr.com.au/locations/{location["suburb_url"]}-{location["streetaddress_url"]}/{location["name_url"]}/'
+
+            item = DictParser.parse(location)
+
+            apply_yes_no("atm", item, "33" in location["offers"])
+            apply_yes_no("drive_through", item, "35" in location["offers"])
+            apply_yes_no(Fuel.DIESEL, item, "102" in location["offers"])
+            apply_yes_no(Fuel.LPG, item, "104" in location["offers"])
+
+            if "35" in location["offers"]:
+                apply_category(Categories.FUEL_STATION, item)
+            if "41" in location["offers"]:
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/OTR': 165,
 'atp/brand_wikidata/Q116394019': 165,
 'atp/category/amenity/fuel': 35,
 'atp/category/multiple': 35,
 'atp/category/shop/convenience': 130,
 'atp/field/country/from_spider_name': 165,
 'atp/field/email/missing': 165,
 'atp/field/image/missing': 165,
 'atp/field/opening_hours/missing': 165,
 'atp/field/phone/missing': 165,
 'atp/field/twitter/missing': 165,
 'atp/nsi/brand_missing': 165,
 'downloader/request_bytes': 693,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 215821,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.029237,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 25, 11, 59, 41, 290759),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 1150,
 'httpcompression/response_count': 1,
 'item_scraped_count': 165,
 'log_count/DEBUG': 177,
 'log_count/INFO': 9,
 'memusage/max': 118493184,
 'memusage/startup': 118493184,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 1, 25, 11, 59, 37, 261522)}
```
https://github.com/osmlab/name-suggestion-index/pull/7691