### PR TITLE
[CooplandsDoncasterGB] Add category

### DIFF
--- a/locations/spiders/cooplands_doncaster_gb.py
+++ b/locations/spiders/cooplands_doncaster_gb.py
@@ -5,13 +5,12 @@ from locations.items import Feature
 from locations.spiders.vapestore_gb import clean_address
 
 
-class CooplandsDoncasterSpider(scrapy.Spider):
-    name = "cooplands_doncaster"
+class CooplandsDoncasterGBSpider(scrapy.Spider):
+    name = "cooplands_doncaster_gb"
     allowed_domains = ["cooplands.co.uk"]
     item_attributes = {
         "brand": "Cooplands",
-        "brand_wikidata": "Q96622197",
-        "country": "GB",
+        "brand_wikidata": "Q5167971",
     }
     start_urls = ["https://cooplands.co.uk/shop-locations"]
 

--- a/locations/spiders/cooplands_doncaster_gb.py
+++ b/locations/spiders/cooplands_doncaster_gb.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.spiders.vapestore_gb import clean_address
@@ -8,10 +9,7 @@ from locations.spiders.vapestore_gb import clean_address
 class CooplandsDoncasterGBSpider(scrapy.Spider):
     name = "cooplands_doncaster_gb"
     allowed_domains = ["cooplands.co.uk"]
-    item_attributes = {
-        "brand": "Cooplands",
-        "brand_wikidata": "Q5167971",
-    }
+    item_attributes = {"brand": "Cooplands", "brand_wikidata": "Q96622197", "extras": Categories.SHOP_BAKERY.value}
     start_urls = ["https://cooplands.co.uk/shop-locations"]
 
     def __init__(self):


### PR DESCRIPTION
Change to use wikidata code referenced by NSI.
Rename spider to pickup country code from name.

{'atp/brand/Cooplands': 24,
 'atp/brand_wikidata/Q5167971': 24,
 'atp/category/shop/bakery': 24,
 'atp/field/city/missing': 24,
 'atp/field/country/from_spider_name': 24,
 'atp/field/email/missing': 24,
 'atp/field/image/missing': 24,
 'atp/field/lat/missing': 24,
 'atp/field/lon/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/state/missing': 24,
 'atp/field/street_address/missing': 24,
 'atp/field/twitter/missing': 24,
 'atp/field/website/missing': 24,
 'atp/nsi/perfect_match': 24,
 'downloader/request_bytes': 662,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7085,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.820753,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 15, 10, 45, 42, 882877, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11362,
 'httpcompression/response_count': 1,
 'item_scraped_count': 24,
 'log_count/DEBUG': 54,
 'log_count/INFO': 9,
 'memusage/max': 136527872,
 'memusage/startup': 136527872,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 15, 10, 45, 41, 62124, tzinfo=datetime.timezone.utc)}
