### PR TITLE
download_delay of 1s is the default, remove from spiders where that is the value set

### DIFF
--- a/locations/spiders/7_11_us.py
+++ b/locations/spiders/7_11_us.py
@@ -11,7 +11,6 @@ class SevenElevenUSSpider(scrapy.spiders.SitemapSpider):
     allowed_domains = ["7-eleven.com"]
     sitemap_urls = ["https://www.7-eleven.com/sitemap.xml"]
     sitemap_rules = [("/locations/", "parse")]
-    download_delay = 1.0
 
     def parse(self, response):
         for ld in response.xpath('//script[@type="application/json"]//text()').getall():

--- a/locations/spiders/aaa.py
+++ b/locations/spiders/aaa.py
@@ -13,7 +13,6 @@ class AAASpider(scrapy.Spider):
         "brand_wikidata": "Q463436",
     }
     allowed_domains = ["tdr.aaa.com"]
-    download_delay = 1.0
 
     def start_requests(self):
         point_files = [

--- a/locations/spiders/apcoa_be.py
+++ b/locations/spiders/apcoa_be.py
@@ -17,7 +17,6 @@ class ApcoaSpider(CrawlSpider, StructuredDataSpider):
             callback="parse_sd",
         ),
     ]
-    download_delay = 1
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         extract_google_position(item, response)

--- a/locations/spiders/ashley_furniture.py
+++ b/locations/spiders/ashley_furniture.py
@@ -8,10 +8,8 @@ class AshleyFurnitureSpider(scrapy.spiders.SitemapSpider):
     item_attributes = {"brand": "Ashley Furniture", "brand_wikidata": "Q4805437"}
     sitemap_urls = ["https://stores.ashleyfurniture.com/sitemap_index.xml"]
     sitemap_rules = [("/store/", "parse_store")]
-    download_delay = 1.0
 
     def parse_store(self, response):
-        item = LinkedDataParser.parse(response, "FurnitureStore")
-        if item:
+        if item := LinkedDataParser.parse(response, "FurnitureStore"):
             item["ref"] = response.url
             yield item

--- a/locations/spiders/ashley_homestore.py
+++ b/locations/spiders/ashley_homestore.py
@@ -10,7 +10,6 @@ class AshleyHomeStoreSpider(CrawlSpider):
     start_urls = ["https://stores.ashleyhomestore.ca/store/"]
     allowed_domains = ["stores.ashleyhomestore.ca"]
     rules = [Rule(LinkExtractor(allow="/store/"), callback="parse_store", follow=True)]
-    download_delay = 1.0
 
     def parse_store(self, response):
         item = LinkedDataParser.parse(response, "FurnitureStore")

--- a/locations/spiders/batteriesplus.py
+++ b/locations/spiders/batteriesplus.py
@@ -10,7 +10,6 @@ daysRe = rf"(?:{'|'.join(DAYS)})"
 
 class BatteriesPlusSpider(scrapy.spiders.SitemapSpider):
     name = "batteriesplus"
