### PR TITLE
Add Denizbank (TR) (3817 locations)

### DIFF
--- a/locations/spiders/denizbank.py
+++ b/locations/spiders/denizbank.py
@@ -1,16 +1,15 @@
 import scrapy
-from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
-from locations.hours import DAYS
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
-class DenizbankSpider(scrapy.Spider):
-    name = "denizbank"
+
+class DenizbankTrSpider(scrapy.Spider):
+    name = "denizbank_tr"
     allowed_domains = ["denizbank.com"]
-    item_attributes = { 'brand': "Denizbank", "brand_wikidata": "Q1115064" }
+    item_attributes = {"brand": "Denizbank", "brand_wikidata": "Q1115064"}
     start_urls = [
-        'https://www.denizbank.com/api/branch-atm?isAtmSearch=true&isBranchSearch=true&isVisuallyImparied=false&isOrthopedicalHandicapped=false&isCurrencySupport=false&keyword=&latitude=&longitude=&cityCode=&townCode=',
+        "https://www.denizbank.com/api/branch-atm?isAtmSearch=true&isBranchSearch=true&isVisuallyImparied=false&isOrthopedicalHandicapped=false&isCurrencySupport=false&keyword=&latitude=&longitude=&cityCode=&townCode=",
     ]
 
     def parse(self, response):
@@ -18,10 +17,10 @@ class DenizbankSpider(scrapy.Spider):
         for poi in data:
             item = DictParser.parse(poi)
             # TODO: map "is-visually-imparied", "is-orthopedical-handicapped", "is-exchange-support" to OSM tags if possible
-            item['ref'] = poi.get('code')
-            item['phone'] = poi.get('phone').strip() if poi.get('phone') else None
-            if poi['record-type'] == 'atm':
+            item["ref"] = poi.get("code")
+            item["phone"] = poi.get("phone").strip() if poi.get("phone") else None
+            if poi["record-type"] == "atm":
                 apply_category(Categories.ATM, item)
-            if poi['record-type'] == 'branch':
+            if poi["record-type"] == "branch":
                 apply_category(Categories.BANK, item)
             yield item

--- a/locations/spiders/denizbank.py
+++ b/locations/spiders/denizbank.py
@@ -18,6 +18,7 @@ class DenizbankTrSpider(scrapy.Spider):
             item = DictParser.parse(poi)
             # TODO: map "is-visually-imparied", "is-orthopedical-handicapped", "is-exchange-support" to OSM tags if possible
             item["ref"] = poi.get("code")
+            item["name"] = "Denizbank"
             item["phone"] = poi.get("phone").strip() if poi.get("phone") else None
             if poi["record-type"] == "atm":
                 apply_category(Categories.ATM, item)

--- a/locations/spiders/denizbank.py
+++ b/locations/spiders/denizbank.py
@@ -4,7 +4,7 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
-class DenizbankTrSpider(scrapy.Spider):
+class DenizbankTRSpider(scrapy.Spider):
     name = "denizbank_tr"
     allowed_domains = ["denizbank.com"]
     item_attributes = {"brand": "Denizbank", "brand_wikidata": "Q1115064"}

--- a/locations/spiders/denizbank.py
+++ b/locations/spiders/denizbank.py
@@ -1,0 +1,27 @@
+import scrapy
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.hours import DAYS
+
+from locations.dict_parser import DictParser
+
+class DenizbankSpider(scrapy.Spider):
+    name = "denizbank"
+    allowed_domains = ["denizbank.com"]
+    item_attributes = { 'brand': "Denizbank", "brand_wikidata": "Q1115064" }
+    start_urls = [
+        'https://www.denizbank.com/api/branch-atm?isAtmSearch=true&isBranchSearch=true&isVisuallyImparied=false&isOrthopedicalHandicapped=false&isCurrencySupport=false&keyword=&latitude=&longitude=&cityCode=&townCode=',
+    ]
+
+    def parse(self, response):
+        data = response.json()
+        for poi in data:
+            item = DictParser.parse(poi)
+            # TODO: map "is-visually-imparied", "is-orthopedical-handicapped", "is-exchange-support" to OSM tags if possible
+            item['ref'] = poi.get('code')
+            item['phone'] = poi.get('phone').strip() if poi.get('phone') else None
+            if poi['record-type'] == 'atm':
+                apply_category(Categories.ATM, item)
+            if poi['record-type'] == 'branch':
+                apply_category(Categories.BANK, item)
+            yield item


### PR DESCRIPTION
```
{'atp/brand/Denizbank': 3817,
 'atp/brand_wikidata/Q1115064': 3817,
 'atp/category/amenity/atm': 3068,
 'atp/category/amenity/bank': 749,
 'atp/field/city/missing': 3817,
 'atp/field/country/from_spider_name': 3817,
 'atp/field/email/missing': 3817,
 'atp/field/image/missing': 3817,
 'atp/field/lat/missing': 86,
 'atp/field/lon/missing': 86,
 'atp/field/opening_hours/missing': 3817,
 'atp/field/phone/invalid': 18,
 'atp/field/phone/missing': 3068,
 'atp/field/postcode/missing': 3817,
 'atp/field/state/missing': 3817,
 'atp/field/street_address/missing': 3817,
 'atp/field/twitter/missing': 3817,
 'atp/field/website/missing': 3817,
 'atp/nsi/category_match': 3817,
 'downloader/request_bytes': 913,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 314854,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.282668,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 5, 20, 10, 29, 24, 639116),
 'httpcompression/response_bytes': 1151107,
 'httpcompression/response_count': 2,
 'item_dropped_count': 8,
 'item_dropped_reasons_count/DropItem': 8,
 'item_scraped_count': 3817,
 'log_count/INFO': 9,
 'log_count/WARNING': 8,
 'memusage/max': 115412992,
 'memusage/startup': 115412992,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 5, 20, 10, 29, 17, 356448)}
```