### PR TITLE
[CGIGroup] Add category

### DIFF
--- a/locations/spiders/cgi_group.py
+++ b/locations/spiders/cgi_group.py
@@ -1,11 +1,12 @@
 import scrapy
 
+from locations.categories import Categories
 from locations.items import Feature
 
 
 class CGIGroupSpider(scrapy.Spider):
     name = "cgi_group"
-    item_attributes = {"brand": "CGI Group", "brand_wikidata": "Q1798370"}
+    item_attributes = {"brand": "CGI Group", "brand_wikidata": "Q1798370", "extras": Categories.OFFICE_COMPANY.value}
     allowed_domains = ["cgi.com"]
     start_urls = (
         "https://www.cgi.com/en/offices?field_address_country_code=All&field_address_administrative_area=All&field_address_locality=All",


### PR DESCRIPTION
{'atp/brand/CGI Group': 282,
 'atp/brand_wikidata/Q1798370': 282,
 'atp/category/office/company': 282,
 'atp/field/country/missing': 282,
 'atp/field/email/missing': 282,
 'atp/field/image/missing': 282,
 'atp/field/lat/missing': 282,
 'atp/field/lon/missing': 282,
 'atp/field/opening_hours/missing': 282,
 'atp/field/operator/missing': 282,
 'atp/field/operator_wikidata/missing': 282,
 'atp/field/phone/invalid': 56,
 'atp/field/phone/missing': 48,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 282,
 'atp/field/street_address/missing': 282,
 'atp/field/twitter/missing': 282,
 'atp/field/website/missing': 282,
 'atp/nsi/brand_missing': 282,
 'downloader/request_bytes': 718,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 81074,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.462107,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 10, 11, 49, 50, 787973, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 517748,
 'httpcompression/response_count': 2,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 282,
 'log_count/DEBUG': 297,
 'log_count/INFO': 9,
 'memusage/max': 136982528,
 'memusage/startup': 136982528,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 10, 11, 49, 45, 325866, tzinfo=datetime.timezone.utc)}
