### PR TITLE
Discard `phone` from yettel_bg.py

### DIFF
--- a/locations/spiders/yettel_bg.py
+++ b/locations/spiders/yettel_bg.py
@@ -19,7 +19,6 @@ class YettelBGSpider(Spider):
             item["lon"], item["lat"] = store["geometry"]["coordinates"]
 
             item["ref"] = store["properties"]["title"]
-            item["phone"] = store["properties"]["gsl_props_phone"]
 
             address_block = Selector(text=store["properties"]["gsl_addressfield"])
 


### PR DESCRIPTION
That info is not useful because all stores have the same value - "123 for Yettel subscribers, 089 123 for other operators, +359 89 123 for subscribers abroad". Also 123 is their national phone number, not an individual shop's phone number.