### PR TITLE
Refresh Sunoco spider.

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -221,6 +221,7 @@ class Fuel(Enum):
     OCTANE_91 = "fuel:octane_91"
     OCTANE_92 = "fuel:octane_92"
     OCTANE_93 = "fuel:octane_93"
+    OCTANE_94 = "fuel:octane_94"
     OCTANE_95 = "fuel:octane_95"
     OCTANE_97 = "fuel:octane_97"
     OCTANE_98 = "fuel:octane_98"

--- a/locations/spiders/sunoco.py
+++ b/locations/spiders/sunoco.py
@@ -1,11 +1,12 @@
 import scrapy
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
 
 from locations.hours import OpeningHours
-from locations.items import Feature
 
 
-class SunocoSpider(scrapy.Spider):
-    name = "sunoco"
+class SunocoUSSpider(scrapy.Spider):
+    name = "sunoco_us"
     item_attributes = {"brand": "Sunoco", "brand_wikidata": "Q1423218"}
     allowed_domains = ["sunoco.com"]
 
@@ -13,8 +14,20 @@ class SunocoSpider(scrapy.Spider):
 
     def parse(self, response):
         for location in response.json():
-            opening_hours = OpeningHours()
+            item = DictParser.parse(location)
+            item['ref'] = location['Store_ID']
+            self.parse_hours(item, location)
+            apply_category(Categories.FUEL_STATION, item)
+            apply_yes_no(Fuel.DIESEL, item, location["HasDiesel"] == "Y")
+            apply_yes_no(Fuel.KEROSENE, item, location["HasKero"] == "Y")
+            apply_yes_no(Fuel.OCTANE_94, item, location["ultra94"] == "Y")
+            apply_yes_no(Extras.ATM, item, location["ATM"] == "Y")
+            apply_yes_no(Extras.CAR_WASH, item, location["CarWash"] == "Y")
+            yield item
 
+    def parse_hours(self, item, location):
+        oh = OpeningHours()
+        try:
             for key, val in location.items():
                 if not key.endswith("_Hours"):
                     continue
@@ -25,26 +38,8 @@ class SunocoSpider(scrapy.Spider):
                     open_time = close_time = "12 AM"
                 else:
                     open_time, close_time = val.split(" to ")
-                opening_hours.add_range(day, open_time, close_time, "%I %p")
-
-            yield Feature(
-                ref=location["Store_ID"],
-                lon=location["Longitude"],
-                lat=location["Latitude"],
-                # name as shown on the Sunoco site
-                name=f"Sunoco #{location['Store_ID']}",
-                addr_full=location["Street_Address"],
-                city=location["City"],
-                state=location["State"],
-                postcode=location["Postalcode"],
-                country="US",
-                phone=location["Phone"],
-                opening_hours=opening_hours.as_opening_hours(),
-                extras={
-                    "amenity:fuel": True,
-                    "atm": location["ATM"] == "Y",
-                    "car_wash": location["CarWash"],
-                    "fuel:diesel": location["HasDiesel"] == "Y",
-                    "fuel:kerosene": location["HasKero"] == "Y",
-                },
-            )
+                oh.add_range(day, open_time, close_time, "%I %p")
+            item["opening_hours"] = oh.as_opening_hours()
+        except Exception:
+            # TODO: we might want to have a common log for failed hours
+            self.crawler.stats.inc_value("atp/hours_parsing/failed")

--- a/locations/spiders/sunoco.py
+++ b/locations/spiders/sunoco.py
@@ -1,7 +1,7 @@
 import scrapy
+
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
-
 from locations.hours import OpeningHours
 
 
@@ -15,7 +15,7 @@ class SunocoUSSpider(scrapy.Spider):
     def parse(self, response):
         for location in response.json():
             item = DictParser.parse(location)
-            item['ref'] = location['Store_ID']
+            item["ref"] = location["Store_ID"]
             self.parse_hours(item, location)
             apply_category(Categories.FUEL_STATION, item)
             apply_yes_no(Fuel.DIESEL, item, location["HasDiesel"] == "Y")


### PR DESCRIPTION
<details>
<summary>Stats:</summary>

```json
{
 "atp/brand/Sunoco": 5814,
 "atp/brand_wikidata/Q1423218": 5814,
 "atp/category/amenity/fuel": 5814,
 "atp/category/multiple": 5814,
 "atp/field/country/from_spider_name": 5814,
 "atp/field/email/missing": 5814,
 "atp/field/image/missing": 5814,
 "atp/field/lat/invalid": 2,
 "atp/field/lat/missing": 25,
 "atp/field/lon/missing": 25,
 "atp/field/name/missing": 5814,
 "atp/field/opening_hours/missing": 1874,
 "atp/field/phone/invalid": 16,
 "atp/field/phone/missing": 601,
 "atp/field/postcode/missing": 5814,
 "atp/field/twitter/missing": 5814,
 "atp/field/website/missing": 5814,
 "atp/nsi/cc_match": 5814,
 "downloader/request_bytes": 617,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 3243346,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 14.763547,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-08-30T22:08:11.389817",
 "item_scraped_count": 5814,
 "log_count/INFO": 9,
 "memusage/max": 124608512,
 "memusage/startup": 124608512,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2023-08-30T22:07:56.626270"
}
```

</details>

`shop=convenience` category was assigned by pipeline, not sure if this expected.