### PR TITLE
Add Lukoil Spdier (4778 locations).

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -244,6 +244,7 @@ class Fuel(Enum):
     AVAUTO_GAS = "fuel:autogas"
     AVJetA1 = "fuel:JetA1"
 
+    HEATING_OIL = "fuel:heating_oil"
     KEROSENE = "fuel:kerosene"
 
 
@@ -283,6 +284,7 @@ class PaymentMethods(Enum):
     APPLE_PAY = "payment:apple_pay"
     BCA_CARD = "payment:bca_card"
     BLIK = "payment:blik"
+    CARDS = "payment:cards"
     CASH = "payment:cash"
     CHEQUE = "payment:cheque"
     COINS = "payment:coins"
@@ -314,6 +316,7 @@ class PaymentMethods(Enum):
     RAKUTEN_PAY = "payment:rakuten_pay"
     SAMSUNG_PAY = "payment:samsung_pay"
     SATISPAY = "payment:satispay"
+    SBP = 'payment:sbp' # https://www.cbr.ru/eng/psystem/sfp/
     TWINT = "payment:twint"
     UNIONPAY = "payment:unionpay"
     VISA = "payment:visa"
@@ -325,17 +328,24 @@ class PaymentMethods(Enum):
 
 
 class FuelCards(Enum):
+    # TODO: clean tags here
     ALLSTAR = "Allstar Card"
     AVIA = "Avia Card"
+    ARIS = 'payment:aris'
     BP = "BP card"
     DEUTSCHLAND = "fuel:discount:deutschland_card"
     DKV = "fuel:discount:dkv"
+    E100 = "payment:e100" # https://e100.eu/en
     ESSO_NATIONAL = "fuel:discount:esso_national"
     EXXONMOBIL_FLEET = "ExxonMobil Fleet Card"
     LOGPAY = "LogPay Card"
+    LUKOIL = "payment:lukoil" # https://lukoil.ru/Products/business/fuelcards
+    LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
     MOBIL = "Mobilcard"
+    PETROL_PLUS_REGION = "payment:petrol_plus_region" # https://www.petrolplus.ru/
     SHELL = "fuel:discount:shell"
     UTA = "fuel:discount:uta"
+    ROSNEFT = "payment:rosneft" # https://www.rn-card.ru/
 
 
 def apply_yes_no(attribute, item: Feature, state: bool, apply_positive_only: bool = True):

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -316,7 +316,7 @@ class PaymentMethods(Enum):
     RAKUTEN_PAY = "payment:rakuten_pay"
     SAMSUNG_PAY = "payment:samsung_pay"
     SATISPAY = "payment:satispay"
-    SBP = 'payment:sbp' # https://www.cbr.ru/eng/psystem/sfp/
+    SBP = "payment:sbp"  # https://www.cbr.ru/eng/psystem/sfp/
     TWINT = "payment:twint"
     UNIONPAY = "payment:unionpay"
     VISA = "payment:visa"
@@ -331,21 +331,21 @@ class FuelCards(Enum):
     # TODO: clean tags here
     ALLSTAR = "Allstar Card"
     AVIA = "Avia Card"
-    ARIS = 'payment:aris'
+    ARIS = "payment:aris"
     BP = "BP card"
     DEUTSCHLAND = "fuel:discount:deutschland_card"
     DKV = "fuel:discount:dkv"
-    E100 = "payment:e100" # https://e100.eu/en
+    E100 = "payment:e100"  # https://e100.eu/en
     ESSO_NATIONAL = "fuel:discount:esso_national"
     EXXONMOBIL_FLEET = "ExxonMobil Fleet Card"
     LOGPAY = "LogPay Card"
-    LUKOIL = "payment:lukoil" # https://lukoil.ru/Products/business/fuelcards
+    LUKOIL = "payment:lukoil"  # https://lukoil.ru/Products/business/fuelcards
     LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
     MOBIL = "Mobilcard"
