### PR TITLE
Overwrote name as many were given as BIA-188 (168 items)

### DIFF
--- a/locations/spiders/aldi_sud_hu.py
+++ b/locations/spiders/aldi_sud_hu.py
@@ -27,5 +27,5 @@ class AldiSudHUSpider(Spider):
                 if not rule.get("closed", False):
                     oh.add_range(day, rule["openFormatted"], rule["closeFormatted"])
             item["opening_hours"] = oh.as_opening_hours()
-
+            item["name"] = "ALDI"
             yield item


### PR DESCRIPTION
The display name that was found using dict parser was not good giving a 3 letter code and 3 digit number. Thus we are changing the name to be closer to what store locator shows. Which is just ALDI

<details><summary>New Stats</summary>

```python
{'atp/brand/ALDI': 168,
 'atp/brand_wikidata/Q41171672': 168,
 'atp/category/shop/supermarket': 168,
 'atp/field/email/missing': 168,
 'atp/field/image/missing': 168,
 'atp/field/state/missing': 168,
 'atp/field/twitter/missing': 168,
 'atp/field/website/missing': 168,
 'atp/nsi/cc_match': 168,
 'downloader/request_bytes': 958,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 81124,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.897858,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 10, 31, 13, 15, 39, 36432, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1092611,
 'httpcompression/response_count': 2,
 'item_scraped_count': 168,
 'log_count/INFO': 9,
 'memusage/max': 133160960,
 'memusage/startup': 133160960,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 10, 31, 13, 15, 36, 138574, tzinfo=datetime.timezone.utc)}
```
</details>