### PR TITLE
Validate geometry the same as lat/lon

### DIFF
--- a/locations/items.py
+++ b/locations/items.py
@@ -58,6 +58,12 @@ def get_lat_lon(item: Feature) -> (float, float):
 
 
 def set_lat_lon(item: Feature, lat: float, lon: float):
-    item["lat"] = lat
-    item["lon"] = lon
-    item["geometry"] = None
+    item["lat"] = None
+    item["lon"] = None
+    if lat and lon:
+        item["geometry"] = {
+            "type": "Point",
+            "coordinates": [lon, lat],
+        }
+    else:
+        item["geometry"] = None

--- a/locations/items.py
+++ b/locations/items.py
@@ -38,3 +38,26 @@ class Feature(scrapy.Item):
         super().__init__(*args, **kwargs)
         if not self._values.get("extras"):
             self.__setitem__("extras", {})
+
+
+def get_lat_lon(item: Feature) -> (float, float):
+    if geometry := item.get("geometry"):
+        if isinstance(geometry, dict):
+            if geometry.get("type") == "Point":
+                if coords := geometry.get("coordinates"):
+                    try:
+                        return float(coords[1]), float(coords[0])
+                    except (TypeError, ValueError):
+                        item["geometry"] = None
+    else:
+        try:
+            return float(item.get("lat")), float(item.get("lon"))
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def set_lat_lon(item: Feature, lat: float, lon: float):
+    item["lat"] = lat
+    item["lon"] = lon
+    item["geometry"] = None

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -2,6 +2,7 @@ import math
 import re
 
 from locations.hours import OpeningHours
+from locations.items import get_lat_lon, set_lat_lon
 
 
 def check_field(item, spider, param, allowed_types, match_regex=None):
@@ -52,33 +53,27 @@ class CheckItemPropertiesPipeline:
         check_field(item, spider, "country", (str,), self.country_regex)
         check_field(item, spider, "brand", (str,))
 
-        if not item.get("geometry"):
-            if lat := item.get("lat"):
-                try:
-                    lat = float(lat)
-                    if not (self.min_lat < lat < self.max_lat):
-                        spider.crawler.stats.inc_value("atp/field/lat/invalid")
-                    if math.fabs(lat) < 0.01:
-                        spider.crawler.stats.inc_value("atp/field/lat/invalid")
-                except:
-                    lat = None
-                    spider.crawler.stats.inc_value("atp/field/lat/invalid")
-                item["lat"] = lat
-            else:
-                spider.crawler.stats.inc_value("atp/field/lat/missing")
-            if lon := item.get("lon"):
-                try:
-                    lon = float(lon)
-                    if not (self.min_lon < lon < self.max_lon):
-                        spider.crawler.stats.inc_value("atp/field/lon/invalid")
-                    if math.fabs(lon) < 0.01:
-                        spider.crawler.stats.inc_value("atp/field/lon/invalid")
-                except:
-                    lon = None
-                    spider.crawler.stats.inc_value("atp/field/lon/invalid")
-                item["lon"] = lon
-            else:
-                spider.crawler.stats.inc_value("atp/field/lon/missing")
+        if coords := get_lat_lon(item):
+            lat, lon = coords
+
+            if not (self.min_lat < lat < self.max_lat):
+                spider.crawler.stats.inc_value("atp/field/lat/invalid")
+                lat = None
+
+            if not (self.min_lon < lon < self.max_lon):
+                spider.crawler.stats.inc_value("atp/field/lon/invalid")
+                lon = None
+
+            if math.fabs(lat) < 3 and math.fabs(lon) < 3:
+                spider.crawler.stats.inc_value("atp/geometry/null_island")
+                lat = None
+                lon = None
+
+            set_lat_lon(item, lat, lon)
+
+        if not (item.get("geometry") or get_lat_lon(item)):
+            spider.crawler.stats.inc_value("atp/field/lat/missing")
+            spider.crawler.stats.inc_value("atp/field/lon/missing")
 
         if twitter := item.get("twitter"):
             if not isinstance(twitter, str):

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -64,10 +64,11 @@ class CheckItemPropertiesPipeline:
                 spider.crawler.stats.inc_value("atp/field/lon/invalid")
                 lon = None
 
