### PR TITLE
[burger_king_tr] add spider + add category to all Burger King spiders

### DIFF
--- a/locations/spiders/burger_king.py
+++ b/locations/spiders/burger_king.py
@@ -1,7 +1,7 @@
 import geonamescache
 import scrapy
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.geo import city_locations, point_locations
 from locations.hours import DAYS_EN, OpeningHours
@@ -9,7 +9,7 @@ from locations.hours import DAYS_EN, OpeningHours
 
 class BurgerKingSpider(scrapy.Spider):
     name = "burgerking"
-    item_attributes = {"brand": "Burger King", "brand_wikidata": "Q177054"}
+    item_attributes = {"brand": "Burger King", "brand_wikidata": "Q177054", "extras": Categories.FAST_FOOD.value}
     download_delay = 2.0
     custom_settings = {"ROBOTSTXT_OBEY": False}
 

--- a/locations/spiders/burger_king_tr.py
+++ b/locations/spiders/burger_king_tr.py
@@ -1,0 +1,18 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.spiders.burger_king import BurgerKingSpider
+
+
+class BurgerKingTRSpider(scrapy.Spider):
+    name = "burger_king_tr"
+    item_attributes = BurgerKingSpider.item_attributes
+    start_urls = ["https://www.burgerking.com.tr/Restaurants/GetRestaurants/"]
+
+    def parse(self, response):
+        for poi in response.json():
+            poi.update(poi.pop("data"))
+            item = DictParser.parse(poi)
+            item["ref"] = poi.get("title")
+            item["street_address"] = item.pop("addr_full", None)
+            yield item


### PR DESCRIPTION
NSI match fails without setting category, probably due to [this commit in NSI](https://github.com/osmlab/name-suggestion-index/commit/b973204b2a7f69a84ea51171c4116e86a9c38ba4), so I set category to all BK spiders.


`burger_king_tr` stats:

```json
{
 "atp/brand/Burger King": 715,
 "atp/brand_wikidata/Q177054": 715,
 "atp/category/amenity/fast_food": 715,
 "atp/field/country/from_spider_name": 715,
 "atp/field/email/missing": 715,
 "atp/field/image/missing": 715,
 "atp/field/opening_hours/missing": 715,
 "atp/field/operator/missing": 715,
 "atp/field/operator_wikidata/missing": 715,
 "atp/field/phone/missing": 715,
 "atp/field/postcode/missing": 715,
 "atp/field/twitter/missing": 715,
 "atp/field/website/missing": 715,
 "atp/nsi/category_match": 715,
 "downloader/request_bytes": 726,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 36245,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 2.233884,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-01-18T08:55:35.699640+00:00",
 "httpcompression/response_bytes": 134139,
 "httpcompression/response_count": 2,
 "item_dropped_count": 1,
 "item_dropped_reasons_count/DropItem": 1,
 "item_scraped_count": 715,
 "log_count/INFO": 10,
 "memusage/max": 140050432,
 "memusage/startup": 140050432,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-01-18T08:55:33.465756+00:00"
}
```