-    PETROL_PLUS_REGION = "payment:petrol_plus_region" # https://www.petrolplus.ru/
+    PETROL_PLUS_REGION = "payment:petrol_plus_region"  # https://www.petrolplus.ru/
     SHELL = "fuel:discount:shell"
     UTA = "fuel:discount:uta"
-    ROSNEFT = "payment:rosneft" # https://www.rn-card.ru/
+    ROSNEFT = "payment:rosneft"  # https://www.rn-card.ru/
 
 
 def apply_yes_no(attribute, item: Feature, state: bool, apply_positive_only: bool = True):

--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -132,9 +132,7 @@ class LukoilSpider(scrapy.Spider):
 
     def get_results(self, response):
         for station in response.json()["GasStations"]:
-            yield JsonRequest(
-                f"https://lukoil.bg/api/cartography/GetObjects?ids=gasStation{station['GasStationId']}"
-            )
+            yield JsonRequest(f"https://lukoil.bg/api/cartography/GetObjects?ids=gasStation{station['GasStationId']}")
 
     def parse(self, response):
         if data := response.json()[0]:

--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -113,8 +113,8 @@ SERVICES = {
 PROPERTIES = {
     "Cafe": None,
     # TODO: map high flow diesel pump, this seems an important attribute for petrol station!
-    "High Flow Diesel": None
-    }
+    "High Flow Diesel": None,
+}
 
 
 class LukoilSpider(scrapy.Spider):

