### PR TITLE
Added category for Petrol Brand (595 Items)

### DIFF
--- a/locations/spiders/petrol.py
+++ b/locations/spiders/petrol.py
@@ -1,7 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import Extras, Fuel, apply_yes_no
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -42,6 +42,7 @@ class PetrolSpider(Spider):
                 elif cat["characteristic"]["key"] == "191":
                     apply_yes_no(Extras.WIFI, item, True)
 
+            apply_category(Categories.FUEL_STATION, item)
             yield item
 
         if len(response.json()) == 100:


### PR DESCRIPTION
NSI has mutliple entries thus category can not be determined.

<details><summary>New Stats</summary>

```python
{'atp/brand/Crodux': 92,
 'atp/brand/Petrol': 503,
 'atp/brand_wikidata/Q174824': 503,
 'atp/brand_wikidata/Q62274622': 92,
 'atp/category/amenity/fuel': 595,
 'atp/field/email/missing': 595,
 'atp/field/image/missing': 595,
 'atp/field/phone/missing': 595,
 'atp/field/state/missing': 595,
 'atp/field/street_address/missing': 595,
 'atp/field/twitter/missing': 595,
 'atp/field/website/missing': 595,
 'atp/nsi/category_match': 595,
 'downloader/request_bytes': 4466,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 1572004,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 19.088117,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 24, 20, 5, 49, 299737),
 'httpcompression/response_bytes': 12319145,
 'httpcompression/response_count': 8,
 'item_scraped_count': 595,
 'log_count/INFO': 9,
 'memusage/max': 132603904,
 'memusage/startup': 132603904,
 'request_depth_max': 6,
 'response_received_count': 8,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2023, 10, 24, 20, 5, 30, 211620)}
 ```
</details>