### PR TITLE
Added fuel category tag for UDF brand

### DIFF
--- a/locations/spiders/united_dairy_farmers_us.py
+++ b/locations/spiders/united_dairy_farmers_us.py
@@ -2,6 +2,7 @@ import re
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -57,4 +58,5 @@ class UnitedDairyFarmersUSSpider(scrapy.Spider):
                 "lon": float(data[8].split(":")[1]),
             }
 
+        apply_category(Categories.FUEL_STATION, properties)
         yield Feature(**properties)


### PR DESCRIPTION
Is in NSI but as advertising, fuel, and ice cream shop. Thus added fueld category tag.

<details><summary>Stats</summary>

```python
{'atp/brand/United Dairy Farmers': 178,
 'atp/brand_wikidata/Q7887677': 178,
 'atp/category/amenity/fuel': 178,
 'atp/cdn/cloudflare/response_count': 180,
 'atp/cdn/cloudflare/response_status_count/200': 180,
 'atp/field/country/from_spider_name': 89,
 'atp/field/email/missing': 178,
 'atp/field/image/missing': 178,
 'atp/field/opening_hours/missing': 178,
 'atp/field/phone/missing': 9,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/street_address/missing': 178,
 'atp/field/twitter/missing': 178,
 'atp/field/website/missing': 178,
 'atp/nsi/category_match': 178,
 'downloader/request_bytes': 69288,
 'downloader/request_count': 180,
 'downloader/request_method_count/GET': 180,
 'downloader/response_bytes': 3337048,
 'downloader/response_count': 180,
 'downloader/response_status_count/200': 180,
 'elapsed_time_seconds': 45.997255,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 19, 8, 43, 496067),
 'httpcompression/response_bytes': 10759451,
 'httpcompression/response_count': 180,
 'item_scraped_count': 178,
 'log_count/DEBUG': 369,
 'log_count/INFO': 9,
 'memusage/max': 132341760,
 'memusage/startup': 132341760,
 'request_depth_max': 1,
 'response_received_count': 180,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 179,
 'scheduler/dequeued/memory': 179,
 'scheduler/enqueued': 179,
 'scheduler/enqueued/memory': 179,
 'start_time': datetime.datetime(2023, 10, 11, 19, 7, 57, 498812)}
```