### PR TITLE
[Neuroth] Add spider

### DIFF
--- a/locations/spiders/neuroth.py
+++ b/locations/spiders/neuroth.py
@@ -1,0 +1,37 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+
+class NeurothSpider(Spider):
+    name = "neuroth"
+    item_attributes = {"brand": "Neuroth", "brand_wikidata": "Q15836645"}
+
+    def start_requests(self) -> Iterable[Request]:
+        for country in ["at", "ba", "ch", "de", "hr", "si", "rs"]:
+            yield JsonRequest("https://{}.neuroth.com/wp-json/neuroth/v1/appointments/stores".format(country))
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = Feature()
+            item["ref"] = location["code"]
+            item["website"] = location["permalink"]
+            item["addr_full"] = location["contact"]["formattedAddress"]
+            item["street_address"] = location["contact"]["address"]
+            item["postcode"] = location["contact"]["zip"]
+            item["city"] = location["contact"]["city"]
+            item["country"] = location["contact"]["country"]
+            item["phone"] = location["contact"]["phone"]
+            item["email"] = location["contact"]["email"]
+            item["extras"]["fax"] = location["contact"]["fax"]
+            item["lat"] = location["coordinates"]["latitude"]
+            item["lon"] = location["coordinates"]["longitude"]
+            item["opening_hours"] = OpeningHours()
+            for rule in location["openingHours"]["openingHoursEntries"]:
+                item["opening_hours"].add_range(DAYS[rule["weekday"] - 1], rule["opens"], rule["closes"], "%H:%M:%S")
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9061

```python
{'atp/brand/Neuroth': 438,
 'atp/brand_wikidata/Q15836645': 438,
 'atp/category/shop/hearing_aids': 438,
 'atp/field/image/missing': 438,
 'atp/field/name/missing': 438,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 438,
 'atp/field/operator_wikidata/missing': 438,
 'atp/field/state/missing': 438,
 'atp/field/twitter/missing': 438,
 'atp/nsi/perfect_match': 438,
 'downloader/request_bytes': 4571,
 'downloader/request_count': 14,
 'downloader/request_method_count/GET': 14,
 'downloader/response_bytes': 75319,
 'downloader/response_count': 14,
 'downloader/response_status_count/200': 14,
 'elapsed_time_seconds': 0.969645,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 24, 11, 14, 12, 259815, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 14,
 'httpcompression/response_bytes': 987280,
 'httpcompression/response_count': 14,
 'item_scraped_count': 438,
 'log_count/INFO': 10,
 'memusage/max': 151760896,
 'memusage/startup': 151760896,
 'response_received_count': 14,
 'robotstxt/request_count': 7,
 'robotstxt/response_count': 7,
 'robotstxt/response_status_count/200': 7,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2023, 12, 24, 11, 14, 11, 290170, tzinfo=datetime.timezone.utc)}
```