### PR TITLE
Added Car Shop Category Tag

### DIFF
--- a/locations/spiders/audi_be.py
+++ b/locations/spiders/audi_be.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -38,5 +39,5 @@ class AudiBeSpider(scrapy.Spider):
             item["phone"] = row.get("TEL")
             item["website"] = row.get("URL")
             item["email"] = row.get("MAIL")
-
+            apply_category(Categories.SHOP_CAR, item)
             yield item


### PR DESCRIPTION
QCode has multiple NSI entries, thus category is not being added.

<details><summary>Stats</summary>

```python
{'atp/brand/Audi': 64,
 'atp/brand_wikidata/Q23317': 64,
 'atp/category/shop/car': 64,
 'atp/field/country/from_spider_name': 64,
 'atp/field/email/missing': 5,
 'atp/field/image/missing': 64,
 'atp/field/opening_hours/missing': 64,
 'atp/field/state/missing': 64,
 'atp/field/twitter/missing': 64,
 'atp/field/website/missing': 2,
 'atp/nsi/category_match': 64,
 'downloader/request_bytes': 372,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 257910,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.437273,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 12, 15, 56, 6, 485524),
 'item_scraped_count': 64,
 'log_count/DEBUG': 76,
 'log_count/INFO': 9,
 'memusage/max': 131612672,
 'memusage/startup': 131612672,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 12, 15, 56, 2, 48251)}
```
</details>