### PR TITLE
Correct regex for additional characters in store URLs

### DIFF
--- a/locations/spiders/papa_johns_gb.py
+++ b/locations/spiders/papa_johns_gb.py
@@ -13,7 +13,7 @@ class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
     }
     download_delay = 1
     sitemap_urls = ["https://www.papajohns.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/([-\w]+)$", "parse_sd")]
+    sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/([-.\w]+)$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
 
     def post_process_item(self, item, response, ld_data):


### PR DESCRIPTION
e.g. https://www.papajohns.co.uk/stores/st.ives-cambridge