### PR TITLE
Fix FedEx.

### DIFF
--- a/locations/commands/sd.py
+++ b/locations/commands/sd.py
@@ -95,4 +95,4 @@ class SdCommand(BaseRunSpiderCommand):
         if stats_dict.get("item_scraped_count", 0) == 0:
             print("failed to decode structured data")
         if opts.stats:
-            print(pprint.pformat(stats_dict))
+            pprint.pprint(stats_dict)

--- a/locations/commands/sd.py
+++ b/locations/commands/sd.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib
+import pprint
 
 from scrapy.commands import BaseRunSpiderCommand
 from scrapy.exceptions import UsageError
@@ -37,7 +38,7 @@ class MySpider(StructuredDataSpider):
 # See what ATP libraries can do with a given web site / web page.
 class SdCommand(BaseRunSpiderCommand):
     requires_project = True
-    default_settings = {"LOG_ENABLED": False}
+    default_settings = {"LOG_LEVEL": "WARNING"}
 
     def syntax(self):
         return "[options] <file or URL to decode>"
@@ -94,5 +95,4 @@ class SdCommand(BaseRunSpiderCommand):
         if stats_dict.get("item_scraped_count", 0) == 0:
             print("failed to decode structured data")
         if opts.stats:
-            for k, v in stats_dict.items():
-                print(k + ": " + str(v))
+            print(pprint.pformat(stats_dict))

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -66,6 +66,8 @@ class LinkedDataParser:
                 item["lon"] = LinkedDataParser.clean_float(LinkedDataParser.get_clean(geo, "longitude"))
 
         item["name"] = LinkedDataParser.get_clean(ld, "name")
+        if isinstance(item["name"], list):
+            item["name"] = item["name"][0]
 
         if addr := LinkedDataParser.get_clean(ld, "address"):
             if isinstance(addr, list):

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -9,9 +9,9 @@ from locations.items import get_lat_lon, set_lat_lon
 
 def check_field(item, spider: Spider, param, allowed_types, match_regex=None):
     if val := item.get(param):
-        if not isinstance(val, *allowed_types):
+        if not isinstance(val, allowed_types):
             spider.crawler.stats.inc_value(f"atp/field/{param}/wrong_type")
-            spider.logger.error(f"Invalid type {type(val).__name__} on {param}")
+            spider.logger.error(f"Invalid type {type(val).__name__} on {param}, expected {allowed_types}")
         elif match_regex and not match_regex.match(val):
             spider.crawler.stats.inc_value(f"atp/field/{param}/invalid")
     else:

--- a/locations/pipelines/closed.py
+++ b/locations/pipelines/closed.py
@@ -9,7 +9,7 @@ class ClosePipeline:
     def process_item(self, item: Feature, spider: Spider):
         if name := item.get("name"):
             for label in self.closed_labels:
-                if label in name.lower():
+                if label in str(name).lower():
                     spider.crawler.stats.inc_value("atp/closed_check")
                     spider.logger.warn(f'Found {label} in {name} ({item.get("ref")})')
                     break

--- a/locations/spiders/fedex.py
+++ b/locations/spiders/fedex.py
@@ -23,3 +23,4 @@ class FedExSpider(SitemapSpider, StructuredDataSpider):
         item["city"] = response.xpath('//span[@class="Address-field Address-city"]/text()').extract_first()
 
         yield item
+

--- a/locations/spiders/fedex.py
+++ b/locations/spiders/fedex.py
@@ -23,4 +23,3 @@ class FedExSpider(SitemapSpider, StructuredDataSpider):
         item["city"] = response.xpath('//span[@class="Address-field Address-city"]/text()').extract_first()
 
         yield item
-


### PR DESCRIPTION
Test me with `scrapy sd https://local.fedex.com/pl-pl/zyrardow/wawek`.

The microdata contains nested itemprop=name, which gets translated as an array of names. Teach LinkedDataParser to use the first name when a list is found.

When an item contains an array of names, an exception is thrown. Teach ClosePipeline to guard against this so that it does not cause items to be lost.

The `scrapy sd` command prints out the found item, then a message saying "failed to decode structured data", which does not explain anything. Change its log level from disabled to warning so that exceptions are not swallowed but it otherwise remains terse.

Sort the stats output from `scrapy sd`.

Fix isinstance() call in CheckItemProperties.