### PR TITLE
[LouisaCoffee] Fix wikidata code

### DIFF
--- a/locations/spiders/louisa_coffee.py
+++ b/locations/spiders/louisa_coffee.py
@@ -5,7 +5,7 @@ from locations.items import Feature
 
 class LouisaCoffeeSpider(scrapy.Spider):
     name = "louisa_coffee"
-    item_attributes = {"brand": "Louisa Coffee", "brand_wikidata": "Q67933328"}
+    item_attributes = {"brand": "Louisa Coffee", "brand_wikidata": "Q96390921"}
     allowed_domains = ["www.louisacoffee.com.tw"]
     start_urls = ("http://www.louisacoffee.com.tw/visit_result",)
 


### PR DESCRIPTION
Use wikidata code from NSI to fix category
{'atp/brand/Louisa Coffee': 10,
 'atp/brand_wikidata/Q96390921': 10,
 'atp/category/amenity/cafe': 10,
 'atp/field/city/missing': 7,
 'atp/field/country/from_reverse_geocoding': 10,
 'atp/field/email/missing': 10,
 'atp/field/image/missing': 10,
 'atp/field/lat/missing': 7,
 'atp/field/lon/missing': 7,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 10,
 'atp/field/operator_wikidata/missing': 10,
 'atp/field/phone/missing': 10,
 'atp/field/postcode/missing': 10,
 'atp/field/street_address/missing': 10,
 'atp/field/twitter/missing': 10,
 'atp/field/website/missing': 10,
 'atp/geometry/null_island': 7,
 'atp/nsi/perfect_match': 10,
 'downloader/request_bytes': 1562,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 4057,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/302': 2,
 'elapsed_time_seconds': 5.227125,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 13, 22, 21, 807652, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 15627,
 'httpcompression/response_count': 1,
 'item_scraped_count': 10,
 'log_count/DEBUG': 26,
 'log_count/INFO': 9,
 'memusage/max': 135479296,
 'memusage/startup': 135479296,
 'response_received_count': 3,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 1, 11, 13, 22, 16, 580527, tzinfo=datetime.timezone.utc)}
