### PR TITLE
[NicholsonsPubsGB] Add Spider

### DIFF
--- a/locations/spiders/nicholsons_pubs_gb.py
+++ b/locations/spiders/nicholsons_pubs_gb.py
@@ -1,0 +1,11 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NicholsonsPubsGBSpider(CrawlSpider, StructuredDataSpider):
+    name = "nicholsons_pubs_gb"
+    item_attributes = {"brand": "Nicholson's", "brand_wikidata": "Q113130666"}
+    start_urls = ["https://www.nicholsonspubs.co.uk/ourvenues"]
+    rules = [Rule(LinkExtractor("/restaurants/"), "parse_sd")]


### PR DESCRIPTION
```python
{"atp/brand/Nicholson's": 77,
 'atp/brand_wikidata/Q113130666': 77,
 'atp/category/amenity/pub': 77,
 'atp/cdn/cloudflare/response_count': 81,
 'atp/cdn/cloudflare/response_status_count/200': 80,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 77,
 'atp/field/image/missing': 77,
 'atp/field/operator/missing': 77,
 'atp/field/operator_wikidata/missing': 77,
 'atp/field/state/missing': 9,
 'atp/nsi/perfect_match': 77,
 'downloader/request_bytes': 33087,
 'downloader/request_count': 81,
 'downloader/request_method_count/GET': 81,
 'downloader/response_bytes': 1516803,
 'downloader/response_count': 81,
 'downloader/response_status_count/200': 80,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.370684,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 14, 18, 0, 37, 978660, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 81,
 'httpcompression/response_bytes': 5543774,
 'httpcompression/response_count': 81,
 'item_scraped_count': 77,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 173170688,
 'memusage/startup': 173170688,
 'request_depth_max': 1,
 'response_received_count': 81,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 80,
 'scheduler/dequeued/memory': 80,
 'scheduler/enqueued': 80,
 'scheduler/enqueued/memory': 80,
 'start_time': datetime.datetime(2024, 1, 14, 18, 0, 36, 607976, tzinfo=datetime.timezone.utc)}
```