### PR TITLE
[BupaGB] Flag closed POIs

### DIFF
--- a/locations/items.py
+++ b/locations/items.py
@@ -2,6 +2,7 @@
 #
 # See documentation in:
 # http://doc.scrapy.org/en/latest/topics/items.html
+from datetime import datetime
 
 import scrapy
 
@@ -78,3 +79,7 @@ def add_social_media(item: Feature, service: str, account: str):
         item[service] = account
     else:
         item["extras"][f"contact:{service}"] = account
+
+
+def set_closed(item: Feature, end_date: datetime = None):
+    item["extras"]["end_date"] = end_date.strftime("%Y-%m-%d") if end_date else "yes"

--- a/locations/spiders/bupa_gb.py
+++ b/locations/spiders/bupa_gb.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories
+from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,4 +14,8 @@ class BupaGBSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "Total Dental Care" in item["name"]:
             item["brand"] = "Total Dental Care"
+
+        if item["name"].lower().endswith(" - closed"):
+            set_closed(item)
+
         yield item

--- a/tests/test_closed.py
+++ b/tests/test_closed.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from locations.items import Feature, set_closed
+
+
+def test_unknown():
+    item = Feature()
+    set_closed(item)
+    assert item["extras"]["end_date"]
+    assert item["extras"]["end_date"] == "yes"
+
+
+def test_date():
+    item = Feature()
+    set_closed(item, datetime(2023, 12, 31))
+    assert item["extras"]["end_date"]
+    assert item["extras"]["end_date"] == "2023-12-31"


### PR DESCRIPTION
Fixes #6562

" - Closed" seems to be a really common suffix, maybe we should move this to a pipeline at some stage.

```python
{'atp/brand/Bupa': 388,
 'atp/brand/Total Dental Care': 5,
 'atp/brand_wikidata/Q931628': 393,
 'atp/category/amenity/dentist': 393,
 'atp/category/multiple': 393,
 'atp/cdn/cloudflare/response_count': 398,
 'atp/cdn/cloudflare/response_status_count/200': 398,
 'atp/field/city/missing': 393,
 'atp/field/country/from_spider_name': 365,
 'atp/field/email/missing': 393,
 'atp/field/opening_hours/missing': 393,
 'atp/field/operator/missing': 393,
 'atp/field/operator_wikidata/missing': 393,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 393,
 'atp/nsi/category_match': 393,
 'downloader/request_bytes': 179405,
 'downloader/request_count': 399,
 'downloader/request_method_count/GET': 399,
 'downloader/response_bytes': 17605319,
 'downloader/response_count': 399,
 'downloader/response_status_count/200': 398,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 5.225615,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 31, 9, 27, 54, 691672, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 399,
 'httpcompression/response_bytes': 121240117,
 'httpcompression/response_count': 398,
 'item_scraped_count': 393,
 'log_count/DEBUG': 804,
 'log_count/INFO': 9,
 'memusage/max': 153493504,
 'memusage/startup': 153493504,
 'request_depth_max': 2,
 'response_received_count': 398,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 398,
 'scheduler/dequeued/memory': 398,
 'scheduler/enqueued': 398,
 'scheduler/enqueued/memory': 398,
 'start_time': datetime.datetime(2023, 12, 31, 9, 27, 49, 466057, tzinfo=datetime.timezone.utc)}
```