### PR TITLE
caffe_nero: fix and split caffe_nero_gb which needs new spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -216,6 +216,7 @@ class Fuel(Enum):
 
 
 class Extras(Enum):
+    AIR_CONDITIONING = "air_conditioning"
     ATM = "atm"
     BABY_CHANGING_TABLE = "changing_table"
     CALLING = "service:phone"
@@ -233,8 +234,10 @@ class Extras(Enum):
     PRINTING = "service:print"
     SCANING = "service:scan"
     SHOWERS = "shower"
+    SMOKING_AREA = "smoking=isolated"
     TAKEAWAY = "takeaway"
     TOILETS = "toilets"
+    TOILETS_WHEELCHAIR = "toilets:wheelchair"
     TRUCK_WASH = "truck_wash"
     WHEELCHAIR = "wheelchair"
     WIFI = "internet_access=wlan"
@@ -319,6 +322,8 @@ def apply_yes_no(attribute, item: Feature, state: bool, apply_positive_only: boo
         tag_key = attribute.value
     else:
         raise TypeError("string or Enum required")
+    if not state and "=" in tag_key:
+        return
 
     if "=" in tag_key:
         tag_key, tag_value = tag_key.split("=")

--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -2,7 +2,7 @@ from locations.items import Feature
 
 
 class DictParser:
-    ref_keys = ["ref", "id", "store-id", "storeNumber", "shop-number", "LocationID", "slug", "storeCode"]
+    ref_keys = ["ref", "id", "store-id", "storeID", "storeNumber", "shop-number", "LocationID", "slug", "storeCode"]
 
     name_keys = ["name", "store-name", "display-name", "title", "businessName"]
 

--- a/locations/spiders/caffe_nero.py
+++ b/locations/spiders/caffe_nero.py
@@ -8,10 +8,15 @@ from locations.dict_parser import DictParser
 class CaffeNeroSpider(Spider):
     name = "caffe_nero"
     item_attributes = {"brand": "Caffe Nero", "brand_wikidata": "Q675808"}
-    start_urls = ["https://caffenero.com/uk/stores/"]
+    allowed_domains = ["caffenero.com", "greencaffenero.pl"]
+    start_urls = ["https://caffenero.com/us/stores/"]
 
     def parse(self, response, **kwargs):
         for region in response.xpath('//li[@role="menuitem"]/a[not(@class="global")]/@href').getall():
+            # GB stores use a different store locator
+            if ".com/uk" in region:
+                continue
+            region = region.replace("http://", "https://")
             yield Request(url=f"{region}/stores/", callback=self.parse_country)
 
     def parse_country(self, response, **kwargs):

--- a/locations/spiders/caffe_nero_gb.py
+++ b/locations/spiders/caffe_nero_gb.py
@@ -18,7 +18,11 @@ class CaffeNeroGBSpider(Spider):
 
     def parse(self, response):
         for location in response.json()["features"]:
-            if not location["properties"]["status"]["open"] or location["properties"]["status"]["opening_soon"] or location["properties"]["status"]["temp_closed"]:
+            if (
+                not location["properties"]["status"]["open"]
+                or location["properties"]["status"]["opening_soon"]
+                or location["properties"]["status"]["temp_closed"]
+            ):
                 continue
 
             item = DictParser.parse(location["properties"])
@@ -33,7 +37,7 @@ class CaffeNeroGBSpider(Spider):
                 if day_name == "holiday":
                     continue
                 item["opening_hours"].add_range(day_name.title(), day_hours["open"], day_hours["close"])
-            
+
             apply_yes_no(Extras.TAKEAWAY, item, location["properties"]["status"]["takeaway"], False)
             apply_yes_no(Extras.DELIVERY, item, location["properties"]["status"]["delivery"], False)
             apply_yes_no(Extras.WIFI, item, location["properties"]["amenities"]["wifi"], False)

--- a/locations/spiders/caffe_nero_gb.py
+++ b/locations/spiders/caffe_nero_gb.py
@@ -1,0 +1,48 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class CaffeNeroGBSpider(Spider):
+    name = "caffe_nero_gb"
+    item_attributes = {"brand": "Caffe Nero", "brand_wikidata": "Q675808"}
+    allowed_domains = ["caffenero-webassets-production.s3.eu-west-2.amazonaws.com"]
+    start_urls = ["https://caffenero-webassets-production.s3.eu-west-2.amazonaws.com/stores/stores_gb.json"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url)
+
+    def parse(self, response):
+        for location in response.json()["features"]:
+            if not location["properties"]["status"]["open"] or location["properties"]["status"]["opening_soon"] or location["properties"]["status"]["temp_closed"]:
+                continue
+
+            item = DictParser.parse(location["properties"])
+            item["geometry"] = location["geometry"]
+            if location["properties"]["status"]["express"]:
+                item["brand"] = "Nero Express"
+
+            item["opening_hours"] = OpeningHours()
+            for day_name, day_hours in location["properties"]["hoursRegular"].items():
+                if day_hours["open"] == "closed" or day_hours["close"] == "closed":
+                    continue
+                if day_name == "holiday":
+                    continue
+                item["opening_hours"].add_range(day_name.title(), day_hours["open"], day_hours["close"])
+            
+            apply_yes_no(Extras.TAKEAWAY, item, location["properties"]["status"]["takeaway"], False)
+            apply_yes_no(Extras.DELIVERY, item, location["properties"]["status"]["delivery"], False)
+            apply_yes_no(Extras.WIFI, item, location["properties"]["amenities"]["wifi"], False)
+            apply_yes_no(Extras.TOILETS, item, location["properties"]["amenities"]["toilet"], False)
+            apply_yes_no(Extras.BABY_CHANGING_TABLE, item, location["properties"]["amenities"]["baby_change"], False)
+            apply_yes_no(Extras.SMOKING_AREA, item, location["properties"]["amenities"]["smoking_area"], False)
+            apply_yes_no(Extras.AIR_CONDITIONING, item, location["properties"]["amenities"]["air_conditioned"], False)
+            apply_yes_no(Extras.WHEELCHAIR, item, location["properties"]["amenities"].get("disabled_access"), False)
+            apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["properties"]["amenities"]["disabled_toilet"], False)
+            apply_yes_no(Extras.OUTDOOR_SEATING, item, location["properties"]["amenities"]["outside_seating"], False)
+
+            yield item


### PR DESCRIPTION
* caffe_nero_gb has been split from caffe_nero because GB stores now use a different store locator method from other countries.
* caffe_nero updated to ignore GB stores.
* caffe_nero_gb now has greatly expanded extra tags for toilets, etc as the new locator method has more data available.
* Fix an error with apply_yes_no that would always apply Extras.WIFI even if disabled/not available for a location.
* Add additional Extras to categories.py.