### PR TITLE
Fuel cards cleanup in categories.py.

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -340,19 +340,19 @@ class PaymentMethods(Enum):
 
 
 class FuelCards(Enum):
-    ALLSTAR = "payment:allstar" # https://allstarcard.co.uk/
-    AVIA = "payment:avia_card" # https://www.aviaitalia.com/en/avia-card/
+    ALLSTAR = "payment:allstar"  # https://allstarcard.co.uk/
+    AVIA = "payment:avia_card"  # https://www.aviaitalia.com/en/avia-card/
     ARIS = "payment:aris"
-    BP = "payment:bp_card" # https://www.bp.com/en/global/corporate/products-and-services.html
+    BP = "payment:bp_card"  # https://www.bp.com/en/global/corporate/products-and-services.html
     DEUTSCHLAND = "fuel:discount:deutschland_card"
     DKV = "payment:dkv"
     E100 = "payment:e100"  # https://e100.eu/en
     ESSO_NATIONAL = "payment:esso_card"
     EXXONMOBIL_FLEET = "payment:exxonmobil_fleet"
-    LOGPAY = "payment:logpay" # https://www.logpay.de/
+    LOGPAY = "payment:logpay"  # https://www.logpay.de/
     LUKOIL = "payment:lukoil"  # https://lukoil.ru/Products/business/fuelcards
     LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
-    MOBIL = "payment:mobilcard" # https://www.mobil.co.nz/en-nz/mobilcard
+    MOBIL = "payment:mobilcard"  # https://www.mobil.co.nz/en-nz/mobilcard
     OMV = "payment:omv"  # https://www.omv.com/en/customers/services/fuel-cards
     PETROL_PLUS_REGION = "payment:petrol_plus_region"  # https://www.petrolplus.ru/
     SHELL = "payment:shell"

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -340,24 +340,23 @@ class PaymentMethods(Enum):
 
 
 class FuelCards(Enum):
-    # TODO: clean tags here
-    ALLSTAR = "Allstar Card"
-    AVIA = "Avia Card"
+    ALLSTAR = "payment:allstar" # https://allstarcard.co.uk/
+    AVIA = "payment:avia_card" # https://www.aviaitalia.com/en/avia-card/
     ARIS = "payment:aris"
-    BP = "BP card"
+    BP = "payment:bp_card" # https://www.bp.com/en/global/corporate/products-and-services.html
     DEUTSCHLAND = "fuel:discount:deutschland_card"
-    DKV = "fuel:discount:dkv"
+    DKV = "payment:dkv"
     E100 = "payment:e100"  # https://e100.eu/en
-    ESSO_NATIONAL = "fuel:discount:esso_national"
-    EXXONMOBIL_FLEET = "ExxonMobil Fleet Card"
-    LOGPAY = "LogPay Card"
+    ESSO_NATIONAL = "payment:esso_card"
+    EXXONMOBIL_FLEET = "payment:exxonmobil_fleet"
+    LOGPAY = "payment:logpay" # https://www.logpay.de/
     LUKOIL = "payment:lukoil"  # https://lukoil.ru/Products/business/fuelcards
     LUKOIL_LOYALTY_PROGRAM = "fuel:discount:lukoil"
-    MOBIL = "Mobilcard"
+    MOBIL = "payment:mobilcard" # https://www.mobil.co.nz/en-nz/mobilcard
     OMV = "payment:omv"  # https://www.omv.com/en/customers/services/fuel-cards
     PETROL_PLUS_REGION = "payment:petrol_plus_region"  # https://www.petrolplus.ru/
-    SHELL = "fuel:discount:shell"
-    UTA = "fuel:discount:uta"
+    SHELL = "payment:shell"
+    UTA = "payment:uta"
     ROSNEFT = "payment:rosneft"  # https://www.rn-card.ru/
     ROUTEX = "payment:routex"  # https://routex.com/
 

--- a/locations/spiders/exxonmobil.py
+++ b/locations/spiders/exxonmobil.py
@@ -93,6 +93,7 @@ class ExxonMobilSpider(SitemapSpider):
             if brand := self.brands.get(location["Brand"]):
                 item.update(brand)
             else:
+                self.crawler.stats.inc_value(f"atp/exxonmobil/unknown_brand/{location['Brand']}")
                 item["brand"] = location["Brand"]
 
             features = [f["Name"] for f in (location["FeaturedItems"] + location["StoreAmenities"])]


### PR DESCRIPTION
My goal for this was to align `FuelCards` to use [common tagging](https://wiki.openstreetmap.org/wiki/Key:payment:*#Fuel_cards).

Currently `exxonmobil.py` is a consumer of most of the cards, I haven't looked at this spider in detail, so please feel free to adjust `FuelCards` if necessary.