### PR TITLE
[NettoSalling] Fix HTML escaping

### DIFF
--- a/locations/spiders/netto_salling.py
+++ b/locations/spiders/netto_salling.py
@@ -1,3 +1,4 @@
+import html
 from datetime import datetime
 
 from scrapy.spiders import SitemapSpider
@@ -21,6 +22,10 @@ class NettoSallingSpider(SitemapSpider, StructuredDataSpider):
     ]
 
     def pre_process_data(self, ld_data, **kwargs):
+        ld_data["name"] = html.unescape(ld_data["name"])
+        ld_data["address"]["streetAddress"] = html.unescape(ld_data["address"]["streetAddress"])
+        ld_data["address"]["addressLocality"] = html.unescape(ld_data["address"]["addressLocality"])
+
         for oh in ld_data.get("openingHoursSpecification", []):
             if oh.get("dayOfWeek"):
                 continue


### PR DESCRIPTION
```python
{'atp/brand/Netto': 1189,
 'atp/brand_wikidata/Q552652': 1189,
 'atp/category/shop/supermarket': 1189,
 'atp/cdn/cloudflare/response_count': 1197,
 'atp/cdn/cloudflare/response_status_count/200': 1195,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/cdn/cloudflare/response_status_count/524': 1,
 'atp/field/country/from_website_url': 1189,
 'atp/field/email/missing': 1189,
 'atp/field/opening_hours/missing': 13,
 'atp/field/phone/missing': 529,
 'atp/field/state/missing': 1189,
 'atp/field/twitter/missing': 660,
 'atp/nsi/perfect_match': 1189,
 'downloader/request_bytes': 741130,
 'downloader/request_count': 1200,
 'downloader/request_method_count/GET': 1200,
 'downloader/response_bytes': 74598575,
 'downloader/response_count': 1200,
 'downloader/response_status_count/200': 1195,
 'downloader/response_status_count/302': 1,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/524': 3,
 'elapsed_time_seconds': 268.588402,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 17, 13, 47, 37, 563171),
 'httpcache/firsthand': 905,
 'httpcache/hit': 295,
 'httpcache/miss': 905,
 'httpcache/store': 905,
 'httpcompression/response_bytes': 425765916,
 'httpcompression/response_count': 1195,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/404': 1,
 'httperror/response_ignored_status_count/524': 1,
 'item_scraped_count': 1189,
 'log_count/DEBUG': 2404,
 'log_count/ERROR': 1,
 'log_count/INFO': 16,
 'memusage/max': 497352704,
 'memusage/startup': 149987328,
 'request_depth_max': 1,
 'response_received_count': 1197,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/524 Unknown Status': 2,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 1197,
 'scheduler/dequeued/memory': 1197,
 'scheduler/enqueued': 1197,
 'scheduler/enqueued/memory': 1197,
 'start_time': datetime.datetime(2023, 11, 17, 13, 43, 8, 974769)}
```