### PR TITLE
[BigLouiesUS] Add category

### DIFF
--- a/locations/spiders/big_louies_us.py
+++ b/locations/spiders/big_louies_us.py
@@ -3,7 +3,11 @@ from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 
 class BigLouiesUSSpider(StoreLocatorWidgetsSpider):
     name = "big_louies_us"
-    item_attributes = {"brand": "Big Louie's", "brand_wikidata": "Q119157997"}
+    item_attributes = {
+        "brand": "Big Louie's",
+        "brand_wikidata": "Q119157997",
+        "extras": {"amenity": "restaurant", "cuisine": "pizza"},
+    }
     key = "178ecac2bff5d20c4041ada5f817d79e"
 
     def parse_item(self, item, location):


### PR DESCRIPTION
{"atp/brand/Big Louie's": 6,
 'atp/brand_wikidata/Q119157997': 6,
 'atp/category/amenity/restaurant': 6,
 'atp/field/city/missing': 6,
 'atp/field/country/from_spider_name': 5,
 'atp/field/email/missing': 6,
 'atp/field/image/missing': 6,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 6,
 'atp/field/operator_wikidata/missing': 6,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 6,
 'atp/field/state/from_reverse_geocoding': 6,
 'atp/field/street_address/missing': 6,
 'atp/field/twitter/missing': 6,
 'atp/field/website/missing': 6,
 'atp/nsi/brand_missing': 6,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8871,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.272209,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 12, 13, 2, 4, 818025, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 31842,
 'httpcompression/response_count': 2,
 'item_scraped_count': 6,
 'log_count/DEBUG': 19,
 'log_count/INFO': 9,
 'memusage/max': 136273920,
 'memusage/startup': 136273920,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 12, 13, 2, 2, 545816, tzinfo=datetime.timezone.utc)}
