### PR TITLE
[BenchmarxGB] Add spider

### DIFF
--- a/locations/spiders/benchmarx_gb.py
+++ b/locations/spiders/benchmarx_gb.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.spiders.vapestore_gb import clean_address
+
+
+class BenchmarxGBSpider(Spider):
+    name = "benchmarx_gb"
+    item_attributes = {"brand": "Benchmarx", "brand_wikidata": "Q102181127"}
+    start_urls = ["https://api.live.benchmarxkitchens.co.uk/locations?pagination=false&locationPageStatus=active"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["hydra:member"]:
+            if location["slug"] == "test-location":
+                continue
+
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["street_address"] = clean_address(
+                [location["line1"], location["line2"], location["line3"], location["line4"]]
+            )
+            item["website"] = "https://www.benchmarxkitchens.co.uk/branches/{}".format(location["slug"])
+            item["extras"]["check_date"] = location["modifiedAt"]
+
+            item["opening_hours"] = OpeningHours()
+            for day, times in location["openingHours"].items():
+                if item.get("opening") and item.get("closing"):
+                    item["opening_hours"].add_range(day, times["opening"], times["closing"])
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Benchmarx': 165,
 'atp/brand_wikidata/Q102181127': 165,
 'atp/category/shop/kitchen': 165,
 'atp/field/image/missing': 165,
 'atp/field/name/missing': 165,
 'atp/field/opening_hours/missing': 165,
 'atp/field/operator/missing': 165,
 'atp/field/operator_wikidata/missing': 165,
 'atp/field/twitter/missing': 165,
 'atp/nsi/perfect_match': 165,
 'downloader/request_bytes': 688,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 407174,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 0.603349,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 11, 15, 14, 54, 766747, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'item_scraped_count': 165,
 'log_count/DEBUG': 183,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 152326144,
 'memusage/startup': 152326144,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 11, 15, 14, 54, 163398, tzinfo=datetime.timezone.utc)}
```