### PR TITLE
[aveda] Added category for aveda (250 items)

### DIFF
--- a/locations/spiders/aveda.py
+++ b/locations/spiders/aveda.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -28,4 +29,5 @@ class AvedaSpider(scrapy.Spider):
             item["phone"] = value.get("PHONE1")
             item["website"] = value.get("WEBURL")
 
+            apply_category(Categories.SHOP_COSMETICS, item)
             yield item


### PR DESCRIPTION
Category was not captured via NSI due to multiple entries.

<details><summary>New Stats</summary>

```python
{'atp/brand/Aveda': 250,
 'atp/brand_wikidata/Q4827965': 250,
 'atp/category/amenity/training': 13,
 'atp/category/multiple': 13,
 'atp/category/shop/cosmetics': 237,
 'atp/field/email/invalid': 9,
 'atp/field/email/missing': 139,
 'atp/field/image/missing': 250,
 'atp/field/opening_hours/missing': 250,
 'atp/field/phone/invalid': 25,
 'atp/field/state/missing': 4,
 'atp/field/twitter/missing': 250,
 'atp/field/website/invalid': 10,
 'atp/field/website/missing': 138,
 'atp/nsi/category_match': 126,
 'atp/nsi/cc_match': 13,
 'atp/nsi/match_failed': 111,
 'downloader/request_bytes': 1280,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 70704,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 43.845029,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 1, 15, 26, 3, 913327, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 300610,
 'httpcompression/response_count': 2,
 'item_scraped_count': 250,
 'log_count/INFO': 9,
 'memusage/max': 144240640,
 'memusage/startup': 144240640,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 1, 15, 25, 20, 68298, tzinfo=datetime.timezone.utc)}
```
</details>