### PR TITLE
Pin pipenv to 2023.6.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV LANG=en_US.UTF-8 \
 RUN curl https://pyenv.run | bash \
  && pyenv install ${PYTHON_VERSION} \
  && pyenv global ${PYTHON_VERSION} \
- && pip install --upgrade pip pipenv
+ && pip install --upgrade pip pipenv==2023.6.26
 
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock


### PR DESCRIPTION
The Docker image build fails with:

```
Traceback (most recent call last):
  File "/home/ubuntu/.pyenv/versions/3.11.4/bin/pipenv", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/cli/options.py", line 58, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/cli/command.py", line 233, in install
    do_install(
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/routines/install.py", line 66, in do_install
    ensure_project(
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/utils/project.py", line 82, in ensure_project
    os.environ["PIP_PYTHON_PATH"] = project.python
                                    ^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/project.py", line 1163, in python
    return project_python(self)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/utils/shell.py", line 404, in project_python
    python = project._which("python")
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pipenv/project.py", line 1172, in _which
    raise RuntimeError("location not created nor specified")
RuntimeError: location not created nor specified
```

It looks like (from https://github.com/pypa/pipenv/issues/5772) that pinning to an older version of pipenv should resolve this.