### PR TITLE
Fix Category for BP Pulse GB

### DIFF
--- a/locations/spiders/bp_pulse_gb.py
+++ b/locations/spiders/bp_pulse_gb.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -26,7 +27,7 @@ class BPPulseGBSpider(Spider):
             item["lat"] = location[0]
             item["lon"] = location[1]
             item["ref"] = ref
-
+            apply_category(Categories.CHARGING_STATION, item)
             yield item
 
         if response.json()["per_page"] * response.meta["page"] < response.json()["total"]:


### PR DESCRIPTION
Hi, this is my first PR here.
I had to "pipenv install exceptiongroup".

Fix to category for BP Pulse GB. 
NSI has 2 categories, namely amenity=charging_station and man_made=charge_point, so explicitly set to resolve.

WAS
{'atp/brand/bp pulse': 3235,
 'atp/brand_wikidata/Q39057719': 3235,
 'atp/category/missing': 3235,
 'atp/field/city/missing': 3235,
 'atp/field/email/missing': 3235,
 'atp/field/image/missing': 3235,
 'atp/field/opening_hours/missing': 3235,
 'atp/field/phone/missing': 3235,
 'atp/field/postcode/missing': 3235,
 'atp/field/state/missing': 3235,
 'atp/field/street_address/missing': 3235,
 'atp/field/twitter/missing': 3235,
 'atp/field/website/missing': 3235,
 'atp/nsi/match_failed': 3235,
...

 NOW:
 {'atp/brand/bp pulse': 3235,
 'atp/brand_wikidata/Q39057719': 3235,
 'atp/category/amenity/charging_station': 3235,
 'atp/field/city/missing': 3235,
 'atp/field/email/missing': 3235,
 'atp/field/image/missing': 3235,
 'atp/field/opening_hours/missing': 3235,
 'atp/field/phone/missing': 3235,
 'atp/field/postcode/missing': 3235,
 'atp/field/state/missing': 3235,
 'atp/field/street_address/missing': 3235,
 'atp/field/twitter/missing': 3235,
 'atp/field/website/missing': 3235,
 'atp/nsi/category_match': 3235,
 'downloader/request_bytes': 1707,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 43498,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 18.644764,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 7, 13, 13, 25, 0, 390801),
 'httpcompression/response_bytes': 179857,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 3235,
 'log_count/DEBUG': 3249,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'memusage/max': 122679296,
 'memusage/startup': 122679296,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 7, 13, 13, 24, 41, 746037)}