### PR TITLE
[LeonsCA] Add brand and category

### DIFF
--- a/locations/spiders/leons_ca.py
+++ b/locations/spiders/leons_ca.py
@@ -1,12 +1,13 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.spiders.vapestore_gb import clean_address
 
 
 class LeonsCASpider(Spider):
     name = "leons_ca"
-    item_attributes = {"brand_wikidata": "Q6524456"}
+    item_attributes = {"brand": "Leon's", "brand_wikidata": "Q6524456"}
     start_urls = [
         "https://stores.shopapps.site/front-end/get_surrounding_stores.php?shop=leons-furniture.myshopify.com&latitude=0&longitude=0&max_distance=100000000&limit=10000000"
     ]
@@ -17,5 +18,5 @@ class LeonsCASpider(Spider):
             location["street_address"] = clean_address([location.pop("address"), location.pop("address2")])
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
-
+            apply_category(Categories.SHOP_FURNITURE, item)
             yield item


### PR DESCRIPTION
{"atp/brand/Leon's": 89,
 'atp/brand_wikidata/Q6524456': 89,
 'atp/category/shop/furniture': 89,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/email/missing': 89,
 'atp/field/image/missing': 89,
 'atp/field/name/missing': 89,
 'atp/field/opening_hours/missing': 89,
 'atp/field/postcode/missing': 89,
 'atp/field/state/from_reverse_geocoding': 89,
 'atp/field/twitter/missing': 89,
 'atp/field/website/missing': 89,
 'atp/nsi/match_failed': 89,
 'downloader/request_bytes': 433,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 18593,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.258176,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 23, 11, 52, 11, 394316, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 241498,
 'httpcompression/response_count': 1,
 'item_scraped_count': 89,
 'log_count/DEBUG': 101,
 'log_count/INFO': 9,
 'memusage/max': 133873664,
 'memusage/startup': 133873664,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 23, 11, 52, 10, 136140, tzinfo=datetime.timezone.utc)}
