### PR TITLE
Add Biedronka PL Spider (3,419 locations)

### DIFF
--- a/locations/spiders/biedronka_pl.py
+++ b/locations/spiders/biedronka_pl.py
@@ -1,0 +1,42 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+
+
+class BiedronkaPLSpider(Spider):
+    name = "biedronka_pl"
+    item_attributes = {"brand": "Biedronka", "brand_wikidata": "Q857182"}
+
+    def start_requests(self):
+        yield JsonRequest(
+            "https://www.biedronka.pl/api/shop/shippingcenter", headers={"X-Requested-With": "XMLHttpRequest"}
+        )
+
+    def parse(self, response, **kwargs):
+        for city in response.json()["items"]:
+            yield JsonRequest(
+                url=f'https://www.biedronka.pl/api/shop/cityshopsbyslug?slug={city["slug"]}',
+                headers={"X-Requested-With": "XMLHttpRequest"},
+                callback=self.parse_city,
+            )
+
+    def parse_city(self, response, **kwargs):
+        for location in response.json()["items"]:
+            location.pop("name")
+            item = DictParser.parse(location)
+
+            item["opening_hours"] = OpeningHours()
+            for day in DAYS_FULL:
+                if times := location.get(f"hours_{day.lower()}"):
+                    if "-" in times:
+                        start, end = times.split("-")
+                        item["opening_hours"].add_range(day, start, end)
+
+            apply_yes_no(Extras.ATM, item, location["atm"] == "1")
+
+            item["website"] = f'https://www.biedronka.pl/pl/shop,id,{location["id"]}'
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Biedronka': 3419,
 'atp/brand_wikidata/Q857182': 3419,
 'atp/category/shop/supermarket': 3419,
 'atp/field/country/from_spider_name': 3419,
 'atp/field/email/missing': 3419,
 'atp/field/image/missing': 3419,
 'atp/field/lat/missing': 494,
 'atp/field/lon/missing': 494,
 'atp/field/opening_hours/missing': 61,
 'atp/field/phone/missing': 3419,
 'atp/field/state/missing': 3419,
 'atp/field/street_address/missing': 3419,
 'atp/field/twitter/missing': 3419,
 'atp/nsi/perfect_match': 3419,
 'downloader/request_bytes': 654132,
 'downloader/request_count': 1358,
 'downloader/request_method_count/GET': 1358,
 'downloader/response_bytes': 7480817,
 'downloader/response_count': 1358,
 'downloader/response_status_count/200': 1358,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 5.957987,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 6, 11, 11, 4, 16, 389554),
 'httpcache/hit': 1358,
 'item_scraped_count': 3419,
 'log_count/DEBUG': 4790,
 'log_count/INFO': 9,
 'memusage/max': 137408512,
 'memusage/startup': 137408512,
 'request_depth_max': 1,
 'response_received_count': 1358,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1357,
 'scheduler/dequeued/memory': 1357,
 'scheduler/enqueued': 1357,
 'scheduler/enqueued/memory': 1357,
 'start_time': datetime.datetime(2023, 6, 11, 11, 4, 10, 431567)}
```

cc @matkoniecz