### PR TITLE
Added category Bank for items (297 Items)

### DIFF
--- a/locations/spiders/techcombank_vn.py
+++ b/locations/spiders/techcombank_vn.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -22,5 +23,5 @@ class TechcombankVNSpider(Spider):
             item["lat"] = location["lat"]
             item["lon"] = location["long"]
             item["phone"] = location.get("phone")
-
+            apply_category(Categories.BANK, item)
             yield item


### PR DESCRIPTION
Has multiple NSI IDs. Thus the category cannot be determined from NSI alone.

<details><summary>New Stats</summary>

```python
{'atp/brand/Techcombank': 297,
 'atp/brand_wikidata/Q10541776': 297,
 'atp/category/amenity/bank': 297,
 'atp/field/city/missing': 297,
 'atp/field/country/from_spider_name': 297,
 'atp/field/email/missing': 297,
 'atp/field/image/missing': 297,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 297,
 'atp/field/phone/invalid': 15,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 297,
 'atp/field/state/missing': 297,
 'atp/field/street_address/missing': 297,
 'atp/field/twitter/missing': 297,
 'atp/field/website/missing': 297,
 'atp/nsi/category_match': 297,
 'downloader/request_bytes': 1223,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 24511,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.639476,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 24, 20, 41, 26, 119271),
 'httpcompression/response_bytes': 102352,
 'httpcompression/response_count': 2,
 'item_scraped_count': 297,
 'log_count/INFO': 9,
 'memusage/max': 132636672,
 'memusage/startup': 132636672,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 24, 20, 41, 20, 479795)}
```
</details>