### PR TITLE
[Ionity] Add category

### DIFF
--- a/locations/spiders/ionity.py
+++ b/locations/spiders/ionity.py
@@ -2,6 +2,7 @@ import re
 
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -26,5 +27,5 @@ class IonitySpider(Spider):
 
             if m := re.search(r"Number of CCS Chargers: (\d+)", location["description"]):
                 item["extras"]["socket:CCS"] = m.group(1)
-
+            apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
2 entries in NSI namely charging_station and charge point, so category set explicitly.

{'atp/brand/Ionity': 549,
 'atp/brand_wikidata/Q42717773': 549,
 'atp/category/amenity/charging_station': 549,
 'atp/field/city/missing': 89,
 'atp/field/country/from_reverse_geocoding': 549,
 'atp/field/email/missing': 549,
 'atp/field/image/missing': 549,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/missing': 549,
 'atp/field/postcode/missing': 499,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 498,
 'atp/field/twitter/missing': 549,
 'atp/field/website/missing': 549,
 'atp/nsi/match_failed': 549,
 'downloader/request_bytes': 603,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 146443,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.983157,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 8, 58, 2, 145028, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 196,
 'httpcompression/response_count': 1,
 'item_scraped_count': 549,
 'log_count/DEBUG': 562,
 'log_count/INFO': 9,
 'memusage/max': 134791168,
 'memusage/startup': 134791168,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 22, 8, 57, 59, 161871, tzinfo=datetime.timezone.utc)}
