### PR TITLE
circle_k: fix spider and make international

### DIFF
--- a/locations/spiders/circle_k.py
+++ b/locations/spiders/circle_k.py
@@ -3,7 +3,7 @@ import re
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import apply_category, apply_yes_no, Categories, Extras, Fuel
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 
 
@@ -35,11 +35,24 @@ class CircleKSpider(Spider):
             apply_yes_no(Extras.BABY_CHANGING_TABLE, item, "EU_BABY_CHANGING" in services)
             apply_yes_no(Extras.SHOWERS, item, "EU_SHOWER" in services)
             apply_yes_no(Extras.WIFI, item, "EU_WIFI" in services)
-            apply_yes_no(Extras.CAR_WASH, item, "car_wash" in services or "car_wash_cleanfreak" in services or "rainstorm_car_wash" in services or "EU_CARWASH" in services or "EU_CARWASH_JETWASH" in services)
+            apply_yes_no(
+                Extras.CAR_WASH,
+                item,
+                "car_wash" in services
+                or "car_wash_cleanfreak" in services
+                or "rainstorm_car_wash" in services
+                or "EU_CARWASH" in services
+                or "EU_CARWASH_JETWASH" in services,
+            )
             apply_yes_no(Fuel.DIESEL, item, "diesel" in services)
             apply_yes_no(Fuel.HGV_DIESEL, item, "EU_TRUCKDIESEL_NETWORK" in services)
             apply_yes_no(Fuel.ADBLUE, item, "EU_ADBLUE_SERVICE" in services)
-            if "gas" in services or "EU_GAS" in services or "diesel" in services or "EU_TRUCKDIESEL_NETWORK" in services:
+            if (
+                "gas" in services
+                or "EU_GAS" in services
+                or "diesel" in services
+                or "EU_TRUCKDIESEL_NETWORK" in services
+            ):
                 apply_category(Categories.FUEL_STATION, item)
             if "ev_charger" in services or "EU_HIGH_SPEED_CHARGER" in services:
                 apply_category(Categories.CHARGING_STATION, item)

--- a/locations/spiders/circle_k.py
+++ b/locations/spiders/circle_k.py
@@ -1,40 +1,38 @@
-import html
+import re
 
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy import Spider
+from scrapy.http import JsonRequest
 
-from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
 
 
-class CircleKSpider(CrawlSpider, StructuredDataSpider):
+class CircleKSpider(Spider):
     name = "circle_k"
-    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010", "country": "US"}
+    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     allowed_domains = ["www.circlek.com"]
-    start_urls = ["https://www.circlek.com/list-united-states-stores?lang=en"]
+    start_urls = ["https://www.circlek.com/stores_master.php?lat=0&lng=0&page=0"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
-    rules = [Rule(LinkExtractor(allow="/store-locator/"), callback="parse_sd")]
-    wanted_types = ["ConvenienceStore"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        days = response.xpath('//div[contains(@class,"hours-item")]')
-        oh = OpeningHours()
-        for day in days:
-            hours = day.xpath("./span[2]/text()").get().strip("\n").strip()
-            oh.add_range(
-                day=day.xpath("./span[1]/text()").get().strip(),
-                open_time="12:00 AM" if hours == "Open 24h" else hours.split(" to ")[0],
-                close_time="12:00 AM" if hours == "Open 24h" else hours.split(" to ")[1],
-                time_format="%I:%M %p",
-            )
-        item["opening_hours"] = oh.as_opening_hours()
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url, meta={"page": 0})
 
-        item["name"] = html.unescape(item["name"])
+    def parse(self, response):
+        if response.json()["count"] == 0:
+            # crawl completed
+            return
 
-        if "Convenience Store" in item["name"]:
-            apply_category(Categories.SHOP_CONVENIENCE, item)
-        if "Gas Station" in item["name"]:
-            apply_category(Categories.FUEL_STATION, item)
+        for location_id, location in response.json()["stores"].items():
+            item = DictParser.parse(location)
+            item["ref"] = location_id
+            item["street_address"] = item.pop("addr_full")
+            item["website"] = "https://www.circlek.com" + item["website"]
+            yield item
 
-        yield item
+        if response.json()["count"] < 10:
+            # crawl completed
+            return
+
+        next_page = response.meta["page"] + 1
+        next_url = re.sub(r"\d+$", str(next_page), response.url)
+        yield JsonRequest(url=next_url, meta={"page": next_page})

--- a/locations/spiders/circle_k.py
+++ b/locations/spiders/circle_k.py
@@ -3,6 +3,7 @@ import re
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import apply_category, apply_yes_no, Categories, Extras, Fuel
 from locations.dict_parser import DictParser
 
 
@@ -27,6 +28,21 @@ class CircleKSpider(Spider):
             item["ref"] = location_id
             item["street_address"] = item.pop("addr_full")
             item["website"] = "https://www.circlek.com" + item["website"]
+            services = [service["name"] for service in location["services"]]
+            apply_yes_no(Extras.ATM, item, "atm" in services or "EU_ATM" in services)
+            apply_yes_no(Extras.INDOOR_SEATING, item, "EU_LOUNGE" in services)
+            apply_yes_no(Extras.TOILETS, item, "public_restrooms" in services or "EU_TOILETS_BOTH" in services)
+            apply_yes_no(Extras.BABY_CHANGING_TABLE, item, "EU_BABY_CHANGING" in services)
+            apply_yes_no(Extras.SHOWERS, item, "EU_SHOWER" in services)
+            apply_yes_no(Extras.WIFI, item, "EU_WIFI" in services)
+            apply_yes_no(Extras.CAR_WASH, item, "car_wash" in services or "car_wash_cleanfreak" in services or "rainstorm_car_wash" in services or "EU_CARWASH" in services or "EU_CARWASH_JETWASH" in services)
+            apply_yes_no(Fuel.DIESEL, item, "diesel" in services)
+            apply_yes_no(Fuel.HGV_DIESEL, item, "EU_TRUCKDIESEL_NETWORK" in services)
+            apply_yes_no(Fuel.ADBLUE, item, "EU_ADBLUE_SERVICE" in services)
+            if "gas" in services or "EU_GAS" in services or "diesel" in services or "EU_TRUCKDIESEL_NETWORK" in services:
+                apply_category(Categories.FUEL_STATION, item)
+            if "ev_charger" in services or "EU_HIGH_SPEED_CHARGER" in services:
+                apply_category(Categories.CHARGING_STATION, item)
             yield item
 
         if response.json()["count"] < 10:


### PR DESCRIPTION
Use a new Circle API which returns global results. The last page which can be requested is
https://www.circlek.com/stores_master.php?lat=0&lng=0&page=959 and with 10 locations returned per page, and page 0 being the first, that equals a count of 9597 locations returned by this API.

Previously before this spider broke, approximately 6600 results were returned from the USA only.