### PR TITLE
[PhotoMeGB] Add spider

### DIFF
--- a/locations/spiders/photome_gb.py
+++ b/locations/spiders/photome_gb.py
@@ -1,0 +1,51 @@
+import urllib
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.items import Feature
+
+
+class PhotoMeGBSpider(Spider):
+    name = "photome_gb"
+    item_attributes = {"brand": "Photo-Me", "brand_wikidata": "Q123456627"}
+    base_url = (
+        "https://services5.arcgis.com/M6ZM30o7d7nGnSp2/arcgis/rest/services/Photo_Me_map_220223/FeatureServer/0/query?"
+    )
+    fields = ["Lookup", "machine_code", "place_name", "postal_code", "family_reference", "Machine_type", "FID"]
+
+    def get_request(self, offset: int, size: int = 1000) -> Request:
+        return JsonRequest(
+            url=self.base_url
+            + urllib.parse.urlencode(
+                {
+                    "where": "1=1",
+                    "inSR": "4326",
+                    "outFields": ",".join(self.fields),
+                    "resultOffset": str(offset),
+                    "resultRecordCount": str(size),
+                    "f": "geojson",
+                }
+            ),
+            meta={"offset": offset, "size": size},
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.get_request(0)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["features"]:
+            item = Feature()
+            item["geometry"] = location["geometry"]
+            item["ref"] = location["id"]
+
+            yield from self.parse_item(item, location, location["properties"]) or []
+
+        if response.json()["properties"]["exceededTransferLimit"]:
+            yield self.get_request(response.meta["offset"] + response.meta["size"], response.meta["size"])
+
+    def parse_item(self, item: Feature, location: dict, properties: dict) -> Iterable[Feature]:
+        item["branch"] = properties["place_name"]
+        item["postcode"] = properties["postal_code"]
+        yield item

--- a/locations/spiders/photome_gb.py
+++ b/locations/spiders/photome_gb.py
@@ -42,7 +42,7 @@ class PhotoMeGBSpider(Spider):
 
             yield from self.parse_item(item, location, location["properties"]) or []
 
-        if response.json()["properties"]["exceededTransferLimit"]:
+        if response.json().get("properties", {}).get("exceededTransferLimit"):
             yield self.get_request(response.meta["offset"] + response.meta["size"], response.meta["size"])
 
     def parse_item(self, item: Feature, location: dict, properties: dict) -> Iterable[Feature]:


### PR DESCRIPTION
```python
{'atp/brand/Photo-Me': 3553,
 'atp/brand_wikidata/Q123456627': 3553,
 'atp/category/amenity/photo_booth': 3553,
 'atp/field/city/missing': 3553,
 'atp/field/country/from_spider_name': 3553,
 'atp/field/email/missing': 3553,
 'atp/field/image/missing': 3553,
 'atp/field/opening_hours/missing': 3553,
 'atp/field/operator/missing': 3553,
 'atp/field/operator_wikidata/missing': 3553,
 'atp/field/phone/missing': 3553,
 'atp/field/state/missing': 3553,
 'atp/field/street_address/missing': 3553,
 'atp/field/twitter/missing': 3553,
 'atp/field/website/missing': 3553,
 'atp/nsi/perfect_match': 3553,
 'downloader/request_bytes': 3446,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 143737,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 4,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 4.387347,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'closespider_errorcount',
 'finish_time': datetime.datetime(2024, 1, 9, 13, 48, 38, 58043, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 3,
 'httpcache/hit': 2,
 'httpcache/miss': 3,
 'httpcache/store': 3,
 'httpcompression/response_bytes': 1022375,
 'httpcompression/response_count': 4,
 'item_scraped_count': 3553,
 'log_count/DEBUG': 3570,
 'log_count/ERROR': 1,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 151760896,
 'memusage/startup': 151760896,
 'request_depth_max': 3,
 'response_received_count': 5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'spider_exceptions/KeyError': 1,
 'start_time': datetime.datetime(2024, 1, 9, 13, 48, 33, 670696, tzinfo=datetime.timezone.utc)}
```