-    # download_delay = 1
     item_attributes = {"brand": "Batteries Plus Bulbs", "brand_wikidata": "Q17005157"}
     allowed_domains = ["batteriesplus.com"]
     sitemap_urls = [

--- a/locations/spiders/baylorscottwhitehealth.py
+++ b/locations/spiders/baylorscottwhitehealth.py
@@ -6,12 +6,8 @@ from locations.items import Feature
 
 class BaylorScottWhiteHealthSpider(scrapy.Spider):
     name = "baylorscottwhite"
-    item_attributes = {
-        "brand": "Baylor Scott & White Health",
-        "brand_wikidata": "Q41568258",
-    }
+    item_attributes = {"brand": "Baylor Scott & White Health", "brand_wikidata": "Q41568258"}
     allowed_domains = ["phyndapi.bswapi.com"]
-    download_delay = 1
     base_url = "https://phyndapi.bswapi.com/V4/Places/GetLocations"
 
     def start_requests(self):

--- a/locations/spiders/bestone_gb.py
+++ b/locations/spiders/bestone_gb.py
@@ -7,7 +7,6 @@ class BestOneGBSpider(scrapy.spiders.SitemapSpider):
     name = "bestone_gb"
     item_attributes = {"brand": "Best-one", "brand_wikidata": "Q4896532"}
     sitemap_urls = ["https://stores.best-one.co.uk/sitemap.xml"]
-    download_delay = 1.0
 
     def parse(self, response):
         for store_type in ["ConvenienceStore", "WholesaleStore"]:

--- a/locations/spiders/designer_shoe_warehouse.py
+++ b/locations/spiders/designer_shoe_warehouse.py
@@ -7,7 +7,6 @@ from locations.items import Feature
 
 
 class DesignerShoeWarehouseSpider(SitemapSpider):
-    download_delay = 1
     name = "dsw"
     item_attributes = {"brand": "Designer Shoe Warehouse", "brand_wikidata": "Q5206207"}
     allowed_domains = [

--- a/locations/spiders/fuddruckers.py
+++ b/locations/spiders/fuddruckers.py
@@ -8,7 +8,6 @@ class FuddruckersSpider(scrapy.Spider):
     item_attributes = {"brand": "Fuddruckers", "brand_wikidata": "Q5507056"}
     start_urls = ["http://www.fuddruckers.com/services/location/get_stores_by_position.php"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
-    download_delay = 1.0
 
     def parse(self, response):
         results = response.json()

--- a/locations/spiders/holland_and_barrett.py
+++ b/locations/spiders/holland_and_barrett.py
@@ -5,10 +5,7 @@ from locations.linked_data_parser import LinkedDataParser
 
 class HollandAndBarrettSpider(SitemapSpider):
     name = "holland_and_barrett"
-    item_attributes = {
-        "brand": "Holland & Barrett",
-        "brand_wikidata": "Q5880870",
-    }
+    item_attributes = {"brand": "Holland & Barrett", "brand_wikidata": "Q5880870"}
     sitemap_urls = [
         "https://www.hollandandbarrett.com/sitemap-stores.xml",
         "https://www.hollandandbarrett.nl/sitemap-stores.xml",
@@ -16,7 +13,6 @@ class HollandAndBarrettSpider(SitemapSpider):
         "https://www.hollandandbarrett.ie/sitemap-stores.xml",
     ]
     sitemap_rules = [("/stores/", "parse"), ("/winkels/", "parse")]
-    download_delay = 1.0
 
     def parse(self, response):
         item = LinkedDataParser.parse(response, "LocalBusiness")

--- a/locations/spiders/iron_mountain.py
+++ b/locations/spiders/iron_mountain.py
@@ -5,12 +5,8 @@ from locations.open_graph_parser import OpenGraphParser
 
 class IronMountainSpider(scrapy.spiders.SitemapSpider):
     name = "iron_mountain"
-    item_attributes = {
-        "brand": "Iron Mountain Incorporated",
-        "brand_wikidata": "Q1673079",
-    }
+    item_attributes = {"brand": "Iron Mountain Incorporated", "brand_wikidata": "Q1673079"}
     sitemap_urls = ["https://locations.ironmountain.com/robots.txt"]
-    download_delay = 1.0
 
     def parse(self, response):
         item = OpenGraphParser.parse(response)

--- a/locations/spiders/lululemon.py
+++ b/locations/spiders/lululemon.py
@@ -12,7 +12,6 @@ class LuLuLemonSpider(SitemapSpider):
     name = "lululemon"
     item_attributes = {"brand": "LuLuLemon", "brand_wikidata": "Q6702957"}
     sitemap_urls = ("https://shop.lululemon.com/sitemap.xml",)
-    download_delay = 1.0
     sitemap_rules = [
         (r"^https://shop.lululemon.com/stores/[^/]+/[^/]+/[^/]+$", "parse_store"),
     ]

--- a/locations/spiders/mcdonalds_baltics.py
+++ b/locations/spiders/mcdonalds_baltics.py
@@ -13,7 +13,6 @@ class McDonaldsBalticsSpider(scrapy.spiders.SitemapSpider):
         "https://mcd.lt/location-sitemap.xml",
         "https://mcdonalds.lv/location-sitemap.xml",
     ]
-    download_delay = 1.0
 
     def parse(self, response):
         item = OpenGraphParser.parse(response)

--- a/locations/spiders/mexx.py
+++ b/locations/spiders/mexx.py
@@ -18,7 +18,6 @@ class MexxSpider(scrapy.Spider):
             "user-agent": BROWSER_DEFAULT,
         },
     }
