### PR TITLE
[A1SI] Fix category

### DIFF
--- a/locations/spiders/a1_si.py
+++ b/locations/spiders/a1_si.py
@@ -1,6 +1,7 @@
 from chompjs import parse_js_object
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_SI, OpeningHours
 
@@ -36,4 +37,5 @@ class A1SISpider(Spider):
             item["street_address"] = item.pop("addr_full", None)
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(location["workingHours"], days=DAYS_SI)
+            apply_category(Categories.SHOP_TELECOMMUNICATION, item)
             yield item


### PR DESCRIPTION
I've set this to shop=telecommunications rather than shop=mobile because they sell services related to mobiles but also phones and broadband/TV/entertainment packages.

{'atp/brand/A1': 57,
 'atp/brand_wikidata/Q68755': 57,
 'atp/category/shop/telecommunication': 57,
 'atp/field/country/from_reverse_geocoding': 57,
 'atp/field/email/missing': 57,
 'atp/field/image/missing': 57,
 'atp/field/operator/missing': 57,
 'atp/field/operator_wikidata/missing': 57,
 'atp/field/twitter/missing': 57,
 'atp/field/website/missing': 57,
 'atp/nsi/brand_missing': 57,
 'downloader/request_bytes': 764,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 263515,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.969052,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 9, 14, 43, 4, 55460, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 57,
 'log_count/DEBUG': 70,
 'log_count/INFO': 9,
 'memusage/max': 137035776,
 'memusage/startup': 137035776,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 9, 14, 43, 0, 86408, tzinfo=datetime.timezone.utc)}
