### PR TITLE
[CircleK SE] Add spider

### DIFF
--- a/locations/spiders/circle_k_se.py
+++ b/locations/spiders/circle_k_se.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CircleKSESpider(SitemapSpider, StructuredDataSpider):
+    name = "circle_k_se"
+    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010", "extras": Categories.FUEL_STATION.value}
+    sitemap_urls = ["https://www.circlek.se/stations/sitemap.xml"]
+    sitemap_rules = [("/station/circle-k-", "parse")]
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            entry["loc"] = entry["loc"].replace("172.16.34.158", "www.circlek.se")
+            yield entry
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        extract_google_position(item, response)
+        apply_category(Categories.FUEL_STATION, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 444,
 'atp/brand_wikidata/Q3268010': 444,
 'atp/category/amenity/fuel': 444,
 'atp/field/email/missing': 444,
 'atp/field/image/missing': 444,
 'atp/field/opening_hours/missing': 235,
 'atp/field/operator/missing': 444,
 'atp/field/operator_wikidata/missing': 444,
 'atp/field/state/missing': 444,
 'atp/field/twitter/missing': 444,
 'atp/nsi/category_match': 444,
 'downloader/request_bytes': 170106,
 'downloader/request_count': 446,
 'downloader/request_method_count/GET': 446,
 'downloader/response_bytes': 5371861,
 'downloader/response_count': 446,
 'downloader/response_status_count/200': 446,
 'elapsed_time_seconds': 3.838555,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 11, 47, 15, 620293, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 446,
 'httpcompression/response_bytes': 35499479,
 'httpcompression/response_count': 446,
 'item_scraped_count': 444,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 147337216,
 'memusage/startup': 147337216,
 'request_depth_max': 1,
 'response_received_count': 446,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 445,
 'scheduler/dequeued/memory': 445,
 'scheduler/enqueued': 445,
 'scheduler/enqueued/memory': 445,
 'start_time': datetime.datetime(2024, 1, 22, 11, 47, 11, 781738, tzinfo=datetime.timezone.utc)}
```