### PR TITLE
Update Waterstones spider to use alphabetical directory

### DIFF
--- a/locations/spiders/waterstones.py
+++ b/locations/spiders/waterstones.py
@@ -9,7 +9,7 @@ class WaterstonesSpider(scrapy.Spider):
     name = "waterstones"
     item_attributes = {"brand": "Waterstones", "brand_wikidata": "Q151779"}
     allowed_domains = ["www.waterstones.com"]
-    start_urls = ["https://www.waterstones.com/bookshops/directory/"+chr(i) for i in range(ord('a'), ord('z')+1)]
+    start_urls = ["https://www.waterstones.com/bookshops/directory/" + chr(i) for i in range(ord("a"), ord("z") + 1)]
     # Use the alphabetical list pages rather than the paginated "view
     # all" list used previously, since in the latter the final page
     # is not reached by a rel=next link.

--- a/locations/spiders/waterstones.py
+++ b/locations/spiders/waterstones.py
@@ -9,7 +9,10 @@ class WaterstonesSpider(scrapy.Spider):
     name = "waterstones"
     item_attributes = {"brand": "Waterstones", "brand_wikidata": "Q151779"}
     allowed_domains = ["www.waterstones.com"]
-    start_urls = ("https://www.waterstones.com/bookshops/viewall",)
+    start_urls = ["https://www.waterstones.com/bookshops/directory/"+chr(i) for i in range(ord('a'), ord('z')+1)]
+    # Use the alphabetical list pages rather than the paginated "view
+    # all" list used previously, since in the latter the final page
+    # is not reached by a rel=next link.
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
@@ -18,10 +21,6 @@ class WaterstonesSpider(scrapy.Spider):
         stores = set(stores)
         for store in stores:
             yield response.follow(store, self.parse_store)
-
-        next_page = response.xpath('//link[@rel="next"]/@href').extract_first()
-        if next_page:
-            yield response.follow(next_page, self.parse)
 
     def parse_store(self, response):
         try:


### PR DESCRIPTION
The existing implementation crawls through a paginated list starting from https://www.waterstones.com/bookshops/viewall . However, a coding error by Waterstones means only 15 pages are linked, ending at https://www.waterstones.com/bookshops/viewall?page=15 . But in fact there's a hidden page 16: https://www.waterstones.com/bookshops/viewall?page=16 that contains the last few stores at the end of the alphabet.

This means the existing spider misses around 20 stores. This PR should fix this, by instead polling the 26 alphabetical pages.