### PR TITLE
Read json with more CPUs

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -63,9 +63,10 @@ tippecanoe --cluster-distance=25 \
            --maximum-zoom=13 \
            --cluster-maxzoom=g \
            --layer="alltheplaces" \
+           --read-parallel \
            --attribution="<a href=\"https://www.alltheplaces.xyz/\">All The Places</a> ${RUN_TIMESTAMP}" \
            -o "${SPIDER_RUN_DIR}/output.pmtiles" \
-           --read-parallel "${SPIDER_RUN_DIR}"/output/*.geojson
+           "${SPIDER_RUN_DIR}"/output/*.geojson
 retval=$?
 if [ ! $retval -eq 0 ]; then
     (>&2 echo "Couldn't generate pmtiles")

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -65,7 +65,7 @@ tippecanoe --cluster-distance=25 \
            --layer="alltheplaces" \
            --attribution="<a href=\"https://www.alltheplaces.xyz/\">All The Places</a> ${RUN_TIMESTAMP}" \
            -o "${SPIDER_RUN_DIR}/output.pmtiles" \
-           -f "${SPIDER_RUN_DIR}"/output/*.geojson
+           --read-parallel "${SPIDER_RUN_DIR}"/output/*.geojson
 retval=$?
 if [ ! $retval -eq 0 ]; then
     (>&2 echo "Couldn't generate pmtiles")


### PR DESCRIPTION
Tippecanoe can consume the directory of GeoJSON files with more CPU if we ask it to with `--read-parallel`.

Consuming the input is even more efficient if it is a GeoJSONSeq instead of GeoJSON, but that's probably not worth it.