-            if math.fabs(lat) < 3 and math.fabs(lon) < 3:
-                spider.crawler.stats.inc_value("atp/geometry/null_island")
-                lat = None
-                lon = None
+            if isinstance(lat, float) and isinstance(lon, float):
+                if math.fabs(lat) < 3 and math.fabs(lon) < 3:
+                    spider.crawler.stats.inc_value("atp/geometry/null_island")
+                    lat = None
+                    lon = None
 
             set_lat_lon(item, lat, lon)
 

--- a/locations/pipelines/country_code_clean_up.py
+++ b/locations/pipelines/country_code_clean_up.py
@@ -1,24 +1,7 @@
 import reverse_geocoder
 
 from locations.country_utils import CountryUtils
-from locations.items import Feature
-
-
-def get_lat_lon(item: Feature) -> (float, float):
-    if geometry := item.get("geometry"):
-        if isinstance(geometry, dict):
-            if geometry.get("type") == "Point":
-                if coords := geometry.get("coordinates"):
-                    try:
-                        return float(coords[1]), float(coords[0])
-                    except (TypeError, ValueError):
-                        pass
-    else:
-        try:
-            return float(item.get("lat")), float(item.get("lon"))
-        except (TypeError, ValueError):
-            pass
-    return None
+from locations.items import get_lat_lon
 
 
 class CountryCodeCleanUpPipeline:

--- a/locations/pipelines/state_clean_up.py
+++ b/locations/pipelines/state_clean_up.py
@@ -1,7 +1,7 @@
 import reverse_geocoder
 from geonamescache import GeonamesCache
 
-from locations.pipelines.country_code_clean_up import get_lat_lon
+from locations.items import get_lat_lon
 from locations.spiders.xfinity import US_TERRITORIES
 
 STATES = {

--- a/tests/test_bad_coords.py
+++ b/tests/test_bad_coords.py
@@ -16,7 +16,7 @@ def get_objects(lat, lon):
             Feature(
                 geometry={
                     "type": "Point",
-                    "coordinates": [lat, lon],
+                    "coordinates": [lon, lat],
                 }
             ),
         ],

--- a/tests/test_bad_coords.py
+++ b/tests/test_bad_coords.py
@@ -64,3 +64,12 @@ def test_bad_geometry():
         assert item.get("lat") is None
         assert item.get("lon") is None
         assert item.get("geometry") is None
+
+
+def test_casting():
+    items, pipeline, spider = get_objects(int(20), "20.0")
+    for item in items:
+        pipeline.process_item(item, spider)
+
+        assert item.get("lat") == 20.0
+        assert item.get("lon") == 20.0

--- a/tests/test_bad_coords.py
+++ b/tests/test_bad_coords.py
@@ -1,9 +1,7 @@
-import pprint
-
 from scrapy import Spider
 from scrapy.crawler import Crawler
 
-from locations.items import Feature
+from locations.items import Feature, get_lat_lon
 from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline
 
 
@@ -58,7 +56,6 @@ def test_invalid():
     for item in items:
         pipeline.process_item(item, spider)
 
-        pprint.pp(item)
         assert item.get("lat") is None
         assert item.get("lon") is None
         assert item.get("geometry") is None
@@ -79,5 +76,4 @@ def test_casting():
     for item in items:
         pipeline.process_item(item, spider)
 
-        assert item.get("lat") == 20.0
-        assert item.get("lon") == 20.0
+        assert get_lat_lon(item) == (20.0, 20.0)

--- a/tests/test_bad_coords.py
+++ b/tests/test_bad_coords.py
@@ -44,6 +44,14 @@ def test_throw_away_null_island():
         assert item.get("lon") is None
         assert item.get("geometry") is None
 
+    items, pipeline, spider = get_objects(0.123, 0.456)
+    for item in items:
+        pipeline.process_item(item, spider)
+
+        assert item.get("lat") is None
+        assert item.get("lon") is None
+        assert item.get("geometry") is None
+
 
 def test_invalid():
     items, pipeline, spider = get_objects("0", "0")


### PR DESCRIPTION
So, currently we are not validating `geometry` at all. This puts Points through the same validation as raw `lat`/`lon`.

Currently we complain (`atp/field/lon/invalid`) about anything within +-0.1 of 0, but still output it, unless lat or lon == 0.0. This complains (`atp/geometry/null_island`) and discards coords of anything within `3.0, 3.0, -3.0, -3.0`.