### PR TITLE
Add America's Kids (US) (20 stores)

### DIFF
--- a/locations/spiders/americas_kids_us.py
+++ b/locations/spiders/americas_kids_us.py
@@ -1,6 +1,6 @@
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 
-from locations.hours import DAYS_FULL, OpeningHours
 
 class AmericasKidsUSSpider(StoreLocatorWidgetsSpider):
     name = "americas_kids_us"
@@ -9,7 +9,7 @@ class AmericasKidsUSSpider(StoreLocatorWidgetsSpider):
         "Kids World": {"brand": "Kids World", "brand_wikidata": "Q119141647"},
         "Lazarus": {"brand": "Lazarus", "brand_wikidata": "Q119141646"},
         "Young Land": {"brand": "Young Land", "brand_wikidata": "Q119141643"},
-        "Young World": {"brand": "Young World", "brand_wikidata": "Q119141641"}
+        "Young World": {"brand": "Young World", "brand_wikidata": "Q119141641"},
     }
     key = "8b5da83104f650ef1c1194d92228c489"
 

--- a/locations/spiders/americas_kids_us.py
+++ b/locations/spiders/americas_kids_us.py
@@ -1,0 +1,29 @@
+from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
+
+from locations.hours import DAYS_FULL, OpeningHours
+
+class AmericasKidsUSSpider(StoreLocatorWidgetsSpider):
+    name = "americas_kids_us"
+    brands = {
+        "Americas Kids": {"brand": "America's Kids", "brand_wikidata": "Q119141496"},
+        "Kids World": {"brand": "Kids World", "brand_wikidata": "Q119141647"},
+        "Lazarus": {"brand": "Lazarus", "brand_wikidata": "Q119141646"},
+        "Young Land": {"brand": "Young Land", "brand_wikidata": "Q119141643"},
+        "Young World": {"brand": "Young World", "brand_wikidata": "Q119141641"}
+    }
+    key = "8b5da83104f650ef1c1194d92228c489"
+
+    def parse_item(self, item, location):
+        for brand_key, brand_details in self.brands.items():
+            if brand_key in location["name"]:
+                item.update(brand_details)
+                break
+        item.pop("image")
+        hours_string = ""
+        for day_name in DAYS_FULL:
+            if location["data"].get(f"hours_{day_name}"):
+                time_range = location["data"].get(f"hours_{day_name}")
+                hours_string = f"{hours_string} {day_name}: {time_range}"
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(hours_string)
+        yield item


### PR DESCRIPTION
 "atp/brand/America's Kids": 11,
 'atp/brand/Kids World': 1,
 'atp/brand/Lazarus': 1,
 'atp/brand/Young Land': 1,
 'atp/brand/Young World': 6,