### PR TITLE
Add pipeline to count potentially closed items

### DIFF
--- a/locations/pipelines/closed.py
+++ b/locations/pipelines/closed.py
@@ -1,0 +1,17 @@
+from scrapy import Spider
+
+from locations.items import Feature
+
+
+class ClosePipeline:
+    closed_labels = ["closed", "coming soon"]
+
+    def process_item(self, item: Feature, spider: Spider):
+        if name := item.get("name"):
+            for label in self.closed_labels:
+                if label in name.lower():
+                    spider.crawler.stats.inc_value(f"atp/closed_check")
+                    spider.logger.warn(f'Found {label} in {name} ({item.get("ref")})')
+                    break
+
+        return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -92,6 +92,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.extract_gb_postcode.ExtractGBPostcodePipeline": 400,
     "locations.pipelines.assert_url_scheme.AssertURLSchemePipeline": 500,
     "locations.pipelines.check_item_properties.CheckItemPropertiesPipeline": 600,
+    "locations.pipelines.closed.ClosePipeline": 650,
     "locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": 700,
     "locations.pipelines.count_categories.CountCategoriesPipeline": 800,
     "locations.pipelines.count_brands.CountBrandsPipeline": 810,


### PR DESCRIPTION
After a discussion with @rjw62, we are outputting too many closed POIs.

There are obviously implications to just removing POIs with "closed" in the name. There is even a brand called ["Closed"](https://www.closed.com/en/stores/)!

So for now, let's count some stats, and add a warning for us when developing spiders. Depending on the numbers, we could see a pipeline being used to drop items, either opt in or opt out per spider, but let's see the numbers first.
