### PR TITLE
Fix Edward Jones spider

### DIFF
--- a/locations/spiders/edwardjones.py
+++ b/locations/spiders/edwardjones.py
@@ -1,5 +1,3 @@
-import json
-
 import requests
 from scrapy.spiders import SitemapSpider
 
@@ -17,4 +15,28 @@ class EdwardJonesSpider(SitemapSpider, StructuredDataSpider):
         oh = OpeningHours()
         oh.from_linked_data(ld_data, time_format="%H:%M:%S")
         item["opening_hours"] = oh.as_opening_hours()
+
+        flag = True
+        page = 1
+        while flag:
+            url = "https://www.edwardjones.com/api/v3/financial-advisor/results?q={postcode}&distance=75&distance_unit=mi&page={page}&searchtype=2".format(
+                postcode=item["postcode"], page=page)
+
+            headers = {"Host": "www.edwardjones.com",
+                       "Accept": "application/json",
+                       "Referer": "https://www.edwardjones.com/us-en/search/financial-advisor/results"}
+            response = requests.get(url, headers=headers, data={}).json()
+
+            for x in response["results"]:
+                if item["website"].endswith(x["faUrl"]):
+                    item["lat"] = x["lat"]
+                    item["lon"] = x["lon"]
+                    flag = False
+
+            count = len(response["results"])
+            if count < response["itemsPerPage"] or count == 0:
+                flag = False
+            else:
+                page = page + 1
+
         yield item

--- a/locations/spiders/edwardjones.py
+++ b/locations/spiders/edwardjones.py
@@ -1,39 +1,20 @@
-import scrapy
+import json
 
-from locations.linked_data_parser import LinkedDataParser
+import requests
+from scrapy.spiders import SitemapSpider
+
+from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class EdwardJonesSpider(scrapy.Spider):
+class EdwardJonesSpider(SitemapSpider, StructuredDataSpider):
     name = "edwardjones"
     item_attributes = {"brand": "Edward Jones", "brand_wikidata": "Q5343830"}
     allowed_domains = ["www.edwardjones.com"]
+    sitemap_urls = ["https://www.edwardjones.com/us-en/sitemap/financial-advisor/sitemap.xml"]
 
-    def get_page(self, n):
-        return scrapy.Request(
-            f"https://www.edwardjones.com/api/v2/financial-advisor/results?q=57717&distance=75000&distance_unit=mi&page={n}",
-            meta={"page": n},
-        )
-
-    def start_requests(self):
-        yield self.get_page(1)
-
-    def parse(self, response):
-        data = response.json()["results"]
-        if data == []:
-            return
-        for row in data:
-            url = "https://www.edwardjones.com" + row["faUrl"]
-            meta = {
-                "lat": row["lat"],
-                "lon": row["lon"],
-            }
-            yield scrapy.Request(url, callback=self.parse_location, meta=meta)
-        yield self.get_page(1 + response.meta["page"])
-
-    def parse_location(self, response):
-        ld = LinkedDataParser.find_linked_data(response, "LocalBusiness")
-        del ld["openingHoursSpecification"]
-        item = LinkedDataParser.parse_ld(ld)
-        item["lat"] = response.meta["lat"]
-        item["lon"] = response.meta["lon"]
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        oh = OpeningHours()
+        oh.from_linked_data(ld_data, time_format="%H:%M:%S")
+        item["opening_hours"] = oh.as_opening_hours()
         yield item

--- a/locations/spiders/edwardjones.py
+++ b/locations/spiders/edwardjones.py
@@ -20,11 +20,14 @@ class EdwardJonesSpider(SitemapSpider, StructuredDataSpider):
         page = 1
         while flag:
             url = "https://www.edwardjones.com/api/v3/financial-advisor/results?q={postcode}&distance=75&distance_unit=mi&page={page}&searchtype=2".format(
-                postcode=item["postcode"], page=page)
+                postcode=item["postcode"], page=page
+            )
 
-            headers = {"Host": "www.edwardjones.com",
-                       "Accept": "application/json",
-                       "Referer": "https://www.edwardjones.com/us-en/search/financial-advisor/results"}
+            headers = {
+                "Host": "www.edwardjones.com",
+                "Accept": "application/json",
+                "Referer": "https://www.edwardjones.com/us-en/search/financial-advisor/results",
+            }
             response = requests.get(url, headers=headers, data={}).json()
 
             for x in response["results"]:

--- a/locations/spiders/edwardjones.py
+++ b/locations/spiders/edwardjones.py
@@ -1,4 +1,4 @@
-import requests
+import scrapy
 from scrapy.spiders import SitemapSpider
 
 from locations.hours import OpeningHours
@@ -16,30 +16,25 @@ class EdwardJonesSpider(SitemapSpider, StructuredDataSpider):
         oh.from_linked_data(ld_data, time_format="%H:%M:%S")
         item["opening_hours"] = oh.as_opening_hours()
 
-        flag = True
-        page = 1
-        while flag:
-            url = "https://www.edwardjones.com/api/v3/financial-advisor/results?q={postcode}&distance=75&distance_unit=mi&page={page}&searchtype=2".format(
-                postcode=item["postcode"], page=page
-            )
+        yield from self.get_location(item, 1)
 
-            headers = {
-                "Host": "www.edwardjones.com",
-                "Accept": "application/json",
-                "Referer": "https://www.edwardjones.com/us-en/search/financial-advisor/results",
-            }
-            response = requests.get(url, headers=headers, data={}).json()
+    def get_location(self, item, page):
+        url = "https://www.edwardjones.com/api/v3/financial-advisor/results?q={postcode}&distance=75&distance_unit=mi&page={page}&searchtype=2".format(
+            postcode=item["postcode"], page=page
+        )
+        yield scrapy.Request(url=url, cb_kwargs={"item": item, "page": 1}, callback=self.parse_location)
 
-            for x in response["results"]:
-                if item["website"].endswith(x["faUrl"]):
-                    item["lat"] = x["lat"]
-                    item["lon"] = x["lon"]
-                    flag = False
+    def parse_location(self, response, item, page):
+        json = response.json()
+        results = json["results"]
 
-            count = len(response["results"])
-            if count < response["itemsPerPage"] or count == 0:
-                flag = False
-            else:
-                page = page + 1
+        for x in results:
+            if item["website"].endswith(x["faUrl"]):
+                item["lat"] = x["lat"]
+                item["lon"] = x["lon"]
+                break
 
-        yield item
+        if ("lat" in item and "lon" in item) or json["resultCount" == 0] or len(results) < json["itemsPerPage"]:
+            yield item
+        else:
+            yield from self.get_location(item, page + 1)


### PR DESCRIPTION
Changes in the website removed the `lat/lon` from the pages. There's some workaround to contact an API (`https://www.edwardjones.com/api/v3/financial-advisor/results?q=" + postcode + "&distance=50&distance_unit=mi&page=1&matchblock=&searchtype=2`), but it's quite cumbersome to get it right and not get blocked.

I'll mark the PR as a draft and think further on it.