### PR TITLE
Add Petrol Spider

### DIFF
--- a/locations/spiders/petrol.py
+++ b/locations/spiders/petrol.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Extras, Fuel, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -33,8 +34,13 @@ class PetrolSpider(Spider):
                 for time_range in times:
                     item["opening_hours"].add_range(day, time_range["open"], time_range["close"])
 
-            if any(cat["characteristic"]["key"] == "211" for cat in location["storeCharacteristics"]):
-                item.update(self.CRODUX)
+            for cat in location["storeCharacteristics"]:
+                if cat["characteristic"]["key"] == "28":
+                    item.update(self.CRODUX)
+                elif cat["characteristic"]["key"] == "160":
+                    apply_yes_no(Fuel.DIESEL, item, True)
+                elif cat["characteristic"]["key"] == "191":
+                    apply_yes_no(Extras.WIFI, item, True)
 
             yield item
 

--- a/locations/spiders/petrol.py
+++ b/locations/spiders/petrol.py
@@ -1,0 +1,42 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class PetrolSpider(Spider):
+    name = "petrol"
+    CRODUX = {"brand": "Crodux", "brand_wikidata": "Q62274622"}
+    PETROL = {"brand": "Petrol", "brand_wikidata": "Q174824"}
+    item_attributes = PETROL
+
+    @staticmethod
+    def make_request(offset):
+        return JsonRequest(
+            f"https://www.petrol.eu/restservices/sales-service/filterStores?offset={offset}", meta={"offset": offset}
+        )
+
+    def start_requests(self):
+        yield self.make_request(0)
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            if location["status"] != "ACTIVE":
+                continue
+            location["location"] = location["location"]["coordinates"][0]
+
+            item = DictParser.parse(location)
+
+            item["opening_hours"] = OpeningHours()
+            for day, times in location["activeOpeningHours"]["times"].items():
+                for time_range in times:
+                    item["opening_hours"].add_range(day, time_range["open"], time_range["close"])
+
+            if any(cat["characteristic"]["key"] == "211" for cat in location["storeCharacteristics"]):
+                item.update(self.CRODUX)
+
+            yield item
+
+        if len(response.json()) == 100:
+            yield self.make_request(response.meta["offset"] + 100)


### PR DESCRIPTION
https://github.com/osmlab/name-suggestion-index/pull/7725
```python
{'atp/brand/Crodux': 93,
 'atp/brand/Petrol': 503,
 'atp/brand_wikidata/Q174824': 503,
 'atp/brand_wikidata/Q62274622': 93,
 'atp/category/amenity/fuel': 93,
 'atp/category/missing': 503,
 'atp/field/email/missing': 596,
 'atp/field/image/missing': 596,
 'atp/field/phone/missing': 596,
 'atp/field/state/missing': 596,
 'atp/field/street_address/missing': 596,
 'atp/field/twitter/missing': 596,
 'atp/field/website/missing': 596,
 'atp/nsi/brand_missing': 503,
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 4458,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 1562314,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 9.308546,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 1, 31, 13, 35, 15, 909422),
 'httpcache/hit': 8,
 'httpcompression/response_bytes': 12295988,
 'httpcompression/response_count': 8,
 'item_scraped_count': 596,
 'log_count/DEBUG': 614,
 'log_count/INFO': 9,
 'memusage/max': 116174848,
 'memusage/startup': 116174848,
 'request_depth_max': 6,
 'response_received_count': 8,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2023, 1, 31, 13, 35, 6, 600876)}
```