### PR TITLE
Use actual ref for JYSK store

### DIFF
--- a/locations/spiders/jysk.py
+++ b/locations/spiders/jysk.py
@@ -50,7 +50,8 @@ class JyskSpider(scrapy.Spider):
         store["house_number"] = store.pop("house")
         item = DictParser.parse(store)
         item["image"] = store.get("image")
-        item["website"] = item["ref"] = locator_url + "?storeId=" + store["shop_id"]
+        item["website"] = locator_url + "?storeId=" + store["shop_id"]
+        item["ref"] = store["shop_id"]
 
         oh = OpeningHours()
         for info in store["opening"]:


### PR DESCRIPTION
It seems like there are no duplicated refs across the websites so there is no point in using the URL address as a ref.