### PR TITLE
moneygram: remove incorrect Polish post office locations

### DIFF
--- a/locations/spiders/moneygram.py
+++ b/locations/spiders/moneygram.py
@@ -19,7 +19,9 @@ class MoneyGramSpider(Where2GetItSpider):
         #
         # 1. Ignore Polish post office locations outside of Poland.
         if item["country"] == "PL" and item["name"][:3] == "UP ":
-            if result := reverse_geocoder.get((float(location["latitude"]), float(location["longitude"])), mode=1, verbose=False):
+            if result := reverse_geocoder.get(
+                (float(location["latitude"]), float(location["longitude"])), mode=1, verbose=False
+            ):
                 if result["cc"] != "PL":
                     item.pop("lat")
                     item.pop("lon")

--- a/locations/spiders/moneygram.py
+++ b/locations/spiders/moneygram.py
@@ -1,3 +1,5 @@
+import reverse_geocoder
+
 from locations.hours import OpeningHours
 from locations.storefinders.where2getit import Where2GetItSpider
 
@@ -10,10 +12,23 @@ class MoneyGramSpider(Where2GetItSpider):
     separate_api_call_per_country = True
 
     def parse_item(self, item, location):
+        # MoneyGram compiles location information provided by
+        # franchises that provide MoneyGram services. Some of these
+        # franchises are providing bad location information which
+        # should be ignored.
+        #
+        # 1. Ignore Polish post office locations outside of Poland.
+        if item["country"] == "PL" and item["name"][:3] == "UP ":
+            if result := reverse_geocoder.get((float(location["latitude"]), float(location["longitude"])), mode=1, verbose=False):
+                if result["cc"] != "PL":
+                    item.pop("lat")
+                    item.pop("lon")
+
         hours_string = ""
         for day_name in ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]:
             if location.get(day_name + "_hours"):
                 hours_string = f"{hours_string} {day_name}: " + location.get(day_name + "_hours")
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(hours_string)
+
         yield item


### PR DESCRIPTION
Some Polish post office locations had incorrect data and were being reported by MoneyGram as being located outside of Poland. Ignore these locations as they're incorrect.

Fixes #5510