### PR TITLE
Fix broken papa_johns_gb spider

### DIFF
--- a/locations/spiders/papa_johns_gb.py
+++ b/locations/spiders/papa_johns_gb.py
@@ -17,7 +17,7 @@ class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
     wanted_types = ["LocalBusiness"]
 
     def post_process_item(self, item, response, ld_data):
-        #extract_google_position(item, response)
+        # extract_google_position(item, response)
         item["website"] = response.url
 
         yield item

--- a/locations/spiders/papa_johns_gb.py
+++ b/locations/spiders/papa_johns_gb.py
@@ -11,12 +11,13 @@ class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
         "brand_wikidata": "Q2759586",
         "country": "GB",
     }
+    download_delay = 1
     sitemap_urls = ["https://www.papajohns.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/(.+)\/home\.aspx$", "parse_sd")]
+    sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/([-\w]+)$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
 
-    def inspect_item(self, item, response):
-        extract_google_position(item, response)
+    def post_process_item(self, item, response, ld_data):
+        #extract_google_position(item, response)
         item["website"] = response.url
 
         yield item


### PR DESCRIPTION
Correct store page regex, update deprecated `inspect_item` function, remove broken position extraction (Google URL no longer contains lat/lon).

Unfortunately, it seems that the store pages no longer provide a lat/lon for each store. It might be possible to add some geocoding based on the address and postcode, but for now I haven't done so.

Run locally, this new version returns 479 stores.