### PR TITLE
jax_tyres_and_auto_au: fix spider

### DIFF
--- a/locations/spiders/jax_tyres_and_auto_au.py
+++ b/locations/spiders/jax_tyres_and_auto_au.py
@@ -37,7 +37,7 @@ class JaxTyresAndAutoAUSpider(Spider):
         day_names = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[1]/p/text()').getall()
         hour_ranges = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[2]/p/text()').getall()
         for i in range(1, 7, 1):
-            if hour_ranges[i].upper() == "CLOSED":
+            if not any(char.isdigit() for char in hour_ranges[i]):
                 continue
             open_time = hour_ranges[i].split(" - ")[0]
             close_time = hour_ranges[i].split(" - ")[1]

--- a/locations/spiders/jax_tyres_and_auto_au.py
+++ b/locations/spiders/jax_tyres_and_auto_au.py
@@ -38,7 +38,7 @@ class JaxTyresAndAutoAUSpider(Spider):
         properties["opening_hours"] = OpeningHours()
         day_names = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[1]/p/text()').getall()
         hour_ranges = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[2]/p/text()').getall()
-        for i in range(1, 7, 1):
-            if m := re.match(r"(\d?\d:\d\d\s*[AP]M)\s*-\s*(\d?\d:\d\d\s*[AP]M)", hour_ranges[i]):
-                properties["opening_hours"].add_range(day_names[i], m.group(1), m.group(2), "%I:%M %p")
+        for day_name, hours in zip(day_names, hour_ranges):
+            if m := re.match(r"(\d?\d:\d\d\s*[AP]M)\s*-\s*(\d?\d:\d\d\s*[AP]M)", hours):
+                properties["opening_hours"].add_range(day_name, m.group(1), m.group(2), "%I:%M %p")
         yield Feature(**properties)

--- a/locations/spiders/jax_tyres_and_auto_au.py
+++ b/locations/spiders/jax_tyres_and_auto_au.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy import Request, Spider
 
 from locations.hours import OpeningHours
@@ -37,9 +39,6 @@ class JaxTyresAndAutoAUSpider(Spider):
         day_names = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[1]/p/text()').getall()
         hour_ranges = response.xpath('//div[contains(@class, "pgStLcSn-openingHours")]/div[2]/p/text()').getall()
         for i in range(1, 7, 1):
-            if not any(char.isdigit() for char in hour_ranges[i]):
-                continue
-            open_time = hour_ranges[i].split(" - ")[0]
-            close_time = hour_ranges[i].split(" - ")[1]
-            properties["opening_hours"].add_range(day_names[i], open_time, close_time, "%I:%M %p")
+            if m := re.match(r"(\d?\d:\d\d\s*[AP]M)\s*-\s*(\d?\d:\d\d\s*[AP]M)", hour_ranges[i]):
+                properties["opening_hours"].add_range(day_names[i], m.group(1), m.group(2), "%I:%M %p")
         yield Feature(**properties)


### PR DESCRIPTION
With upcoming public holidays in Australia this week, this spider is broken due to unhandled day names such as "Good Friday". Unfortunately for such weeks with a public holiday, there is no place on the website showing what the usual hours would have been. Thus the hours for this spider will constantly fluctuate depending on whether the given week has a public holiday.