### PR TITLE
Add CDNStatsMiddleware

### DIFF
--- a/locations/middlewares/cdnstats.py
+++ b/locations/middlewares/cdnstats.py
@@ -1,0 +1,20 @@
+class CDNStatsMiddleware:
+    """
+    Collect response status code stats for known CDNs.
+    """
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def __init__(self, crawler):
+        self.crawler = crawler
+
+    def process_response(self, request, response, spider):
+        if response.headers.get(b"Server") == b"cloudflare":
+            self.crawler.stats.inc_value("atp/cdn/cloudflare/response_count")
+            self.crawler.stats.inc_value(f"atp/cdn/cloudflare/response_status_count/{response.status}")
+        elif response.headers.get(b"Server") == b"AkamaiGHost":
+            self.crawler.stats.inc_value("atp/cdn/akamai/response_count")
+            self.crawler.stats.inc_value(f"atp/cdn/akamai/response_status_count/{response.status}")
+        return response

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -66,9 +66,9 @@ TELNETCONSOLE_ENABLED = False
 
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
-# DOWNLOADER_MIDDLEWARES = {
-#    'locations.middlewares.MyCustomDownloaderMiddleware': 543,
-# }
+DOWNLOADER_MIDDLEWARES = {
+    "locations.middlewares.cdnstats.CDNStatsMiddleware": 500,
+}
 
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html


### PR DESCRIPTION
Count cloudflare and akamai requests and there status codes. The stats after the next weekly would be interesting, I wonder if we have any akamai results, the broken lowes spider gets nothing. For some sites Cloudflare lets us through, others we use Playwright, we probably have a ton of spiders failing just because of it or maybe even failing half way though. Anyway, it'll be interesting.