### PR TITLE
[RsgGroup] Add category

### DIFF
--- a/locations/spiders/rsg_group.py
+++ b/locations/spiders/rsg_group.py
@@ -32,5 +32,6 @@ class RSGGroupSpider(WoosmapSpider):
 
         if brand := self.BRANDS.get(brand_id):
             item.update(brand)
-
+        else:
+            item.update(self.MC_FIT)
         yield item


### PR DESCRIPTION
If there is no provided sub-brand data, then set to parent brand as default.
{'atp/brand/JOHN REED Fitness': 50,
 'atp/brand/McFit': 300,
 'atp/brand_wikidata/Q106434148': 50,
 'atp/brand_wikidata/Q871302': 300,
 'atp/category/leisure/fitness_centre': 350,
 'atp/cdn/cloudflare/response_count': 4,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/country/from_reverse_geocoding': 4,
 'atp/field/email/missing': 350,
 'atp/field/image/missing': 350,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 350,
 'atp/field/operator_wikidata/missing': 350,
 'atp/field/phone/missing': 5,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/state/missing': 343,
 'atp/field/twitter/missing': 350,
 'atp/field/website/missing': 3,
 'atp/nsi/perfect_match': 350,
 'downloader/request_bytes': 1623,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 253625,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.121395,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 19, 11, 31, 33, 118344, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4659447,
 'httpcompression/response_count': 3,
 'item_scraped_count': 350,
 'log_count/DEBUG': 365,
 'log_count/INFO': 9,
 'memusage/max': 136605696,
 'memusage/startup': 136605696,
 'request_depth_max': 2,
 'response_received_count': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 1, 19, 11, 31, 27, 996949, tzinfo=datetime.timezone.utc)}
