### PR TITLE
[WillScot] Add spider

### DIFF
--- a/locations/spiders/willscot.py
+++ b/locations/spiders/willscot.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WillscotSpider(SitemapSpider, StructuredDataSpider):
+    name = "willscot"
+    item_attributes = {"brand": "WillScot", "brand_wikidata": "Q123415387"}
+    sitemap_urls = ["https://www.willscot.com/sitemaps/sitemap-willscot%20us-en.xml"]
+    sitemap_rules = [("/locations/", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        extract_google_position(item, response)
+
+        if item["name"].startswith("Mobile Office Trailers") or item["name"].startswith("Portable Storage Units"):
+            item["name"] = None
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/WillScot': 117,
 'atp/brand_wikidata/Q123415387': 117,
 'atp/category/shop/rental': 117,
 'atp/field/country/from_reverse_geocoding': 113,
 'atp/field/country/missing': 4,
 'atp/field/email/missing': 117,
 'atp/field/image/missing': 117,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 117,
 'atp/field/phone/invalid': 4,
 'atp/nsi/perfect_match': 117,
 'downloader/request_bytes': 81841,
 'downloader/request_count': 119,
 'downloader/request_method_count/GET': 119,
 'downloader/response_bytes': 9986979,
 'downloader/response_count': 119,
 'downloader/response_status_count/200': 119,
 'elapsed_time_seconds': 2.317751,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 15, 11, 30, 32, 455416),
 'httpcache/hit': 119,
 'httpcompression/response_bytes': 50137990,
 'httpcompression/response_count': 119,
 'item_scraped_count': 117,
 'log_count/DEBUG': 248,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 162058240,
 'memusage/startup': 162058240,
 'request_depth_max': 1,
 'response_received_count': 119,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 118,
 'scheduler/dequeued/memory': 118,
 'scheduler/enqueued': 118,
 'scheduler/enqueued/memory': 118,
 'start_time': datetime.datetime(2023, 11, 15, 11, 30, 30, 137665)}
```