### PR TITLE
[EgAmericaUS] Add category

### DIFF
--- a/locations/spiders/eg_america_us.py
+++ b/locations/spiders/eg_america_us.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -38,4 +39,5 @@ class EGAmericaUSSpider(Spider):
             item.update(self.brands[location["bannerId"]])
             item["street_address"] = item.pop("addr_full", None)
             item["website"] = location.get("pageUrl")
+            apply_category(Categories.FUEL_STATION, item)
             yield item


### PR DESCRIPTION
Most of these have multiple entries in NSI, so setting category explicitly.
{'atp/brand/Certified Oil': 66,
 'atp/brand/Cumberland Farms': 577,
 'atp/brand/Fastrac': 70,
 'atp/brand/Kwik Shop': 115,
 "atp/brand/Loaf 'N Jug": 168,
 'atp/brand/Minit Mart': 90,
 'atp/brand/Quik Stop': 115,
 'atp/brand/Sprint': 34,
 'atp/brand/TomThumb': 117,
 'atp/brand/Turkey Hill': 262,
 'atp/brand_wikidata/Q100148356': 66,
 'atp/brand_wikidata/Q105141709': 115,
 'atp/brand_wikidata/Q1143685': 577,
 'atp/brand_wikidata/Q117324848': 70,
 'atp/brand_wikidata/Q123012206': 117,
 'atp/brand_wikidata/Q123012447': 34,
 'atp/brand_wikidata/Q18154470': 90,
 'atp/brand_wikidata/Q42376970': 262,
 'atp/brand_wikidata/Q6450417': 115,
 'atp/brand_wikidata/Q6663398': 168,
 'atp/category/amenity/fuel': 1614,
 'atp/category/multiple': 90,
 'atp/field/country/from_reverse_geocoding': 1614,
 'atp/field/email/missing': 1614,
 'atp/field/image/missing': 1614,
 'atp/field/name/missing': 151,
 'atp/field/opening_hours/missing': 1614,
 'atp/field/operator/missing': 1614,
 'atp/field/operator_wikidata/missing': 1614,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 14,
 'atp/field/twitter/missing': 1614,
 'atp/field/website/missing': 22,
 'atp/nsi/brand_missing': 151,
 'atp/nsi/category_match': 1373,
 'atp/nsi/perfect_match': 90,
 'downloader/request_bytes': 869,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 148477,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.168241,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 8, 51, 22, 92674, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 749902,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1614,
 'log_count/DEBUG': 1627,
 'log_count/INFO': 9,
 'memusage/max': 136613888,
 'memusage/startup': 136613888,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 18, 8, 51, 14, 924433, tzinfo=datetime.timezone.utc)}
