### PR TITLE
Reformatted radisson hotels to get it working again.

### DIFF
--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -28,12 +28,11 @@ class RadissonHotelsSpider(scrapy.Spider):
     }
     custom_settings = {
         "DEFAULT_REQUEST_HEADERS": {
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "Accept": "*/*",
             "User-Agent": BROWSER_DEFAULT,
             "Connection": "keep-alive",
-            "Accept-Language": "en-US,en;q=0.9",
-        },
-        "ROBOTSTXT_OBEY": False,
+            "Accept-Language": "fr-FR",
+        }
     }
 
     def parse(self, response):


### PR DESCRIPTION
I could not get the last scrapy request to return something. . But I noticed that the city, postal code, and the country are also in the 2nd request. Thus, we lose extracting the email and phone. I turned the robotstxt obey setting to false and still nothing returned. 

<details><summary>New Stats</summary>

```python
{'atp/brand/Art’otel': 7,
 'atp/brand/Country Inn & Suites by Radisson': 15,
 'atp/brand/Park Inn by Radisson': 111,
 'atp/brand/Park Plaza Hotels & Resorts': 36,
 'atp/brand/Prizeotel': 14,
 'atp/brand/Radisson': 96,
 'atp/brand/Radisson Blu': 333,
 'atp/brand/Radisson Collection': 36,
 'atp/brand/Radisson Individuals': 41,
 'atp/brand/Radisson RED': 19,
 'atp/brand_wikidata/Q14516231': 7,
 'atp/brand_wikidata/Q1751979': 96,
 'atp/brand_wikidata/Q2052550': 36,
 'atp/brand_wikidata/Q28233721': 19,
 'atp/brand_wikidata/Q5177332': 15,
 'atp/brand_wikidata/Q60711675': 111,
 'atp/brand_wikidata/Q60716706': 36,
 'atp/brand_wikidata/Q7281341': 333,
 'atp/category/missing': 62,
 'atp/category/tourism/hotel': 646,
 'atp/field/brand_wikidata/missing': 55,
 'atp/field/email/missing': 708,
 'atp/field/image/missing': 228,
 'atp/field/opening_hours/missing': 708,
 'atp/field/phone/missing': 708,
 'atp/field/postcode/missing': 708,
 'atp/field/state/missing': 708,
 'atp/field/twitter/missing': 98,
 'atp/nsi/brand_missing': 7,
 'atp/nsi/perfect_match': 646,
 'downloader/request_bytes': 1150288,
 'downloader/request_count': 411,
 'downloader/request_method_count/GET': 411,
 'downloader/response_bytes': 19912652,
 'downloader/response_count': 411,
 'downloader/response_status_count/200': 409,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 504.497224,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 13, 17, 51, 10, 810436),
 'httpcompression/response_bytes': 173635950,
 'httpcompression/response_count': 409,
 'item_scraped_count': 708,
 'log_count/DEBUG': 1212,
 'log_count/INFO': 17,
 'memusage/max': 484196352,
 'memusage/startup': 362545152,
 'request_depth_max': 1,
 'response_received_count': 409,
 'scheduler/dequeued': 411,
 'scheduler/dequeued/memory': 411,
 'scheduler/enqueued': 411,
 'scheduler/enqueued/memory': 411,
 'start_time': datetime.datetime(2023, 10, 13, 17, 42, 46, 313212),
 'tt/item_scraped_host_count/www.radissonhotels.com': 708,
 'tt_lineage': 'S_ATP',
 'tt_requires_proxy': False}
 ```
</details>