### PR TITLE
[hibbett_sports] Added qcode for hibbett sports spider (673 items)

### DIFF
--- a/locations/spiders/hibbett_sports.py
+++ b/locations/spiders/hibbett_sports.py
@@ -6,7 +6,7 @@ from locations.hours import OpeningHours
 
 class HibbettSportsSpider(scrapy.Spider):
     name = "hibbett_sports"
-    item_attributes = {"brand": "Hibbett Sports", "brand_wikidata": "Hibbett Sports"}
+    item_attributes = {"brand": "Hibbett Sports", "brand_wikidata": "Q5750671"}
     allowed_domains = ["hibbett.com"]
     start_urls = [
         "https://www.hibbett.com/on/demandware.store/Sites-Hibbett-US-Site/default/Stores-GetNearestStores?latitude=40.7127753&longitude=-74.0059728&countryCode=US&distanceUnit=mi&maxdistance=1000"


### PR DESCRIPTION
Did not have wikidata qcode for hibbett sports

<details><summary>New Stats</summary>

```python
{'atp/brand/Hibbett Sports': 673,
 'atp/brand_wikidata/Q5750671': 673,
 'atp/category/shop/sports': 673,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/email/missing': 669,
 'atp/field/image/missing': 673,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 1,
 'atp/field/state/from_reverse_geocoding': 6,
 'atp/field/twitter/missing': 673,
 'atp/field/website/missing': 673,
 'atp/nsi/perfect_match': 673,
 'downloader/request_bytes': 459,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 48843,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.427406,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 1, 15, 34, 30, 431873, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 598800,
 'httpcompression/response_count': 1,
 'item_scraped_count': 673,
 'log_count/INFO': 9,
 'memusage/max': 144257024,
 'memusage/startup': 144257024,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 1, 15, 34, 28, 4467, tzinfo=datetime.timezone.utc)}
```
</details>