### PR TITLE
[BlackberrysIN] Add spider

### DIFF
--- a/locations/spiders/blackberrys_in.py
+++ b/locations/spiders/blackberrys_in.py
@@ -1,0 +1,12 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BlackberrysINSpider(CrawlSpider, StructuredDataSpider):
+    name = "blackberrys_in"
+    item_attributes = {"brand": "Blackberrys", "brand_wikidata": "Q4922570"}
+    start_urls = ["https://stores.blackberrys.com/"]
+    rules = [Rule(LinkExtractor(r"page=\d+$")), Rule(LinkExtractor("/Home"), callback="parse_sd")]
+    wanted_types = ["Store"]


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/commit/7acec782848b55ebddda833ddc6c18ba71a3bbd5

```python
{'atp/category/missing': 354,
 'atp/field/brand/missing': 354,
 'atp/field/brand_wikidata/missing': 354,
 'atp/field/email/missing': 354,
 'atp/field/image/missing': 354,
 'atp/field/opening_hours/missing': 354,
 'atp/field/operator/missing': 354,
 'atp/field/operator_wikidata/missing': 354,
 'atp/field/twitter/missing': 354,
 'downloader/request_bytes': 172121,
 'downloader/request_count': 428,
 'downloader/request_method_count/GET': 428,
 'downloader/response_bytes': 7359030,
 'downloader/response_count': 428,
 'downloader/response_status_count/200': 416,
 'downloader/response_status_count/404': 12,
 'dupefilter/filtered': 120,
 'elapsed_time_seconds': 510.855306,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 5, 23, 15, 54, 40451, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 421,
 'httpcache/hit': 7,
 'httpcache/miss': 421,
 'httpcache/store': 421,
 'httpcompression/response_bytes': 60341045,
 'httpcompression/response_count': 428,
 'item_dropped_count': 354,
 'item_dropped_reasons_count/DropItem': 354,
 'item_scraped_count': 354,
 'log_count/INFO': 18,
 'log_count/WARNING': 1,
 'memusage/max': 195710976,
 'memusage/startup': 153767936,
 'request_depth_max': 30,
 'response_received_count': 428,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 427,
 'scheduler/dequeued/memory': 427,
 'scheduler/enqueued': 427,
 'scheduler/enqueued/memory': 427,
 'start_time': datetime.datetime(2024, 1, 5, 23, 7, 23, 185145, tzinfo=datetime.timezone.utc)}
```

Duplicate linked data is causing the duplicate items, but they are being caught by the pipeline.