### PR TITLE
Fix category for all Decathlon spiders

### DIFF
--- a/locations/spiders/decathlon_fr.py
+++ b/locations/spiders/decathlon_fr.py
@@ -2,12 +2,13 @@ import re
 
 from unidecode import unidecode
 
+from locations.categories import Categories
 from locations.storefinders.woosmap import WoosmapSpider
 
 
 class DecathlonFRSpider(WoosmapSpider):
     name = "decathlon_fr"
-    item_attributes = {"brand": "Decathlon", "brand_wikidata": "Q509349"}
+    item_attributes = {"brand": "Decathlon", "brand_wikidata": "Q509349", "extras": Categories.SHOP_SPORTS.value}
     key = "woos-c7283e70-7b4b-3c7d-bbfe-e65958b8769b"
     origin = "https://www.decathlon.fr"
     website_template = "https://www.decathlon.fr/store-view/magasin-de-sports-{slug}-{ref}"


### PR DESCRIPTION
For almost all Decathlon spiders NSI match failed due [to multiple categories for the same wikidata](https://nsi.guide/?t=brands&tt=Q509349). This PR is adding category to `item_attributes` of `decathlon_fr` which all Decathlon spiders use.