### PR TITLE
Add Inver Spider

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -33,6 +33,7 @@ class DictParser:
         "state-province",
         "province",
         "state-code",
+        "county",
     ]
 
     country_keys = [

--- a/locations/spiders/inver.py
+++ b/locations/spiders/inver.py
@@ -1,0 +1,33 @@
+from scrapy import Spider
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.spiders.vapestore_gb import clean_address
+
+
+class InverSpider(Spider):
+    name = "inver"
+    item_attributes = {"brand": "Inver", "brand_wikidata": "Q112579016"}
+    start_urls = [
+        "https://inverenergy.ie/wp-admin/admin-ajax.php?action=get_station_data",
+        "https://inverenergy.ie/canada/wp-admin/admin-ajax.php?action=get_station_data",
+    ]
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["data"]:
+            item = DictParser.parse(location)
+            item["addr_full"] = clean_address(item.get("addr_full"))
+
+            apply_yes_no(Extras.TOILETS, item, "toilet" in location["services"])
+            apply_yes_no(Extras.ATM, item, "atm" in location["services"])
+            apply_yes_no(Extras.CAR_WASH, item, "carwash" in location["services"])
+            apply_yes_no(Fuel.ADBLUE, item, "adblue" in location["services"])
+            apply_yes_no("hgv", item, "hgv_access" in location["services"])
+
+            if "convenience_store" in location["services"]:
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+            apply_category(Categories.FUEL_STATION, item)
+
+            item["ref"] = f'{item["country"]}-{item["ref"]}'
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Inver': 94,
 'atp/brand_wikidata/Q112579016': 94,
 'atp/category/amenity/fuel': 94,
 'atp/category/multiple': 9,
 'atp/field/city/missing': 94,
 'atp/field/email/missing': 94,
 'atp/field/image/missing': 94,
 'atp/field/opening_hours/missing': 94,
 'atp/field/phone/missing': 94,
 'atp/field/postcode/missing': 82,
 'atp/field/street_address/missing': 94,
 'atp/field/twitter/missing': 94,
 'atp/field/website/missing': 94,
 'atp/nsi/brand_missing': 94,
 'downloader/request_bytes': 993,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 10340,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 1.871383,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 27, 15, 31, 50, 486487),
 'httpcache/hit': 3,
 'httpcompression/response_bytes': 36775,
 'httpcompression/response_count': 3,
 'item_scraped_count': 94,
 'log_count/DEBUG': 103,
 'log_count/INFO': 8,
 'memusage/max': 118267904,
 'memusage/startup': 118267904,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 1, 27, 15, 31, 48, 615104)}
```
https://github.com/osmlab/name-suggestion-index/pull/7702