### PR TITLE
[MarksCA] Add spider

### DIFF
--- a/locations/spiders/marks_ca.py
+++ b/locations/spiders/marks_ca.py
@@ -1,0 +1,67 @@
+from typing import Any
+from urllib.parse import urljoin
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders.sitemap import iterloc
+from scrapy.utils.sitemap import Sitemap
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class MarksCASpider(Spider):
+    name = "marks_ca"
+    item_attributes = {"brand": "Mark's", "brand_wikidata": "Q6766373"}
+    start_urls = ["https://www.marks.com/sitemap_Store-en_CA-CAD.xml"]
+    user_agent = BROWSER_DEFAULT
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for url in iterloc(Sitemap(response.body)):
+            ref = url.removesuffix(".html").split("-")[-1]
+            yield JsonRequest(
+                url="https://apim.marks.com/v1/store/store/{}".format(ref),
+                callback=self.parse_location,
+                headers={"Ocp-Apim-Subscription-Key": "c01ef3612328420c9f5cd9277e815a0e", "baseSiteId": "MKS"},
+            )
+
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        location = response.json()
+        item = Feature()
+        item["ref"] = str(location["id"])
+        item["lat"] = location["geoPoint"]["latitude"]
+        item["lon"] = location["geoPoint"]["longitude"]
+        item["branch"] = location["displayName"]
+        item["city"] = location["address"]["city"]["name"]
+        item["state"] = location["address"]["region"]["name"]
+        item["country"] = location["address"]["country"]["isocode"]
+        item["email"] = location["address"]["email"]
+        item["phone"] = location["address"]["phone"]
+        item["postcode"] = location["address"]["postalCode"]
+        item["street_address"] = clean_address([location["address"]["line1"], location["address"]["line2"]])
+
+        item["opening_hours"] = OpeningHours()
+        for rule in location["openingHours"]["weekDayOpeningList"]:
+            if rule["closed"]:
+                continue
+            item["opening_hours"].add_range(
+                rule["weekDay"],
+                rule["openingTime"]["formattedHour"],
+                rule["closingTime"]["formattedHour"],
+                time_format="%I:%M %p",
+            )
+
+        for link in location["hreflangLinkData"]:
+            if link["hreflang"] == "x-default":
+                item["website"] = urljoin("https://www.marks.com", link["href"])
+            elif link["hreflang"] == "en":
+                item["extras"]["website:en"] = urljoin("https://www.marks.com", link["href"])
+            elif link["hreflang"] == "fr":
+                item["extras"]["website:fr"] = urljoin("https://www.lequipeur.com", link["href"])
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+
+        yield item


### PR DESCRIPTION
```python
{"atp/brand/Mark's": 379,
 'atp/brand_wikidata/Q6766373': 379,
 'atp/category/shop/clothes': 379,
 'atp/field/city/missing': 379,
 'atp/field/image/missing': 379,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/name/missing': 379,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 379,
 'atp/field/operator_wikidata/missing': 379,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 379,
 'atp/geometry/null_island': 1,
 'atp/nsi/match_failed': 379,
 'downloader/request_bytes': 759164,
 'downloader/request_count': 386,
 'downloader/request_method_count/GET': 386,
 'downloader/response_bytes': 758255,
 'downloader/response_count': 386,
 'downloader/response_status_count/200': 381,
 'downloader/response_status_count/400': 4,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.181479,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 13, 13, 12, 2, 851928, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 386,
 'httpcompression/response_bytes': 1748484,
 'httpcompression/response_count': 381,
 'httperror/response_ignored_count': 4,
 'httperror/response_ignored_status_count/400': 4,
 'item_scraped_count': 379,
 'log_count/INFO': 14,
 'log_count/WARNING': 1,
 'memusage/max': 151867392,
 'memusage/startup': 151867392,
 'request_depth_max': 1,
 'response_received_count': 386,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 384,
 'scheduler/dequeued/memory': 384,
 'scheduler/enqueued': 384,
 'scheduler/enqueued/memory': 384,
 'start_time': datetime.datetime(2023, 12, 13, 13, 12, 0, 670449, tzinfo=datetime.timezone.utc)}
```