### PR TITLE
fix: Don't flood logs with warnings for duplicate items

### DIFF
--- a/locations/logformatter.py
+++ b/locations/logformatter.py
@@ -1,0 +1,16 @@
+import logging
+import os
+
+from scrapy import logformatter
+
+
+class DebugDuplicateLogFormatter(logformatter.LogFormatter):
+    def dropped(self, item, exception, response, spider):
+        return {
+            "level": logging.DEBUG,
+            "msg": "Dropped: %(exception)s" + os.linesep + "%(item)s",
+            "args": {
+                "exception": exception,
+                "item": item,
+            },
+        }

--- a/locations/pipelines/duplicates.py
+++ b/locations/pipelines/duplicates.py
@@ -1,9 +1,12 @@
+import logging
+
 from scrapy.exceptions import DropItem
 
 
 class DuplicatesPipeline:
     def __init__(self):
         self.ids_seen = set()
+        self.duplicate_count = 0
 
     def process_item(self, item, spider):
         if hasattr(spider, "no_refs") and getattr(spider, "no_refs"):
@@ -11,7 +14,11 @@ class DuplicatesPipeline:
 
         ref = (spider.name, item["ref"])
         if ref in self.ids_seen:
-            raise DropItem("Duplicate item found: %s" % item)
+            self.duplicate_count = self.duplicate_count + 1
+            raise DropItem()
         else:
             self.ids_seen.add(ref)
             return item
+
+    def close_spider(self, spider):
+        logging.info(f"Dropped {self.duplicate_count} duplicate items")

--- a/locations/pipelines/duplicates.py
+++ b/locations/pipelines/duplicates.py
@@ -2,6 +2,7 @@ import logging
 
 from scrapy.exceptions import DropItem
 
+logger = logging.getLogger(__name__)
 
 class DuplicatesPipeline:
     def __init__(self):
@@ -21,4 +22,4 @@ class DuplicatesPipeline:
             return item
 
     def close_spider(self, spider):
-        logging.info(f"Dropped {self.duplicate_count} duplicate items")
+        logger.info(f"Dropped {self.duplicate_count} duplicate items")

--- a/locations/pipelines/duplicates.py
+++ b/locations/pipelines/duplicates.py
@@ -9,7 +9,7 @@ class DuplicatesPipeline:
         self.duplicate_count = 0
 
     def process_item(self, item, spider):
-        if hasattr(spider, "no_refs") and getattr(spider, "no_refs"):
+        if getattr(spider, "no_refs", False):
             return item
 
         ref = (spider.name, item["ref"])

--- a/locations/pipelines/duplicates.py
+++ b/locations/pipelines/duplicates.py
@@ -4,6 +4,7 @@ from scrapy.exceptions import DropItem
 
 logger = logging.getLogger(__name__)
 
+
 class DuplicatesPipeline:
     def __init__(self):
         self.ids_seen = set()

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -153,4 +153,3 @@ REQUESTS_CACHE_BACKEND_SETTINGS = {
     "backend": "filesystem",
     "wal": True,
 }
-

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -110,6 +110,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.count_brands.CountBrandsPipeline": 810,
 }
 
+LOG_FORMATTER = "locations.logformatter.DebugDuplicateLogFormatter"
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
@@ -152,3 +153,4 @@ REQUESTS_CACHE_BACKEND_SETTINGS = {
     "backend": "filesystem",
     "wal": True,
 }
+


### PR DESCRIPTION
We currently see ~2.5m duplicates for a full run. That's a lot of log lines.

The log formatter changes the log level from `WARNING` to `DEBUG`.

(~800k `starbucks`, ~460k `usps`)