### PR TITLE
Fix category for Beev GB

### DIFF
--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -2,6 +2,7 @@ import pprint
 
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.spiders.vapestore_gb import clean_address
@@ -34,4 +35,5 @@ class BEEVGBSpider(Spider):
             # TODO: count location["ChargePoints"]?
             # apply_yes_no(Extras.FEE, item, not location["Tariff"]["IsFree"], False)
             # item["extras"]["charge"] = location["Tariff"]["Price"]
+            apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
Resolve multiple NSI entries by setting category.
WAS:
{'atp/brand/Be.EV': 1817,
 'atp/brand_wikidata/Q118263083': 1817,
 'atp/category/missing': 1817,
 'atp/field/email/missing': 1817,
 'atp/field/image/missing': 1817,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 5,
 'atp/field/phone/missing': 1817,
 'atp/field/state/missing': 1817,
 'atp/field/twitter/missing': 1817,
 'atp/field/website/missing': 1817,
 'atp/nsi/match_failed': 1817,
...
NOW:

{'atp/brand/Be.EV': 1817,
 'atp/brand_wikidata/Q118263083': 1817,
 'atp/category/amenity/charging_station': 1817,
 'atp/field/email/missing': 1817,
 'atp/field/image/missing': 1817,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 5,
 'atp/field/phone/missing': 1817,
 'atp/field/state/missing': 1817,
 'atp/field/twitter/missing': 1817,
 'atp/field/website/missing': 1817,
 'atp/nsi/category_match': 1815,
 'atp/nsi/match_failed': 2,
 'downloader/request_bytes': 631,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 172759,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.389707,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 7, 14, 11, 26, 48, 312049),
 'httpcompression/response_bytes': 1952889,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1817,
 'log_count/DEBUG': 1830,
 'log_count/INFO': 8,
 'memusage/max': 122294272,
 'memusage/startup': 122294272,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 7, 14, 11, 26, 44, 922342)}