### PR TITLE
[Caesars] Add category

### DIFF
--- a/locations/spiders/caesars.py
+++ b/locations/spiders/caesars.py
@@ -5,11 +5,7 @@ from locations.items import Feature
 
 class CaesarsSpider(scrapy.Spider):
     name = "caesars"
-    item_attributes = {
-        "brand": "Caesars Entertainment",
-        "brand_wikidata": "Q18636524",
-        "extras": {"amenity": "casino"}
-    }
+    item_attributes = {"brand": "Caesars Entertainment", "brand_wikidata": "Q18636524", "extras": {"amenity": "casino"}}
     start_urls = ["https://www.caesars.com/api/v1/properties"]
 
     def parse(self, response):

--- a/locations/spiders/caesars.py
+++ b/locations/spiders/caesars.py
@@ -5,7 +5,11 @@ from locations.items import Feature
 
 class CaesarsSpider(scrapy.Spider):
     name = "caesars"
-    item_attributes = {"brand": "Caesars Entertainment", "brand_wikidata": "Q18636524"}
+    item_attributes = {
+        "brand": "Caesars Entertainment",
+        "brand_wikidata": "Q18636524",
+        "extras": {"leisure": "resort", "amenity": "casino"},
+    }
     start_urls = ["https://www.caesars.com/api/v1/properties"]
 
     def parse(self, response):

--- a/locations/spiders/caesars.py
+++ b/locations/spiders/caesars.py
@@ -8,7 +8,7 @@ class CaesarsSpider(scrapy.Spider):
     item_attributes = {
         "brand": "Caesars Entertainment",
         "brand_wikidata": "Q18636524",
-        "extras": {"leisure": "resort", "amenity": "casino"},
+        "extras": {"amenity": "casino"}
     }
     start_urls = ["https://www.caesars.com/api/v1/properties"]
 


### PR DESCRIPTION
I've made this "resort" rather than "hotel" because this venue sells gambling services primarily rather than hotel services (ref [this page](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dresort))
So, leisure=resort and amenity=casino.
{'atp/brand/Caesars Entertainment': 58,
 'atp/brand_wikidata/Q18636524': 58,
 'atp/category/amenity/casino': 58,
 'atp/category/multiple': 58,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 58,
 'atp/field/image/missing': 58,
 'atp/field/opening_hours/missing': 58,
 'atp/field/operator/missing': 58,
 'atp/field/operator_wikidata/missing': 58,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 6,
 'atp/field/postcode/missing': 1,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 58,
 'atp/field/website/missing': 1,
 'atp/nsi/brand_missing': 58,
 'downloader/request_bytes': 792,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28340,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.94583,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 10, 10, 58, 5, 356465, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 258909,
 'httpcompression/response_count': 2,
 'item_scraped_count': 58,
 'log_count/DEBUG': 71,
 'log_count/INFO': 9,
 'memusage/max': 137785344,
 'memusage/startup': 137785344,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 10, 10, 58, 2, 410635, tzinfo=datetime.timezone.utc)}
