### PR TITLE
[jefferson_univ_hosp] Added Clinic category (451 items)

### DIFF
--- a/locations/spiders/jefferson_university_hospital.py
+++ b/locations/spiders/jefferson_university_hospital.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -31,7 +32,13 @@ class JeffersonUniversityHospitalSpider(scrapy.Spider):
             yield scrapy.Request(url=f'{domain}{url.get("page_url")}.model.json', callback=self.parse_location)
 
     def parse_location(self, response):
+        location_data = response.json().get("locationLinkingData")
         item = DictParser.parse(response.json().get("locationLinkingData"))
         item["ref"] = item["website"]
 
+        if item["name"] == item["street_address"]:
+            item["name"] = f"{location_data['parentOrganization']} {location_data['@type']} at {item.get('city')}"
+            self.crawler.stats.inc_value("jefferson_univ_hosp/name_is_same_as_address")
+
+        apply_category(Categories.CLINIC, item)
         yield item


### PR DESCRIPTION
Added the clinic category as the type coming in from the response all said MedicalClinic.

Also I noticed that some of the names coming in were identical to the address, thus I changed up the name if that is the case.

<details><summary>New Stats</summary>

```python
{'atp/brand/Jefferson University Hospital': 451,
 'atp/brand_wikidata/Q59676202': 451,
 'atp/category/amenity/clinic': 451,
 'atp/category/multiple': 451,
 'atp/field/country/from_reverse_geocoding': 446,
 'atp/field/country/missing': 5,
 'atp/field/email/missing': 451,
 'atp/field/image/missing': 451,
 'atp/field/lat/missing': 5,
 'atp/field/lon/missing': 5,
 'atp/field/opening_hours/missing': 451,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 7,
 'atp/field/state/from_reverse_geocoding': 6,
 'atp/field/twitter/missing': 451,
 'atp/nsi/brand_missing': 451,
 'downloader/request_bytes': 333338,
 'downloader/request_count': 455,
 'downloader/request_method_count/GET': 455,
 'downloader/response_bytes': 19352787,
 'downloader/response_count': 455,
 'downloader/response_status_count/200': 453,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 544.832766,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 29, 19, 30, 39, 634768, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 186599033,
 'httpcompression/response_count': 451,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/301': 2,
 'item_scraped_count': 451,
 'jefferson_univ_hosp/name_is_same_as_address': 28,
 'log_count/INFO': 20,
 'memusage/max': 395972608,
 'memusage/startup': 144240640,
 'request_depth_max': 2,
 'response_received_count': 455,
 'scheduler/dequeued': 455,
 'scheduler/dequeued/memory': 455,
 'scheduler/enqueued': 455,
 'scheduler/enqueued/memory': 455,
 'start_time': datetime.datetime(2023, 11, 29, 19, 21, 34, 802002, tzinfo=datetime.timezone.utc)}
```
</details>