### PR TITLE
[BiopedCA] Add spider

### DIFF
--- a/locations/spiders/bioped_ca.py
+++ b/locations/spiders/bioped_ca.py
@@ -1,0 +1,18 @@
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+
+
+class BiopedCASpider(Spider):
+    name = "bioped_ca"
+    item_attributes = {"brand": "BioPed", "brand_wikidata": "Q123409898"}
+    start_urls = ["https://www.bioped.com/wp-content/uploads/agile-store-locator/locator-data.json"]
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("street")
+            item["extras"]["fax"] = location["fax"]
+            item["website"] = response.urljoin(location["page_url"])
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/8932

```python
{'atp/brand/BioPed': 96,
 'atp/brand_wikidata/Q123409898': 96,
 'atp/category/missing': 96,
 'atp/closed_check': 1,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 96,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 96,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 5,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 96,
 'atp/geometry/null_island': 1,
 'atp/nsi/brand_missing': 96,
 'downloader/request_bytes': 708,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12886,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.582155,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 16, 14, 37, 2, 682011),
 'httpcache/firsthand': 2,
 'httpcache/miss': 2,
 'httpcache/store': 2,
 'httpcompression/response_bytes': 91920,
 'httpcompression/response_count': 2,
 'item_scraped_count': 96,
 'log_count/DEBUG': 111,
 'log_count/INFO': 10,
 'log_count/WARNING': 2,
 'memusage/max': 150446080,
 'memusage/startup': 150446080,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 16, 14, 37, 0, 99856)}
```