### PR TITLE
[Aurecon] Add category

### DIFF
--- a/locations/spiders/aurecongroup.py
+++ b/locations/spiders/aurecongroup.py
@@ -5,7 +5,7 @@ from locations.items import Feature
 
 class AureconGroupSpider(scrapy.Spider):
     name = "aurecongroup"
-    item_attributes = {"brand": "Aurecon", "brand_wikidata": "Q2871849"}
+    item_attributes = {"brand": "Aurecon", "brand_wikidata": "Q2871849", "extras": {"office": "construction_company"}}
     allowed_domains = ["www.aurecon.com"]
     download_delay = 0.1
     start_urls = ("https://www.aurecongroup.com/locations",)


### PR DESCRIPTION
{'atp/brand/Aurecon Group': 28,
 'atp/brand_wikidata/Q2871849': 28,
 'atp/category/office/construction_company': 28,
 'atp/field/country/from_reverse_geocoding': 27,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 28,
 'atp/field/image/missing': 28,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 2,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 2,
 'atp/field/name/missing': 28,
 'atp/field/opening_hours/missing': 28,
 'atp/field/operator/missing': 28,
 'atp/field/operator_wikidata/missing': 28,
 'atp/field/phone/invalid': 2,
 'atp/field/postcode/missing': 28,
 'atp/field/state/missing': 2,
 'atp/field/street_address/missing': 28,
 'atp/field/twitter/missing': 28,
 'atp/field/website/missing': 28,
 'atp/nsi/brand_missing': 28,
 'downloader/request_bytes': 793,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 67826,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.235555,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 15, 36, 20, 364943, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 286490,
 'httpcompression/response_count': 2,
 'item_dropped_count': 3,
 'item_dropped_reasons_count/DropItem': 3,
 'item_scraped_count': 28,
 'log_count/DEBUG': 44,
 'log_count/INFO': 9,
 'memusage/max': 136257536,
 'memusage/startup': 136257536,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 17, 15, 36, 16, 129388, tzinfo=datetime.timezone.utc)}
