### PR TITLE
OpeningHours: introduce add_ranges_from_string

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -190,12 +190,17 @@ DAYS_ES = {
 
 NAMED_DAY_RANGES_EN = {
     "Daily": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
+    "All days": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
     "Weekdays": ["Mo", "Tu", "We", "Th", "Fr"],
     "Weekends": ["Sa", "Su"],
 }
 
 DELIMITERS_EN = {
     "-",
+    "–",
+    "—",
+    "―",
+    "‒",
     "to",
     "and",
     "from",

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -358,7 +358,9 @@ class OpeningHours:
                             if d := sanitise_day(day):
                                 self.add_range(d, start_time, end_time, time_format)
 
-    def add_ranges_from_string(self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, delimiters=DELIMITERS_EN):
+    def add_ranges_from_string(
+        self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, delimiters=DELIMITERS_EN
+    ):
         # Build two regular expressions--one for extracting 12h
         # opening hour information, and one for extracting 24h
         # opening hour information from a supplied string.
@@ -413,8 +415,12 @@ class OpeningHours:
         days_regex = days_regex + r"|".join(days_regex_parts) + r")"
         time_regex_12h = r"(?<!\d)(0?[0-9]|1[012])(?:(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?)?\s*([AP]M)?(?!\d)"
         time_regex_24h = r"(?<!\d)(0?[0-9]|1[0-9]|2[0-4])(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?(?!\d)"
-        full_regex_12h = days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_12h + delimiter_regex + time_regex_12h
-        full_regex_24h = days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_24h + delimiter_regex + time_regex_24h
+        full_regex_12h = (
+            days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_12h + delimiter_regex + time_regex_12h
+        )
+        full_regex_24h = (
+            days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_24h + delimiter_regex + time_regex_24h
+        )
 
         # Execute both regular expressions.
         results_12h = re.findall(full_regex_12h, ranges_string, re.IGNORECASE)

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -184,6 +184,7 @@ NAMED_DAY_RANGES_EN = {
     "Weekends": ["Sa", "Su"],
 }
 
+
 def day_range(start_day, end_day):
     start_ix = DAYS.index(start_day)
     end_ix = DAYS.index(end_day)
@@ -333,7 +334,7 @@ class OpeningHours:
                             if d := sanitise_day(day):
                                 self.add_range(d, start_time, end_time, time_format)
 
-    def add_ranges_from_string(self, ranges_string, days = DAYS_EN, named_day_ranges = NAMED_DAY_RANGES_EN):
+    def add_ranges_from_string(self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN):
         # Build two regular expressions--one for extracting 12h
         # opening hour information, and one for extracting 24h
         # opening hour information from a supplied string.
@@ -346,7 +347,7 @@ class OpeningHours:
         for i in range(0, 6, 1):
             start_day_string = r"(?<!\w)(" + r"|".join(day_synonyms[DAYS[i]]) + r")(?!\w)"
             end_days = []
-            for j in range(i+1, 7, 1):
+            for j in range(i + 1, 7, 1):
                 end_days.append("|".join(day_synonyms[DAYS[j]]))
             end_days_string = r"(?<!\w)(" + r"|".join(end_days) + r")(?!\w)"
             days_regex_parts.append(start_day_string + delimiter_regex + end_days_string)

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -344,6 +344,7 @@ def test_ld_parse_time_format():
     )
     assert o.as_opening_hours() == "Sa 12:00-14:00"
 
+
 def test_add_ranges_from_string():
     o = OpeningHours()
     o.add_ranges_from_string("Monday-Wednesday: 5pm - 7pm")
@@ -352,7 +353,10 @@ def test_add_ranges_from_string():
     o.add_ranges_from_string("Thurs 2PM-6:30PM")
     o.add_ranges_from_string(" Fri    9am  -  11am ")
     o.add_ranges_from_string("Weekends: 8:00 AM to 6:00 PM")
-    assert o.as_opening_hours() == "Mo-Tu 08:00-14:00,15:00-16:35,17:00-19:00; We 08:00-14:00,17:00-19:00; Th 14:00-18:30; Fr 09:00-11:00; Sa-Su 08:00-18:00"
+    assert (
+        o.as_opening_hours()
+        == "Mo-Tu 08:00-14:00,15:00-16:35,17:00-19:00; We 08:00-14:00,17:00-19:00; Th 14:00-18:30; Fr 09:00-11:00; Sa-Su 08:00-18:00"
+    )
 
     o = OpeningHours()
     o.add_ranges_from_string("Monday to Thursday 7am to 7pm, Friday 12am to 11:59pm, Weekends CLOSED")

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -343,3 +343,21 @@ def test_ld_parse_time_format():
         "%H:%M:%S",
     )
     assert o.as_opening_hours() == "Sa 12:00-14:00"
