### PR TITLE
[unicredit_de] remove superfluous spider

### DIFF
--- a/locations/spiders/hypovereinsbank_de.py
+++ b/locations/spiders/hypovereinsbank_de.py
@@ -7,6 +7,10 @@ class HypovereinsbankDESpider(UberallSpider):
     item_attributes = {"brand": "HypoVereinsbank", "brand_wikidata": "Q220189"}
     key = "QZ7auxGUWKL0MfAnUOgweafKIwrXPb"
     business_id_filter = 77215
+    # Ignores:
+    # 599793 - Wealth Management
+    # 337143 - Unternehmenskunden (corporate clients services)
+    # 337141 - Private Banking
 
     def parse_item(self, item, feature, **kwargs):
         item["website"] = "https://www.hypovereinsbank.de/hvb/kontaktwege/filiale#!/l/{}/{}/{}".format(

--- a/locations/spiders/unicredit_de.py
+++ b/locations/spiders/unicredit_de.py
@@ -1,7 +1,0 @@
-from locations.storefinders.uberall import UberallSpider
-
-
-class UnicreditDeSpider(UberallSpider):
-    name = "unicredit_de"
-    item_attributes = {"brand": "UniCredit", "brand_wikidata": "Q45568"}
-    key = "QZ7auxGUWKL0MfAnUOgweafKIwrXPb"


### PR DESCRIPTION
  I was going to add categories to unicredit_de but noticed that Unicredit is present in Germany under HypoVereinsbank brand for which we already have a spider with exactly the same data source and good categories.