### PR TITLE
bulgarian_posts_bg: fix spider

### DIFF
--- a/locations/spiders/bulgarian_posts_bg.py
+++ b/locations/spiders/bulgarian_posts_bg.py
@@ -27,8 +27,11 @@ class BulgarianPostsBGSpider(Spider):
             item["opening_hours"] = OpeningHours()
             for day_name in DAYS_FULL:
                 if location[f"working_hours_{day_name.lower()}"]:
-                    item["opening_hours"].add_range(
-                        day_name, *location[f"working_hours_{day_name.lower()}"].split("-", 1), "%H:%M"
-                    )
+                    try:
+                        item["opening_hours"].add_range(
+                            day_name, *location[f"working_hours_{day_name.lower()}"].split("-", 1), "%H:%M"
+                        )
+                    except ValueError:
+                        continue
             apply_category(Categories.POST_OFFICE, item)
             yield item


### PR DESCRIPTION
Gracefully ignore invalid opening hours (e.g. 145:15 as a HH:MM).