### PR TITLE
[EconofitnessCA] Add spider

### DIFF
--- a/locations/spiders/econofitness_ca.py
+++ b/locations/spiders/econofitness_ca.py
@@ -1,0 +1,18 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class EconofitnessCASpider(CrawlSpider, StructuredDataSpider):
+    name = "econofitness_ca"
+    item_attributes = {"brand": "Éconofitness", "brand_wikidata": "Q123073582"}
+    start_urls = ["https://econofitness.ca/en/results?searchmode=searchall&searchtext=&filters="]
+    rules = [Rule(LinkExtractor(r"/en/gym/[-\w]+/\d+-"), callback="parse_sd")]
+    wanted_types = ["ExerciseGym"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removesuffix(" 24/7")
+        item["lat"] = response.xpath("//@data-lat").get()
+        item["lon"] = response.xpath("//@data-lon").get()
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/8904
```python
{'atp/brand/Éconofitness': 68,
 'atp/brand_wikidata/Q123073582': 68,
 'atp/category/missing': 68,
 'atp/field/email/missing': 68,
 'atp/field/image/dropped': 68,
 'atp/field/image/missing': 68,
 'atp/field/name/missing': 68,
 'atp/field/state/from_reverse_geocoding': 68,
 'atp/field/twitter/missing': 68,
 'atp/nsi/brand_missing': 68,
 'downloader/request_bytes': 48094,
 'downloader/request_count': 70,
 'downloader/request_method_count/GET': 70,
 'downloader/response_bytes': 2155675,
 'downloader/response_count': 70,
 'downloader/response_status_count/200': 70,
 'elapsed_time_seconds': 2.148722,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 6, 23, 3, 41, 578070),
 'httpcache/hit': 70,
 'httpcompression/response_bytes': 17082904,
 'httpcompression/response_count': 70,
 'item_scraped_count': 68,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 155594752,
 'memusage/startup': 155594752,
 'request_depth_max': 1,
 'response_received_count': 70,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 69,
 'scheduler/dequeued/memory': 69,
 'scheduler/enqueued': 69,
 'scheduler/enqueued/memory': 69,
 'start_time': datetime.datetime(2023, 11, 6, 23, 3, 39, 429348)}
```