### PR TITLE
Only finsh writing a file, if we have written an item (and header)

### DIFF
--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -149,4 +149,5 @@ class GeoJsonExporter(JsonItemExporter):
         self.file.write(to_bytes(header.getvalue(), self.encoding))
 
     def finish_exporting(self):
-        self.file.write(b"\n]}\n")
+        if not self.first_item:
+            self.file.write(b"\n]}\n")


### PR DESCRIPTION
The [latest version](https://docs.scrapy.org/en/2.10/news.html#scrapy-2-10-0-2023-08-04) of scrapy, now finishes exporting json exporters, even if they didn't export an item. Which is good for them.

However only write the header when writing the first item, so we are now outputting [broken JSON](https://data.alltheplaces.xyz/runs/2023-08-19-13-31-56/output/84lumber.geojson) on spiders with 0 items.

This restores the old functionality of an empty file on spiders with 0 items.