### PR TITLE
Pmtiles support in weekly run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,15 @@ ENV LANG=en_US.UTF-8 \
     PYENV_ROOT="/home/ubuntu/.pyenv" \
     PATH="/home/ubuntu/.pyenv/versions/${PYTHON_VERSION}/bin:/home/ubuntu/.pyenv/bin:/home/ubuntu/.pyenv/shims:$PATH"
 
+# install tippecanoe
+ARG TIPPECANOE_VERSION=2.29.0
+RUN curl -sL https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.tar.gz | tar -xz \
+ && cd tippecanoe-${TIPPECANOE_VERSION} \
+ && make -j \
+ && sudo make install \
+ && cd .. \
+ && rm -rf tippecanoe-${TIPPECANOE_VERSION}
+
 # install pyenv & python
 RUN curl https://pyenv.run | bash \
  && pyenv install ${PYTHON_VERSION} \

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -58,6 +58,22 @@ OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson | wc -l | tr -d ' ')
 scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPIDER_RUN_DIR}/stats/_insights.json"
 (>&2 echo "Done comparing against Name Suggestion Index and OpenStreetMap")
 
+tippecanoe --cluster-distance=25 \
+           --drop-rate=1 \
+           --maximum-zoom=13 \
+           --cluster-maxzoom=g \
+           --layer="alltheplaces" \
+           --attribution="<a href=\"https://www.alltheplaces.xyz/\">All The Places</a> ${RUN_TIMESTAMP}" \
+           -o "${SPIDER_RUN_DIR}/output.pmtiles" \
+           -f "${SPIDER_RUN_DIR}"/output/*.geojson
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't generate pmtiles")
+    exit 1
+fi
+(>&2 echo "Done generating pmtiles")
+
+(>&2 echo "Writing out summary JSON")
 echo "{\"count\": ${SPIDER_COUNT}, \"results\": []}" >> "${SPIDER_RUN_DIR}/stats/_results.json"
 for spider in $(scrapy list)
 do
@@ -158,6 +174,7 @@ RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -n --compact-output \
     --arg run_id "${RUN_TIMESTAMP}" \
     --arg run_output_url "${RUN_URL_PREFIX}/output.zip" \
+    --arg run_pmtiles_url "${RUN_URL_PREFIX}/output.pmtiles" \
     --arg run_stats_url "${RUN_URL_PREFIX}/stats/_results.json" \
     --arg run_insights_url "${RUN_URL_PREFIX}/stats/_insights.json" \
     --arg run_start_time "${RUN_START}" \
@@ -165,7 +182,7 @@ jq -n --compact-output \
     --arg run_output_size "${OUTPUT_FILESIZE}" \
     --arg run_spider_count "${SPIDER_COUNT}" \
     --arg run_line_count "${OUTPUT_LINECOUNT}" \
-    '{"run_id": $run_id, "output_url": $run_output_url, "stats_url": $run_stats_url, "insights_url": $run_insights_url, "start_time": $run_start_time, "end_time": $run_end_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber }' \
+    '{"run_id": $run_id, "output_url": $run_output_url, "pmtiles_url": $run_pmtiles_url, "stats_url": $run_stats_url, "insights_url": $run_insights_url, "start_time": $run_start_time, "end_time": $run_end_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber }' \
     > latest.json
 
 retval=$?


### PR DESCRIPTION
This adds Tippecanoe to the Docker image used in the weekly run and then calls it as part of the weekly run to generate a pmtiles file that will get uploaded as part of the artifacts generated by the build.

This can then by used so @jleedev doesn't have to regenerate the mbtiles with [alltheplaces-serve](https://github.com/jleedev/alltheplaces-serve/tree/main) and we can load them up in [Rapid editor](https://github.com/facebook/Rapid/discussions/993).