### PR TITLE
[CrocsEU] Remove stockists

### DIFF
--- a/locations/spiders/crocs_eu.py
+++ b/locations/spiders/crocs_eu.py
@@ -3,22 +3,20 @@ import scrapy
 from locations.dict_parser import DictParser
 
 
-class CrocsEuSpider(scrapy.Spider):
+class CrocsEUSpider(scrapy.Spider):
     name = "crocs_eu"
-    item_attributes = {
-        "brand": "Crocs",
-        "brand_wikidata": "Q926699",
-    }
-    allowed_domains = ["crocs"]
+    item_attributes = {"brand": "Crocs", "brand_wikidata": "Q926699"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
-
     start_urls = [
-        "https://crocs.locally.com/stores/conversion_data?has_data=true&company_id=1762&store_mode=&style=&color=&upc=&category=&inline=1&show_links_in_list=&parent_domain=&map_center_lat=46.661219&map_center_lng=2.587603&map_distance_diag=3000&sort_by=proximity&no_variants=0&only_retailer_id=&dealers_company_id=&only_store_id=false&uses_alt_coords=false&zoom_level=10&lang=en-gb&forced_coords=1"
+        "https://crocs.locally.com/stores/conversion_data?has_data=true&company_id=1762&category=Outlet&inline=1&map_center_lat=46.661219&map_center_lng=2.587603&map_distance_diag=3000&sort_by=proximity&lang=en-gb",
+        "https://crocs.locally.com/stores/conversion_data?has_data=true&company_id=1762&category=Store&inline=1&map_center_lat=46.661219&map_center_lng=2.587603&map_distance_diag=3000&sort_by=proximity&lang=en-gb",
     ]
+    skip_auto_cc_spider_name = True
 
     def parse(self, response):
         results = response.json()["markers"]
         for data in results:
             item = DictParser.parse(data)
+            item["street_address"] = item.pop("addr_full")
 
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Crocs': 169,
 'atp/brand_wikidata/Q926699': 169,
 'atp/category/shop/shoes': 169,
 'atp/field/email/missing': 169,
 'atp/field/image/missing': 169,
 'atp/field/opening_hours/missing': 169,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 131,
 'atp/field/postcode/missing': 30,
 'atp/field/state/missing': 158,
 'atp/field/twitter/missing': 169,
 'atp/field/website/missing': 169,
 'atp/nsi/perfect_match': 169,
 'downloader/request_bytes': 951,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 71673,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.591903,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 7, 10, 13, 23, 135398),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 541578,
 'httpcompression/response_count': 2,
 'item_scraped_count': 169,
 'log_count/DEBUG': 183,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 157110272,
 'memusage/startup': 157110272,
 'response_received_count': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 11, 7, 10, 13, 22, 543495)}
```