### PR TITLE
bunnings: fix spider and include New Zealand stores

### DIFF
--- a/locations/spiders/bunnings.py
+++ b/locations/spiders/bunnings.py
@@ -1,48 +1,74 @@
+import secrets
+import string
+
 import scrapy
 
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.items import Feature
 
 
 class BunningsSpider(scrapy.Spider):
     name = "bunnings"
     allowed_domains = ["bunnings.com.au"]
-    start_urls = ("https://api.prod.bunnings.com.au/v1/stores/country/AU?fields=FULL",)
+    start_urls = [
+        "https://api.prod.bunnings.com.au/v1/stores/country/AU?fields=FULL",
+        "https://api.prod.bunnings.com.au/v1/stores/country/NZ?fields=FULL",
+    ]
     item_attributes = {"brand": "Bunnings", "brand_wikidata": "Q4997829"}
     custom_settings = {
-        "DEFAULT_REQUEST_HEADERS": {
-            "Authorization": "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IkJGRTFEMDBBRUZERkVDNzM4N0E1RUFFMzkxNjRFM0MwMUJBNzVDODciLCJ4NXQiOiJ2LUhRQ3VfZjdIT0hwZXJqa1dUandCdW5YSWMiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2J1bm5pbmdzLmNvbS5hdS8iLCJuYmYiOjE2NzE5Nzc2NTksImlhdCI6MTY3MTk3NzY1OSwiZXhwIjoxNjcyNDA5NjU5LCJhdWQiOlsiQ2hlY2tvdXQtQXBpIiwiY3VzdG9tZXJfYnVubmluZ3MiLCJodHRwczovL2J1bm5pbmdzLmNvbS5hdS9yZXNvdXJjZXMiXSwic2NvcGUiOlsiY2hrOmV4ZWMiLCJjbTphY2Nlc3MiLCJlY29tOmFjY2VzcyIsImNoazpwdWIiXSwiYW1yIjpbImV4dGVybmFsIl0sImNsaWVudF9pZCI6ImJ1ZHBfZ3Vlc3RfdXNlcl9hdSIsInN1YiI6IjA3YWNlYzQ5LTcwNDEtNDZhZS05NTUwLTU3MTMxMDJiZTMyZSIsImF1dGhfdGltZSI6MTY3MTk3NzY1OCwiaWRwIjoibG9jYWxsb29wYmFjayIsImItaWQiOiIwN2FjZWM0OS03MDQxLTQ2YWUtOTU1MC01NzEzMTAyYmUzMmUiLCJiLXJvbGUiOiJndWVzdCIsImItdHlwZSI6Imd1ZXN0IiwibG9jYWxlIjoiZW5fQVUiLCJiLWNvdW50cnkiOiJBVSIsInVzZXJfbmFtZSI6IjA3YWNlYzQ5LTcwNDEtNDZhZS05NTUwLTU3MTMxMDJiZTMyZSIsImFjdGl2YXRpb25fc3RhdHVzIjoiRmFsc2UiLCJiLXJiYWMiOlt7ImFzYyI6Ijc4NTUyZDhlLTIyMDItNDA4Zi04OGJlLWFiMzlhODZlY2QwZCIsInR5cGUiOiJDIiwicm9sIjpbIkNISzpHdWVzdCIsIkNISzpHdWVzdCJdfV0sInNpZCI6IjhGRDIwMDk4NTZFNDE1RTIwNUI4M0JFQzU4QzgwMTg0IiwianRpIjoiM0YxMzUxQ0E2NzdGREVCNzY4RUZDOTREMDVEMzYwMjEifQ.qAaoeuVbKECBttFWEdv4rguiiNWgW0091bw9klcdESBW6llp8YmYq0-TDEbNN0gilb385czPcbRWNMl0Uigh3hNjlNPc5InEcSEsRiKFXE1bm_R2X5WzEI47OmtRAogC5zuQThk-u_WRuc3C3pHw2Bu2x3kZ6QQpo9RjjNtyGL_CnC6GL_VzK_T1wZHKDMmVctozLmkIhf3KLas7x0AzpRHfKeZO68cR62oxwW0RTMK01EwdHy9_7X9vnb0Duvb-R1h0VLjGhqU6fWgmgMNuNsvW2Rlsh4ZQz0uGIwT_LNZbYRA4tcacdt-Oie_egmF6KjLdg-VXTkUmV35Nc7HPtg",
-            "clientId": "mHPVWnzuBkrW7rmt56XGwKkb5Gp9BJMk",
-            "country": "AU",
-            "locale": "en_AU",
-        }
+        "COOKIES_ENABLED": True,
     }
