### PR TITLE
[CaffeNeroGB] Use live url

### DIFF
--- a/locations/spiders/caffe_nero_gb.py
+++ b/locations/spiders/caffe_nero_gb.py
@@ -1,5 +1,8 @@
+import re
+from typing import Any
+
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -9,14 +12,15 @@ from locations.hours import OpeningHours
 class CaffeNeroGBSpider(Spider):
     name = "caffe_nero_gb"
     item_attributes = {"brand": "Caffe Nero", "brand_wikidata": "Q675808"}
-    allowed_domains = ["caffenero-webassets-production.s3.eu-west-2.amazonaws.com"]
-    start_urls = ["https://caffenero-webassets-production.s3.eu-west-2.amazonaws.com/stores/stores_gb.json"]
+    allowed_domains = ["caffenero.com", "caffenerowebsite.blob.core.windows.net"]
+    start_urls = ["https://caffenero.com/uk/stores/"]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            re.search(r"loadGeoJson\(\n\s+'(https://.+)', {", response.text).group(1), callback=self.parse_geojson
+        )
 
-    def parse(self, response):
+    def parse_geojson(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["features"]:
             if (
                 not location["properties"]["status"]["open"]
@@ -29,6 +33,8 @@ class CaffeNeroGBSpider(Spider):
             item["geometry"] = location["geometry"]
             if location["properties"]["status"]["express"]:
                 item["brand"] = "Nero Express"
+
+            item["branch"] = item.pop("name")
 
             item["opening_hours"] = OpeningHours()
             for day_name, day_hours in location["properties"]["hoursRegular"].items():


### PR DESCRIPTION
Fixes #6729

```python
{'atp/brand/Caffe Nero': 582,
 'atp/brand/Nero Express': 33,
 'atp/brand_wikidata/Q675808': 615,
 'atp/category/amenity/cafe': 615,
 'atp/field/city/missing': 615,
 'atp/field/country/from_spider_name': 615,
 'atp/field/email/missing': 615,
 'atp/field/image/missing': 615,
 'atp/field/name/missing': 615,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 615,
 'atp/field/operator_wikidata/missing': 615,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 615,
 'atp/field/street_address/missing': 615,
 'atp/field/twitter/missing': 615,
 'atp/nsi/match_failed': 615,
 'downloader/request_bytes': 2244,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 588666,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.308637,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 9, 21, 38, 418106, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 6,
 'httpcompression/response_bytes': 88600,
 'httpcompression/response_count': 2,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 615,
 'log_count/DEBUG': 725,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 154177536,
 'memusage/startup': 154177536,
 'request_depth_max': 1,
 'response_received_count': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 1, 16, 9, 21, 37, 109469, tzinfo=datetime.timezone.utc)}
```