### PR TITLE
Added fuel station category tag for f24 brand

### DIFF
--- a/locations/spiders/f24.py
+++ b/locations/spiders/f24.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
@@ -34,6 +35,8 @@ class F24Spider(Spider):
 
             if brand := self.BRANDS.get(location["net"]):
                 item.update(brand)
+
+            apply_category(Categories.FUEL_STATION, item)
 
             yield item
 


### PR DESCRIPTION
Brands are in NSI, but have same QID for different categories, thus category never gets added.

<details><summary>Stats</summary>

```python
{'atp/brand/F24': 140,
 'atp/brand/Q8': 107,
 'atp/brand_wikidata/Q12310853': 140,
 'atp/brand_wikidata/Q1634762': 107,
 'atp/category/amenity/fuel': 247,
 'atp/field/country/from_website_url': 247,
 'atp/field/email/missing': 247,
 'atp/field/image/missing': 247,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/postcode/missing': 247,
 'atp/field/state/missing': 247,
 'atp/field/twitter/missing': 247,
 'atp/nsi/category_match': 247,
 'downloader/request_bytes': 673,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 366766,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.497765,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 16, 27, 54, 258159),
 'httpcompression/response_bytes': 73,
 'httpcompression/response_count': 1,
 'item_scraped_count': 247,
 'log_count/DEBUG': 260,
 'log_count/INFO': 9,
 'memusage/max': 132136960,
 'memusage/startup': 132136960,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 11, 16, 27, 50, 760394)}
```
</details>