### PR TITLE
[KohlsUS] Fix spider

### DIFF
--- a/locations/spiders/kohls_us.py
+++ b/locations/spiders/kohls_us.py
@@ -1,5 +1,3 @@
-import re
-
 from scrapy.spiders import SitemapSpider
 
 from locations.hours import OpeningHours
@@ -13,14 +11,12 @@ class KohlsUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.kohls.com/sitemap_store.xml"]
     sitemap_rules = [(r"\/stores\/\w{2}\/\w+-(\d+)\.shtml$", "parse_sd")]
     wanted_types = ["DepartmentStore"]
+    custom_settings = {"REDIRECT_ENABLED": False}
 
     def post_process_item(self, item, response, ld_data):
-        item["ref"] = re.search(self.sitemap_rules[0][0], response.url).group(1)
-        if "|" in item["name"]:
-            item["name"] = item["name"].split("|")[0]
+        item["branch"] = item.pop("name").removeprefix("Kohl's ").removesuffix(" Department & Clothing Store")
         item.pop("image")
         item.pop("facebook")
-        item.pop("twitter")
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(ld_data["openingHours"])
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Kohl's": 1154,
 'atp/brand_wikidata/Q967265': 1154,
 'atp/category/shop/department_store': 1154,
 'atp/field/country/from_spider_name': 1154,
 'atp/field/email/missing': 1154,
 'atp/field/image/missing': 1154,
 'atp/field/operator/missing': 1154,
 'atp/field/operator_wikidata/missing': 1154,
 'atp/field/twitter/missing': 1154,
 'atp/nsi/perfect_match': 1154,
 'downloader/request_bytes': 1612577,
 'downloader/request_count': 1159,
 'downloader/request_method_count/GET': 1159,
 'downloader/response_bytes': 58330517,
 'downloader/response_count': 1159,
 'downloader/response_status_count/200': 1156,
 'downloader/response_status_count/301': 3,
 'elapsed_time_seconds': 11.942035,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 21, 21, 7, 56, 238008, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1159,
 'httpcompression/response_bytes': 191380468,
 'httpcompression/response_count': 1155,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/301': 3,
 'item_scraped_count': 1154,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'memusage/max': 147038208,
 'memusage/startup': 147038208,
 'request_depth_max': 1,
 'response_received_count': 1159,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1158,
 'scheduler/dequeued/memory': 1158,
 'scheduler/enqueued': 1158,
 'scheduler/enqueued/memory': 1158,
 'start_time': datetime.datetime(2024, 1, 21, 21, 7, 44, 295973, tzinfo=datetime.timezone.utc)}
```