### PR TITLE
[FocusOnFurnitureAU] Add category

### DIFF
--- a/locations/spiders/focus_on_furniture_au.py
+++ b/locations/spiders/focus_on_furniture_au.py
@@ -1,9 +1,14 @@
+from locations.categories import Categories
 from locations.storefinders.stockinstore import StockInStoreSpider
 
 
 class FocusOnFurnitureAUSpider(StockInStoreSpider):
     name = "focus_on_furniture_au"
-    item_attributes = {"brand": "Focus on Furniture", "brand_wikidata": "Q117746060"}
+    item_attributes = {
+        "brand": "Focus on Furniture",
+        "brand_wikidata": "Q117746060",
+        "extras": Categories.SHOP_FURNITURE.value,
+    }
     api_site_id = "10100"
     api_widget_id = "107"
     api_widget_type = "product"


### PR DESCRIPTION
{'atp/brand/Focus on Furniture': 24,
 'atp/brand_wikidata/Q117746060': 24,
 'atp/category/shop/furniture': 24,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/twitter/missing': 24,
 'atp/field/website/missing': 23,
 'atp/nsi/brand_missing': 24,
 'downloader/request_bytes': 853,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 8576,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.160755,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 11, 14, 40, 59, 164005, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 64110,
 'httpcompression/response_count': 2,
 'item_scraped_count': 24,
 'log_count/DEBUG': 50,
 'log_count/INFO': 9,
 'memusage/max': 136282112,
 'memusage/startup': 136282112,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 11, 14, 40, 56, 3250, tzinfo=datetime.timezone.utc)}
