### PR TITLE
action: fix spider

### DIFF
--- a/locations/spiders/action.py
+++ b/locations/spiders/action.py
@@ -33,5 +33,7 @@ class ActionSpider(Spider):
         for day_hours in location["openingHours"]:
             if day_hours["thisWeek"]["closed"]:
                 continue
-            item["opening_hours"].add_range(day_hours["dayName"], day_hours["thisWeek"]["opening"], day_hours["thisWeek"]["closing"])
+            item["opening_hours"].add_range(
+                day_hours["dayName"], day_hours["thisWeek"]["opening"], day_hours["thisWeek"]["closing"]
+            )
         yield item

--- a/locations/spiders/action.py
+++ b/locations/spiders/action.py
@@ -1,64 +1,37 @@
-import json
+from scrapy import Spider
+from scrapy.http import JsonRequest
 
-import scrapy
-
+from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
-from locations.items import Feature
 
 
-class ActionSpider(scrapy.Spider):
+class ActionSpider(Spider):
     name = "action"
     item_attributes = {"brand": "Action", "brand_wikidata": "Q2634111"}
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Accept": "*/*"}}
-    start_urls = [
-        "https://www.action.com/api/graphql/?operationName=GetAllStores&variables=%7B%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2288dea5f796a93dfca07d438ec8abf640c704eb626a10f68034d903d687321cbe%22%7D%2C%22headers%22%3A%7B%22Accept-Language%22%3A%22fr-BE%22%7D%7D"
-    ]
+    start_urls = ["https://www.action.com/api/stores/all/"]
 
-    def parse(self, response, **kwargs):
-        for store in response.json().get("data").get("getAllStores"):
-            query_params = {
-                "operationName": "GetStore",
-                "variables": {"branchNumber": store.get("branchNumber")},
-                "extensions": {
-                    "persistedQuery": {
-                        "version": 1,
-                        "sha256Hash": "1d7097673467141e6bf473c254649e26ff2fc3d941a2d252175bc6066ce76092",
-                    },
-                    "headers": {"Accept-Language": store.get("cultureName")},
-                },
-            }
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url, callback=self.parse_location_list)
 
-            variables_json = json.dumps(query_params["variables"])
-            extensions_json = json.dumps(query_params["extensions"])
+    def parse_location_list(self, response):
+        for location in response.json()["items"]:
+            location_id = location["id"]
+            yield JsonRequest(url=f"https://www.action.com/api/stores/{location_id}/", callback=self.parse_location)
 
-            query_url = f"https://www.action.com/api/graphql/?operationName=GetStore&variables={variables_json}&extensions={extensions_json}"
-
-            yield scrapy.Request(
-                url=query_url, callback=self.parse_store, headers={"Accept-Language": store.get("cultureName")}
-            )
-
-    def parse_store(self, response):
-        store = response.json().get("data").get("getStore")
-        geoloc = store.get("geoLocation")
-        oh = OpeningHours()
-        for opening_hour in store.get("openingTimes"):
-            oh.add_range(DAYS_FULL[opening_hour.get("dayOfWeek") - 1], opening_hour["opening"], opening_hour["closing"])
-
-        yield Feature(
-            {
-                "ref": str(store.get("id")),
-                "name": store.get("name"),
-                "street_address": " ".join(
-                    filter(None, [store.get("houseNumber"), store.get("houseNumberAddition"), store.get("street")])
-                ),
-                "housenumber": store.get("houseNumber"),
-                "street": store.get("street"),
-                "postcode": store.get("postalCode"),
-                "city": store.get("city"),
-                "country": store.get("countryCode"),
-                "website": f"https://www.action.com{store.get('url')}" if store.get("url") else None,
-                "lat": geoloc.get("lat"),
-                "lon": geoloc.get("long"),
-                "opening_hours": oh,
-            }
-        )
+    def parse_location(self, response):
+        location = response.json()["data"]
+        if location["permanentlyClosedDate"]:
+            return
+        item = DictParser.parse(location)
+        item["ref"] = location["branchNumber"]
+        item["name"] = location["store"]
+        item["housenumber"] = "".join(filter(None, [location["houseNumber"], location["houseNumberAddition"]]))
+        item["street"] = location["street"]
+        item["website"] = "https://www.action.com" + location["url"]
+        item["opening_hours"] = OpeningHours()
+        for day_hours in location["openingHours"]:
+            if day_hours["thisWeek"]["closed"]:
+                continue
+            item["opening_hours"].add_range(day_hours["dayName"], day_hours["thisWeek"]["opening"], day_hours["thisWeek"]["closing"])
+        yield item


### PR DESCRIPTION
Whilst a GraphQL API still exists, it has changed and no longer provides in the list of all locations the required IETF language tag (e.g. fr-FR) for each location. Some language variants of the Action website use a much simpler API that returns the same information previously captured, just without the fuss of having to reverse geocode coordinates and map countries to IETF language tags. Language variants of the Action website which use a GraphQL based store locator are broken because whilst they show a marker for a location in every country, details of locations in countries not using the same IETF language tag as the store locator language variant will not load.