### PR TITLE
Improve coop GB tagging

### DIFF
--- a/locations/spiders/central_england_cooperative.py
+++ b/locations/spiders/central_england_cooperative.py
@@ -1,24 +1,46 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CentralEnglandCooperativeSpider(SitemapSpider):
+def set_operator(brand: dict, item: Feature):
+    item["extras"]["operator"] = brand["brand"]
+    item["extras"]["operator:wikidata"] = brand["brand_wikidata"]
+
+
+COOP_FOOD = {"brand": "The Co-operative Food", "brand_wikidata": "Q107617274"}
+COOP_FUNERALCARE = {"brand": "The Co-operative Funeralcare", "brand_wikidata": "Q7726521"}
+
+CENTRAL_COOP = {"brand": "Central England Co-operative", "brand_wikidata": "Q16986583"}
+
+
+class CentralEnglandCooperativeSpider(SitemapSpider, StructuredDataSpider):
     name = "central_england_cooperative"
-    item_attributes = {
-        "brand": "Central England Co-operative",
-        "brand_wikidata": "Q16986583",
-        "country": "GB",
-    }
     sitemap_urls = ["https://stores.centralengland.coop/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/stores\.centralengland\.coop\/[-\w]+\/.*$",
-            "parse_item",
-        )
-    ]
+    sitemap_rules = [(r"https:\/\/stores\.centralengland\.coop\/[-\w]+\/.*$", "parse")]
 
-    def parse_item(self, response):
-        MicrodataParser.convert_to_json_ld(response)
-        return LinkedDataParser.parse(response, "LocalBusiness")
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["image"] = None
+
+        if "logo-food" in ld_data["logo"]:
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+            set_operator(CENTRAL_COOP, item)
+
+            item.update(COOP_FOOD)
+            item["brand"], item["branch"] = item.pop("name").split(" - ", 1)
+        elif "logo-funeral" in ld_data["logo"]:
+            apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
+            set_operator(CENTRAL_COOP, item)
+
+            if "Central Co-op Funeral" in item["name"]:
+                item.update(COOP_FUNERALCARE)
+                item["branch"] = item.pop("name").replace("Central Co-op Funeral", "").strip(" -")
+        else:
+            apply_category(Categories.SHOP_FLORIST, item)
+            set_operator(CENTRAL_COOP, item)
+
+            item["brand"], item["branch"] = item.pop("name").split(" - ", 1)
+
+        yield item

--- a/locations/spiders/chelmsford_star_coop_gb.py
+++ b/locations/spiders/chelmsford_star_coop_gb.py
@@ -3,11 +3,13 @@ from scrapy import Spider
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.spiders.central_england_cooperative import COOP_FOOD, COOP_FUNERALCARE, set_operator
+
+CHELMSFORD_STAR_COOP = {"brand": "Chelmsford Star Co-operative Society", "brand_wikidata": "Q5089972"}
 
 
 class ChelmsfordStarCoopGBSpider(Spider):
     name = "chelmsford_star_coop_gb"
-    item_attributes = {"brand": "Chelmsford Star Coop", "brand_wikidata": "Q5089972"}
     start_urls = ["https://www.chelmsfordstar.coop/find-us/"]
 
     def parse(self, response):
@@ -28,12 +30,18 @@ class ChelmsfordStarCoopGBSpider(Spider):
             item = DictParser.parse(store)
 
             if any(cat["name"] == "Food" for cat in store["categories"]):
+                item.update(COOP_FOOD)
                 apply_category(Categories.SHOP_SUPERMARKET, item)
             elif any(cat["name"] == "Funeral" for cat in store["categories"]):
+                item.update(COOP_FUNERALCARE)
                 apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
             elif any(cat["name"] == "Travel" for cat in store["categories"]):
+                item["brand"] = "Coop Travel"
                 apply_category(Categories.SHOP_TRAVEL_AGENCY, item)
             elif any(cat["name"] == "Department store (Quadrant)" for cat in store["categories"]):
+                item["brand"] = "Quadrant"
                 apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+
+            set_operator(CHELMSFORD_STAR_COOP, item)
 
             yield item

--- a/locations/spiders/heart_of_england_cooperative_gb.py
+++ b/locations/spiders/heart_of_england_cooperative_gb.py
@@ -1,4 +1,4 @@
-from cssselect import Selector
+from scrapy import Selector
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature

--- a/locations/spiders/heart_of_england_cooperative_gb.py
+++ b/locations/spiders/heart_of_england_cooperative_gb.py
@@ -1,7 +1,22 @@
+from cssselect import Selector
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.central_england_cooperative import COOP_FOOD, set_operator
 from locations.storefinders.super_store_finder import SuperStoreFinderSpider
 
+HEART_OF_ENGLAND_COOP = {"brand": "Heart of England Co-operative Society", "brand_wikidata": "Q5692254"}
 
-class HeartOfEnglandCooperativeGBSpiderSpider(SuperStoreFinderSpider):
+
+class HeartOfEnglandCooperativeGBSpider(SuperStoreFinderSpider):
     name = "heart_of_england_cooperative_gb"
-    item_attributes = {"brand": "Heart of England Co-operative", "brand_wikidata": "Q5692254"}
     start_urls = ["https://www.cawtest.com/heartofengland/wp-content/plugins/superstorefinder-wp/ssf-wp-xml.php"]
+
+    def parse_item(self, item: Feature, location: Selector, **kwargs):
+        item["branch"] = item.pop("name")
+
+        item.update(COOP_FOOD)
+        set_operator(HEART_OF_ENGLAND_COOP, item)
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+
+        yield item

