### PR TITLE
[SwarcoEConnect] Add category

### DIFF
--- a/locations/spiders/swarco_e_connect.py
+++ b/locations/spiders/swarco_e_connect.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -12,4 +13,6 @@ class SwarcoEConnectSpider(Spider):
         for location in response.json():
             if not location["visible"]:
                 continue
-            yield DictParser.parse(location)
+            item = DictParser.parse(location)
+            apply_category(Categories.CHARGING_STATION, item)
+            yield item


### PR DESCRIPTION
{'atp/brand/Swarco E.Connect': 1033,
 'atp/brand_wikidata/Q118383410': 1033,
 'atp/category/amenity/charging_station': 1033,
 'atp/field/city/missing': 3,
 'atp/field/country/from_reverse_geocoding': 1031,
 'atp/field/country/missing': 2,
 'atp/field/email/missing': 1033,
 'atp/field/image/missing': 1033,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/name/missing': 1033,
 'atp/field/opening_hours/missing': 1033,
 'atp/field/phone/missing': 1033,
 'atp/field/postcode/missing': 1033,
 'atp/field/state/missing': 2,
 'atp/field/street_address/missing': 1033,
 'atp/field/twitter/missing': 1033,
 'atp/field/website/missing': 1033,
 'atp/nsi/category_match': 1031,
 'atp/nsi/match_failed': 2,
 'downloader/request_bytes': 633,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13460,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.297185,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 21, 13, 50, 18, 388662, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 167145,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1033,
 'log_count/DEBUG': 1046,
 'log_count/INFO': 9,
 'memusage/max': 134631424,
 'memusage/startup': 134631424,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 21, 13, 50, 15, 91477, tzinfo=datetime.timezone.utc)}
