### PR TITLE
[mcdonalds_pl] Fix broken spider + more attributes.

### DIFF
--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -22,7 +22,7 @@ class McDonaldsPLSpider(scrapy.Spider):
                         oh.add_range(DAYS[int(day) - 1], "00:00", "23:59")
                     else:
                         oh.add_range(DAYS[int(day) - 1], time.get("from"), time.get("to"))
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
             except Exception as e:
                 self.logger.warning(f"Failed to parse opening hours: {hours}")
 

--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -18,12 +18,12 @@ class McDonaldsPLSpider(scrapy.Spider):
             try:
                 oh = OpeningHours()
                 for day, time in hours.items():
-                    if time.get("alwaysOpen") == True:
+                    if time.get("alwaysOpen") is True:
                         oh.add_range(DAYS[int(day) - 1], "00:00", "23:59")
                     else:
                         oh.add_range(DAYS[int(day) - 1], time.get("from"), time.get("to"))
                 item["opening_hours"] = oh
-            except Exception as e:
+            except:
                 self.logger.warning(f"Failed to parse opening hours: {hours}")
 
     def parse(self, response):

--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 import scrapy
 
 from locations.categories import Extras, apply_yes_no
@@ -31,6 +33,7 @@ class McDonaldsPLSpider(scrapy.Spider):
         for poi in places:
             poi["street_address"] = poi.pop("address")
             item = DictParser.parse(poi)
+            item["website"] = urljoin("https://mcdonalds.pl/restauracje/", poi["slug"])
             self.parse_hours(item, poi)
             apply_yes_no(Extras.WIFI, item, poi.get("wifi"))
             apply_yes_no(Extras.DELIVERY, item, poi.get("mcDelivery"))

--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -1,9 +1,8 @@
 import scrapy
+
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
-
-from locations.items import Feature
 from locations.spiders.mcdonalds import McDonaldsSpider
 
 
@@ -12,26 +11,25 @@ class McDonaldsPLSpider(scrapy.Spider):
     item_attributes = McDonaldsSpider.item_attributes
     allowed_domains = ["mcdonalds.pl"]
 
-    start_urls = ['https://mcdonalds.pl/data/places']
+    start_urls = ["https://mcdonalds.pl/data/places"]
 
     def parse_hours(self, item, poi):
         if hours := poi.get("hours"):
             try:
                 oh = OpeningHours()
                 for day, time in hours.items():
-                    if time.get('alwaysOpen') == True:
-                        oh.add_range(DAYS[int(day) - 1], '00:00', '23:59')
+                    if time.get("alwaysOpen") == True:
+                        oh.add_range(DAYS[int(day) - 1], "00:00", "23:59")
                     else:
-                        oh.add_range(DAYS[int(day) - 1], time.get('from'), time.get('to'))
-                item['opening_hours'] = oh.as_opening_hours()
+                        oh.add_range(DAYS[int(day) - 1], time.get("from"), time.get("to"))
+                item["opening_hours"] = oh.as_opening_hours()
             except Exception as e:
-                self.logger.warning(f'Failed to parse opening hours: {hours}')
-                pass
+                self.logger.warning(f"Failed to parse opening hours: {hours}")
 
     def parse(self, response):
         places = response.json().get("places")
         for poi in places:
-            poi['street_address'] = poi.pop('address')
+            poi["street_address"] = poi.pop("address")
             item = DictParser.parse(poi)
             self.parse_hours(item, poi)
             apply_yes_no(Extras.WIFI, item, poi.get("wifi"))

--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -1,4 +1,7 @@
 import scrapy
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
 
 from locations.items import Feature
 from locations.spiders.mcdonalds import McDonaldsSpider
@@ -9,83 +12,29 @@ class McDonaldsPLSpider(scrapy.Spider):
     item_attributes = McDonaldsSpider.item_attributes
     allowed_domains = ["mcdonalds.pl"]
 
-    start_urls = ("https://mcdonalds.pl/restauracje/getMarkers",)
+    start_urls = ['https://mcdonalds.pl/data/places']
 
