### PR TITLE
ci/run_all_spiders.sh: save end time of each build to history.json

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -151,6 +151,8 @@ if [ ! $retval -eq 0 ]; then
     exit 1
 fi
 
+RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
 (>&2 echo "Creating latest.json")
 
 jq -n --compact-output \
@@ -159,10 +161,11 @@ jq -n --compact-output \
     --arg run_stats_url "${RUN_URL_PREFIX}/stats/_results.json" \
     --arg run_insights_url "${RUN_URL_PREFIX}/stats/_insights.json" \
     --arg run_start_time "${RUN_START}" \
+    --arg run_end_time "${RUN_END}" \
     --arg run_output_size "${OUTPUT_FILESIZE}" \
     --arg run_spider_count "${SPIDER_COUNT}" \
     --arg run_line_count "${OUTPUT_LINECOUNT}" \
-    '{"run_id": $run_id, "output_url": $run_output_url, "stats_url": $run_stats_url, "insights_url": $run_insights_url, "start_time": $run_start_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber }' \
+    '{"run_id": $run_id, "output_url": $run_output_url, "stats_url": $run_stats_url, "insights_url": $run_insights_url, "start_time": $run_start_time, "end_time": $run_end_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber }' \
     > latest.json
 
 retval=$?


### PR DESCRIPTION
Currently, the start time of a build is saved in history.json. Also saving the end time of a build allows for statistics to be more easily captured for how long it is taking to complete each complete build. With this data, it may then be possible to see the effect of efforts to optimise spider crawls to reduce overall build times.