### PR TITLE
[hilton] fix broken spider.

### DIFF
--- a/locations/spiders/hilton.py
+++ b/locations/spiders/hilton.py
@@ -16,7 +16,7 @@ class HiltonSpider(SitemapSpider, StructuredDataSpider):
         "USER_AGENT": CHROME_LATEST,
         "DOWNLOAD_DELAY": 0.2,
     }
-    visited_pages = []
+    visited_pages = set()
 
     HILTON_DOUBLETREE = ["DoubleTree by Hilton", "Q2504643"]
     HILTON_HOTELS = ["Hilton Hotels & Resorts", "Q598884"]
@@ -60,7 +60,7 @@ class HiltonSpider(SitemapSpider, StructuredDataSpider):
                     continue
 
                 yield scrapy.Request(hotel_url, callback=self.parse_sd)
-                self.visited_pages.append(hotel_name)
+                self.visited_pages.add(hotel_name)
 
     def lookup_brand(self, response):
         if "-dt-doubletree-" in response.url:

--- a/locations/spiders/hilton.py
+++ b/locations/spiders/hilton.py
@@ -1,13 +1,21 @@
+from pathlib import Path
+from urllib.parse import urlparse
 import geonamescache
 import scrapy
+from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import CHROME_118
 
 
-class HiltonSpider(scrapy.spiders.SitemapSpider, StructuredDataSpider):
+class HiltonSpider(SitemapSpider, StructuredDataSpider):
     name = "hilton"
     sitemap_urls = ["https://www.hilton.com/sitemap.xml"]
-    download_delay = 0.2
+    custom_settings = {
+        "USER_AGENT": CHROME_118,
+        "DOWNLOAD_DELAY": 0.2,
+    }
+    visited_pages = []
 
     HILTON_DOUBLETREE = ["DoubleTree by Hilton", "Q2504643"]
     HILTON_HOTELS = ["Hilton Hotels & Resorts", "Q598884"]
@@ -43,7 +51,15 @@ class HiltonSpider(scrapy.spiders.SitemapSpider, StructuredDataSpider):
             if x.url.endswith(".xml"):
                 yield x
             elif x.url.endswith("/hotel-info/"):
-                yield scrapy.Request(x.url.replace("/hotel-info/", "/"), callback=self.parse_sd)
+                hotel_url = x.url.replace("/hotel-info/", "/")
+                hotel_name = Path(urlparse(hotel_url).path).name
+                
+                if hotel_name in self.visited_pages:
+                    # There are localized pages for each hotel, don't scrape same hotel twice.
+                    continue
+
+                yield scrapy.Request(hotel_url, callback=self.parse_sd)
+                self.visited_pages.append(hotel_name)
 
     def lookup_brand(self, response):
         if "-dt-doubletree-" in response.url:
@@ -57,7 +73,12 @@ class HiltonSpider(scrapy.spiders.SitemapSpider, StructuredDataSpider):
         if brand := self.lookup_brand(response):
             if isinstance(brand, str):
                 return
-            item["ref"] = response.url
+            
+            # Last part of url is unique
+            item["ref"] = Path(urlparse(response.url).path).name
+            # Website provided in structured data does not work, so replace it with working url
+            item["website"] = response.url
+
             item["brand"], item["brand_wikidata"] = brand
             # In many cases the street address is set by Hilton to be the full address
             # of the property. A certain amount of fixup can be attempted.

--- a/locations/spiders/hilton.py
+++ b/locations/spiders/hilton.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from urllib.parse import urlparse
+
 import geonamescache
 import scrapy
 from scrapy.spiders import SitemapSpider
@@ -53,7 +54,7 @@ class HiltonSpider(SitemapSpider, StructuredDataSpider):
             elif x.url.endswith("/hotel-info/"):
                 hotel_url = x.url.replace("/hotel-info/", "/")
                 hotel_name = Path(urlparse(hotel_url).path).name
-                
+
                 if hotel_name in self.visited_pages:
                     # There are localized pages for each hotel, don't scrape same hotel twice.
                     continue
@@ -73,7 +74,7 @@ class HiltonSpider(SitemapSpider, StructuredDataSpider):
         if brand := self.lookup_brand(response):
             if isinstance(brand, str):
                 return
-            
+
             # Last part of url is unique
             item["ref"] = Path(urlparse(response.url).path).name
             # Website provided in structured data does not work, so replace it with working url

--- a/locations/spiders/hilton.py
+++ b/locations/spiders/hilton.py
@@ -6,14 +6,14 @@ import scrapy
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import CHROME_118
+from locations.user_agents import CHROME_LATEST
 
 
 class HiltonSpider(SitemapSpider, StructuredDataSpider):
     name = "hilton"
     sitemap_urls = ["https://www.hilton.com/sitemap.xml"]
     custom_settings = {
-        "USER_AGENT": CHROME_118,
+        "USER_AGENT": CHROME_LATEST,
         "DOWNLOAD_DELAY": 0.2,
     }
     visited_pages = []

