### PR TITLE
[loxam_fr] Created a sitemapspider for Loxam in France (1049 items)

### DIFF
--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -7,11 +7,8 @@ class LoxamFrSpider(SitemapSpider, StructuredDataSpider):
     name = "loxam_fr"
     item_attributes = {"brand": "Loxam", "brand_wikidata": "Q3264407"}
     allowed_domains = ["agence.loxam.fr"]
-    sitemap_urls = [
-        "https://agence.loxam.fr/locationsitemap1.xml",
-        "https://agence.loxam.fr/locationsitemap2.xml",
-        "https://agence.loxam.fr/locationsitemap3.xml",
-    ]
+    sitemap_urls = ["https://agence.loxam.fr/robots.txt"]
+    sitemap_follow = ["locationsitemap"]
     sitemap_rules = [("", "parse_sd")]
     requires_proxy = True
 

--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -1,0 +1,42 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class LoxamFrSpider(SitemapSpider):
+    name = "loxam_fr"
+    item_attributes = {"brand": "Loxam", "brand_wikidata": "Q3264407"}
+    allowed_domains = ["agence.loxam.fr"]
+    sitemap_urls = [
+        "https://agence.loxam.fr/locationsitemap1.xml",
+        "https://agence.loxam.fr/locationsitemap2.xml",
+        "https://agence.loxam.fr/locationsitemap3.xml",
+    ]
+    sitemap_rules = [("", "parse_store")]
+    requires_proxy = True
+
+    def parse_hours(self, item, store_hours):
+        oh = OpeningHours()
+        for hours in store_hours.split(","):
+            if hours:
+                day = hours.split(" ")[0]
+                open_time = hours.split(" ")[1].split("-")[0]
+                close_time = hours.split(" ")[1].split("-")[1]
+                oh.add_range(day, open_time, close_time, "%H:%M")
+            item["opening_hours"] = oh.as_opening_hours()
+
+    def parse_store(self, response):
+        script_content = response.xpath('//script[contains(@type,"application/ld+json")]')
+        for content in script_content:
+            json_data = json.loads(content.xpath("./text()").get(), strict=False)
+            if "address" in json_data:
+                item = DictParser.parse(json_data)
+                item["ref"] = json_data["url"].split("-")[0][1:]
+                self.parse_hours(
+                    item, json_data["openingHours"].replace(" - ", "-").replace("  ", "").replace("\n", "")
+                )
+                item["website"] = response.request.url
+                yield item

--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -14,3 +14,7 @@ class LoxamFrSpider(SitemapSpider, StructuredDataSpider):
     ]
     sitemap_rules = [("", "parse_sd")]
     requires_proxy = True
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image", None)
+        yield item

--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -1,12 +1,9 @@
-import json
-
 from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LoxamFrSpider(SitemapSpider):
+class LoxamFrSpider(SitemapSpider, StructuredDataSpider):
     name = "loxam_fr"
     item_attributes = {"brand": "Loxam", "brand_wikidata": "Q3264407"}
     allowed_domains = ["agence.loxam.fr"]
@@ -15,28 +12,5 @@ class LoxamFrSpider(SitemapSpider):
         "https://agence.loxam.fr/locationsitemap2.xml",
         "https://agence.loxam.fr/locationsitemap3.xml",
     ]
-    sitemap_rules = [("", "parse_store")]
+    sitemap_rules = [("", "parse_sd")]
     requires_proxy = True
-
-    def parse_hours(self, item, store_hours):
-        oh = OpeningHours()
-        for hours in store_hours.split(","):
-            if hours:
-                day = hours.split(" ")[0]
-                open_time = hours.split(" ")[1].split("-")[0]
-                close_time = hours.split(" ")[1].split("-")[1]
-                oh.add_range(day, open_time, close_time, "%H:%M")
-            item["opening_hours"] = oh.as_opening_hours()
-
-    def parse_store(self, response):
-        script_content = response.xpath('//script[contains(@type,"application/ld+json")]')
-        for content in script_content:
-            json_data = json.loads(content.xpath("./text()").get(), strict=False)
-            if "address" in json_data:
-                item = DictParser.parse(json_data)
-                item["ref"] = json_data["url"].split("-")[0][1:]
-                self.parse_hours(
-                    item, json_data["openingHours"].replace(" - ", "-").replace("  ", "").replace("\n", "")
-                )
-                item["website"] = response.request.url
-                yield item

--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -1,3 +1,5 @@
+from html import unescape
+
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
@@ -14,7 +16,7 @@ class LoxamFrSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item.pop("image", None)
-        item["name"] = html.unescape(item["name"])
-        item["street_address"] = html.unescape(item["street_address"])
-        item["city"] = html.unescape(item["city"])
+        item["name"] = unescape(item["name"])
+        item["street_address"] = unescape(item["street_address"])
+        item["city"] = unescape(item["city"])
         yield item

--- a/locations/spiders/loxam_fr.py
+++ b/locations/spiders/loxam_fr.py
@@ -14,4 +14,7 @@ class LoxamFrSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item.pop("image", None)
+        item["name"] = html.unescape(item["name"])
+        item["street_address"] = html.unescape(item["street_address"])
+        item["city"] = html.unescape(item["city"])
         yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Loxam': 1049,
 'atp/brand_wikidata/Q3264407': 1049,
 'atp/category/shop/tool_hire': 1049,
 'atp/field/email/missing': 1049,
 'atp/field/image/missing': 1049,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1049,
 'atp/field/operator_wikidata/missing': 1049,
 'atp/field/state/missing': 1049,
 'atp/field/twitter/missing': 1049,
 'atp/nsi/perfect_match': 1049,
 'downloader/request_bytes': 527869,
 'downloader/request_count': 1053,
 'downloader/request_method_count/GET': 1053,
 'downloader/response_bytes': 24230468,
 'downloader/response_count': 1053,
 'downloader/response_status_count/200': 1053,
 'elapsed_time_seconds': 1275.127449,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 18, 19, 15, 24, 242285, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 148254088,
 'httpcompression/response_count': 1053,
 'item_scraped_count': 1049,
 'log_count/INFO': 30,
 'memusage/max': 278564864,
 'memusage/startup': 137310208,
 'request_depth_max': 1,
 'response_received_count': 1053,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1052,
 'scheduler/dequeued/memory': 1052,
 'scheduler/enqueued': 1052,
 'scheduler/enqueued/memory': 1052,
 'start_time': datetime.datetime(2024, 1, 18, 18, 54, 9, 114836, tzinfo=datetime.timezone.utc)}
```
</details>