### PR TITLE
add_ranges_from_string: improve function

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -689,12 +689,9 @@ class OpeningHours:
             days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_24h + delimiter_regex + time_regex_24h + r")+)"
         )
 
-        # Replace named times in source ranges string (e.g. midnight -> 24:00)
-        ranges_string_12h = ranges_string
-        ranges_string_24h = ranges_string
-        for named_time_name, named_time_time in named_times.items():
-            ranges_string_12h = ranges_string_12h.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
-            ranges_string_24h = ranges_string_24h.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+        # Replace named times in source ranges string (e.g. midnight -> 00:00)
+        ranges_string_12h = self.replace_named_times(ranges_string, named_times, False)
+        ranges_string_24h = self.replace_named_times(ranges_string, named_times, True)
 
         # Execute both regular expressions.
         results_12h = re.findall(full_regex_12h, ranges_string_12h, re.IGNORECASE)
@@ -754,3 +751,27 @@ class OpeningHours:
                 day_list = day_range(start_day, end_day)
             for day in day_list:
                 self.add_range(day, result[1], result[2])
+
+    @staticmethod
+    def replace_named_times(hours_string: str, named_times: dict, time_24h: bool = True) -> str:
+        """
+        Replaces named times (e.g. Midnight) in a string with their
+        12h equivalent (e.g. 12:00AM) or 24h equivalent (e.g 00:00).
+        :param hours_string: string of opening hours information
+                             containing named times.
+        :param named_times: dict where the key is the string to
+                            replace, the value is an array of 2
+                            items, the first value being 24h
+                            time replacement, second being 12h
+                            time replacement.
+        :returns: hours_string with named times replaced with their
+                  24h equivalent or 12h equivalent times.
+        """
+        replaced_hours_string = hours_string
+        if time_24h is True:
+            for named_time_name, named_time_time in named_times.items():
+                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+        else:
+            for named_time_name, named_time_time in named_times.items():
+                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
+        return replaced_hours_string

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -429,6 +429,7 @@ DAYS_SR = {
     "Ned": "Su",
     "Nedelja": "Su",
     "Недеља": "Su",
+}
 
 NAMED_DAY_RANGES_DK = {
     "Hverdage": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"], # Weekdays
@@ -452,7 +453,7 @@ NAMED_DAY_RANGES_RU = {
     "По выходным": ["Sa", "Su"],  # Weekends
 }
 
-DELIMITERS_EN = {
+DELIMITERS_EN = [
     "-",
     "–",
     "—",
@@ -464,14 +465,14 @@ DELIMITERS_EN = {
     "thru",
     "through",
     "until",
-}
+]
 
-DELIMITERS_ES = {
+DELIMITERS_ES = [
     "-",
     "a",
     "y",
     "de",
-}
+]
 
 
 def day_range(start_day, end_day):
@@ -625,22 +626,54 @@ class OpeningHours:
                             if d := sanitise_day(day):
                                 self.add_range(d, start_time, end_time, time_format)
 
-    def add_ranges_from_string(
-        self, ranges_string, days=DAYS_EN, named_day_ranges=NAMED_DAY_RANGES_EN, named_times=NAMED_TIMES_EN, delimiters=DELIMITERS_EN
-    ):
-        # Build two regular expressions--one for extracting 12h
-        # opening hour information, and one for extracting 24h
-        # opening hour information from a supplied string.
-        days_regex = r"(?:"
-        days_regex_parts = []
-
-        # Build delimiters regular expression.
+    @staticmethod
+    def delimiters_regex(delimiters: list[str] = DELIMITERS_EN) -> str:
+        """
+        Creates a regular expression for capturing delimiters within
+        a string containing time information. For example, in the
+        string of "Monday: 10am-2pm", ":" and "-" are both
+        delimiters.
+        :param delimiters: list of strings which are delimiters to
+                           capture with the created regular
+                           expression.
+        :returns: regular expression which captures delimiters in a
+                  string containing opening time information.
+        """
         delimiter_regex = r"\s*(?:"
         delimiter_regex_parts = []
         for delimiter in delimiters:
             delimiter_regex_parts.append(re.escape(delimiter))
         delimiter_regex = delimiter_regex + r"|".join(delimiter_regex_parts) + r")\s*"
+        return delimiter_regex
 
+    @staticmethod
+    def single_days_regex(days: dict = DAYS_EN) -> str:
+        """
+        Creates a regular expression for capturing single day names
+        within a string containing time information. For example, in the
+        string of "Monday: 9am-5pm", "Monday" is captured.
+        :param days: dictionary mapping localised day names to those
+                     within DAYS ("Mo", "Tu", ...).
+        :returns: regular expression which captures single day names
+                  in a string containing opening time information.
+        """
+        single_days_regex = r"(?<!\w)(" + r"|".join(map(re.escape, days.keys())) + r")(?!\w)"
+        return single_days_regex
+
+    @staticmethod
+    def day_ranges_regex(days: dict = DAYS_EN, delimiters: list[str] = DELIMITERS_EN) -> list[str]:
+        """
+        Creates a list of regular expressions for capturing all
+        combinations of day ranges, with wrap-around for ranges
+        which wrap around both Monday and Sunday as the first days
+        of a week. For example, a regular expression is created for
+        capturing strings of "Mon-Sun", "Sun to Sat", "Tue and Wed".
+        :param days: dictionary mapping localised day names to those
+                     within DAYS ("Mo", "Tu", ...).
+        :returns: list of regular expressions which capture day
+                  ranges in a given string containing opening time
+                  information.
+        """
         # For each day of the week, create a list of synonyms.
         day_synonyms = defaultdict(list)
         for synonym, day in sorted(days.items()):
@@ -650,13 +683,14 @@ class OpeningHours:
         # listed as such due to business vs. weekend hours), create
         # a regular expression of all day ranges possible in the
         # week starting Monday (or later).
+        days_regex_parts = []
         for i in range(0, 6, 1):
             start_day_string = r"(?<!\w)(" + r"|".join(day_synonyms[DAYS[i]]) + r")(?!\w)"
             end_days = []
             for j in range(i + 1, 7, 1):
                 end_days.append("|".join(day_synonyms[DAYS[j]]))
             end_days_string = r"(?<!\w)(" + r"|".join(end_days) + r")(?!\w)"
-            days_regex_parts.append(start_day_string + delimiter_regex + end_days_string)
+            days_regex_parts.append(start_day_string + OpeningHours.delimiters_regex(delimiters) + end_days_string)
 
         # Some sources will have a week start on Sunday and will
         # express day ranges as Sunday to Thursday (for example).
@@ -667,52 +701,183 @@ class OpeningHours:
         for j in range(0, 6, 1):
             end_days.append("|".join(day_synonyms[DAYS[j]]))
         end_days_string = r"(?<!\w)(" + r"|".join(end_days) + r")(?!\w)"
-        days_regex_parts.append(start_day_string + delimiter_regex + end_days_string)
+        days_regex_parts.append(start_day_string + OpeningHours.delimiters_regex(delimiters) + end_days_string)
 
-        # Create a regular expression for named day ranges.
-        named_day_range_regex = r"(?<!\w)(" + r"|".join(named_day_ranges.keys()) + r")(?!\w)"
-        days_regex_parts.append(named_day_range_regex)
+        return days_regex_parts
 
-        # Create a regular expression for single days of the week.
-        single_days_regex = r"(?<!\w)(" + r"|".join(days.keys()) + r")(?!\w)"
-        days_regex_parts.append(single_days_regex)
+    @staticmethod
+    def named_day_ranges_regex(named_day_ranges: dict = NAMED_DAY_RANGES_EN) -> str:
+        """
+        Creates a regular expression for capturing named day ranges
+        within a string containing time information. For example, in
+        the string of "Weekends: 9am-5pm", "Weekends" is captured.
+        :param named_day_ranges: dictionary mapping localised named
+                                 day ranges to lists of days from
+                                 DAYS ("Mo", "Tu", ...).
+        :returns: regular expression which captures named day ranges
+                  in a string containing opening time information.
+        """
+        named_day_ranges_regex = r"(?<!\w)(" + r"|".join(map(re.escape, named_day_ranges.keys())) + r")(?!\w)"
+        return named_day_ranges_regex
 
-        # Compile regular expression parts together to create the
-        # two regular expressions.
+    @staticmethod
+    def replace_named_times(hours_string: str, named_times: dict = NAMED_TIMES_EN, time_24h: bool = True) -> str:
+        """
+        Replaces named times (e.g. Midnight) in a string with their
+        12h equivalent (e.g. 12:00AM) or 24h equivalent (e.g 00:00).
+        :param hours_string: string of opening hours information
+                             containing named times.
+        :param named_times: dictionary mapping localised named times
+                            of day to a tuple of equivalent 24hr time
+                            and 12hr time respectively.
+        :param time_24h: boolean for whether the resulting string
+                         should have named times replaced with 24h
+                         or 12h time ranges.
+        :returns: string with named times replaced with their 24h
+                  equivalent or 12h equivalent times.
+        """
+        replaced_hours_string = hours_string
+        if time_24h is True:
+            for named_time_name, named_time_time in named_times.items():
+                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+        else:
+            for named_time_name, named_time_time in named_times.items():
+                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
+        return replaced_hours_string
+
+    @staticmethod
+    def time_of_day_regex(time_24h: bool = True) -> str:
+        """
+        Creates a regular expression for capturing times of day in
+        either 24h or 12h notation.
+        :param time_24h: boolean for whether the resulting regular
+                         expression should capture 24h or 12h
+                         opening time information.
+        :returns: regular expression which captures times of day in
+                  a string.
+        """
+        if time_24h is True:
+            # Regular expression for extracting 24h times (e.g. 15:45)
+            time_regex = r"(?<!\d)(\d(?!\d)|[01]\d|2[0-4])(?:[:\.]?([0-5]\d))(?:[:\.]?[0-5]\d)?(?!(?:\d|[AP]M))"
+        else:
+            # Regular expression for extracting 12h times (e.g. 9:30AM)
+            time_regex = r"(?<!\d)(\d(?!\d)|0\d|1[012])(?:(?:[:\.]?([0-5]\d))(?:[:\.]?[0-5]\d)?)?\s*([AP]M)?(?!\d)"
+        return time_regex
+
+    @staticmethod
+    def hours_extraction_regex(time_24h: bool = True, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, delimiters: list[str] = DELIMITERS_EN) -> str:
+        """
+        Creates a regular expression for capturing opening time
+        information from a localised string.
+        :param time_24h: boolean for whether the resulting regular
+                         expression should capture 24h or 12h
+                         opening time information.
+        :param days: dictionary mapping localised day names to those
+                     within DAYS ("Mo", "Tu", ...).
+        :param named_day_ranges: dictionary mapping localised named
+                                 day ranges to lists of days from
+                                 DAYS ("Mo", "Tu", ...).
+        :param delimiters: list of strings which are delimiters to
+                           capture with the created regular
+                           expression.
+        :returns: regular expression which can extract opening time
+                  information from a string.
+        """
+        # Create a regular expression for capturing day names and
+        # day ranges from within a string containing opening time
+        # information. This regular expression is designed to
+        # capture the following types of strings:
+        #   Mon-Wed
+        #   Tuesday to Thursday
+        #   Saturday
+        #   Weekends
+        days_regex = r"(?:"
+        days_regex_parts = OpeningHours.day_ranges_regex(days=days, delimiters=delimiters)
+        days_regex_parts.append(OpeningHours.named_day_ranges_regex(named_day_ranges=named_day_ranges))
+        days_regex_parts.append(OpeningHours.single_days_regex(days=days))
         days_regex = days_regex + r"|".join(days_regex_parts) + r")"
-        time_regex_12h = r"(?<!\d)(\d(?!\d)|0\d|1[012])(?:(?:[:\.]?([0-5]\d))(?:[:\.]?[0-5]\d)?)?\s*([AP]M)?(?!\d)"
-        time_regex_24h = r"(?<!\d)(\d(?!\d)|[01]\d|2[0-4])(?:[:\.]?([0-5]\d))(?:[:\.]?[0-5]\d)?(?!(?:\d|[AP]M))"
-        full_regex_12h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_12h + delimiter_regex + time_regex_12h + r")+)"
-        )
-        full_regex_24h = (
-            days_regex + r"(?:\W+|" + delimiter_regex + r")((?:(?:\s*,?\s*)?" + time_regex_24h + delimiter_regex + time_regex_24h + r")+)"
-        )
 
-        # Replace named times in source ranges string (e.g. midnight -> 00:00)
-        ranges_string_12h = self.replace_named_times(ranges_string, named_times, False)
-        ranges_string_24h = self.replace_named_times(ranges_string, named_times, True)
+        full_regex = (
+            days_regex + r"(?:\W+|" + OpeningHours.delimiters_regex(delimiters) + r")((?:(?:\s*,?\s*)?" + OpeningHours.time_of_day_regex(time_24h=time_24h) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=time_24h) + r")+)"
+        )
+        return full_regex
+
+    @staticmethod
+    def days_in_day_range(day_range: list[str], days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN) -> list[str]:
+        """
+        """
+        day_list = []
+        if len(day_range) == 1 or days[day_range[0].title()] == days[day_range[1].title()]:
+            if day_range[0].title() in named_day_ranges.keys():
+                day_list = named_day_ranges[day_range[0].title()]
+            else:
+                day_list = [days[day_range[0].title()]]
+        elif len(day_range) == 2:
+            start_day_index = DAYS.index(days[day_range[0].title()])
+            end_day_index = DAYS.index(days[day_range[1].title()])
+            if start_day_index > end_day_index:
+                day_list = DAYS[start_day_index:] + DAYS[:end_day_index+1]
+            else:
+                day_list = DAYS[start_day_index:end_day_index+1]
+        return day_list
+
+    @staticmethod
+    def extract_hours_from_string(ranges_string: str, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, named_times: dict = NAMED_TIMES_EN, delimiters: list[str] = DELIMITERS_EN) -> list[tuple]:
+        """
+        Extracts opening time information from a localised string.
+        For every day or day range in the localised string with an
+        opening hours range supplied, this function will return a
+        tuple containing a day/day range, an opening time, and
+        closing time, all in a normalised format.
+        :param ranges_string: localised string containing opening
+                              time information.
+        :param days: dictionary mapping localised day names to those
+                     within DAYS ("Mo", "Tu", ...).
+        :param named_day_ranges: dictionary mapping localised named
+                                 day ranges to lists of days from
+                                 DAYS ("Mo", "Tu", ...).
+        :param named_times: dictionary mapping localised named times
+                            of day to a tuple of equivalent 24hr time
+                            and 12hr time respectively.
+        :param delimiters: list of strings which are delimiters to
+                           capture with the created regular
+                           expression.
+        :returns: list of tuples where each tuple has a list of days
+                  at each end of a day range (e.g. ["Mon", "Sat"] or
+                  a list containing a single ["Weekday"], an opening time in 24h notation and a
+                  closing time in 24h notation.
+        """
+        # Create regular expressions for extracting opening time information from a string.
+        hours_extraction_regex_24h = OpeningHours.hours_extraction_regex(time_24h=True, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters)
+        hours_extraction_regex_12h = OpeningHours.hours_extraction_regex(time_24h=False, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters)
+
+        # Replace named times in source ranges string (e.g. midnight -> 00:00).
+        ranges_string_24h = OpeningHours.replace_named_times(ranges_string, named_times, True)
+        ranges_string_12h = OpeningHours.replace_named_times(ranges_string, named_times, False)
 
         # Execute both regular expressions.