--- a/locations/user_agents.py
+++ b/locations/user_agents.py
@@ -6,6 +6,7 @@ FIREFOX_107 = "Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/
 FIREFOX_LATEST = FIREFOX_107
 
 CHROME_106 = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
-CHROME_LATEST = CHROME_106
+CHROME_118 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+CHROME_LATEST = CHROME_118
 
 BROWSER_DEFAULT = FIREFOX_ESR_LATEST

--- a/locations/user_agents.py
+++ b/locations/user_agents.py
@@ -6,7 +6,9 @@ FIREFOX_107 = "Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/
 FIREFOX_LATEST = FIREFOX_107
 
 CHROME_106 = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
-CHROME_118 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+CHROME_118 = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+)
 CHROME_LATEST = CHROME_118
 
 BROWSER_DEFAULT = FIREFOX_ESR_LATEST


### PR DESCRIPTION
Hilton website now likes only latest browsers.
<details><summary>Stats:</summary>

```json
{
 "atp/brand/Canopy by Hilton": 43,
 "atp/brand/Conrad Hotels & Resorts": 50,
 "atp/brand/DoubleTree by Hilton": 696,
 "atp/brand/Embassy Suites": 273,
 "atp/brand/Hampton by Hilton": 2985,
 "atp/brand/Hilton Garden Inn": 1023,
 "atp/brand/Hilton Hotels & Resorts": 619,
 "atp/brand/Home2 Suites by Hilton": 684,
 "atp/brand/Homewood Suites by Hilton": 544,
 "atp/brand/LXR Hotels & Resorts": 9,
 "atp/brand/Motto by Hilton": 8,
 "atp/brand/Tru by Hilton": 263,
 "atp/brand/Waldorf Astoria": 36,
 "atp/brand_wikidata/Q112144350": 8,
 "atp/brand_wikidata/Q1162859": 1023,
 "atp/brand_wikidata/Q24907770": 263,
 "atp/brand_wikidata/Q2504643": 696,
 "atp/brand_wikidata/Q30632909": 43,
 "atp/brand_wikidata/Q3239392": 36,
 "atp/brand_wikidata/Q5369524": 273,
 "atp/brand_wikidata/Q5646230": 2985,
 "atp/brand_wikidata/Q5887912": 684,
 "atp/brand_wikidata/Q5890701": 544,
 "atp/brand_wikidata/Q598884": 619,
 "atp/brand_wikidata/Q64605184": 9,
 "atp/brand_wikidata/Q855525": 50,
 "atp/category/tourism/hotel": 7233,
 "atp/field/email/invalid": 31,
 "atp/field/email/missing": 6434,
 "atp/field/image/dropped": 9,
 "atp/field/image/missing": 9,
 "atp/field/opening_hours/missing": 7233,
 "atp/field/phone/invalid": 22,
 "atp/field/phone/missing": 16,
 "atp/field/postcode/missing": 145,
 "atp/field/state/missing": 1393,
 "atp/field/street_address/missing": 219,
 "atp/field/twitter/missing": 133,
 "atp/nsi/cc_match": 2985,
 "atp/nsi/perfect_match": 4248,
 "downloader/request_bytes": 11211377,
 "downloader/request_count": 7601,
 "downloader/request_method_count/GET": 7601,
 "downloader/response_bytes": 1890055113,
 "downloader/response_count": 7601,
 "downloader/response_status_count/200": 7593,
 "downloader/response_status_count/301": 4,
 "downloader/response_status_count/308": 1,
 "downloader/response_status_count/404": 1,
 "downloader/response_status_count/502": 2,
 "dupefilter/filtered": 1,
 "elapsed_time_seconds": 2367.997958,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-10-12T12:27:39.970989",
 "httpcompression/response_bytes": 2383861681,
 "httpcompression/response_count": 7550,
 "httperror/response_ignored_count": 1,
 "httperror/response_ignored_status_count/404": 1,
 "item_scraped_count": 7233,
 "log_count/ERROR": 17,
 "log_count/INFO": 50,
 "log_count/WARNING": 30,
 "memusage/max": 2884624384,
 "memusage/startup": 140181504,
 "request_depth_max": 2,
 "response_received_count": 7594,
 "retry/count": 2,
 "retry/reason_count/502 Bad Gateway": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 7600,
 "scheduler/dequeued/memory": 7600,
 "scheduler/enqueued": 7600,
 "scheduler/enqueued/memory": 7600,
 "start_time": "2023-10-12T11:48:11.973031"
}
```
</details>

I also made sure a `carrefour_be` spider which uses CHROME_LATEST still work.