### PR TITLE
Add Żabka spider (~9506 stores)

### DIFF
--- a/locations/spiders/zabka_pl.py
+++ b/locations/spiders/zabka_pl.py
@@ -1,0 +1,35 @@
+import scrapy
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class ZabkaPLSpider(scrapy.Spider):
+    name = "zabka_pl"
+    item_attributes = {"brand": "Żabka", "brand_wikidata": "Q2589061"}
+
+    # URL extracted by observing request made by Żappka Android app (using HTTP Toolkit)
+    start_urls = ["https://partner-api.zabkamobile.pl/v2/shops"]
+
+    def start_requests(self):
+        # Authorization header is hard-coded into the Żappka app and does not appear to change (as of version 3.14.10).
+        headers = {
+            "Authorization": "PartnerKey 424A0B7AD0E9EA136510474D89061BBDC007B9BE5256A638EA28CC19D2BB15CD",
+        }
+        yield JsonRequest(url=self.start_urls[0], headers=headers)
+
+    def parse(self, response):
+        for location in response.json():
+            item = DictParser.parse(location)
+            # unset "state" field, it is taken from the "region" field which is some internal Żabka ID
+            item["state"] = None
+            item["opening_hours"] = OpeningHours()
+
+            # Each franchisee is required to be open Mon-Sat with the same hours
+            # But the hours for Sundays are set in the "nonTradingDays" field, which
+            # contains the opening hours for each specific Sunday.
+            item["opening_hours"].add_days_range(
+                ["Mo", "Tu", "We", "Th", "Fr", "Sa"], location["openTime"], location["closeTime"]
+            )
+            yield item


### PR DESCRIPTION
Polish Convenience store brand.

I have extracted the API endpoint and key from the store's app: https://play.google.com/store/apps/details?id=pl.zabka.apb2c&hl=en_US

It is better than the one that can be found on the website, because it returns all the shops in one huge JSON along with all the data for each shop. The website API would need to make a HTTP request for each of the 9000 shops separately. 

I have added opening hours for Monday-Saturday, but due to Polish law Sundays are considered non-working days, but the shops can be open if the owner or the owner's family member is working there. This means that each franchisee sets the opening hours for each specific Sunday, and it ends up in the `"nonTradingDays"` field:

```json
   "nonTradingDays": [
      {
        "date": "2023-07-16",
        "openTime": "09:00",
        "closeTime": "21:00"
      },
      {
        "date": "2023-07-23",
        "openTime": "09:00",
        "closeTime": "21:00"
      },
      {
        "date": "2023-07-30",
        "openTime": "09:00",
        "closeTime": "21:00"
      }
    ]
```

In practice almost all stores will be open each Sunday with the same hours. Unfortunately not all of them have the data filled in (even if the plaque on the door says otherwise), so I did not attempt to parse this field.