### PR TITLE
[BNPParibasBankPL] Don't crash on records missing ids

### DIFF
--- a/locations/spiders/bnp_paribas_bank_pl.py
+++ b/locations/spiders/bnp_paribas_bank_pl.py
@@ -30,6 +30,8 @@ class BNPParibasBankPLSpider(scrapy.Spider):
 
         for poi in details.get("department_retail_business").values():
             branch = poi.get("basicParameters")
+            if not branch.get("branch_id"):
+                continue  # Currently 2 don't have ids
             branch["street_address"] = branch.pop("street")
             item = DictParser.parse(branch)
             item["ref"] = branch["branch_id"]


### PR DESCRIPTION
```python
{'atp/brand/BNP Paribas Bank Polska': 934,
 'atp/brand/Euronet': 6861,
 'atp/brand/Planet Cash': 4084,
 'atp/brand_wikidata/Q117744569': 4084,
 'atp/brand_wikidata/Q20744004': 934,
 'atp/brand_wikidata/Q5412010': 6861,
 'atp/category/amenity/atm': 11503,
 'atp/category/amenity/bank': 376,
 'atp/field/country/from_spider_name': 11879,
 'atp/field/email/missing': 11503,
 'atp/field/image/missing': 11879,
 'atp/field/phone/missing': 11879,
 'atp/field/state/missing': 11879,
 'atp/field/twitter/missing': 11879,
 'atp/field/website/missing': 11879,
 'atp/nsi/category_match': 934,
 'atp/nsi/perfect_match': 10945,
 'downloader/request_bytes': 1226,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 447347,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 6.100365,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 15, 16, 13, 24, 360622),
 'httpcache/hit': 3,
 'httpcompression/response_bytes': 3779472,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 11879,
 'log_count/DEBUG': 11895,
 'log_count/INFO': 9,
 'memusage/max': 149823488,
 'memusage/startup': 149823488,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2023, 11, 15, 16, 13, 18, 260257)}
```