### PR TITLE
Add Brico io IT Spider

### DIFF
--- a/locations/spiders/brico_io_it.py
+++ b/locations/spiders/brico_io_it.py
@@ -1,0 +1,38 @@
+from scrapy import Spider
+
+from locations.hours import DAYS_IT, OpeningHours, sanitise_day
+from locations.items import Feature
+
+
+class Brico_ioITSpider(Spider):
+    name = "brico_io_it"
+    item_attributes = {"brand_wikidata": "Q15965705"}
+    start_urls = ["https://www.bricoio.it/api/organa/stores.aspx"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            if not location["Attivo"]:
+                continue
+
+            item = Feature()
+            item["ref"] = location["Codice"]
+            item["name"] = location["Nome"]
+            item["street_address"] = location["Indirizzo"]["Descrizione"]
+            item["city"] = location["Indirizzo"]["Localita"]
+            item["state"] = location["Indirizzo"]["Provincia"]
+            item["postcode"] = location["Indirizzo"]["CodicePostale"]
+            item["country"] = location["Indirizzo"]["Nazione"]
+            item["phone"] = location["Telefono"].replace("/", "")
+            item["email"] = location["Email"]
+            item["lat"] = location["Coordinate"]["Latitudine"]
+            item["lon"] = location["Coordinate"]["Longitudine"]
+            item["website"] = f'https://www.bricoio.it{location["URL"]}'
+
+            item["opening_hours"] = OpeningHours()
+            for rule in location["Orari"]["FasceOrarie"]:
+                day = sanitise_day(rule["Giorno"][:3], DAYS_IT)
+                for time in rule["Orario"].split(" / "):
+                    start_time, end_time = time.split("-")
+                    item["opening_hours"].add_range(day, start_time, end_time, time_format="%H.%M")
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Brico Io': 113,
 'atp/brand_wikidata/Q15965705': 113,
 'atp/category/missing': 113,
 'atp/field/email/missing': 22,
 'atp/field/image/missing': 113,
 'atp/field/phone/invalid': 4,
 'atp/field/twitter/missing': 113,
 'atp/nsi/brand_missing': 113,
 'downloader/request_bytes': 677,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16992,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.699473,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 25, 14, 40, 13, 456695),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 212496,
 'httpcompression/response_count': 2,
 'item_scraped_count': 113,
 'log_count/DEBUG': 125,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 118448128,
 'memusage/startup': 118448128,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 1, 25, 14, 40, 10, 757222)}
```
https://github.com/osmlab/name-suggestion-index/pull/7688