### PR TITLE
[BeefeaterGB] Add spider

### DIFF
--- a/locations/spiders/beefeater_gb.py
+++ b/locations/spiders/beefeater_gb.py
@@ -4,6 +4,7 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.items import set_closed
 from locations.spiders.vapestore_gb import clean_address
 
 
@@ -26,5 +27,8 @@ class BeefeaterGBSpider(Spider):
             )
             item["website"] = response.urljoin(location["path"])
             item["phone"] = location["contactInfo"]
+
+            if "closed-sites" in item["website"]:
+                set_closed(item)
 
             yield item

--- a/locations/spiders/beefeater_gb.py
+++ b/locations/spiders/beefeater_gb.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+from locations.spiders.vapestore_gb import clean_address
+
+
+class BeefeaterGBSpider(Spider):
+    name = "beefeater_gb"
+    item_attributes = {"brand": "Beefeater", "brand_wikidata": "Q4879766"}
+    start_urls = ["https://www.beefeater.co.uk/en-gb/locations.search.json"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["addr_full"] = clean_address(
+                [
+                    location["address1"],
+                    location["address2"],
+                    location["address3"],
+                    location["address4"],
+                    "United Kingdom",
+                ]
+            )
+            item["website"] = response.urljoin(location["path"])
+            item["phone"] = location["contactInfo"]
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Beefeater': 172,
 'atp/brand_wikidata/Q4879766': 172,
 'atp/category/amenity/restaurant': 172,
 'atp/field/city/missing': 172,
 'atp/field/country/from_spider_name': 172,
 'atp/field/email/missing': 172,
 'atp/field/image/missing': 172,
 'atp/field/opening_hours/missing': 172,
 'atp/field/operator/missing': 172,
 'atp/field/operator_wikidata/missing': 172,
 'atp/field/state/missing': 172,
 'atp/field/twitter/missing': 172,
 'atp/nsi/perfect_match': 172,
 'downloader/request_bytes': 637,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13333,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.867883,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 14, 22, 47, 36, 795733, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 46236,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 172,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 172527616,
 'memusage/startup': 172527616,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 14, 22, 47, 35, 927850, tzinfo=datetime.timezone.utc)}
```