### PR TITLE
[cenex] Added Fuel Category Tag (1317 items)

### DIFF
--- a/locations/spiders/cenex.py
+++ b/locations/spiders/cenex.py
@@ -1,6 +1,6 @@
 import scrapy
 
-from locations.categories import Extras, Fuel, apply_yes_no
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.spiders.vapestore_gb import clean_address
 
@@ -60,6 +60,7 @@ class CenexSpider(scrapy.Spider):
                 opening_hours="24/7" if "24-Hour Fueling" in amenities else None,
             )
 
+            apply_category(Categories.FUEL_STATION, item)
             apply_yes_no(Extras.ATM, item, "ATM" in amenities)
             apply_yes_no(Extras.COMPRESSED_AIR, item, "Air" in amenities)
             apply_yes_no(Fuel.BIODIESEL, item, "Biodiesel" in amenities)


### PR DESCRIPTION
Added category here as there are multiple NSI entries.

<details><summary>New Stats</summary>

```python
{'atp/brand/Cenex': 1317,
 'atp/brand_wikidata/Q62127191': 1317,
 'atp/category/amenity/fuel': 1317,
 'atp/field/email/missing': 1317,
 'atp/field/image/missing': 1317,
 'atp/field/opening_hours/missing': 317,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/missing': 1317,
 'atp/field/website/missing': 1317,
 'atp/nsi/category_match': 1317,
 'downloader/request_bytes': 1231,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 965754,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.999585,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 21, 16, 19, 50, 536462),
 'item_scraped_count': 1317,
 'log_count/DEBUG': 1337,
 'log_count/INFO': 9,
 'memusage/max': 135008256,
 'memusage/startup': 135008256,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 21, 16, 19, 45, 536877)}
```
</details>