### PR TITLE
Add liberty_au spider (92 locations)

### DIFF
--- a/locations/spiders/liberty_au.py
+++ b/locations/spiders/liberty_au.py
@@ -1,6 +1,8 @@
 import scrapy
+from scrapy import Selector
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
 class LibertyAUSpider(scrapy.Spider):
@@ -9,23 +11,11 @@ class LibertyAUSpider(scrapy.Spider):
     allowed_domains = ["libertyconvenience.com.au"]
     start_urls = ["https://www.libertyconvenience.com.au/wp-admin/admin-ajax.php?action=store_search&autoload=1"]
 
-    def parse_hours(store_hours):
-        pass
-
     def parse(self, response):
-        locations = response.json()
-        for loc in locations:
-            yield Feature(
-                {
-                    "ref": loc["id"],
-                    "branch": loc["store"],
-                    "street_address": loc["address"],
-                    "city": loc["city"],
-                    "state": loc["state"],
-                    "postcode": loc["zip"],
-                    "country": loc["country"],
-                    "lat": loc["lat"],
-                    "lon": loc["lng"],
-                    "phone": loc["phone"],
-                }
-            )
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full", None)
+            hours_string = " ".join(filter(None, Selector(text=location["hours"]).xpath("//text()").getall()))
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours_string)
+            yield item

--- a/locations/spiders/liberty_au.py
+++ b/locations/spiders/liberty_au.py
@@ -1,0 +1,31 @@
+import scrapy
+
+from locations.items import Feature
+
+
+class LibertyAUSpider(scrapy.Spider):
+    name = "liberty_au"
+    item_attributes = {"brand": "Liberty Oil", "brand_wikidata": "Q106687078"}
+    allowed_domains = ["libertyconvenience.com.au"]
+    start_urls = ["https://www.libertyconvenience.com.au/wp-admin/admin-ajax.php?action=store_search&autoload=1"]
+
+    def parse_hours(store_hours):
+        pass
+
+    def parse(self, response):
+        locations = response.json()
+        for loc in locations:
+            yield Feature(
+                {
+                    "ref": loc["id"],
+                    "branch": loc["store"],
+                    "street_address": loc["address"],
+                    "city": loc["city"],
+                    "state": loc["state"],
+                    "postcode": loc["zip"],
+                    "country": loc["country"],
+                    "lat": loc["lat"],
+                    "lon": loc["lng"],
+                    "phone": loc["phone"],
+                }
+            )


### PR DESCRIPTION
Added a `liberty_au` spider for Liberty fuel stations in Australia.

Closes #6071