### PR TITLE
[OpticalCenter] Add spider

### DIFF
--- a/locations/spiders/optical_center.py
+++ b/locations/spiders/optical_center.py
@@ -27,6 +27,7 @@ class OpticalCenterSpider(CrawlSpider, StructuredDataSpider):
         item["ref"] = response.url.split("/")[-1]
         item["street_address"] = html.unescape(item["street_address"])
         item["city"] = html.unescape(item["city"])
+        item["name"] = html.unescape(item["name"])
 
         # x-default is a lie, it's always FR, the whole thing is a lie, it's about domains not languages
         for link in response.xpath('//link[@rel="alternate"][@hreflang][@href]'):

--- a/locations/spiders/optical_center.py
+++ b/locations/spiders/optical_center.py
@@ -1,0 +1,51 @@
+import html
+import json
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class OpticalCenterSpider(CrawlSpider, StructuredDataSpider):
+    name = "optical_center"
+    item_attributes = {"brand": "Optical Center", "brand_wikidata": "Q3354448"}
+    start_urls = ["https://optician.optical-center.co.uk/site-map"]
+    rules = [
+        Rule(
+            LinkExtractor(
+                restrict_xpaths='//a[@class="lf-sitemap-hierarchy__location__link__item lf-site-map__main__content__location__link__item"]'
+            ),
+            callback="parse_sd",
+        )
+    ]
+
+    def iter_linked_data(self, response):
+        yield json.loads(response.xpath("//script[@data-lf-location-json]/text()").get())
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["ref"] = response.url.split("/")[-1]
+        item["street_address"] = html.unescape(item["street_address"])
+        item["city"] = html.unescape(item["city"])
+
+        # x-default is a lie, it's always FR, the whole thing is a lie, it's about domains not languages
+        for link in response.xpath('//link[@rel="alternate"][@hreflang][@href]'):
+            if link.attrib["hreflang"] == "x-default":
+                continue
+            item["extras"]["website:{}".format(link.attrib["hreflang"])] = link.attrib["href"]
+
+        # Try to get the local url
+        if item["country"] == "CA":
+            item["website"] = item["extras"]["website:en"] = item["extras"]["website:en-CA"]
+            item["extras"]["website:fr"] = item["extras"]["website:fr-CA"]
+        elif item["country"] == "BE":
+            item["website"] = item["extras"]["website:nl"]
+        elif item["country"] == "CH":
+            item["website"] = item["extras"]["website:de"]
+        else:
+            item["website"] = item["extras"].get("website:{}".format(item["country"].lower()), response.url)
+
+        del item["extras"]["website:en-CA"]
+        del item["extras"]["website:fr-CA"]
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/9018
```python
{'atp/brand/Optical Center': 882,
 'atp/brand_wikidata/Q3354448': 882,
 'atp/category/shop/optician': 882,
 'atp/field/email/missing': 2,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 882,
 'atp/field/operator_wikidata/missing': 882,
 'atp/field/phone/missing': 4,
 'atp/field/state/from_reverse_geocoding': 10,
 'atp/field/state/missing': 872,
 'atp/field/twitter/missing': 882,
 'atp/nsi/perfect_match': 882,
 'downloader/request_bytes': 504184,
 'downloader/request_count': 920,
 'downloader/request_method_count/GET': 920,
 'downloader/response_bytes': 35732726,
 'downloader/response_count': 920,
 'downloader/response_status_count/200': 884,
 'downloader/response_status_count/301': 36,
 'elapsed_time_seconds': 13.271561,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 18, 15, 39, 15, 703446, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 920,
 'httpcompression/response_bytes': 342409819,
 'httpcompression/response_count': 884,
 'item_scraped_count': 882,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 152858624,
 'memusage/startup': 152858624,
 'request_depth_max': 1,
 'response_received_count': 884,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 919,
 'scheduler/dequeued/memory': 919,
 'scheduler/enqueued': 919,
 'scheduler/enqueued/memory': 919,
 'start_time': datetime.datetime(2023, 12, 18, 15, 39, 2, 431885, tzinfo=datetime.timezone.utc)}
```