### PR TITLE
[TheBigBiscuitUS] Add category

### DIFF
--- a/locations/spiders/the_big_biscuit_us.py
+++ b/locations/spiders/the_big_biscuit_us.py
@@ -7,7 +7,11 @@ from locations.hours import DAYS, OpeningHours
 
 class TheBigBiscuitUSSpider(Spider):
     name = "the_big_biscuit_us"
-    item_attributes = {"brand": "The Big Biscuit", "brand_wikidata": "Q124125449"}
+    item_attributes = {
+        "brand": "The Big Biscuit",
+        "brand_wikidata": "Q124125449",
+        "extras": {"amenity": "restaurant", "cuisine": "american"},
+    }
     allowed_domains = ["www.bigbiscuit.com"]
     start_urls = ["https://bigbiscuit.com/locations/"]
 


### PR DESCRIPTION
{'atp/brand/The Big Biscuit': 24,
 'atp/brand_wikidata/Q124125449': 24,
 'atp/category/amenity/restaurant': 24,
 'atp/field/city/missing': 24,
 'atp/field/country/from_spider_name': 24,
 'atp/field/email/missing': 24,
 'atp/field/image/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/postcode/missing': 24,
 'atp/field/state/from_reverse_geocoding': 24,
 'atp/field/street_address/missing': 24,
 'atp/field/twitter/missing': 24,
 'atp/nsi/brand_missing': 24,
 'downloader/request_bytes': 610,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 32442,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.61656,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 13, 31, 28, 959018, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 137361,
 'httpcompression/response_count': 2,
 'item_scraped_count': 24,
 'log_count/DEBUG': 37,
 'log_count/INFO': 9,
 'memusage/max': 136069120,
 'memusage/startup': 136069120,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 22, 13, 31, 26, 342458, tzinfo=datetime.timezone.utc)}
