### PR TITLE
Added supermarket category (61 items)

### DIFF
--- a/locations/spiders/marcs.py
+++ b/locations/spiders/marcs.py
@@ -3,6 +3,7 @@ import json
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -44,4 +45,6 @@ class MarcsSpider(CrawlSpider):
             "opening_hours": oh.as_opening_hours(),
         }
 
-        yield Feature(**properties)
+        item = Feature(**properties)
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item


### PR DESCRIPTION
Multiple NSI entries, thus adding category here. 

I am not sure if this should be supermarket or pharmacy. I think supermarket because it seems similar to a walmart supercenter where there is a pharmacy in the store but it is also a supermarket.

<details><summary>New Stats</summary>

```python
{"atp/brand/Marc's": 61,
 'atp/brand_wikidata/Q17080259': 61,
 'atp/category/shop/supermarket': 61,
 'atp/field/email/missing': 61,
 'atp/field/image/missing': 61,
 'atp/field/postcode/missing': 61,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/twitter/missing': 61,
 'atp/nsi/category_match': 61,
 'downloader/request_bytes': 91555,
 'downloader/request_count': 123,
 'downloader/request_method_count/GET': 123,
 'downloader/response_bytes': 1995732,
 'downloader/response_count': 123,
 'downloader/response_status_count/200': 62,
 'downloader/response_status_count/301': 61,
 'elapsed_time_seconds': 146.40613,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 29, 1, 8, 59, 2613, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3900974,
 'httpcompression/response_count': 62,
 'item_scraped_count': 61,
 'log_count/DEBUG': 195,
 'log_count/INFO': 11,
 'memusage/max': 369414144,
 'memusage/startup': 132907008,
 'request_depth_max': 1,
 'response_received_count': 62,
 'scheduler/dequeued': 123,
 'scheduler/dequeued/memory': 123,
 'scheduler/enqueued': 123,
 'scheduler/enqueued/memory': 123,
 'start_time': datetime.datetime(2023, 10, 29, 1, 6, 32, 596483, tzinfo=datetime.timezone.utc)}
```
</details>