### PR TITLE
[Cue] Add category and ref

### DIFF
--- a/locations/spiders/cue.py
+++ b/locations/spiders/cue.py
@@ -3,13 +3,14 @@ import json
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
 class CueSpider(Spider):
     name = "cue"
-    item_attributes = {"brand": "Cue", "brand_wikidata": "Q5192554"}
+    item_attributes = {"brand": "Cue", "brand_wikidata": "Q5192554", "extras": Categories.SHOP_CLOTHES.value}
     allowed_domains = ["www.cue.com"]
     start_urls = [
         "https://www.cue.com/Geolocation/GetStoresByState",
@@ -41,6 +42,7 @@ class CueSpider(Spider):
             if not location["Active"]:
                 continue
             item = DictParser.parse(location)
+            item["ref"] = location["StoreID"]
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(str(location["StoreHours"]))
 


### PR DESCRIPTION
Was yielding 1 POI due to no ref being set. Now:
{'atp/brand/Cue': 36,
 'atp/brand_wikidata/Q5192554': 36,
 'atp/category/shop/clothes': 36,
 'atp/cdn/cloudflare/response_count': 11,
 'atp/cdn/cloudflare/response_status_count/200': 11,
 'atp/field/email/missing': 36,
 'atp/field/image/missing': 36,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 36,
 'atp/field/operator_wikidata/missing': 36,
 'atp/field/state/missing': 4,
 'atp/field/street_address/missing': 36,
 'atp/field/twitter/missing': 36,
 'atp/field/website/missing': 36,
 'atp/nsi/brand_missing': 36,
 'downloader/request_bytes': 3969,
 'downloader/request_count': 11,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 10,
 'downloader/response_bytes': 18210,
 'downloader/response_count': 11,
 'downloader/response_status_count/200': 11,
 'elapsed_time_seconds': 12.939734,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 16, 15, 54, 51, 735252, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 54435,
 'httpcompression/response_count': 11,
 'item_dropped_count': 8,
 'item_dropped_reasons_count/DropItem': 8,
 'item_scraped_count': 36,
 'log_count/DEBUG': 66,
 'log_count/INFO': 9,
 'memusage/max': 136376320,
 'memusage/startup': 136376320,
 'response_received_count': 11,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2024, 1, 16, 15, 54, 38, 795518, tzinfo=datetime.timezone.utc)}
