### PR TITLE
Add Odeon GB Spider

### DIFF
--- a/locations/spiders/odeon_gb.py
+++ b/locations/spiders/odeon_gb.py
@@ -1,0 +1,29 @@
+import json
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+
+
+class OdeonGBSpider(Spider):
+    name = "odeon_gb"
+    item_attributes = {"brand": "Odeon", "brand_wikidata": "Q6127470"}
+    start_urls = ["https://www.odeon.co.uk/cinemas/"]
+
+    def parse(self, response, **kwargs):
+        data = json.loads(response.xpath("//@data-v-site-list").get())
+        for location in data["config"]["cinemas"]:
+            location["address"] = ", ".join(
+                filter(
+                    None,
+                    [
+                        location.pop("addressLine1"),
+                        location.pop("addressLine2"),
+                        location.pop("addressLine3"),
+                        location.pop("addressLine4"),
+                        "United Kingdom",
+                    ],
+                )
+            )
+            location["url"] = f'https://www.odeon.co.uk{location["url"]}'
+            yield DictParser.parse(location)

--- a/locations/spiders/odeon_gb.py
+++ b/locations/spiders/odeon_gb.py
@@ -9,6 +9,7 @@ class OdeonGBSpider(Spider):
     name = "odeon_gb"
     item_attributes = {"brand": "Odeon", "brand_wikidata": "Q6127470"}
     start_urls = ["https://www.odeon.co.uk/cinemas/"]
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         data = json.loads(response.xpath("//@data-v-site-list").get())


### PR DESCRIPTION
Fixes #4696

```python
{'atp/brand/Odeon': 110,
 'atp/brand_wikidata/Q6127470': 110,
 'atp/category/amenity/cinema': 110,
 'atp/field/city/missing': 110,
 'atp/field/country/from_spider_name': 110,
 'atp/field/email/missing': 110,
 'atp/field/image/missing': 110,
 'atp/field/opening_hours/missing': 110,
 'atp/field/phone/missing': 110,
 'atp/field/state/missing': 110,
 'atp/field/street_address/missing': 110,
 'atp/field/twitter/missing': 110,
 'atp/nsi/perfect_match': 110,
 'downloader/request_bytes': 771,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 27347,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.54261,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 30, 9, 28, 43, 648774),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 172742,
 'httpcompression/response_count': 2,
 'item_scraped_count': 110,
 'log_count/DEBUG': 122,
 'log_count/INFO': 9,
 'memusage/max': 111927296,
 'memusage/startup': 111927296,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 1, 30, 9, 28, 41, 106164)}
```