### PR TITLE
Switch from using Sitemap to 'Full Store List' web page for Specsavers

### DIFF
--- a/locations/spiders/specsavers_gb.py
+++ b/locations/spiders/specsavers_gb.py
@@ -1,19 +1,20 @@
-from scrapy.spiders import SitemapSpider
-
+import scrapy
+import re
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class SpecsaversGBSpider(SitemapSpider, StructuredDataSpider):
+class SpecsaversGBSpider(StructuredDataSpider,scrapy.Spider):
     name = "specsavers_gb"
     item_attributes = {"brand": "Specsavers", "brand_wikidata": "Q2000610"}
     allowed_domains = ["specsavers.co.uk"]
-    sitemap_urls = ["https://www.specsavers.co.uk/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)",
-            "parse_sd",
-        ),
-    ]
+    start_urls = ["https://www.specsavers.co.uk/stores/full-store-list"]
+
+    def parse(self, response):
+        for link in response.xpath('//*/@href').getall():
+            if re.fullmatch("https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)",
+                            response.urljoin(link) ):
+                yield scrapy.Request(response.urljoin(link), callback=self.parse_sd)
+
     # Stores that include hearing tests are given an extra page e.g.
     # https://www.specsavers.co.uk/stores/barnsley-hearing
     # We can't just ignore any that end with "-hearing" as some are valid e.g

--- a/locations/spiders/specsavers_gb.py
+++ b/locations/spiders/specsavers_gb.py
@@ -1,20 +1,14 @@
-import re
-
-import scrapy
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class SpecsaversGBSpider(StructuredDataSpider, scrapy.Spider):
+class SpecsaversGBSpider(CrawlSpider, StructuredDataSpider):
     name = "specsavers_gb"
     item_attributes = {"brand": "Specsavers", "brand_wikidata": "Q2000610"}
-    allowed_domains = ["specsavers.co.uk"]
     start_urls = ["https://www.specsavers.co.uk/stores/full-store-list"]
-
-    def parse(self, response):
-        for link in response.xpath("//*/@href").getall():
-            if re.fullmatch("https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)", response.urljoin(link)):
-                yield scrapy.Request(response.urljoin(link), callback=self.parse_sd)
+    rules = [Rule(LinkExtractor(allow=r"https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)"), callback="parse_sd")]
 
     # Stores that include hearing tests are given an extra page e.g.
     # https://www.specsavers.co.uk/stores/barnsley-hearing

--- a/locations/spiders/specsavers_gb.py
+++ b/locations/spiders/specsavers_gb.py
@@ -1,18 +1,19 @@
-import scrapy
 import re
+
+import scrapy
+
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class SpecsaversGBSpider(StructuredDataSpider,scrapy.Spider):
+class SpecsaversGBSpider(StructuredDataSpider, scrapy.Spider):
     name = "specsavers_gb"
     item_attributes = {"brand": "Specsavers", "brand_wikidata": "Q2000610"}
     allowed_domains = ["specsavers.co.uk"]
     start_urls = ["https://www.specsavers.co.uk/stores/full-store-list"]
 
     def parse(self, response):
-        for link in response.xpath('//*/@href').getall():
-            if re.fullmatch("https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)",
-                            response.urljoin(link) ):
+        for link in response.xpath("//*/@href").getall():
+            if re.fullmatch("https:\/\/www\.specsavers\.co\.uk\/stores\/(.+)", response.urljoin(link)):
                 yield scrapy.Request(response.urljoin(link), callback=self.parse_sd)
 
     # Stores that include hearing tests are given an extra page e.g.


### PR DESCRIPTION
This spider previously used the Specsavers' sitemap at https://www.specsavers.co.uk/sitemap.xml but by comparing the data with OSM, I noticed a number of stores were missing from the sitemap. Specsavers also has a 'Full Store List' web page at https://www.specsavers.co.uk/stores/full-store-list which appears to be more complete.

I'm not sure if how I've coded it is the best way to do it, but when run locally the new spider appears to work, and returns 913 stores, compared to 838 from the current spider at the last ATP run.

This seems to be a big improvement. However, there's still at least one store that's missing from the Full Store List page: https://www.specsavers.co.uk/stores/addlestone .