### PR TITLE
[TaxAssistGB] Add spider

### DIFF
--- a/locations/spiders/tax_assist_gb.py
+++ b/locations/spiders/tax_assist_gb.py
@@ -6,6 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class TaxAssistGBSpider(CrawlSpider, StructuredDataSpider):
     name = "tax_assist_gb"
+    item_attributes = {"brand": "TaxAssist Accountants", "brand_wikidata": "Q122459380"}
     start_urls = ["https://www.taxassist.co.uk/locations"]
     rules = [Rule(LinkExtractor("/accountants/"), "parse_sd")]
     wanted_types = ["AccountingService"]

--- a/locations/spiders/tax_assist_gb.py
+++ b/locations/spiders/tax_assist_gb.py
@@ -1,0 +1,16 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TaxAssistGBSpider(CrawlSpider, StructuredDataSpider):
+    name = "tax_assist_gb"
+    start_urls = ["https://www.taxassist.co.uk/locations"]
+    rules = [Rule(LinkExtractor("/accountants/"), "parse_sd")]
+    wanted_types = ["AccountingService"]
+
+    def pre_process_data(self, ld_data, **kwargs):
+        for rule in ld_data.get("openingHoursSpecification", []):
+            if rule["opens"] == "00:00" and rule["closes"] == "00:00":
+                rule.pop("opens")

--- a/locations/spiders/tax_assist_gb.py
+++ b/locations/spiders/tax_assist_gb.py
@@ -8,7 +8,7 @@ class TaxAssistGBSpider(CrawlSpider, StructuredDataSpider):
     name = "tax_assist_gb"
     item_attributes = {"brand": "TaxAssist Accountants", "brand_wikidata": "Q122459380"}
     start_urls = ["https://www.taxassist.co.uk/locations"]
-    rules = [Rule(LinkExtractor("/accountants/"), "parse_sd")]
+    rules = [Rule(LinkExtractor("/accountants/", restrict_xpaths='//div[contains(., "Local Offices")]'), "parse_sd")]
     wanted_types = ["AccountingService"]
 
     def pre_process_data(self, ld_data, **kwargs):


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/8959

```python
{'atp/brand/TaxAssist Accountants': 414,
 'atp/brand_wikidata/Q122459380': 414,
 'atp/category/missing': 414,
 'atp/cdn/cloudflare/response_count': 416,
 'atp/cdn/cloudflare/response_status_count/200': 416,
 'atp/field/city/missing': 7,
 'atp/field/country/from_spider_name': 139,
 'atp/field/email/missing': 414,
 'atp/field/image/missing': 189,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 414,
 'atp/nsi/brand_missing': 414,
 'downloader/request_bytes': 452894,
 'downloader/request_count': 416,
 'downloader/request_method_count/GET': 416,
 'downloader/response_bytes': 6045432,
 'downloader/response_count': 416,
 'downloader/response_status_count/200': 416,
 'elapsed_time_seconds': 5.208267,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 11, 21, 46, 615207, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 416,
 'httpcompression/response_bytes': 24036574,
 'httpcompression/response_count': 415,
 'item_scraped_count': 414,
 'log_count/DEBUG': 842,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 150999040,
 'memusage/startup': 150999040,
 'request_depth_max': 1,
 'response_received_count': 416,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'start_time': datetime.datetime(2023, 11, 22, 11, 21, 41, 406940, tzinfo=datetime.timezone.utc)}
```