### PR TITLE
[PJsCoffeeUS] Correct Q code to fix category

### DIFF
--- a/locations/spiders/pjs_coffee_us.py
+++ b/locations/spiders/pjs_coffee_us.py
@@ -6,7 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class PjsCoffeeUSSpider(CrawlSpider, StructuredDataSpider):
     name = "pjs_coffee_us"
-    item_attributes = {"brand_wikidata": "Q120513813"}
+    item_attributes = {"brand_wikidata": "Q7119454"}
     start_urls = ["https://locations.pjscoffee.com/"]
     rules = [
         Rule(LinkExtractor(r"/\w\w/(?:\w+/)?$")),


### PR DESCRIPTION
{"atp/brand/PJ's Coffee of New Orleans": 180,
 'atp/brand_wikidata/Q7119454': 180,
 'atp/category/amenity/cafe': 180,
 'atp/field/brand/missing': 180,
 'atp/field/country/from_spider_name': 180,
 'atp/field/email/missing': 180,
 'atp/field/image/dropped': 180,
 'atp/field/image/missing': 180,
 'atp/field/name/missing': 180,
 'atp/field/opening_hours/missing': 28,
 'atp/field/phone/missing': 16,
 'atp/nsi/perfect_match': 180,
 'downloader/request_bytes': 115848,
 'downloader/request_count': 304,
 'downloader/request_method_count/GET': 304,
 'downloader/response_bytes': 5284785,
 'downloader/response_count': 304,
 'downloader/response_status_count/200': 304,
 'dupefilter/filtered': 230,
 'elapsed_time_seconds': 376.49412,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 23, 9, 9, 59, 985006, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 28182143,
 'httpcompression/response_count': 304,
 'item_scraped_count': 180,
 'log_count/DEBUG': 496,
 'log_count/INFO': 15,
 'memusage/max': 292261888,
 'memusage/startup': 134615040,
 'request_depth_max': 3,
 'response_received_count': 304,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 303,
 'scheduler/dequeued/memory': 303,
 'scheduler/enqueued': 303,
 'scheduler/enqueued/memory': 303,
 'start_time': datetime.datetime(2023, 11, 23, 9, 3, 43, 490886, tzinfo=datetime.timezone.utc)}