--- a/locations/spiders/midcounties_cooperative_gb.py
+++ b/locations/spiders/midcounties_cooperative_gb.py
@@ -18,8 +18,6 @@ class MidcountiesCooperativeGBSpider(Spider):
         for store in response.json()["stores"]:
             item = DictParser.parse(store)
 
-            item["website"] = store.get("branchLink")
-
             item["street_address"] = ", ".join(
                 filter(None, [store.get("addressLine1"), store.get("addressLine2"), store.get("addressLine3")])
             )

--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -1,10 +1,20 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.spiders.central_england_cooperative import COOP_FOOD, set_operator
 from locations.structured_data_spider import StructuredDataSpider
+
+SOUTHERN_COOP = {"brand": "The Southern Co-operative", "brand_wikidata": "Q7569773"}
 
 
 class SouthernCoopSpider(SitemapSpider, StructuredDataSpider):
     name = "southern_coop"
-    item_attributes = {"brand": "Southern Co-op", "brand_wikidata": "Q7569773"}
-    sitemap_urls = ["https://stores.thesouthernco-operative.co.uk/sitemap.xml"]
-    sitemap_rules = [(r".co\.uk\/[-\w]+\/[-\w]+\/[-\w]+\.html$", "parse_sd")]
+    sitemap_urls = ["https://stores.southern.coop/robots.txt"]
+    sitemap_rules = [(r"\.coop\/[-\w]+\/[-\w]+\/[-\w]+\.html$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        set_operator(SOUTHERN_COOP, item)
+        item.update(COOP_FOOD)
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+
+        yield item

--- a/locations/spiders/the_cooperative_group.py
+++ b/locations/spiders/the_cooperative_group.py
@@ -1,45 +1,32 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.linked_data_parser import LinkedDataParser
+from locations.spiders.central_england_cooperative import COOP_FOOD, COOP_FUNERALCARE, set_operator
+from locations.structured_data_spider import StructuredDataSpider
+
+THE_COOPERATIVE_GROUP = {"brand": "The Co-operative Group", "brand_wikidata": "Q117202"}
 
 
-class TheCooperativeGroupSpider(SitemapSpider):
+class TheCooperativeGroupSpider(SitemapSpider, StructuredDataSpider):
     name = "the_cooperative_group"
-    item_attributes = {"brand": "The Co-operative Group", "brand_wikidata": "Q117202"}
     sitemap_urls = [
         "https://www.coop.co.uk/store-finder/sitemap.xml",
         "https://www.coop.co.uk/funeralcare/funeral-directors/sitemap.xml",
     ]
     sitemap_rules = [
-        (
-            r"https:\/\/www\.coop\.co\.uk\/store-finder\/[-\w]+\/[-\w]+$",
-            "parse_store",
-        ),
-        (
-            r"https:\/\/www\.coop\.co\.uk\/funeralcare\/funeral-directors\/",
-            "parse_funeralcare",
-        ),
+        ("/store-finder/", "parse_sd"),
+        ("/funeralcare/funeral-directors/", "parse_sd"),
     ]
+    wanted_types = ["ConvenienceStore", "LocalBusiness"]
 
-    def parse_store(self, response):
-        item = LinkedDataParser.parse(response, "ConvenienceStore")
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if ld_data["@type"] == "ConvenienceStore":
+            item.update(COOP_FOOD)
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+        else:
+            item.update(COOP_FUNERALCARE)
+            apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
 
-        if item is None:
-            return
+        set_operator(THE_COOPERATIVE_GROUP, item)
 
-        item["ref"] = item["website"]
-        apply_category(Categories.SHOP_CONVENIENCE, item)
-
-        return item
-
-    def parse_funeralcare(self, response):
-        item = LinkedDataParser.parse(response, "LocalBusiness")
-
-        if item is None:
-            return
-
-        item["ref"] = item["website"]
-        apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
-
-        return item
+        yield item

--- a/locations/spiders/the_cooperative_group.py
+++ b/locations/spiders/the_cooperative_group.py
@@ -1,10 +1,11 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.spiders.central_england_cooperative import COOP_FOOD, COOP_FUNERALCARE, set_operator
+from locations.spiders.central_england_cooperative import COOP_FUNERALCARE, set_operator
 from locations.structured_data_spider import StructuredDataSpider
 
 THE_COOPERATIVE_GROUP = {"brand": "The Co-operative Group", "brand_wikidata": "Q117202"}
+THE_COOPERATIVE_GROUP_FOOD = {"brand": "Co-op Food", "brand_wikidata": "Q3277439"}
 
 
 class TheCooperativeGroupSpider(SitemapSpider, StructuredDataSpider):
@@ -21,7 +22,7 @@ class TheCooperativeGroupSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if ld_data["@type"] == "ConvenienceStore":
-            item.update(COOP_FOOD)
+            item.update(THE_COOPERATIVE_GROUP_FOOD)
             apply_category(Categories.SHOP_CONVENIENCE, item)
         else:
             item.update(COOP_FUNERALCARE)


### PR DESCRIPTION
I'm sure there are still issues, but it's an improvement.

"Coop" in GB is a PATA, it's a mix of companies (I think like Goodwill in US), however they have had internal drama. So the don't actually share a brand any more, but do share the mindshare.

I have 2 within 5 mins of my flat. 1 is a Southern (aka green), I always thought the other was Central, but it's actually Group.

Group is the big one, the small ones stayed with it. They are a coop of coops and (mostly) share a brand (aka blue). The mid sized ones fragmented.

Thanks for reading my anecdote.