### PR TITLE
[AB GR] Add Spider

### DIFF
--- a/locations/spiders/ab_gr.py
+++ b/locations/spiders/ab_gr.py
@@ -1,0 +1,68 @@
+import json
+from typing import Any, Iterable
+from urllib.parse import urlencode
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class AbGRSpider(Spider):
+    name = "ab_gr"
+    item_attributes = {"brand": "AB", "brand_wikidata": "Q4721807", "nsi_id": "N/A"}
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://www.ab.gr/api/v1/?{}".format(
+                urlencode(
+                    {
+                        "operationName": "GetStoreSearch",
+                        "variables": json.dumps(
+                            {
+                                "pageSize": 3000,
+                                "lang": "en",
+                                "query": "",
+                                "currentPage": 0,
+                                "options": "STORELOCATOR_MINIFIED",
+                            }
+                        ),
+                        "extensions": json.dumps(
+                            {
+                                "persistedQuery": {
+                                    "version": 1,
+                                    "sha256Hash": "9dc67fed7b358c14d80bbd04c6524ef76f4298a142ed7ab86732442271f4ad46",
+                                }
+                            }
+                        ),
+                    }
+                )
+            )
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]["storeSearchJSON"]["stores"]:
+            item = DictParser.parse(location)
+            item["ref"] = item.pop("name")
+            item["branch"] = location["localizedName"]
+            item["addr_full"] = location["address"]["formattedAddress"]
+            item["phone"] = "; ".join(location["address"]["phone"].split(","))
+            item["website"] = "https://www.ab.gr/storedetails/{}".format(location["urlName"])
+
+            services = [s["code"] for s in location["storeServices"]]
+            apply_yes_no(Extras.WIFI, item, "FREEWIFI" in services)
+
+            if location["groceryStoreType"] == "ABCITY":
+                item["name"] = "AB City"
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+            else:
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+                if location["groceryStoreType"] == "AB":
+                    item["name"] = "ΑΒ Βασιλόπουλος"
+                elif location["groceryStoreType"] == "FOODMRKT":
+                    item["name"] = "AB Food Market"
+                elif location["groceryStoreType"] == "SHOPNGO":
+                    item["name"] = "AB Shop & Go"
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/AB': 622,
 'atp/brand_wikidata/Q4721807': 622,
 'atp/category/shop/convenience': 20,
 'atp/category/shop/supermarket': 602,
 'atp/field/email/missing': 622,
 'atp/field/image/missing': 622,
 'atp/field/opening_hours/missing': 622,
 'atp/field/operator/missing': 622,
 'atp/field/operator_wikidata/missing': 622,
 'atp/field/phone/invalid': 11,
 'atp/field/phone/missing': 194,
 'atp/field/state/missing': 622,
 'atp/field/twitter/missing': 622,
 'downloader/request_bytes': 1078,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 92886,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.54019,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 11, 31, 26, 408882, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 728621,
 'httpcompression/response_count': 2,
 'item_scraped_count': 622,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 145956864,
 'memusage/startup': 145956864,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 18, 11, 31, 25, 868692, tzinfo=datetime.timezone.utc)}
```