### PR TITLE
Ensure coords aren't turned to ints

### DIFF
--- a/.github/workflows/pytest-pr.yaml
+++ b/.github/workflows/pytest-pr.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
     - '.github/workflows/*.yaml'
+    - 'locations/commands/*.py'
+    - 'locations/middlewares/*.py'
+    - 'locations/pipelines/*.py'
+    - 'locations/storefinders/*.py'
     - 'locations/*.py'
     - 'tests/*.py'
 

--- a/locations/pipelines/country_code_clean_up.py
+++ b/locations/pipelines/country_code_clean_up.py
@@ -9,7 +9,10 @@ def get_lat_lon(item: Feature) -> (float, float):
         if isinstance(geometry, dict):
             if geometry.get("type") == "Point":
                 if coords := geometry.get("coordinates"):
-                    return coords[1], coords[0]
+                    try:
+                        return float(coords[1]), float(coords[0])
+                    except TypeError:
+                        pass
     else:
         try:
             return float(item.get("lat")), float(item.get("lon"))


### PR DESCRIPTION
Some of the geocoding tests are failing because coords were ints.

I'll check why the tests didn't trigger on the last PR tomorrow, or Monday.