### PR TITLE
[Vival FR] Add spider

### DIFF
--- a/locations/spiders/vival_fr.py
+++ b/locations/spiders/vival_fr.py
@@ -1,0 +1,10 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class VivalFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "vival_fr"
+    item_attributes = {"brand": "Vival", "brand_wikidata": "Q7937525"}
+    sitemap_urls = ["https://magasins.vival.fr/robots.txt"]
+    wanted_types = ["LocalBusiness"]


### PR DESCRIPTION
```python
{'atp/brand/Vival': 1493,
 'atp/brand_wikidata/Q7937525': 1493,
 'atp/category/shop/convenience': 1493,
 'atp/field/email/missing': 1490,
 'atp/field/image/dropped': 38,
 'atp/field/image/missing': 38,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 1493,
 'atp/field/operator_wikidata/missing': 1493,
 'atp/field/phone/missing': 104,
 'atp/field/state/missing': 1493,
 'atp/field/twitter/missing': 1493,
 'atp/nsi/perfect_match': 1493,
 'downloader/request_bytes': 611202,
 'downloader/request_count': 1453,
 'downloader/request_method_count/GET': 1453,
 'downloader/response_bytes': 11763079,
 'downloader/response_count': 1453,
 'downloader/response_status_count/200': 1447,
 'downloader/response_status_count/301': 5,
 'downloader/response_status_count/403': 1,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 30.911841,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 10, 29, 20, 110978, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 556,
 'httpcache/hit': 897,
 'httpcache/miss': 556,
 'httpcache/store': 556,
 'httpcompression/response_bytes': 50796585,
 'httpcompression/response_count': 1446,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/403': 1,
 'item_scraped_count': 1493,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'memusage/max': 147304448,
 'memusage/startup': 147304448,
 'request_depth_max': 2,
 'response_received_count': 1448,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1452,
 'scheduler/dequeued/memory': 1452,
 'scheduler/enqueued': 1452,
 'scheduler/enqueued/memory': 1452,
 'start_time': datetime.datetime(2024, 1, 18, 10, 28, 49, 199137, tzinfo=datetime.timezone.utc)}
```