### PR TITLE
[DunelmGB] Add category

### DIFF
--- a/locations/spiders/dunelm_gb.py
+++ b/locations/spiders/dunelm_gb.py
@@ -7,7 +7,11 @@ from locations.hours import OpeningHours
 
 class DunelmGB(Spider):
     name = "dunelm_gb"
-    item_attributes = {"brand": "Dunelm", "brand_wikidata": "Q5315020"}
+    item_attributes = {
+        "brand": "Dunelm",
+        "brand_wikidata": "Q5315020",
+        "extras": {"shop": "houseware"},
+    }
 
     def start_requests(self):
         yield JsonRequest(


### PR DESCRIPTION
NSI has 2 entries, namely amenity/cafe, and shop/interior_decoration.
To disambiguate category is set more correctly, I believe, to shop/houseware.
{'atp/brand/Dunelm': 182,
 'atp/brand_wikidata/Q5315020': 182,
 'atp/category/shop/houseware': 182,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 182,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 113,
 'atp/field/twitter/missing': 182,
 'atp/nsi/match_failed': 182,
 'downloader/request_bytes': 1116,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 171769,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.448571,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 22, 15, 48, 35, 252787, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1390787,
 'httpcompression/response_count': 1,
 'item_scraped_count': 182,
 'log_count/DEBUG': 197,
 'log_count/INFO': 9,
 'memusage/max': 133963776,
 'memusage/startup': 133963776,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 22, 15, 48, 31, 804216, tzinfo=datetime.timezone.utc)}
