### PR TITLE
[PagueMenosBR] Add Spider

### DIFF
--- a/locations/spiders/pague_menos_br.py
+++ b/locations/spiders/pague_menos_br.py
@@ -1,0 +1,36 @@
+import json
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+
+
+class PagueMenosBRSpider(Spider):
+    name = "pague_menos_br"
+    item_attributes = {"brand": "Pague Menos", "brand_wikidata": "Q7124466"}
+    start_urls = ["https://www.paguemenos.com.br/nossas-lojas"]
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Collect cookies
+        yield JsonRequest(
+            "https://pmenos.paguemenos.com.br/wp-json/wp/v2/lojas?per_page=9999&page=1&order=asc",
+            callback=self.parse_api,
+        )
+
+    def parse_api(self, response: Response, **kwargs: Any) -> Any:
+        for location in json.loads(response.xpath("//text()").get()):
+            item = Feature()
+            item["ref"] = location["meta_box"]["id_loja"]
+            item["website"] = location["link"]
+            item["phone"] = location["meta_box"]["telefone"].split("/")[0]
+            item["street_address"] = location["meta_box"]["endereco"]
+            item["city"] = location["meta_box"]["cidade"]
+            item["state"] = location["meta_box"]["uf"]
+            item["postcode"] = location["meta_box"]["cep"]
+
+            yield item


### PR DESCRIPTION
Fixes #6602

```python
{'atp/brand/Pague Menos': 1104,
 'atp/brand_wikidata/Q7124466': 1104,
 'atp/category/amenity/pharmacy': 1104,
 'atp/category/multiple': 1104,
 'atp/field/country/from_spider_name': 1104,
 'atp/field/email/missing': 1104,
 'atp/field/image/missing': 1104,
 'atp/field/lat/missing': 1104,
 'atp/field/lon/missing': 1104,
 'atp/field/name/missing': 1104,
 'atp/field/opening_hours/missing': 1104,
 'atp/field/operator/missing': 1104,
 'atp/field/operator_wikidata/missing': 1104,
 'atp/field/phone/invalid': 54,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 1104,
 'atp/nsi/perfect_match': 1104,
 'downloader/request_bytes': 1577,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 2793591,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 6.047567,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 5, 13, 47, 26, 777704, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 4,
 'item_scraped_count': 1104,
 'log_count/DEBUG': 1123,
 'log_count/INFO': 11,
 'memusage/max': 156962816,
 'memusage/startup': 156962816,
 'request_depth_max': 1,
 'response_received_count': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 1, 5, 13, 47, 20, 730137, tzinfo=datetime.timezone.utc)}
```