### PR TITLE
Added new brandname and wikidata code for Carhartt WIP

### DIFF
--- a/locations/spiders/carhartt_wip.py
+++ b/locations/spiders/carhartt_wip.py
@@ -7,9 +7,7 @@ from locations.items import Feature
 
 class CarharttWipSpider(Spider):
     name = "carhartt_wip"
-    item_attributes = {
-        "brand": "Carhartt WIP",
-    }
+    item_attributes = {"brand": "Carhartt Work in Progress", "brand_wikidata": "Q123015694"}
     graphql_url = "https://carharrt-storefinder-api.herokuapp.com/graphql"
 
     def start_requests(self):


### PR DESCRIPTION
Just created a wikidata page for Carhartt WIP brand and also have a PR for NSI addition.
https://github.com/osmlab/name-suggestion-index/pull/8788

<details><summary>Stats</summary>

```python
{'atp/brand/Carhartt Work in Progress': 86,
 'atp/brand_wikidata/Q123015694': 86,
 'atp/category/missing': 86,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 86,
 'atp/field/opening_hours/missing': 3,
 'atp/field/phone/missing': 2,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/state/missing': 84,
 'atp/field/twitter/missing': 86,
 'atp/nsi/brand_missing': 86,
 'downloader/request_bytes': 7856,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 3,
 'downloader/response_bytes': 134920,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.757359,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 22, 29, 20, 768212),
 'item_scraped_count': 86,
 'log_count/DEBUG': 102,
 'log_count/INFO': 9,
 'memusage/max': 132485120,
 'memusage/startup': 132485120,
 'response_received_count': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2023, 10, 11, 22, 29, 15, 10853)}
```
</details>