### PR TITLE
[CrossroadsIGAUS] Add category

### DIFF
--- a/locations/spiders/crossroads_iga_us.py
+++ b/locations/spiders/crossroads_iga_us.py
@@ -14,4 +14,6 @@ class CrossroadsIGAUSSpider(StoreLocatorWidgetsSpider):
                 apply_category(Categories.SHOP_SUPERMARKET, item)
             if "Fuel" in location["filters"]:
                 apply_category(Categories.FUEL_STATION, item)
+        else:
+            apply_category(Categories.SHOP_DOITYOURSELF, item)
         yield item


### PR DESCRIPTION
If there is no data in "filters" (which identifies supermarket and fuel station), then it is the one DIY store.
{'atp/brand/Crossroads IGA': 19,
 'atp/brand_wikidata/Q119141723': 19,
 'atp/category/amenity/fuel': 18,
 'atp/category/multiple': 18,
 'atp/category/shop/doityourself': 1,
 'atp/field/city/missing': 19,
 'atp/field/country/from_spider_name': 19,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 19,
 'atp/field/opening_hours/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 19,
 'atp/field/state/from_reverse_geocoding': 19,
 'atp/field/street_address/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/field/website/missing': 19,
 'atp/nsi/brand_missing': 19,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8423,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.591986,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 15, 42, 9, 233562, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27569,
 'httpcompression/response_count': 2,
 'item_scraped_count': 19,
 'log_count/DEBUG': 32,
 'log_count/INFO': 9,
 'memusage/max': 135892992,
 'memusage/startup': 135892992,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 18, 15, 42, 6, 641576, tzinfo=datetime.timezone.utc)}
