### PR TITLE
[DPD DE] Fix opening hours

### DIFF
--- a/locations/spiders/dpd_de.py
+++ b/locations/spiders/dpd_de.py
@@ -3,6 +3,8 @@ import csv
 import scrapy
 from scrapy import FormRequest
 
+from locations.categories import apply_category
+from locations.hours import DAYS_DE, OpeningHours, sanitise_day
 from locations.items import Feature
 from locations.searchable_points import open_searchable_points
 
@@ -22,8 +24,6 @@ class DPDDESpider(scrapy.Spider):
                 results = csv.DictReader(open_file)
                 for result in results:
                     if result["country"] == "DE":
-                        headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
                         formdata = {
                             "ctl00$hidMarkerHouse": "https://my.dpd.de/themes/Icons/summer2020/house.svg",
                             "ctl00$hidMarkerShop": "https://my.dpd.de/themes/Icons/summer2020/parcelshop.svg",
@@ -49,7 +49,6 @@ class DPDDESpider(scrapy.Spider):
                         rq = FormRequest.from_response(
                             response,
                             formdata=formdata,
-                            headers=headers,
                             callback=self.shops_results,
                             meta=result,
                         )
@@ -94,8 +93,7 @@ class DPDDESpider(scrapy.Spider):
             item["postcode"] = plz
             item["ref"] = lat + lng
             item["housenumber"] = housenumber
-
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            apply_category({"post_office": "post_partner"}, item)
 
             formdata = {
                 "ctl00$ctl16": "ctl00$ContentPlaceHolder1$modShopFinder$ctl01|ctl00$ContentPlaceHolder1$modShopFinder$repShopList$ctl0"
@@ -126,9 +124,8 @@ class DPDDESpider(scrapy.Spider):
             rq = FormRequest.from_response(
                 response,
                 formdata=formdata,
-                headers=headers,
                 callback=self.opening_hours_parse,
-                meta=item,
+                meta={"item": item},
             )
 
             yield rq
@@ -137,8 +134,8 @@ class DPDDESpider(scrapy.Spider):
         body = response.css("body")
         shop_details = body.css("div.panShopDetails")
         shops = shop_details.css("div.panBusinessHour")
-        item = response.meta
-        opening_shop = dict()
+        item = response.meta["item"]
+        item["opening_hours"] = OpeningHours()
         if len(shops) > 0:
             for nr in range(7):
                 day = shops.css(
@@ -151,13 +148,8 @@ class DPDDESpider(scrapy.Spider):
                     .extract()[0]
                     .split(" ")
                 )
-
-                for element in opening_hours:
-                    if element == "-":
-                        del opening_hours[1]
-
-                opening_shop[day] = opening_hours
-
-            item["opening_hours"] = opening_shop
+                if "Geschlossen" in opening_hours:
+                    continue
+                item["opening_hours"].add_range(sanitise_day(day, DAYS_DE), opening_hours[0], opening_hours[-1])
 
         yield item


### PR DESCRIPTION
```python
{'atp/brand/DPD': 5040,
 'atp/brand_wikidata/Q541030': 5040,
 'atp/category/missing': 5040,
 'atp/field/country/from_spider_name': 5040,
 'atp/field/email/missing': 5040,
 'atp/field/image/missing': 5040,
 'atp/field/opening_hours/missing': 4635,
 'atp/field/operator/missing': 5040,
 'atp/field/operator_wikidata/missing': 5040,
 'atp/field/phone/missing': 5040,
 'atp/field/state/missing': 5040,
 'atp/field/street_address/missing': 5040,
 'atp/field/twitter/missing': 5040,
 'atp/field/website/missing': 5040,
 'atp/nsi/match_failed': 5040,
 'downloader/request_bytes': 244433252,
 'downloader/request_count': 10940,
 'downloader/request_method_count/GET': 3,
 'downloader/request_method_count/POST': 10937,
 'downloader/response_bytes': 954977886,
 'downloader/response_count': 10940,
 'downloader/response_status_count/200': 10939,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 13057.171045,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 15, 14, 35, 13, 216546, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 10733,
 'httpcache/hit': 207,
 'httpcache/miss': 10733,
 'httpcache/store': 10733,
 'item_dropped_count': 4898,
 'item_dropped_reasons_count/DropItem': 4898,
 'item_scraped_count': 5040,
 'log_count/INFO': 227,
 'log_count/WARNING': 1,
 'memusage/max': 328429568,
 'memusage/startup': 149950464,
 'request_depth_max': 2,
 'response_received_count': 10939,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 10939,
 'scheduler/dequeued/memory': 10939,
 'scheduler/enqueued': 10939,
 'scheduler/enqueued/memory': 10939,
 'start_time': datetime.datetime(2024, 1, 15, 10, 57, 36, 45501, tzinfo=datetime.timezone.utc)}
```