### PR TITLE
[go_ape_gb] Added category for go ape gb (37 items)

### DIFF
--- a/locations/spiders/go_ape_gb.py
+++ b/locations/spiders/go_ape_gb.py
@@ -2,6 +2,7 @@ import re
 
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -14,5 +15,5 @@ class GoApeGB(SitemapSpider, StructuredDataSpider):
 
     def inspect_item(self, item, response):
         item["ref"] = re.match(self.sitemap_rules[0][0], response.url).group(1)
-
+        apply_category({"leisure": "sports_centre", "aerialway": "zip_line"}, item)
         yield item


### PR DESCRIPTION
As aerialway is not a top level tag I added sports centre. Will to debate or change if there is another tag better suited for a ropes course with ziplining.

<details><summary>New Stats</summary>

```python
{'atp/brand/Go Ape': 37,
 'atp/brand_wikidata/Q5574692': 37,
 'atp/category/leisure/sports_centre': 37,
 'atp/cdn/cloudflare/response_count': 40,
 'atp/cdn/cloudflare/response_status_count/200': 40,
 'atp/field/city/missing': 25,
 'atp/field/email/missing': 37,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 37,
 'atp/field/operator_wikidata/missing': 37,
 'atp/field/phone/missing': 36,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 9,
 'atp/field/street_address/missing': 3,
 'atp/nsi/brand_missing': 37,
 'downloader/request_bytes': 16319,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 647660,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 40,
 'elapsed_time_seconds': 47.552664,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 6, 19, 14, 7, 439472, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3509286,
 'httpcompression/response_count': 40,
 'item_scraped_count': 37,
 'log_count/INFO': 9,
 'memusage/max': 146198528,
 'memusage/startup': 146198528,
 'request_depth_max': 1,
 'response_received_count': 40,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2023, 12, 6, 19, 13, 19, 886808, tzinfo=datetime.timezone.utc)}
```
</details>