-    download_delay = 1.0
 
     def start_requests(self):
         for country_code in self.gc.get_countries().keys():

--- a/locations/spiders/new_look_gb.py
+++ b/locations/spiders/new_look_gb.py
@@ -9,7 +9,6 @@ class NewLookGB(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.newlook.com/uk/sitemap/maps/sitemap_uk_pos_en_1.xml"]
     sitemap_rules = [(r"https:\/\/www\.newlook\.com\/uk\/store\/[-\w]+-(\d+)$", "parse_sd")]
     wanted_types = ["Store"]
-    download_delay = 1
 
     def sitemap_filter(self, entries):
         for entry in entries:

--- a/locations/spiders/papa_johns_gb.py
+++ b/locations/spiders/papa_johns_gb.py
@@ -1,17 +1,11 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
     name = "papa_johns_gb"
-    item_attributes = {
-        "brand": "Papa John's",
-        "brand_wikidata": "Q2759586",
-        "country": "GB",
-    }
-    download_delay = 1
+    item_attributes = {"brand": "Papa John's", "brand_wikidata": "Q2759586"}
     sitemap_urls = ["https://www.papajohns.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/([-.\w]+)$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
@@ -19,5 +13,4 @@ class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data):
         # extract_google_position(item, response)
         item["website"] = response.url
-
         yield item

--- a/locations/spiders/potbelly_sandwichshop.py
+++ b/locations/spiders/potbelly_sandwichshop.py
@@ -11,7 +11,6 @@ class PotbellySandwichShopSpider(Spider):
     name = "potbelly_sandwich"
     item_attributes = {"brand": "Potbelly Sandwich Shop", "brand_wikidata": "Q7234777"}
     allowed_domains = ["www.potbelly.com", "api.prod.potbelly.com"]
-    download_delay = 1.0
     start_urls = [
         "https://www.potbelly.com/sitemap_locations.xml",
     ]

--- a/locations/spiders/premier_gb.py
+++ b/locations/spiders/premier_gb.py
@@ -5,15 +5,10 @@ from locations.open_graph_parser import OpenGraphParser
 
 class PremierGBSpider(scrapy.spiders.SitemapSpider):
     name = "premier_gb"
-    item_attributes = {
-        "brand": "Premier",
-        "brand_wikidata": "Q7240340",
-        "country": "GB",
-    }
+    item_attributes = {"brand": "Premier", "brand_wikidata": "Q7240340"}
     allowed_domains = ["premier-stores.co.uk"]
     sitemap_urls = ["https://www.premier-stores.co.uk/sitemap.xml"]
     sitemap_rules = [("/our-stores/", "parse_store")]
-    download_delay = 1.0
 
     def parse_store(self, response):
         yield OpenGraphParser.parse(response)

--- a/locations/spiders/redlion.py
+++ b/locations/spiders/redlion.py
@@ -14,7 +14,6 @@ class RedLionSpider(scrapy.spiders.SitemapSpider):
         "/red-lion-hotels/": ("Red Lion Hotels", "Q25047720"),
         "/red-lion-inn-suites/": ("Red Lion Hotels", "Q25047720"),
     }
-    download_delay = 1.0
 
     def _parse_sitemap(self, response):
         for x in super()._parse_sitemap(response):

--- a/locations/spiders/scotiabank.py
+++ b/locations/spiders/scotiabank.py
@@ -30,7 +30,6 @@ def calculate_offset_point(x, y, d, b):
 
 class ScotiabankSpider(scrapy.Spider):
     name = "scotiabank"
