### PR TITLE
[Rainbow] Fix Spider

### DIFF
--- a/locations/spiders/rainbow_shops.py
+++ b/locations/spiders/rainbow_shops.py
@@ -1,73 +1,24 @@
-import json
+import html
 
-import scrapy
+from scrapy.spiders import SitemapSpider
 
-from locations.hours import DAYS, OpeningHours
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class RainbowShopsSpider(scrapy.Spider):
+class RainbowShopsSpider(SitemapSpider, StructuredDataSpider):
     name = "rainbow_shops"
-    allowed_domains = ["rainbowshops.com"]
-    start_urls = [
-        "https://stores.rainbowshops.com/umbraco/api/location/GetAllLocations",
-    ]
-    item_attributes = {"brand": "Rainbow Shops", "brand_wikidata": "Q7284708"}
+    allowed_domains = ["stores.rainbowshops.com"]
+    item_attributes = {"brand": "Rainbow", "brand_wikidata": "Q7284708"}
+    sitemap_urls = ["https://stores.rainbowshops.com/robots.txt"]
+    sitemap_rules = [(r"com/\w\w/[^/]+/(\d+)/$", "parse")]
+    time_format = "%I:%M%p"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response):
-        base_url = "https://stores.rainbowshops.com/umbraco/api/Location/GetDataByState?region={region}"
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = html.unescape(item.pop("name"))
+        item["street_address"] = html.unescape(item["street_address"])
+        item["city"] = html.unescape(item["city"])
+        item["lat"] = response.xpath("//@data-lat").get()
+        item["lon"] = response.xpath("//@data-lng").get()
 
-        data = response.xpath("//text()").extract_first()
-        states = json.loads(data)
-
-        for state in states:
-            region = state["MainAddress.Region"]
-            url = base_url.format(region=region)
-
-            yield scrapy.Request(url=url, callback=self.parse_stores)
-
-        ## To get PR
-        url = "https://stores.rainbowshops.com/umbraco/api/location/GetDataByCoordinates?longitude=-64.748032&latitude=17.729958&distance=undefined&units=miles"
-        yield scrapy.Request(url=url, callback=self.parse_stores)
-
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        for day in DAYS:
-            open_time = hours[day]["Ranges"][0]["StartTime"]
-            close_time = hours[day]["Ranges"][0]["EndTime"]
-            if open_time is not None:
-                opening_hours.add_range(
-                    day=day,
-                    open_time=open_time,
-                    close_time=close_time,
-                    time_format="%I:%M%p",
-                )
-
-        return opening_hours.as_opening_hours()
-
-    def parse_stores(self, response):
-        data = response.xpath("//text()").extract_first()
-        places = json.loads(data)
-
-        for place in places["StoreLocations"]:
-            properties = {
-                "ref": place["ExtraData"]["ReferenceCode"],
-                "name": place["ExtraData"]["LocationDescriptor"],
-                "addr_full": place["ExtraData"]["Address"]["AddressNonStruct_Line1"],
-                "city": place["ExtraData"]["Address"]["Locality"],
-                "state": place["ExtraData"]["Address"]["Region"],
-                "postcode": place["ExtraData"]["Address"]["PostalCode"],
-                "country": place["ExtraData"]["Address"]["CountryCode"],
-                "lat": place["Location"]["coordinates"][1],
-                "lon": place["Location"]["coordinates"][0],
-                "phone": place["ExtraData"]["Phone"],
-            }
-
-            try:
-                hours = self.parse_hours(place["ExtraData"]["HoursOfOpStruct"])
-                if hours:
-                    properties["opening_hours"] = hours
-            except:
-                pass
-
-            yield Feature(**properties)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Rainbow': 964,
 'atp/brand_wikidata/Q7284708': 964,
 'atp/category/shop/clothes': 964,
 'atp/field/email/missing': 964,
 'atp/field/image/missing': 964,
 'atp/field/operator/missing': 964,
 'atp/field/operator_wikidata/missing': 964,
 'atp/field/postcode/missing': 964,
 'atp/field/twitter/missing': 964,
 'atp/nsi/perfect_match': 964,
 'downloader/request_bytes': 534297,
 'downloader/request_count': 982,
 'downloader/request_method_count/GET': 982,
 'downloader/response_bytes': 12298587,
 'downloader/response_count': 982,
 'downloader/response_status_count/200': 982,
 'elapsed_time_seconds': 6.122563,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 10, 22, 19, 774078, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 982,
 'httpcompression/response_bytes': 45422997,
 'httpcompression/response_count': 982,
 'item_scraped_count': 964,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 150601728,
 'memusage/startup': 150601728,
 'request_depth_max': 2,
 'response_received_count': 982,
 'scheduler/dequeued': 982,
 'scheduler/dequeued/memory': 982,
 'scheduler/enqueued': 982,
 'scheduler/enqueued/memory': 982,
 'start_time': datetime.datetime(2024, 1, 22, 10, 22, 13, 651515, tzinfo=datetime.timezone.utc)}
```