### PR TITLE
Added fuel station category tag for Sonic_ca (290 Items)

### DIFF
--- a/locations/spiders/sonic_ca.py
+++ b/locations/spiders/sonic_ca.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -10,4 +11,6 @@ class SonicCASpider(Spider):
 
     def parse(self, response, **kwargs):
         for location in response.json()["markers"]:
-            yield DictParser.parse(location)
+            item = DictParser.parse(location)
+            apply_category(Categories.FUEL_STATION, item)
+            yield item


### PR DESCRIPTION
NSI has two entries, thus category does not get added.

<details><summary>New Stats</summary>

```python
{'atp/brand/Sonic': 290,
 'atp/brand_wikidata/Q118669677': 290,
 'atp/category/amenity/fuel': 290,
 'atp/field/city/missing': 290,
 'atp/field/country/from_spider_name': 290,
 'atp/field/email/missing': 290,
 'atp/field/image/missing': 290,
 'atp/field/opening_hours/missing': 290,
 'atp/field/phone/missing': 290,
 'atp/field/postcode/missing': 290,
 'atp/field/state/from_reverse_geocoding': 290,
 'atp/field/street_address/missing': 290,
 'atp/field/twitter/missing': 290,
 'atp/field/website/missing': 290,
 'atp/nsi/category_match': 290,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17701,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.792387,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 25, 13, 3, 53, 578310),
 'httpcompression/response_bytes': 99951,
 'httpcompression/response_count': 2,
 'item_scraped_count': 290,
 'log_count/INFO': 9,
 'memusage/max': 132628480,
 'memusage/startup': 132628480,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 25, 13, 3, 48, 785923)}
```
</details>