### PR TITLE
[HowardHanna] Add wikidata Q code to fix category

### DIFF
--- a/locations/spiders/howardhanna.py
+++ b/locations/spiders/howardhanna.py
@@ -7,7 +7,7 @@ from locations.items import Feature
 
 class HowardHannaSpider(SitemapSpider):
     name = "howardhanna"
-    item_attributes = {"brand": "Howard Hanna"}
+    item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
     allowed_domains = ["howardhanna.com"]
     sitemap_urls = ["https://www.howardhanna.com/Seo/OfficeSitemap"]
     sitemap_rules = [(r"/Office/Detail/", "parse")]


### PR DESCRIPTION
{'atp/brand/Howard Hanna': 386,
 'atp/brand_wikidata/Q119573413': 386,
 'atp/category/office/estate_agent': 386,
 'atp/field/country/from_reverse_geocoding': 386,
 'atp/field/email/missing': 386,
 'atp/field/image/missing': 386,
 'atp/field/opening_hours/missing': 386,
 'atp/field/phone/missing': 15,
 'atp/field/postcode/missing': 386,
 'atp/field/street_address/missing': 386,
 'atp/field/twitter/missing': 386,
 'atp/nsi/perfect_match': 386,
 'downloader/request_bytes': 406481,
 'downloader/request_count': 774,
 'downloader/request_method_count/GET': 774,
 'downloader/response_bytes': 28266855,
 'downloader/response_count': 774,
 'downloader/response_status_count/200': 774,
 'elapsed_time_seconds': 936.509029,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 12, 32, 15, 422825, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 93951082,
 'httpcompression/response_count': 774,
 'item_scraped_count': 386,
 'log_count/DEBUG': 1171,
 'log_count/INFO': 24,
 'memusage/max': 422350848,
 'memusage/startup': 134332416,
 'request_depth_max': 2,
 'response_received_count': 774,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 773,
 'scheduler/dequeued/memory': 773,
 'scheduler/enqueued': 773,
 'scheduler/enqueued/memory': 773,
 'start_time': datetime.datetime(2023, 11, 22, 12, 16, 38, 913796, tzinfo=datetime.timezone.utc)}
