### PR TITLE
Added car repair category tag to Midas_au Brand

### DIFF
--- a/locations/spiders/midas_au.py
+++ b/locations/spiders/midas_au.py
@@ -4,6 +4,7 @@ from urllib.parse import unquote
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -56,4 +57,5 @@ class MidasAUSpider(Spider):
                     break
             properties["opening_hours"] = OpeningHours()
             properties["opening_hours"].add_ranges_from_string(hours_string)
+            apply_category(Categories.SHOP_CAR_REPAIR, properties)
             yield Feature(**properties)


### PR DESCRIPTION
I added apply_category to apply the category. But not sure if we should instead change the brand qcode. The qcode is correct, but the global/US https://www.wikidata.org/wiki/Q3312613 Midas qcode is in NSI as Car Repair and includes the globe. Curious what others think, should we add another Midas AU in NSI?

<details><summary>Stats</summary>

```python
{'atp/brand/Midas': 79,
 'atp/brand_wikidata/Q118383658': 79,
 'atp/category/shop/car_repair': 79,
 'atp/field/city/missing': 79,
 'atp/field/country/from_spider_name': 79,
 'atp/field/email/invalid': 1,
 'atp/field/image/missing': 79,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 79,
 'atp/field/state/missing': 79,
 'atp/field/street_address/missing': 79,
 'atp/field/twitter/missing': 79,
 'atp/nsi/brand_missing': 79,
 'downloader/request_bytes': 839,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 30392,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.763681,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 11, 23, 29, 26, 654056),
 'httpcompression/response_bytes': 341893,
 'httpcompression/response_count': 2,
 'item_scraped_count': 79,
 'log_count/INFO': 9,
 'memusage/max': 132489216,
 'memusage/startup': 132489216,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 11, 23, 29, 22, 890375)}
```
</details>