### PR TITLE
Add OMV spider (1627 locations).

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -283,7 +283,6 @@ class Extras(Enum):
     WIFI = "internet_access=wlan"
 
 
-
 class PaymentMethods(Enum):
     ALIPAY = "payment:alipay"
     AMERICAN_EXPRESS = "payment:american_express"
@@ -350,7 +349,7 @@ class FuelCards(Enum):
     LUKOIL = "payment:lukoil"  # https://lukoil.ru/Products/business/fuelcards
     LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
     MOBIL = "Mobilcard"
-    OMV = 'payment:omv'  # https://www.omv.com/en/customers/services/fuel-cards
+    OMV = "payment:omv"  # https://www.omv.com/en/customers/services/fuel-cards
     PETROL_PLUS_REGION = "payment:petrol_plus_region"  # https://www.petrolplus.ru/
     SHELL = "fuel:discount:shell"
     UTA = "fuel:discount:uta"

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -278,8 +278,10 @@ class Extras(Enum):
     TOILETS = "toilets"
     TOILETS_WHEELCHAIR = "toilets:wheelchair"
     TRUCK_WASH = "truck_wash"
+    VACUUM_CLEANER = "vacuum_cleaner"
     WHEELCHAIR = "wheelchair"
     WIFI = "internet_access=wlan"
+
 
 
 class PaymentMethods(Enum):
@@ -348,10 +350,12 @@ class FuelCards(Enum):
     LUKOIL = "payment:lukoil"  # https://lukoil.ru/Products/business/fuelcards
     LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
     MOBIL = "Mobilcard"
+    OMV = 'payment:omv'  # https://www.omv.com/en/customers/services/fuel-cards
     PETROL_PLUS_REGION = "payment:petrol_plus_region"  # https://www.petrolplus.ru/
     SHELL = "fuel:discount:shell"
     UTA = "fuel:discount:uta"
     ROSNEFT = "payment:rosneft"  # https://www.rn-card.ru/
+    ROUTEX = "payment:routex"  # https://routex.com/
 
 
 def apply_yes_no(attribute, item: Feature, state: bool, apply_positive_only: bool = True):

--- a/locations/spiders/omv.py
+++ b/locations/spiders/omv.py
@@ -1,8 +1,8 @@
-import scrapy
-import requests as r
 import re
-from locations.categories import Categories, Fuel, FuelCards, PaymentMethods, apply_category, Extras, apply_yes_no
 
+import scrapy
+
+from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
@@ -69,19 +69,19 @@ PAYMENT_METHODS_MAP = {
     "DKV": FuelCards.DKV,
     "Master Card": PaymentMethods.MASTER_CARD,
     "OMV Card": FuelCards.OMV,
-    'Routex Card': FuelCards.ROUTEX,
+    "Routex Card": FuelCards.ROUTEX,
     "UTA": FuelCards.UTA,
     "VISA Card": PaymentMethods.VISA,
     # TODO: find payment methods for the following
-    'ARBÖ Card': None,
-    'Cadhoc': None,
-    'CadouPass': None,
-    'CheckDejeuner': None,
-    'GustoPass': None,
-    'SmartPass': None,
-    'TicketRestaurant': None,
-    'Westaco': None,
-    'jö Karte': None,
+    "ARBÖ Card": None,
+    "Cadhoc": None,
+    "CadouPass": None,
+    "CheckDejeuner": None,
+    "GustoPass": None,
+    "SmartPass": None,
+    "TicketRestaurant": None,
+    "Westaco": None,
+    "jö Karte": None,
     "Lotto Toto acceptence": None,
 }
 

