### PR TITLE
[voyagecare] Added Category (352 items)

### DIFF
--- a/locations/spiders/voyagecare.py
+++ b/locations/spiders/voyagecare.py
@@ -37,5 +37,5 @@ class VoyageCareSpider(scrapy.Spider):
                 "lon": float(store["properties"]["address1_longitude"]),
                 "website": response.url,
             }
-            apply_category({"amenity": "social_facility", "social_facility:for": "disabled"})
+            apply_category({"amenity": "social_facility", "social_facility:for": "disabled"}, properties)
             yield Feature(**properties)

--- a/locations/spiders/voyagecare.py
+++ b/locations/spiders/voyagecare.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import apply_category
 from locations.items import Feature
 
 
@@ -36,4 +37,5 @@ class VoyageCareSpider(scrapy.Spider):
                 "lon": float(store["properties"]["address1_longitude"]),
                 "website": response.url,
             }
+            apply_category({"amenity": "social_facility", "social_facility:for": "disabled"})
             yield Feature(**properties)


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Voyage Care': 352,
 'atp/category/amenity/social_facility': 352,
 'atp/field/brand_wikidata/missing': 352,
 'atp/field/city/missing': 125,
 'atp/field/email/missing': 352,
 'atp/field/image/missing': 352,
 'atp/field/name/missing': 3,
 'atp/field/opening_hours/missing': 352,
 'atp/field/phone/missing': 352,
 'atp/field/postcode/missing': 41,
 'atp/field/state/missing': 63,
 'atp/field/street_address/missing': 352,
 'atp/field/twitter/missing': 352,
 'downloader/request_bytes': 619,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 180833,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.164059,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 29, 20, 1, 32, 780177, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 914251,
 'httpcompression/response_count': 2,
 'item_scraped_count': 352,
 'log_count/DEBUG': 355,
 'log_count/INFO': 9,
 'memusage/max': 144044032,
 'memusage/startup': 144044032,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 11, 29, 20, 1, 24, 616118, tzinfo=datetime.timezone.utc)}
```
</details>