### PR TITLE
Added Charging Station Category to Fastned

### DIFF
--- a/locations/spiders/fastned.py
+++ b/locations/spiders/fastned.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -11,6 +12,9 @@ class FastnedSpider(Spider):
     def parse(self, response, **kwargs):
         for location in response.json():
             item = DictParser.parse(location)
+
+            apply_category(Categories.CHARGING_STATION, item)
+            item["extras"]["operator"] = "Fastned"
 
             # TODO: connector data available in location["connectors"]
             yield item


### PR DESCRIPTION
Category does not get added in apply_nsi_categories as there are ambiguous matches.

<details><summary>Stats</summary>

```python
{'atp/brand/Fastned': 280,
 'atp/brand_wikidata/Q19935749': 280,
 'atp/category/amenity/charging_station': 280,
 'atp/field/email/missing': 280,
 'atp/field/image/missing': 280,
 'atp/field/opening_hours/missing': 280,
 'atp/field/phone/missing': 280,
 'atp/field/postcode/missing': 278,
 'atp/field/state/missing': 280,
 'atp/field/street_address/missing': 280,
 'atp/field/twitter/missing': 280,
 'atp/field/website/missing': 280,
 'atp/nsi/category_match': 242,
 'atp/nsi/match_failed': 38,
 'downloader/request_bytes': 618,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13531,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.600944,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 5, 13, 2, 16, 658450),
 'httpcompression/response_bytes': 101045,
 'httpcompression/response_count': 1,
 'item_scraped_count': 280,
 'log_count/DEBUG': 293,
 'log_count/INFO': 9,
 'memusage/max': 131878912,
 'memusage/startup': 131878912,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 5, 13, 2, 14, 57506)}
```
</details>