### PR TITLE
Add Specsavers (GB/GG/JE/IM/CA/AU) (2611 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -67,6 +67,7 @@ class Categories(Enum):
     SHOP_GIFT = {"shop": "gift"}
     SHOP_HAIRDRESSER = {"shop": "hairdresser"}
     SHOP_HARDWARE = {"shop": "hardware"}
+    SHOP_HEARING_AIDS = {"shop": "hearing_aids"}
     SHOP_JEWELRY = {"shop": "jewelry"}
     SHOP_LAUNDRY = {"shop": "laundry"}
     SHOP_MOBILE_PHONE = {"shop": "mobile_phone"}

--- a/locations/spiders/specsavers.py
+++ b/locations/spiders/specsavers.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -109,8 +109,8 @@ fragment sectionalNotification on StoreSectionalNotification {
                         "latitude": 0,
                         "longitude": 0,
                         "radiusInKm": 100000,
-                    }
-                }
+                    },
+                },
             }
             yield JsonRequest(url=url, data=data, method="POST")
 
@@ -118,8 +118,16 @@ fragment sectionalNotification on StoreSectionalNotification {
         for location in response.json()["data"]["storesSearch"]["stores"]:
             store = location["store"]
             base_item = DictParser.parse(store)
-            base_item["street_address"] = ", ".join(filter(None, [store["address"].get("line1"), store["address"].get("line2"), store["address"].get("line3")]))
-            if store.get("optical") and store.get("audiology") and store["optical"]["storeNumber"] == store["audiology"]["storeNumber"]:
+            base_item["street_address"] = ", ".join(
+                filter(
+                    None, [store["address"].get("line1"), store["address"].get("line2"), store["address"].get("line3")]
+                )
+            )
+            if (
+                store.get("optical")
+                and store.get("audiology")
+                and store["optical"]["storeNumber"] == store["audiology"]["storeNumber"]
+            ):
                 store["optical"]["storeNumber"] = store["optical"]["storeNumber"] + "_O"
                 store["audiology"]["storeNumber"] = store["audiology"]["storeNumber"] + "_A"
             for store_type in ["optical", "audiology"]:

--- a/locations/spiders/specsavers.py
+++ b/locations/spiders/specsavers.py
@@ -123,6 +123,12 @@ fragment sectionalNotification on StoreSectionalNotification {
                     None, [store["address"].get("line1"), store["address"].get("line2"), store["address"].get("line3")]
                 )
             )
