### PR TITLE
Add Neonet (PL) (259 locations).

### DIFF
--- a/locations/spiders/neonet_pl.py
+++ b/locations/spiders/neonet_pl.py
@@ -4,7 +4,7 @@ import json
 from scrapy.spiders import SitemapSpider
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, sanitise_day
+from locations.hours import OpeningHours
 
 
 class NeonetPLSpider(SitemapSpider):

--- a/locations/spiders/neonet_pl.py
+++ b/locations/spiders/neonet_pl.py
@@ -1,0 +1,25 @@
+import html
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, sanitise_day
+
+
+class NeonetPLSpider(SitemapSpider):
+    name = "neonet_pl"
+    item_attributes = {"brand": "Neonet", "brand_wikidata": "Q11790622"}
+    sitemap_urls = ["https://sklepy.neonet.pl/sitemap.xml"]
+    sitemap_rules = [(r"/polska/.*[0-9]$", "parse")]
+
+    def parse(self, response):
+        data = json.loads(
+            html.unescape(response.xpath('//*[@type = "application/ld+json"]').xpath("normalize-space()").get())
+        )[1]
+        item = DictParser.parse(data)
+        item["ref"] = data.get("@id")
+        oh = OpeningHours()
+        oh.from_linked_data(data)
+        item["opening_hours"] = oh.as_opening_hours()
+        yield item

--- a/locations/spiders/neonet_pl.py
+++ b/locations/spiders/neonet_pl.py
@@ -20,5 +20,5 @@ class NeonetPLSpider(SitemapSpider):
         item = DictParser.parse(data)
         item["ref"] = data.get("@id")
         item["opening_hours"] = OpeningHours()
-        item['opening_hours'].from_linked_data(data)
+        item["opening_hours"].from_linked_data(data)
         yield item

--- a/locations/spiders/neonet_pl.py
+++ b/locations/spiders/neonet_pl.py
@@ -19,7 +19,6 @@ class NeonetPLSpider(SitemapSpider):
         )[1]
         item = DictParser.parse(data)
         item["ref"] = data.get("@id")
-        oh = OpeningHours()
-        oh.from_linked_data(data)
-        item["opening_hours"] = oh.as_opening_hours()
+        item["opening_hours"] = OpeningHours()
+        item['opening_hours'].from_linked_data(data)
         yield item


### PR DESCRIPTION
Stats:
```json
{
 "atp/brand/Neonet": 259,
 "atp/brand_wikidata/Q11790622": 259,
 "atp/category/shop/electronics": 259,
 "atp/field/country/from_spider_name": 259,
 "atp/field/email/missing": 259,
 "atp/field/image/missing": 259,
 "atp/field/state/missing": 257,
 "atp/field/twitter/missing": 259,
 "atp/nsi/perfect_match": 259,
 "downloader/request_bytes": 104059,
 "downloader/request_count": 262,
 "downloader/request_method_count/GET": 262,
 "downloader/response_bytes": 3324188,
 "downloader/response_count": 262,
 "downloader/response_status_count/200": 261,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 320.872311,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-10-11T11:20:47.815586",
 "httpcompression/response_bytes": 14225241,
 "httpcompression/response_count": 261,
 "httperror/response_ignored_count": 1,
 "httperror/response_ignored_status_count/404": 1,
 "item_scraped_count": 259,
 "log_count/INFO": 16,
 "memusage/max": 283656192,
 "memusage/startup": 141193216,
 "request_depth_max": 1,
 "response_received_count": 262,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 261,
 "scheduler/dequeued/memory": 261,
 "scheduler/enqueued": 261,
 "scheduler/enqueued/memory": 261,
 "start_time": "2023-10-11T11:15:26.943275"
}
```