### PR TITLE
[PottersAceHomeCenterUS] Add category

### DIFF
--- a/locations/spiders/potters_ace_home_center_us.py
+++ b/locations/spiders/potters_ace_home_center_us.py
@@ -1,10 +1,15 @@
+from locations.categories import Categories
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 
 
 class PottersAceHomeCenterUSSpider(StoreLocatorWidgetsSpider):
     name = "potters_ace_home_center_us"
-    item_attributes = {"brand": "Potter's Ace Home Center", "brand_wikidata": "Q119141289"}
+    item_attributes = {
+        "brand": "Potter's Ace Home Center",
+        "brand_wikidata": "Q119141289",
+        "extras": Categories.SHOP_DOITYOURSELF.value,
+    }
     key = "5b64c14c90736e1bdbdc612010148f0d"
 
     def parse_item(self, item, location):


### PR DESCRIPTION
{"atp/brand/Potter's Ace Home Center": 21,
 'atp/brand_wikidata/Q119141289': 21,
 'atp/category/shop/doityourself': 21,
 'atp/field/city/missing': 21,
 'atp/field/email/missing': 21,
 'atp/field/image/missing': 21,
 'atp/field/operator/missing': 21,
 'atp/field/operator_wikidata/missing': 21,
 'atp/field/postcode/missing': 21,
 'atp/field/state/from_reverse_geocoding': 21,
 'atp/field/street_address/missing': 21,
 'atp/field/twitter/missing': 21,
 'atp/field/website/missing': 21,
 'atp/nsi/brand_missing': 21,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7773,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.61411,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 9, 37, 48, 427718, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39035,
 'httpcompression/response_count': 2,
 'item_scraped_count': 21,
 'log_count/DEBUG': 34,
 'log_count/INFO': 9,
 'memusage/max': 136794112,
 'memusage/startup': 136794112,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 16, 9, 37, 45, 813608, tzinfo=datetime.timezone.utc)}
