### PR TITLE
[Caltex] Add category

### DIFF
--- a/locations/spiders/caltex.py
+++ b/locations/spiders/caltex.py
@@ -96,6 +96,6 @@ class CaltexSpider(Spider):
                 apply_yes_no(Fuel.ADBLUE, item, "Bulk AdBlue" in location["fuelsName"], False)
                 apply_yes_no(Fuel.KEROSENE, item, "Kerosene" in location["fuelsName"], False)
 
-                apply_category(Categories.FUEL_STATION, item)
+            apply_category(Categories.FUEL_STATION, item)
 
             yield item


### PR DESCRIPTION
Previously this was setting category only for fuel stations with fuel types listed. Those without fuel types are also fuel stations so category set for all.
{'atp/brand/Caltex': 1894,
 'atp/brand_wikidata/Q277470': 1894,
 'atp/category/amenity/fuel': 1894,
 'atp/field/city/missing': 457,
 'atp/field/country/from_reverse_geocoding': 755,
 'atp/field/email/missing': 1894,
 'atp/field/image/missing': 1894,
 'atp/field/opening_hours/missing': 1894,
 'atp/field/operator/missing': 1894,
 'atp/field/operator_wikidata/missing': 1894,
 'atp/field/phone/invalid': 82,
 'atp/field/phone/missing': 797,
 'atp/field/postcode/missing': 670,
 'atp/field/state/missing': 572,
 'atp/field/street_address/missing': 1894,
 'atp/field/twitter/missing': 1894,
 'atp/field/website/missing': 1894,
 'atp/nsi/category_match': 1893,
 'atp/nsi/match_failed': 1,
 'downloader/request_bytes': 5025,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 221723,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 10.276535,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 11, 13, 18, 305438, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3054984,
 'httpcompression/response_count': 8,
 'item_scraped_count': 1894,
 'log_count/DEBUG': 1913,
 'log_count/INFO': 9,
 'memusage/max': 135761920,
 'memusage/startup': 135761920,
 'response_received_count': 8,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2024, 1, 18, 11, 13, 8, 28903, tzinfo=datetime.timezone.utc)}
