### PR TITLE
[BaskinRobbinsUS] Collect coords again

### DIFF
--- a/locations/spiders/baskin_robbins_us.py
+++ b/locations/spiders/baskin_robbins_us.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
@@ -11,5 +13,11 @@ class BaskinRobbinsUSSpider(SitemapSpider, StructuredDataSpider):
     wanted_types = ["IceCreamShop"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        if not item.get("name") == "Baskin-Robbins - Closed™":
-            yield item
+        if item.get("name") == "Baskin-Robbins - Closed™":
+            return
+
+        item["ref"] = item["website"] = response.url
+        if m := re.search(r'"geocodedCoordinate":{"latitude":(-?\d+\.\d+),"longitude":(-?\d+\.\d+)}', response.text):
+            item["lat"], item["lon"] = m.groups()
+
+        yield item


### PR DESCRIPTION
They did have structured coords when I added it, but they seem to have changes the site :(

```python
{'atp/brand/Baskin-Robbins': 2207,
 'atp/brand_wikidata/Q584601': 2207,
 'atp/category/amenity/ice_cream': 2207,
 'atp/cdn/cloudflare/response_count': 2233,
 'atp/cdn/cloudflare/response_status_count/200': 2233,
 'atp/field/email/missing': 2207,
 'atp/field/lat/missing': 24,
 'atp/field/lon/missing': 24,
 'atp/field/phone/missing': 41,
 'atp/nsi/cc_match': 2207,
 'downloader/request_bytes': 1273204,
 'downloader/request_count': 2233,
 'downloader/request_method_count/GET': 2233,
 'downloader/response_bytes': 61191555,
 'downloader/response_count': 2233,
 'downloader/response_status_count/200': 2233,
 'elapsed_time_seconds': 25.568343,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 1, 21, 44, 49, 564627, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 943,
 'httpcache/hit': 1290,
 'httpcache/miss': 943,
 'httpcache/store': 943,
 'httpcompression/response_bytes': 202645136,
 'httpcompression/response_count': 2233,
 'item_scraped_count': 2207,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 148574208,
 'memusage/startup': 148574208,
 'request_depth_max': 3,
 'response_received_count': 2233,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2232,
 'scheduler/dequeued/memory': 2232,
 'scheduler/enqueued': 2232,
 'scheduler/enqueued/memory': 2232,
 'start_time': datetime.datetime(2023, 12, 1, 21, 44, 23, 996284, tzinfo=datetime.timezone.utc)}
```