### PR TITLE
storefinders/wp_store_locator: don't check max_results error on autoload

### DIFF
--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -71,7 +71,7 @@ class WPStoreLocatorSpider(Spider):
                     yield JsonRequest(url=url)
 
     def parse(self, response, **kwargs):
-        if len(response.json()) >= self.max_results:
+        if self.max_results != 0 and len(response.json()) >= self.max_results:
             raise RuntimeError(
                 "Locations have probably been truncated due to max_results (or more) locations being returned by a single geographic radius search. Use more granular searchable_points_files and a smaller search_radius."
             )


### PR DESCRIPTION
If autoload=1 as a parameter to WP Store Locator and the server has been configured to support returning all locations at once, we should not check self.max_results versus the number of locations returned, as there is no maximum that should be checked against.