+
+def test_add_ranges_from_string():
+    o = OpeningHours()
+    o.add_ranges_from_string("Monday-Wednesday: 5pm - 7pm")
+    o.add_ranges_from_string("Monday-Wednesday 08:00-14:00")
+    o.add_ranges_from_string("Monday to Tuesday: 15:00:01 to 16:35")
+    o.add_ranges_from_string("Thurs 2PM-6:30PM")
+    o.add_ranges_from_string(" Fri    9am  -  11am ")
+    o.add_ranges_from_string("Weekends: 8:00 AM to 6:00 PM")
+    assert o.as_opening_hours() == "Mo-Tu 08:00-14:00,15:00-16:35,17:00-19:00; We 08:00-14:00,17:00-19:00; Th 14:00-18:30; Fr 09:00-11:00; Sa-Su 08:00-18:00"
+
+    o = OpeningHours()
+    o.add_ranges_from_string("Monday to Thursday 7am to 7pm, Friday 12am to 11:59pm, Weekends CLOSED")
+    assert o.as_opening_hours() == "Mo-Th 07:00-19:00; Fr 00:00-24:00"
+
+    o = OpeningHours()
+    o.add_ranges_from_string("Monday - Sunday: 00:00 - 23:59")
+    assert o.as_opening_hours() == "24/7"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -363,5 +363,9 @@ def test_add_ranges_from_string():
     assert o.as_opening_hours() == "Mo-Th 07:00-19:00; Fr 00:00-24:00"
 
     o = OpeningHours()
+    o.add_ranges_from_string("Sunday to Thursday 0800-1400, Wed-Sat 1300-1800")
+    assert o.as_opening_hours() == "Mo-Tu 08:00-14:00; We-Th 08:00-14:00,13:00-18:00; Fr-Sa 13:00-18:00; Su 08:00-14:00"
+
+    o = OpeningHours()
     o.add_ranges_from_string("Monday - Sunday: 00:00 - 23:59")
     assert o.as_opening_hours() == "24/7"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,7 +1,7 @@
 import json
 import time
 
-from locations.hours import DAYS, DAYS_BG, DAYS_DE, OpeningHours, day_range, sanitise_day
+from locations.hours import DAYS, DAYS_BG, DAYS_DE, DAYS_ES, DELIMITERS_ES, OpeningHours, day_range, sanitise_day
 
 
 def test_day_range():
@@ -369,3 +369,8 @@ def test_add_ranges_from_string():
     o = OpeningHours()
     o.add_ranges_from_string("Monday - Sunday: 00:00 - 23:59")
     assert o.as_opening_hours() == "24/7"
+
+    o = OpeningHours()
+    o.add_ranges_from_string("Lunes a Domingo: 11:00 a 20:30 / Viernes y Sábado: 11:00 a 21:00", days=DAYS_ES, named_day_ranges={}, delimiters=DELIMITERS_ES)
+    o.add_ranges_from_string("Lunes a Sábado de 09:00 a 10:15 / Domingo de 09:00:00 a 10:00:00", days=DAYS_ES, named_day_ranges={}, delimiters=DELIMITERS_ES)
+    assert o.as_opening_hours() == "Mo-Th 09:00-10:15,11:00-20:30; Fr-Sa 09:00-10:15,11:00-20:30,11:00-21:00; Su 09:00-10:00,11:00-20:30"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -371,6 +371,19 @@ def test_add_ranges_from_string():
     assert o.as_opening_hours() == "24/7"
 
     o = OpeningHours()
-    o.add_ranges_from_string("Lunes a Domingo: 11:00 a 20:30 / Viernes y Sábado: 11:00 a 21:00", days=DAYS_ES, named_day_ranges={}, delimiters=DELIMITERS_ES)
-    o.add_ranges_from_string("Lunes a Sábado de 09:00 a 10:15 / Domingo de 09:00:00 a 10:00:00", days=DAYS_ES, named_day_ranges={}, delimiters=DELIMITERS_ES)
-    assert o.as_opening_hours() == "Mo-Th 09:00-10:15,11:00-20:30; Fr-Sa 09:00-10:15,11:00-20:30,11:00-21:00; Su 09:00-10:00,11:00-20:30"
+    o.add_ranges_from_string(
+        "Lunes a Domingo: 11:00 a 20:30 / Viernes y Sábado: 11:00 a 21:00",
+        days=DAYS_ES,
+        named_day_ranges={},
+        delimiters=DELIMITERS_ES,
+    )
+    o.add_ranges_from_string(
+        "Lunes a Sábado de 09:00 a 10:15 / Domingo de 09:00:00 a 10:00:00",
+        days=DAYS_ES,
+        named_day_ranges={},
+        delimiters=DELIMITERS_ES,
+    )
+    assert (
+        o.as_opening_hours()
+        == "Mo-Th 09:00-10:15,11:00-20:30; Fr-Sa 09:00-10:15,11:00-20:30,11:00-21:00; Su 09:00-10:00,11:00-20:30"
+    )


### PR DESCRIPTION
add_ranges_from_string is added as a parser function designed to help translate from opening hours provided as human readable text in a fuzzy format.

This function is intended to add opening hours ranges based on the following type of ranges that may be found in source data:

1. Monday-Wednesday: 5pm - 7pm
2. Monday-Wednesday 08:00-14:00
3. Monday to Tuesday: 15:00:01 to 16:35
4. Thurs 2PM-6:30PM
5.  Fri    9am  -  11am
6. Weekends: 8:00 AM to 6:00 PM
7. Monday to Thursday 7am to 7pm, Friday 7am to 10pm, Weekends CLOSED

This function works with a source that may mix and match from the type of examples listed above. For example, if a source uses both 12h and 24h times to describe opening hours.

This function does not currently support extraction of multiple opening hours on the same day of a week. Only the first opening time of each day is extracted. This function should therefore not be used if the source data has the potential to list multiple opening hours for the same day.

This function does not currently support named times of each day such as 'Midday' and "Midnight". It is possible to replace these prior to the input string being provided to this function.

This function allows specification of days and day ranges in langauges other than the default English.