### PR TITLE
Enhance OpeningHours add_ranges_from_string and use it with Store Rocket store finder

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -512,7 +512,12 @@ class OpeningHours:
                                 self.add_range(d, start_time, end_time, time_format)
 
     def add_ranges_from_string(
-        self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, named_times=NAMED_TIMES_EN, delimiters=DELIMITERS_EN
+        self,
+        ranges_string,
+        days=DAYS_EN,
+        named_day_ranges=NAMED_DAY_RANGES_EN,
+        named_times=NAMED_TIMES_EN,
+        delimiters=DELIMITERS_EN,
     ):
         # Build two regular expressions--one for extracting 12h
         # opening hour information, and one for extracting 24h
@@ -569,18 +574,40 @@ class OpeningHours:
         time_regex_12h = r"(?<!\d)(0?[0-9]|1[012])(?:(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?)?\s*([AP]M)?(?!\d)"
         time_regex_24h = r"(?<!\d)(0?[0-9]|1[0-9]|2[0-4])(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?(?!(?:\d|[AP]M))"
         full_regex_12h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_12h + delimiter_regex + time_regex_12h + r")+)"
+            days_regex
+            + r"(?:\W+|"
+            + delimiter_regex
+            + r")((?:(?:\s*,?\s*)?"
+            + time_regex_12h
+            + delimiter_regex
+            + time_regex_12h
+            + r")+)"
         )
         full_regex_24h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_24h + delimiter_regex + time_regex_24h + r")+)"
+            days_regex
+            + r"(?:\W+|"
+            + delimiter_regex
+            + r")((?:(?:\s*,?\s*)?"
+            + time_regex_24h
+            + delimiter_regex
+            + time_regex_24h
+            + r")+)"
         )
 
         # Replace named times in source ranges string (e.g. midnight -> 24:00)
         ranges_string_12h = ranges_string
         ranges_string_24h = ranges_string
         for named_time_name, named_time_time in named_times.items():
-            ranges_string_12h = ranges_string_12h.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
-            ranges_string_24h = ranges_string_24h.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+            ranges_string_12h = (
+                ranges_string_12h.replace(named_time_name.lower(), named_time_time[0])
+                .replace(named_time_name.title(), named_time_time[0])
+                .replace(named_time_name.upper(), named_time_time[0])
+            )
+            ranges_string_24h = (
+                ranges_string_24h.replace(named_time_name.lower(), named_time_time[1])
+                .replace(named_time_name.title(), named_time_time[1])
+                .replace(named_time_name.upper(), named_time_time[1])
+            )
 
         # Execute both regular expressions.
         results_12h = re.findall(full_regex_12h, ranges_string_12h, re.IGNORECASE)
@@ -593,15 +620,21 @@ class OpeningHours:
             for result in results_24h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
                 start_and_end_days = list(filter(None, result[:time_start_index]))
-                time_ranges = re.findall(time_regex_24h + delimiter_regex + time_regex_24h, result[time_start_index], re.IGNORECASE)
+                time_ranges = re.findall(
+                    time_regex_24h + delimiter_regex + time_regex_24h, result[time_start_index], re.IGNORECASE
+                )
                 for time_range in time_ranges:
