### PR TITLE
[Qdoba] Collect all locations

### DIFF
--- a/locations/spiders/qdoba.py
+++ b/locations/spiders/qdoba.py
@@ -1,85 +1,12 @@
-import json
-import re
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import Feature
-
-DAY_MAPPING = {
-    "MONDAY": "Mo",
-    "TUESDAY": "Tu",
-    "WEDNESDAY": "We",
-    "THURSDAY": "Th",
-    "FRIDAY": "Fr",
-    "SATURDAY": "Sa",
-    "SUNDAY": "Su",
-}
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class QdobaSpider(scrapy.Spider):
+class QdobaSpider(SitemapSpider, StructuredDataSpider):
     name = "qdoba"
     item_attributes = {"brand": "Qdoba", "brand_wikidata": "Q1363885"}
     allowed_domains = ["qdoba.com"]
-    start_urls = (
-        "https://locations.qdoba.com/us.html",
-        "https://locations.qdoba.com/ca.html",
-    )
-
-    def parse_hours(self, store_hours):
-        opening_hours = OpeningHours()
-        store_data = json.loads(store_hours)
-
-        for store_day in store_data:
-            if len(store_day["intervals"]) < 1:
-                continue
-            day = DAY_MAPPING[store_day["day"]]
-            open_time = str(store_day["intervals"][0]["start"])
-            if open_time == "0":
-                open_time = "0000"
-            close_time = str(store_day["intervals"][0]["end"])
-            if close_time == "0":
-                close_time = "2359"
-            opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H%M")
-
-        return opening_hours.as_opening_hours()
-
-    def parse(self, response):
-        urls = response.xpath('//a[@class="c-directory-list-content-item-link"]/@href').extract()
-        is_store_list = response.xpath('//a[@class="location-card-visit"]/@href').extract()
-        is_resturant_page = response.xpath('//main[@itemtype="http://schema.org/Restaurant"]').extract_first()
-
-        if is_resturant_page:
-            yield scrapy.Request(response.url, callback=self.parse_store)
-        else:
-            if not urls and is_store_list:
-                for store_url in is_store_list:
-                    yield scrapy.Request(response.urljoin(store_url), callback=self.parse_store)
-
-            for url in urls:
-                yield scrapy.Request(response.urljoin(url), dont_filter=True)
-
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-
-        properties = {
-            "ref": ref,
-            "name": response.xpath('normalize-space(//span[@class="location-name-brand"]/text())').extract_first(),
-            "street_address": response.xpath(
-                'normalize-space(//span[@class="c-address-street-1"]/text())'
-            ).extract_first(),
-            "city": response.xpath('normalize-space(//span[@itemprop="addressLocality"]/text())').extract_first(),
-            "state": response.xpath('normalize-space(//abbr[@itemprop="addressRegion"]/text())').extract_first(),
-            "postcode": response.xpath('normalize-space(//span[@itemprop="postalCode"]/text())').extract_first(),
-            "country": response.xpath('normalize-space(//abbr[@itemprop="addressCountry"]/text())').extract_first(),
-            "phone": response.xpath('normalize-space(//span[@itemprop="telephone"]//text())').extract_first(),
-            "website": response.url,
-            "lat": response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first(),
-            "lon": response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first(),
-        }
-
-        hours = response.xpath('//span[@class="c-location-hours-today js-location-hours"]/@data-days').extract_first()
-        if hours:
-            properties["opening_hours"] = self.parse_hours(hours)
-
-        yield Feature(**properties)
+    sitemap_urls = ["https://locations.qdoba.com/sitemap.xml"]
+    sitemap_rules = [(r"com/\w\w/\w\w/[^/]+/[^/]+\.html", "parse")]
+    wanted_types = ["Restaurant"]


### PR DESCRIPTION
```python
{'atp/brand/Qdoba': 769,
 'atp/brand_wikidata/Q1363885': 769,
 'atp/category/amenity/fast_food': 769,
 'atp/cdn/cloudflare/response_count': 771,
 'atp/cdn/cloudflare/response_status_count/200': 771,
 'atp/closed_check': 1,
 'atp/field/email/missing': 767,
 'atp/field/image/missing': 55,
 'atp/field/opening_hours/missing': 22,
 'atp/field/operator/missing': 769,
 'atp/field/operator_wikidata/missing': 769,
 'atp/field/phone/missing': 30,
 'atp/nsi/perfect_match': 769,
 'downloader/request_bytes': 424853,
 'downloader/request_count': 771,
 'downloader/request_method_count/GET': 771,
 'downloader/response_bytes': 10439921,
 'downloader/response_count': 771,
 'downloader/response_status_count/200': 771,
 'elapsed_time_seconds': 911.1332,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 17, 10, 27, 538736, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 743,
 'httpcache/hit': 28,
 'httpcache/miss': 743,
 'httpcache/store': 743,
 'httpcompression/response_bytes': 57376931,
 'httpcompression/response_count': 771,
 'item_scraped_count': 769,
 'log_count/INFO': 25,
 'log_count/WARNING': 2,
 'memusage/max': 287236096,
 'memusage/startup': 151429120,
 'request_depth_max': 1,
 'response_received_count': 771,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 770,
 'scheduler/dequeued/memory': 770,
 'scheduler/enqueued': 770,
 'scheduler/enqueued/memory': 770,
 'start_time': datetime.datetime(2024, 1, 18, 16, 55, 16, 405536, tzinfo=datetime.timezone.utc)}
```