### PR TITLE
[LensCrafters] Fix spider

### DIFF
--- a/locations/spiders/lenscrafters.py
+++ b/locations/spiders/lenscrafters.py
@@ -1,59 +1,31 @@
 import re
 
-import scrapy
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.items import set_closed
+from locations.spiders.tesco_gb import set_located_in
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LensCraftersSpider(scrapy.Spider):
+class LensCraftersSpider(SitemapSpider, StructuredDataSpider):
     name = "lenscrafters"
-    item_attributes = {"brand": "Lenscrafters", "brand_wikidata": "Q6523209", "extras": Categories.SHOP_OPTICIAN.value}
-    allowed_domains = ["local.lenscrafters.com"]
-    start_urls = ["https://local.lenscrafters.com/"]
+    MACYS = {"brand": "Macy's", "brand_wikidata": "Q629269"}
+    item_attributes = {"brand": "LensCrafters", "brand_wikidata": "Q6523209", "extras": Categories.SHOP_OPTICIAN.value}
+    sitemap_urls = ["https://local.lenscrafters.com/robots.txt"]
+    sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+\.html$", "parse")]
+    wanted_types = ["LocalBusiness"]
 
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        for group in hours:
-            if "Closed" in group:
-                pass
-            else:
-                days, open_time, close_time = re.search(r"([a-zA-Z,]+)\s([\d:]+)-([\d:]+)", group).groups()
-                days = days.split(",")
-                for day in days:
-                    opening_hours.add_range(
-                        day=day,
-                        open_time=open_time,
-                        close_time=close_time,
-                        time_format="%H:%M",
-                    )
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if m := re.search(r"{\"latitude\":(-?\d+\.\d+),\"longitude\":(-?\d+\.\d+)}", response.text):
+            item["lat"], item["lon"] = m.groups()
 
-        return opening_hours.as_opening_hours()
+        if item["name"].endswith(" - Closed"):
+            item["name"] = item["name"].removesuffix(" - Closed")
+            set_closed(item)
 
-    def parse(self, response):
-        urls = response.xpath('//a[@class="Directory-listLink Link--directory"]/@href').extract()
+        if item["name"].endswith(" at Macy's"):
+            item["name"] = item["name"].removesuffix(" at Macy's")
+            set_located_in(self.MACYS, item)
 
-        # If cannot find 'Directory-listLink Link--directory' then this is a store page
-        if len(urls) == 0:
-            properties = {
-                "name": response.xpath('//h1[@id="location-name"]/text()').extract_first(),
-                "street_address": response.xpath('//span[@class="c-address-street-1"]/text()').extract_first(),
-                "city": response.xpath('//span[@class="c-address-city"]/text()').extract_first(),
-                "state": response.xpath('//abbr[@class="c-address-state"]/text()').extract_first(),
-                "postcode": response.xpath('//span[@class="c-address-postal-code"]/text()').extract_first(),
-                "phone": response.xpath('//div[@id="phone-main"]/text()').extract_first(),
-                "ref": response.xpath('//link[@rel="canonical"]/@href').extract_first(),
-                "website": response.xpath('//link[@rel="canonical"]/@href').extract_first(),
-                "lat": response.xpath('//meta[@itemprop="latitude"]/@content').extract_first(),
-                "lon": response.xpath('//meta[@itemprop="longitude"]/@content').extract_first(),
-            }
-
-            hours = self.parse_hours(response.xpath('//*[@itemprop="openingHours"]/@content').extract())
-            if hours:
-                properties["opening_hours"] = hours
-
-            yield Feature(**properties)
-        else:
-            for path in urls:
-                yield scrapy.Request(url=response.urljoin(path), callback=self.parse)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/LensCrafters': 932,
 'atp/brand_wikidata/Q6523209': 932,
 'atp/category/shop/optician': 932,
 'atp/cdn/cloudflare/response_count': 937,
 'atp/cdn/cloudflare/response_status_count/200': 937,
 'atp/closed_poi': 1,
 'atp/field/email/missing': 932,
 'atp/field/operator/missing': 932,
 'atp/field/operator_wikidata/missing': 932,
 'atp/nsi/cc_match': 927,
 'atp/nsi/match_failed': 5,
 'downloader/request_bytes': 396911,
 'downloader/request_count': 937,
 'downloader/request_method_count/GET': 937,
 'downloader/response_bytes': 18390740,
 'downloader/response_count': 937,
 'downloader/response_status_count/200': 937,
 'elapsed_time_seconds': 6.336417,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 13, 58, 33, 7455, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 937,
 'httpcompression/response_bytes': 101951845,
 'httpcompression/response_count': 937,
 'item_scraped_count': 932,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 146735104,
 'memusage/startup': 146735104,
 'request_depth_max': 3,
 'response_received_count': 937,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 936,
 'scheduler/dequeued/memory': 936,
 'scheduler/enqueued': 936,
 'scheduler/enqueued/memory': 936,
 'start_time': datetime.datetime(2024, 1, 17, 13, 58, 26, 671038, tzinfo=datetime.timezone.utc)}
```