### PR TITLE
[StaplesCA] Add spider

### DIFF
--- a/locations/spiders/staples_ca.py
+++ b/locations/spiders/staples_ca.py
@@ -1,0 +1,27 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class StaplesCASpider(SitemapSpider, StructuredDataSpider):
+    name = "staples_ca"
+    item_attributes = {"brand": "Staples", "brand_wikidata": "Q17149420"}
+    sitemap_urls = ["https://stores.staples.ca/robots.txt"]
+    sitemap_rules = [(r".+/office-supplies-\w\w-\d+\.html$", "parse_sd")]
+    wanted_types = ["OfficeEquipmentStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"], item["branch"] = item["name"].removeprefix("About ").rsplit(" ", 1)
+        item["extras"]["website:en"] = response.url
+        item["extras"]["website:fr"] = response.xpath(
+            '//a[contains(@href, "https://locations.bureauengros.com/")]/@href'
+        ).get()
+
+        item["website"] = (
+            item["extras"]["website:fr"] if item["name"] == "Bureau en Gros" else item["extras"]["website:en"]
+        )
+
+        apply_category(Categories.SHOP_STATIONERY, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Staples': 300,
 'atp/brand_wikidata/Q17149420': 300,
 'atp/category/shop/stationery': 300,
 'atp/field/country/from_spider_name': 300,
 'atp/field/email/missing': 300,
 'atp/field/image/dropped': 300,
 'atp/field/image/missing': 300,
 'atp/nsi/match_failed': 300,
 'downloader/request_bytes': 117036,
 'downloader/request_count': 304,
 'downloader/request_method_count/GET': 304,
 'downloader/response_bytes': 6715867,
 'downloader/response_count': 304,
 'downloader/response_status_count/200': 303,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 2.387351,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 16, 10, 50, 8, 698591),
 'httpcache/hit': 304,
 'httpcompression/response_bytes': 41734087,
 'httpcompression/response_count': 303,
 'item_scraped_count': 300,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 150593536,
 'memusage/startup': 150593536,
 'request_depth_max': 2,
 'response_received_count': 303,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 303,
 'scheduler/dequeued/memory': 303,
 'scheduler/enqueued': 303,
 'scheduler/enqueued/memory': 303,
 'start_time': datetime.datetime(2023, 11, 16, 10, 50, 6, 311240)}
```