### PR TITLE
[Ralph Lauren] Flag as requiring a proxy

### DIFF
--- a/locations/spiders/ralph_lauren.py
+++ b/locations/spiders/ralph_lauren.py
@@ -14,6 +14,7 @@ class RalphLaurenSpider(scrapy.Spider):
     custom_settings = {"COOKIES_ENABLED": False, "ROBOTSTXT_OBEY": False}
     download_delay = 10
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         for country in filter(


### PR DESCRIPTION
Rel: https://github.com/alltheplaces/alltheplaces/pull/5949

I see it worked one week, but then not again. I'm in the same situation as before, it fails from GB due to redirects. US vpn works:

```python
{'atp/brand/Polo Ralph Lauren': 481,
 'atp/brand_wikidata/Q1641437': 481,
 'atp/category/shop/clothes': 481,
 'atp/field/brand/missing': 481,
 'atp/field/city/missing': 2,
 'atp/field/country/from_reverse_geocoding': 19,
 'atp/field/email/invalid': 4,
 'atp/field/email/missing': 440,
 'atp/field/image/missing': 481,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 481,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 26,
 'atp/field/state/missing': 208,
 'atp/field/twitter/missing': 481,
 'atp/nsi/perfect_match': 481,
 'downloader/request_bytes': 19295,
 'downloader/request_count': 48,
 'downloader/request_method_count/GET': 48,
 'downloader/response_bytes': 5291585,
 'downloader/response_count': 48,
 'downloader/response_status_count/200': 48,
 'elapsed_time_seconds': 582.675782,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 13, 46, 36, 52951),
 'httpcompression/response_bytes': 32348133,
 'httpcompression/response_count': 48,
 'item_scraped_count': 481,
 'log_count/DEBUG': 540,
 'log_count/INFO': 18,
 'memusage/max': 420573184,
 'memusage/startup': 146583552,
 'request_depth_max': 1,
 'response_received_count': 48,
 'scheduler/dequeued': 48,
 'scheduler/dequeued/memory': 48,
 'scheduler/enqueued': 48,
 'scheduler/enqueued/memory': 48,
 'start_time': datetime.datetime(2023, 10, 11, 13, 36, 53, 377169)}
```