### PR TITLE
[dunelm_gb] Added category for dunelm_gb (182 items)

### DIFF
--- a/locations/spiders/dunelm_gb.py
+++ b/locations/spiders/dunelm_gb.py
@@ -1,6 +1,7 @@
 from scrapy.http import JsonRequest
 from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -29,9 +30,7 @@ class DunelmGB(Spider):
     def parse(self, response, **kwargs):
         for store in response.json()["results"][0]["hits"]:
             store["location"] = store["_geoloc"]
-
             item = DictParser.parse(store)
-
             item["ref"] = store["sapStoreId"]
             item["website"] = "https://www.dunelm.com/stores/" + store["uri"]
 
@@ -40,7 +39,6 @@ class DunelmGB(Spider):
                 oh.add_range(rule["day"], rule["open"], rule["close"])
 
             item["opening_hours"] = oh.as_opening_hours()
-
             item["extras"] = {"storeType": store.get("storeType")}
-
+            apply_category({"shop": "interior_decoration"}, item)
             yield item


### PR DESCRIPTION
Duplicate NSI Entries means category tag does not get added.

<details><summary>New Stats</summary>

```python
{'atp/brand/Dunelm': 182,
 'atp/brand_wikidata/Q5315020': 182,
 'atp/category/shop/interior_decoration': 182,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 182,
 'atp/field/operator/missing': 182,
 'atp/field/operator_wikidata/missing': 182,
 'atp/field/state/missing': 113,
 'atp/field/twitter/missing': 182,
 'atp/nsi/category_match': 181,
 'atp/nsi/match_failed': 1,
 'downloader/request_bytes': 1116,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 170325,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.949263,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 4, 21, 6, 28, 982559, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1391729,
 'httpcompression/response_count': 1,
 'item_scraped_count': 182,
 'log_count/INFO': 9,
 'memusage/max': 146477056,
 'memusage/startup': 146477056,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 4, 21, 6, 26, 33296, tzinfo=datetime.timezone.utc)}
```
</details>