### PR TITLE
goodyear_eu: fix errors and rename

### DIFF
--- a/locations/spiders/goodyear.py
+++ b/locations/spiders/goodyear.py
@@ -5,17 +5,13 @@ from scrapy.spiders import SitemapSpider
 from locations.items import Feature
 
 
-class GoodyearEUSpider(SitemapSpider):
-    name = "goodyear_eu"
+class GoodyearSpider(SitemapSpider):
+    name = "goodyear"
     item_attributes = {"brand": "Goodyear", "brand_wikidata": "Q620875"}
     allowed_domains = ["www.goodyear.eu"]
     sitemap_urls = ["https://www.goodyear.eu/robots.txt"]
-    sitemap_rules = [(r"", "parse_store")]
-
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            if "dealers" in entry["loc"]:
-                yield entry
+    sitemap_follow = [r"/(?!ru_ru)[a-z]{2}_[a-z]{2}/consumer.dealers-sitemap.xml"]
+    sitemap_rules = [(r"\/dealers\/\d+\/", "parse_store")]
 
     def parse_store(self, response):
         item = Feature()


### PR DESCRIPTION
* Ignore sitemap for Russia as Goodyear have exited Russia and all pages result in 404 errors in the Russia sitemap.

* Ignore nested sitemaps that don't have location pages.

* Ignore "find a dealer" pages that aren't location pages.

* Remove _eu suffix as this spider also picks up non-EU countries such as South Africa. It's really a global spider, less the US.