### PR TITLE
[SephoraBR] Add category

### DIFF
--- a/locations/spiders/sephora_br.py
+++ b/locations/spiders/sephora_br.py
@@ -3,13 +3,14 @@ import re
 
 from scrapy import Spider
 
+from locations.categories import Categories
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
 
 class SephoraBRSpider(Spider):
     name = "sephora_br"
-    item_attributes = {"brand": "Sephora", "brand_wikidata": "Q2408041"}
+    item_attributes = {"brand": "Sephora", "brand_wikidata": "Q2408041", "extras": Categories.SHOP_COSMETICS.value}
     allowed_domains = ["www.sephora.com.br"]
     start_urls = ["https://www.sephora.com.br/nossas-lojas/"]
     user_agent = BROWSER_DEFAULT


### PR DESCRIPTION
NSI category does not resolve because there is amenity/vending_machine as well as shop/cosmetics. So set explicitly.
 {'atp/brand/Sephora': 34,
 'atp/brand_wikidata/Q2408041': 34,
 'atp/category/shop/cosmetics': 34,
 'atp/field/city/missing': 34,
 'atp/field/country/from_spider_name': 34,
 'atp/field/email/missing': 34,
 'atp/field/image/missing': 34,
 'atp/field/opening_hours/missing': 34,
 'atp/field/operator/missing': 34,
 'atp/field/operator_wikidata/missing': 34,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 34,
 'atp/field/street_address/missing': 34,
 'atp/field/twitter/missing': 34,
 'atp/field/website/missing': 34,
 'atp/nsi/category_match': 34,
 'downloader/request_bytes': 529,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 50203,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.906701,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 8, 56, 46, 137604, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 254288,
 'httpcompression/response_count': 2,
 'item_scraped_count': 34,
 'log_count/DEBUG': 47,
 'log_count/INFO': 9,
 'memusage/max': 136597504,
 'memusage/startup': 136597504,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 11, 8, 56, 43, 230903, tzinfo=datetime.timezone.utc)}
