### PR TITLE
Added starbucks_au (68 items)

### DIFF
--- a/locations/spiders/starbucks_au.py
+++ b/locations/spiders/starbucks_au.py
@@ -1,0 +1,43 @@
+import html
+import re
+
+import chompjs
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, sanitise_day
+
+
+class StarbucksAUSpider(scrapy.Spider):
+    name = "starbucks_au"
+    item_attributes = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
+    start_urls = ["https://www.starbucks.com.au/find-a-store/"]
+
+    def parse(self, response, **kwargs):
+        stores = chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "features")]/text()').re_first(r"let features = (.+);")
+        )
+        for store in stores["features"]:
+            if "closed" in store["properties"].get("address", ""):
+                continue
+            item = DictParser.parse(store["properties"])
+            item["website"] = store["properties"].get("store_link")
+            item["opening_hours"] = OpeningHours()
+            if timing := store["properties"].get("openhours"):
+                for day, start_time, start_am_pm, end_time, end_am_pm in re.findall(
+                    r"(\w+)<.+?>\s*(\d+[.:\d]*)\s*(am|pm)?.+?(\d+[.:\d]*)\s*(am|pm)?", html.unescape(timing)
+                ):
+                    if day := sanitise_day(day):
+                        open_time, close_time = [
+                            t + ":00" if ":" not in t else t
+                            for t in [start_time.replace(".", ":"), end_time.replace(".", ":")]
+                        ]
+                        time_format = "%H:%M"
+                        if start_am_pm and end_am_pm:
+                            open_time = f"{open_time} {start_am_pm}"
+                            close_time = f"{close_time} {end_am_pm}"
+                            time_format = "%I:%M %p"
+                        item["opening_hours"].add_range(day, open_time, close_time, time_format=time_format)
+            apply_category(Categories.COFFEE_SHOP, item)
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Starbucks': 68,
 'atp/brand_wikidata/Q37158': 68,
 'atp/category/amenity/cafe': 68,
 'atp/field/city/missing': 68,
 'atp/field/country/from_spider_name': 68,
 'atp/field/email/missing': 68,
 'atp/field/image/missing': 68,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/operator/missing': 68,
 'atp/field/operator_wikidata/missing': 68,
 'atp/field/phone/missing': 68,
 'atp/field/postcode/missing': 68,
 'atp/field/state/missing': 68,
 'atp/field/street_address/missing': 68,
 'atp/field/twitter/missing': 68,
 'atp/nsi/match_failed': 68,
 'downloader/request_bytes': 625,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 60527,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.658282,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 17, 19, 42, 41, 81033, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 245878,
 'httpcompression/response_count': 2,
 'item_scraped_count': 68,
 'log_count/DEBUG': 87,
 'log_count/INFO': 9,
 'memusage/max': 137445376,
 'memusage/startup': 137445376,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 17, 19, 42, 34, 422751, tzinfo=datetime.timezone.utc)}
```
</details>