### PR TITLE
Set category for Nisa Local

### DIFF
--- a/locations/spiders/nisalocal_gb.py
+++ b/locations/spiders/nisalocal_gb.py
@@ -1,6 +1,7 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -11,3 +12,7 @@ class NisaLocalGBSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.nisalocally.co.uk/stores/index.html"]
     rules = [Rule(LinkExtractor(allow=".*/stores/.*"), callback="parse_sd", follow=True)]
     download_delay = 0.5
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+        yield item


### PR DESCRIPTION
There are two NSI entries, namely "Nisa" and "Nisa Local" so the NSI match is failing and we are not picking up the category. They are all convenience stores so category set.
Before:
{'atp/brand/Nisa': 1298,
 'atp/brand_wikidata/Q16999069': 1298,
 'atp/category/missing': 1298,
 'atp/cdn/cloudflare/response_count': 248,
 'atp/cdn/cloudflare/response_status_count/200': 248,
 'atp/field/email/missing': 1298,
 'atp/field/opening_hours/missing': 96,
 'atp/field/phone/missing': 182,
 'atp/field/state/missing': 1298,
 'atp/field/twitter/invalid': 1298,
 'atp/nsi/match_failed': 1298,

After:
{'atp/brand/Nisa': 1298,
 'atp/brand_wikidata/Q16999069': 1298,
 'atp/category/shop/convenience': 1298,
 'atp/cdn/cloudflare/response_count': 248,
 'atp/cdn/cloudflare/response_status_count/200': 248,
 'atp/field/email/missing': 1298,
 'atp/field/opening_hours/missing': 96,
 'atp/field/phone/missing': 182,
 'atp/field/state/missing': 1298,
 'atp/field/twitter/invalid': 1298,
 'atp/nsi/match_failed': 1298,
 'downloader/request_bytes': 1774375,
 'downloader/request_count': 1949,
 'downloader/request_method_count/GET': 1949,
 'downloader/response_bytes': 442638857,
 'downloader/response_count': 1949,
 'downloader/response_status_count/200': 1944,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 4,
 'dupefilter/filtered': 11105,
 'elapsed_time_seconds': 1188.234661,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 8, 3, 9, 13, 46, 384288),
 'httpcompression/response_bytes': 77,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1298,
 'log_count/DEBUG': 3261,
 'log_count/INFO': 27,
 'memusage/max': 278568960,
 'memusage/startup': 121294848,
 'offsite/domains': 2,
 'offsite/filtered': 30,
 'request_depth_max': 5,
 'response_received_count': 1948,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1948,
 'scheduler/dequeued/memory': 1948,
 'scheduler/enqueued': 1948,
 'scheduler/enqueued/memory': 1948,
 'start_time': datetime.datetime(2023, 8, 3, 8, 53, 58, 149627)}