### PR TITLE
[ecars] Add category

### DIFF
--- a/locations/spiders/ecars.py
+++ b/locations/spiders/ecars.py
@@ -3,6 +3,7 @@ import logging
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -29,5 +30,5 @@ class EcarsSpider(Spider):
 
             item = DictParser.parse(location)
             item["addr_full"] = location["dn"]
-
+            apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
{'atp/brand/ecars': 699,
 'atp/brand_wikidata/Q3050566': 699,
 'atp/category/amenity/charging_station': 699,
 'atp/field/city/missing': 141,
 'atp/field/country/from_reverse_geocoding': 699,
 'atp/field/email/missing': 699,
 'atp/field/image/missing': 699,
 'atp/field/name/missing': 699,
 'atp/field/opening_hours/missing': 699,
 'atp/field/phone/missing': 699,
 'atp/field/postcode/missing': 694,
 'atp/field/state/missing': 21,
 'atp/field/street_address/missing': 699,
 'atp/field/twitter/missing': 699,
 'atp/field/website/missing': 699,
 'atp/nsi/category_match': 699,
 'downloader/request_bytes': 454,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 29029,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.538887,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 21, 14, 58, 51, 928842, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 265640,
 'httpcompression/response_count': 1,
 'item_scraped_count': 699,
 'log_count/DEBUG': 711,
 'log_count/INFO': 9,
 'memusage/max': 132894720,
 'memusage/startup': 132894720,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 21, 14, 58, 49, 389955, tzinfo=datetime.timezone.utc)}
