### PR TITLE
[BadcockUS] Add spider

### DIFF
--- a/locations/spiders/badcock_us.py
+++ b/locations/spiders/badcock_us.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
+
+
+class BadcockUSSpider(Spider):
+    name = "badcock_us"
+    item_attributes = {"brand": "Badcock", "brand_wikidata": "Q4840663"}
+    start_urls = ["https://www.badcock.com/StoreLocator/GetRemainingShops"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.xpath("//li[@data-shopid]"):
+            item = Feature()
+            item["ref"] = location.xpath("@data-shopid").get()
+            item["website"] = response.urljoin(location.xpath('.//a[@class="shop-link"]/@href').get())
+            item["branch"] = location.xpath(".//@data-shop-title").get()
+            item["lat"] = location.xpath(".//@data-latitude").get()
+            item["lon"] = location.xpath(".//@data-longitude").get()
+            item["street_address"] = location.xpath('.//div[@class="short-description"]/p[1]/text()').get()
+            item["addr_full"] = clean_address(
+                location.xpath('.//div[@class="short-description"]/p[position()<3]/text()').getall()
+            )
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/commit/773e969fb686ef7d82df93699a05f9c116c4b980

```python
{'atp/brand/Badcock': 356,
 'atp/brand_wikidata/Q4840663': 356,
 'atp/category/missing': 356,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/city/missing': 356,
 'atp/field/country/from_spider_name': 356,
 'atp/field/email/missing': 356,
 'atp/field/image/missing': 356,
 'atp/field/name/missing': 356,
 'atp/field/opening_hours/missing': 356,
 'atp/field/operator/missing': 356,
 'atp/field/operator_wikidata/missing': 356,
 'atp/field/phone/missing': 356,
 'atp/field/postcode/missing': 356,
 'atp/field/state/from_reverse_geocoding': 356,
 'atp/field/twitter/missing': 356,
 'atp/nsi/brand_missing': 356,
 'downloader/request_bytes': 692,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 52735,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.538103,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 12, 30, 53, 271779, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 745717,
 'httpcompression/response_count': 2,
 'item_scraped_count': 356,
 'log_count/DEBUG': 370,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 146882560,
 'memusage/startup': 146882560,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 22, 12, 30, 49, 733676, tzinfo=datetime.timezone.utc)}
```