### PR TITLE
[kfc_ru] fix broken spider

### DIFF
--- a/locations/spiders/kfc_ru.py
+++ b/locations/spiders/kfc_ru.py
@@ -12,7 +12,7 @@ class KfcRUSpider(scrapy.Spider):
     item_attributes = {"brand": "KFC", "brand_wikidata": "Q524757"}
 
     def start_requests(self):
-        yield JsonRequest("https://api.kfc.digital/api/store/v2/store.get_restaurants?showClosed=false")
+        yield JsonRequest("https://api.prod.digital.uni.rest/api/store/v2/store.get_restaurants?showClosed=false")
 
     def parse(self, response):
         for poi in response.json().get("searchResults"):


### PR DESCRIPTION
Website's backend moved to a new URL.

Stats:

```json
{
 "atp/brand/KFC": 678,
 "atp/brand_wikidata/Q524757": 678,
 "atp/category/amenity/fast_food": 678,
 "atp/field/country/from_spider_name": 678,
 "atp/field/email/missing": 678,
 "atp/field/image/missing": 678,
 "atp/field/lat/invalid": 1,
 "atp/field/lat/missing": 17,
 "atp/field/lon/invalid": 1,
 "atp/field/lon/missing": 17,
 "atp/field/opening_hours/missing": 1,
 "atp/field/phone/invalid": 234,
 "atp/field/phone/missing": 16,
 "atp/field/postcode/missing": 678,
 "atp/field/state/missing": 678,
 "atp/field/street_address/missing": 678,
 "atp/field/twitter/missing": 678,
 "atp/field/website/missing": 678,
 "atp/nsi/cc_match": 678,
 "downloader/request_bytes": 688,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 464994,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 1,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 5.077478,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2023-12-01T14:51:07.265880+00:00",
 "httpcompression/response_bytes": 5106620,
 "httpcompression/response_count": 1,
 "item_scraped_count": 678,
 "log_count/INFO": 11,
 "memusage/max": 140328960,
 "memusage/startup": 140328960,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2023-12-01T14:51:02.188402+00:00"
}
```