--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -1,0 +1,197 @@
+import scrapy
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+from locations.categories import Extras, Fuel, FuelCards, PaymentMethods, apply_yes_no
+from locations.items import Feature
+
+FUEL_TYPES_MAPPING = {
+    Fuel.OCTANE_80: ['80'],
+    Fuel.OCTANE_87: ['rbob-87'],
+    Fuel.OCTANE_89: ['rbob-89'],
+    Fuel.OCTANE_92: ['92-ecto', '92-euro'],
+    Fuel.OCTANE_93: ['93'],
+    Fuel.OCTANE_95: ['95-euro', '95-ecto', '95-ecto-plus', 'euro-luk', 'petrol-95-ethanol'],
+    Fuel.OCTANE_98: ['98-ecto', '98-euro'],
+    Fuel.OCTANE_100: ['100-ecto', '100-euro'],
+    Fuel.DIESEL: ['dt-ecto', 'dt-euro', 'dt', 'diesel-ecto-with-fame', 'marked-diesel'],
+    Fuel.LPG: ['lpg-auto', 'gaz', 'gpl-auto'],
+    Fuel.KEROSENE: ['kerosene'],
+    Fuel.HEATING_OIL: ['heating-oil'],
+}
+
+LUKOIL_BRAND = {'brand': 'Лукойл', 'brand_wikidata': "Q329347"}
+
+COMPANY_BRANDS = {
+    # Companies under LUKOIL brand
+    "Lukoil": LUKOIL_BRAND,
+    "ЛУКОЙЛ": LUKOIL_BRAND,
+    "LICARD": LUKOIL_BRAND,
+    # Companies with other brands
+    "Teboil": {'brand': 'Teboil', 'brand_wikidata': "Q7692079"}
+}
+
+PAYMENT_METHODS = {
+    'ARIS Poland fuel card': FuelCards.ARIS,
+    'ARIS fuel card': FuelCards.ARIS,
+    'American Express': PaymentMethods.AMERICAN_EXPRESS,
+    'Bank cards': PaymentMethods.CARDS,
+    'Cash': PaymentMethods.CASH,
+    'Contactless Payments': PaymentMethods.CONTACTLESS,
+    'DKV fuel card': FuelCards.DKV,
+    'E-100 fuel card': FuelCards.E100,
+    'EuroShell fuel card': FuelCards.SHELL,
+    'Fast payment system': PaymentMethods.SBP,
+    'LUKOIL fuel card': FuelCards.LUKOIL,
+    'LUKOIL FleetCard': FuelCards.LUKOIL,
+    'LUKOIL loyalty card payment': FuelCards.LUKOIL_LOYALTY_PROGRAM,
+    'Maestro': PaymentMethods.MAESTRO,
+    'Non-cash payment methods': PaymentMethods.CARDS,
+    'Petrol +Region fuel card': FuelCards.PETROL_PLUS_REGION,
+    'Rosneft fuel card': FuelCards.ROSNEFT,
+    'UTA fuel card': FuelCards.UTA,
+    'Vpay': PaymentMethods.V_PAY,
+    'Карта AMEX': PaymentMethods.AMERICAN_EXPRESS,
+    # TODO: unable to find/create payment method for the following
+    '"Халва" cards': None,
+    'Bancontact/mister cash': None,
+    'Gift Cards': None,
+    'Inforcom fuel card': None,
+    'Travelcard': None,
+    'Postpay': None
+}
+
+SERVICES = {
+    'ATM ': Extras.ATM,
+    'Car Wash': Extras.CAR_WASH,
+    'Diesel Exhaust Fluid': Fuel.ADBLUE,
+    'Diesel exhaust fluid (AdBlue)': Fuel.ADBLUE,
+    'Hot Dog Sales': 'fast_food=hotdog',
+    "Restroom": Extras.TOILETS,
+    'Wi-Fi': Extras.WIFI,
+    "air tower": Extras.COMPRESSED_AIR,
+    "handicap accessible restroom": Extras.TOILETS_WHEELCHAIR,
+    # Values below are not mapped as they should exist as separate POIs, 
+    # or already mapped in other attributes, or not possible to map at all.
+    'ASE': None,
+    'Auto Repairs': None,
+    'Autodor payment system acceptance': None,
+    'C-Store': None,
+    'Cash advance': None,
+    'Cashback': None,
+    'Coffee': None,
+    'EPOS terminal (electronic point of sales)': None,
+    'Electric charge': None,
+    'Full Service Gas': None,
+    'Hotel / Motel': None,
+    'Insurance': None,
+    'Kids corner': None,
+    'Laundry': None,
+    'Lukoil Loyalty Card acceptance': None,
+    'Lukoil Loyalty Card distribution': None,
+    'Lukoil Loyalty Card rewards acceptance': None,
+    'Lukoil Rapida Credit Card (Sign in)': None,
+    'Lukoil Rapida Credit Card (pay balance)': None,
+    'Mobile phone recharge': None,
+    'None': None,
+    'Oil Change': None,
+    'Paid parking': None,
+    'Parking': None,
+    'Playground': None,
+    'Rapida payment system acceptance': None,
+    'Refill "Platon"': None,
+    'State Inspection': None,
+    'Truck Stop': None,
+    'Vacuum': None,
+    'border crossing payments acceptance': None,
+    'marketing promotions': None,
+    'road tax vignette (sales)': None,
+    'tire shop': None,
+    'toll payments acceptance': None,
+}
+
+PROPERTIES = {
+    "Cafe": None
+}
+
+
+class LukoilSpider(scrapy.Spider):
+    name = "lukoil"
+    download_delay = 0.10
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    handle_httpstatus_list = [403]
+
+    def start_requests(self):
+        yield scrapy.Request(
+            "https://lukoil.bg/api/cartography/GetCountryDependentSearchObjectData?form=gasStation",
+            callback=self.get_results,
+        )
+
+    def get_results(self, response):
+        for station in response.json()["GasStations"]:
+            yield scrapy.Request(
+                "https://lukoil.bg/api/cartography/GetObjects?ids=gasStation{station_id}".format(
+                    station_id=station["GasStationId"]
+                )
+            )
+
+    def parse(self, response):
+        if data := response.json()[0]:
+            poi = data.get("GasStation")
+            item = DictParser.parse(poi)
+            item["ref"] = poi.get("GasStationId")
+            item['image'] = poi.get("StationPhotoUrl")
+            self.parse_brand(item, poi)
+            self.parse_attribute(item, poi, 'PaymentTypes', PAYMENT_METHODS)
+            self.parse_attribute(item, poi, 'Services', SERVICES)
+            self.parse_attribute(item, poi, 'Properties', PROPERTIES)
+            self.parse_hours(item, poi)
+            self.parse_fuel_types(item, data)
+            yield item
+
+    def parse_brand(self, item: Feature, poi: dict):
+        if company_name := poi.get("Company", {}).get("Name", ''):
+            for brand, brand_tags in COMPANY_BRANDS.items():
+                if brand.lower() in company_name.lower():
+                    item["brand"] = brand_tags['brand']
+                    item["brand_wikidata"] = brand_tags['brand_wikidata']
+                    break
+            else:
+                self.logger.warning(f"Unknown brand: {company_name}")
+                self.crawler.stats.inc_value(f"atp/lukoil/brand/failed/{company_name}")
+
+    def parse_attribute(self, item: Feature, poi: dict, attribute_name: str, mapping: dict):
+        for attribute_entity in poi.get(attribute_name, []):
+            if tag := mapping.get(attribute_entity.get('Name')):
+                apply_yes_no(tag, item, True)
+            else:
+                self.crawler.stats.inc_value(f"atp/lukoil/{attribute_name}/failed/{attribute_entity.get('Name')}")
+
+    def parse_hours(self, item: Feature, poi: dict):
+        if poi.get("TwentyFourHour"):
+            item["opening_hours"] = "24/7"
+            return
+        try:
+            oh = OpeningHours()
+            if poi.get("StationBusinessHours") is not None:
+                for index, time in enumerate(poi.get("StationBusinessHours", {}).get("Days")):
+                    if time is not None:
+                        if time["EndTime"] == "1.00:00:00":
+                            time["EndTime"] = "23:59:00"
+                        oh.add_range(DAYS[index], time["StartTime"], time["EndTime"], time_format="%H:%M:%S")
+                item["opening_hours"] = oh
+        except:
+            self.crawler.stats.inc_value("atp/lukoil/hours/failed")
+
+    def parse_fuel_types(self, item: Feature, data: dict):
+        if fuels := data.get('Fuels'):
+            for fuel_type in fuels:
+                # Use fuel icon to determine fuel type as fuel name is not always available
+                if fuel_icon := fuel_type.get("IconFileNameBase", ''):
+                    for fuel, types in FUEL_TYPES_MAPPING.items():
+                        if fuel_icon.replace('.png', '') in types:
+                            apply_yes_no(fuel, item, True)
+                            break
+                    else:
+                        self.logger.warning(f"Unknown fuel type: {fuel_type}")
+                        self.crawler.stats.inc_value(f"atp/lukoil/fuel/failed/{fuel_icon}")
+

