### PR TITLE
ace_hardware: rewrite to use KiboSpider

### DIFF
--- a/locations/spiders/ace_hardware.py
+++ b/locations/spiders/ace_hardware.py
@@ -1,13 +1,9 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.kibo import KiboSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AceHardwareSpider(CrawlSpider, StructuredDataSpider):
+class AceHardwareSpider(KiboSpider):
     name = "ace_hardware"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
-    start_urls = ["https://www.acehardware.com/store-directory"]
-    rules = [Rule(LinkExtractor(allow="/store-details/"), callback="parse_sd")]
+    start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
     user_agent = BROWSER_DEFAULT


### PR DESCRIPTION
KiboSpider reduces the number of requests from 4413 to 5 for ace_hardware and significantly simplifies ace_hardware to just a single start URL for the Kibo Storefront Location API URI of ace_hardware.