### PR TITLE
Fix Shell spider

### DIFF
--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -9,8 +9,7 @@ class ShellSpider(scrapy.Spider):
     name = "shell"
     item_attributes = {"brand": "Shell", "brand_wikidata": "Q110716465"}
     url_template = "https://shellgsllocator.geoapp.me/api/v1/locations/within_bounds?sw%5B%5D={}&sw%5B%5D={}&ne%5B%5D={}&ne%5B%5D={}"
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    download_delay = 0.5
+    custom_settings = {"ROBOTSTXT_OBEY": False, "AUTOTHROTTLE_ENABLED": True}
 
     def start_requests(self):
         yield scrapy.Request(self.url_template.format(-90, -180, 90, 180))


### PR DESCRIPTION
It was being blocked at 0.5 seconds. I ran this until 10k pois with no errors, we should expect 41,534 pois.

This and the BP spider share a lot of code. We should make a geo.me base spider at some point, however currently BP only uses v1 of the API, while Shell can use both. Once they both use v2 (or another geo.me spider comes along) I'll write a base spider.