### PR TITLE
[LibertyAU] Add category

### DIFF
--- a/locations/spiders/liberty_au.py
+++ b/locations/spiders/liberty_au.py
@@ -1,6 +1,7 @@
 import scrapy
 from scrapy import Selector
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -18,4 +19,5 @@ class LibertyAUSpider(scrapy.Spider):
             hours_string = " ".join(filter(None, Selector(text=location["hours"]).xpath("//text()").getall()))
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(hours_string)
+            apply_category(Categories.FUEL_STATION, item)
             yield item


### PR DESCRIPTION
{'atp/brand/Liberty Oil': 94,
 'atp/brand_wikidata/Q106687078': 94,
 'atp/category/amenity/fuel': 94,
 'atp/field/email/missing': 94,
 'atp/field/image/missing': 94,
 'atp/field/name/missing': 94,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 12,
 'atp/field/postcode/missing': 7,
 'atp/field/twitter/missing': 94,
 'atp/field/website/missing': 93,
 'atp/nsi/brand_missing': 94,
 'downloader/request_bytes': 684,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 86221,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.102635,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 23, 11, 42, 42, 20051, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 94,
 'log_count/DEBUG': 107,
 'log_count/INFO': 9,
 'memusage/max': 134225920,
 'memusage/startup': 134225920,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 23, 11, 42, 36, 917416, tzinfo=datetime.timezone.utc)}