-        results_12h = re.findall(full_regex_12h, ranges_string_12h, re.IGNORECASE)
-        results_24h = re.findall(full_regex_24h, ranges_string_24h, re.IGNORECASE)
+        results_24h = re.findall(hours_extraction_regex_24h, ranges_string_24h, re.IGNORECASE)
+        if len(results_24h) == 0:
+            results_12h = re.findall(hours_extraction_regex_12h, ranges_string_12h, re.IGNORECASE)
 
         # Normalise results to 24h time.
-        results_normalised = []
+        results = []
         if len(results_24h) > 0:
             # Parse 24h opening hour information.
             for result in results_24h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
-                start_and_end_days = list(filter(None, result[:time_start_index]))
-                time_ranges = re.findall(time_regex_24h + delimiter_regex + time_regex_24h, result[time_start_index], re.IGNORECASE)
+                day_range = list(filter(None, result[:time_start_index]))
+                days_in_range = OpeningHours.days_in_day_range(day_range=day_range, days=days, named_day_ranges=named_day_ranges)
+                time_ranges = re.findall(OpeningHours.time_of_day_regex(time_24h=True) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=True), result[time_start_index], re.IGNORECASE)
                 for time_range in time_ranges:
-                    results_normalised.append([start_and_end_days, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"])
+                    results.append((days_in_range, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"))
         elif len(results_12h) > 0:
             # Parse 12h opening hour information.
             for result in results_12h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
-                start_and_end_days = list(filter(None, result[:time_start_index]))
-                time_ranges = re.findall(time_regex_12h + delimiter_regex + time_regex_12h, result[time_start_index], re.IGNORECASE)
+                day_range = list(filter(None, result[:time_start_index]))
+                days_in_range = OpeningHours.days_in_day_range(day_range=day_range, days=days, named_day_ranges=named_day_ranges)
+                time_ranges = re.findall(OpeningHours.time_of_day_regex(time_24h=False) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=False), result[time_start_index], re.IGNORECASE)
                 for time_range in time_ranges:
                     if time_range[1]:
                         time_start = f"{time_range[0]}:{time_range[1]}"
@@ -736,42 +901,30 @@ class OpeningHours:
                         time_end = f"{time_end}PM"
                     time_end_24h = time.strptime(time_end, "%I:%M%p")
                     time_end_24h = time.strftime("%H:%M", time_end_24h)
-                    results_normalised.append([start_and_end_days, time_start_24h, time_end_24h])
+                    results.append((days_in_range, time_start_24h, time_end_24h))
+        return results
 
-        # Add ranges to OpeningHours object from normalised results.
-        for result in results_normalised:
-            if len(result[0]) == 1:
-                if result[0][0].title() in named_day_ranges.keys():
-                    day_list = named_day_ranges[result[0][0].title()]
-                else:
-                    day_list = [days[result[0][0].title()]]
-            else:
-                start_day = days[result[0][0].title()]
-                end_day = days[result[0][1].title()]
-                day_list = day_range(start_day, end_day)
-            for day in day_list:
+    def add_ranges_from_string(self, ranges_string: str, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, named_times: dict = NAMED_TIMES_EN, delimiters: list[str] = DELIMITERS_EN) -> None:
+        """
+        Adds opening hour information from a localised string.
+        :param ranges_string: localised string containing opening
+                              time information.
+        :param days: dictionary mapping localised day names to those
+                     within DAYS ("Mo", "Tu", ...).
+        :param named_day_ranges: dictionary mapping localised named
+                                 day ranges to lists of days from
+                                 DAYS ("Mo", "Tu", ...).
+        :param named_times: dictionary mapping localised named times
+                            of day to a tuple of equivalent 24hr time
+                            and 12hr time respectively.
+        :param delimiters: list of strings which are delimiters to
+                           capture with the created regular
+                           expression.
+        """
+        # Extract opening time information from localised string.
+        results = OpeningHours.extract_hours_from_string(ranges_string=ranges_string, days=days, named_day_ranges=named_day_ranges, named_times=named_times, delimiters=delimiters)
+
+        # Add ranges to OpeningHours object.
+        for result in results:
+            for day in result[0]:
                 self.add_range(day, result[1], result[2])
-
-    @staticmethod
-    def replace_named_times(hours_string: str, named_times: dict, time_24h: bool = True) -> str:
-        """
-        Replaces named times (e.g. Midnight) in a string with their
-        12h equivalent (e.g. 12:00AM) or 24h equivalent (e.g 00:00).
-        :param hours_string: string of opening hours information
-                             containing named times.
-        :param named_times: dict where the key is the string to
-                            replace, the value is an array of 2
-                            items, the first value being 24h
-                            time replacement, second being 12h
-                            time replacement.
-        :returns: hours_string with named times replaced with their
-                  24h equivalent or 12h equivalent times.
-        """
-        replaced_hours_string = hours_string
-        if time_24h is True:
-            for named_time_name, named_time_time in named_times.items():
-                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
-        else:
-            for named_time_name, named_time_time in named_times.items():
-                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
-        return replaced_hours_string

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -432,7 +432,7 @@ DAYS_SR = {
 }
 
 NAMED_DAY_RANGES_DK = {
-    "Hverdage": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"], # Weekdays
+    "Hverdage": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],  # Weekdays
 }
 
 NAMED_DAY_RANGES_EN = {
@@ -739,10 +739,18 @@ class OpeningHours:
         replaced_hours_string = hours_string
         if time_24h is True:
             for named_time_name, named_time_time in named_times.items():
-                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[1]).replace(named_time_name.title(), named_time_time[1]).replace(named_time_name.upper(), named_time_time[1])
+                replaced_hours_string = (
+                    replaced_hours_string.replace(named_time_name.lower(), named_time_time[1])
+                    .replace(named_time_name.title(), named_time_time[1])
+                    .replace(named_time_name.upper(), named_time_time[1])
+                )
         else:
             for named_time_name, named_time_time in named_times.items():
-                replaced_hours_string = replaced_hours_string.replace(named_time_name.lower(), named_time_time[0]).replace(named_time_name.title(), named_time_time[0]).replace(named_time_name.upper(), named_time_time[0])
+                replaced_hours_string = (
+                    replaced_hours_string.replace(named_time_name.lower(), named_time_time[0])
+                    .replace(named_time_name.title(), named_time_time[0])
+                    .replace(named_time_name.upper(), named_time_time[0])
+                )
         return replaced_hours_string
 
     @staticmethod
@@ -765,7 +773,12 @@ class OpeningHours:
         return time_regex
 
     @staticmethod
-    def hours_extraction_regex(time_24h: bool = True, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, delimiters: list[str] = DELIMITERS_EN) -> str:
+    def hours_extraction_regex(
+        time_24h: bool = True,
+        days: dict = DAYS_EN,
+        named_day_ranges: dict = NAMED_DAY_RANGES_EN,
+        delimiters: list[str] = DELIMITERS_EN,
+    ) -> str:
         """
         Creates a regular expression for capturing opening time
         information from a localised string.
@@ -798,14 +811,22 @@ class OpeningHours:
         days_regex = days_regex + r"|".join(days_regex_parts) + r")"
 
         full_regex = (
-            days_regex + r"(?:\W+|" + OpeningHours.delimiters_regex(delimiters) + r")((?:(?:\s*,?\s*)?" + OpeningHours.time_of_day_regex(time_24h=time_24h) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=time_24h) + r")+)"
+            days_regex
+            + r"(?:\W+|"
+            + OpeningHours.delimiters_regex(delimiters)
+            + r")((?:(?:\s*,?\s*)?"
+            + OpeningHours.time_of_day_regex(time_24h=time_24h)
+            + OpeningHours.delimiters_regex(delimiters)
+            + OpeningHours.time_of_day_regex(time_24h=time_24h)
+            + r")+)"
         )
         return full_regex
 
     @staticmethod
-    def days_in_day_range(day_range: list[str], days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN) -> list[str]:
-        """
-        """
+    def days_in_day_range(
+        day_range: list[str], days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN
+    ) -> list[str]:
+        """ """
         day_list = []
         if len(day_range) == 1 or days[day_range[0].title()] == days[day_range[1].title()]:
             if day_range[0].title() in named_day_ranges.keys():
@@ -816,13 +837,19 @@ class OpeningHours:
             start_day_index = DAYS.index(days[day_range[0].title()])
             end_day_index = DAYS.index(days[day_range[1].title()])
             if start_day_index > end_day_index:
-                day_list = DAYS[start_day_index:] + DAYS[:end_day_index+1]
+                day_list = DAYS[start_day_index:] + DAYS[: end_day_index + 1]
             else:
-                day_list = DAYS[start_day_index:end_day_index+1]
+                day_list = DAYS[start_day_index : end_day_index + 1]
         return day_list
 
     @staticmethod
-    def extract_hours_from_string(ranges_string: str, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, named_times: dict = NAMED_TIMES_EN, delimiters: list[str] = DELIMITERS_EN) -> list[tuple]:
+    def extract_hours_from_string(
+        ranges_string: str,
+        days: dict = DAYS_EN,
+        named_day_ranges: dict = NAMED_DAY_RANGES_EN,
+        named_times: dict = NAMED_TIMES_EN,
+        delimiters: list[str] = DELIMITERS_EN,
+    ) -> list[tuple]:
         """
         Extracts opening time information from a localised string.
         For every day or day range in the localised string with an
@@ -848,8 +875,12 @@ class OpeningHours:
                   closing time in 24h notation.
         """
         # Create regular expressions for extracting opening time information from a string.
-        hours_extraction_regex_24h = OpeningHours.hours_extraction_regex(time_24h=True, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters)
-        hours_extraction_regex_12h = OpeningHours.hours_extraction_regex(time_24h=False, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters)
+        hours_extraction_regex_24h = OpeningHours.hours_extraction_regex(
+            time_24h=True, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters
+        )
+        hours_extraction_regex_12h = OpeningHours.hours_extraction_regex(
+            time_24h=False, days=days, named_day_ranges=named_day_ranges, delimiters=delimiters
+        )
 
         # Replace named times in source ranges string (e.g. midnight -> 00:00).
         ranges_string_24h = OpeningHours.replace_named_times(ranges_string, named_times, True)
@@ -867,17 +898,35 @@ class OpeningHours:
             for result in results_24h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
                 day_range = list(filter(None, result[:time_start_index]))
-                days_in_range = OpeningHours.days_in_day_range(day_range=day_range, days=days, named_day_ranges=named_day_ranges)
-                time_ranges = re.findall(OpeningHours.time_of_day_regex(time_24h=True) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=True), result[time_start_index], re.IGNORECASE)
+                days_in_range = OpeningHours.days_in_day_range(
+                    day_range=day_range, days=days, named_day_ranges=named_day_ranges
+                )
+                time_ranges = re.findall(
+                    OpeningHours.time_of_day_regex(time_24h=True)
+                    + OpeningHours.delimiters_regex(delimiters)
+                    + OpeningHours.time_of_day_regex(time_24h=True),
+                    result[time_start_index],
+                    re.IGNORECASE,
+                )
                 for time_range in time_ranges:
-                    results.append((days_in_range, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}"))
+                    results.append(
+                        (days_in_range, f"{time_range[0]}:{time_range[1]}", f"{time_range[2]}:{time_range[3]}")
+                    )
         elif len(results_12h) > 0:
             # Parse 12h opening hour information.
             for result in results_12h:
                 time_start_index = result.index(next(filter(lambda x: len(x) > 0 and x[0].isdigit(), result)))
                 day_range = list(filter(None, result[:time_start_index]))
-                days_in_range = OpeningHours.days_in_day_range(day_range=day_range, days=days, named_day_ranges=named_day_ranges)
-                time_ranges = re.findall(OpeningHours.time_of_day_regex(time_24h=False) + OpeningHours.delimiters_regex(delimiters) + OpeningHours.time_of_day_regex(time_24h=False), result[time_start_index], re.IGNORECASE)
+                days_in_range = OpeningHours.days_in_day_range(
+                    day_range=day_range, days=days, named_day_ranges=named_day_ranges
+                )
+                time_ranges = re.findall(
+                    OpeningHours.time_of_day_regex(time_24h=False)
+                    + OpeningHours.delimiters_regex(delimiters)
+                    + OpeningHours.time_of_day_regex(time_24h=False),
+                    result[time_start_index],
+                    re.IGNORECASE,
+                )
                 for time_range in time_ranges:
                     if time_range[1]:
                         time_start = f"{time_range[0]}:{time_range[1]}"
@@ -904,7 +953,14 @@ class OpeningHours:
                     results.append((days_in_range, time_start_24h, time_end_24h))
         return results
 
-    def add_ranges_from_string(self, ranges_string: str, days: dict = DAYS_EN, named_day_ranges: dict = NAMED_DAY_RANGES_EN, named_times: dict = NAMED_TIMES_EN, delimiters: list[str] = DELIMITERS_EN) -> None:
+    def add_ranges_from_string(
+        self,
+        ranges_string: str,
+        days: dict = DAYS_EN,
+        named_day_ranges: dict = NAMED_DAY_RANGES_EN,
+        named_times: dict = NAMED_TIMES_EN,
+        delimiters: list[str] = DELIMITERS_EN,
+    ) -> None:
         """
         Adds opening hour information from a localised string.
         :param ranges_string: localised string containing opening
@@ -922,7 +978,13 @@ class OpeningHours:
                            expression.
         """
         # Extract opening time information from localised string.
-        results = OpeningHours.extract_hours_from_string(ranges_string=ranges_string, days=days, named_day_ranges=named_day_ranges, named_times=named_times, delimiters=delimiters)
+        results = OpeningHours.extract_hours_from_string(
+            ranges_string=ranges_string,
+            days=days,
+            named_day_ranges=named_day_ranges,
+            named_times=named_times,
+            delimiters=delimiters,
+        )
 
         # Add ranges to OpeningHours object.
         for result in results:

--- a/locations/spiders/fastbreak_us.py
+++ b/locations/spiders/fastbreak_us.py
@@ -1,5 +1,3 @@
-from locations.hours import OpeningHours, sanitise_day
-from locations.items import Feature
 from locations.storefinders.storerocket import StoreRocketSpider
 
 
@@ -8,13 +6,3 @@ class FastbreakUSSpider(StoreRocketSpider):
     item_attributes = {"brand": "Fastbreak", "brand_wikidata": "Q116731804"}
     storerocket_id = "WwzpABj4dD"
     base_url = "https://www.myfastbreak.com/locations"
-
-    def parse_item(self, item: Feature, location: dict, **kwargs):
-        item["opening_hours"] = OpeningHours()
-        for day, times in location["hours"].items():
-            day = sanitise_day(day)
-            if day and times:
-                start_time, end_time = times.split("-")
-                item["opening_hours"].add_range(day, start_time, end_time)
-
-        yield item

--- a/locations/spiders/ribcrib_us.py
+++ b/locations/spiders/ribcrib_us.py
@@ -1,4 +1,3 @@
-from locations.hours import OpeningHours
 from locations.storefinders.storerocket import StoreRocketSpider
 
 
@@ -9,10 +8,4 @@ class RibCribUSSpider(StoreRocketSpider):
 
     def parse_item(self, item, location):
         item["website"] = "https://ribcrib.com/locations/?location=" + location.get("slug")
-        hours_string = ""
-        for day, hours in location.get("hours", {}).items():
-            day = day.title()
-            hours_string = f"{hours_string} {day}: {hours}"
-        item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_ranges_from_string(hours_string)
         yield item

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -39,9 +39,9 @@ class StoreRocketSpider(Spider):
                     continue
                 hour_ranges = location[day].split(",")
                 for hour_range in hour_ranges:
-                    open_time = hour_range.split("-")[0].strip().replace(" ", "")
-                    close_time = hour_range.split("-")[1].strip().replace(" ", "")
-                    if "AM" in open_time.upper() or "PM" in open_time.upper() or "AM" in close_time.upper() or "PM" in close_time.upper():
+                    open_time = hour_range.split("-")[0].strip().replace(" ", "").upper()
+                    close_time = hour_range.split("-")[1].strip().replace(" ", "").upper()
+                    if "AM" in open_time or "PM" in open_time or "AM" in close_time or "PM" in close_time:
                         if ":" not in open_time:
                             open_time.replace("AM", ":00AM").replace("PM", ":00PM")
                         if ":" not in close_time:

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -35,11 +35,20 @@ class StoreRocketSpider(Spider):
             for day in ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]:
                 if not location[day]:
                     continue
+                if "CLOSED" in location[day].upper():
+                    continue
                 hour_ranges = location[day].split(",")
                 for hour_range in hour_ranges:
-                    open_time = hour_range.split("-")[0].strip()
-                    close_time = hour_range.split("-")[1].strip()
-                    item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
+                    open_time = hour_range.split("-")[0].strip().replace(" ", "")
+                    close_time = hour_range.split("-")[1].strip().replace(" ", "")
+                    if "AM" in open_time.upper() or "PM" in open_time.upper() or "AM" in close_time.upper() or "PM" in close_time.upper():
+                        if ":" not in open_time:
+                            open_time.replace("AM", ":00AM").replace("PM", ":00PM")
+                        if ":" not in close_time:
+                            close_time.replace("AM", ":00AM").replace("PM", ":00PM")
+                        item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time, "%I:%M%p")
+                    else:
+                        item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
 
             yield from self.parse_item(item, location) or []
 

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -2,6 +2,7 @@ from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 
 
@@ -29,6 +30,16 @@ class StoreRocketSpider(Spider):
 
             if self.base_url:
                 item["website"] = f'{self.base_url}?location={location["slug"]}'
+
+            item["opening_hours"] = OpeningHours()
+            for day in ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]:
+                if not location[day]:
+                    continue
+                hour_ranges = location[day].split(",")
+                for hour_range in hour_ranges:
+                    open_time = hour_range.split("-")[0].strip()
+                    close_time = hour_range.split("-")[1].strip()
+                    item["opening_hours"].add_range(DAYS_EN[day.title()], open_time, close_time)
 
             yield from self.parse_item(item, location) or []
 

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -371,6 +371,14 @@ def test_add_ranges_from_string():
     assert o.as_opening_hours() == "24/7"
 
     o = OpeningHours()
+    o.add_ranges_from_string("Monday: 08:00 - Midday, 14:00 - Midnight   tue-sat: Midnight-0800")
+    assert o.as_opening_hours() == "Mo 08:00-12:00,14:00-24:00; Tu-Sa 00:00-08:00"
+
+    o = OpeningHours()
+    o.add_ranges_from_string("Wed 2am-3am, 11am-1pm, 6pm-7pm, Thu midday-3:30pm 4:30pm-5:15pm")
+    assert o.as_opening_hours() == "We 02:00-03:00,11:00-13:00,18:00-19:00; Th 12:00-15:30,16:30-17:15"
+
+    o = OpeningHours()
     o.add_ranges_from_string(
         "Lunes a Domingo: 11:00 a 20:30 / Viernes y Sábado: 11:00 a 21:00",
         days=DAYS_ES,


### PR DESCRIPTION
1. Support multiple time ranges in a single day (or across a range of days) being specified. E.g. Mon-Fri 08:00-13:00, 14:00-18:00. There is no limit to how many ranges can exist per day (e.g. 3 or more are allowed, even though it is unlikely a use case for this exists).
2. Support named times such as Midday and Midnight. These named times can be localised into different languages as required.
3. Split overly complex add_ranges_from_string function into smaller functions.
4. Update StoreRocket store finder to use add_ranges_from_string

Replaces #5009 