-    def store_hours(self, data):
-        day_groups = []
-        this_day_group = {}
-        weekdays = {
-            "1": "Mo",
-            "2": "Th",
-            "3": "We",
-            "4": "Tu",
-            "5": "Fr",
-            "6": "Sa",
-            "7": "Su",
-        }
-
-        for index in data:
-            hours = ""
-
-            short_day = weekdays[index]
-            hours = "{}-{}".format(data[index]["from"], data[index]["to"])
-            if not this_day_group:
-                this_day_group = {
-                    "from_day": short_day,
-                    "to_day": short_day,
-                    "hours": hours,
-                }
-
-            elif hours == this_day_group["hours"]:
-                this_day_group["to_day"] = short_day
-
-            elif hours != this_day_group["hours"]:
-                day_groups.append(this_day_group)
-                this_day_group = {
-                    "from_day": short_day,
-                    "to_day": short_day,
-                    "hours": hours,
-                }
-
-        day_groups.append(this_day_group)
-
-        if not day_groups:
-            return None
-
-        opening_hours = ""
-        if len(day_groups) == 1 and day_groups[0]["hours"] in (
-            "00:00-23:59",
-            "00:00-00:00",
-        ):
-            opening_hours = "24/7"
-        else:
-            for day_group in day_groups:
-                if day_group["from_day"] == day_group["to_day"]:
-                    opening_hours += "{from_day} {hours}; ".format(**day_group)
-                else:
-                    opening_hours += "{from_day}-{to_day} {hours}; ".format(**day_group)
-            opening_hours = opening_hours[:-2]
-
-        return opening_hours
+    def parse_hours(self, item, poi):
+        if hours := poi.get("hours"):
+            try:
+                oh = OpeningHours()
+                for day, time in hours.items():
+                    if time.get('alwaysOpen') == True:
+                        oh.add_range(DAYS[int(day) - 1], '00:00', '23:59')
+                    else:
+                        oh.add_range(DAYS[int(day) - 1], time.get('from'), time.get('to'))
+                item['opening_hours'] = oh.as_opening_hours()
+            except Exception as e:
+                self.logger.warning(f'Failed to parse opening hours: {hours}')
+                pass
 
     def parse(self, response):
-        results = response.json()
-
-        for item in results:
-            properties = {
-                "addr_full": item["address"],
-                "city": item["city"],
-                "name": "McDonald's",
-                "postcode": item["postCode"],
-                "phone": item["phone"],
-                "ref": item["id"],
-                "lon": item["lng"],
-                "lat": item["lat"],
-                "state": item["province"],
-            }
-
-            opening_hours = self.store_hours(item["hours"])
-            if opening_hours:
-                properties["opening_hours"] = opening_hours
-
-            yield Feature(**properties)
+        places = response.json().get("places")
+        for poi in places:
+            poi['street_address'] = poi.pop('address')
+            item = DictParser.parse(poi)
+            self.parse_hours(item, poi)
+            apply_yes_no(Extras.WIFI, item, poi.get("wifi"))
+            apply_yes_no(Extras.DELIVERY, item, poi.get("mcDelivery"))
+            apply_yes_no(Extras.DRIVE_THROUGH, item, poi.get("mcDrive"))
+            yield item


### PR DESCRIPTION
Similar to #5954.
<details><summary>Stats</summary>

```json
{
 "atp/brand/McDonald's": 532,
 "atp/brand_wikidata/Q38076": 532,
 "atp/category/amenity/fast_food": 532,
 "atp/field/country/from_spider_name": 532,
 "atp/field/email/missing": 532,
 "atp/field/image/missing": 532,
 "atp/field/name/missing": 532,
 "atp/field/twitter/missing": 532,
 "atp/field/website/missing": 532,
 "atp/nsi/category_match": 532,
 "downloader/request_bytes": 607,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 88650,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 2.708991,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-09-27T07:41:08.994143",
 "httpcompression/response_bytes": 1233915,
 "httpcompression/response_count": 1,
 "item_scraped_count": 532,
 "log_count/INFO": 10,
 "memusage/max": 140705792,
 "memusage/startup": 140705792,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2023-09-27T07:41:06.285152"
}
```
</details>