### PR TITLE
[SpeedyStopUS] Add category

### DIFF
--- a/locations/spiders/speedy_stop_us.py
+++ b/locations/spiders/speedy_stop_us.py
@@ -1,7 +1,12 @@
+from locations.categories import Categories
 from locations.storefinders.closeby import ClosebySpider
 
 
 class SpeedyStopUSSpider(ClosebySpider):
     name = "speedy_stop_us"
-    item_attributes = {"brand": "Speedy Stop", "brand_wikidata": "Q123419843"}
+    item_attributes = {
+        "brand": "Speedy Stop",
+        "brand_wikidata": "Q123419843",
+        "extras": Categories.FUEL_STATION.value,
+    }
     api_key = "c9271c9124f5bdd13fc0258d3453ed6f"


### PR DESCRIPTION
{'atp/brand/Speedy Stop': 26,
 'atp/brand_wikidata/Q123419843': 26,
 'atp/category/amenity/fuel': 26,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/city/missing': 26,
 'atp/field/country/from_spider_name': 26,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 26,
 'atp/field/opening_hours/missing': 26,
 'atp/field/operator/missing': 26,
 'atp/field/operator_wikidata/missing': 26,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 26,
 'atp/field/state/from_reverse_geocoding': 26,
 'atp/field/street_address/missing': 26,
 'atp/field/twitter/missing': 26,
 'atp/field/website/missing': 19,
 'atp/nsi/brand_missing': 26,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 11538,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.344372,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 15, 10, 14, 31, 707863, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 92512,
 'httpcompression/response_count': 2,
 'item_scraped_count': 26,
 'log_count/DEBUG': 39,
 'log_count/INFO': 9,
 'memusage/max': 136552448,
 'memusage/startup': 136552448,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 15, 10, 14, 28, 363491, tzinfo=datetime.timezone.utc)}
