### PR TITLE
[under_armour] Added Clothes Category (199 items)

### DIFF
--- a/locations/spiders/under_armour.py
+++ b/locations/spiders/under_armour.py
@@ -2,6 +2,7 @@ import re
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.linked_data_parser import LinkedDataParser
 
 
@@ -23,4 +24,5 @@ class UnderArmourSpider(scrapy.spiders.SitemapSpider):
             text = re.sub(r" +//.*", "", text, flags=re.M)
             script.root.text = text
         item = LinkedDataParser.parse(response, "SportingGoodsStore")
+        apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
Duplicate NSI entries means it does not get the shop=clothes tag.

<details><summary>New Stats</summary>

```python
{'atp/brand/Under Armour': 199,
 'atp/brand_wikidata/Q2031485': 199,
 'atp/category/shop/clothes': 199,
 'atp/field/email/missing': 199,
 'atp/field/opening_hours/missing': 199,
 'atp/field/state/from_reverse_geocoding': 22,
 'atp/field/twitter/missing': 199,
 'atp/nsi/match_failed': 199,
 'downloader/request_bytes': 80591,
 'downloader/request_count': 202,
 'downloader/request_method_count/GET': 202,
 'downloader/response_bytes': 6466826,
 'downloader/response_count': 202,
 'downloader/response_status_count/200': 202,
 'elapsed_time_seconds': 245.959147,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 11, 30, 19, 37, 44, 340297, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 44128347,
 'httpcompression/response_count': 201,
 'item_scraped_count': 199,
 'log_count/INFO': 13,
 'memusage/max': 632066048,
 'memusage/startup': 144252928,
 'request_depth_max': 2,
 'response_received_count': 202,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 201,
 'scheduler/dequeued/memory': 201,
 'scheduler/enqueued': 201,
 'scheduler/enqueued/memory': 201,
 'start_time': datetime.datetime(2023, 11, 30, 19, 33, 38, 381150, tzinfo=datetime.timezone.utc)}
</details>