### PR TITLE
[DelikatesyCentrumPL] Fix category

### DIFF
--- a/locations/spiders/delikatesy_centrum_pl.py
+++ b/locations/spiders/delikatesy_centrum_pl.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -31,4 +32,5 @@ class DelikatesyCentrumPLSpider(Spider):
                 if not day_hours["hours"] or day_hours["hours"] == "czynne":
                     continue
                 item["opening_hours"].add_range(day_hours["day"].title(), *day_hours["hours"].split("-", 1), "%H:%M")
+            apply_category(Categories.SHOP_SUPERMARKET, item)
             yield item


### PR DESCRIPTION
There are 2 categories in NSI, namely shop=convenience and shop=supermarket.
Nothing in the data we scrape to indicate size of store.
Hence set to supermarket.
{'atp/brand/Delikatesy Centrum': 1459,
 'atp/brand_wikidata/Q11693824': 1459,
 'atp/category/shop/supermarket': 1459,
 'atp/field/country/from_spider_name': 1459,
 'atp/field/email/missing': 1459,
 'atp/field/image/missing': 1459,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 38,
 'atp/field/phone/missing': 1459,
 'atp/field/state/missing': 1459,
 'atp/field/street_address/missing': 1459,
 'atp/field/twitter/missing': 1459,
 'atp/field/website/missing': 1459,
 'atp/nsi/category_match': 1459,
 'downloader/request_bytes': 1014,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 617737,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.081187,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 15, 14, 7, 21, 824558, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4478119,
 'httpcompression/response_count': 3,
 'item_scraped_count': 1459,
 'log_count/DEBUG': 1480,
 'log_count/INFO': 9,
 'memusage/max': 133959680,
 'memusage/startup': 133959680,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 11, 15, 14, 7, 17, 743371, tzinfo=datetime.timezone.utc)}
