### PR TITLE
Restore PL spelling mistake

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -13,6 +13,9 @@ DAYS_FULL = [
     "Sunday",
 ]
 
+# The below DAYS dicts are provided to be used with sanitise_day inorder for us to do best attempts at matching the
+# given day into an English 2 char day to be used inside ATP and then to be exported to OSM formatted opening hours.
+
 DAYS_AT = {"Mo": "Mo", "Di": "Tu", "Mi": "We", "Do": "Th", "Fr": "Fr", "Sa": "Sa", "So": "Su"}
 
 DAYS_EN = {
@@ -263,6 +266,7 @@ DAYS_PL = {
     "Ni": "Su",
     "Nie": "Su",
     "Niedz": "Su",
+    "Niedzela": "Su",
     "Niedziela": "Su",
 }
 DAYS_PT = {


### PR DESCRIPTION
Rel: https://github.com/alltheplaces/alltheplaces/pull/6148#discussion_r1359878410

These dicts are for converting supplied days to OSM days, common spelling mistakes and acronyms are expected.