### PR TITLE
[GreatWolfResortsUS] Add category

### DIFF
--- a/locations/spiders/great_wolf_us.py
+++ b/locations/spiders/great_wolf_us.py
@@ -8,7 +8,11 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class GreatWolfResortsUS(SitemapSpider, StructuredDataSpider):
     name = "great_wolf_resorts_us"
-    item_attributes = {"brand": " Great Wolf Resorts", "brand_wikidata": "Q5600260"}
+    item_attributes = {
+        "brand": " Great Wolf Resorts",
+        "brand_wikidata": "Q5600260",
+        "extras": {"leisure": "water_park"},
+    }
     allowed_domains = ["www.greatwolf.com"]
     sitemap_urls = ["https://www.greatwolf.com/php-root.sitemap.xml"]
     sitemap_rules = [(r"/customer-service$", "parse_sd")]


### PR DESCRIPTION
{'atp/brand/ Great Wolf Resorts': 21,
 'atp/brand_wikidata/Q5600260': 21,
 'atp/category/leisure/water_park': 21,
 'atp/cdn/cloudflare/response_count': 23,
 'atp/cdn/cloudflare/response_status_count/200': 23,
 'atp/field/country/from_spider_name': 21,
 'atp/field/email/missing': 21,
 'atp/field/image/missing': 21,
 'atp/field/opening_hours/missing': 21,
 'atp/field/operator/missing': 21,
 'atp/field/operator_wikidata/missing': 21,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 21,
 'atp/nsi/brand_missing': 21,
 'downloader/request_bytes': 11467,
 'downloader/request_count': 23,
 'downloader/request_method_count/GET': 23,
 'downloader/response_bytes': 305147,
 'downloader/response_count': 23,
 'downloader/response_status_count/200': 23,
 'elapsed_time_seconds': 38.155476,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 9, 20, 39, 360714, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1718006,
 'httpcompression/response_count': 23,
 'item_scraped_count': 21,
 'log_count/DEBUG': 55,
 'log_count/INFO': 9,
 'memusage/max': 136970240,
 'memusage/startup': 136970240,
 'request_depth_max': 1,
 'response_received_count': 23,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 22,
 'scheduler/dequeued/memory': 22,
 'scheduler/enqueued': 22,
 'scheduler/enqueued/memory': 22,
 'start_time': datetime.datetime(2024, 1, 16, 9, 20, 1, 205238, tzinfo=datetime.timezone.utc)}
