### PR TITLE
Added shop=supermarket category tag for East of England Coop Brand (178 Items)

### DIFF
--- a/locations/spiders/east_of_england_coop.py
+++ b/locations/spiders/east_of_england_coop.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.linked_data_parser import LinkedDataParser
 from locations.microdata_parser import MicrodataParser
 
@@ -42,4 +43,5 @@ class EastOfEnglandCoopSpider(SitemapSpider):
         if item.get("lon") is None:
             item["lon"] = response.xpath('//div[@class="store-map"]/@data-long').get()
 
+        apply_category(Categories.SHOP_SUPERMARKET, item)
         return item


### PR DESCRIPTION
Multiple NSI entries. Thus Category tag is not added.

<details><summary>New Stats</summary>

```python
{'atp/brand/East of England Co-op': 178,
 'atp/brand_wikidata/Q5329759': 178,
 'atp/category/shop/supermarket': 178,
 'atp/field/email/missing': 178,
 'atp/field/image/missing': 178,
 'atp/field/opening_hours/missing': 178,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 178,
 'atp/nsi/category_match': 178,
 'downloader/request_bytes': 121140,
 'downloader/request_count': 230,
 'downloader/request_method_count/GET': 230,
 'downloader/response_bytes': 6577448,
 'downloader/response_count': 230,
 'downloader/response_status_count/200': 222,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 1,
 'downloader/response_status_count/404': 2,
 'downloader/response_status_count/500': 3,
 'elapsed_time_seconds': 281.78884,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 25, 13, 48, 24, 535521),
 'httpcompression/response_bytes': 30258201,
 'httpcompression/response_count': 227,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/404': 2,
 'httperror/response_ignored_status_count/500': 1,
 'item_scraped_count': 178,
 'log_count/ERROR': 1,
 'log_count/INFO': 16,
 'memusage/max': 292040704,
 'memusage/startup': 132468736,
 'request_depth_max': 1,
 'response_received_count': 225,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/500 Internal Server Error': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 229,
 'scheduler/dequeued/memory': 229,
 'scheduler/enqueued': 229,
 'scheduler/enqueued/memory': 229,
 'start_time': datetime.datetime(2023, 10, 25, 13, 43, 42, 746681)}
```
</details>