-    download_delay = 1.0
     allowed_domains = ["scotiabank.com"]
     item_attributes = {"brand": "Scotiabank", "brand_wikidata": "Q451476"}
     base_url = "https://mapsms.scotiabank.com/branches?1=1&latitude={lat}&longitude={lon}&recordlimit=20&locationtypes=1&options=&languagespoken=any&language=en&address=&province=&city="

--- a/locations/spiders/specsavers_gb.py
+++ b/locations/spiders/specsavers_gb.py
@@ -17,5 +17,4 @@ class SpecsaversGBSpider(CrawlSpider, StructuredDataSpider):
     # However the fake ones currently redirect to "?hearing=true"
     # So we can disable redirecting
     custom_settings = {"REDIRECT_ENABLED": False}
-    download_delay = 1
     wanted_types = ["Optician"]

--- a/locations/spiders/sullivans_steakhouse.py
+++ b/locations/spiders/sullivans_steakhouse.py
@@ -10,7 +10,6 @@ class SullivansSteakhouseSpider(SitemapSpider):
     item_attributes = {"brand": "Sullivan's Steakhouse"}
     allowed_domains = ["www.sullivanssteakhouse.com"]
     sitemap_urls = ["https://www.sullivanssteakhouse.com/locations-sitemap.xml"]
-    # download_delay = 1
 
     def parse(self, response):
         ld = json.loads(

--- a/locations/spiders/tacobell.py
+++ b/locations/spiders/tacobell.py
@@ -15,7 +15,6 @@ class TacobellSpider(scrapy.spiders.SitemapSpider):
         # "https://tacobell.es/restaurantes-sitemap.xml",
         # "https://tacobell.nl/location-sitemap.xml",
     ]
-    download_delay = 1.0
 
     def _parse_sitemap(self, response):
         def follow_link(url):

--- a/locations/spiders/thebodyshop.py
+++ b/locations/spiders/thebodyshop.py
@@ -7,7 +7,6 @@ class TheBodyShopSpider(scrapy.spiders.SitemapSpider):
     name = "thebodyshop"
     item_attributes = {"brand": "The Body Shop", "brand_wikidata": "Q837851"}
     allowed_domains = ["thebodyshop.com"]
-    download_delay = 1.0
     sitemap_urls = ["https://www.thebodyshop.com/sitemap.xml"]
 
     parse_pages = {

--- a/locations/spiders/toolstation.py
+++ b/locations/spiders/toolstation.py
@@ -9,7 +9,6 @@ from locations.dict_parser import DictParser
 class ToolstationSpider(scrapy.spiders.SitemapSpider):
     name = "toolstation"
     item_attributes = {"brand": "Toolstation", "brand_wikidata": "Q7824103"}
-    download_delay = 1.0
     sitemap_urls = [
         "https://www.toolstation.com/sitemap/branches.xml",
         "https://www.toolstation.fr/sitemap/branches.xml",

--- a/locations/spiders/whidbey_coffee.py
+++ b/locations/spiders/whidbey_coffee.py
@@ -11,7 +11,6 @@ class WhidbeyCoffeeSpider(scrapy.Spider):
     name = "whidbeycoffee"
     item_attributes = {"brand": "Whidbey Coffee"}
     allowed_domains = ["www.whidbeycoffee.com"]
-    download_delay = 1
     start_urls = ("https://www.whidbeycoffee.com/sitemap_pages_1.xml",)
 
     def parse(self, response):

--- a/locations/spiders/wyndham.py
+++ b/locations/spiders/wyndham.py
@@ -33,7 +33,6 @@ BRANDS = {
 
 class WyndhamSpider(SitemapSpider):
     name = "wyndham"
-    download_delay = 1
     allowed_domains = ["www.wyndhamhotels.com"]
     sitemap_urls = ["https://www.wyndhamhotels.com/sitemap.xml"]
     sitemap_follow = [r"https:\/\/www\.wyndhamhotels\.com\/sitemap_en-us_([\w]{2})_properties_\d\.xml"]


### PR DESCRIPTION
A few general clean ups around download_delay. Should not be too contentious. We should think about some of the other non-default values  perhaps.
