### PR TITLE
[jysk] Improve spider.

### DIFF
--- a/locations/spiders/jysk.py
+++ b/locations/spiders/jysk.py
@@ -5,7 +5,6 @@ import scrapy
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class JyskSpider(scrapy.Spider):

--- a/locations/spiders/jysk.py
+++ b/locations/spiders/jysk.py
@@ -16,12 +16,14 @@ class JyskSpider(scrapy.Spider):
         main_urls = response.xpath(
             "//div[contains(@class, 'col-xs-12 col-sm-4 col-md-4 panels-flexible-region-inside columns')][1]//li/a/@href"
         ).getall()
-        franchise_urls = response.xpath(
-            "//div[contains(@class, 'col-xs-12 col-sm-4 col-md-4 panels-flexible-region-inside columns')][2]//li/a/@href"
-        ).getall()
+
         # There are Jysk owned stores and Jysk franchise stores.
         # Only Jysk owned stores have standartized store locator, franchise stores have different website format.
         # For this spider we are interested only in Jysk owned stores. Others should be scraped with different spiders.
+        # For reference:
+        # franchise_urls = response.xpath(
+        #     "//div[contains(@class, 'col-xs-12 col-sm-4 col-md-4 panels-flexible-region-inside columns')][2]//li/a/@href"
+        # ).getall()
         for url in main_urls:
             self.logger.info("Found country site: %s", url)
             yield scrapy.Request(urljoin(url, "stores-locator"), callback=self.parse_country_site)


### PR DESCRIPTION
Rel: #6180 

I noticed that we can visit every country specific site without listing them explicitly.
Also Jysk does not block my IP.

Stats:
```json
{
 "atp/brand/JYSK": 3142,
 "atp/brand_wikidata/Q138913": 3142,
 "atp/category/shop/furniture": 3142,
 "atp/field/country/from_website_url": 3142,
 "atp/field/email/missing": 3142,
 "atp/field/image/missing": 72,
 "atp/field/opening_hours/missing": 11,
 "atp/field/phone/invalid": 3,
 "atp/field/phone/missing": 98,
 "atp/field/state/missing": 3142,
 "atp/field/street_address/missing": 3142,
 "atp/field/twitter/missing": 3142,
 "atp/nsi/cc_match": 3142,
 "downloader/request_bytes": 1170399,
 "downloader/request_count": 3368,
 "downloader/request_method_count/GET": 3368,
 "downloader/response_bytes": 4509409,
 "downloader/response_count": 3368,
 "downloader/response_status_count/200": 3205,
 "downloader/response_status_count/301": 163,
 "elapsed_time_seconds": 3328.129274,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-10-19T13:21:53.118271",
 "httpcompression/response_bytes": 14269044,
 "httpcompression/response_count": 3205,
 "item_scraped_count": 3142,
 "log_count/INFO": 3263,
 "memusage/max": 357138432,
 "memusage/startup": 145620992,
 "request_depth_max": 2,
 "response_received_count": 3205,
 "robotstxt/request_count": 34,
 "robotstxt/response_count": 34,
 "robotstxt/response_status_count/200": 34,
 "scheduler/dequeued": 3329,
 "scheduler/dequeued/memory": 3329,
 "scheduler/enqueued": 3329,
 "scheduler/enqueued/memory": 3329,
 "start_time": "2023-10-19T12:26:24.988997"
}
```