### PR TITLE
Fix category for ChargePlace Scotland GB

### DIFF
--- a/locations/spiders/charge_place_scotland_gb.py
+++ b/locations/spiders/charge_place_scotland_gb.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -24,4 +25,5 @@ class ChargePlaceScotlandGBSpider(Spider):
             item["image"] = location["properties"]["imageUrl"]
             item["website"] = f'https://chargeplacescotland.org/cpmap/chargepoint/{item["ref"]}/'
             # TODO: connectors available location["properties"]["connectorGroups"]
+            apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
ChargePlace Scotland has 2 NSI entries, namely amenity=charging_station and man_made=charge_point. Explicity set category to resolve this.
WAS
{'atp/brand/ChargePlace Scotland': 2635,
 'atp/brand_wikidata/Q105359316': 2635,
 'atp/category/missing': 2635,
 'atp/field/email/missing': 2635,
 'atp/field/image/missing': 2381,
 'atp/field/opening_hours/missing': 2635,
 'atp/field/phone/missing': 2635,
 'atp/field/state/missing': 2635,
 'atp/field/street_address/missing': 2635,
 'atp/field/twitter/missing': 2635,
 'atp/nsi/match_failed': 2635,

...

 NOW:
{'atp/brand/ChargePlace Scotland': 2635,
 'atp/brand_wikidata/Q105359316': 2635,
 'atp/category/amenity/charging_station': 2635,
 'atp/field/email/missing': 2635,
 'atp/field/image/missing': 2381,
 'atp/field/opening_hours/missing': 2635,
 'atp/field/phone/missing': 2635,
 'atp/field/state/missing': 2635,
 'atp/field/street_address/missing': 2635,
 'atp/field/twitter/missing': 2635,
 'atp/nsi/category_match': 2635,
 'downloader/request_bytes': 427,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 2562265,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.133306,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 7, 14, 10, 47, 52, 396803),
 'item_scraped_count': 2635,
 'log_count/DEBUG': 2647,
 'log_count/INFO': 8,
 'memusage/max': 121675776,
 'memusage/startup': 121675776,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 7, 14, 10, 47, 49, 263497)}