### PR TITLE
linked_data_parser: fix enhanced field extraction

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -141,7 +141,6 @@ class LinkedDataParser:
             types = [types]
         types = [LinkedDataParser.clean_type(t) for t in types]
         for t in types:
-            print(t)
             LinkedDataParser.parse_enhanced(t, ld, item)
 
         return item

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -136,7 +136,12 @@ class LinkedDataParser:
         if item["ref"] == "":
             item["ref"] = None
 
-        if t := LinkedDataParser.clean_type(ld.get("@type", "")):
+        types = ld.get("@type", [])
+        if not isinstance(types, list):
+            types = [types]
+        types = [LinkedDataParser.clean_type(t) for t in types]
+        for t in types:
+            print(t)
             LinkedDataParser.parse_enhanced(t, ld, item)
 
         return item


### PR DESCRIPTION
Commit 530406b4d3d1a29198799e285969bd066da22e9a introduced the concept of "enhanced field extraction" from linked data. For example, a "hotel" type may have a star rating field that can be extracted, but this field is not applicable to some other types.

It is possible for some locations to have multiple types (e.g. banfield_pet_hospital). Commit 530406b4d3d1a29198799e285969bd066da22e9a was not able to handle multiple types, causing spiders such as banfield_pet_hospital to break.

With this fix, the "enhanced field extraction" is now applied for each and every type for linked data, e.g. "localbusiness" and "hotel" would trigger the enhanced field extraction twice, once for "localbusiness" and once for "hotel".