### PR TITLE
storefinders/woosmap: add origin as a required class attribute

### DIFF
--- a/locations/spiders/accor.py
+++ b/locations/spiders/accor.py
@@ -4,7 +4,7 @@ from locations.storefinders.woosmap import WoosmapSpider
 class AccorSpider(WoosmapSpider):
     name = "accor"
     key = "accor-prod-woos"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://accor.com/"}}
+    origin = "https://accor.com"
 
     brand_mapping = {
         "SUI": {"brand": "Novotel", "brand_wikidata": "Q420545"},
@@ -49,6 +49,8 @@ class AccorSpider(WoosmapSpider):
     # "ART", "TRI", "MTS", "21C", "SLS", "TOR", "FAE", "DHA", "HYD"
 
     def parse_item(self, item, feature, **kwargs):
+        if "COMING SOON" in item["name"].upper():
+            return
         if match := self.brand_mapping.get(feature["properties"]["types"][0]):
             item.update(match)
         item["website"] = f"https://all.accor.com/hotel/{item['ref']}/index.en.shtml"

--- a/locations/spiders/carrefour_fr.py
+++ b/locations/spiders/carrefour_fr.py
@@ -7,7 +7,7 @@ class CarrefourFRSpider(WoosmapSpider):
     item_attributes = {"brand": "Carrefour", "brand_wikidata": "Q217599"}
 
     key = "woos-26fe76aa-ff24-3255-b25b-e1bde7b7a683"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.carrefour.fr"}}
+    origin = "https://www.carrefour.fr"
 
     brands = {
         "CARREFOUR CITY": {"brand": "Carrefour City", "brand_wikidata": "Q2940187"},

--- a/locations/spiders/cora_fr.py
+++ b/locations/spiders/cora_fr.py
@@ -5,7 +5,7 @@ class CoraFRSpider(WoosmapSpider):
     name = "cora_fr"
     item_attributes = {"brand": "Cora", "brand_wikidata": "Q686643"}
     key = "woos-789d2f65-5cee-39a3-9e38-a31bd63a6b57"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.cora.fr/"}}
+    origin = "https://www.cora.fr"
 
     def parse_item(self, item, feature, **kwargs):
         # Filter only on CORA shop and not affiliated shop

--- a/locations/spiders/e_leclerc.py
+++ b/locations/spiders/e_leclerc.py
@@ -4,9 +4,9 @@ from locations.storefinders.woosmap import WoosmapSpider
 
 class ELeclercSpider(WoosmapSpider):
     name = "e_leclerc"
-    item_attributes = {"brand": "E.Leclerc", "brand_wikidata": "Q1273376", "nsi_id": -1}
+    item_attributes = {"brand": "E.Leclerc", "brand_wikidata": "Q1273376"}
     key = "woos-6256d36f-af9b-3b64-a84f-22b2342121ba"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.e.leclerc"}}
+    origin = "https://www.e.leclerc"
 
     brands = {
         "Jardi": ({"brand": "E.Leclerc Jardi"}, Categories.SHOP_GARDEN_CENTRE),

--- a/locations/spiders/leroy_merlin.py
+++ b/locations/spiders/leroy_merlin.py
@@ -5,4 +5,4 @@ class LeroyMerlin(WoosmapSpider):
     name = "leroy_merlin"
     item_attributes = {"brand": "Leroy Merlin", "brand_wikidata": "Q889624"}
     key = "woos-47262215-fc76-3bd2-8e0d-d8fda2544349&_=1670855900"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.leroymerlin.fr/"}}
+    origin = "https://www.leroymerlin.fr"

--- a/locations/spiders/mcdonalds_fr.py
+++ b/locations/spiders/mcdonalds_fr.py
@@ -7,7 +7,7 @@ class McDonaldsFRSpider(WoosmapSpider):
     name = "mcdonalds_fr"
     item_attributes = McDonaldsSpider.item_attributes
     key = "woos-77bec2e5-8f40-35ba-b483-67df0d5401be"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.mcdonalds.fr"}}
+    origin = "https://www.mcdonalds.fr"
 
     def parse_item(self, item, feature, **kwargs):
         item[

--- a/locations/spiders/rsg_group.py
+++ b/locations/spiders/rsg_group.py
@@ -5,8 +5,7 @@ from locations.storefinders.woosmap import WoosmapSpider
 class RSGGroupSpider(WoosmapSpider):
     name = "rsg_group"
     key = "woos-3cb8caa3-ad4d-3e7b-b7d6-221a7b72398d&stores_by_page=300"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://www.mcfit.com"}}
-    item_attributes = {"extras": Categories.GYM.value}
+    origin = "https://www.mcfit.com"
 
     JOHN_REED = {"brand": "JOHN REED Fitness", "brand_wikidata": "Q106434148"}
     MC_FIT = {"brand": "McFit", "brand_wikidata": "Q871302"}
@@ -25,6 +24,8 @@ class RSGGroupSpider(WoosmapSpider):
             return
         if item["ref"] == "5814289014024709637":
             return  # Head Office
+        if "COMING SOON" in item["name"].upper():
+            return
 
         brand_id = feature["properties"]["types"][0]
         if brand_id in ["GG", "franchise"]:

--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -5,7 +5,7 @@ from locations.storefinders.woosmap import WoosmapSpider
 class TotalEnergiesSpider(WoosmapSpider):
     name = "totalenergies"
     key = "mapstore-prod-woos"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://totalenergies.com"}}
+    origin = "https://totalenergies.com"
 
     BRANDS = {
         "tot": {"brand": "Total", "brand_wikidata": "Q154037"},

--- a/locations/spiders/united_colors_of_benetton.py
+++ b/locations/spiders/united_colors_of_benetton.py
@@ -5,7 +5,7 @@ class UnitedColorsOfBenettonSpider(WoosmapSpider):
     name = "united_colors_of_benetton"
     item_attributes = {"brand": "United Colors of Benetton", "brand_wikidata": "Q817139"}
     key = "woos-77ab54a0-3d40-3188-8f64-58f02485a654"
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Origin": "https://world.benetton.com/"}}
+    origin = "https://world.benetton.com"
 
     def parse_item(self, item, feature, **kwargs):
         item.pop("website")

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -7,15 +7,18 @@ from locations.hours import DAYS, OpeningHours
 # Documentation available at https://developers.woosmap.com/products/search-api/get-started/
 #
 # To use this spider, supply the API 'key' which typically starts
-# with 'woos-' followed by a UUID.
+# with 'woos-' followed by a UUID. Also supply a value for 'origin'
+# which is the HTTP 'Origin' header value, typically similar to
+# 'https://www.brandname.example'.
 
 
 class WoosmapSpider(Spider):
     dataset_attributes = {"source": "api", "api": "woosmap.com"}
     key = ""
+    origin = ""
 
     def start_requests(self):
-        yield JsonRequest(url=f"https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page=1")
+        yield JsonRequest(url=f"https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page=1", headers={"Origin": self.origin})
 
     def parse(self, response, **kwargs):
         if features := response.json()["features"]:
@@ -25,17 +28,19 @@ class WoosmapSpider(Spider):
                 item["street_address"] = ", ".join(filter(None, feature["properties"]["address"]["lines"]))
                 item["geometry"] = feature["geometry"]
 
-                oh = OpeningHours()
+                item["opening_hours"] = OpeningHours()
                 for day, rules in feature["properties"].get("opening_hours", {}).get("usual", {}).items():
                     for hours in rules:
                         if hours.get("all-day"):
                             start = "00:00"
-                            end = "23:59"
+                            end = "24:00"
                         else:
                             start = hours["start"]
                             end = hours["end"]
-                        oh.add_range(DAYS[int(day) - 1], start, end)
-                item["opening_hours"] = oh.as_opening_hours()
+                        if day == "default":
+                            item["opening_hours"].add_days_range(DAYS, start, end)
+                        else:
+                            item["opening_hours"].add_range(DAYS[int(day) - 1], start, end)
 
                 yield from self.parse_item(item, feature) or []
 

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -18,7 +18,10 @@ class WoosmapSpider(Spider):
     origin = ""
 
     def start_requests(self):
-        yield JsonRequest(url=f"https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page=1", headers={"Origin": self.origin})
+        yield JsonRequest(
+            url=f"https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page=1",
+            headers={"Origin": self.origin},
+        )
 
     def parse(self, response, **kwargs):
         if features := response.json()["features"]:


### PR DESCRIPTION
Woosmap always requires an "Origin" HTTP header to be provided. Update the store finder to require an "origin" attribute be supplied, that is then sent to the Woosmap API along with the API key for the brand.

Woosmap additionally appears to allow opening hours to be specified as "default" e.g. hours applying across all days of the week. Allow this "default" hours specification method to be used.