--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -1,25 +1,26 @@
 import scrapy
+
+from locations.categories import Extras, Fuel, FuelCards, PaymentMethods, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
-from locations.categories import Extras, Fuel, FuelCards, PaymentMethods, apply_yes_no
 from locations.items import Feature
 
 FUEL_TYPES_MAPPING = {
-    Fuel.OCTANE_80: ['80'],
-    Fuel.OCTANE_87: ['rbob-87'],
-    Fuel.OCTANE_89: ['rbob-89'],
-    Fuel.OCTANE_92: ['92-ecto', '92-euro'],
-    Fuel.OCTANE_93: ['93'],
-    Fuel.OCTANE_95: ['95-euro', '95-ecto', '95-ecto-plus', 'euro-luk', 'petrol-95-ethanol'],
-    Fuel.OCTANE_98: ['98-ecto', '98-euro'],
-    Fuel.OCTANE_100: ['100-ecto', '100-euro'],
-    Fuel.DIESEL: ['dt-ecto', 'dt-euro', 'dt', 'diesel-ecto-with-fame', 'marked-diesel'],
-    Fuel.LPG: ['lpg-auto', 'gaz', 'gpl-auto'],
-    Fuel.KEROSENE: ['kerosene'],
-    Fuel.HEATING_OIL: ['heating-oil'],
+    Fuel.OCTANE_80: ["80"],
+    Fuel.OCTANE_87: ["rbob-87"],
+    Fuel.OCTANE_89: ["rbob-89"],
+    Fuel.OCTANE_92: ["92-ecto", "92-euro"],
+    Fuel.OCTANE_93: ["93"],
+    Fuel.OCTANE_95: ["95-euro", "95-ecto", "95-ecto-plus", "euro-luk", "petrol-95-ethanol"],
+    Fuel.OCTANE_98: ["98-ecto", "98-euro"],
+    Fuel.OCTANE_100: ["100-ecto", "100-euro"],
+    Fuel.DIESEL: ["dt-ecto", "dt-euro", "dt", "diesel-ecto-with-fame", "marked-diesel"],
+    Fuel.LPG: ["lpg-auto", "gaz", "gpl-auto"],
+    Fuel.KEROSENE: ["kerosene"],
+    Fuel.HEATING_OIL: ["heating-oil"],
 }
 
