### PR TITLE
Fix category for Chargy GB

### DIFF
--- a/locations/spiders/chargy_gb.py
+++ b/locations/spiders/chargy_gb.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -22,5 +23,5 @@ class ChargyGBSpider(Spider):
             item["website"] = "https://char.gy/" + charger["properties"]["slug"]
             item["street_address"] = charger["properties"]["description"]
             item["postcode"] = charger["properties"]["postcode"]
-
+            apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
char.gy has 2 NSI entries, namely amenity=charging_station and man_made=charge_point. Set category to resolve this.
WAS
{'atp/brand/char.gy': 2836,
 'atp/brand_wikidata/Q113465698': 2836,
 'atp/category/missing': 2836,
 'atp/field/city/missing': 2836,
 'atp/field/email/missing': 2836,
 'atp/field/image/missing': 2836,
 'atp/field/opening_hours/missing': 2836,
 'atp/field/phone/missing': 2836,
 'atp/field/state/missing': 2836,
 'atp/field/twitter/missing': 2836,
 'atp/nsi/match_failed': 2836,

...

 NOW:
{'atp/brand/char.gy': 2836,
 'atp/brand_wikidata/Q113465698': 2836,
 'atp/category/amenity/charging_station': 2836,
 'atp/field/city/missing': 2836,
 'atp/field/email/missing': 2836,
 'atp/field/image/missing': 2836,
 'atp/field/opening_hours/missing': 2836,
 'atp/field/phone/missing': 2836,
 'atp/field/state/missing': 2836,
 'atp/field/twitter/missing': 2836,
 'atp/nsi/category_match': 2836,
 'downloader/request_bytes': 631,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 112996,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.799424,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 7, 14, 8, 11, 39, 73935),
 'httpcompression/response_bytes': 888897,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2836,
 'log_count/DEBUG': 2849,
 'log_count/INFO': 8,
 'memusage/max': 122150912,
 'memusage/startup': 122150912,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 7, 14, 8, 11, 34, 274511)}