### PR TITLE
storefinders/woosmap: fix pagination search

### DIFF
--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -21,6 +21,7 @@ class WoosmapSpider(Spider):
         yield JsonRequest(
             url=f"https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page=1",
             headers={"Origin": self.origin},
+            meta={"referrer_policy": "no-referrer"},
         )
 
     def parse(self, response, **kwargs):
@@ -50,7 +51,9 @@ class WoosmapSpider(Spider):
         if pagination := response.json()["pagination"]:
             if pagination["page"] < pagination["pageCount"]:
                 yield JsonRequest(
-                    url=f'https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page={pagination["page"]+1}'
+                    url=f'https://api.woosmap.com/stores?key={self.key}&stores_by_page=300&page={pagination["page"]+1}',
+                    headers={"Origin": self.origin},
+                    meta={"referrer_policy": "no-referrer"},
                 )
 
     def parse_item(self, item, feature, **kwargs):


### PR DESCRIPTION
An Origin header needs to be sent on every API request, but a previous change had forgotten to send the Origin header on page 2..n requests.

Also do not send a referrer header for page 1 -> page 2 -> page 3 -> etc.