-LUKOIL_BRAND = {'brand': 'Лукойл', 'brand_wikidata': "Q329347"}
+LUKOIL_BRAND = {"brand": "Лукойл", "brand_wikidata": "Q329347"}
 
 COMPANY_BRANDS = {
     # Companies under LUKOIL brand
@@ -27,91 +28,89 @@ COMPANY_BRANDS = {
     "ЛУКОЙЛ": LUKOIL_BRAND,
     "LICARD": LUKOIL_BRAND,
     # Companies with other brands
-    "Teboil": {'brand': 'Teboil', 'brand_wikidata': "Q7692079"}
+    "Teboil": {"brand": "Teboil", "brand_wikidata": "Q7692079"},
 }
 
 PAYMENT_METHODS = {
-    'ARIS Poland fuel card': FuelCards.ARIS,
-    'ARIS fuel card': FuelCards.ARIS,
-    'American Express': PaymentMethods.AMERICAN_EXPRESS,
-    'Bank cards': PaymentMethods.CARDS,
-    'Cash': PaymentMethods.CASH,
-    'Contactless Payments': PaymentMethods.CONTACTLESS,
-    'DKV fuel card': FuelCards.DKV,
-    'E-100 fuel card': FuelCards.E100,
-    'EuroShell fuel card': FuelCards.SHELL,
-    'Fast payment system': PaymentMethods.SBP,
-    'LUKOIL fuel card': FuelCards.LUKOIL,
-    'LUKOIL FleetCard': FuelCards.LUKOIL,
-    'LUKOIL loyalty card payment': FuelCards.LUKOIL_LOYALTY_PROGRAM,
-    'Maestro': PaymentMethods.MAESTRO,
-    'Non-cash payment methods': PaymentMethods.CARDS,
-    'Petrol +Region fuel card': FuelCards.PETROL_PLUS_REGION,
-    'Rosneft fuel card': FuelCards.ROSNEFT,
-    'UTA fuel card': FuelCards.UTA,
-    'Vpay': PaymentMethods.V_PAY,
-    'Карта AMEX': PaymentMethods.AMERICAN_EXPRESS,
+    "ARIS Poland fuel card": FuelCards.ARIS,
+    "ARIS fuel card": FuelCards.ARIS,
+    "American Express": PaymentMethods.AMERICAN_EXPRESS,
+    "Bank cards": PaymentMethods.CARDS,
+    "Cash": PaymentMethods.CASH,
+    "Contactless Payments": PaymentMethods.CONTACTLESS,
+    "DKV fuel card": FuelCards.DKV,
+    "E-100 fuel card": FuelCards.E100,
+    "EuroShell fuel card": FuelCards.SHELL,
+    "Fast payment system": PaymentMethods.SBP,
+    "LUKOIL fuel card": FuelCards.LUKOIL,
+    "LUKOIL FleetCard": FuelCards.LUKOIL,
+    "LUKOIL loyalty card payment": FuelCards.LUKOIL_LOYALTY_PROGRAM,
+    "Maestro": PaymentMethods.MAESTRO,
+    "Non-cash payment methods": PaymentMethods.CARDS,
+    "Petrol +Region fuel card": FuelCards.PETROL_PLUS_REGION,
+    "Rosneft fuel card": FuelCards.ROSNEFT,
+    "UTA fuel card": FuelCards.UTA,
+    "Vpay": PaymentMethods.V_PAY,
+    "Карта AMEX": PaymentMethods.AMERICAN_EXPRESS,
     # TODO: unable to find/create payment method for the following
     '"Халва" cards': None,
-    'Bancontact/mister cash': None,
-    'Gift Cards': None,
-    'Inforcom fuel card': None,
-    'Travelcard': None,
-    'Postpay': None
+    "Bancontact/mister cash": None,
+    "Gift Cards": None,
+    "Inforcom fuel card": None,
+    "Travelcard": None,
+    "Postpay": None,
 }
 
 SERVICES = {
-    'ATM ': Extras.ATM,
-    'Car Wash': Extras.CAR_WASH,
-    'Diesel Exhaust Fluid': Fuel.ADBLUE,
-    'Diesel exhaust fluid (AdBlue)': Fuel.ADBLUE,
-    'Hot Dog Sales': 'fast_food=hotdog',
+    "ATM ": Extras.ATM,
+    "Car Wash": Extras.CAR_WASH,
+    "Diesel Exhaust Fluid": Fuel.ADBLUE,
+    "Diesel exhaust fluid (AdBlue)": Fuel.ADBLUE,
+    "Hot Dog Sales": "fast_food=hotdog",
     "Restroom": Extras.TOILETS,
-    'Wi-Fi': Extras.WIFI,
+    "Wi-Fi": Extras.WIFI,
     "air tower": Extras.COMPRESSED_AIR,
     "handicap accessible restroom": Extras.TOILETS_WHEELCHAIR,
-    # Values below are not mapped as they should exist as separate POIs, 
+    # Values below are not mapped as they should exist as separate POIs,
     # or already mapped in other attributes, or not possible to map at all.
-    'ASE': None,
-    'Auto Repairs': None,
-    'Autodor payment system acceptance': None,
-    'C-Store': None,
-    'Cash advance': None,
-    'Cashback': None,
-    'Coffee': None,
-    'EPOS terminal (electronic point of sales)': None,
-    'Electric charge': None,
-    'Full Service Gas': None,
-    'Hotel / Motel': None,
-    'Insurance': None,
-    'Kids corner': None,
-    'Laundry': None,
-    'Lukoil Loyalty Card acceptance': None,
-    'Lukoil Loyalty Card distribution': None,
-    'Lukoil Loyalty Card rewards acceptance': None,
-    'Lukoil Rapida Credit Card (Sign in)': None,
-    'Lukoil Rapida Credit Card (pay balance)': None,
-    'Mobile phone recharge': None,
-    'None': None,
-    'Oil Change': None,
-    'Paid parking': None,
-    'Parking': None,
-    'Playground': None,
-    'Rapida payment system acceptance': None,
+    "ASE": None,
+    "Auto Repairs": None,
+    "Autodor payment system acceptance": None,
+    "C-Store": None,
+    "Cash advance": None,
+    "Cashback": None,
+    "Coffee": None,
+    "EPOS terminal (electronic point of sales)": None,
+    "Electric charge": None,
+    "Full Service Gas": None,
+    "Hotel / Motel": None,
+    "Insurance": None,
+    "Kids corner": None,
+    "Laundry": None,
+    "Lukoil Loyalty Card acceptance": None,
+    "Lukoil Loyalty Card distribution": None,
+    "Lukoil Loyalty Card rewards acceptance": None,
+    "Lukoil Rapida Credit Card (Sign in)": None,
+    "Lukoil Rapida Credit Card (pay balance)": None,
+    "Mobile phone recharge": None,
+    "None": None,
+    "Oil Change": None,
+    "Paid parking": None,
+    "Parking": None,
+    "Playground": None,
+    "Rapida payment system acceptance": None,
     'Refill "Platon"': None,
-    'State Inspection': None,
-    'Truck Stop': None,
-    'Vacuum': None,
-    'border crossing payments acceptance': None,
-    'marketing promotions': None,
-    'road tax vignette (sales)': None,
-    'tire shop': None,
-    'toll payments acceptance': None,
+    "State Inspection": None,
+    "Truck Stop": None,
+    "Vacuum": None,
+    "border crossing payments acceptance": None,
+    "marketing promotions": None,
+    "road tax vignette (sales)": None,
+    "tire shop": None,
+    "toll payments acceptance": None,
 }
 
-PROPERTIES = {
-    "Cafe": None
-}
+PROPERTIES = {"Cafe": None}
 
 
 class LukoilSpider(scrapy.Spider):
@@ -139,21 +138,21 @@ class LukoilSpider(scrapy.Spider):
             poi = data.get("GasStation")
             item = DictParser.parse(poi)
             item["ref"] = poi.get("GasStationId")
-            item['image'] = poi.get("StationPhotoUrl")
+            item["image"] = poi.get("StationPhotoUrl")
             self.parse_brand(item, poi)
-            self.parse_attribute(item, poi, 'PaymentTypes', PAYMENT_METHODS)
-            self.parse_attribute(item, poi, 'Services', SERVICES)
-            self.parse_attribute(item, poi, 'Properties', PROPERTIES)
+            self.parse_attribute(item, poi, "PaymentTypes", PAYMENT_METHODS)
+            self.parse_attribute(item, poi, "Services", SERVICES)
+            self.parse_attribute(item, poi, "Properties", PROPERTIES)
             self.parse_hours(item, poi)
             self.parse_fuel_types(item, data)
             yield item
 
     def parse_brand(self, item: Feature, poi: dict):
-        if company_name := poi.get("Company", {}).get("Name", ''):
+        if company_name := poi.get("Company", {}).get("Name", ""):
             for brand, brand_tags in COMPANY_BRANDS.items():
                 if brand.lower() in company_name.lower():
-                    item["brand"] = brand_tags['brand']
-                    item["brand_wikidata"] = brand_tags['brand_wikidata']
+                    item["brand"] = brand_tags["brand"]
+                    item["brand_wikidata"] = brand_tags["brand_wikidata"]
                     break
             else:
                 self.logger.warning(f"Unknown brand: {company_name}")
@@ -161,7 +160,7 @@ class LukoilSpider(scrapy.Spider):
 
     def parse_attribute(self, item: Feature, poi: dict, attribute_name: str, mapping: dict):
         for attribute_entity in poi.get(attribute_name, []):
-            if tag := mapping.get(attribute_entity.get('Name')):
+            if tag := mapping.get(attribute_entity.get("Name")):
                 apply_yes_no(tag, item, True)
             else:
                 self.crawler.stats.inc_value(f"atp/lukoil/{attribute_name}/failed/{attribute_entity.get('Name')}")
@@ -183,15 +182,14 @@ class LukoilSpider(scrapy.Spider):
             self.crawler.stats.inc_value("atp/lukoil/hours/failed")
 
     def parse_fuel_types(self, item: Feature, data: dict):
-        if fuels := data.get('Fuels'):
+        if fuels := data.get("Fuels"):
             for fuel_type in fuels:
                 # Use fuel icon to determine fuel type as fuel name is not always available
-                if fuel_icon := fuel_type.get("IconFileNameBase", ''):
+                if fuel_icon := fuel_type.get("IconFileNameBase", ""):
                     for fuel, types in FUEL_TYPES_MAPPING.items():
-                        if fuel_icon.replace('.png', '') in types:
+                        if fuel_icon.replace(".png", "") in types:
                             apply_yes_no(fuel, item, True)
                             break
                     else:
                         self.logger.warning(f"Unknown fuel type: {fuel_type}")
                         self.crawler.stats.inc_value(f"atp/lukoil/fuel/failed/{fuel_icon}")
-

--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -27,7 +27,7 @@ COMPANY_BRANDS = {
     "Lukoil": LUKOIL_BRAND,
     "ЛУКОЙЛ": LUKOIL_BRAND,
     "LICARD": LUKOIL_BRAND,
-    # Companies with other brands
+    # Companies owned by Lukoil, but having other brand
     "Teboil": {"brand": "Teboil", "brand_wikidata": "Q7692079"},
 }
 
@@ -52,7 +52,7 @@ PAYMENT_METHODS = {
     "UTA fuel card": FuelCards.UTA,
     "Vpay": PaymentMethods.V_PAY,
     "Карта AMEX": PaymentMethods.AMERICAN_EXPRESS,
-    # TODO: unable to find/create payment method for the following
+    # TODO: find payment methods for the following
     '"Халва" cards': None,
     "Bancontact/mister cash": None,
     "Gift Cards": None,
@@ -110,7 +110,11 @@ SERVICES = {
     "toll payments acceptance": None,
 }
 
-PROPERTIES = {"Cafe": None}
+PROPERTIES = {
+    "Cafe": None,
+    # TODO: map high flow diesel pump, this seems an important attribute for petrol station!
+    "High Flow Diesel": None
+    }
 
 
 class LukoilSpider(scrapy.Spider):


### PR DESCRIPTION
- I use `lukoil.bg` domain as regular `lukoil.ru` is blocked for my IP, as a result all addresses in RU became Latin (instead of Cyrilic).
- Not sure if I added new `FuelCards` correctly, I tried to keep them [in line with OSM](https://wiki.openstreetmap.org/wiki/Key:payment:*#Fuel_cards). Please let me know if I'm wrong.

<details>
<summary><b>Stats:</b></summary>

```python
{'atp/brand/Teboil': 408,
 'atp/brand/Лукойл': 4369,
 'atp/brand_wikidata/Q329347': 4369,
 'atp/brand_wikidata/Q7692079': 408,
 'atp/category/amenity/fuel': 4778,
 'atp/field/brand/missing': 1,
 'atp/field/brand_wikidata/missing': 1,
 'atp/field/city/missing': 824,
 'atp/field/country/from_reverse_geocoding': 4771,
 'atp/field/country/missing': 7,
 'atp/field/email/invalid': 112,
 'atp/field/email/missing': 3652,
 'atp/field/image/missing': 4227,
 'atp/field/lat/missing': 7,
 'atp/field/lon/missing': 7,
 'atp/field/opening_hours/missing': 3,
 'atp/field/phone/invalid': 103,
 'atp/field/phone/missing': 3682,
 'atp/field/postcode/missing': 1632,
 'atp/field/state/missing': 54,
 'atp/field/street_address/missing': 4778,
 'atp/field/twitter/missing': 4778,
 'atp/field/website/missing': 4778,
 'atp/lukoil/brand/failed/Неизвестный контрагент': 1,
 'atp/nsi/category_match': 1627,
 'atp/nsi/cc_match': 2735,
 'atp/nsi/match_failed': 7,
 'atp/nsi/perfect_match': 408,
 'downloader/request_bytes': 2399584,
 'downloader/request_count': 4779,
 'downloader/request_method_count/GET': 4779,
 'downloader/response_bytes': 8631551,
 'downloader/response_count': 4779,
 'downloader/response_status_count/200': 4779,
 'elapsed_time_seconds': 602.528619,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 8, 19, 8, 23, 12, 178817),
 'httpcompression/response_bytes': 19330754,
 'httpcompression/response_count': 4779,
 'item_scraped_count': 4778,
 'log_count/INFO': 19,
 'log_count/WARNING': 1,
 'memusage/max': 395706368,
 'memusage/startup': 124293120,
 'request_depth_max': 1,
 'response_received_count': 4779,
 'scheduler/dequeued': 4779,
 'scheduler/dequeued/memory': 4779,
 'scheduler/enqueued': 4779,
 'scheduler/enqueued/memory': 4779,
 'start_time': datetime.datetime(2023, 8, 19, 8, 13, 9, 650198)}
```

</details>