### PR TITLE
Add Truworths Spider

### DIFF
--- a/locations/spiders/truworths.py
+++ b/locations/spiders/truworths.py
@@ -1,0 +1,42 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class TruworthsSpider(Spider):
+    name = "truworths"
+    start_urls = ["https://www.identity.co.za/ccstore/v1/assembler/pages/Default/storeSearch?Nr=AND(product.active:1)"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    BRANDS = {
+        "Truworths": {"brand": "Truworths", "brand_wikidata": "Q24233998"},
+        "Identity": {"brand": "Identity", "brand_wikidata": "Q116378109"},
+        "Loads of Living": {"brand": "Loads of Living", "brand_wikidata": "Q116418933"},
+        "Office London": {"brand": "Office London", "brand_wikidata": "Q116418894"},
+    }
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["resultsList"]["records"]:
+            clean_location = {}
+            for key, value in location["attributes"].items():
+                clean_location[key.replace("store.", "")] = value[0]
+            clean_location["street_address"] = ", ".join(
+                filter(None, [clean_location.pop("address1", ""), clean_location.pop("address2", "")])
+            )
+            clean_location["lat"], clean_location["lon"] = clean_location.pop("geocode", ",").split(",")
+
+            item = DictParser.parse(clean_location)
+
+            if brand := self.BRANDS.get(clean_location["companyName"]):
+                item.update(brand)
+
+            apply_category(Categories.SHOP_CLOTHES, item)
+
+            yield item
+
+        if offset := response.json()["resultsList"].get("lastRecNum"):
+            yield response.follow(
+                response.json()["resultsList"]["pagingActionTemplate"]["link"]
+                .replace("%7Boffset%7D", str(offset))
+                .replace("%7BrecordsPerPage%7D", str(response.json()["resultsList"]["recsPerPage"]))
+            )


### PR DESCRIPTION
```python
{'atp/brand/Identity': 238,
 'atp/brand/Loads of Living': 8,
 'atp/brand/Office London': 18,
 'atp/brand/Truworths': 443,
 'atp/brand_wikidata/Q116378109': 238,
 'atp/brand_wikidata/Q116418894': 18,
 'atp/brand_wikidata/Q116418933': 8,
 'atp/brand_wikidata/Q24233998': 443,
 'atp/category/shop/clothes': 708,
 'atp/field/brand/missing': 1,
 'atp/field/brand_wikidata/missing': 1,
 'atp/field/country/from_reverse_geocoding': 687,
 'atp/field/country/missing': 21,
 'atp/field/email/missing': 708,
 'atp/field/image/missing': 708,
 'atp/field/lat/missing': 21,
 'atp/field/lon/missing': 21,
 'atp/field/opening_hours/missing': 708,
 'atp/field/phone/invalid': 37,
 'atp/field/phone/missing': 6,
 'atp/field/state/missing': 708,
 'atp/field/twitter/missing': 708,
 'atp/field/website/missing': 708,
 'atp/nsi/brand_missing': 264,
 'atp/nsi/perfect_match': 443,
 'downloader/request_bytes': 5436,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 68019,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 12.31947,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 25, 13, 35, 20, 505491),
 'httpcache/firsthand': 9,
 'httpcache/miss': 9,
 'httpcache/store': 9,
 'httpcompression/response_bytes': 355149,
 'httpcompression/response_count': 9,
 'item_scraped_count': 708,
 'log_count/DEBUG': 727,
 'log_count/INFO': 9,
 'memusage/max': 118378496,
 'memusage/startup': 118378496,
 'request_depth_max': 8,
 'response_received_count': 9,
 'scheduler/dequeued': 9,
 'scheduler/dequeued/memory': 9,
 'scheduler/enqueued': 9,
 'scheduler/enqueued/memory': 9,
 'start_time': datetime.datetime(2023, 1, 25, 13, 35, 8, 186021)}
```

https://github.com/osmlab/name-suggestion-index/pull/7684