### PR TITLE
[MaxolIE] Collect coords

### DIFF
--- a/locations/spiders/maxol_ie.py
+++ b/locations/spiders/maxol_ie.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 from scrapy.spiders import SitemapSpider
@@ -13,6 +14,9 @@ class MaxolIESpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"\.ie\/[-\w]+\/[-.\w]+\/[-\/\w]+$", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = html.unescape(item["name"])
+        item["street_address"] = html.unescape(item["street_address"])
+
         if m := re.search(r"\"latitude\":(-?\d+\.\d+),\"longitude\":(-?\d+\.\d+)", response.text):
             item["lat"], item["lon"] = m.groups()
 

--- a/locations/spiders/maxol_ie.py
+++ b/locations/spiders/maxol_ie.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories
@@ -9,3 +11,9 @@ class MaxolIESpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Maxol", "brand_wikidata": "Q3302837", "extras": Categories.FUEL_STATION.value}
     sitemap_urls = ["https://stations.maxol.ie/sitemap.xml"]
     sitemap_rules = [(r"\.ie\/[-\w]+\/[-.\w]+\/[-\/\w]+$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if m := re.search(r"\"latitude\":(-?\d+\.\d+),\"longitude\":(-?\d+\.\d+)", response.text):
+            item["lat"], item["lon"] = m.groups()
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Maxol': 240,
 'atp/brand_wikidata/Q3302837': 240,
 'atp/category/amenity/fuel': 240,
 'atp/cdn/cloudflare/response_count': 243,
 'atp/cdn/cloudflare/response_status_count/200': 243,
 'atp/field/email/missing': 240,
 'atp/field/image/missing': 240,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 240,
 'atp/field/operator_wikidata/missing': 240,
 'atp/field/phone/missing': 240,
 'atp/field/twitter/missing': 240,
 'atp/nsi/category_match': 240,
 'downloader/request_bytes': 91241,
 'downloader/request_count': 243,
 'downloader/request_method_count/GET': 243,
 'downloader/response_bytes': 2916116,
 'downloader/response_count': 243,
 'downloader/response_status_count/200': 243,
 'elapsed_time_seconds': 1.559781,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 10, 11, 24, 10, 310301, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 243,
 'httpcompression/response_bytes': 12439475,
 'httpcompression/response_count': 243,
 'item_scraped_count': 240,
 'log_count/DEBUG': 495,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 152117248,
 'memusage/startup': 152117248,
 'request_depth_max': 2,
 'response_received_count': 243,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 242,
 'scheduler/dequeued/memory': 242,
 'scheduler/enqueued': 242,
 'scheduler/enqueued/memory': 242,
 'start_time': datetime.datetime(2024, 1, 10, 11, 24, 8, 750520, tzinfo=datetime.timezone.utc)}
```