### PR TITLE
Hemköp SE (Supermarket chain Sweden) adding spider (199 items)

### DIFF
--- a/locations/spiders/hemkop_se.py
+++ b/locations/spiders/hemkop_se.py
@@ -1,0 +1,29 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_SE, OpeningHours, sanitise_day
+
+
+class HemkopSESpider(scrapy.Spider):
+    name = "hemkop_se"
+    item_attributes = {"brand": "Hemköp", "brand_wikidata": "Q10521746"}
+    start_urls = ["https://www.hemkop.se/axfood/rest/search/store?q=*&sort=display-name-asc"]
+
+    def parse(self, response):
+        for store in response.json()["results"]:
+            item = DictParser.parse(store)
+            item["branch"] = item.pop("name").removeprefix("Hemköp ")
+            item["phone"] = store["address"]["phoneNumber"]
+            item["website"] = "https://www.hemkop.se/butik/{}".format(item["ref"])
+
+            try:
+                item["opening_hours"] = OpeningHours()
+                for rule in store["openingHours"]:
+                    day, times = rule.split(" ")
+                    start_time, end_time = times.split("-")
+                    if day := sanitise_day(day, DAYS_SE):
+                        item["opening_hours"].add_range(day, start_time, end_time)
+            except:
+                pass
+
+            yield item


### PR DESCRIPTION
Adding spider for Hemköp (a Swedish supermarket chain).

```bash
{'atp/brand/Hemköp': 199,
 'atp/brand_wikidata/Q10521746': 199,
 'atp/category/shop/supermarket': 199,
 'atp/field/country/from_spider_name': 199,
 'atp/field/email/missing': 199,
 'atp/field/image/missing': 199,
 'atp/field/name/missing': 199,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 199,
 'atp/field/operator_wikidata/missing': 199,
 'atp/field/state/missing': 199,
 'atp/field/twitter/missing': 199,
 'atp/nsi/perfect_match': 199,
 'downloader/request_bytes': 648,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 18691,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.213838,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 31, 12, 9, 37, 848140, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 143484,
 'httpcompression/response_count': 2,
 'item_scraped_count': 199,
 'log_count/DEBUG': 213,
 'log_count/INFO': 9,
 'memusage/max': 130584576,
 'memusage/startup': 130584576,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2023, 12, 31, 12, 9, 34, 634302, tzinfo=datetime.timezone.utc)}
```