### PR TITLE
Always output geometry

### DIFF
--- a/locations/exporters.py
+++ b/locations/exporters.py
@@ -120,8 +120,7 @@ class LineDelimitedGeoJsonExporter(JsonLinesItemExporter):
                 }
             except ValueError:
                 logging.warning("Couldn't convert lat (%s) and lon (%s) to float", lat, lon)
-        if geometry:
-            feature.append(("geometry", geometry))
+        feature.append(("geometry", geometry))
 
         return feature
 
@@ -167,8 +166,7 @@ class GeoJsonExporter(JsonItemExporter):
                 }
             except ValueError:
                 logging.warning("Couldn't convert lat (%s) and lon (%s) to float", lat, lon)
-        if geometry:
-            feature.append(("geometry", geometry))
+        feature.append(("geometry", geometry))
 
         return feature
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,4 +1,4 @@
-from locations.exporters import item_to_properties
+from locations.exporters import GeoJsonExporter, LineDelimitedGeoJsonExporter, item_to_properties
 from locations.items import Feature
 
 
@@ -16,3 +16,25 @@ def test_item_to_properties():
     item["extras"]["b"] = ""
 
     assert item_to_properties(item) == {"ref": "a"}
+
+
+def test_has_geom():
+    def has_geom(props: []) -> bool:
+        return any(k == "geometry" for k, v in props)
+
+    item = Feature()
+    geojson_exporter = GeoJsonExporter(None)
+    ld_geojson_exporter = LineDelimitedGeoJsonExporter(None)
+
+    assert has_geom(geojson_exporter._get_serialized_fields(item))
+    assert has_geom(ld_geojson_exporter._get_serialized_fields(item))
+
+    item["lat"] = item["lon"] = 1
+
+    assert has_geom(geojson_exporter._get_serialized_fields(item))
+    assert has_geom(ld_geojson_exporter._get_serialized_fields(item))
+
+    item["lat"] = item["lon"] = 0
+
+    assert has_geom(geojson_exporter._get_serialized_fields(item))
+    assert has_geom(ld_geojson_exporter._get_serialized_fields(item))


### PR DESCRIPTION
Weirdly not outputting `geometry` is against the spec, it wants `"geometry": null` when there isn't any.