### PR TITLE
[DoorsPlusAU] Add category

### DIFF
--- a/locations/spiders/doors_plus_au.py
+++ b/locations/spiders/doors_plus_au.py
@@ -3,6 +3,10 @@ from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 class DoorsPlusAUSpider(WPStoreLocatorSpider):
     name = "doors_plus_au"
-    item_attributes = {"brand": "Doors Plus", "brand_wikidata": "Q78945358"}
+    item_attributes = {
+        "brand": "Doors Plus",
+        "brand_wikidata": "Q78945358",
+        "extras": {"shop": "doors"},
+    }
     allowed_domains = ["www.doorsplus.com.au"]
     time_format = "%I:%M %p"


### PR DESCRIPTION
{'atp/brand/Doors Plus': 22,
 'atp/brand_wikidata/Q78945358': 22,
 'atp/category/shop/doors': 22,
 'atp/field/email/missing': 22,
 'atp/field/image/missing': 22,
 'atp/field/operator/missing': 22,
 'atp/field/operator_wikidata/missing': 22,
 'atp/field/twitter/missing': 22,
 'atp/nsi/brand_missing': 22,
 'downloader/request_bytes': 681,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4477,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.328035,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 8, 58, 8, 327025, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 35242,
 'httpcompression/response_count': 2,
 'item_scraped_count': 22,
 'log_count/DEBUG': 35,
 'log_count/INFO': 9,
 'memusage/max': 137019392,
 'memusage/startup': 137019392,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 16, 8, 58, 4, 998990, tzinfo=datetime.timezone.utc)}
