### PR TITLE
Fixed the format for Fantastiko's refs

### DIFF
--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -17,5 +17,6 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         data = json.loads(response.xpath('//input[@id="shops-initial"]/@value').get())[0]
         item["lat"] = data["lat"]
         item["lon"] = data["lng"]
+        item["ref"] = data["ref"].rsplit("/f")[1]
 
         yield item

--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -17,6 +17,8 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         data = json.loads(response.xpath('//input[@id="shops-initial"]/@value').get())[0]
         item["lat"] = data["lat"]
         item["lon"] = data["lng"]
-        item["ref"] = response.xpath('//span[@class="feat-title white shop-number inline_block middle"]/text()').extract()
+        item["ref"] = response.xpath(
+            '//span[@class="feat-title white shop-number inline_block middle"]/text()'
+        ).extract()
 
         yield item

--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -17,6 +17,6 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         data = json.loads(response.xpath('//input[@id="shops-initial"]/@value').get())[0]
         item["lat"] = data["lat"]
         item["lon"] = data["lng"]
-        item["ref"] = response.xpath('//span[@class="shop-number"]/@value').get()
+        item["ref"] = response.xpath('//span[@class="feat-title white shop-number inline_block middle"]/@value').get()
 
         yield item

--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -17,6 +17,6 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         data = json.loads(response.xpath('//input[@id="shops-initial"]/@value').get())[0]
         item["lat"] = data["lat"]
         item["lon"] = data["lng"]
-        item["ref"] = response.xpath('//span[@class="feat-title white shop-number inline_block middle"]/@value').get()
+        item["ref"] = response.xpath('//span[@class="feat-title white shop-number inline_block middle"]/text()').extract()
 
         yield item

--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -17,6 +17,6 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         data = json.loads(response.xpath('//input[@id="shops-initial"]/@value').get())[0]
         item["lat"] = data["lat"]
         item["lon"] = data["lng"]
-        item["ref"] = data["ref"].rsplit("/f")[1]
+        item["ref"] = response.xpath('//span[@class="shop-number"]/@value').get()
 
         yield item

--- a/locations/spiders/fantastiko_bg.py
+++ b/locations/spiders/fantastiko_bg.py
@@ -19,6 +19,6 @@ class FantastikoBGSpider(SitemapSpider, StructuredDataSpider):
         item["lon"] = data["lng"]
         item["ref"] = response.xpath(
             '//span[@class="feat-title white shop-number inline_block middle"]/text()'
-        ).extract()
+        ).extract_first()
 
         yield item


### PR DESCRIPTION
Currently the refs look like `https://www.fantastico.bg/shops/f{number}` when they should be a simple number. This PR addresses this problem.