### PR TITLE
more consistency for brand name in insight.json

### DIFF
--- a/locations/commands/insights.py
+++ b/locations/commands/insights.py
@@ -224,6 +224,12 @@ class InsightsCommand(ScrapyCommand):
             wikidata_dict[wikidata_code] = record
             return record
 
+        def get_brand_name(item_tags: dict):
+            # Prefer English brand name for insights application (https://www.alltheplaces.xyz/wikidata.html).
+            if brand_name := item_tags.get("brand:en"):
+                return brand_name
+            return item_tags.get("brand")
+
         # A dict keyed by wikidata code.
         wikidata_dict = {}
 
@@ -251,7 +257,7 @@ class InsightsCommand(ScrapyCommand):
         # Build a lookup table from NSI id's to associated brand name if any.
         nsi_id_to_brand = {}
         for item in nsi.iter_nsi():
-            if brand := item.get("tags", {}).get("brand"):
+            if brand := get_brand_name(item.get("tags", {})):
                 nsi_id_to_brand[item["id"]] = brand
 
         # TODO: Could go through ATP spiders themselves looking for Q-codes. Add an atp_count=-1
@@ -264,14 +270,14 @@ class InsightsCommand(ScrapyCommand):
             brand_wikidata = properties.get("brand:wikidata")
             if not brand_wikidata:
                 continue
-            brand = properties.get("brand")
+            brand = get_brand_name(properties)
             r = lookup_code(brand_wikidata)
 
-            if properties.get("nsi_id"):
+            if nsi_id := properties.get("nsi_id"):
                 # If we have found the brand in NSI then show the NSI brand name in the
                 # output JSON to help highlight where a spider brand name differs from
                 # the NSI brand name.
-                r["nsi_brand"] = nsi_id_to_brand.get(properties.get("nsi_id"))
+                r["nsi_brand"] = nsi_id_to_brand.get(nsi_id)
 
             count = r.get("atp_count")
             if not count:


### PR DESCRIPTION
The insights command produces output for consumption by: https://www.alltheplaces.xyz/wikidata.html. We are not comparing multiple language names at this point so prefer the English brand name if available for consistency. This avoids:

![image](https://github.com/alltheplaces/alltheplaces/assets/1497536/49ef85c8-4127-49cc-ba30-01f188de3be4)
