### PR TITLE
[OspreyGB] Add category

### DIFF
--- a/locations/spiders/osprey_gb.py
+++ b/locations/spiders/osprey_gb.py
@@ -1,5 +1,6 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -12,4 +13,6 @@ class OspreyGBSpider(Spider):
 
     def parse(self, response, **kwargs):
         for location in response.json():
-            yield DictParser.parse(location)
+            item = DictParser.parse(location)
+            apply_category(Categories.CHARGING_STATION, item)
+            yield item


### PR DESCRIPTION
{'atp/brand/Osprey': 305,
 'atp/brand_wikidata/Q117706577': 305,
 'atp/category/amenity/charging_station': 305,
 'atp/field/city/missing': 305,
 'atp/field/country/from_spider_name': 305,
 'atp/field/email/missing': 305,
 'atp/field/image/missing': 305,
 'atp/field/name/missing': 305,
 'atp/field/opening_hours/missing': 305,
 'atp/field/phone/missing': 305,
 'atp/field/postcode/missing': 303,
 'atp/field/state/missing': 305,
 'atp/field/street_address/missing': 305,
 'atp/field/twitter/missing': 305,
 'atp/field/website/missing': 305,
 'atp/nsi/category_match': 305,
 'downloader/request_bytes': 734,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 22123,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/401': 1,
 'elapsed_time_seconds': 1.962094,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 13, 45, 19, 364786, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 118007,
 'httpcompression/response_count': 1,
 'item_scraped_count': 305,
 'log_count/DEBUG': 319,
 'log_count/INFO': 9,
 'memusage/max': 134471680,
 'memusage/startup': 134471680,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/401': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 22, 13, 45, 17, 402692, tzinfo=datetime.timezone.utc)}
