### PR TITLE
Added supermarket category to brand (145 Items)

### DIFF
--- a/locations/spiders/safeway_ca.py
+++ b/locations/spiders/safeway_ca.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -31,7 +32,9 @@ class SafewayCaSpider(scrapy.Spider):
             "opening_hours": self.parse_hours(response),
         }
 
-        yield Feature(**properties)
+        item = Feature(**properties)
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item
 
     def parse_hours(self, response):
         tbl = response.css(".holiday_hours_tbl")[-1].xpath("./tbody//text()")

--- a/locations/spiders/safeway_ca.py
+++ b/locations/spiders/safeway_ca.py
@@ -42,6 +42,11 @@ class SafewayCaSpider(scrapy.Spider):
         opening_hours = OpeningHours()
         for day, span in zip(*[iter(vals)] * 2):
             day = day[:2]
-            open_time, close_time = span.split(" to ")
+            span_split = span.split(" to ")
+            if len(span_split) == 2:
+                open_time = span_split[0]
+                close_time = span_split[1]
+            else:
+                continue
             opening_hours.add_range(day, open_time, close_time, "%I:%M %p")
         return opening_hours.as_opening_hours()


### PR DESCRIPTION
Not sure if I should add the brand to NSI or not. Kind of a toss up. As Safeway Canada https://www.wikidata.org/wiki/Q17111901 is independent (as of 2013) from safeway USA https://www.wikidata.org/wiki/Q1508234. Although it still uses the same logo and such as its USA counterpart. The USA counterpart does have an entry in NSI with the same name. 

Maybe the the USA entry in NSI should change the include to be "us" instead of "001". Then we could include "ca" for canadian one.

<details><summary>New Stats</summary>

```python
{'atp/brand/Safeway': 145,
 'atp/brand_wikidata/Q17111901': 145,
 'atp/category/shop/supermarket': 145,
 'atp/cdn/cloudflare/response_count': 154,
 'atp/cdn/cloudflare/response_status_count/200': 154,
 'atp/field/country/from_spider_name': 145,
 'atp/field/email/missing': 145,
 'atp/field/image/missing': 145,
 'atp/field/state/from_reverse_geocoding': 145,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 145,
 'atp/field/twitter/missing': 145,
 'atp/nsi/brand_missing': 145,
 'downloader/request_bytes': 57501,
 'downloader/request_count': 154,
 'downloader/request_method_count/GET': 154,
 'downloader/response_bytes': 4638094,
 'downloader/response_count': 154,
 'downloader/response_status_count/200': 154,
 'elapsed_time_seconds': 187.101675,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 25, 19, 3, 5, 387319),
 'httpcompression/response_bytes': 23284471,
 'httpcompression/response_count': 154,
 'item_scraped_count': 145,
 'log_count/ERROR': 7,
 'log_count/INFO': 12,
 'memusage/max': 401002496,
 'memusage/startup': 132657152,
 'request_depth_max': 1,
 'response_received_count': 154,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 153,
 'scheduler/dequeued/memory': 153,
 'scheduler/enqueued': 153,
 'scheduler/enqueued/memory': 153,
 'spider_exceptions/ValueError': 7,
 'start_time': datetime.datetime(2023, 10, 25, 18, 59, 58, 285644)}
```
</details>