### PR TITLE
Set category for Caffe Nero GB

### DIFF
--- a/locations/spiders/caffe_nero_gb.py
+++ b/locations/spiders/caffe_nero_gb.py
@@ -1,7 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -48,5 +48,5 @@ class CaffeNeroGBSpider(Spider):
             apply_yes_no(Extras.WHEELCHAIR, item, location["properties"]["amenities"].get("disabled_access"), False)
             apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["properties"]["amenities"]["disabled_toilet"], False)
             apply_yes_no(Extras.OUTDOOR_SEATING, item, location["properties"]["amenities"]["outside_seating"], False)
-
+            apply_category(Categories.COFFEE_SHOP, item)
             yield item


### PR DESCRIPTION
There are 2 entries in NSI, namely Caffe Nero and Caffe Nero Express, so the category is not being set.
Set the category to amenity=cafe and cuisine=coffee_shop rather than shop=coffee (a shop selling coffee products)

Before:
{'atp/brand/Caffe Nero': 597,
 'atp/brand/Nero Express': 33,
 'atp/brand_wikidata/Q675808': 630,
 'atp/category/missing': 630,
 'atp/field/city/missing': 630,
 'atp/field/country/from_spider_name': 630,
 'atp/field/email/missing': 630,
 'atp/field/image/missing': 630,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 630,
 'atp/field/street_address/missing': 630,
 'atp/field/twitter/missing': 630,
 'atp/field/website/missing': 630,
 'atp/nsi/match_failed': 630,
 
After:
{'atp/brand/Caffe Nero': 597,
 'atp/brand/Nero Express': 33,
 'atp/brand_wikidata/Q675808': 630,
 'atp/category/amenity/cafe': 630,
 'atp/field/city/missing': 630,
 'atp/field/country/from_spider_name': 630,
 'atp/field/email/missing': 630,
 'atp/field/image/missing': 630,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 630,
 'atp/field/street_address/missing': 630,
 'atp/field/twitter/missing': 630,
 'atp/field/website/missing': 630,
 'atp/nsi/match_failed': 630,
 'downloader/request_bytes': 720,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 583832,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.431504,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 8, 3, 12, 28, 22, 341445),
 'item_scraped_count': 630,
 'log_count/DEBUG': 643,
 'log_count/INFO': 8,
 'memusage/max': 122003456,
 'memusage/startup': 122003456,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 8, 3, 12, 28, 19, 909941)}