### PR TITLE
[Fastrac] Add category

### DIFF
--- a/locations/spiders/fastrac_cafe_us.py
+++ b/locations/spiders/fastrac_cafe_us.py
@@ -1,11 +1,13 @@
 import scrapy
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 
 
 class FastracCafeUSSpider(scrapy.Spider):
     name = "fastrac_cafe_us"
-    item_attributes = {"brand": "Fastrac Cafe", "brand_wikidata": "Q117324848"}
+    item_attributes = {"brand": "Fastrac Cafe", "brand_wikidata": "Q117324848", "extras": Categories.FUEL_STATION.value}
+
     # A pageNumber higher than available gives us all the POIs
     start_urls = ["https://fastraccafe.com/api/stores-locator/store-locator-search/results?bannerId=16&pageNumber=100"]
 


### PR DESCRIPTION
NSI has the fuel station as well as the advertising totem, so set the category explicitly.
{'atp/brand/Fastrac Cafe': 70,
 'atp/brand_wikidata/Q117324848': 70,
 'atp/category/amenity/fuel': 70,
 'atp/field/country/from_spider_name': 70,
 'atp/field/email/missing': 70,
 'atp/field/image/missing': 70,
 'atp/field/opening_hours/missing': 70,
 'atp/field/operator/missing': 70,
 'atp/field/operator_wikidata/missing': 70,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 13,
 'atp/field/twitter/missing': 70,
 'atp/nsi/category_match': 70,
 'downloader/request_bytes': 848,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7432,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.996971,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 10, 32, 7, 158424, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39881,
 'httpcompression/response_count': 2,
 'item_scraped_count': 70,
 'log_count/DEBUG': 83,
 'log_count/INFO': 9,
 'memusage/max': 136536064,
 'memusage/startup': 136536064,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 17, 10, 32, 5, 161453, tzinfo=datetime.timezone.utc)}
