### PR TITLE
[media_markt] Fixed Spider (285 Items)

### DIFF
--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -12,8 +12,6 @@ class MediaMarktSpider(StructuredDataSpider):
     name = "media_markt"
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
     start_urls = ["https://www.mediamarkt.de/de/store/store-finder"]
-    user_agent = BROWSER_DEFAULT
-    rules = [Rule(LinkExtractor(allow=r"https://www.mediamarkt.de/de/store/"), callback="parse_sd")]
 
     def _parse(self, response):
         script = response.xpath('//script[contains(text(), "__PRELOADED_STATE__")]/text()').extract_first()

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -1,11 +1,8 @@
 import json
 
 from scrapy.http import Request
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import Rule
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class MediaMarktSpider(StructuredDataSpider):

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -10,7 +10,7 @@ class MediaMarktSpider(StructuredDataSpider):
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
     start_urls = ["https://www.mediamarkt.de/de/store/store-finder"]
 
-    def _parse(self, response):
+    def parse(self, response):
         script = response.xpath('//script[contains(text(), "__PRELOADED_STATE__")]/text()').extract_first()
         script = script[script.index("{") : script.rindex("}") + 1]
         state = json.loads(script)["apolloState"]["ROOT_QUERY"]['localStorePage({"uid":"store-finder"})']["content"]

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -1,11 +1,27 @@
+import json
+
+from scrapy.http import Request
 from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import Rule
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class MediaMarktSpider(CrawlSpider, StructuredDataSpider):
+class MediaMarktSpider(StructuredDataSpider):
     name = "media_markt"
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
     start_urls = ["https://www.mediamarkt.de/de/store/store-finder"]
+    user_agent = BROWSER_DEFAULT
     rules = [Rule(LinkExtractor(allow=r"https://www.mediamarkt.de/de/store/"), callback="parse_sd")]
+
+    def _parse(self, response):
+        script = response.xpath('//script[contains(text(), "__PRELOADED_STATE__")]/text()').extract_first()
+        script = script[script.index("{") : script.rindex("}") + 1]
+        state = json.loads(script)["apolloState"]["ROOT_QUERY"]['localStorePage({"uid":"store-finder"})']["content"]
+
+        for item in state:
+            if item.get("__typename") == "GraphqlLocalStorePageContentAccordion":
+                for region in item["regions"]:
+                    for store in region["regionStores"]:
+                        yield Request(f"https://www.mediamarkt.de/de/store/{store['uid']}", callback=self.parse_sd)


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/MediaMarkt': 285,
 'atp/brand_wikidata/Q2381223': 285,
 'atp/category/shop/electronics': 285,
 'atp/cdn/cloudflare/response_count': 288,
 'atp/cdn/cloudflare/response_status_count/200': 287,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 284,
 'atp/field/phone/invalid': 279,
 'atp/field/state/missing': 285,
 'atp/nsi/perfect_match': 285,
 'downloader/request_bytes': 366275,
 'downloader/request_count': 574,
 'downloader/request_method_count/GET': 574,
 'downloader/response_bytes': 31060020,
 'downloader/response_count': 574,
 'downloader/response_status_count/200': 287,
 'downloader/response_status_count/301': 286,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 696.439155,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 20, 14, 19, 53, 511614),
 'httpcompression/response_bytes': 163069708,
 'httpcompression/response_count': 288,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 285,
 'log_count/DEBUG': 870,
 'log_count/INFO': 21,
 'memusage/max': 344305664,
 'memusage/startup': 134623232,
 'request_depth_max': 1,
 'response_received_count': 288,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 573,
 'scheduler/dequeued/memory': 573,
 'scheduler/enqueued': 573,
 'scheduler/enqueued/memory': 573,
 'start_time': datetime.datetime(2023, 11, 20, 14, 8, 17, 72459)}
```
</details>