### PR TITLE
[completude] Added category and changed name as all POIs were missing one. (37 items)

### DIFF
--- a/locations/spiders/completude.py
+++ b/locations/spiders/completude.py
@@ -2,6 +2,7 @@ import re
 
 import scrapy
 
+from locations.categories import apply_category
 from locations.items import Feature
 
 
@@ -31,13 +32,15 @@ class CompletudeSpider(scrapy.Spider):
                 "city": city,
                 "postcode": postal,
                 "phone": response.xpath('//ul[@class="list-contacts"]/li[1]/a/span/text()').extract_first(),
-                "name": response.xpath('//select[@name="agency"]/option[2]/text()').extract_first(),
+                "name": response.xpath('//select[@name="agency"]/option[2]/text()').extract_first()
+                or f"Completude Office in {city}",
                 "country": "FR",
                 "lat": float(response.xpath('//div[@class="google-map map-default"]/@data-lat').extract_first()),
                 "lon": float(response.xpath('//div[@class="google-map map-default"]/@data-lng').extract_first()),
                 "website": response.url,
             }
 
+            apply_category({"office": "tutoring"}, properties)
             yield Feature(**properties)
         except:
             pass


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Complétude': 37,
 'atp/brand_wikidata/Q2990589': 37,
 'atp/category/office/tutoring': 37,
 'atp/field/email/missing': 37,
 'atp/field/image/missing': 37,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 37,
 'atp/field/operator_wikidata/missing': 37,
 'atp/field/state/missing': 37,
 'atp/field/twitter/missing': 37,
 'atp/nsi/brand_missing': 37,
 'downloader/request_bytes': 15527,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 43,
 'downloader/response_bytes': 2050406,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'dupefilter/filtered': 5,
 'elapsed_time_seconds': 50.42433,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 6, 18, 34, 18, 942365, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9183815,
 'httpcompression/response_count': 42,
 'item_scraped_count': 37,
 'log_count/DEBUG': 92,
 'log_count/INFO': 9,
 'memusage/max': 146259968,
 'memusage/startup': 146259968,
 'request_depth_max': 1,
 'response_received_count': 43,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 42,
 'scheduler/dequeued/memory': 42,
 'scheduler/enqueued': 42,
 'scheduler/enqueued/memory': 42,
 'start_time': datetime.datetime(2023, 12, 6, 18, 33, 28, 518035, tzinfo=datetime.timezone.utc)}
```
</details>