### PR TITLE
[handelsbanken_se] Added Category (1465 items)

### DIFF
--- a/locations/spiders/handelsbanken_se.py
+++ b/locations/spiders/handelsbanken_se.py
@@ -44,7 +44,7 @@ class HandelsbankenSESpider(scrapy.Spider):
                 "lon": store.get("location").get("lng"),
                 "opening_hours": oh,
             }
-            if location_type == "ATM":
+            if location_type in ["ATM", "CRS"]:
                 apply_category(Categories.ATM, properties)
             elif location_type == "Branch":
                 apply_category(Categories.BANK, properties)

--- a/locations/spiders/handelsbanken_se.py
+++ b/locations/spiders/handelsbanken_se.py
@@ -2,7 +2,7 @@ import json
 
 import scrapy
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, apply_category, apply_yes_no
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
@@ -46,6 +46,8 @@ class HandelsbankenSESpider(scrapy.Spider):
             }
             if location_type in ["ATM", "CRS"]:
                 apply_category(Categories.ATM, properties)
+                if location_type == "CRS":
+                    apply_yes_no("cash_out", properties, True)
             elif location_type == "Branch":
                 apply_category(Categories.BANK, properties)
             yield Feature(**properties)


### PR DESCRIPTION
The only other location type that was scraped is CRS. Which I looked up and mean Cash Receiving System. I assume these are the same thing in the eyes of OSM.  I looked up 5 of the ones that were CRS (there were about 600) on google street view and they looked like ATMs to me. 

<details><summary>New Stats</summary>

```python
{'atp/brand/Handelsbanken': 1465,
 'atp/brand_wikidata/Q1421630': 1465,
 'atp/category/amenity/atm': 1260,
 'atp/category/amenity/bank': 205,
 'atp/field/email/missing': 1260,
 'atp/field/image/missing': 1465,
 'atp/field/opening_hours/missing': 1264,
 'atp/field/phone/missing': 1260,
 'atp/field/state/missing': 1465,
 'atp/field/twitter/missing': 1465,
 'atp/field/website/invalid': 205,
 'atp/field/website/missing': 1260,
 'atp/nsi/category_match': 1465,
 'downloader/request_bytes': 732,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 75402,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.655393,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 27, 20, 4, 11, 934078),
 'httpcompression/response_bytes': 1100682,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1465,
 'log_count/INFO': 9,
 'memusage/max': 135004160,
 'memusage/startup': 135004160,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 27, 20, 4, 8, 278685)}
```
</details>