### PR TITLE
Add Metizsoft store finder and sample brands

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -27,6 +27,7 @@ class DictParser:
         "town",
         "locality",
         "suburb",
+        "city-name",
         # JP
         "市区町村",  # "municipality"
     ]
@@ -40,6 +41,7 @@ class DictParser:
         "province",
         "state-code",
         "county",
+        "state-name",
         # JP
         "都道府県",  # "prefecture"
     ]
@@ -87,6 +89,7 @@ class DictParser:
         "lat",
         "display-lat",
         "yext-display-lat",
+        "mapLatitude",
     ]
 
     lon_keys = [
@@ -96,6 +99,7 @@ class DictParser:
         "lng",
         "display-lng",
         "yext-display-lng",
+        "mapLongitude",
     ]
 
     website_keys = ["url", "website", "permalink", "store-url"]

--- a/locations/spiders/cloud_9_smoke_shop_australia_au.py
+++ b/locations/spiders/cloud_9_smoke_shop_australia_au.py
@@ -2,6 +2,7 @@ import json
 
 from locations.storefinders.metizsoft import MetizsoftSpider
 
+
 class Cloud9SmokeShopAustraliaAUSpider(MetizsoftSpider):
     name = "cloud_9_smoke_shop_australia_au"
     item_attributes = {"brand": "Cloud 9 Smoke Shop Australia", "brand_wikidata": "Q117822054"}

--- a/locations/spiders/cloud_9_smoke_shop_australia_au.py
+++ b/locations/spiders/cloud_9_smoke_shop_australia_au.py
@@ -1,0 +1,17 @@
+import json
+
+from locations.storefinders.metizsoft import MetizsoftSpider
+
+class Cloud9SmokeShopAustraliaAUSpider(MetizsoftSpider):
+    name = "cloud_9_smoke_shop_australia_au"
+    item_attributes = {"brand": "Cloud 9 Smoke Shop Australia", "brand_wikidata": "Q117822054"}
+    shopify_url = "cloud-9-smoke-shop-australia.myshopify.com"
+
+    def parse_item(self, item, location):
+        extra_fields = json.loads(location["extra_fields"])
+        for extra_field in extra_fields:
+            if extra_field["fieldnm"] == "764@Mobile":
+                item["phone"] = extra_field["fieldvalue"].strip()
+                break
+        item.pop("website")
+        yield item

--- a/locations/spiders/just_watches_in.py
+++ b/locations/spiders/just_watches_in.py
@@ -1,0 +1,19 @@
+import re
+
+from locations.hours import DAYS, OpeningHours
+from locations.storefinders.metizsoft import MetizsoftSpider
+
+class JustWatchesINSpider(MetizsoftSpider):
+    name = "just_watches_in"
+    item_attributes = {"brand": "Just Watches", "brand_wikidata": "Q117822349"}
+    shopify_url = "justwatchesstore.myshopify.com"
+
+    def parse_item(self, item, location):
+        if "ALL DAYS" in location["hour_of_operation"]:
+            if m := re.match("(\d{2})\.(\d{2}) ([AP])\.M - (\d{2})\.(\d{2}) ([AP])\.M", location["hour_of_operation"]):
+                start_time = m.group(1) + ":" + m.group(2) + m.group(3) + "M"
+                end_time = m.group(4) + ":" + m.group(5) + m.group(6) + "M"
+                item["opening_hours"] = OpeningHours()
+                item["opening_hours"].add_days_range(DAYS, start_time, end_time, "%I:%M%p")
+        item.pop("email")
+        yield item

--- a/locations/spiders/just_watches_in.py
+++ b/locations/spiders/just_watches_in.py
@@ -3,6 +3,7 @@ import re
 from locations.hours import DAYS, OpeningHours
 from locations.storefinders.metizsoft import MetizsoftSpider
 
+
 class JustWatchesINSpider(MetizsoftSpider):
     name = "just_watches_in"
     item_attributes = {"brand": "Just Watches", "brand_wikidata": "Q117822349"}

--- a/locations/spiders/just_watches_in.py
+++ b/locations/spiders/just_watches_in.py
@@ -11,7 +11,7 @@ class JustWatchesINSpider(MetizsoftSpider):
 
     def parse_item(self, item, location):
         if "ALL DAYS" in location["hour_of_operation"]:
