### PR TITLE
Build the docker image every 6 hours instead of on every merge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
 name: Build and Push Image to ECR
 
 on:
-  push:
-    branches: [ master ]
+  schedule:
+    - cron: '23 */6 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
With all the action on the repo, the image repository is filling up fast. Instead of scaling with the number of commits, I want it to scale with time, so I'm adjusting the image build to happen every 6 hours instead of every commit.