### PR TITLE
fantastic_furniture_au: fix spider

### DIFF
--- a/locations/spiders/fantastic_furniture_au.py
+++ b/locations/spiders/fantastic_furniture_au.py
@@ -43,12 +43,16 @@ class FantasticFurnitureAUSpider(Spider):
                         '//div[contains(@class, "trading_hours")]/ul/li/*[self::strong or self::small]/text()'
                     ).getall()
                 )
+                .upper()
                 .replace(" - ", " ")
                 .replace(" AM", "AM")
                 .replace(" PM", "PM")
+                .replace("CLOSED", "0:00AM 0:00AM")
                 .split(" ")
             )
             hours_raw = [hours_raw[n : n + 3] for n in range(0, len(hours_raw), 3)]
             for day in hours_raw:
+                if day[1] == "0:00AM" and day[2] == "0:00AM":
+                    continue
                 item["opening_hours"].add_range(day[0], day[1], day[2], "%I:%M%p")
             yield item


### PR DESCRIPTION
A public holiday this week in Australia has demonstrated that opening hours for Fantastic Furniture are sometimes changed to align with public holidays due in the next week. In this case, Friday is "CLOSED", so the spider needs to be able to accomodate these temporary changes to hours. Unfortunately there is no information available to determine whether hours are normal or holiday hours, so the opening hours for this spider will seemingly fluctuate regularly.