### PR TITLE
[LundsAndByerlys] Add category

### DIFF
--- a/locations/spiders/lundsandbyerlys.py
+++ b/locations/spiders/lundsandbyerlys.py
@@ -1,7 +1,12 @@
+from locations.categories import Categories
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class LundsAndByerlysSpider(WPStoreLocatorSpider):
     name = "lundsandbyerlys"
-    item_attributes = {"brand": "Lunds & Byerlys", "brand_wikidata": "Q19903424"}
+    item_attributes = {
+        "brand": "Lunds & Byerlys",
+        "brand_wikidata": "Q19903424",
+        "extras": Categories.SHOP_SUPERMARKET.value,
+    }
     allowed_domains = ["lundsandbyerlys.com"]


### PR DESCRIPTION
{'atp/brand/Lunds & Byerlys': 29,
 'atp/brand_wikidata/Q19903424': 29,
 'atp/category/shop/supermarket': 29,
 'atp/field/email/missing': 29,
 'atp/field/image/missing': 29,
 'atp/field/opening_hours/missing': 29,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/twitter/missing': 29,
 'atp/field/website/invalid': 27,
 'atp/nsi/brand_missing': 29,
 'downloader/request_bytes': 679,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3061,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.15833,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 10, 51, 48, 174253, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11220,
 'httpcompression/response_count': 2,
 'item_scraped_count': 29,
 'log_count/DEBUG': 42,
 'log_count/INFO': 9,
 'memusage/max': 136409088,
 'memusage/startup': 136409088,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 11, 10, 51, 46, 15923, tzinfo=datetime.timezone.utc)}
