### PR TITLE
[CasinoFR] Add category

### DIFF
--- a/locations/spiders/casino_fr.py
+++ b/locations/spiders/casino_fr.py
@@ -1,6 +1,7 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.spiders.vapestore_gb import clean_address
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -14,3 +15,7 @@ class CasinoFRSpider(CrawlSpider, StructuredDataSpider):
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["address"]["streetAddress"] = clean_address(ld_data["address"]["streetAddress"])
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item


### PR DESCRIPTION
3 entries in NSI - for fuel stations, advertising totem, and supermarkets
Disambiguate this by setting category explicitly to supermarket for these POIs
{'atp/brand/Casino Supermarchés': 376,
 'atp/brand_wikidata/Q89029184': 376,
 'atp/category/shop/supermarket': 376,
 'atp/field/country/from_spider_name': 376,
 'atp/field/email/missing': 376,
 'atp/field/image/missing': 376,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 376,
 'atp/nsi/category_match': 376,
 'downloader/request_bytes': 185936,
 'downloader/request_count': 378,
 'downloader/request_method_count/GET': 378,
 'downloader/response_bytes': 19044361,
 'downloader/response_count': 378,
 'downloader/response_status_count/200': 377,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 468.028862,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 13, 12, 4, 904780, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 66710603,
 'httpcompression/response_count': 377,
 'item_scraped_count': 376,
 'log_count/DEBUG': 765,
 'log_count/INFO': 16,
 'memusage/max': 305860608,
 'memusage/startup': 134131712,
 'request_depth_max': 1,
 'response_received_count': 378,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 377,
 'scheduler/dequeued/memory': 377,
 'scheduler/enqueued': 377,
 'scheduler/enqueued/memory': 377,
 'start_time': datetime.datetime(2023, 11, 22, 13, 4, 16, 875918, tzinfo=datetime.timezone.utc)}
2023-11-22 13:12:04 [scrapy.core.engine] INFO: Spider closed (finished)
