### PR TITLE
Add Krefel BE Spider

### DIFF
--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -1,0 +1,21 @@
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+
+
+class KrefelBESpider(Spider):
+    name = "krefel_be"
+    item_attributes = {"brand": "Krëfel", "brand_wikidata": "Q3200093"}
+    start_urls = ["https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=fr"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["stores"]:
+            location["ref"] = location.pop("name")
+            location["website"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
+            location["phone"] = ";".join(
+                filter(None, [location["address"].get("phone"), location["address"].get("phone2")])
+            ).replace("/", "")
+            location["address"]["house_number"] = location["address"].pop("line2", "")
+            location["address"]["street"] = location["address"].pop("line1")
+
+            yield DictParser.parse(location)


### PR DESCRIPTION
```python
{'atp/brand/Krëfel': 75,
 'atp/brand_wikidata/Q3200093': 75,
 'atp/category/shop/electronics': 75,
 'atp/field/country/from_spider_name': 75,
 'atp/field/email/missing': 75,
 'atp/field/image/missing': 75,
 'atp/field/opening_hours/missing': 75,
 'atp/field/state/missing': 75,
 'atp/field/street_address/missing': 75,
 'atp/field/twitter/missing': 75,
 'atp/nsi/perfect_match': 75,
 'downloader/request_bytes': 637,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 11563,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.206226,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 2, 6, 12, 17, 39, 939395),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 244842,
 'httpcompression/response_count': 1,
 'item_scraped_count': 75,
 'log_count/DEBUG': 84,
 'log_count/INFO': 9,
 'memusage/max': 116256768,
 'memusage/startup': 116256768,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 2, 6, 12, 17, 38, 733169)}
```
https://github.com/osmlab/name-suggestion-index/pull/7747