### PR TITLE
[WillysSE] Add spider

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -160,12 +160,19 @@ DAYS_HU = {
 
 DAYS_SE = {
     "Måndag": "Mo",
+    "Mån": "Mo",
     "Tisdag": "Tu",
+    "Tis": "Tu",
     "Onsdag": "We",
+    "Ons": "We",
     "Torsdag": "Th",
+    "Tors": "Th",
     "Fredag": "Fr",
+    "Fre": "Fr",
     "Lördag": "Sa",
+    "Lör": "Sa",
     "Söndag": "Su",
+    "Sön": "Su",
 }
 DAYS_SI = {
     "Po": "Mo",

--- a/locations/spiders/willys_se.py
+++ b/locations/spiders/willys_se.py
@@ -1,0 +1,26 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_SE, OpeningHours, sanitise_day
+
+
+class WillysSESpider(scrapy.Spider):
+    name = "willys_se"
+    item_attributes = {"brand": "Willys", "brand_wikidata": "Q10720214"}
+    start_urls = ["https://www.willys.se/axfood/rest/search/store?q=*&sort=display-name-asc"]
+
+    def parse(self, response):
+        for store in response.json()["results"]:
+            item = DictParser.parse(store)
+            item["branch"] = item.pop("name").removeprefix("Wh ").removeprefix("Willys ")
+            item["phone"] = store["address"]["phoneNumber"]
+            item["website"] = "https://www.willys.se/butik/{}".format(item["ref"])
+
+            item["opening_hours"] = OpeningHours()
+            for rule in store["openingHours"]:
+                day, times = rule.split(" ")
+                start_time, end_time = times.split("-")
+                if day := sanitise_day(day, DAYS_SE):
+                    item["opening_hours"].add_range(day, start_time, end_time)
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Willys': 234,
 'atp/brand_wikidata/Q10720214': 234,
 'atp/category/shop/supermarket': 234,
 'atp/field/country/from_spider_name': 234,
 'atp/field/email/missing': 234,
 'atp/field/image/missing': 234,
 'atp/field/name/missing': 234,
 'atp/field/operator/missing': 234,
 'atp/field/operator_wikidata/missing': 234,
 'atp/field/state/missing': 234,
 'atp/field/twitter/missing': 234,
 'atp/nsi/perfect_match': 234,
 'downloader/request_bytes': 648,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 21497,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.633671,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 21, 15, 48, 30, 24489, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 217553,
 'httpcompression/response_count': 2,
 'item_scraped_count': 234,
 'log_count/DEBUG': 249,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 152903680,
 'memusage/startup': 152903680,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 21, 15, 48, 29, 390818, tzinfo=datetime.timezone.utc)}
```