-                    results_normalised.append([start_and_end_days, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"])
+                    results_normalised.append(
+                        [start_and_end_days, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"]
+                    )
         elif len(results_12h) > 0:
             # Parse 12h opening hour information.
             for result in results_12h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
                 start_and_end_days = list(filter(None, result[:time_start_index]))
-                time_ranges = re.findall(time_regex_12h + delimiter_regex + time_regex_12h, result[time_start_index], re.IGNORECASE)
+                time_ranges = re.findall(
+                    time_regex_12h + delimiter_regex + time_regex_12h, result[time_start_index], re.IGNORECASE
+                )
                 for time_range in time_ranges:
                     if time_range[1]:
                         time_start = f"{time_range[0]}:{time_range[1]}"

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -338,6 +338,11 @@ NAMED_DAY_RANGES_EN = {
     "Weekends": ["Sa", "Su"],
 }
 
+NAMED_TIMES_EN = {
+    "Midday": ["12:00PM", "12:00"],
+    "Midnight": ["12:00AM", "00:00"],
+}
+
 DELIMITERS_EN = {
     "-",
     "–",
@@ -507,7 +512,7 @@ class OpeningHours:
                                 self.add_range(d, start_time, end_time, time_format)
 
     def add_ranges_from_string(
-        self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, delimiters=DELIMITERS_EN
+        self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, named_times=NAMED_TIMES_EN, delimiters=DELIMITERS_EN
     ):
         # Build two regular expressions--one for extracting 12h
         # opening hour information, and one for extracting 24h
@@ -564,54 +569,63 @@ class OpeningHours:
         time_regex_12h = r"(?<!\d)(0?[0-9]|1[012])(?:(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?)?\s*([AP]M)?(?!\d)"
         time_regex_24h = r"(?<!\d)(0?[0-9]|1[0-9]|2[0-4])(?:[:\.]?([0-5][0-9]))(?:[:\.]?[0-5][0-9])?(?!(?:\d|[AP]M))"
         full_regex_12h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_12h + delimiter_regex + time_regex_12h
+            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_12h + delimiter_regex + time_regex_12h + r")+)"
         )
         full_regex_24h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")" + time_regex_24h + delimiter_regex + time_regex_24h
+            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_24h + delimiter_regex + time_regex_24h + r")+)"
         )
 
+        # Replace named times in source ranges string (e.g. midnight -> 24:00)
+        ranges_string_12h = ranges_string
+        ranges_string_24h = ranges_string
+        for named_time_name, named_time_time in named_times.items():
+            ranges_string_12h = ranges_string_12h.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
+            ranges_string_24h = ranges_string_24h.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+
         # Execute both regular expressions.
-        results_12h = re.findall(full_regex_12h, ranges_string, re.IGNORECASE)
-        results_24h = re.findall(full_regex_24h, ranges_string, re.IGNORECASE)
+        results_12h = re.findall(full_regex_12h, ranges_string_12h, re.IGNORECASE)
+        results_24h = re.findall(full_regex_24h, ranges_string_24h, re.IGNORECASE)
 
         # Normalise results to 24h time.
         results_normalised = []
         if len(results_24h) > 0:
             # Parse 24h opening hour information.
             for result in results_24h:
-                time_start = result[-4] + ":" + result[-3]
-                time_end = result[-2] + ":" + result[-1]
-                start_and_end_days = list(filter(None, result[:-4]))
-                results_normalised.append([start_and_end_days, time_start, time_end])
+                time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
+                start_and_end_days = list(filter(None, result[:time_start_index]))
+                time_ranges = re.findall(time_regex_24h + delimiter_regex + time_regex_24h, result[time_start_index], re.IGNORECASE)
+                for time_range in time_ranges:
+                    results_normalised.append([start_and_end_days, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"])
         elif len(results_12h) > 0:
             # Parse 12h opening hour information.
             for result in results_12h:
-                time_start = result[-6] + ":"
-                if result[-5]:
-                    time_start = time_start + result[-5]
-                else:
-                    time_start = time_start + "00"
-                if result[-4]:
-                    time_start = time_start + result[-4].upper()
-                else:
-                    # If AM/PM is not specified, it is almost always going to be AM for start times.
-                    time_start = time_start + "AM"
-                time_start_24h = time.strptime(time_start, "%I:%M%p")
-                time_start_24h = time.strftime("%H:%M", time_start_24h)
-                time_end = result[-3] + ":"
-                if result[-2]:
-                    time_end = time_end + result[-2]
-                else:
-                    time_end = time_end + "00"
-                if result[-1]:
-                    time_end = time_end + result[-1].upper()
-                else:
-                    # If AM/PM is not specified, it is almost always going to be PM for end times.
-                    time_end = time_end + "PM"
-                time_end_24h = time.strptime(time_end, "%I:%M%p")
-                time_end_24h = time.strftime("%H:%M", time_end_24h)
-                start_and_end_days = list(filter(None, result[:-6]))
-                results_normalised.append([start_and_end_days, time_start_24h, time_end_24h])
+                time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
+                start_and_end_days = list(filter(None, result[:time_start_index]))
+                time_ranges = re.findall(time_regex_12h + delimiter_regex + time_regex_12h, result[time_start_index], re.IGNORECASE)
+                for time_range in time_ranges:
+                    if time_range[1]:
+                        time_start = f"{time_range[0]}:{time_range[1]}"
+                    else:
+                        time_start = f"{time_range[0]}:00"
+                    if time_range[2]:
+                        time_start = f"{time_start}{time_range[2].upper()}"
+                    else:
+                        # If AM/PM is not specified, it is almost always going to be AM for start times.
+                        time_start = f"{time_start}AM"
+                    time_start_24h = time.strptime(time_start, "%I:%M%p")
+                    time_start_24h = time.strftime("%H:%M", time_start_24h)
+                    if time_range[4]:
+                        time_end = f"{time_range[3]}:{time_range[4]}"
+                    else:
+                        time_end = f"{time_range[3]}:00"
+                    if time_range[5]:
+                        time_end = f"{time_end}{time_range[5].upper()}"
+                    else:
+                        # If AM/PM is not specified, it is almost always going to be PM for start times.
+                        time_end = f"{time_end}PM"
+                    time_end_24h = time.strptime(time_end, "%I:%M%p")
+                    time_end_24h = time.strftime("%H:%M", time_end_24h)
+                    results_normalised.append([start_and_end_days, time_start_24h, time_end_24h])
 
         # Add ranges to OpeningHours object from normalised results.
         for result in results_normalised:

--- a/locations/spiders/fastbreak_us.py
+++ b/locations/spiders/fastbreak_us.py
@@ -1,5 +1,3 @@
-from locations.hours import OpeningHours, sanitise_day
-from locations.items import Feature
 from locations.storefinders.storerocket import StoreRocketSpider
 
 
@@ -8,13 +6,3 @@ class FastbreakUSSpider(StoreRocketSpider):
     item_attributes = {"brand": "Fastbreak", "brand_wikidata": "Q116731804"}
     storerocket_id = "WwzpABj4dD"
     base_url = "https://www.myfastbreak.com/locations"
-
-    def parse_item(self, item: Feature, location: dict, **kwargs):
-        item["opening_hours"] = OpeningHours()
-        for day, times in location["hours"].items():
-            day = sanitise_day(day)
-            if day and times:
-                start_time, end_time = times.split("-")
-                item["opening_hours"].add_range(day, start_time, end_time)
-
-        yield item

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -39,9 +39,9 @@ class StoreRocketSpider(Spider):
                     continue
                 hour_ranges = location[day].split(",")
                 for hour_range in hour_ranges:
-                    open_time = hour_range.split("-")[0].strip().replace(" ", "")
-                    close_time = hour_range.split("-")[1].strip().replace(" ", "")
-                    if "AM" in open_time.upper() or "PM" in open_time.upper() or "AM" in close_time.upper() or "PM" in close_time.upper():
+                    open_time = hour_range.split("-")[0].strip().replace(" ", "").upper()
+                    close_time = hour_range.split("-")[1].strip().replace(" ", "").upper()
+                    if "AM" in open_time or "PM" in open_time or "AM" in close_time or "PM" in close_time:
                         if ":" not in open_time:
                             open_time.replace("AM", ":00AM").replace("PM", ":00PM")
                         if ":" not in close_time:

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -35,11 +35,20 @@ class StoreRocketSpider(Spider):
             for day in ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]:
                 if not location[day]:
                     continue
+                if "CLOSED" in location[day].upper():
+                    continue
                 hour_ranges = location[day].split(",")
                 for hour_range in hour_ranges:
-                    open_time = hour_range.split("-")[0].strip()
-                    close_time = hour_range.split("-")[1].strip()
-                    item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
+                    open_time = hour_range.split("-")[0].strip().replace(" ", "")
+                    close_time = hour_range.split("-")[1].strip().replace(" ", "")
+                    if "AM" in open_time.upper() or "PM" in open_time.upper() or "AM" in close_time.upper() or "PM" in close_time.upper():
+                        if ":" not in open_time:
+                            open_time.replace("AM", ":00AM").replace("PM", ":00PM")
+                        if ":" not in close_time:
+                            close_time.replace("AM", ":00AM").replace("PM", ":00PM")
+                        item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time, "%I:%M%p")
+                    else:
+                        item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
 
             yield from self.parse_item(item, location) or []
 

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -2,6 +2,7 @@ from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 
 
@@ -29,6 +30,16 @@ class StoreRocketSpider(Spider):
 
             if self.base_url:
                 item["website"] = f'{self.base_url}?location={location["slug"]}'
+
+            item["opening_hours"] = OpeningHours()
+            for day in ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]:
+                if not location[day]:
+                    continue
+                hour_ranges = location[day].split(",")
+                for hour_range in hour_ranges:
+                    open_time = hour_range.split("-")[0].strip()
+                    close_time = hour_range.split("-")[1].strip()
+                    item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
 
             yield from self.parse_item(item, location) or []
 

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -371,6 +371,14 @@ def test_add_ranges_from_string():
     assert o.as_opening_hours() == "24/7"
 
     o = OpeningHours()
+    o.add_ranges_from_string("Monday: 08:00 - Midday, 14:00 - Midnight   tue-sat: Midnight-0800")
+    assert o.as_opening_hours() == "Mo 08:00-12:00,14:00-24:00; Tu-Sa 00:00-08:00"
+
+    o = OpeningHours()
+    o.add_ranges_from_string("Wed 2am-3am, 11am-1pm, 6pm-7pm, Thu midday-3:30pm 4:30pm-5:15pm")
+    assert o.as_opening_hours() == "We 02:00-03:00,11:00-13:00,18:00-19:00; Th 12:00-15:30,16:30-17:15"
+
+    o = OpeningHours()
     o.add_ranges_from_string(
         "Lunes a Domingo: 11:00 a 20:30 / Viernes y Sábado: 11:00 a 21:00",
         days=DAYS_ES,


### PR DESCRIPTION
Store Rocket store finder can now automatically extract opening hours using an enhanced add_ranges_from_string function in OpeningHours that now supports named days (e.g. midday) and multiple time ranges on a single day (e.g. Mon-Wed 08:00-13:00,14:00-18:00).