### PR TITLE
[AdriaticFurnitureAU] Add category

### DIFF
--- a/locations/spiders/adriatic_furniture_au.py
+++ b/locations/spiders/adriatic_furniture_au.py
@@ -1,8 +1,13 @@
+from locations.categories import Categories
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class AdriaticFurnitureAUSpider(WPStoreLocatorSpider):
     name = "adriatic_furniture_au"
-    item_attributes = {"brand": "Adriatic Furniture", "brand_wikidata": "Q117856796"}
+    item_attributes = {
+        "brand": "Adriatic Furniture",
+        "brand_wikidata": "Q117856796",
+        "extras": Categories.SHOP_FURNITURE.value,
+    }
     allowed_domains = ["www.adriatic.com.au"]
     time_format = "%I:%M %p"


### PR DESCRIPTION
{'atp/brand/Adriatic Furniture': 8,
 'atp/brand_wikidata/Q117856796': 8,
 'atp/category/shop/furniture': 8,
 'atp/field/image/missing': 8,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/missing': 8,
 'atp/nsi/brand_missing': 8,
 'downloader/request_bytes': 731,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 2202,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.375364,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 14, 31, 56, 452400, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7924,
 'httpcompression/response_count': 2,
 'item_scraped_count': 8,
 'log_count/DEBUG': 21,
 'log_count/INFO': 9,
 'memusage/max': 136228864,
 'memusage/startup': 136228864,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 11, 14, 31, 53, 77036, tzinfo=datetime.timezone.utc)}
