### PR TITLE
Delete lat/lon instead of None

### DIFF
--- a/locations/items.py
+++ b/locations/items.py
@@ -58,8 +58,8 @@ def get_lat_lon(item: Feature) -> (float, float):
 
 
 def set_lat_lon(item: Feature, lat: float, lon: float):
-    item["lat"] = None
-    item["lon"] = None
+    del item["lat"]
+    del item["lon"]
     if lat and lon:
         item["geometry"] = {
             "type": "Point",

--- a/locations/items.py
+++ b/locations/items.py
@@ -58,8 +58,8 @@ def get_lat_lon(item: Feature) -> (float, float):
 
 
 def set_lat_lon(item: Feature, lat: float, lon: float):
-    del item["lat"]
-    del item["lon"]
+    item.pop("lat", None)
+    item.pop("lon", None)
     if lat and lon:
         item["geometry"] = {
             "type": "Point",


### PR DESCRIPTION
Makes the logged output less confusing as we have moved these fields elsewhere, not accidentally populated them with nothing.