### PR TITLE
[RocketUS] Add spider

### DIFF
--- a/locations/spiders/rocket_us.py
+++ b/locations/spiders/rocket_us.py
@@ -1,0 +1,29 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class RocketUSSpider(Spider):
+    name = "rocket_us"
+    item_attributes = {"brand": "Rocket", "brand_wikidata": "Q121513516"}
+    start_urls = ["https://rocketstores.com/wp-json/stations/v1/locations"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json()["stations"]:
+            item = Feature()
+            item["ref"] = location["ID"]
+            item["lat"] = location["latitude"]
+            item["lon"] = location["longitude"]
+            item["branch"] = location["store_name"]
+            item["street_address"] = location["address"]
+            item["city"] = location["city"]
+            item["state"] = location["state"]
+            item["postcode"] = location["zip"]
+            item["country"] = location["country"]
+            item["phone"] = location["phone_number"]
+            item["located_in"] = location["brand"]["name"]
+
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/8828
Fixes #6182

```python
{'atp/brand/Rocket': 453,
 'atp/brand_wikidata/Q121513516': 453,
 'atp/category/shop/convenience': 453,
 'atp/field/email/missing': 453,
 'atp/field/image/missing': 453,
 'atp/field/name/missing': 453,
 'atp/field/opening_hours/missing': 453,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/missing': 453,
 'atp/field/website/missing': 453,
 'atp/nsi/brand_missing': 453,
 'downloader/request_bytes': 633,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 309376,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.831167,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 7, 13, 7, 21, 544441),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 24,
 'httpcompression/response_count': 1,
 'item_scraped_count': 453,
 'log_count/DEBUG': 467,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 159109120,
 'memusage/startup': 159109120,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 7, 13, 7, 18, 713274)}
```