### PR TITLE
[Orlen] Fix POIs without category.

### DIFF
--- a/locations/spiders/orlen.py
+++ b/locations/spiders/orlen.py
@@ -109,6 +109,7 @@ class OrlenSpider(scrapy.Spider):
         apply_yes_no(Extras.COMPRESSED_AIR, item, "Compressor" in services_names)
         apply_yes_no(Extras.ATM, item, "Cash point" in services_names)
 
+        # TODO: output separate item for charging station
         if "Electric car chargers" in services_names:
             apply_category(Categories.CHARGING_STATION, item)
 
@@ -134,4 +135,5 @@ class OrlenSpider(scrapy.Spider):
                 item["opening_hours"] = OpeningHours()
                 item["opening_hours"].add_days_range(DAYS, match.group(1) + ":00", match.group(2) + ":00")
 
+        apply_category(Categories.FUEL_STATION, item)
         yield item


### PR DESCRIPTION
For most POIs in this spider NSI match failed due to ambiguous match so category was not assigned ([stats ](https://data.alltheplaces.xyz/runs/2023-09-09-13-32-00/stats/orlen.json) from last ATP run)
```
"atp/category/missing": 2781,
"atp/nsi/match_failed": 2670,
```

It's fixed now.
<details><summary> Stats after fix</summary>

```json
{
 "atp/brand/Bliska": 14,
 "atp/brand/ORLEN Benzina": 307,
 "atp/brand/Orlen": 1936,
 "atp/brand/Ventus": 2,
 "atp/brand/star": 565,
 "atp/brand_wikidata/Q109930371": 565,
 "atp/brand_wikidata/Q11130894": 307,
 "atp/brand_wikidata/Q4016378": 14,
 "atp/brand_wikidata/Q971649": 1936,
 "atp/category/amenity/charging_station;fuel": 153,
 "atp/category/amenity/fuel": 2780,
 "atp/field/brand/missing": 109,
 "atp/field/brand_wikidata/missing": 111,
 "atp/field/country/from_reverse_geocoding": 2933,
 "atp/field/email/missing": 2933,
 "atp/field/image/missing": 2933,
 "atp/field/opening_hours/missing": 1079,
 "atp/field/phone/invalid": 516,
 "atp/field/state/missing": 33,
 "atp/field/street_address/missing": 2933,
 "atp/field/twitter/missing": 2933,
 "atp/field/website/missing": 2933,
 "atp/nsi/category_match": 2660,
 "atp/nsi/match_failed": 162,
 "downloader/request_bytes": 2977675,
 "downloader/request_count": 2935,
 "downloader/request_method_count/GET": 2935,
 "downloader/response_bytes": 4805554,
 "downloader/response_count": 2935,
 "downloader/response_status_count/200": 2935,
 "elapsed_time_seconds": 3577.832016,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-09-11T18:03:33.108456",
 "item_scraped_count": 2933,
 "log_count/INFO": 69,
 "memusage/max": 394862592,
 "memusage/startup": 139452416,
 "request_depth_max": 2,
 "response_received_count": 2935,
 "scheduler/dequeued": 2935,
 "scheduler/dequeued/memory": 2935,
 "scheduler/enqueued": 2935,
 "scheduler/enqueued/memory": 2935,
 "start_time": "2023-09-11T17:03:55.276440"
}
```