### PR TITLE
[Poundland] Drop extra locations

### DIFF
--- a/locations/spiders/poundland.py
+++ b/locations/spiders/poundland.py
@@ -12,7 +12,7 @@ class PoundlandSpider(WoosmapSpider):
     def parse_item(self, item: Feature, feature: dict, **kwargs):
         item["branch"] = item.pop("name")
 
-        if "Pep Shop" in feature["properties"]["tags"]:
+        if "Pep Shop" in feature["properties"]["tags"] or item["branch"].startswith("Pep & Co "):
             pep = item.deepcopy()
 
             pep["ref"] = pep["ref"] + "_pep"
@@ -24,6 +24,9 @@ class PoundlandSpider(WoosmapSpider):
             pep["located_in_wikidata"] = self.item_attributes["brand_wikidata"]
 
             yield pep
+
+        if item["branch"].startswith("Pep & Co "):
+            return
 
         apply_yes_no(Extras.ATM, item, "ATM" in feature["properties"]["tags"])
         item["extras"]["icestore"] = "yes" if "Ice Store" in feature["properties"]["tags"] else "no"


### PR DESCRIPTION
Possibly fixes #6673, I want @rjw62 to review.

The drops the numbers:
```patch
 'atp/brand/Pep&Co': 769,
- 'atp/brand/Poundland': 807,
+ 'atp/brand/Poundland': 793,
```

But it leaves us with some ones that I'm questioning. They end up with 3 pois in proximity, a Poundland with it's Pep and a near by Pep (Which used to have a Poundland). They may be bad source data, or they may be valid.

1. B25 8UJ
2. PE21 6EH/PE21 6QX
3. L20 4XX
4. N9 0TZ