### PR TITLE
[LewiatanPL] Fix category

### DIFF
--- a/locations/spiders/lewiatan_pl.py
+++ b/locations/spiders/lewiatan_pl.py
@@ -2,6 +2,7 @@ import html
 
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -16,5 +17,5 @@ class LewiatanPLSpider(Spider):
             item["extras"]["operator"] = html.unescape(item.pop("name"))
             item["street_address"] = item.pop("addr_full")
             item["website"] = response.urljoin(location["url"])
-
+            apply_category(Categories.SHOP_SUPERMARKET, item)
             yield item


### PR DESCRIPTION
There are 2 categories in NSI, namely shop=convenience and shop=supermarket.
Nothing in the data we scrape to indicate size of store.
Hence set to supermarket.
{'atp/brand/Lewiatan': 2863,
 'atp/brand_wikidata/Q11755396': 2863,
 'atp/category/shop/supermarket': 2863,
 'atp/field/country/from_spider_name': 2863,
 'atp/field/email/missing': 2863,
 'atp/field/image/missing': 2863,
 'atp/field/name/missing': 2863,
 'atp/field/opening_hours/missing': 2863,
 'atp/field/phone/invalid': 381,
 'atp/field/phone/missing': 1385,
 'atp/field/state/missing': 2863,
 'atp/field/twitter/missing': 2863,
 'atp/nsi/category_match': 2863,
 'downloader/request_bytes': 612,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1301467,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.01745,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 15, 11, 55, 47, 579082, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1657,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2863,
 'log_count/DEBUG': 2876,
 'log_count/INFO': 9,
 'memusage/max': 135249920,
 'memusage/startup': 135249920,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 15, 11, 55, 41, 561632, tzinfo=datetime.timezone.utc)}

