### PR TITLE
[BarBurritoCA] Add spider

### DIFF
--- a/locations/spiders/bar_burrito_ca.py
+++ b/locations/spiders/bar_burrito_ca.py
@@ -6,7 +6,7 @@ from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 class BarBurritoCASpider(WPStoreLocatorSpider):
     name = "bar_burrito_ca"
-    item_attributes = {"brand": "BarBurrito", "brand_wikidata": "Q123765650"}
+    item_attributes = {"brand": "BarBurrito", "brand_wikidata": "Q104844862"}
     allowed_domains = ["www.barburrito.ca"]
 
     def parse_item(self, item: Feature, location: dict, **kwargs):

--- a/locations/spiders/bar_burrito_ca.py
+++ b/locations/spiders/bar_burrito_ca.py
@@ -1,0 +1,20 @@
+import html
+
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class BarBurritoCASpider(WPStoreLocatorSpider):
+    name = "bar_burrito_ca"
+    item_attributes = {"brand": "BarBurrito", "brand_wikidata": "Q123765650"}
+    allowed_domains = ["www.barburrito.ca"]
+
+    def parse_item(self, item: Feature, location: dict, **kwargs):
+        item["branch"] = html.unescape(item.pop("name"))
+        del item["addr_full"]
+
+        yield item
+
+    def parse_opening_hours(self, location: dict, **kwargs):
+        # TODO: php serialized format
+        return None


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9029

```python
{'atp/brand/Barburrito': 326,
 'atp/brand_wikidata/Q123765650': 326,
 'atp/category/missing': 326,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 326,
 'atp/field/image/missing': 326,
 'atp/field/name/missing': 326,
 'atp/field/opening_hours/missing': 326,
 'atp/field/operator/missing': 326,
 'atp/field/operator_wikidata/missing': 326,
 'atp/field/phone/missing': 39,
 'atp/field/twitter/missing': 326,
 'atp/nsi/brand_missing': 326,
 'downloader/request_bytes': 675,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29578,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.411987,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 13, 11, 1, 0, 746354, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 294723,
 'httpcompression/response_count': 2,
 'item_dropped_count': 23,
 'item_dropped_reasons_count/DropItem': 23,
 'item_scraped_count': 326,
 'log_count/DEBUG': 363,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 147083264,
 'memusage/startup': 147083264,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 13, 11, 0, 58, 334367, tzinfo=datetime.timezone.utc)}
```