### PR TITLE
Add spider for ICA supermarkets in Sweden (1322 entries)

### DIFF
--- a/locations/spiders/hemkop_se.py
+++ b/locations/spiders/hemkop_se.py
@@ -1,0 +1,29 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_SE, OpeningHours, sanitise_day
+
+
+class HemkopSESpider(scrapy.Spider):
+    name = "hemkop_se"
+    item_attributes = {"brand": "Hemköp", "brand_wikidata": "Q10521746"}
+    start_urls = ["https://www.hemkop.se/axfood/rest/search/store?q=*&sort=display-name-asc"]
+
+    def parse(self, response):
+        for store in response.json()["results"]:
+            item = DictParser.parse(store)
+            item["branch"] = item.pop("name").removeprefix("Hemköp ")
+            item["phone"] = store["address"]["phoneNumber"]
+            item["website"] = "https://www.hemkop.se/butik/{}".format(item["ref"])
+
+            try:
+                item["opening_hours"] = OpeningHours()
+                for rule in store["openingHours"]:
+                    day, times = rule.split(" ")
+                    start_time, end_time = times.split("-")
+                    if day := sanitise_day(day, DAYS_SE):
+                        item["opening_hours"].add_range(day, start_time, end_time)
+            except:
+                pass
+
+            yield item

--- a/locations/spiders/ica_se.py
+++ b/locations/spiders/ica_se.py
@@ -7,7 +7,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class IcaSESpider(SitemapSpider, StructuredDataSpider):
     name = "ica_se"
     item_attributes = {"brand": "ICA", "brand_wikidata": "Q1663776", "extras": Categories.SHOP_SUPERMARKET.value}
-    sitemap_urls = ["https://www.ica.se/butiker/sitemaps/1/", "https://www.ica.se/butiker/sitemap.xml"]
+    sitemap_urls = ["https://www.ica.se/butiker/sitemaps/", "https://www.ica.se/butiker/sitemap.xml"]
     sitemap_rules = [
         (r"/butiker/.+\d+/$", "parse_sd"),
     ]

--- a/locations/spiders/ica_se.py
+++ b/locations/spiders/ica_se.py
@@ -1,6 +1,7 @@
-from locations.structured_data_spider import StructuredDataSpider
 from scrapy.spiders import SitemapSpider
+
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class IcaSESpider(SitemapSpider, StructuredDataSpider):

--- a/locations/spiders/ica_se.py
+++ b/locations/spiders/ica_se.py
@@ -1,0 +1,12 @@
+from locations.structured_data_spider import StructuredDataSpider
+from scrapy.spiders import SitemapSpider
+from locations.categories import Categories, apply_category
+
+
+class IcaSESpider(SitemapSpider, StructuredDataSpider):
+    name = "ica_se"
+    item_attributes = {"brand": "ICA", "brand_wikidata": "Q1663776", "extras": Categories.SHOP_SUPERMARKET.value}
+    sitemap_urls = ["https://www.ica.se/butiker/sitemaps/1/", "https://www.ica.se/butiker/sitemap.xml"]
+    sitemap_rules = [
+        (r"/butiker/.+\d+/$", "parse_sd"),
+    ]


### PR DESCRIPTION
```
{'atp/brand/ICA': 1322,
 'atp/brand_wikidata/Q1663776': 1322,
 'atp/category/shop/supermarket': 1322,
 'atp/field/email/missing': 1322,
 'atp/field/image/dropped': 1322,
 'atp/field/image/missing': 1322,
 'atp/field/lat/missing': 12,
 'atp/field/lon/missing': 12,
 'atp/field/opening_hours/missing': 28,
 'atp/field/operator/missing': 1322,
 'atp/field/operator_wikidata/missing': 1322,
 'atp/field/phone/missing': 38,
 'atp/field/state/missing': 1322,
 'atp/nsi/match_failed': 1322,
 'downloader/request_bytes': 793403,
 'downloader/request_count': 1342,
 'downloader/request_method_count/GET': 1342,
 'downloader/response_bytes': 55826198,
 'downloader/response_count': 1342,
 'downloader/response_status_count/200': 1341,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 1626.437517,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2023, 12, 31, 20, 2, 20, 246216, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 230615474,
 'httpcompression/response_count': 1341,
 'item_scraped_count': 1322,
 'log_count/DEBUG': 2675,
 'log_count/INFO': 37,
 'memusage/max': 330477568,
 'memusage/startup': 131780608,
 'request_depth_max': 1,
 'response_received_count': 1341,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1341,
 'scheduler/dequeued/memory': 1341,
 'scheduler/enqueued': 1341,
 'scheduler/enqueued/memory': 1341,
 'start_time': datetime.datetime(2023, 12, 31, 19, 35, 13, 808699, tzinfo=datetime.timezone.utc)}
```