### PR TITLE
linked_data_parser: don't return None values from LD+JSON objects

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -24,11 +24,11 @@ class LinkedDataParser:
 
             if isinstance(ld_obj, dict):
                 if "@graph" in ld_obj:
-                    yield from ld_obj["@graph"]
+                    yield from filter(None, ld_obj["@graph"])
                 else:
                     yield ld_obj
             elif isinstance(ld_obj, list):
-                yield from ld_obj
+                yield from filter(None, ld_obj)
             else:
                 raise TypeError(ld_obj)
 


### PR DESCRIPTION
Fixes errors such as those found at
https://data.alltheplaces.xyz/runs/2023-08-26-13-32-00/logs/dunkin_us.txt where LinkedDataParser iter_linked_data was yielding None's, and StructuredDataSpider was not expecting this.

This error could occur if source LD+JSON data was a list of different structured data dictionaries, including a null value.