### PR TITLE
Add spider for TSB (UK high street bank)

### DIFF
--- a/locations/spiders/tsb_gb.py
+++ b/locations/spiders/tsb_gb.py
@@ -1,0 +1,16 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TSBGB(SitemapSpider, StructuredDataSpider):
+    name = "tsb_gb"
+    item_attributes = {
+        "brand": "TSB",
+        "brand_wikidata": "Q7671560",
+        "extras": Categories.BANK.value,
+    }
+    sitemap_urls = ["https://branches.tsb.co.uk/sitemap.xml"]
+    sitemap_rules = [(r"https:\/\/branches\.tsb\.co\.uk\/[-\w]+\/[-\/\w]+\.html$", "parse_sd")]
+    wanted_types = ["BankOrCreditUnion", "FinancialService"]


### PR DESCRIPTION
Should implement issue #4614 .

I don't understand why, but I seemed to need
`wanted_types = ["BankOrCreditUnion", "FinancialService"]`
rather than
`wanted_types = [["BankOrCreditUnion", "FinancialService"]]`
as was suggested in the issue thread. With the wanted_types line either missing or being the latter above, I would get no results.

Running locally, the spider returns 264 branches, which is consistent with the 220 branches quoted at https://en.wikipedia.org/wiki/TSB_Bank_(United_Kingdom), plus around 43 "popup" locations referred to at https://www.tsb.co.uk/news-releases/tsb-to-launch-pop-ups-across-uk/ .