### PR TITLE
Added Kindergarten Category Tag

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -121,6 +121,7 @@ class Categories(Enum):
     FUEL_STATION = {"amenity": "fuel"}
     HOSPITAL = {"amenity": "hospital", "healthcare": "hospital"}
     HOTEL = {"tourism": "hotel"}
+    KINDERGARTEN = {"amenity": "kindergarten"}
     LIBRARY = {"amenity": "library"}
     MONEY_TRANSFER = {"amenity": "money_transfer"}
     MUSEUM = {"tourism": "museum"}

--- a/locations/spiders/childcare_network_us.py
+++ b/locations/spiders/childcare_network_us.py
@@ -6,6 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class ChildcareNetworkUSSpider(SitemapSpider, StructuredDataSpider):
     name = "childcare_network_us"
+    item_attributes = {"brand": "Childcare Network", "brand_wikidata": "Q110127908"}
     sitemap_urls = ["https://schools.childcarenetwork.com/robots.txt"]
     sitemap_rules = [(r"\.com/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
     wanted_types = ["EducationalOrganization"]
@@ -13,5 +14,4 @@ class ChildcareNetworkUSSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = response.xpath("//h2/text()").get()
-        apply_category({"amenity": "kindergarten"}, item)
         yield item

--- a/locations/spiders/childcare_network_us.py
+++ b/locations/spiders/childcare_network_us.py
@@ -1,6 +1,5 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 

--- a/locations/spiders/childcare_network_us.py
+++ b/locations/spiders/childcare_network_us.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -12,5 +13,5 @@ class ChildcareNetworkUSSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = response.xpath("//h2/text()").get()
-
+        apply_category({"amenity": "kindergarten"}, item)
         yield item


### PR DESCRIPTION
A collection of daycares for little youngsters to young for primary, middle, and secondary schools.

<details><summary>Stats</summary>

```python
{'atp/category/amenity/kindergarten': 228,
 'atp/field/brand/missing': 228,
 'atp/field/brand_wikidata/missing': 228,
 'atp/field/country/from_spider_name': 228,
 'atp/field/email/missing': 228,
 'atp/field/image/dropped': 228,
 'atp/field/image/missing': 228,
 'downloader/request_bytes': 92613,
 'downloader/request_count': 232,
 'downloader/request_method_count/GET': 232,
 'downloader/response_bytes': 4431461,
 'downloader/response_count': 232,
 'downloader/response_status_count/200': 231,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 3.954842,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 5, 12, 46, 52, 374096),
 'httpcompression/response_bytes': 21629085,
 'httpcompression/response_count': 231,
 'item_scraped_count': 228,
 'log_count/DEBUG': 461,
 'log_count/INFO': 9,
 'memusage/max': 131985408,
 'memusage/startup': 131985408,
 'request_depth_max': 2,
 'response_received_count': 231,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 231,
 'scheduler/dequeued/memory': 231,
 'scheduler/enqueued': 231,
 'scheduler/enqueued/memory': 231,
 'start_time': datetime.datetime(2023, 10, 5, 12, 46, 48, 419254)}
```
</details>