### PR TITLE
Add Vakif Katilim (TR) (314 locations)

### DIFF
--- a/locations/spiders/vakif_katilim_tr.py
+++ b/locations/spiders/vakif_katilim_tr.py
@@ -1,15 +1,12 @@
-
-
 import scrapy
-from locations.categories import Categories
-from locations.categories import apply_category
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class VakifKatilimTRSpider(scrapy.Spider):
     name = "vakif_katilim_tr"
-    item_attributes = { 'brand': "Vakıf Katılım", "brand_wikidata": "Q31188912" }
+    item_attributes = {"brand": "Vakıf Katılım", "brand_wikidata": "Q31188912"}
     start_urls = ["https://www.vakifkatilim.com.tr/tr/diger/subeler-ve-atmler"]
 
     def parse(self, response):
@@ -23,9 +20,9 @@ class VakifKatilimTRSpider(scrapy.Spider):
         data = response.json()
         for poi in data.get("information"):
             item = DictParser.parse(poi)
-            item['ref'] = poi.get("branchType")
-            item['extras']['addr:district'] = poi.get("districtName")
-            if poi.get('type'):
+            item["ref"] = poi.get("branchType")
+            item["extras"]["addr:district"] = poi.get("districtName")
+            if poi.get("type"):
                 apply_category(Categories.ATM, item)
             else:
                 apply_category(Categories.BANK, item)


### PR DESCRIPTION
```
{'atp/brand/Vakıf Katılım': 314,
 'atp/brand_wikidata/Q31188912': 314,
 'atp/category/amenity/atm': 146,
 'atp/category/amenity/bank': 168,
 'atp/field/country/from_spider_name': 314,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 314,
 'atp/field/opening_hours/missing': 314,
 'atp/field/postcode/missing': 314,
 'atp/field/state/missing': 314,
 'atp/field/street_address/missing': 314,
 'atp/field/twitter/missing': 314,
 'atp/field/website/missing': 314,
 'atp/nsi/category_match': 314,
 'downloader/request_bytes': 1911,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 256411,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.5515,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 5, 21, 19, 48, 54, 570205),
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 314,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 116244480,
 'memusage/startup': 116244480,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 5, 21, 19, 48, 50, 18705)}
```