### PR TITLE
Add GB car repair spider

### DIFF
--- a/locations/spiders/gov_mot_gb.py
+++ b/locations/spiders/gov_mot_gb.py
@@ -1,0 +1,61 @@
+import json
+
+from scrapy import Request
+from scrapy.spiders import CSVFeedSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.arnold_clark import ArnoldClarkSpider
+from locations.spiders.kwik_fit_gb import KwikFitGBSpider
+from locations.spiders.vapestore_gb import clean_address
+
+
+class GovMOTGBSpider(CSVFeedSpider):
+    name = "gov_mot_gb"
+    dataset_attributes = {
+        "license": "Open Government Licence v3.0",
+        "license:website": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        "license:wikidata": "Q99891702",
+        "attribution": "required",
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0.",
+    }
+
+    def start_requests(self):
+        yield Request(
+            url="https://www.gov.uk/government/publications/active-mot-test-stations", callback=self.get_dataset
+        )
+
+    def get_dataset(self, response, **kwargs):
+        ld = json.loads(
+            response.xpath('//script[@type="application/ld+json"][contains(text(), "Dataset")]/text()').get()
+        )
+        for dist in ld["distribution"]:
+            if dist["encodingFormat"] == "text/csv" and dist["name"] == "Active MOT test stations":
+                yield Request(url=dist["contentUrl"])
+
+    def parse_row(self, response, row):
+        item = Feature()
+        item["ref"] = row["Site ID"]
+        item["name"] = row["Trading Name"]
+        item["street_address"] = clean_address([row["Address1"], row["Address2"], row["Address3"]])
+        item["city"] = row["Town"]
+        item["postcode"] = row["Postcode"]
+        item["phone"] = row["Phone"]
+        # Class 1	Class 2	Class 3	Class 4	Class 5	Class 7
+
+        if item["name"] == "KWIK FIT":
+            item.update(KwikFitGBSpider.item_attributes)
+        elif item["name"] == "HALFORDS AUTOCENTRE":
+            item.update({"brand": "Halfords Autocentre", "brand_wikidata": "Q5641894"})
+        elif item["name"] == "ATS EUROMASTER LIMITED":
+            item.update({"brand": "ATS Euromaster", "brand_wikidata": "Q4654920"})
+        elif item["name"] == "ARNOLD CLARK":
+            item.update(ArnoldClarkSpider.item_attributes)
+        elif item["name"] == "FORMULA ONE AUTOCENTRES LIMITED":
+            item.update({"brand": "Formula One Autocentres", "brand_wikidata": "Q79239635"})
+        elif item["name"] in ["N/A", "VARIOUS"]:
+            item["name"] = None
+
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
+
+        yield item


### PR DESCRIPTION
So a little to unpack here.

MOT is a test on cars every year. Garages that do the test register with the government.

This is a gov dataset, not first party. So I've prefixed it with `gov_`. I've not thought about this much, so there may be a better solution.

I've added `brand:wikidata` for the bigger chains

```
    127 FORMULA ONE AUTOCENTRES LIMITED
    141 ARNOLD CLARK
    189 ATS EUROMASTER LIMITED
    506 HALFORDS AUTOCENTRE
    530 KWIK FIT
```

But it's the smaller/independent ones that are quite interesting, we wouldn't usually see that data and its license is compatible with OSM.