### PR TITLE
jefferson_university_hospital: fix spider to remove an error

### DIFF
--- a/locations/spiders/jefferson_university_hospital.py
+++ b/locations/spiders/jefferson_university_hospital.py
@@ -12,7 +12,7 @@ class JeffersonUniversityHospitalSpider(scrapy.Spider):
     }
     allowed_domains = ["jeffersonhealth.org", "jeffersonhealth-prod.searchstax.com"]
     user_agent = BROWSER_DEFAULT
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "REDIRECT_ENABLED": False}
 
     def start_requests(self):
         url = "https://jeffersonhealth-prod.searchstax.com/solr/jh-prod/search-name-location?rows=10&start=0&fq=content_type:health2021/content-type/location"


### PR DESCRIPTION
This spider was returning an error from a page that is missing and redirects back to a location finder page, where the spider is unable to extract required data. Ignoring redirects removes this single error.