### PR TITLE
Fixed the bug easypay_bg.py that caused countries of all items to be set to BG

### DIFF
--- a/locations/spiders/easypay.py
+++ b/locations/spiders/easypay.py
@@ -3,8 +3,8 @@ from scrapy.spiders import CSVFeedSpider
 from locations.dict_parser import DictParser
 
 
-class EasypayBGSpider(CSVFeedSpider):
-    name = "easypay"  # the name is not set to easypay_bg, because then name would be used to extract "country", and "country" in every item would be set to "BG", which is wrong.
+class EasypaySpider(CSVFeedSpider):
+    name = "easypay"  # the name is not set to easypay_bg, because then name would be used to extract "country" by the pipeline, and "country" in every item would be set to "BG", which is wrong.
     item_attributes = {"brand": "EasyPay", "brand_wikidata": "Q110583289"}
     start_urls = ["https://www.easypay.bg/site/en/offices.csv"]
     delimiter = "|"

--- a/locations/spiders/easypay_bg.py
+++ b/locations/spiders/easypay_bg.py
@@ -4,7 +4,7 @@ from locations.dict_parser import DictParser
 
 
 class EasypayBGSpider(CSVFeedSpider):
-    name = "easypay" #the name is not set to easypay_bg, because then name would be used to extract "country", and "country" in every item would be set to "BG", which is wrong.
+    name = "easypay"  # the name is not set to easypay_bg, because then name would be used to extract "country", and "country" in every item would be set to "BG", which is wrong.
     item_attributes = {"brand": "EasyPay", "brand_wikidata": "Q110583289"}
     start_urls = ["https://www.easypay.bg/site/en/offices.csv"]
     delimiter = "|"

--- a/locations/spiders/easypay_bg.py
+++ b/locations/spiders/easypay_bg.py
@@ -4,7 +4,7 @@ from locations.dict_parser import DictParser
 
 
 class EasypayBGSpider(CSVFeedSpider):
-    name = "easypay_bg"
+    name = "easypay" #the name is not set to easypay_bg, because then name would be used to extract "country", and "country" in every item would be set to "BG", which is wrong.
     item_attributes = {"brand": "EasyPay", "brand_wikidata": "Q110583289"}
     start_urls = ["https://www.easypay.bg/site/en/offices.csv"]
     delimiter = "|"


### PR DESCRIPTION
Fixes #6032 

## Description
So, as there is no country data in the csv, the country is set to `None` for all items. The pipeline then runs [country_code_clean_up.py](https://github.com/alltheplaces/alltheplaces/blob/master/locations/pipelines/country_code_clean_up.py#L20). And it extracts the country from the **spider name**, which in this case is `easypay_bg`. This is why all countries were set to `BG`. The reverse geocoding did not even happen.

So the sipder name is changed to `easypay`. Now reverse geocoding takes care of all the countries. The distribution is as follows:

BG-3267
RO-24
CY-14
GR-10
MK-3
AT-1

In the future, if more spiders for easypay were to be created, the spider name can be changed to `easypay_1`.
The file name, and the class name can also be changed  if required, in order to match the spider name.