### PR TITLE
[NHSScotlandGB] Fix spider

### DIFF
--- a/locations/spiders/nhs_scotland_gb.py
+++ b/locations/spiders/nhs_scotland_gb.py
@@ -4,6 +4,7 @@ from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.spiders.vapestore_gb import clean_address
 
@@ -39,7 +40,6 @@ def ignore(item):
 
 class NHSScotlandGBSpider(Spider):
     name = "nhs_scotland_gb"
-    item_attributes = {"brand": "NHS Scotland", "brand_wikidata": "Q16933548"}
     services = {
         "dental-services": Categories.DENTIST,
         "aes-and-minor-injuries-units": Categories.CLINIC_URGENT,
@@ -70,12 +70,24 @@ class NHSScotlandGBSpider(Spider):
         item = Feature()
         extract_google_position(item, response)
         apply_category(self.services.get(service), item)
-        item["name"] = response.xpath('//input[@id="ServiceName"]/@value').get().strip()
-        item["website"] = item["ref"] = response.url
-        item["postcode"] = response.xpath('//input[@id="ServicePostcode"]/@value').get().strip()
-        # TODO opening_hours = response.xpath('//div[@class="panel-times"]//dd').getall()
+        item["name"] = (response.xpath('//input[@id="ServiceName"]/@value').get() or "").strip()
         item["addr_full"] = clean_address(response.xpath("//address/text()").getall())
+        item["website"] = item["ref"] = response.url
         if external_url := response.xpath('//a[@class="external"]/@href').get():
             item["website"] = external_url
+
+        item["opening_hours"] = OpeningHours()
+        for day, times in zip(
+            response.xpath('//div[@class="panel-times"]/dl/dt/text()').getall(),
+            response.xpath('//div[@class="panel-times"]/dl/dd/text()').getall(),
+        ):
+            day = day.strip()
+            times = times.strip()
+            if times == "Closed":
+                continue
+            if times == "24 hours":
+                times = "00:00 - 24:00"
+            item["opening_hours"].add_range(day, *times.split(" - "))
+
         if not ignore(item):
             yield item


### PR DESCRIPTION
```python
{'atp/category/amenity/clinic': 66,
 'atp/category/amenity/dentist': 988,
 'atp/category/amenity/doctors': 1071,
 'atp/category/amenity/hospital': 141,
 'atp/category/amenity/pharmacy': 930,
 'atp/category/multiple': 3196,
 'atp/category/shop/optician': 462,
 'atp/field/brand/missing': 3658,
 'atp/field/brand_wikidata/missing': 3658,
 'atp/field/city/missing': 3658,
 'atp/field/country/from_spider_name': 3658,
 'atp/field/email/missing': 3658,
 'atp/field/image/missing': 3658,
 'atp/field/lat/missing': 74,
 'atp/field/lon/missing': 74,
 'atp/field/name/missing': 42,
 'atp/field/opening_hours/missing': 118,
 'atp/field/operator/missing': 3658,
 'atp/field/operator_wikidata/missing': 3658,
 'atp/field/phone/missing': 3658,
 'atp/field/postcode/missing': 60,
 'atp/field/state/missing': 3658,
 'atp/field/street_address/missing': 3658,
 'atp/field/twitter/missing': 3658,
 'atp/field/website/invalid': 1,
 'downloader/request_bytes': 2850199,
 'downloader/request_count': 5031,
 'downloader/request_method_count/GET': 5031,
 'downloader/response_bytes': 268308187,
 'downloader/response_count': 5031,
 'downloader/response_status_count/200': 5030,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 12992,
 'elapsed_time_seconds': 38.524452,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 15, 13, 40, 17, 30182, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 5031,
 'httpcompression/response_bytes': 1340131088,
 'httpcompression/response_count': 5031,
 'item_scraped_count': 3658,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 151592960,
 'memusage/startup': 151592960,
 'request_depth_max': 27,
 'response_received_count': 5031,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 5030,
 'scheduler/dequeued/memory': 5030,
 'scheduler/enqueued': 5030,
 'scheduler/enqueued/memory': 5030,
 'start_time': datetime.datetime(2024, 1, 15, 13, 39, 38, 505730, tzinfo=datetime.timezone.utc)}
```