### PR TITLE
[BlakesLotaburgers] Fix wikidata code

### DIFF
--- a/locations/spiders/blakes_lotaburgers.py
+++ b/locations/spiders/blakes_lotaburgers.py
@@ -7,7 +7,7 @@ from locations.hours import OpeningHours
 
 class BlakesLotaburgersSpider(Spider):
     name = "blakes_lotaburgers"
-    item_attributes = {"brand": "Blakes Lotaburgers", "brand_wikidata": "Q492430"}
+    item_attributes = {"brand": "Blakes Lotaburgers", "brand_wikidata": "Q4924308"}
     allowed_domains = ["www.lotaburger.com"]
     start_urls = ["https://www.lotaburger.com/wp-json/ip/v1/blakes_location_json/"]
 


### PR DESCRIPTION
Wikidata code had a typo - was missing trailing "8".
Fixed so that category can be picked up from NSI.
{'atp/brand/Blakes Lotaburgers': 73,
 'atp/brand_wikidata/Q4924308': 73,
 'atp/category/amenity/fast_food': 73,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_reverse_geocoding': 73,
 'atp/field/email/missing': 73,
 'atp/field/image/missing': 73,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/phone/missing': 3,
 'atp/field/twitter/missing': 73,
 'atp/nsi/perfect_match': 73,
 'downloader/request_bytes': 806,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12389,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.68966,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 9, 14, 29, 55, 48725, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 153850,
 'httpcompression/response_count': 2,
 'item_scraped_count': 73,
 'log_count/DEBUG': 86,
 'log_count/INFO': 9,
 'memusage/max': 136617984,
 'memusage/startup': 136617984,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 9, 14, 29, 52, 359065, tzinfo=datetime.timezone.utc)}
