### PR TITLE
[vtb_ru] fix broken spider

### DIFF
--- a/locations/spiders/vtb_ru.py
+++ b/locations/spiders/vtb_ru.py
@@ -2,10 +2,21 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_RU, OpeningHours
+from locations.hours import OpeningHours
 
 # TODO: scrape ATMs from
 # https://online.vtb.ru/msa/api-gw/attm/attm-dictionary/atm/nearby/filtered/?longitude=36.6153309807117&latitude=54.66560792903764&radius=100
+
+
+DAYS_MAPPING = {
+    "1": "Mo",
+    "2": "Tu",
+    "3": "We",
+    "4": "Th",
+    "5": "Fr",
+    "6": "Sa",
+    "7": "Su",
+}
 
 
 class VtbRUSpider(scrapy.Spider):
@@ -18,8 +29,23 @@ class VtbRUSpider(scrapy.Spider):
         for poi in response.json()["branches"]:
             poi.update(poi.pop("coordinates"))
             item = DictParser.parse(poi)
-            oh = OpeningHours()
-            oh.add_ranges_from_string(poi.get("scheduleFl"), DAYS_RU)
-            item["opening_hours"] = oh.as_opening_hours()
+            item["ref"] = poi["Biskvit_id"]
             apply_category(Categories.BANK, item)
+            self.parse_hours(item, poi)
             yield item
+
+    def parse_hours(self, item, poi):
+        if hours := poi.get("scheduleFl"):
+            try:
+                oh = OpeningHours()
+                for day_number, times in hours.items():
+                    # Days off
+                    if times == "выходной":
+                        continue
+                    day = DAYS_MAPPING.get(day_number)
+                    open, close = times.split("-")
+                    oh.add_range(day, open, close)
+
+                item["opening_hours"] = oh.as_opening_hours()
+            except Exception as e:
+                self.logger.warning(f"Couldn't parse hours: {hours}, {e}")


### PR DESCRIPTION
Data on website has changed and this broke the spider. All good now.

Stats:

```json
{
  "atp/brand/ВТБ": 1239,
  "atp/brand_wikidata/Q1549389": 1239,
  "atp/category/amenity/bank": 1239,
  "atp/field/country/from_spider_name": 1239,
  "atp/field/email/missing": 1239,
  "atp/field/image/missing": 1239,
  "atp/field/name/missing": 1239,
  "atp/field/opening_hours/missing": 58,
  "atp/field/operator/missing": 1239,
  "atp/field/operator_wikidata/missing": 1239,
  "atp/field/phone/missing": 1239,
  "atp/field/postcode/missing": 1239,
  "atp/field/state/missing": 1239,
  "atp/field/street_address/missing": 1239,
  "atp/field/twitter/missing": 1239,
  "atp/field/website/missing": 1239,
  "atp/nsi/category_match": 1239,
  "downloader/request_bytes": 657,
  "downloader/request_count": 2,
  "downloader/request_method_count/GET": 2,
  "downloader/response_bytes": 80868,
  "downloader/response_count": 2,
  "downloader/response_status_count/200": 1,
  "downloader/response_status_count/404": 1,
  "elapsed_time_seconds": 2.181275,
  "feedexport/success_count/FileFeedStorage": 1,
  "finish_reason": "finished",
  "finish_time": "2023-12-04T10:00:28.032934+00:00",
  "httpcompression/response_bytes": 988917,
  "httpcompression/response_count": 1,
  "item_scraped_count": 1239,
  "log_count/INFO": 10,
  "memusage/max": 143343616,
  "memusage/startup": 143343616,
  "response_received_count": 2,
  "robotstxt/request_count": 1,
  "robotstxt/response_count": 1,
  "robotstxt/response_status_count/404": 1,
  "scheduler/dequeued": 1,
  "scheduler/dequeued/memory": 1,
  "scheduler/enqueued": 1,
  "scheduler/enqueued/memory": 1,
  "start_time": "2023-12-04T10:00:25.851659+00:00"
}
```