### PR TITLE
Fix Jack in the Box spider

### DIFF
--- a/locations/spiders/jackinthebox.py
+++ b/locations/spiders/jackinthebox.py
@@ -9,3 +9,4 @@ class JackInTheBoxSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://locations.jackinthebox.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     download_delay = 0.5
+    json_parser = "chompjs"


### PR DESCRIPTION
There's an error in the JSON (trailing `}`). `chompjs` does the trick.