--- a/locations/spiders/omv.py
+++ b/locations/spiders/omv.py
@@ -1,0 +1,187 @@
+import scrapy
+import requests as r
+import re
+from locations.categories import Categories, Fuel, FuelCards, PaymentMethods, apply_category, Extras, apply_yes_no
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+# List of brands and countries where they operate:
+# https://www.omv.com/en/customers/services/filling-stations
+BRANDS_AND_COUNTRIES = {
+    "OMV": {
+        "countries": ["AUT", "BGR", "HUN", "CZE", "ROU", "SRB", "SVK"],
+        "brand": "OMV",
+        "brand_wikidata": "Q168238",
+    },
+    "PETROM": {"countries": ["ROU", "MDA"], "brand": "Petrom", "brand_wikidata": "Q1755034"},
+    "AVANTI": {"countries": ["AUT"], "brand": "Avanti", "brand_wikidata": "Q168238"},
+    "HOFER": {"countries": ["AUT"], "brand": "Hofer Diskont", "brand_wikidata": "Q107803455"},
+}
+
+SITE_FEATURES_MAP = {
+    "ATM": Extras.ATM,
+    "Car wash hall": Extras.CAR_WASH,
+    "CNG": Fuel.CNG,
+    # TODO: map high flow pump, this seems an important attribute for petrol stations!
+    "High speed pump": None,
+    "Hydrogen": Fuel.LH2,
+    "LPG": Fuel.LPG,
+    "LPG gas cylinder": Fuel.PROPANE,
+    "MaxxMotion 100plus": Fuel.OCTANE_100,
+    "MaxxMotion 95": Fuel.OCTANE_95,
+    "MaxxMotion Diesel": Fuel.DIESEL,
+    "Self-service car wash": Extras.CAR_WASH,
+    "Vacuum cleaner": Extras.VACUUM_CLEANER,
+    "WIFI": Extras.WIFI,
+    # TODO: map the following where possible
+    "Alzabox": None,
+    "Bank service": None,
+    "Car care areas": None,
+    "Coffee corner": None,
+    "Digital Vignette": None,
+    "Electric fast charging": None,
+    "Geis point": None,
+    "HUGO highway toll": None,
+    "Medipoint": None,
+    "My Auchan": None,
+    "Open 24 hours": None,
+    "Pay at the pump": None,
+    "Postal service": None,
+    "Restaurant": None,
+    "SMILE & DRIVE": None,
+    "Sazka terminal": None,
+    "Shop": None,
+    "Spar Express": None,
+    "Super Shop": None,
+    "Tabacco shop": None,
+    "Tankomat open 24 hours": None,
+    "Ticketportal": None,
+    "VIVA shop": None,
+    "Vignette": None,
+    "Waste oil collection": None,
+}
+
+PAYMENT_METHODS_MAP = {
+    "American Express Card": PaymentMethods.AMERICAN_EXPRESS,
+    "ATM Card": PaymentMethods.CARDS,
+    "Diners Club Card": PaymentMethods.DINERS_CLUB,
+    "DKV": FuelCards.DKV,
+    "Master Card": PaymentMethods.MASTER_CARD,
+    "OMV Card": FuelCards.OMV,
+    'Routex Card': FuelCards.ROUTEX,
+    "UTA": FuelCards.UTA,
+    "VISA Card": PaymentMethods.VISA,
+    # TODO: find payment methods for the following
+    'ARBÖ Card': None,
+    'Cadhoc': None,
+    'CadouPass': None,
+    'CheckDejeuner': None,
+    'GustoPass': None,
+    'SmartPass': None,
+    'TicketRestaurant': None,
+    'Westaco': None,
+    'jö Karte': None,
+    "Lotto Toto acceptence": None,
+}
+
+
+class OmvSpider(scrapy.Spider):
+    name = "omv"
+    start_urls = ["https://www.omv.at/de-at/tanken/tankstellensuche"]
+    download_delay = 0.10
+    api_url = "https://app.wigeogis.com/kunden/omv/data/getresults.php"
+    details_url = "https://app.wigeogis.com/kunden/omv/data/details.php"
+
+    def parse(self, response):
+        javascript_code = response.xpath("//script[contains(., 'var IConfHash')]/text()").get()
+        iconf_hash = re.search(r"var IConfHash = '([^']+)'", javascript_code).group(1)
+        iconf_ts = re.search(r"var IConfTs = '([^']+)'", javascript_code).group(1)
+
+        for brand, brand_data in BRANDS_AND_COUNTRIES.items():
+            for country in brand_data["countries"]:
+                yield scrapy.FormRequest(
+                    url=self.api_url,
+                    formdata={
+                        "CTRISO": country,
+                        "BRAND": brand,
+                        "VEHICLE": "CAR",
+                        "MODE": "NEXTDOOR",
+                        "ANZ": "1000",
+                        "HASH": iconf_hash,
+                        "TS": iconf_ts,
+                    },
+                    callback=self.parse_pois,
+                    meta={
+                        "country": country,
+                        "brand": brand_data["brand"],
+                        "brand_wikidata": brand_data["brand_wikidata"],
+                        "HASH": iconf_hash,
+                        "TS": iconf_ts,
+                    },
+                )
+
+    def parse_pois(self, response):
+        for poi in response.json():
+            yield scrapy.FormRequest(
+                url=self.details_url,
+                formdata={
+                    "ID": poi["sid"],
+                    "HASH": response.meta["HASH"],
+                    "TS": response.meta["TS"],
+                },
+                callback=self.parse_poi,
+                meta=response.meta,
+            )
+
+    def parse_poi(self, response):
+        data = response.json()
+        details = data.get("siteDetails", {})
+        item = DictParser.parse(details)
+        item["ref"] = details.get("sid")
+        item["lat"] = details.get("y_coordinates")
+        item["lon"] = details.get("x_coordinates")
+        item["street_address"] = details.get("address_l")
+        item["city"] = details.get("town_l")
+        item["phone"] = details.get("telnr") if details.get("telnr") != "NO TELEPHONE" else None
+        item["brand"] = response.meta["brand"]
+        item["brand_wikidata"] = response.meta["brand_wikidata"]
+        item["country"] = response.meta["country"]
+        self.parse_hours(item, details)
+        self.parse_attribute(item, data, "siteFeatures", SITE_FEATURES_MAP)
+        self.parse_attribute(item, data, "paymentDetails", PAYMENT_METHODS_MAP)
+        apply_category(Categories.FUEL_STATION, item)
+        # TODO: fuel types are provided as images, parse them somehow. OCR?
+        yield item
+
+    def parse_hours(self, item, details):
+        """
+        Example opening hours string:
+            "dayOfWeek=1,closed=FALSE,from=05:00,to=22:00#dayOfWeek=2,closed=FALSE,from=05:00,to=22:00"
+        """
+        oh = OpeningHours()
+        hours = details.get("opening_hours")
+        try:
+            if hours:
+                for day in hours.split("#"):
+                    dayOfWeek, closed, fromTime, toTime = day.split(",")
+                    dayOfWeek = dayOfWeek.split("=")[1]
+                    closed = closed.split("=")[1]
+                    fromTime = fromTime.split("=")[1]
+                    toTime = toTime.split("=")[1]
+                    if closed == "TRUE":
+                        continue
+                    oh.add_range(DAYS[int(dayOfWeek) - 1], fromTime, toTime)
+                item["opening_hours"] = oh.as_opening_hours()
+        except Exception as e:
+            self.logger.error(f"Error parsing hours: {hours}, {e}")
+
+    def parse_attribute(self, item, data: dict, attribute_name: str, mapping: dict):
+        for attribute in data.get(attribute_name, []):
+            title = attribute.get("title")
+            # Some titles have brackets at the end of the string - remove them.
+            title = title.split("(")[0].strip()
+            if tag := mapping.get(title):
+                apply_yes_no(tag, item, True)
+            else:
+                self.crawler.stats.inc_value(f"atp/omv/{attribute_name}/failed/{title}")


