### PR TITLE
[lincolnshire_cooperative] Added categories for different types of shops of lincolnshire (184 items)

### DIFF
--- a/locations/spiders/lincolnshire_cooperative.py
+++ b/locations/spiders/lincolnshire_cooperative.py
@@ -2,6 +2,7 @@ import json
 
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.linked_data_parser import LinkedDataParser
 
 
@@ -18,6 +19,15 @@ class LincolnshireCooperativeSpider(SitemapSpider):
             "parse_item",
         )
     ]
+    categories = [
+        ("food store", Categories.SHOP_CONVENIENCE),
+        ("pharmacy", Categories.PHARMACY),
+        ("funeral", Categories.SHOP_FUNERAL_DIRECTORS),
+        ("florist", Categories.SHOP_FLORIST),
+        ("coffee", Categories.COFFEE_SHOP),
+        ("filling station", Categories.FUEL_STATION),
+        ("travel", Categories.SHOP_TRAVEL_AGENCY),
+    ]
 
     def parse_item(self, response):
         ld_item = response.xpath('//script[@type="application/ld+json"]//text()').get()
@@ -30,5 +40,10 @@ class LincolnshireCooperativeSpider(SitemapSpider):
 
         if item.get("phone"):
             item["phone"] = item["phone"].replace(" (24 hours)", "")
+
+        for label, cat in self.categories:
+            if label in item["name"].lower():
+                apply_category(cat, item)
+                break
 
         return item


### PR DESCRIPTION
There seems to be another lincolnshire wikidata [Q6551231](https://www.wikidata.org/wiki/Q6551231), This is in NSI as supermarkets, but from the ones I saw of the Co-ops they looked closer to convenience stores then full on grocery stores. 

<details><summary>New Stats</summary>

```python
{'atp/brand/Lincolnshire Co-operative': 184,
 'atp/brand_wikidata/Q5329759': 184,
 'atp/category/amenity/cafe': 1,
 'atp/category/amenity/fuel': 1,
 'atp/category/amenity/pharmacy': 44,
 'atp/category/missing': 3,
 'atp/category/multiple': 44,
 'atp/category/shop/convenience': 100,
 'atp/category/shop/florist': 1,
 'atp/category/shop/funeral_directors': 21,
 'atp/category/shop/travel_agency': 13,
 'atp/field/email/missing': 184,
 'atp/field/image/dropped': 2,
 'atp/field/image/invalid': 182,
 'atp/field/image/missing': 2,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 184,
 'atp/field/operator_wikidata/missing': 184,
 'atp/field/state/missing': 184,
 'atp/field/twitter/missing': 184,
 'atp/nsi/category_match': 100,
 'atp/nsi/match_failed': 84,
 'atp/operator/East of England Co-operative Society': 100,
 'atp/operator_wikidata/Q5329759': 100,
 'downloader/request_bytes': 155364,
 'downloader/request_count': 269,
 'downloader/request_method_count/GET': 269,
 'downloader/response_bytes': 3452261,
 'downloader/response_count': 269,
 'downloader/response_status_count/200': 269,
 'elapsed_time_seconds': 335.917119,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 4, 21, 7, 59, 954295, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 23120988,
 'httpcompression/response_count': 269,
 'item_scraped_count': 184,
 'log_count/INFO': 14,
 'memusage/max': 298225664,
 'memusage/startup': 146616320,
 'request_depth_max': 2,
 'response_received_count': 269,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 268,
 'scheduler/dequeued/memory': 268,
 'scheduler/enqueued': 268,
 'scheduler/enqueued/memory': 268,
 'start_time': datetime.datetime(2023, 12, 4, 21, 2, 24, 37176, tzinfo=datetime.timezone.utc)}
</details>