### PR TITLE
Switch to reverse_geocoder single threaded mode

### DIFF
--- a/locations/pipelines/country_code_clean_up.py
+++ b/locations/pipelines/country_code_clean_up.py
@@ -48,12 +48,12 @@ class CountryCodeCleanUpPipeline:
         if not getattr(spider, "skip_auto_cc_geocoder", False):
             # Still no country set, try an offline reverse geocoder.
             if location := get_lat_lon(item):
-                if results := reverse_geocoder.search([(location[0], location[1])]):
+                if result := reverse_geocoder.get((location[0], location[1]), mode=1, verbose=False):
                     spider.crawler.stats.inc_value("atp/field/country/from_reverse_geocoding")
-                    item["country"] = results[0]["cc"]
+                    item["country"] = result["cc"]
 
                     if not item.get("state"):
-                        item["state"] = results[0].get("admin1")
+                        item["state"] = result.get("admin1")
 
                     return item
 

--- a/locations/pipelines/state_clean_up.py
+++ b/locations/pipelines/state_clean_up.py
@@ -53,9 +53,9 @@ class StateCodeCleanUpPipeline:
 
         if not state:  # geocode state
             if location := get_lat_lon(item):
-                if results := reverse_geocoder.search([(location[0], location[1])]):
+                if result := reverse_geocoder.get((location[0], location[1]), mode=1, verbose=False):
                     spider.crawler.stats.inc_value("atp/field/state/from_reverse_geocoding")
-                    state = results[0]["admin1"]
+                    state = result["admin1"]
 
         item["state"] = StateCodeCleanUpPipeline.clean_state(state, country)
 


### PR DESCRIPTION
By default, reverse_geocoder uses multiple threads since we only ever ask for 1 POI at a time, it wastes a lot of CPU time setting them up.

```python
from scrapy.spiders import Spider

from locations.items import Feature


class Test2Spider(Spider):
    name = "test2"
    start_urls = ["data:,"]

    def parse(self, response, **kwargs):
        for i in range(10000):
            yield Feature(ref=str(i), lat=45, lon=-90)
```
mode=2 (default) took 721 seconds
mode=1 took 2.734139 seconds