### PR TITLE
[Fitness19US] Add category

### DIFF
--- a/locations/spiders/fitness19_us.py
+++ b/locations/spiders/fitness19_us.py
@@ -2,12 +2,13 @@ import re
 
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class Fitness19USSpider(SitemapSpider, StructuredDataSpider):
     name = "fitness19_us"
-    item_attributes = {"brand": "Fitness 19", "brand_wikidata": "Q121787953"}
+    item_attributes = {"brand": "Fitness 19", "brand_wikidata": "Q121787953", "extras": Categories.GYM.value}
     sitemap_urls = ["https://www.fitness19.com/location-sitemap.xml"]
     wanted_types = ["LocalBusiness"]
 


### PR DESCRIPTION
{'atp/brand/Fitness 19': 76,
 'atp/brand_wikidata/Q121787953': 76,
 'atp/category/leisure/fitness_centre': 76,
 'atp/field/country/from_spider_name': 76,
 'atp/field/email/missing': 76,
 'atp/field/image/dropped': 76,
 'atp/field/image/missing': 76,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 76,
 'atp/field/operator/missing': 76,
 'atp/field/operator_wikidata/missing': 76,
 'atp/field/twitter/missing': 28,
 'atp/nsi/brand_missing': 76,
 'downloader/request_bytes': 32993,
 'downloader/request_count': 78,
 'downloader/request_method_count/GET': 78,
 'downloader/response_bytes': 3461751,
 'downloader/response_count': 78,
 'downloader/response_status_count/200': 78,
 'elapsed_time_seconds': 92.411683,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 10, 33, 39, 624979, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 19116291,
 'httpcompression/response_count': 78,
 'item_scraped_count': 76,
 'log_count/DEBUG': 165,
 'log_count/INFO': 10,
 'memusage/max': 276561920,
 'memusage/startup': 136155136,
 'request_depth_max': 1,
 'response_received_count': 78,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 77,
 'scheduler/dequeued/memory': 77,
 'scheduler/enqueued': 77,
 'scheduler/enqueued/memory': 77,
 'start_time': datetime.datetime(2024, 1, 22, 10, 32, 7, 213296, tzinfo=datetime.timezone.utc)}
