### PR TITLE
[KarweiNL] Add spider

### DIFF
--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -1,0 +1,10 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class KarweiNLSpider(SitemapSpider, StructuredDataSpider):
+    name = "karwei_nl"
+    item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
+    sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
+    wanted_types = ["HardwareStore"]


### PR DESCRIPTION
```python
{'atp/brand/Karwei': 130,
 'atp/brand_wikidata/Q2097480': 130,
 'atp/category/shop/doityourself': 130,
 'atp/field/country/from_spider_name': 130,
 'atp/field/email/missing': 130,
 'atp/field/image/missing': 130,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 130,
 'atp/field/operator_wikidata/missing': 130,
 'atp/field/state/missing': 130,
 'atp/field/twitter/missing': 130,
 'atp/geometry/null_island': 1,
 'atp/nsi/perfect_match': 130,
 'downloader/request_bytes': 72872,
 'downloader/request_count': 133,
 'downloader/request_method_count/GET': 133,
 'downloader/response_bytes': 1561196,
 'downloader/response_count': 133,
 'downloader/response_status_count/200': 132,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 158.670991,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 15, 15, 40, 34, 30551, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 133,
 'httpcache/miss': 133,
 'httpcache/store': 133,
 'httpcompression/response_bytes': 4849051,
 'httpcompression/response_count': 130,
 'item_scraped_count': 130,
 'log_count/DEBUG': 275,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 280350720,
 'memusage/startup': 151396352,
 'request_depth_max': 1,
 'response_received_count': 133,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 131,
 'scheduler/dequeued/memory': 131,
 'scheduler/enqueued': 131,
 'scheduler/enqueued/memory': 131,
 'start_time': datetime.datetime(2024, 1, 15, 15, 37, 55, 359560, tzinfo=datetime.timezone.utc)}
```