### PR TITLE
[bridgestone_select] add category

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -100,6 +100,7 @@ class Categories(Enum):
     SHOP_TOYS = {"shop": "toys"}
     SHOP_TRADE = {"shop": "trade"}
     SHOP_TRAVEL_AGENCY = {"shop": "travel_agency"}
+    SHOP_TYRES = {"shop": "tyres"}
     SHOP_VARIETY_STORE = {"shop": "variety_store"}
     SHOP_WATCHES = {"shop": "watches"}
     SHOP_WHOLESALE = {"shop": "wholesale"}

--- a/locations/spiders/bridgestone_select.py
+++ b/locations/spiders/bridgestone_select.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category, apply_yes_no
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -22,4 +23,6 @@ class BridgestoneSelectSpider(SitemapSpider, StructuredDataSpider):
         item.pop("facebook", None)
         if "generic-" in item.get("image", ""):
             item.pop("image", None)
+        apply_category(Categories.SHOP_TYRES, item)
+        apply_yes_no("repair", item, True)
         yield item


### PR DESCRIPTION
TBH I would be happy to just use `brand:wikidata=Q179433` and let pipeline to apply category from NSI, but I'm not sure if it's right to use a brand from NSI here. 

@davidhicks what do you think? [It looks like OSM has most of these POIs with `brand:wikidata=Q179433`.](https://overpass-turbo.eu/s/1Elt)