### PR TITLE
sainsburys: fix spider

### DIFF
--- a/locations/spiders/sainsburys.py
+++ b/locations/spiders/sainsburys.py
@@ -26,7 +26,8 @@ class SainsburysSpider(scrapy.Spider):
 
             store["street_address"] = ", ".join(filter(None, [store["address1"], store["address2"]]))
 
-            store["name"] = store["other_name"]
+            if store.get("other_name"):
+                store["name"] = store["other_name"]
 
             item = DictParser.parse(store)
 


### PR DESCRIPTION
At least one location did not have the "other_name" field populated, meaning that the name of the store was being extracted as a None value, causing a fatal error due to invalid handling of the None value. The number of stores returned by this spider has therefore been incorrect, as results have been truncated.

This change will only use the "other_name" field if it contains a value, otherwise, the abbreviated "name" field will be used.