-            if m := re.match("(\d{2})\.(\d{2}) ([AP])\.M - (\d{2})\.(\d{2}) ([AP])\.M", location["hour_of_operation"]):
+            if m := re.match(r"(\d{2})\.(\d{2}) ([AP])\.M - (\d{2})\.(\d{2}) ([AP])\.M", location["hour_of_operation"]):
                 start_time = m.group(1) + ":" + m.group(2) + m.group(3) + "M"
                 end_time = m.group(4) + ":" + m.group(5) + m.group(6) + "M"
                 item["opening_hours"] = OpeningHours()

--- a/locations/spiders/mr_liquor_au.py
+++ b/locations/spiders/mr_liquor_au.py
@@ -1,5 +1,6 @@
 from locations.storefinders.metizsoft import MetizsoftSpider
 
+
 class MrLiquorAUSpider(MetizsoftSpider):
     name = "mr_liquor_au"
     item_attributes = {"brand": "Mr Liquor", "brand_wikidata": "Q117822077"}

--- a/locations/spiders/mr_liquor_au.py
+++ b/locations/spiders/mr_liquor_au.py
@@ -1,0 +1,6 @@
+from locations.storefinders.metizsoft import MetizsoftSpider
+
+class MrLiquorAUSpider(MetizsoftSpider):
+    name = "mr_liquor_au"
+    item_attributes = {"brand": "Mr Liquor", "brand_wikidata": "Q117822077"}
+    shopify_url = "mr-liquor.myshopify.com"

--- a/locations/storefinders/metizsoft.py
+++ b/locations/storefinders/metizsoft.py
@@ -1,0 +1,33 @@
+from scrapy import Spider
+from scrapy.http import FormRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+# To use, specify the Shopify URL for the brand in the format of
+# {brand-name}.myshopify.com . You may then need to override the
+# parse_item function to adjust extracted field values.
+
+class MetizsoftSpider(Spider):
+    dataset_attributes = {"source": "api", "api": "storelocator.metizapps.com"}
+    shopify_url = ""
+
+    def start_requests(self):
+        yield FormRequest(url=f"https://storelocator.metizapps.com/stores/storeDataGet", method="POST", formdata={"shopData": self.shopify_url})
+
+    def parse(self, response, **kwargs):
+        if not response.json()["success"]:
+            return
+
+        for location in response.json()["data"]["result"]:
+            if location["delete_status"] != "0" or location["storestatus"] != "1":
+                continue
+            item = DictParser.parse(location)
+            item["street_address"] = ", ".join(filter(None, [location["address"], location["address2"]]))
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(location["hour_of_operation"].replace("</br>", " "))
+            yield from self.parse_item(item, location)
+
+    def parse_item(self, item, location: {}, **kwargs):
+        yield item

--- a/locations/storefinders/metizsoft.py
+++ b/locations/storefinders/metizsoft.py
@@ -15,7 +15,7 @@ class MetizsoftSpider(Spider):
 
     def start_requests(self):
         yield FormRequest(
-            url=f"https://storelocator.metizapps.com/stores/storeDataGet",
+            url="https://storelocator.metizapps.com/stores/storeDataGet",
             method="POST",
             formdata={"shopData": self.shopify_url},
         )

--- a/locations/storefinders/metizsoft.py
+++ b/locations/storefinders/metizsoft.py
@@ -4,17 +4,21 @@ from scrapy.http import FormRequest
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
-
 # To use, specify the Shopify URL for the brand in the format of
 # {brand-name}.myshopify.com . You may then need to override the
 # parse_item function to adjust extracted field values.
+
 
 class MetizsoftSpider(Spider):
     dataset_attributes = {"source": "api", "api": "storelocator.metizapps.com"}
     shopify_url = ""
 
     def start_requests(self):
-        yield FormRequest(url=f"https://storelocator.metizapps.com/stores/storeDataGet", method="POST", formdata={"shopData": self.shopify_url})
+        yield FormRequest(
+            url=f"https://storelocator.metizapps.com/stores/storeDataGet",
+            method="POST",
+            formdata={"shopData": self.shopify_url},
+        )
 
     def parse(self, response, **kwargs):
         if not response.json()["success"]:


### PR DESCRIPTION
Metizsoft is a store locator plugin for Shopify that appears to be widely used amongst smaller brands to allow look-up of stockists at independent or other retail chain stores. However, Metizsoft store locator is also used by some small brands for locating their brick and mortar stores.