### PR TITLE
albertsons: fix errors in spider

### DIFF
--- a/locations/microdata_parser.py
+++ b/locations/microdata_parser.py
@@ -41,7 +41,10 @@ def property_value(element: lxml.html.HtmlElement):
         # the element at the time the attribute is set, or the empty string if
         # there is no such attribute or if parsing it results in an error.
         value = element.attrib.get("src", "")
-        value = urljoin(element.base_url, value)
+        try:
+            value = urljoin(element.base_url, value)
+        except ValueError:
+            value = None
         return value
     # If the element is an a, area, or link element
     elif element.tag in ["a", "area", "link"]:
@@ -50,7 +53,10 @@ def property_value(element: lxml.html.HtmlElement):
         # of the element at the time the attribute is set, or the empty string
         # if there is no such attribute or if parsing it results in an error.
         value = element.attrib.get("href", "")
-        value = urljoin(element.base_url, value)
+        try:
+            value = urljoin(element.base_url, value)
+        except ValueError:
+            value = None
         return value
     # If the element is an object element
     elif element.tag == "object":
@@ -59,7 +65,10 @@ def property_value(element: lxml.html.HtmlElement):
         # of the element at the time the attribute is set, or the empty string
         # if there is no such attribute or if parsing it results in an error.
         value = element.attrib.get("data", "")
-        value = urljoin(element.base_url, value)
+        try:
+            value = urljoin(element.base_url, value)
+        except ValueError:
+            value = None
         return value
     # If the element is a data element
     # If the element is a meter element
@@ -167,8 +176,11 @@ def get_object(item: lxml.html.HtmlElement, memory=None):
     # 5. If the item has a global identifier, add an entry to result called
     # "id" whose value is the global identifier of item.
     if itemid := item.attrib.get("itemid"):
-        value = urljoin(item.base_url, itemid)
-        result["id"] = value
+        try:
+            value = urljoin(item.base_url, itemid)
+            result["id"] = value
+        except ValueError:
+            pass
 
     # 6. Let properties be an empty object.
     properties = {}

--- a/locations/spiders/albertsons.py
+++ b/locations/spiders/albertsons.py
@@ -96,7 +96,7 @@ class AlbertsonsSpider(SitemapSpider, StructuredDataSpider):
         item.update(self.brands[response.url.split("/")[2].split(".")[-2]])
 
         # Remove fields that are not specific to individual stores.
-        item.pop("facebook")
-        item.pop("twitter")
+        item.pop("facebook", None)
+        item.pop("twitter", None)
 
         yield item

--- a/locations/spiders/albertsons.py
+++ b/locations/spiders/albertsons.py
@@ -95,4 +95,8 @@ class AlbertsonsSpider(SitemapSpider, StructuredDataSpider):
 
         item.update(self.brands[response.url.split("/")[2].split(".")[-2]])
 
+        # Remove fields that are not specific to individual stores.
+        item.pop("facebook")
+        item.pop("twitter")
+
         yield item


### PR DESCRIPTION
* microdata_parser was erroring on incorrect URLs in Albertson's store webpages which contain e.g.: a href="https://www.[c_bannerURLName].com/pharmacy/covid-19.html" (example: https://local.pharmacy.acmemarkets.com/pa/west-chester/907-paoli-pike.html)

* Facebook and Twitter fields are not store specific, so ignore them.