### PR TITLE
storefinders/where2getit: fix use of api_filter

### DIFF
--- a/locations/spiders/true_value_us.py
+++ b/locations/spiders/true_value_us.py
@@ -7,7 +7,9 @@ class TrueValueUSSpider(Where2GetItSpider):
     api_brand_name = "truevalue"
     api_key = "EDF319D8-F561-11E7-9BF7-BFAAF3F4F7A7"
     api_filter = {
-        "truevaluebranded": {"eq": "Branded"},
-        "excluded": {"distinctfrom": "1"},
-        "active": {"eq": "1"},
+        "and": {
+            "truevaluebranded": {"eq": "Branded"},
+            "excluded": {"distinctfrom": "1"},
+            "active": {"eq": "1"},
+        }
     }

--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -101,9 +101,7 @@ class Where2GetItSpider(Spider):
             else:
                 location_clause = {"country": {"eq": country_code}}
         if self.api_filter:
-            where_clause = {
-                "and": self.api_filter | location_clause
-            }
+            where_clause = {"and": self.api_filter | location_clause}
         else:
             where_clause = location_clause
 

--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -102,10 +102,7 @@ class Where2GetItSpider(Spider):
                 location_clause = {"country": {"eq": country_code}}
         if self.api_filter:
             where_clause = {
-                "and": {
-                    self.api_filter,
-                    location_clause,
-                }
+                "and": self.api_filter | location_clause
             }
         else:
             where_clause = location_clause


### PR DESCRIPTION
There was a problem with use of the api_filter attribute due to incorrect merging of dictionaries together into a single filter query.