### PR TITLE
Add Lenta (RU) (794 locations)

### DIFF
--- a/locations/spiders/lenta_ru.py
+++ b/locations/spiders/lenta_ru.py
@@ -18,8 +18,8 @@ class LentaRUSpider(scrapy.Spider):
     def parse(self, response):
         for poi in response.json():
             item = DictParser.parse(poi)
-            item['street_address'] = poi.get("address")
-            item['addr_full'] = None
+            item["street_address"] = poi.get("address")
+            item["addr_full"] = None
             self.parse_hours(item, poi)
             # A few stores are marked as pet shops
             if poi.get("type") == "zoo":

--- a/locations/spiders/lenta_ru.py
+++ b/locations/spiders/lenta_ru.py
@@ -18,6 +18,8 @@ class LentaRUSpider(scrapy.Spider):
     def parse(self, response):
         for poi in response.json():
             item = DictParser.parse(poi)
+            item['street_address'] = poi.get("address")
+            item['addr_full'] = None
             self.parse_hours(item, poi)
             # A few stores are marked as pet shops
             if poi.get("type") == "zoo":

--- a/locations/spiders/lenta_ru.py
+++ b/locations/spiders/lenta_ru.py
@@ -1,15 +1,15 @@
 import scrapy
 from scrapy.http import JsonRequest
-from locations.categories import Categories, apply_category
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
 
 class LentaRUSpider(scrapy.Spider):
     name = "lenta_ru"
-    item_attributes = {'brand': 'Лента', 'brand_wikidata': 'Q4258608'}
-    custom_settings = {'ROBOTSTXT_OBEY': False}
+    item_attributes = {"brand": "Лента", "brand_wikidata": "Q4258608"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     allowed_domains = ["lenta.com"]
 
     def start_requests(self):
@@ -20,17 +20,14 @@ class LentaRUSpider(scrapy.Spider):
             item = DictParser.parse(poi)
             self.parse_hours(item, poi)
             # A few stores are marked as pet shops
-            if poi.get('type') == 'zoo':
+            if poi.get("type") == "zoo":
                 apply_category(Categories.SHOP_PET, item)
             yield item
 
     def parse_hours(self, item, poi):
-        if poi.get('is24hStore'):
+        if poi.get("is24hStore"):
             item["opening_hours"] = "24/7"
         else:
             oh = OpeningHours()
-            oh.add_days_range(DAYS, poi.get('opensAt'), poi.get('closesAt'))
+            oh.add_days_range(DAYS, poi.get("opensAt"), poi.get("closesAt"))
             item["opening_hours"] = oh.as_opening_hours()
-
-
-

--- a/locations/spiders/lenta_ru.py
+++ b/locations/spiders/lenta_ru.py
@@ -1,0 +1,36 @@
+import scrapy
+from scrapy.http import JsonRequest
+from locations.categories import Categories, apply_category
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class LentaRUSpider(scrapy.Spider):
+    name = "lenta_ru"
+    item_attributes = {'brand': 'Лента', 'brand_wikidata': 'Q4258608'}
+    custom_settings = {'ROBOTSTXT_OBEY': False}
+    allowed_domains = ["lenta.com"]
+
+    def start_requests(self):
+        yield JsonRequest("https://lenta.com/api/v2/stores")
+
+    def parse(self, response):
+        for poi in response.json():
+            item = DictParser.parse(poi)
+            self.parse_hours(item, poi)
+            # A few stores are marked as pet shops
+            if poi.get('type') == 'zoo':
+                apply_category(Categories.SHOP_PET, item)
+            yield item
+
+    def parse_hours(self, item, poi):
+        if poi.get('is24hStore'):
+            item["opening_hours"] = "24/7"
+        else:
+            oh = OpeningHours()
+            oh.add_days_range(DAYS, poi.get('opensAt'), poi.get('closesAt'))
+            item["opening_hours"] = oh.as_opening_hours()
+
+
+


### PR DESCRIPTION
Stats:
```python
{'atp/brand/Лента': 794,
 'atp/brand_wikidata/Q4258608': 794,
 'atp/category/shop/pet': 14,
 'atp/category/shop/supermarket': 780,
 'atp/field/country/from_spider_name': 794,
 'atp/field/email/missing': 794,
 'atp/field/image/missing': 794,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/missing': 794,
 'atp/field/postcode/missing': 794,
 'atp/field/state/missing': 794,
 'atp/field/street_address/missing': 794,
 'atp/field/twitter/missing': 794,
 'atp/field/website/missing': 794,
 'atp/nsi/perfect_match': 794,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.web._newclient.ResponseNeverReceived': 1,
 'downloader/request_bytes': 634,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 250172,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 31.885464,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 7, 2, 14, 25, 17, 473773),
 'item_scraped_count': 794,
 'log_count/INFO': 9,
 'memusage/max': 115884032,
 'memusage/startup': 115884032,
 'response_received_count': 1,
 'retry/count': 1,
 'retry/reason_count/twisted.web._newclient.ResponseNeverReceived': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 7, 2, 14, 24, 45, 588309)}
```