### PR TITLE
[DrummondGolfAU] Add category

### DIFF
--- a/locations/spiders/drummond_golf_au.py
+++ b/locations/spiders/drummond_golf_au.py
@@ -5,7 +5,13 @@ from locations.items import Feature
 
 class DrummondGolfAUSpider(XMLFeedSpider):
     name = "drummond_golf_au"
-    item_attributes = {"brand": "Drummond Golf", "brand_wikidata": "Q124065894"}
+    item_attributes = {
+        "brand": "Drummond Golf",
+        "brand_wikidata": "Q124065894",
+        "extras": {
+            "shop": "golf",
+        },
+    }
     allowed_domains = ["www.drummondgolf.com.au"]
     start_urls = [
         "https://www.drummondgolf.com.au/storelocator/index/search/?lat=-33.870&lng=151.210&radius=20000&page_limit=10000"


### PR DESCRIPTION
{'atp/brand/Drummond Golf': 50,
 'atp/brand_wikidata/Q124065894': 50,
 'atp/category/shop/golf': 50,
 'atp/field/country/from_spider_name': 50,
 'atp/field/image/dropped': 1,
 'atp/field/image/missing': 1,
 'atp/field/opening_hours/missing': 50,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/twitter/missing': 50,
 'atp/nsi/brand_missing': 50,
 'downloader/request_bytes': 698,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 105634,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.627022,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 10, 8, 47, 55, 285589, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 102,
 'httpcompression/response_count': 1,
 'item_scraped_count': 50,
 'log_count/DEBUG': 63,
 'log_count/INFO': 9,
 'memusage/max': 136880128,
 'memusage/startup': 136880128,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 10, 8, 47, 52, 658567, tzinfo=datetime.timezone.utc)}
