### PR TITLE
red_rooster_au: fix spider

### DIFF
--- a/locations/spiders/red_rooster_au.py
+++ b/locations/spiders/red_rooster_au.py
@@ -23,7 +23,6 @@ class RedRoosterAUSpider(Spider):
 
     def parse(self, response):
         for location in response.json()["store"]:
-            print(location)
             item = DictParser.parse(location)
             if (
                 location["attributes"]["isStorePermanentclosed"]

--- a/locations/spiders/red_rooster_au.py
+++ b/locations/spiders/red_rooster_au.py
@@ -25,7 +25,11 @@ class RedRoosterAUSpider(Spider):
         for location in response.json()["store"]:
             print(location)
             item = DictParser.parse(location)
-            if location["attributes"]["isStorePermanentclosed"] or not location["attributes"]["isEnabled"] or location["attributes"]["storeName"] == "Red Rooster Lab Test Store":
+            if (
+                location["attributes"]["isStorePermanentclosed"]
+                or not location["attributes"]["isEnabled"]
+                or location["attributes"]["storeName"] == "Red Rooster Lab Test Store"
+            ):
                 continue
 
             item["name"] = location["attributes"]["storeName"]

--- a/locations/spiders/red_rooster_au.py
+++ b/locations/spiders/red_rooster_au.py
@@ -23,14 +23,15 @@ class RedRoosterAUSpider(Spider):
 
     def parse(self, response):
         for location in response.json()["store"]:
+            print(location)
             item = DictParser.parse(location)
-            if location["attributes"]["isStorePermanentclosed"] or not location["attributes"]["isEnabled"]:
+            if location["attributes"]["isStorePermanentclosed"] or not location["attributes"]["isEnabled"] or location["attributes"]["storeName"] == "Red Rooster Lab Test Store":
                 continue
 
-            item["ref"] = location["relationships"]["salesforce"]["data"]["attributes"]["storeNumber"]
             item["name"] = location["attributes"]["storeName"]
             item["phone"] = location["attributes"].get("storePhone")
             item["email"] = location["attributes"].get("storeEmail")
+            item["ref"] = item["email"].split("@", 1)[0][-4:]
 
             if "urlPath" in location["relationships"].keys():
                 item["website"] = (


### PR DESCRIPTION
Salesforce data within store list data no longer exists to obtain a store number from. Fall back to using the last 4 digits of the store e-mail address as the store number.