### PR TITLE
Fix incorrect operator:wikidata field typos

### DIFF
--- a/locations/spiders/fastned.py
+++ b/locations/spiders/fastned.py
@@ -15,7 +15,7 @@ class FastnedSpider(Spider):
 
             apply_category(Categories.CHARGING_STATION, item)
             item["operator"] = self.item_attributes["brand"]
-            item["operator:wikidata"] = self.item_attributes["brand_wikidata"]
+            item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
 
             # TODO: connector data available in location["connectors"]
             yield item

--- a/locations/spiders/fire_and_rescue_nsw_au.py
+++ b/locations/spiders/fire_and_rescue_nsw_au.py
@@ -7,7 +7,7 @@ from locations.items import Feature
 
 class FireAndRescueNSWAUSpider(SitemapSpider):
     name = "fire_and_rescue_nsw_au"
-    item_attributes = {"operator": "Fire and Rescue New South Wales", "operator:wikidata": "Q5451532"}
+    item_attributes = {"operator": "Fire and Rescue New South Wales", "operator_wikidata": "Q5451532"}
     allowed_domains = ["www.fire.nsw.gov.au"]
     sitemap_urls = ["https://www.fire.nsw.gov.au/feeds/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/www\.fire\.nsw\.gov\.au\/page\.php\?id=9210&station=\d+", "parse")]

--- a/locations/spiders/great_western_railway_gb.py
+++ b/locations/spiders/great_western_railway_gb.py
@@ -7,7 +7,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class GreatWesternRailwayGBSpider(StructuredDataSpider):
     name = "great_western_railway_gb"
-    item_attributes = {"operator": "Great Western Railway", "operator:wikidata": "Q1419438"}
+    item_attributes = {"operator": "Great Western Railway", "operator_wikidata": "Q1419438"}
     start_urls = ["https://www.gwr.com/api/stations"]
     wanted_types = ["TrainStation"]
     search_for_twitter = False

--- a/locations/spiders/marks_and_spencer.py
+++ b/locations/spiders/marks_and_spencer.py
@@ -42,7 +42,7 @@ class MarksAndSpencerSpider(scrapy.Spider):
 
             if store["storeType"] == "mands":
                 properties["operator"] = "Marks and Spencer"
-                properties["operator:wikidata"] = "Q714491"
+                properties["operator_wikidata"] = "Q714491"
 
             name = store["name"].lower()
             if name.endswith("foodhall"):

--- a/locations/spiders/midcounties_cooperative_gb.py
+++ b/locations/spiders/midcounties_cooperative_gb.py
@@ -10,7 +10,7 @@ class MidcountiesCooperativeGBSpider(Spider):
     item_attributes = {
         "brand": "Your Co-op",
         "operator": "Midcounties Co-operative",
-        "operator:wikidata": "Q6841138",
+        "operator_wikidata": "Q6841138",
     }
     start_urls = ["https://www.midcounties.coop/static/js/stores.json"]
     no_refs = True

--- a/locations/spiders/national_rail_gb.py
+++ b/locations/spiders/national_rail_gb.py
@@ -59,7 +59,7 @@ class NationalRailGBSpider(Spider):
             item["lon"] = location["longitude"]
             item["postcode"] = location["postcode"]
             item["website"] = "https://www.nationalrail.co.uk/stations/{}/".format(location["crsCode"].lower())
-            item["operator"], item["operator:wikidata"] = self.operators.get(
+            item["operator"], item["operator_wikidata"] = self.operators.get(
                 location["operator"], (location["operator"], None)
             )
 

--- a/locations/spiders/northern_railway_gb.py
+++ b/locations/spiders/northern_railway_gb.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class NorthernRailwayGBSpider(Spider):
     name = "northern_railway_gb"
-    item_attributes = {"operator": "Northern", "operator:wikidata": "Q85789775"}
+    item_attributes = {"operator": "Northern", "operator_wikidata": "Q85789775"}
     start_urls = ["https://www.northernrailway.co.uk/api/northern_station_list_auto_complete"]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/nsw_ambulance_au.py
+++ b/locations/spiders/nsw_ambulance_au.py
@@ -50,5 +50,5 @@ class NSWAmbulanceAUSpider(Spider):
             ]:
                 properties["state"] = "ACT"
                 properties["operator"] = "Australian Capital Territory Ambulance Service"
-                properties["operator:wikidata"] = "Q4823922"
+                properties["operator_wikidata"] = "Q4823922"
             yield Feature(**properties)

--- a/locations/spiders/scotrail_gb.py
+++ b/locations/spiders/scotrail_gb.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class ScotrailGBSpider(CrawlSpider):
     name = "scotrail_gb"
-    item_attributes = {"operator": "ScotRail", "operator:wikidata": "Q18356161"}
+    item_attributes = {"operator": "ScotRail", "operator_wikidata": "Q18356161"}
     start_urls = ["https://www.scotrail.co.uk/plan-your-journey/stations-and-facilities"]
     rules = [Rule(LinkExtractor(allow=r"/plan-your-journey/stations-and-facilities/\w{3}$"), callback="parse")]
     requires_proxy = True

--- a/locations/spiders/southeastern_railway_gb.py
+++ b/locations/spiders/southeastern_railway_gb.py
@@ -9,7 +9,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class SoutheasternRailwayGBSpider(SitemapSpider, StructuredDataSpider):
     name = "southeastern_railway_gb"
-    item_attributes = {"operator": "Southeastern", "operator:wikidata": "Q1696490"}
+    item_attributes = {"operator": "Southeastern", "operator_wikidata": "Q1696490"}
     sitemap_urls = ["https://www.southeasternrailway.co.uk/robots.txt"]
     sitemap_rules = [("/station-information/stations/", "parse")]
     search_for_facebook = False

--- a/locations/spiders/transport_for_wales_gb.py
+++ b/locations/spiders/transport_for_wales_gb.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 
 class TransportForWalesGB(Spider):
     name = "transport_for_wales_gb"
-    item_attributes = {"operator": "Transport for Wales", "operator:wikidata": "Q104878180"}
+    item_attributes = {"operator": "Transport for Wales", "operator_wikidata": "Q104878180"}
     start_urls = ["https://tfw.wales/api/stations/links/{}".format(letter) for letter in string.ascii_uppercase]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/winterthur_ch.py
+++ b/locations/spiders/winterthur_ch.py
@@ -56,7 +56,7 @@ class WinterthurCHSpider(scrapy.Spider):
                 "city": "Winterthur",
                 "country": "CH",
                 "operator": "Stadtgrün Winterthur",
-                "operator:wikidata": "Q56825906",
+                "operator_wikidata": "Q56825906",
             }
             apply_category(Categories.LEISURE_PLAYGROUND, item)
             if name_words := props.get("name", "").split():
@@ -80,7 +80,7 @@ class WinterthurCHSpider(scrapy.Spider):
                     "city": "Winterthur",
                     "country": "CH",
                     "operator": "Stadtgrün Winterthur",
-                    "operator:wikidata": "Q56825906",
+                    "operator_wikidata": "Q56825906",
                     "extras": {
                         "backrest": self.parse_bench_backrest(btype),
                         "colour": self.parse_bench_colour(btype),


### PR DESCRIPTION
Commit fd3a6c24df32d7f9a2b06f8d5fb68bfe5b87f753 accidentally used "operator:wikidata" as a field of locations.items.Feature, instead of "operator_wikidata" (correct field name).