+    client_id = "mHPVWnzuBkrW7rmt56XGwKkb5Gp9BJMk"
+    auth_token = ""
+
+    def start_requests(self):
+        nonce = "".join(secrets.choice(string.ascii_letters + string.digits) for i in range(18))
+        yield scrapy.Request(
+            f"https://authorisation.api.bunnings.com.au/connect/authorize?response_type=token&scope=chk:exec cm:access ecom:access chk:pub &client_id=budp_guest_user_au&redirect_uri=https://www.bunnings.com.au/static/guest.html&nonce={nonce}&acr_values=",
+            self.parse_guest_login_page,
+        )
+
+    def parse_guest_login_page(self, response):
+        self.auth_token = response.request.url.split("#access_token=", 1)[1].split("&token_type=", 1)[0]
+        for url in self.start_urls:
+            yield scrapy.Request(
+                url,
+                self.parse,
+                headers={
+                    "Authorization": "Bearer " + self.auth_token,
+                    "clientId": self.client_id,
+                    "country": "AU",
+                    "locale": "en_AU",
+                },
+            )
 
     def parse(self, response):
-        data = response.json().get("data", {}).get("pointOfServices")
-        for store in data:
+        if response.json()["statusDetails"]["state"] != "SUCCESS":
+            return
+        for location in response.json()["data"]["pointOfServices"]:
+            item = DictParser.parse(location)
+            item["ref"] = location["name"]
+            item["name"] = location["displayName"]
+            item["phone"] = location["address"]["phone"]
+            item["email"] = location["address"]["email"]
+            if item["country"] == "NZ":
+                item.pop("state")
+                website_prefix = "https://www.bunnings.co.nz/stores/"
+            else:
+                item["state"] = location["address"]["region"]["isocode"]
+                website_prefix = "https://www.bunnings.com.au/stores/"
+            if "urlRegion" in location:
+                item["website"] = website_prefix + location["urlRegion"] + "/" + item["name"].lower().replace(" ", "-")
+            if "mapIcon" in location:
+                item["extras"]["website:map"] = location["mapIcon"]["url"]
             oh = OpeningHours()
-            for day in store.get("openingHours", {}).get("weekDayOpeningList"):
-                oh.add_range(
-                    day=day.get("weekDay"),
-                    open_time=day.get("openingTime", {}).get("formattedHour"),
-                    close_time=day.get("closingTime", {}).get("formattedHour"),
-                    time_format="%I:%M %p",
-                )
-
-            properties = {
-                "ref": store.get("address", {}).get("id"),
-                "name": store.get("displayName"),
-                "lat": store.get("geoPoint", {}).get("latitude"),
-                "lon": store.get("geoPoint", {}).get("longitude"),
-                "street_address": store.get("address", {}).get("formattedAddress"),
-                "city": store.get("pricingRegion"),
-                "postcode": store.get("address", {}).get("postalCode"),
-                "country": store.get("country", {}).get("isocode"),
-                "phone": store.get("address", {}).get("phone"),
-                "email": store.get("address", {}).get("email"),
-                "website": f'https://www.bunnings.com.au/stores/{store.get("storeRegion").lower()}/{store.get("displayName").lower().replace(" ", "-")}',
-                "opening_hours": oh.as_opening_hours(),
-            }
-
-            yield Feature(**properties)
+            for day in location["openingHours"]["weekDayOpeningList"]:
+                if not day["closed"]:
+                    oh.add_range(
+                        day=day["weekDay"],
+                        open_time=day["openingTime"]["formattedHour"],
+                        close_time=day["closingTime"]["formattedHour"],
+                        time_format="%I:%M %p",
+                    )
+            item["opening_hours"] = oh.as_opening_hours()
+            yield item


### PR DESCRIPTION
The Bunnings API used for locating stores requires a guest/anonymous OAUTH login process to be completed, and an Authorization Bearer header to be sent when calling the API.

The spider has largely been rewritten using DictParser, fixing numerous incorrect field values in the process.

The rewritten spider also extracts New Zealand Bunnings stores.

Currently 351 stores are returned by the API, with 41 being in New Zealand and the remainder in Australia.