+            if base_item["state"] == "GGY":
+                base_item["country"] = "GG"
+            elif base_item["state"] == "JSY":
+                base_item["country"] = "JE"
+            elif base_item["state"] == "IMN":
+                base_item["country"] = "IM"
             if (
                 store.get("optical")
                 and store.get("audiology")

--- a/locations/spiders/specsavers.py
+++ b/locations/spiders/specsavers.py
@@ -23,80 +23,80 @@ class SpecsaversSpider(Spider):
                 country_code = "GB"
             url = f"https://{domain}/graphql"
             graphql_query = """query storeSearchQuery($query: StoresGeographicSearch!, $limit: Int = 10000, $offset: Int = 0) {
-	storesSearch(query: $query, limit: $limit, offset: $offset) {
-		count
-		offset
-		total
-		stores {
-			distance
-			store {
-				id
-				name
-				shortName
-				address { ...address }
-				coordinates {
-					longitude
-					latitude
-				}
-				accessibility {
-					description
-					accessibility
-					parkingAvailable
-					parkingDescription
-				}
-				url
-				timeZone
-				contactInfo { ...storeContactInfo }
-				optical {
-					id
-					storeNumber
-					contactInfo { ...storeContactInfo }
-					enabledForOnlineBooking
-					onlineAppointmentTypes
-					winkAdditionalFields {
-					winkId
-					winkName
-					winkStoreId
-					}
-				}
-				audiology {
-					id
-					storeNumber
-					contactInfo { ...storeContactInfo }
-					enabledForOnlineBooking
-					onlineAppointmentTypes
-				}
-				sectionalNotification { ...sectionalNotification }
-			}
-		}
-	}
+    storesSearch(query: $query, limit: $limit, offset: $offset) {
+        count
+        offset
+        total
+        stores {
+            distance
+            store {
+                id
+                name
+                shortName
+                address { ...address }
+                coordinates {
+                    longitude
+                    latitude
+                }
+                accessibility {
+                    description
+                    accessibility
+                    parkingAvailable
+                    parkingDescription
+                }
+                url
+                timeZone
+                contactInfo { ...storeContactInfo }
+                optical {
+                    id
+                    storeNumber
+                    contactInfo { ...storeContactInfo }
+                    enabledForOnlineBooking
+                    onlineAppointmentTypes
+                    winkAdditionalFields {
+                    winkId
+                    winkName
+                    winkStoreId
+                    }
+                }
+                audiology {
+                    id
+                    storeNumber
+                    contactInfo { ...storeContactInfo }
+                    enabledForOnlineBooking
+                    onlineAppointmentTypes
+                }
+                sectionalNotification { ...sectionalNotification }
+            }
+        }
+    }
 }
 fragment address on Address {
-	id
-	name
-	line1
-	line2
-	line3
-	postcode
-	city
-	region
-	countryCode
-	country
+    id
+    name
+    line1
+    line2
+    line3
+    postcode
+    city
+    region
+    countryCode
+    country
 }
 fragment storeContactInfo on ContactInfo {
-	email
-	phone
+    email
+    phone
 }
 fragment sectionalNotification on StoreSectionalNotification {
-	title
-	headline
-	important
-	type
-	moreInfoLink
-	phoneNumber
-	includeBookingJourney
-	expiryDate
-	activeInactive
+    title
+    headline
+    important
+    type
+    moreInfoLink
+    phoneNumber
+    includeBookingJourney
+    expiryDate
+    activeInactive
 }"""
             data = {
                 "operationName": "storeSearchQuery",

--- a/locations/spiders/specsavers.py
+++ b/locations/spiders/specsavers.py
@@ -1,0 +1,138 @@
+from copy import deepcopy
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import apply_category, Categories
+from locations.dict_parser import DictParser
+
+
+class SpecsaversSpider(Spider):
+    name = "specsavers"
+    item_attributes = {"brand": "Specsavers", "brand_wikidata": "Q2000610"}
+    allowed_domains = [
+        "www.specsavers.co.uk",
+        "www.specsavers.ca",
+        "www.specsavers.com.au",
+    ]
+
+    def start_requests(self):
+        for domain in self.allowed_domains:
+            country_code = domain[-2:].upper()
+            if country_code == "UK":
+                country_code = "GB"
+            url = f"https://{domain}/graphql"
+            graphql_query = """query storeSearchQuery($query: StoresGeographicSearch!, $limit: Int = 10000, $offset: Int = 0) {
+	storesSearch(query: $query, limit: $limit, offset: $offset) {
+		count
+		offset
+		total
+		stores {
+			distance
+			store {
+				id
+				name
+				shortName
+				address { ...address }
+				coordinates {
+					longitude
+					latitude
+				}
+				accessibility {
+					description
+					accessibility
+					parkingAvailable
+					parkingDescription
+				}
+				url
+				timeZone
+				contactInfo { ...storeContactInfo }
+				optical {
+					id
+					storeNumber
+					contactInfo { ...storeContactInfo }
+					enabledForOnlineBooking
+					onlineAppointmentTypes
+					winkAdditionalFields {
+					winkId
+					winkName
+					winkStoreId
+					}
+				}
+				audiology {
+					id
+					storeNumber
+					contactInfo { ...storeContactInfo }
+					enabledForOnlineBooking
+					onlineAppointmentTypes
+				}
+				sectionalNotification { ...sectionalNotification }
+			}
+		}
+	}
+}
+fragment address on Address {
+	id
+	name
+	line1
+	line2
+	line3
+	postcode
+	city
+	region
+	countryCode
+	country
+}
+fragment storeContactInfo on ContactInfo {
+	email
+	phone
+}
+fragment sectionalNotification on StoreSectionalNotification {
+	title
+	headline
+	important
+	type
+	moreInfoLink
+	phoneNumber
+	includeBookingJourney
+	expiryDate
+	activeInactive
+}"""
+            data = {
+                "operationName": "storeSearchQuery",
+                "query": graphql_query,
+                "variables": {
+                    "limit": 10000,
+                    "offset": 0,
+                    "query": {
+                        "countryCode": country_code,
+                        "latitude": 0,
+                        "longitude": 0,
+                        "radiusInKm": 100000,
+                    }
+                }
+            }
+            yield JsonRequest(url=url, data=data, method="POST")
+
+    def parse(self, response):
+        for location in response.json()["data"]["storesSearch"]["stores"]:
+            store = location["store"]
+            base_item = DictParser.parse(store)
+            base_item["street_address"] = ", ".join(filter(None, [store["address"].get("line1"), store["address"].get("line2"), store["address"].get("line3")]))
+            if store.get("optical") and store.get("audiology") and store["optical"]["storeNumber"] == store["audiology"]["storeNumber"]:
+                store["optical"]["storeNumber"] = store["optical"]["storeNumber"] + "_O"
+                store["audiology"]["storeNumber"] = store["audiology"]["storeNumber"] + "_A"
+            for store_type in ["optical", "audiology"]:
+                if not store.get(store_type):
+                    continue
+                item = deepcopy(base_item)
+                item["ref"] = store[store_type]["storeNumber"]
+                item["phone"] = store[store_type]["contactInfo"].get("phone")
+                item["email"] = store[store_type]["contactInfo"].get("email")
+                if store_type == "optical":
+                    apply_category(Categories.SHOP_OPTICIAN, item)
+                    item["extras"]["healthcare"] = "optometrist"
+                elif store_type == "audiology":
+                    apply_category(Categories.SHOP_HEARING_AIDS, item)
+                    item["extras"]["healthcare"] = "audiologist"
+                yield item

--- a/locations/spiders/specsavers_au_nz.py
+++ b/locations/spiders/specsavers_au_nz.py
@@ -1,7 +1,0 @@
-from locations.storefinders.yext import YextSpider
-
-
-class SpecsaversAUNZSpider(YextSpider):
-    name = "specsavers_au_nz"
-    item_attributes = {"brand": "Specsavers", "brand_wikidata": "Q2000610"}
-    api_key = "be3071a8d4114a2731d389952dd3eeb2"


### PR DESCRIPTION
 'atp/category/healthcare/audiologist': 1208,
 'atp/category/healthcare/optometrist': 1403,

Removes specsavers_au_nz spider which was broken. New Zealand and European locations for Specsavers use a different store locator (not based on Sparql queries).

Partially reverses #5319 now that the store locator for some countries has changed to Sparql, and the Cloudflare blocking of the past is no longer in place.