### PR TITLE
[EdekaDE] Add category

### DIFF
--- a/locations/spiders/edeka_de.py
+++ b/locations/spiders/edeka_de.py
@@ -74,7 +74,8 @@ class EdekaDESpider(scrapy.Spider):
                 item.update(self.MARKT_BACKEREI)
             elif "ellimarkt" in name:
                 item.update(self.ELLI)
-
+            else:
+                item.update(self.EDEKA)
             yield item
 
         if next := response.json()["_links"].get("next"):


### PR DESCRIPTION
Some POIs do not match the specific brands, but these are supermarkets, so set them to the "parent" brand EDEKA.
{'atp/brand/CAP': 64,
 'atp/brand/E-Center': 328,
 'atp/brand/EDEKA': 4536,
 'atp/brand/EDEKA aktiv markt': 42,
 'atp/brand/EDEKA xpress': 38,
 'atp/brand/Elli': 16,
 'atp/brand/HERKULES Ecenter': 37,
 'atp/brand/MARKTKAUF': 124,
 'atp/brand/Markt-Bäckerei': 126,
 'atp/brand/NP': 230,
 'atp/brand/diska': 106,
 'atp/brand/nah und gut': 503,
 'atp/brand_wikidata/Q1022827': 64,
 'atp/brand_wikidata/Q1533254': 124,
 'atp/brand_wikidata/Q15836148': 230,
 'atp/brand_wikidata/Q1719433': 126,
 'atp/brand_wikidata/Q62390177': 106,
 'atp/brand_wikidata/Q701755': 5500,
 'atp/category/shop/bakery': 126,
 'atp/category/shop/supermarket': 6024,
 'atp/field/country/from_spider_name': 6150,
 'atp/field/email/missing': 2951,
 'atp/field/image/missing': 6150,
 'atp/field/opening_hours/missing': 30,
 'atp/field/operator/missing': 6150,
 'atp/field/operator_wikidata/missing': 6150,
 'atp/field/twitter/missing': 6150,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 1060,
 'atp/nsi/match_failed': 5500,
 'atp/nsi/perfect_match': 650,
 'downloader/request_bytes': 25430,
 'downloader/request_count': 63,
 'downloader/request_method_count/GET': 63,
 'downloader/response_bytes': 1517566,
 'downloader/response_count': 63,
 'downloader/response_status_count/200': 63,
 'elapsed_time_seconds': 74.906384,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 14, 21, 35, 150500, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24448391,
 'httpcompression/response_count': 63,
 'item_scraped_count': 6150,
 'log_count/DEBUG': 6224,
 'log_count/INFO': 10,
 'memusage/max': 269791232,
 'memusage/startup': 136183808,
 'request_depth_max': 61,
 'response_received_count': 63,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 62,
 'scheduler/dequeued/memory': 62,
 'scheduler/enqueued': 62,
 'scheduler/enqueued/memory': 62,
 'start_time': datetime.datetime(2024, 1, 18, 14, 20, 20, 244116, tzinfo=datetime.timezone.utc)}
