### PR TITLE
[NorthernCaliforniaBreweries] Add category

### DIFF
--- a/locations/spiders/northern_california_breweries.py
+++ b/locations/spiders/northern_california_breweries.py
@@ -8,6 +8,7 @@ from locations.items import Feature
 
 class NorthernCaliforniaBreweriesSpider(scrapy.Spider):
     name = "northern_california_breweries"
+    item_attributes = {"brand": "", "brand_wikidata": "", "extras": {"craft": "brewery"}}
     allowed_domains = ["projects.sfchronicle.com"]
     start_urls = ("http://projects.sfchronicle.com/2017/brewery-map/",)
 


### PR DESCRIPTION
{'atp/category/craft/brewery': 343,
 'atp/field/brand/missing': 343,
 'atp/field/brand_wikidata/missing': 343,
 'atp/field/email/missing': 343,
 'atp/field/image/missing': 343,
 'atp/field/lat/missing': 343,
 'atp/field/lon/missing': 343,
 'atp/field/name/missing': 343,
 'atp/field/opening_hours/missing': 343,
 'atp/field/operator/missing': 343,
 'atp/field/operator_wikidata/missing': 343,
 'atp/field/phone/missing': 343,
 'atp/field/postcode/missing': 343,
 'atp/field/twitter/missing': 343,
 'atp/field/website/invalid': 1,
 'downloader/request_bytes': 2681,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 236074,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/301': 3,
 'elapsed_time_seconds': 6.232836,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 12, 8, 47, 738389, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1264984,
 'httpcompression/response_count': 3,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 343,
 'log_count/DEBUG': 351,
 'log_count/INFO': 9,
 'memusage/max': 136597504,
 'memusage/startup': 136597504,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2024, 1, 17, 12, 8, 41, 505553, tzinfo=datetime.timezone.utc)}
