### PR TITLE
[JSWethersoon] Switch to crawl spider

### DIFF
--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -10,3 +10,8 @@ class JDWetherspoonSpider(CrawlSpider, StructuredDataSpider):
     allowed_domains = ["www.jdwetherspoon.com"]
     start_urls = ["https://www.jdwetherspoon.com/pubs/all-pubs"]
     rules = [Rule(LinkExtractor(allow="/pubs/all-pubs/"), callback="parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item.get("postcode") and item.get("postcode") in item.get("street_address"):
+            item["addr_full"] = item.pop("street_address")
+        yield item

--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -1,12 +1,12 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class JDWetherspoonSpider(SitemapSpider, StructuredDataSpider):
+class JDWetherspoonSpider(CrawlSpider, StructuredDataSpider):
     name = "j_d_wetherspoon"
-    item_attributes = {"brand": "J D Wetherspoon", "brand_wikidata": "Q6109362"}
+    item_attributes = {"brand": "Wetherspoon", "brand_wikidata": "Q6109362"}
     allowed_domains = ["www.jdwetherspoon.com"]
-    sitemap_urls = ["https://www.jdwetherspoon.com/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.jdwetherspoon\.com\/pubs\/all-pubs(?:\/[\w\-]+){3}", "parse_sd")]
-    custom_settings = {"REDIRECT_ENABLED": False}  # Numerous location pages don't exist.
+    start_urls = ["https://www.jdwetherspoon.com/pubs/all-pubs"]
+    rules = [Rule(LinkExtractor(allow="/pubs/all-pubs/"), callback="parse_sd")]


### PR DESCRIPTION
Sitemap is out of date

```python
{'atp/brand/Wetherspoon': 820,
 'atp/brand_wikidata/Q6109362': 820,
 'atp/category/amenity/pub': 820,
 'atp/field/country/from_reverse_geocoding': 820,
 'atp/field/email/missing': 820,
 'atp/field/image/missing': 6,
 'atp/field/opening_hours/missing': 6,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 7,
 'atp/field/twitter/missing': 820,
 'atp/nsi/perfect_match': 820,
 'downloader/request_bytes': 394676,
 'downloader/request_count': 822,
 'downloader/request_method_count/GET': 822,
 'downloader/response_bytes': 55605849,
 'downloader/response_count': 822,
 'downloader/response_status_count/200': 822,
 'elapsed_time_seconds': 1001.767391,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 30, 17, 3, 48, 138261),
 'httpcache/firsthand': 822,
 'httpcache/miss': 822,
 'httpcache/store': 822,
 'item_scraped_count': 820,
 'log_count/DEBUG': 1654,
 'log_count/INFO': 26,
 'log_count/WARNING': 1,
 'memusage/max': 406941696,
 'memusage/startup': 147271680,
 'request_depth_max': 1,
 'response_received_count': 822,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 821,
 'scheduler/dequeued/memory': 821,
 'scheduler/enqueued': 821,
 'scheduler/enqueued/memory': 821,
 'start_time': datetime.datetime(2023, 10, 30, 16, 47, 6, 370870)}
```