### PR TITLE
[Vans] Remove duplicates and stockists

### DIFF
--- a/locations/spiders/vans.py
+++ b/locations/spiders/vans.py
@@ -1,31 +1,11 @@
-import json
-
-import scrapy
 from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class VansSpider(SitemapSpider):
+class VansSpider(SitemapSpider, StructuredDataSpider):
     name = "vans"
     item_attributes = {"brand": "Vans", "brand_wikidata": "Q1135366"}
     allowed_domains = ["vans.com"]
     sitemap_urls = ["https://www.vans.com/sitemaps/store-locations.xml"]
-    sitemap_rules = [("", "parse")]
-
-    def parse(self, response):
-        data = response.xpath('//script[text()[contains(.,"LocalBusiness")]]/text()')
-        # page 01
-        if data:
-            for store in data:
-                data_json = json.loads(store.get())
-                item = DictParser.parse(data_json)
-                item["ref"] = data_json.get("url")
-                item["name"] = data_json.get("@name")
-                yield item
-
-        # page 02
-        else:
-            urls = response.xpath('//div[@class="itemlist"]/a/@href')
-            for url in urls:
-                yield scrapy.Request(url=response.urljoin(url.get()), callback=self.parse)
+    sitemap_rules = [(r"/stores/\w+/[-%\w]+/\w+\d{3}$", "parse_sd")]

--- a/locations/spiders/vans.py
+++ b/locations/spiders/vans.py
@@ -8,4 +8,4 @@ class VansSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Vans", "brand_wikidata": "Q1135366"}
     allowed_domains = ["vans.com"]
     sitemap_urls = ["https://www.vans.com/sitemaps/store-locations.xml"]
-    sitemap_rules = [(r"/stores/\w+/[-%\w]+/\w+\d{3}$", "parse_sd")]
+    sitemap_rules = [(r"/stores/.+/.+/\w+\d+$", "parse_sd")]


### PR DESCRIPTION
There were duplicates because the POIs were being collected by both the city list pages and the actual page. (The list pages have bad data)

```patch
+https://www.vans.com/en-us/stores/tx/cedar-park/usa196
-https://www.vans.com/en-us/stores/cedar-park/usa196
```
The [stockets](https://www.vans.com/en-us/stores/nc/raleigh/journ-cvm4325ga1) have ids like `famou-3699h95bca` where the first bit maps to the company like `famou` -> "Famous Footwear".

Whereas it looks like real vans never contain a `-`.