### PR TITLE
bunnings: fix spider

### DIFF
--- a/locations/spiders/bunnings.py
+++ b/locations/spiders/bunnings.py
@@ -49,8 +49,8 @@ class BunningsSpider(scrapy.Spider):
             item = DictParser.parse(location)
             item["ref"] = location["name"]
             item["name"] = location["displayName"]
-            item["phone"] = location["address"]["phone"]
-            item["email"] = location["address"]["email"]
+            item["phone"] = location["address"].get("phone")
+            item["email"] = location["address"].get("email")
             if item["country"] == "NZ":
                 item.pop("state")
                 website_prefix = "https://www.bunnings.co.nz/stores/"


### PR DESCRIPTION
E-mail field appears to be optional, so use .get() for e-mail (and phone) fields instead of just assuming these fields are always populated.