### PR TITLE
enterprise: fix spider

### DIFF
--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -1,5 +1,4 @@
 import geonamescache
-
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -15,7 +14,9 @@ class EnterpriseSpider(Spider):
         gc = geonamescache.GeonamesCache()
         countries = gc.get_countries()
         for country_code in countries.keys():
-            yield JsonRequest(url=f"https://prd.location.enterprise.com/enterprise-sls/search/location/enterprise/web/country/{country_code}")
+            yield JsonRequest(
+                url=f"https://prd.location.enterprise.com/enterprise-sls/search/location/enterprise/web/country/{country_code}"
+            )
 
     def parse(self, response):
         for location in response.json():

--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -1,38 +1,29 @@
-import scrapy
+import geonamescache
 
-from locations.items import Feature
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
 
 
-class EnterpriseSpider(scrapy.Spider):
+class EnterpriseSpider(Spider):
     name = "enterprise"
     item_attributes = {"brand": "Enterprise Rent-A-Car", "brand_wikidata": "Q17085454"}
-    allowed_domains = ["www.enterprise.com"]
-    start_urls = ("https://www.enterprise.com/en/car-rental/locations.html",)
+    allowed_domains = ["prd.location.enterprise.com"]
+
+    def start_requests(self):
+        gc = geonamescache.GeonamesCache()
+        countries = gc.get_countries()
+        for country_code in countries.keys():
+            yield JsonRequest(url=f"https://prd.location.enterprise.com/enterprise-sls/search/location/enterprise/web/country/{country_code}")
 
     def parse(self, response):
-        for u in response.xpath('//div[@class="cf"]/ul/li/a/@href').extract():
-            if u.startswith("/en/car-rental/locations"):
-                country = u.rsplit("/", 1)[1].rsplit(".", 1)[0]
-                yield scrapy.Request(
-                    "https://www.enterprise.com/en/car-rental/locations/%s/_jcr_content.mapdata.js" % country,
-                    callback=self.parse_country,
-                )
-
-    def parse_country(self, response):
-        data = response.json()
-        if data:
-            for d in data:
-                properties = {
-                    "name": d.get("name"),
-                    "phone": d.get("formatted_phone"),
-                    "website": d.get("url"),
-                    "addr_full": " ".join(d.get("address_lines") or []),
-                    "city": d.get("city"),
-                    "state": d.get("state"),
-                    "postcode": d.get("postal_code"),
-                    "country": d.get("country_code"),
-                    "lat": d.get("latitude"),
-                    "lon": d.get("longitude"),
-                    "ref": d.get("station_id"),
-                }
-                yield Feature(**properties)
+        for location in response.json():
+            if location["closed"] or not location["physicalLocation"]:
+                continue
+            item = DictParser.parse(location)
+            item["ref"] = location["stationId"]
+            item["name"] = location["locationNameTranslation"]
+            item["street_address"] = ", ".join(filter(None, location["addressLines"]))
+            item["phone"] = location["formattedPhone"]
+            yield item


### PR DESCRIPTION
Returns 7306 results from across the world.

Note that other API queries can extract opening hours, the website and other details of each location however this would result in 7306 additional queries, hence is not yet implemented in this updated spider.