### PR TITLE
[indigo] change to operator, add category

### DIFF
--- a/locations/spiders/indigo.py
+++ b/locations/spiders/indigo.py
@@ -1,14 +1,14 @@
-import json
 from urllib.parse import urlencode
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class IndigoCASpider(scrapy.Spider):
     name = "indigo"
-    item_attributes = {"brand": "Indigo", "brand_wikidata": "Q3559970"}
+    item_attributes = {"operator": "Indigo", "operator_wikidata": "Q3559970"}
     url = "https://salesforce.parkindigo.com/locations?"
 
     def start_requests(self):
@@ -26,6 +26,7 @@ class IndigoCASpider(scrapy.Spider):
             item["lat"] = lot.get("geoLocation", {}).get("x")
             item["lon"] = lot.get("geoLocation", {}).get("y")
             item["street_address"] = lot.get("address", {}).get("lines", [None])[0]
+            apply_category(Categories.PARKING, item)
             yield item
 
         if not data.get("last"):


### PR DESCRIPTION
Still got some `atp/nsi/match_failed`... 

Stats:

```json
{
 "atp/brand/Indigo": 3785,
 "atp/brand_wikidata/Q3559970": 3785,
 "atp/category/amenity/parking": 4260,
 "atp/field/brand/missing": 475,
 "atp/field/brand_wikidata/missing": 475,
 "atp/field/city/missing": 1,
 "atp/field/email/missing": 4260,
 "atp/field/image/missing": 4260,
 "atp/field/lat/missing": 2,
 "atp/field/lon/missing": 2,
 "atp/field/opening_hours/missing": 4260,
 "atp/field/phone/invalid": 79,
 "atp/field/phone/missing": 164,
 "atp/field/state/from_reverse_geocoding": 135,
 "atp/field/street_address/missing": 1,
 "atp/field/twitter/missing": 4260,
 "atp/field/website/missing": 4260,
 "atp/geometry/null_island": 2,
 "atp/nsi/cc_match": 3785,
 "atp/nsi/match_failed": 475,
 "atp/operator/Indigo": 4260,
 "atp/operator_wikidata/Q3559970": 4260,
 "downloader/request_bytes": 61788,
 "downloader/request_count": 145,
 "downloader/request_method_count/GET": 145,
 "downloader/response_bytes": 5576129,
 "downloader/response_count": 145,
 "downloader/response_status_count/200": 144,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 177.647987,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-01-11T10:59:24.773265+00:00",
 "item_dropped_count": 50,
 "item_dropped_reasons_count/DropItem": 50,
 "item_scraped_count": 4260,
 "log_count/INFO": 12,
 "memusage/max": 342491136,
 "memusage/startup": 140427264,
 "request_depth_max": 143,
 "response_received_count": 145,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 144,
 "scheduler/dequeued/memory": 144,
 "scheduler/enqueued": 144,
 "scheduler/enqueued/memory": 144,
 "start_time": "2024-01-11T10:56:27.125278+00:00"
}
```