### PR TITLE
Add Rooms To Go brands (US) (200 stores)

### DIFF
--- a/locations/spiders/rooms_to_go_us.py
+++ b/locations/spiders/rooms_to_go_us.py
@@ -1,0 +1,13 @@
+from locations.storefinders.stockist import StockistSpider
+
+
+class RoomsToGoUSSpider(StockistSpider):
+    name = "rooms_to_go_us"
+    item_attributes = {"brand": "Rooms To Go", "brand_wikidata": "Q7366329"}
+    key = "u11672"
+
+    def parse_item(self, item, location):
+        if "RTG KIDS" in item["name"].upper():
+            item["brand"] = "Rooms to Go Kids"
+            item["brand_wikidata"] = "Q119443278"
+        yield item


### PR DESCRIPTION
 'atp/brand/Rooms To Go': 114,
 'atp/brand/Rooms to Go Kids': 86,