### PR TITLE
Fix CMD path in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ RUN playwright install firefox
 
 COPY . .
 
-CMD ["/opt/app/ci/run_all_spiders.sh"]
+CMD ["/home/ubuntu/ci/run_all_spiders.sh"]


### PR DESCRIPTION
The weekly run failed this past weekend because the script path in the Docker image changed.