### PR TITLE
[CampingWorldAU] Add category

### DIFF
--- a/locations/spiders/camping_world_au.py
+++ b/locations/spiders/camping_world_au.py
@@ -1,13 +1,18 @@
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
 class CampingWorldAUSpider(Spider):
     name = "camping_world_au"
-    item_attributes = {"brand": "Camping World", "brand_wikidata": "Q124062618"}
+    item_attributes = {
+        "brand": "Camping World",
+        "brand_wikidata": "Q124062618",
+        "extras": Categories.SHOP_OUTDOOR.value,
+    }
     allowed_domains = ["www.campingworld.com.au"]
     start_urls = [
         "https://www.campingworld.com.au/index.php?hcs=locatoraid&hcrand=3018&hca=search:search//product/_PRODUCT_/lat//lng//limit/1000"


### PR DESCRIPTION
{'atp/brand/Camping World': 13,
 'atp/brand_wikidata/Q124062618': 13,
 'atp/category/shop/outdoor': 13,
 'atp/field/country/from_spider_name': 13,
 'atp/field/image/missing': 13,
 'atp/field/operator/missing': 13,
 'atp/field/operator_wikidata/missing': 13,
 'atp/field/twitter/missing': 13,
 'atp/field/website/missing': 13,
 'atp/nsi/brand_missing': 13,
 'downloader/request_bytes': 813,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3854,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.492398,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 12, 9, 50, 50, 516025, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17020,
 'httpcompression/response_count': 2,
 'item_scraped_count': 13,
 'log_count/DEBUG': 26,
 'log_count/INFO': 9,
 'memusage/max': 135884800,
 'memusage/startup': 135884800,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 12, 9, 50, 46, 23627, tzinfo=datetime.timezone.utc)}
