### PR TITLE
[TedsCameraStoresAU] Add category

### DIFF
--- a/locations/spiders/teds_camera_stores_au.py
+++ b/locations/spiders/teds_camera_stores_au.py
@@ -6,7 +6,13 @@ from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
 
 class TedsCameraStoresAUSpider(AmastyStoreLocatorSpider):
     name = "teds_camera_stores_au"
-    item_attributes = {"brand": "Ted's Camera Stores", "brand_wikidata": "Q117958394"}
+    item_attributes = {
+        "brand": "Ted's Camera Stores",
+        "brand_wikidata": "Q117958394",
+        "extras": {
+            "shop": "camera",
+        },
+    }
     allowed_domains = ["www.teds.com.au"]
 
     def start_requests(self):


### PR DESCRIPTION
{"atp/brand/Ted's Camera Stores": 19,
 'atp/brand_wikidata/Q117958394': 19,
 'atp/category/shop/camera': 19,
 'atp/field/city/missing': 19,
 'atp/field/country/from_spider_name': 19,
 'atp/field/image/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/postcode/missing': 19,
 'atp/field/state/missing': 19,
 'atp/field/street_address/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/nsi/brand_missing': 19,
 'downloader/request_bytes': 9778,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 20,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1637320,
 'downloader/response_count': 21,
 'downloader/response_status_count/200': 21,
 'elapsed_time_seconds': 24.806141,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 14, 16, 50, 567734, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4657499,
 'httpcompression/response_count': 20,
 'item_scraped_count': 19,
 'log_count/DEBUG': 51,
 'log_count/INFO': 9,
 'memusage/max': 135188480,
 'memusage/startup': 135188480,
 'request_depth_max': 1,
 'response_received_count': 21,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 20,
 'scheduler/dequeued/memory': 20,
 'scheduler/enqueued': 20,
 'scheduler/enqueued/memory': 20,
 'start_time': datetime.datetime(2024, 1, 11, 14, 16, 25, 761593, tzinfo=datetime.timezone.utc)}
