### PR TITLE
Implement top-level operator and operator_wikidata fields

### DIFF
--- a/docs/SPIDER_NAMING.md
+++ b/docs/SPIDER_NAMING.md
@@ -7,8 +7,8 @@ At the time of writing there is a
 containing all of our spiders.
 
 The file and the spider within it should share the same name.
-The name should reflect the brand or company name that the
-spider is for. Lower case characters must be used.
+The name should reflect the brand or company name (operator) that
+the spider is for. Lower case characters must be used.
 If your Python file is `great_name.py` then your spider
 should look something like:
 
@@ -21,11 +21,11 @@ class GreatNameSpider(scrapy.Spider):
 
 The camel case approach illustrated for the class name
 is further recommended. If you know the company / brand
-that you are spidering only has outlets in one country then it
+that you are spidering only has locations in one country then it
 is helpful to suffix your name with the
 [ISO alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-for that country. For example,  if `great_name` only had outlets in
-South Africa, then name the spider file `great_name_za.py`.
+for that country. For example,  if `great_name` only had locations
+in South Africa, then name the spider file `great_name_za.py`.
 Internally, it should look something like:
 
 ```python
@@ -36,9 +36,8 @@ class GreatNameZASpider(scrapy.Spider):
 ```
 
 If a brand / company is present in multiple territories, and
-the spider is able
-to access all of these using a common approach / API, then do not
-qualify the spider name with a country code.
+the spider is able to access all of these using a common approach /
+API, then do not qualify the spider name with a country code.
 An example of this would be the
 [Decathlon spider](../locations/spiders/decathlon.py).
 

--- a/docs/WHY_SPIDER.md
+++ b/docs/WHY_SPIDER.md
@@ -22,9 +22,9 @@ and at reasonable expense.
 ### What to spider?
 
 Make no mistake, we cannot write a spider for every website in the world. This
-is not our intention. However, for the major brands and companies, and especially
-the ones that a lot of people wish to find and visit then it can make
-a lot of sense.
+is not our intention. However, for the major brands, companies, and
+operators, and especially the ones that a lot of people wish to find
+and visit then it can make a lot of sense.
 
 If we are writing tens of lines of code to generate thousands of good quality
 POIs for a site then we are winning. This is possible for companies like
@@ -32,10 +32,13 @@ McDonald's, Starbucks, Exxon, Mobil, BP, Shell and many more.
 
 Sometimes we can relax the few sites rule when considering the importance
 to the company / brand in terms of number of visitors to their locations.
-For example, COSTCO and IKEA would fall into this bucket.
+For example, COSTCO and IKEA would fall into this bucket. Important
+public services such as hospitals, police stations, fire stations
+and public toilets are worth spending the time to develop a spider
+for due to their importance to the public.
 
-A not unreasonable rule of thumb would be that if a site is important enough
-to have merited an entry in the
+A not unreasonable rule of thumb would be that if a brand or
+operator  is important enough to have merited an entry in the
 [name suggestion index (NSI)](https://nsi.guide/?t=brands)
 then it probably also merits a spider. Of course some
 brands merit an NSI entry but do not have one yet! Read their pages,

--- a/docs/WIKIDATA.md
+++ b/docs/WIKIDATA.md
@@ -63,8 +63,8 @@ dig deeper, perhaps  going directly to the
 ### Name Suggestion Index (NSI)
 
 The NSI is essentially a well curated subset of
-Wikidata brand and company QIDs. The main goal of the project is to aid
-[OpenStreetMap](https://www.openstreetmap.org/)
+Wikidata brand and operator (company) QIDs. The main goal of the
+project is to aid [OpenStreetMap](https://www.openstreetmap.org/)
 editing of POIs by allowing easy import of common data. This
 is well described in a
 [video of a presentation](https://2019.stateofthemap.us/program/sat/mapping-brands-with-the-name-suggestion-index.html)

--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -33,6 +33,8 @@ mapping = (
     ("image", "image"),
     ("brand", "brand"),
     ("brand_wikidata", "brand:wikidata"),
+    ("operator", "operator"),
+    ("operator_wikidata", "operator:wikidata"),
     ("located_in", "located_in"),
     ("located_in_wikidata", "located_in:wikidata"),
     ("nsi_id", "nsi_id"),

--- a/locations/items.py
+++ b/locations/items.py
@@ -30,6 +30,8 @@ class Feature(scrapy.Item):
     ref = scrapy.Field()
     brand = scrapy.Field()
     brand_wikidata = scrapy.Field()
+    operator = scrapy.Field()
+    operator_wikidata = scrapy.Field()
     located_in = scrapy.Field()
     located_in_wikidata = scrapy.Field()
     nsi_id = scrapy.Field()

--- a/locations/pipelines/apply_nsi_categories.py
+++ b/locations/pipelines/apply_nsi_categories.py
@@ -11,7 +11,7 @@ class ApplyNSICategoriesPipeline:
         if item.get("nsi_id"):
             return item
 
-        code = item.get("brand_wikidata")
+        code = item.get("brand_wikidata", item.get("operator_wikidata"))
         if not code:
             return item
 
@@ -22,8 +22,11 @@ class ApplyNSICategoriesPipeline:
 
         matches = self.wikidata_cache.get(code)
 
-        if len(matches) == 0:
+        if len(matches) == 0 and item.get("brand_wikidata"):
             spider.crawler.stats.inc_value("atp/nsi/brand_missing")
+            return item
+        elif len(matches) == 0 and item.get("operator_wikidata"):
+            spider.crawler.stats.inc_value("atp/nsi/operator_missing")
             return item
 
         if len(matches) == 1:
@@ -84,6 +87,8 @@ class ApplyNSICategoriesPipeline:
         for key, value in match["tags"].items():
             if key == "brand:wikidata":
                 key = "brand_wikidata"
+            elif key == "operator:wikidata":
+                key = "operator_wikidata"
 
             # Fields defined in Feature are added directly otherwise add them to extras
             # Never override anything set by the spider

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -45,6 +45,7 @@ class CheckItemPropertiesPipeline:
 
     def process_item(self, item, spider):  # noqa: C901
         check_field(item, spider, "brand_wikidata", allowed_types=(str,), match_regex=self.wikidata_regex)
+        check_field(item, spider, "operator_wikidata", allowed_types=(str,), match_regex=self.wikidata_regex)
         check_field(item, spider, "website", (str,), self.url_regex)
         check_field(item, spider, "image", (str,), self.url_regex)
         check_field(item, spider, "email", (str,), self.email_regex)
@@ -56,6 +57,7 @@ class CheckItemPropertiesPipeline:
         check_field(item, spider, "country", (str,), self.country_regex)
         check_field(item, spider, "name", (str,))
         check_field(item, spider, "brand", (str,))
+        check_field(item, spider, "operator", (str,))
 
         if coords := get_lat_lon(item):
             lat, lon = coords

--- a/locations/pipelines/count_operators.py
+++ b/locations/pipelines/count_operators.py
@@ -1,0 +1,7 @@
+class CountOperatorsPipeline:
+    def process_item(self, item, spider):
+        if operator := item.get("operator"):
+            spider.crawler.stats.inc_value(f"atp/operator/{operator}")
+        if wikidata := item.get("operator_wikidata"):
+            spider.crawler.stats.inc_value(f"atp/operator_wikidata/{wikidata}")
+        return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -110,6 +110,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": 700,
     "locations.pipelines.count_categories.CountCategoriesPipeline": 800,
     "locations.pipelines.count_brands.CountBrandsPipeline": 810,
+    "locations.pipelines.count_operators.CountOperatorsPipeline": 820,
 }
 
 LOG_FORMATTER = "locations.logformatter.DebugDuplicateLogFormatter"

--- a/locations/spiders/bern_ch.py
+++ b/locations/spiders/bern_ch.py
@@ -97,11 +97,11 @@ class BernCHSpider(scrapy.Spider):
         item, props = self.parse_feature(f), f["properties"]
         if operator := props.get("punktname"):
             operator_wikidata, extras = self.operators.get(operator, (None, {}))
+            item["operator"] = operator
+            item["operator_wikidata"] = operator_wikidata
             item["extras"].update(
                 {
-                    "operator": operator,
                     "operator:phone": props.get("telefon"),
-                    "operator:wikidata": operator_wikidata,
                 }
             )
             item["extras"].update(extras)
@@ -129,9 +129,9 @@ class BernCHSpider(scrapy.Spider):
 
     def parse_bicycle_tube_vending_machine(self, f):
         item, props = self.parse_feature(f), f["properties"]
+        item["operator"] = props.get("punktname")
         item["extras"].update(
             {
-                "operator": props.get("punktname"),
                 "operator:email": props.get("email"),
                 "operator:phone": props.get("telefon"),
                 "operator:website": props.get("url"),

--- a/locations/spiders/burger_king.py
+++ b/locations/spiders/burger_king.py
@@ -172,7 +172,7 @@ class BurgerKingSpider(scrapy.Spider):
             item["country"] = country_code
             item["addr_full"] = None
             item["website"] = self.store_locator_templates.get(country_code, "").format(row["_id"]) or None
-            item["extras"]["operator"] = row.get("franchiseGroupName")
+            item["operator"] = row.get("franchiseGroupName")
             apply_yes_no(Extras.WIFI, item, row.get("hasWifi"), True)
             apply_yes_no(Extras.DRIVE_THROUGH, item, row.get("hasDriveThru"), True)
             apply_yes_no(Extras.DELIVERY, item, row.get("hasDelivery"), True)

--- a/locations/spiders/central_england_cooperative.py
+++ b/locations/spiders/central_england_cooperative.py
@@ -6,8 +6,8 @@ from locations.structured_data_spider import StructuredDataSpider
 
 
 def set_operator(brand: dict, item: Feature):
-    item["extras"]["operator"] = brand["brand"]
-    item["extras"]["operator:wikidata"] = brand["brand_wikidata"]
+    item["operator"] = brand["brand"]
+    item["operator_wikidata"] = brand["brand_wikidata"]
 
 
 COOP_FOOD = {"brand": "The Co-operative Food", "brand_wikidata": "Q107617274"}

--- a/locations/spiders/coop_food_gb.py
+++ b/locations/spiders/coop_food_gb.py
@@ -49,8 +49,8 @@ class CoopFoodGBSpider(scrapy.Spider):
                 "lon": float(store["position"]["x"]),
                 "lat": float(store["position"]["y"]),
                 "phone": store["phone"],
+                "operator": store["society"],
                 "extras": {
-                    "operator": store["society"],
                     "location_type": store["location_type"],
                 },
             }

--- a/locations/spiders/easypay.py
+++ b/locations/spiders/easypay.py
@@ -12,5 +12,5 @@ class EasypaySpider(CSVFeedSpider):
 
     def parse_row(self, response, row):
         item = DictParser.parse(row)
-        item["extras"]["operator"] = row["operator"]
+        item["operator"] = row["operator"]
         yield item

--- a/locations/spiders/fastned.py
+++ b/locations/spiders/fastned.py
@@ -14,7 +14,8 @@ class FastnedSpider(Spider):
             item = DictParser.parse(location)
 
             apply_category(Categories.CHARGING_STATION, item)
-            item["extras"]["operator"] = "Fastned"
+            item["operator"] = self.item_attributes["brand"]
+            item["operator:wikidata"] = self.item_attributes["brand_wikidata"]
 
             # TODO: connector data available in location["connectors"]
             yield item

--- a/locations/spiders/fire_and_rescue_nsw_au.py
+++ b/locations/spiders/fire_and_rescue_nsw_au.py
@@ -7,6 +7,7 @@ from locations.items import Feature
 
 class FireAndRescueNSWAUSpider(SitemapSpider):
     name = "fire_and_rescue_nsw_au"
+    item_attributes = {"operator": "Fire and Rescue New South Wales", "operator:wikidata": "Q5451532"}
     allowed_domains = ["www.fire.nsw.gov.au"]
     sitemap_urls = ["https://www.fire.nsw.gov.au/feeds/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/www\.fire\.nsw\.gov\.au\/page\.php\?id=9210&station=\d+", "parse")]
@@ -34,6 +35,4 @@ class FireAndRescueNSWAUSpider(SitemapSpider):
         }
         extract_google_position(properties, response)
         apply_category({"amenity": "fire_station"}, properties)
-        properties["extras"]["operator"] = "Fire and Rescue New South Wales"
-        properties["extras"]["operator:wikidata"] = "Q5451532"
         yield Feature(**properties)

--- a/locations/spiders/follett.py
+++ b/locations/spiders/follett.py
@@ -9,6 +9,7 @@ from locations.structured_data_spider import clean_facebook, clean_twitter
 
 class FollettSpider(Spider):
     name = "follett"
+    item_attributes = {"operator": "Follett Corporation", "operator_wikidata": "Q5464641"}
     allowed_domains = ["svc.bkstr.com"]
     start_urls = ["https://svc.bkstr.com/store/byName?storeType=FMS&langId=-1&schoolName=*"]
 
@@ -71,10 +72,6 @@ class FollettSpider(Spider):
                     hours_string = f"{hours_string} {day_name}: {day_hours}"
                 properties["opening_hours"] = OpeningHours()
                 properties["opening_hours"].add_ranges_from_string(hours_string)
-
-        properties["extras"] = {}
-        properties["extras"]["operator"] = "Follett Corporation"
-        properties["extras"]["operator:wikidata"] = "Q5464641"
 
         apply_category(Categories.SHOP_BOOKS, properties)
         properties["extras"]["books"] = "academic"

--- a/locations/spiders/godfathers_pizza.py
+++ b/locations/spiders/godfathers_pizza.py
@@ -28,7 +28,7 @@ class GodfathersPizzaSpider(scrapy.Spider):
                 "lat": store["latitude"],
                 "lon": store["longitude"],
                 "phone": store["phoneNumber"],
-                "extras": {"operator": store["franchiseNm"]},
+                "operator": store["franchiseNm"],
             }
 
             yield Feature(**properties)

--- a/locations/spiders/goodwill.py
+++ b/locations/spiders/goodwill.py
@@ -61,9 +61,9 @@ class GoodwillSpider(scrapy.Spider):
                 "lat": store.get("LocationLatitude1"),
                 "lon": store.get("LocationLongitude1"),
                 "website": f'https://www.goodwill.org/locator/location/?store={b64_wrap(store["LocationId"])}&lat={b64_wrap(store["LocationLatitude1"])}&lng={b64_wrap(store["LocationLongitude1"])}',
+                "operator": store.get("Name_Parent"),
                 "extras": {
                     "store_categories": store.get("calcd_ServicesOffered"),
-                    "operator": store.get("Name_Parent"),
                     "operator:website": store.get("LocationParentWebsite"),
                     "operator:phone": store.get("Phone_Parent"),
                     "operator:facebook": store.get("LocationParentURLFacebook"),

--- a/locations/spiders/great_western_railway_gb.py
+++ b/locations/spiders/great_western_railway_gb.py
@@ -7,7 +7,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class GreatWesternRailwayGBSpider(StructuredDataSpider):
     name = "great_western_railway_gb"
-    item_attributes = {"extras": {"operator": "Great Western Railway", "operator:wikidata": "Q1419438"}}
+    item_attributes = {"operator": "Great Western Railway", "operator:wikidata": "Q1419438"}
     start_urls = ["https://www.gwr.com/api/stations"]
     wanted_types = ["TrainStation"]
     search_for_twitter = False

--- a/locations/spiders/ich_tanke_strom.py
+++ b/locations/spiders/ich_tanke_strom.py
@@ -70,6 +70,8 @@ class IchTankeStromSpider(scrapy.Spider):
             properties = {
                 "brand": tags.pop("brand", None),
                 "brand_wikidata": tags.pop("brand:wikidata", None),
+                "operator": tags.pop("operator", None),
+                "operator_wikidata": tags.pop("operator:wikidata", None),
                 "extras": tags,
                 "lat": lat,
                 "lon": lon,

--- a/locations/spiders/kroger_us.py
+++ b/locations/spiders/kroger_us.py
@@ -93,7 +93,7 @@ class KrogerUSSpider(SitemapSpider):
                 "phone": location["phoneNumber"].get("raw"),
                 "website": response.meta["url_map"][location["locationId"]],
                 "branch": location["vanityName"],
-                "extras": {"operator": location["legalName"]},
+                "operator": location["legalName"],
             }
 
             for url, brand in BRANDS.items():

--- a/locations/spiders/lewiatan_pl.py
+++ b/locations/spiders/lewiatan_pl.py
@@ -14,7 +14,7 @@ class LewiatanPLSpider(Spider):
     def parse(self, response, **kwargs):
         for location in response.json()["data"]:
             item = DictParser.parse(location)
-            item["extras"]["operator"] = html.unescape(item.pop("name"))
+            item["operator"] = html.unescape(item.pop("name"))
             item["street_address"] = item.pop("addr_full")
             item["website"] = response.urljoin(location["url"])
             apply_category(Categories.SHOP_SUPERMARKET, item)

--- a/locations/spiders/marks_and_spencer.py
+++ b/locations/spiders/marks_and_spencer.py
@@ -41,8 +41,8 @@ class MarksAndSpencerSpider(scrapy.Spider):
             }
 
             if store["storeType"] == "mands":
-                properties["extras"]["operator"] = "Marks and Spencer"
-                properties["extras"]["operator:wikidata"] = "Q714491"
+                properties["operator"] = "Marks and Spencer"
+                properties["operator:wikidata"] = "Q714491"
 
             name = store["name"].lower()
             if name.endswith("foodhall"):

--- a/locations/spiders/midcounties_cooperative_gb.py
+++ b/locations/spiders/midcounties_cooperative_gb.py
@@ -9,7 +9,8 @@ class MidcountiesCooperativeGBSpider(Spider):
     name = "midcounties_cooperative_gb"
     item_attributes = {
         "brand": "Your Co-op",
-        "extras": {"operator": "Midcounties Co-operative", "operator:wikidata": "Q6841138"},
+        "operator": "Midcounties Co-operative",
+        "operator:wikidata": "Q6841138",
     }
     start_urls = ["https://www.midcounties.coop/static/js/stores.json"]
     no_refs = True

--- a/locations/spiders/morrisons_gb.py
+++ b/locations/spiders/morrisons_gb.py
@@ -6,11 +6,7 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.items import Feature
-
-
-def set_operator(brand: {}, item: Feature):
-    item["extras"]["operator"] = brand.get("brand")
-    item["extras"]["operator:wikidata"] = brand.get("brand_wikidata")
+from locations.spiders.central_england_cooperative import set_operator
 
 
 class MorrisonsGBSpider(Spider):

--- a/locations/spiders/national_rail_gb.py
+++ b/locations/spiders/national_rail_gb.py
@@ -59,7 +59,7 @@ class NationalRailGBSpider(Spider):
             item["lon"] = location["longitude"]
             item["postcode"] = location["postcode"]
             item["website"] = "https://www.nationalrail.co.uk/stations/{}/".format(location["crsCode"].lower())
-            item["extras"]["operator"], item["extras"]["operator:wikidata"] = self.operators.get(
+            item["operator"], item["operator:wikidata"] = self.operators.get(
                 location["operator"], (location["operator"], None)
             )
 

--- a/locations/spiders/northern_railway_gb.py
+++ b/locations/spiders/northern_railway_gb.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class NorthernRailwayGBSpider(Spider):
     name = "northern_railway_gb"
-    item_attributes = {"extras": {"operator": "Northern", "operator:wikidata": "Q85789775"}}
+    item_attributes = {"operator": "Northern", "operator:wikidata": "Q85789775"}
     start_urls = ["https://www.northernrailway.co.uk/api/northern_station_list_auto_complete"]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/nsw_ambulance_au.py
+++ b/locations/spiders/nsw_ambulance_au.py
@@ -7,6 +7,7 @@ from locations.items import Feature
 
 class NSWAmbulanceAUSpider(Spider):
     name = "nsw_ambulance_au"
+    item_attributes = {"operator": "New South Wales Ambulance", "operator_wikidata": "Q4741948"}
     allowed_domains = ["portal.spatial.nsw.gov.au"]
     start_urls = [
         "https://portal.spatial.nsw.gov.au/server/rest/services/NSW_FOI_Health_Facilities/FeatureServer/0/query?f=geojson"
@@ -48,9 +49,6 @@ class NSWAmbulanceAUSpider(Spider):
                 "SOUTHCARE HELO AMBULANCE STATION",
             ]:
                 properties["state"] = "ACT"
-                properties["extras"]["operator"] = "Australian Capital Territory Ambulance Service"
-                properties["extras"]["operator:wikidata"] = "Q4823922"
-            else:
-                properties["extras"]["operator"] = "New South Wales Ambulance"
-                properties["extras"]["operator:wikidata"] = "Q4741948"
+                properties["operator"] = "Australian Capital Territory Ambulance Service"
+                properties["operator:wikidata"] = "Q4823922"
             yield Feature(**properties)

--- a/locations/spiders/nsw_police_force_au.py
+++ b/locations/spiders/nsw_police_force_au.py
@@ -9,6 +9,7 @@ from locations.items import Feature
 
 class NSWPoliceForceAUSpider(CrawlSpider):
     name = "nsw_police_force_au"
+    item_attributes = {"operator": "New South Wales Police Force", "operator_wikidata": "Q7011763"}
     allowed_domains = ["www.police.nsw.gov.au", "portal.spatial.nsw.gov.au"]
     start_urls = ["https://www.police.nsw.gov.au/about_us/regions_commands_districts"]
     rules = [
@@ -67,6 +68,4 @@ class NSWPoliceForceAUSpider(CrawlSpider):
             else:
                 properties["addr_full"] = ", ".join(filter(None, [properties.get("addr_full"), contact_line.strip()]))
         apply_category({"amenity": "police"}, properties)
-        properties["extras"]["operator"] = "New South Wales Police Force"
-        properties["extras"]["operator:wikidata"] = "Q7011763"
         yield Feature(**properties)

--- a/locations/spiders/nsw_rural_fire_service_au.py
+++ b/locations/spiders/nsw_rural_fire_service_au.py
@@ -7,6 +7,7 @@ from locations.items import Feature
 
 class NSWRuralFireServiceAUSpider(Spider):
     name = "nsw_rural_fire_service_au"
+    item_attributes = {"brand": "New South Wales Rural Fire Service", "brand_wikidata": "Q7011777"}
     allowed_domains = ["portal.spatial.nsw.gov.au"]
     start_urls = [
         "https://portal.spatial.nsw.gov.au/server/rest/services/NSW_FOI_Emergency_Service_Facilities/FeatureServer/2/query?f=geojson"
@@ -35,6 +36,4 @@ class NSWRuralFireServiceAUSpider(Spider):
             else:
                 apply_category({"office": "government"}, properties)
                 apply_category({"government": "fire_service"}, properties)
-            properties["extras"]["operator"] = "New South Wales Rural Fire Service"
-            properties["extras"]["operator:wikidata"] = "Q7011777"
             yield Feature(**properties)

--- a/locations/spiders/nsw_state_emergency_service_au.py
+++ b/locations/spiders/nsw_state_emergency_service_au.py
@@ -7,6 +7,7 @@ from locations.items import Feature
 
 class NSWStateEmergencyServiceAUSpider(Spider):
     name = "nsw_state_emergency_service_au"
+    item_attributes = {"operator": "New South Wales State Emergency Service", "operator_wikidata": "Q7011790"}
     allowed_domains = ["portal.spatial.nsw.gov.au"]
     start_urls = [
         "https://portal.spatial.nsw.gov.au/server/rest/services/NSW_FOI_Emergency_Service_Facilities/FeatureServer/3/query?f=geojson"
@@ -40,6 +41,4 @@ class NSWStateEmergencyServiceAUSpider(Spider):
             else:
                 apply_category({"office": "government"}, properties)
                 apply_category({"government": "emergency"}, properties)
-            properties["extras"]["operator"] = "New South Wales State Emergency Service"
-            properties["extras"]["operator:wikidata"] = "Q7011790"
             yield Feature(**properties)

--- a/locations/spiders/opendata_mos_household_services_ru.py
+++ b/locations/spiders/opendata_mos_household_services_ru.py
@@ -122,7 +122,7 @@ class OpendataMosSpider(scrapy.Spider):
         item = DictParser.parse(cells)
         item["lat"] = cells.get("Latitude_WGS84")
         item["lon"] = cells.get("Longitude_WGS84")
-        item["extras"]["operator"] = cells.get("OperatingCompany")
+        item["operator"] = cells.get("OperatingCompany")
         self.parse_phones(item, cells)
         self.parse_hours(item, cells)
         self.parse_extra_fields(item, cells)

--- a/locations/spiders/scotrail_gb.py
+++ b/locations/spiders/scotrail_gb.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class ScotrailGBSpider(CrawlSpider):
     name = "scotrail_gb"
-    item_attributes = {"extras": {"operator": "ScotRail", "operator:wikidata": "Q18356161"}}
+    item_attributes = {"operator": "ScotRail", "operator:wikidata": "Q18356161"}
     start_urls = ["https://www.scotrail.co.uk/plan-your-journey/stations-and-facilities"]
     rules = [Rule(LinkExtractor(allow=r"/plan-your-journey/stations-and-facilities/\w{3}$"), callback="parse")]
     requires_proxy = True

--- a/locations/spiders/southeastern_railway_gb.py
+++ b/locations/spiders/southeastern_railway_gb.py
@@ -9,7 +9,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class SoutheasternRailwayGBSpider(SitemapSpider, StructuredDataSpider):
     name = "southeastern_railway_gb"
-    item_attributes = {"extras": {"operator": "Southeastern", "operator:wikidata": "Q1696490"}}
+    item_attributes = {"operator": "Southeastern", "operator:wikidata": "Q1696490"}
     sitemap_urls = ["https://www.southeasternrailway.co.uk/robots.txt"]
     sitemap_rules = [("/station-information/stations/", "parse")]
     search_for_facebook = False

--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -117,6 +117,8 @@ class StadtZuerichCHSpider(scrapy.Spider):
             "postcode": tags.pop("addr:postcode", None),
             "ref": tags.pop("ref"),
             "street": tags.pop("addr:street", None),
+            "operator": tags.pop("operator", None),
+            "operator_wikidata": tags.pop("operator:wikidata", None),
         }
         item["extras"] = {k: v for (k, v) in tags.items() if v}
         item = {k: v for (k, v) in item.items() if v}

--- a/locations/spiders/tim_hortons.py
+++ b/locations/spiders/tim_hortons.py
@@ -89,7 +89,7 @@ class TimHortonsSpider(Spider):
             item["image"] = (location["restaurantImage"] or {}).get("asset", {}).get("url")
             item["extras"]["check_date"] = location["check_date"]
             if location["operator_id"] is not None:
-                item["extras"]["operator"] = location["operator"]
+                item["operator"] = location["operator"]
                 item["extras"]["operator:ref"] = str(location["operator_id"])
 
             if isinstance(item["email"], list):

--- a/locations/spiders/transport_for_wales_gb.py
+++ b/locations/spiders/transport_for_wales_gb.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 
 class TransportForWalesGB(Spider):
     name = "transport_for_wales_gb"
-    item_attributes = {"extras": {"operator": "Transport for Wales", "operator:wikidata": "Q104878180"}}
+    item_attributes = {"operator": "Transport for Wales", "operator:wikidata": "Q104878180"}
     start_urls = ["https://tfw.wales/api/stations/links/{}".format(letter) for letter in string.ascii_uppercase]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -60,9 +60,9 @@ class VerizonUSSpider(scrapy.Spider):
             "website": response.url,
             "lat": store_data["geo"].get("latitude"),
             "lon": store_data["geo"].get("longitude"),
+            "operator": (store_data.get("posStoreDetail") or {}).get("businessName"),
             "extras": {
                 # Sometimes 'postStoreDetail' exists with "None" value, usual get w/ default syntax isn't reliable
-                "operator": (store_data.get("posStoreDetail") or {}).get("businessName"),
                 "retail_id": store_data.get("retailId"),
                 "store_type": (store_data.get("posStoreDetail") or {}).get("storeType"),
                 "store_type_note": ";".join(store_data.get("typeOfStore")),

--- a/locations/spiders/visa.py
+++ b/locations/spiders/visa.py
@@ -63,7 +63,7 @@ class VisaSpider(Spider):
 
                 item = DictParser.parse(location)
 
-                item["extras"]["operator"] = location.get("ownerBusName")
+                item["operator"] = location.get("ownerBusName")
                 item["located_in"] = location.get("placeName")
 
                 apply_category(Categories.ATM, item)

--- a/locations/spiders/winterthur_ch.py
+++ b/locations/spiders/winterthur_ch.py
@@ -1,5 +1,3 @@
-import logging
-
 import pyproj
 import scrapy
 
@@ -22,19 +20,10 @@ class WinterthurCHSpider(scrapy.Spider):
     }
     no_refs = True
 
-    # Swiss LV95 (https://epsg.io/2056) -> lat/lon (https://epsg.io/4326)
-    coord_transformer = pyproj.Transformer.from_crs(2056, 4326)
-
     def start_requests(self):
         yield scrapy.Request(
             "https://stadtplan.winterthur.ch/stadtgruen/spielplatzkontrolle-service/Collections/Playgrounds/Items/",
             callback=self.parse_playgrounds,
-        )
-        yield scrapy.Request(
-            "https://stadtplan.winterthur.ch/wfs/SitzbankWfs?service=wfs"
-            + "&version=2.0.0&request=GetFeature&format=json"
-            + "&typeNames=ms:SitzbankWfs",
-            callback=self.parse_benches,
         )
 
     def parse_playgrounds(self, response):
@@ -42,12 +31,14 @@ class WinterthurCHSpider(scrapy.Spider):
             "KG": "Kindergarten",
             "SH": "Schulhaus",
         }
+        # Swiss LV95 (https://epsg.io/2056) -> lat/lon (https://epsg.io/4326)
+        coord_transformer = pyproj.Transformer.from_crs(2056, 4326)
         for f in response.json():
             props = f["properties"]
             coords = f["geometry"].get("coordinates", [])
             if len(coords) < 2:
                 continue
-            lat, lon = self.coord_transformer.transform(coords[0], coords[1])
+            lat, lon = coord_transformer.transform(coords[0], coords[1])
             item = {
                 "lat": lat,
                 "lon": lon,
@@ -68,85 +59,3 @@ class WinterthurCHSpider(scrapy.Spider):
             if ref_emergency and ref_emergency > 0:
                 item["extras"]["ref:emergency"] = str(ref_emergency)
             yield Feature(**item)
-
-    def parse_benches(self, response):
-        for m in response.json()["FeatureCollection"]["member"]:
-            if f := m.get("SitzbankWfs"):
-                coords = f["msGeometry"]["Point"]["pos"].split()
-                [x, y] = [float(c) for c in coords[:2]]
-                lat, lon = self.coord_transformer.transform(x, y)
-                btype = (f.get("Banktyp") or "").strip()
-                item = {
-                    "lat": lat,
-                    "lon": lon,
-                    "city": "Winterthur",
-                    "country": "CH",
-                    "extras": {
-                        "backrest": self.parse_bench_backrest(btype),
-                        "colour": self.parse_bench_colour(btype),
-                        "inscription": self.parse_bench_inscription(f),
-                        "material": self.parse_bench_material(btype),
-                        "material:wikidata": self.parse_bench_material_wikidata(btype),
-                        "operator": "Stadtgrün Winterthur",
-                        "operator:wikidata": "Q56825906",
-                    },
-                    "ref": f["Banknummer"],
-                }
-                apply_category(Categories.BENCH, item)
-                yield Feature(**item)
-
-    def parse_bench_backrest(self, btype):
-        backrests = {
-            "Eichenbank mit Lehne": "yes",
-            "Eichenbank ohne Lehne": "no",
-            "Eichenbank Halbling": "no",
-            "Eichenbank Spezial": "no",
-            "Eichenbank Tisch/Bank": "no",
-            "Sitzbank braun": "yes",
-            "Sitzbank grau": "yes",
-            "Sitzbank rot": "yes",
-            "Sitzbank Eiche": "yes",
-            "Standardbank Latten braun": "yes",
-            "Standardbank Latten grau": "yes",
-            "Standardbank Latten rot": "yes",
-            "undefiniert": None,
-            "": None,
-        }
-        if btype in backrests:
-            return backrests[btype]
-        logging.error(f'cannot determine backrest for "{btype}"')
-        return None
-
-    def parse_bench_colour(self, btype):
-        # RGB values according to photographs of benches in Winterthur.
-        colours = {
-            "braun": "#DDBB88",
-            "eichenbank": "#DDBB88",
-            "eiche": "#DDBB88",
-            "grau": "#AABBDD",
-            "rot": "#FF6633",
-        }
-        for word in btype.lower().split():
-            if col := colours.get(word):
-                return col
-        if btype not in {"", "undefiniert"}:
-            logging.error(f'cannot determine color for "{btype}"')
-        return None
-
-    def parse_bench_material(self, btype):
-        for word in btype.split():
-            if word in {"Eiche", "Eichenbank", "Latten"}:
-                return "wood"
-        return None
-
-    def parse_bench_material_wikidata(self, btype):
-        for word in btype.split():
-            if word in {"Eiche", "Eichenbank"}:
-                return "Q33036816"
-        return None
-
-    def parse_bench_inscription(self, f):
-        if ins := (f.get("Widmung") or "").strip():
-            return ins
-        else:
-            return None


### PR DESCRIPTION
Many locations of interest to AllThePlaces are known primarily by their operator. Examples include fire stations, police stations and hospitals which may be operated by the same public or private organisation on behalf of a government agency. Many other locations are known primarily by their brand, but due to their franchise arrangements, are also known by their franchise owner (operator). For numerous franchises, hundreds of locations may be operated by the same franchise owner.

Treating `operator` and `operator_wikidata` as top-level fields of the `Feature` class makes sense because these fields often carry equal weight ot he existing `brand` and `brand_wikidata` top-level fields. Benefits include better statistics collection on operators, better name-suggestion-index interoperability (where operators and brands are equally weighted) and simplifed spider code.