### PR TITLE
More generic handling of 0:XX opening-hours times in pret_a_manger spider

### DIFF
--- a/locations/spiders/pret_a_manger.py
+++ b/locations/spiders/pret_a_manger.py
@@ -32,10 +32,10 @@ class PretAMangerSpider(scrapy.Spider):
                     if len(rule) != 2:
                         continue
 
-                    if rule[0].startswith('0:'):
-                        rule[0] = rule[0].replace('0:','12:',1)
-                    if rule[1].startswith('0:'):
-                        rule[1] = rule[1].replace('0:','12:',1)
+                    if rule[0].startswith("0:"):
+                        rule[0] = rule[0].replace("0:", "12:", 1)
+                    if rule[1].startswith("0:"):
+                        rule[1] = rule[1].replace("0:", "12:", 1)
 
                     oh.add_range(DAYS[i], rule[0], rule[1], "%I:%M%p")
 

--- a/locations/spiders/pret_a_manger.py
+++ b/locations/spiders/pret_a_manger.py
@@ -32,12 +32,10 @@ class PretAMangerSpider(scrapy.Spider):
                     if len(rule) != 2:
                         continue
 
-                    if rule[0] == "0:00AM":
-                        rule[0] = "12:00AM"
-                    if rule[1] == "0:00AM":
-                        rule[1] = "12:00AM"
-                    if rule[0] == "0:01AM":
-                        rule[0] = "12:01AM"
+                    if rule[0].startswith('0:'):
+                        rule[0] = rule[0].replace('0:','12:',1)
+                    if rule[1].startswith('0:'):
+                        rule[1] = rule[1].replace('0:','12:',1)
 
                     oh.add_range(DAYS[i], rule[0], rule[1], "%I:%M%p")
 


### PR DESCRIPTION
The API used in the Pret a Manger scraper https://api1.pret.com/v1/shops lists 603 stores, but the spider is currently only returning 181 of them.

The problem is that an error that occurs when a time of "0:59" is given to `oh.add_range(DAYS[i], rule[0], rule[1], "%I:%M%p")`. There's already an attempt in the code to convert "0:XX" to "12:XX" to work with the %I time format, but this only deals with some specific cases. This PR aims to convert all instances of "0:XX" to "12:XX".

The new code avoids the error. When run locally, I now get all 603 stores returned (596 pret + 7 veggie pret).