### PR TITLE
Tweaks to Wren Kitchens GB Spider

### DIFF
--- a/locations/spiders/wrenkitchens_gb.py
+++ b/locations/spiders/wrenkitchens_gb.py
@@ -16,7 +16,7 @@ class WrenKitchensGB(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.wrenkitchens.com/showrooms/"]
     rules = [
         Rule(
-            LinkExtractor(allow=r"https:\/\/www\.wrenkitchens\.com\/showrooms\/([_\w]+)$"),
+            LinkExtractor(allow=r"https:\/\/www\.wrenkitchens\.com\/showrooms\/([-\w]+)$"),
             callback="parse_sd",
             follow=False,
         )
@@ -24,6 +24,7 @@ class WrenKitchensGB(CrawlSpider, StructuredDataSpider):
     download_delay = 0.5
     wanted_types = ["HomeAndConstructionBusiness"]
 
-    def inspect_item(self, item, response):
+    def post_process_item(self, item, response, ld_data):
         google_url.extract_google_position(item, response)
+        item["website"] = response.url #Some URLs redirect
         yield item

--- a/locations/spiders/wrenkitchens_gb.py
+++ b/locations/spiders/wrenkitchens_gb.py
@@ -26,5 +26,5 @@ class WrenKitchensGB(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data):
         google_url.extract_google_position(item, response)
-        item["website"] = response.url #Some URLs redirect
+        item["website"] = response.url  # Some URLs redirect
         yield item


### PR DESCRIPTION
* Allow hyphens in store URLs (underscores already included in \w). This adds three previously missing stores, e.g. https://www.wrenkitchens.com/showrooms/tunbridge-wells
* Upgrade from deprecated `inspect_item`
* Use final URL for store websites (some store links from the `/showrooms/` page redirect to the final URL)