### PR TITLE
[NationalTrustGB] Add category

### DIFF
--- a/locations/spiders/national_trust_gb.py
+++ b/locations/spiders/national_trust_gb.py
@@ -6,7 +6,11 @@ from locations.hours import OpeningHours
 
 class NationalTrustGBSpider(Spider):
     name = "national_trust_gb"
-    item_attributes = {"brand": "National Trust", "brand_wikidata": "Q333515"}
+    item_attributes = {
+        "brand": "National Trust",
+        "brand_wikidata": "Q333515",
+        "extras": {"tourism": "attraction"},
+    }
     allowed_domains = ["www.nationaltrust.org.uk"]
     start_urls = [
         "https://www.nationaltrust.org.uk/api/search/places?query=sw6%203er&placeSort=distance&lat=51.4672197&lon=-0.1925168&milesRadius=10000&pageStartIndex=0&pageSize=10000&lang=en&publicationChannel=NATIONAL_TRUST_ORG_UK&maxPlaceResults=1000&maxLocationPageResults=0"


### PR DESCRIPTION
{'atp/brand/National Trust': 598,
 'atp/brand_wikidata/Q333515': 598,
 'atp/category/tourism/attraction': 598,
 'atp/field/city/missing': 65,
 'atp/field/country/from_spider_name': 598,
 'atp/field/email/missing': 598,
 'atp/field/opening_hours/missing': 598,
 'atp/field/operator/missing': 598,
 'atp/field/operator_wikidata/missing': 598,
 'atp/field/phone/missing': 598,
 'atp/field/postcode/missing': 598,
 'atp/field/state/missing': 10,
 'atp/field/street_address/missing': 598,
 'atp/field/twitter/missing': 598,
 'atp/nsi/match_failed': 598,
 'downloader/request_bytes': 847,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 183421,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.655382,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 12, 57, 14, 498541, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1486271,
 'httpcompression/response_count': 2,
 'item_scraped_count': 598,
 'log_count/DEBUG': 611,
 'log_count/INFO': 9,
 'memusage/max': 136847360,
 'memusage/startup': 136847360,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 17, 12, 57, 11, 843159, tzinfo=datetime.timezone.utc)}
