### PR TITLE
Change untaxed diesel tag to be close to OSM.

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -216,7 +216,7 @@ class Fuel(Enum):
     GTL_DIESEL = "fuel:GTL_diesel"
     HGV_DIESEL = "fuel:HGV_diesel"
     BIODIESEL = "fuel:biodiesel"
-    UNTAXED_DIESEL = "fuel:untaxed_diesel"
+    UNTAXED_DIESEL = "fuel:taxfree_diesel"
     COLD_WEATHER_DIESEL = "fuel:diesel:class2"
     # Octane levels
     OCTANE_80 = "fuel:octane_80"


### PR DESCRIPTION
- https://wiki.openstreetmap.org/wiki/Key:fuel#How_to_map
- https://taginfo.openstreetmap.org/keys/fuel%3Ataxfree_diesel#overview