### PR TITLE
Add category to Boots NO

### DIFF
--- a/locations/spiders/boots_no.py
+++ b/locations/spiders/boots_no.py
@@ -3,12 +3,13 @@ import urllib.parse
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
 class BootsNOSpider(scrapy.Spider):
     name = "boots_no"
-    item_attributes = {"brand": "Apotek", "brand_wikidata": "Q4581428"}
+    item_attributes = {"brand": "Boots", "brand_wikidata": "Q6123139"}
     allowed_domains = ["apotek.boots.no", "zpin.it"]
     download_delay = 0.5
     start_urls = [
@@ -33,6 +34,7 @@ class BootsNOSpider(scrapy.Spider):
             "website": response.meta["website"],
         }
 
+        apply_category(Categories.PHARMACY, properties)
         yield Feature(**properties)
 
     def parse_store(self, response):

--- a/locations/spiders/boots_no.py
+++ b/locations/spiders/boots_no.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class BootsNOSpider(scrapy.Spider):
     name = "boots_no"
-    item_attributes = {"brand": "Boots", "brand_wikidata": "Q6123139"}
+    item_attributes = {"brand": "Apotek", "brand_wikidata": "Q4581428"}
     allowed_domains = ["apotek.boots.no", "zpin.it"]
     download_delay = 0.5
     start_urls = [


### PR DESCRIPTION
The qcode pointed to Boots in the united kingdom. But Apotek is the pharmacy chain that is in norway.

<details><summary>Stats</summary>

```python
{'atp/brand/Apotek': 153,
 'atp/brand_wikidata/Q4581428': 153,
 'atp/category/amenity/pharmacy': 153,
 'atp/category/multiple': 153,
 'atp/field/city/missing': 153,
 'atp/field/email/missing': 153,
 'atp/field/image/missing': 153,
 'atp/field/opening_hours/missing': 153,
 'atp/field/phone/missing': 153,
 'atp/field/postcode/missing': 153,
 'atp/field/state/missing': 153,
 'atp/field/street_address/missing': 153,
 'atp/field/twitter/missing': 153,
 'atp/nsi/perfect_match': 153,
 'downloader/request_bytes': 115978,
 'downloader/request_count': 309,
 'downloader/request_method_count/GET': 309,
 'downloader/response_bytes': 5131379,
 'downloader/response_count': 309,
 'downloader/response_status_count/200': 307,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 97.158714,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 16, 41, 54, 157755),
 'httpcompression/response_bytes': 37493501,
 'httpcompression/response_count': 307,
 'item_scraped_count': 153,
 'log_count/DEBUG': 473,
 'log_count/INFO': 10,
 'memusage/max': 289124352,
 'memusage/startup': 132399104,
 'request_depth_max': 2,
 'response_received_count': 309,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 307,
 'scheduler/dequeued/memory': 307,
 'scheduler/enqueued': 307,
 'scheduler/enqueued/memory': 307,
 'start_time': datetime.datetime(2023, 10, 11, 16, 40, 16, 999041)}
```
</details>