### PR TITLE
[cox_health] dded some Categories for Healthcare (55 items)

### DIFF
--- a/locations/spiders/cox_health.py
+++ b/locations/spiders/cox_health.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -9,6 +10,16 @@ class CoxHealthSpider(scrapy.Spider):
     item_attributes = {"brand": "CoxHealth", "brand_wikidata": "Q5179867"}
     allowed_domains = ["coxhealth.com"]
     start_urls = ("https://www.coxhealth.com/our-hospitals-and-clinics/our-locations/",)
+
+    categories = [
+        ("Hospital", Categories.HOSPITAL),
+        ("Urgent Care", Categories.CLINIC_URGENT),
+        ("Clinic", Categories.CLINIC),
+        ("Surgery", {"amenity": "hospital", "healthcare": "hospital", "healthcare:speciality": "surgery"}),
+        ("Pharmacy", Categories.PHARMACY),
+        ("Dialysis", {"healthcare": "dialysis"}),
+        ("Fitness Center", {"liesure": "fitness_centre"}),
+    ]
 
     def parse(self, response):
         urls = response.xpath('//div[@class="card-action"]//a/@href').extract()
@@ -59,5 +70,10 @@ class CoxHealthSpider(scrapy.Spider):
             "lat": float(xy[5].strip(",")),
             "lon": float(xy[3].strip(",")),
         }
+
+        for label, cat in self.categories:
+            if label in properties.get("name"):
+                apply_category(cat, properties)
+                break
 
         yield Feature(**properties)


### PR DESCRIPTION
Added some categories.

<details><summary>New Stats</summary>

```python
{'atp/brand/CoxHealth': 55,
 'atp/brand_wikidata/Q5179867': 55,
 'atp/category/amenity/clinic': 22,
 'atp/category/amenity/hospital': 3,
 'atp/category/amenity/pharmacy': 3,
 'atp/category/healthcare/dialysis': 4,
 'atp/category/missing': 23,
 'atp/category/multiple': 28,
 'atp/field/email/missing': 55,
 'atp/field/image/missing': 55,
 'atp/field/opening_hours/missing': 55,
 'atp/field/operator/missing': 55,
 'atp/field/operator_wikidata/missing': 55,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/twitter/missing': 55,
 'atp/field/website/missing': 55,
 'atp/nsi/brand_missing': 55,
 'downloader/request_bytes': 37714,
 'downloader/request_count': 86,
 'downloader/request_method_count/GET': 86,
 'downloader/response_bytes': 809177,
 'downloader/response_count': 86,
 'downloader/response_status_count/200': 86,
 'elapsed_time_seconds': 105.430866,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 6, 20, 31, 34, 771484, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4535004,
 'httpcompression/response_count': 86,
 'item_dropped_count': 29,
 'item_dropped_reasons_count/DropItem': 29,
 'item_scraped_count': 55,
 'log_count/INFO': 10,
 'memusage/max': 393486336,
 'memusage/startup': 146366464,
 'request_depth_max': 1,
 'response_received_count': 86,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 85,
 'scheduler/dequeued/memory': 85,
 'scheduler/enqueued': 85,
 'scheduler/enqueued/memory': 85,
 'start_time': datetime.datetime(2023, 12, 6, 20, 29, 49, 340618, tzinfo=datetime.timezone.utc)}```
</details>