### PR TITLE
[ace_safes_gb] Added category for Ace Safes GB (50 items)

### DIFF
--- a/locations/spiders/ace_safes_gb.py
+++ b/locations/spiders/ace_safes_gb.py
@@ -1,3 +1,4 @@
+from locations.categories import apply_category
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 
 
@@ -8,4 +9,5 @@ class AceSafesGBSpider(StoreLocatorWidgetsSpider):
 
     def parse_item(self, item, location):
         item["city"] = item.pop("addr_full")
+        apply_category({"shop": "safe"}, item)
         yield item


### PR DESCRIPTION
Do not think this needs to be added to NSI as there are very few safe retail stores. Also shop=safe is not used often.

<details><summary>New Stats</summary>

```python
{'atp/brand/Ace Safes': 50,
 'atp/brand_wikidata/Q119157844': 50,
 'atp/category/shop/safe': 50,
 'atp/field/country/from_spider_name': 50,
 'atp/field/email/missing': 50,
 'atp/field/image/missing': 50,
 'atp/field/opening_hours/missing': 50,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/postcode/missing': 50,
 'atp/field/state/missing': 50,
 'atp/field/street_address/missing': 50,
 'atp/field/twitter/missing': 50,
 'atp/field/website/missing': 50,
 'atp/nsi/brand_missing': 50,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7441,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.170861,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 6, 16, 51, 25, 749160, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27565,
 'httpcompression/response_count': 2,
 'item_scraped_count': 50,
 'log_count/INFO': 9,
 'memusage/max': 146329600,
 'memusage/startup': 146329600,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 6, 16, 51, 23, 578299, tzinfo=datetime.timezone.utc)}
```
</details>