### PR DESCRIPTION
<details>
<summary>Run stats</summary>

```python
{'atp/brand/Avanti': 134,
 'atp/brand/Hofer Diskont': 76,
 'atp/brand/OMV': 961,
 'atp/brand/Petrom': 456,
 'atp/brand_wikidata/Q107803455': 76,
 'atp/brand_wikidata/Q168238': 1095,
 'atp/brand_wikidata/Q1755034': 456,
 'atp/category/amenity/fuel': 1627,
 'atp/field/email/missing': 1627,
 'atp/field/image/missing': 1627,
 'atp/field/name/missing': 1627,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 120,
 'atp/field/state/missing': 1627,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 1627,
 'atp/field/website/missing': 1627,
 'atp/nsi/category_match': 663,
 'atp/nsi/cc_match': 432,
 'atp/nsi/perfect_match': 532,
 'atp/omv/paymentDetails/failed/ARBÖ Card': 1,
 'atp/omv/paymentDetails/failed/Cadhoc': 533,
 'atp/omv/paymentDetails/failed/CadouPass': 533,
 'atp/omv/paymentDetails/failed/CheckDejeuner': 533,
 'atp/omv/paymentDetails/failed/GustoPass': 533,
 'atp/omv/paymentDetails/failed/SmartPass': 533,
 'atp/omv/paymentDetails/failed/TicketRestaurant': 533,
 'atp/omv/paymentDetails/failed/Westaco': 313,
 'atp/omv/paymentDetails/failed/jö Karte': 188,
 'atp/omv/siteFeatures/failed/Alzabox': 14,
 'atp/omv/siteFeatures/failed/Bank service': 15,
 'atp/omv/siteFeatures/failed/Car care areas': 129,
 'atp/omv/siteFeatures/failed/Coffee corner': 1,
 'atp/omv/siteFeatures/failed/Digital Vignette': 163,
 'atp/omv/siteFeatures/failed/Electric fast charging': 107,
 'atp/omv/siteFeatures/failed/Electric fast charging - 300 KW': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - AC 43 kw, CCS DC 50 kw': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - Ionity: CCS 350 kw': 7,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300 KW; 4 CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion AC/DC 300KW; 4CCS - 1AC': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 150KW; 4 CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 150KW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 300KW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 22kw, CCS DC 50kw; Ionity: CCS 350kw': 3,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 43 kw, CCS DC 50 kw': 9,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 43kw, CCS DC 50kw; Ionity: CCS 350kw': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics:AC 22 kw,CCS DC 50 kw; Ionity:CCS 350 kw': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics:AC22kw,CCSDC50kw;Tesla:120kw;Ionity:350kw': 1,
 'atp/omv/siteFeatures/failed/Geis point': 14,
 'atp/omv/siteFeatures/failed/HUGO highway toll': 64,
 'atp/omv/siteFeatures/failed/High speed pump': 805,
 'atp/omv/siteFeatures/failed/Lotto Toto acceptence': 180,
 'atp/omv/siteFeatures/failed/Medipoint': 93,
 'atp/omv/siteFeatures/failed/My Auchan': 360,
 'atp/omv/siteFeatures/failed/Open 24 hours': 1131,
 'atp/omv/siteFeatures/failed/Pay at the pump': 196,
 'atp/omv/siteFeatures/failed/Postal service': 158,
 'atp/omv/siteFeatures/failed/Restaurant': 322,
 'atp/omv/siteFeatures/failed/SMILE & DRIVE': 100,
 'atp/omv/siteFeatures/failed/Sazka terminal': 119,
 'atp/omv/siteFeatures/failed/Shop': 1360,
 'atp/omv/siteFeatures/failed/Spar Express': 87,
 'atp/omv/siteFeatures/failed/Super Shop': 200,
 'atp/omv/siteFeatures/failed/Tabacco shop': 3,
 'atp/omv/siteFeatures/failed/Tankomat open 24 hours': 196,
 'atp/omv/siteFeatures/failed/Ticketportal': 342,
 'atp/omv/siteFeatures/failed/VIVA shop': 798,
 'atp/omv/siteFeatures/failed/Vignette': 1129,
 'atp/omv/siteFeatures/failed/Waste oil collection': 50,
 'downloader/request_bytes': 840024,
 'downloader/request_count': 1641,
 'downloader/request_method_count/GET': 3,
 'downloader/request_method_count/POST': 1638,
 'downloader/response_bytes': 4632638,
 'downloader/response_count': 1641,
 'downloader/response_status_count/200': 1641,
 'elapsed_time_seconds': 204.662059,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 8, 27, 18, 44, 12, 48672),
 'httpcompression/response_bytes': 7222443,
 'httpcompression/response_count': 1617,
 'item_scraped_count': 1627,
 'log_count/ERROR': 1,
 'log_count/INFO': 12,
 'memusage/max': 299958272,
 'memusage/startup': 123129856,
 'request_depth_max': 2,
 'response_received_count': 1641,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 1639,
 'scheduler/dequeued/memory': 1639,
 'scheduler/enqueued': 1639,
 'scheduler/enqueued/memory': 1639,
 'start_time': datetime.datetime(2023, 8, 27, 18, 40, 47, 386613)}
```

</details>

As comment in the code says fuel types are images, for example:
 
<img width="845" alt="image" src="https://github.com/alltheplaces/alltheplaces/assets/35237910/d111f4c6-8e40-4dca-ab83-0efadd23502e">


