### PR TITLE
[SparPL] Add category

### DIFF
--- a/locations/spiders/spar_pl.py
+++ b/locations/spiders/spar_pl.py
@@ -1,6 +1,7 @@
 from scrapy import FormRequest, Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -8,6 +9,7 @@ from locations.hours import OpeningHours
 class SparPLSpider(Spider):
     name = "spar_pl"
     item_attributes = {"brand": "Spar", "brand_wikidata": "Q610492"}
+    EUROSPAR = {"brand": "Eurospar", "brand_wikidata": "Q12309283"}
 
     def start_requests(self):
         yield FormRequest(
@@ -29,4 +31,8 @@ class SparPLSpider(Spider):
             days = ["poniedzialek", "wtorek", "sroda", "czwartek", "piatek", "sobota", "niedziela"]
             for day in days:
                 item["opening_hours"].add_ranges_from_string(f"{day} {shop[day]}")
+            if "EUROSPAR" in shop["format"]:
+                item.update(self.EUROSPAR)
+            else:
+                apply_category(Categories.SHOP_CONVENIENCE, item)
             yield item


### PR DESCRIPTION
{'atp/brand/Eurospar': 34,
 'atp/brand/Spar': 186,
 'atp/brand_wikidata/Q12309283': 34,
 'atp/brand_wikidata/Q610492': 186,
 'atp/category/shop/convenience': 186,
 'atp/category/shop/supermarket': 34,
 'atp/field/country/from_spider_name': 220,
 'atp/field/email/missing': 220,
 'atp/field/image/missing': 220,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/name/missing': 186,
 'atp/field/opening_hours/missing': 220,
 'atp/field/operator/missing': 220,
 'atp/field/operator_wikidata/missing': 220,
 'atp/field/phone/missing': 220,
 'atp/field/state/missing': 220,
 'atp/field/twitter/missing': 220,
 'atp/nsi/match_failed': 186,
 'atp/nsi/perfect_match': 34,
 'downloader/request_bytes': 707,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 17096,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.514323,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 11, 24, 43, 25321, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 102539,
 'httpcompression/response_count': 2,
 'item_scraped_count': 220,
 'log_count/DEBUG': 233,
 'log_count/INFO': 9,
 'memusage/max': 136208384,
 'memusage/startup': 136208384,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 17, 11, 24, 40, 510998, tzinfo=datetime.timezone.utc)}
