### PR TITLE
lincraft_au: fix spider

### DIFF
--- a/locations/spiders/lincraft_au.py
+++ b/locations/spiders/lincraft_au.py
@@ -9,22 +9,6 @@ class LincraftAUSpider(StockistSpider):
 
     def parse_item(self, item, location):
         item["website"] = location["custom_fields"][0]["value"].replace("lincraftau.myshopify.com", "lincraft.com.au")
-        oh = OpeningHours()
-        hours_raw = (
-            " ".join(location["description"].split())
-            .replace("Store Trading Hours", "")
-            .replace("9am-10am-5pm", "10am-5pm")
-            .replace("-", " ")
-            .split()
-        )
-        hours_raw = hours_raw = [hours_raw[n : n + 3] for n in range(0, len(hours_raw), 3)]
-        for day in hours_raw:
-            open_time = day[1].upper()
-            if ":" not in open_time:
-                open_time = open_time.replace("AM", ":00AM").replace("PM", ":00PM")
-            close_time = day[2].upper()
-            if ":" not in close_time:
-                close_time = close_time.replace("AM", ":00AM").replace("PM", ":00PM")
-            oh.add_range(day[0], open_time, close_time, "%I:%M%p")
-        item["opening_hours"] = oh.as_opening_hours()
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(location["description"])
         yield item


### PR DESCRIPTION
Simplify opening hours extraction and ensure it gracefully fails when holiday opening hours are present. Unfortunately normal business hours are replaced with holiday hours, so around holiday times, this spider won't return opening hours information.