### PR TITLE
[GasNZ] Add category

### DIFF
--- a/locations/spiders/gas_nz.py
+++ b/locations/spiders/gas_nz.py
@@ -1,4 +1,4 @@
-from locations.categories import Fuel, apply_yes_no
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 
 
@@ -12,4 +12,5 @@ class GASNZSpider(StoreLocatorWidgetsSpider):
         apply_yes_no(Fuel.OCTANE_91, item, "Unleaded 91" in location["filters"])
         apply_yes_no(Fuel.OCTANE_95, item, "Premium 95" in location["filters"])
         apply_yes_no(Fuel.DIESEL, item, "Diesel" in location["filters"])
+        apply_category(Categories.FUEL_STATION, item)
         yield item


### PR DESCRIPTION
{'atp/brand/G.A.S.': 123,
 'atp/brand_wikidata/Q112189761': 123,
 'atp/category/amenity/fuel': 123,
 'atp/field/city/missing': 123,
 'atp/field/country/from_spider_name': 123,
 'atp/field/image/missing': 123,
 'atp/field/postcode/missing': 123,
 'atp/field/state/missing': 123,
 'atp/field/street_address/missing': 123,
 'atp/field/twitter/missing': 123,
 'atp/field/website/missing': 123,
 'atp/nsi/category_match': 123,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 27572,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.243424,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 23, 10, 32, 51, 540456, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 358844,
 'httpcompression/response_count': 2,
 'item_scraped_count': 123,
 'log_count/DEBUG': 136,
 'log_count/INFO': 9,
 'memusage/max': 134266880,
 'memusage/startup': 134266880,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 23, 10, 32, 49, 297032, tzinfo=datetime.timezone.utc)}
