### PR TITLE
Add Aroma RS Spider

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -107,7 +107,7 @@ class DictParser:
             address = obj
 
         item["housenumber"] = DictParser.get_first_key(address, DictParser.house_number_keys)
-        item["street"] = DictParser.get_first_key(address, ["street", "streetName"])
+        item["street"] = DictParser.get_first_key(address, ["street", "street-name"])
         item["street_address"] = DictParser.get_first_key(address, DictParser.street_address_keys)
         item["city"] = DictParser.get_first_key(address, DictParser.city_keys)
         item["state"] = DictParser.get_first_key(address, DictParser.region_keys)

--- a/locations/pipelines.py
+++ b/locations/pipelines.py
@@ -189,6 +189,7 @@ class CheckItemPropertiesPipeline:
         r"(?:/?|[/?]\S+)$",
         re.IGNORECASE,
     )
+    country_regex = re.compile(r"(^[A-Z]{2}$)")
     email_regex = re.compile(r"(^[-\w_.+]+@[-\w]+\.[-\w.]+$)")
     twitter_regex = re.compile(r"^@?([-\w_]+)$")
     wikidata_regex = re.compile(
@@ -212,7 +213,7 @@ class CheckItemPropertiesPipeline:
         check_field(item, spider, "city", (str,))
         check_field(item, spider, "state", (str,))
         check_field(item, spider, "postcode", (str,))
-        check_field(item, spider, "country", (str,))
+        check_field(item, spider, "country", (str,), self.country_regex)
         check_field(item, spider, "brand", (str,))
 
         if lat := item.get("lat"):

--- a/locations/spiders/aroma_rs.py
+++ b/locations/spiders/aroma_rs.py
@@ -1,0 +1,21 @@
+import json
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+
+
+class AromaRSSpider(Spider):
+    name = "aroma_rs"
+    item_attributes = {"brand": "Арома", "brand_wikidata": "Q116446961"}
+    start_urls = ["https://aromamarketi.rs/lokacije/"]
+
+    def parse(self, response, **kwargs):
+        data = response.xpath('//script[@class="module__store_finder__storedata"]/text()').get()
+
+        for location in json.loads(data):
+            item = DictParser.parse(location["location"])
+            item["country"] = location["location"]["country_short"]
+            item["ref"] = item["name"] = location["title"]
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Арома': 63,
 'atp/brand_wikidata/Q116446961': 63,
 'atp/category/missing': 63,
 'atp/field/email/missing': 63,
 'atp/field/image/missing': 63,
 'atp/field/opening_hours/missing': 63,
 'atp/field/phone/missing': 63,
 'atp/field/postcode/missing': 35,
 'atp/field/street_address/missing': 63,
 'atp/field/twitter/missing': 63,
 'atp/field/website/missing': 63,
 'atp/nsi/brand_missing': 63,
 'downloader/request_bytes': 609,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17475,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.59354,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 27, 14, 24, 34, 831454),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 114615,
 'httpcompression/response_count': 2,
 'item_scraped_count': 63,
 'log_count/DEBUG': 71,
 'log_count/INFO': 9,
 'memusage/max': 118575104,
 'memusage/startup': 118575104,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 1, 27, 14, 24, 33, 237914)}
```
https://github.com/osmlab/name-suggestion-index/pull/7705