### PR TITLE
Add Spider for Eurochange (UK Bureau de Change)

### DIFF
--- a/locations/spiders/eurochange_gb.py
+++ b/locations/spiders/eurochange_gb.py
@@ -1,7 +1,8 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
 
 class WilkoGBSpider(SitemapSpider, StructuredDataSpider):
     name = "eurochange_gb"

--- a/locations/spiders/eurochange_gb.py
+++ b/locations/spiders/eurochange_gb.py
@@ -25,5 +25,5 @@ class WilkoGBSpider(SitemapSpider, StructuredDataSpider):
             item["image"] = None
         if "NM Money" in item["name"]:
             item.update(self.NM_MONEY)
-            item["website"] = item["website"].replace("eurochange.co.uk","nmmoney.co.uk")
+            item["website"] = item["website"].replace("eurochange.co.uk", "nmmoney.co.uk")
         yield from self.inspect_item(item, response)

--- a/locations/spiders/eurochange_gb.py
+++ b/locations/spiders/eurochange_gb.py
@@ -1,0 +1,29 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WilkoGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "eurochange_gb"
+    EUROCHANGE = {"brand": "Eurochange", "brand_wikidata": "Q86525249"}
+    NM_MONEY = {"brand": "NM Money", "brand_wikidata": "Q86529747"}
+    item_attributes = EUROCHANGE
+    allowed_domains = ["www.eurochange.co.uk"]
+    sitemap_urls = ["https://www.eurochange.co.uk/sitemap.xml"]
+    sitemap_rules = [
+        (
+            r"https:\/\/www\.eurochange\.co\.uk\/branches\/([\w-]+\/[\w-]+)$",
+            "parse_sd",
+        ),
+    ]
+    wanted_types = ["Store"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "facebook" in item.keys() and item["facebook"] == "https://www.facebook.com/eurochange/":
+            item["facebook"] = None
+        if "image" in item.keys() and item["image"] == "https://www.eurochange.co.uk/assets/img/logo.svg":
+            item["image"] = None
+        if "NM Money" in item["name"]:
+            item.update(self.NM_MONEY)
+            item["website"] = item["website"].replace("eurochange.co.uk","nmmoney.co.uk")
+        yield from self.inspect_item(item, response)

--- a/locations/spiders/eurochange_gb.py
+++ b/locations/spiders/eurochange_gb.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
-
+from locations.hours import OpeningHours
 
 class WilkoGBSpider(SitemapSpider, StructuredDataSpider):
     name = "eurochange_gb"
@@ -19,11 +19,13 @@ class WilkoGBSpider(SitemapSpider, StructuredDataSpider):
     wanted_types = ["Store"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        if "facebook" in item.keys() and item["facebook"] == "https://www.facebook.com/eurochange/":
+        if item.get("facebook") == "https://www.facebook.com/eurochange/":
             item["facebook"] = None
-        if "image" in item.keys() and item["image"] == "https://www.eurochange.co.uk/assets/img/logo.svg":
+        if item.get("image") == "https://www.eurochange.co.uk/assets/img/logo.svg":
             item["image"] = None
         if "NM Money" in item["name"]:
             item.update(self.NM_MONEY)
             item["website"] = item["website"].replace("eurochange.co.uk", "nmmoney.co.uk")
-        yield from self.inspect_item(item, response)
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].from_linked_data(ld_data, time_format="%H.%M")
+        yield item


### PR DESCRIPTION
The spider runs locally for me, returning 188 "Eurochange" branches and 3 "NM Money" branches.

However, I can't figure out why the StructuredDataSpider isn't picking up the opening hours though, as they're present in the embedded ld+json. If anyone has any thoughts...

I don't know if it's the right thing to do or not, but I've removed the Facebook and image field as they were just generic brand links.