### PR TITLE
Add Prada (Global) (373 stores)

### DIFF
--- a/locations/spiders/prada.py
+++ b/locations/spiders/prada.py
@@ -1,0 +1,45 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.hours import DAYS_EN, OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class Prada(SitemapSpider, StructuredDataSpider):
+    name = "prada"
+    item_attributes = {"brand": "Prada", "brand_wikidata": "Q193136"}
+    allowed_domains = ["www.prada.com"]
+    sitemap_urls = ["https://www.prada.com/us/en/sitemap.xml"]
+    sitemap_rules = [(r"/store-locator/store\.[\w%]+\.\d+\.html$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image")
+        item.pop("facebook")
+        item.pop("twitter")
+        item["ref"] = response.xpath('//div[contains(@class, "singleStore")]/@data-store-id').extract_first()
+
+        # Note that some stores open and close multiple times per day, hence the somewhat complicated OpeningHours extraction that follows.
+        hours_raw = (
+            ld_data["openingHours"]
+            .replace("--", "0:00 am - 0:00 am")
+            .replace("-", "")
+            .replace(" am", "AM")
+            .replace(" pm", "PM")
+            .split()
+        )
+        oh = OpeningHours()
+        current_day = None
+        start_time = None
+        for segment in hours_raw:
+            if segment in DAYS_EN:
+                current_day = DAYS_EN[segment]
+            elif start_time is None:
+                start_time = segment
+            else:
+                if start_time != "0:00AM" and segment != "0:00AM":
+                    oh.add_range(current_day, start_time, segment, "%I:%M%p")
+                start_time = None
+        item["opening_hours"] = oh.as_opening_hours()
+
+        yield item


### PR DESCRIPTION
Note that this spider currently extracts 373 stores, but the store finder on the website indicates only 368 stores exist. There could be a few recently closed stores that are being extracted from the sitemap? It isn't clear yet why the difference exists and if it were due to recently closed stores, how these stores could be enumerated and removed from the sites extracted.

The street_address field extracted from linked data is very messy. Sometimes it really is street_address, sometimes it is full_addr, but most of the time it is neither and is a street_address and state combined in a myriad of creative ways. Many street_address fields are completely in other languages such as Simplified Chinese or Korean.

Closes issue #4721