### PR TITLE
135 items)[ricoh_europe] Added category (135 items)

### DIFF
--- a/locations/spiders/ricoh_europe.py
+++ b/locations/spiders/ricoh_europe.py
@@ -63,6 +63,7 @@ class RicohEuropeSpider(scrapy.Spider):
                     "phone": store["Phone"],
                 }
                 apply_category(Categories.OFFICE_COMPANY, properties)
+                apply_category({"company": "consulting"}, properties)
                 yield Feature(**properties)
             else:
                 pass

--- a/locations/spiders/ricoh_europe.py
+++ b/locations/spiders/ricoh_europe.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -61,7 +62,7 @@ class RicohEuropeSpider(scrapy.Spider):
                     "lon": store["Longitude"],
                     "phone": store["Phone"],
                 }
-
+                apply_category(Categories.OFFICE_COMPANY, properties)
                 yield Feature(**properties)
             else:
                 pass


### PR DESCRIPTION
Could use a 2nd opinion about this company. Bloomberg says it is mainly a holding company. On it's main page and on it's linked in page it seems more of an IT consulting company. Thus I put the category as just an office company. Not sure if we should add this to NSI or if that is the correct category.

<details><summary>New Stats</summary>

```python
{'atp/brand/Ricoh': 135,
 'atp/category/office/company': 135,
 'atp/field/brand_wikidata/missing': 135,
 'atp/field/email/missing': 135,
 'atp/field/image/missing': 135,
 'atp/field/opening_hours/missing': 135,
 'atp/field/operator/missing': 135,
 'atp/field/operator_wikidata/missing': 135,
 'atp/field/phone/invalid': 34,
 'atp/field/twitter/missing': 135,
 'atp/field/website/missing': 135,
 'downloader/request_bytes': 8205,
 'downloader/request_count': 24,
 'downloader/request_method_count/GET': 24,
 'downloader/response_bytes': 557047,
 'downloader/response_count': 24,
 'downloader/response_status_count/200': 24,
 'elapsed_time_seconds': 27.514062,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 5, 18, 29, 9, 654103, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 135,
 'log_count/INFO': 9,
 'memusage/max': 145580032,
 'memusage/startup': 145580032,
 'response_received_count': 24,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 23,
 'scheduler/dequeued/memory': 23,
 'scheduler/enqueued': 23,
 'scheduler/enqueued/memory': 23,
 'start_time': datetime.datetime(2023, 12, 5, 18, 28, 42, 140041, tzinfo=datetime.timezone.utc)}
```
</details>