### PR TITLE
[VideoproAU] Add category

### DIFF
--- a/locations/spiders/videopro_au.py
+++ b/locations/spiders/videopro_au.py
@@ -1,9 +1,10 @@
+from locations.categories import Categories
 from locations.storefinders.localisr import LocalisrSpider
 
 
 class VideoproAUSpider(LocalisrSpider):
     name = "videopro_au"
-    item_attributes = {"brand": "Videopro", "brand_wikidata": "Q120648551"}
+    item_attributes = {"brand": "Videopro", "brand_wikidata": "Q120648551", "extras": Categories.SHOP_ELECTRONICS.value}
     api_key = "2RVE9OR1648JPW0X5EMRZNVQD3YK792GZO3PQ40"
     # The search radius appears to be ignored, so a single search
     # coordinate is returning locations all across Australia.


### PR DESCRIPTION
{'atp/brand/Videopro': 3,
 'atp/brand_wikidata/Q120648551': 3,
 'atp/category/shop/electronics': 3,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/field/email/invalid': 1,
 'atp/field/image/missing': 3,
 'atp/field/operator/missing': 3,
 'atp/field/operator_wikidata/missing': 3,
 'atp/field/twitter/missing': 3,
 'atp/field/website/missing': 3,
 'atp/nsi/brand_missing': 3,
 'downloader/request_bytes': 1451,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 6009,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.817519,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 11, 37, 52, 741769, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 16288,
 'httpcompression/response_count': 2,
 'item_scraped_count': 3,
 'log_count/DEBUG': 17,
 'log_count/INFO': 9,
 'memusage/max': 136069120,
 'memusage/startup': 136069120,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 1, 16, 11, 37, 48, 924250, tzinfo=datetime.timezone.utc)}

