### PR TITLE
[BlackRedWhitePL] Fix refs

### DIFF
--- a/locations/spiders/black_red_white_pl.py
+++ b/locations/spiders/black_red_white_pl.py
@@ -7,5 +7,6 @@ class BlackRedWhitePLSpider(SitemapSpider, StructuredDataSpider):
     name = "black_red_white_pl"
     item_attributes = {"brand": "Black Red White", "brand_wikidata": "Q4921546"}
     sitemap_urls = ["https://www.brw.pl/sitemap/salony.xml"]
-    sitemap_follow = ["salony"]
-    no_refs = True
+
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data["@id"] = None


### PR DESCRIPTION
The site is giving `https://www.brw.pl/logo.svg` as all the refs, I guess that's why the `no_refs` was enabled. However we can use the url as the ref.