### PR TITLE
[Scrubsandbeyond] Add Q code to add NSI category

### DIFF
--- a/locations/spiders/scrubs_and_beyond.py
+++ b/locations/spiders/scrubs_and_beyond.py
@@ -1,6 +1,5 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,7 +8,6 @@ class ScrubsAndBeyondSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Scrubs and Beyond",
         "brand_wikidata": "Q119972011",
-        "extras": Categories.SHOP_CLOTHES.value,
     }
     allowed_domains = ["locations.scrubsandbeyond.com"]
     sitemap_urls = ("https://locations.scrubsandbeyond.com/robots.txt",)

--- a/locations/spiders/scrubs_and_beyond.py
+++ b/locations/spiders/scrubs_and_beyond.py
@@ -1,11 +1,16 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class ScrubsAndBeyondSpider(SitemapSpider, StructuredDataSpider):
     name = "scrubs_and_beyond"
-    item_attributes = {"brand": "Scrubs and Beyond"}
+    item_attributes = {
+        "brand": "Scrubs and Beyond",
+        "brand_wikidata": "Q119972011",
+        "extras": Categories.SHOP_CLOTHES.value,
+    }
     allowed_domains = ["locations.scrubsandbeyond.com"]
     sitemap_urls = ("https://locations.scrubsandbeyond.com/robots.txt",)
     sitemap_rules = [


### PR DESCRIPTION
This just needs the wikidata Q code because then that picks up the NSI category correctly.
{'atp/brand/Scrubs and Beyond': 122,
 'atp/brand_wikidata/Q119972011': 122,
 'atp/category/shop/clothes': 122,
 'atp/field/country/from_reverse_geocoding': 122,
 'atp/field/email/missing': 122,
 'atp/field/image/dropped': 122,
 'atp/field/image/missing': 122,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 1,
 'atp/nsi/perfect_match': 122,
 'downloader/request_bytes': 52791,
 'downloader/request_count': 126,
 'downloader/request_method_count/GET': 126,
 'downloader/response_bytes': 3923992,
 'downloader/response_count': 126,
 'downloader/response_status_count/200': 126,
 'elapsed_time_seconds': 152.081706,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 23, 10, 55, 47, 234679, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27334327,
 'httpcompression/response_count': 125,
 'item_scraped_count': 122,
 'log_count/DEBUG': 259,
 'log_count/INFO': 11,
 'memusage/max': 404090880,
 'memusage/startup': 134512640,
 'request_depth_max': 3,
 'response_received_count': 126,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 125,
 'scheduler/dequeued/memory': 125,
 'scheduler/enqueued': 125,
 'scheduler/enqueued/memory': 125,
 'start_time': datetime.datetime(2023, 11, 23, 10, 53, 15, 152973, tzinfo=datetime.timezone.utc)}
