### PR TITLE
[Metro US] Add spider

### DIFF
--- a/locations/spiders/metro_us.py
+++ b/locations/spiders/metro_us.py
@@ -1,0 +1,27 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MetroUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "metro_us"
+    item_attributes = {"brand": "Metro by T-Mobile", "brand_wikidata": "Q1925685"}
+    start_urls = ["https://www.metrobyt-mobile.com/stores/"]
+    rules = [
+        Rule(LinkExtractor(r"com/stores/\w\w/$")),
+        Rule(LinkExtractor(r"com/stores/bd/metro-by-t-mobile-[^/]+-(\d+)/$"), callback="parse_sd"),
+    ]
+    wanted_types = ["Store"]
+
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data["openingHours"] = ld_data.pop("openingHoursSpecification")
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Metro by T-Mobile ")
+        item["street_address"] = (
+            item["street_address"].replace(item["postcode"], "").replace(item["state"], "").strip(" ,")
+        )
+        item.pop("image", None)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Metro by T-Mobile': 6393,
 'atp/brand_wikidata/Q1925685': 6393,
 'atp/category/shop/mobile_phone': 6393,
 'atp/field/email/missing': 6393,
 'atp/field/image/missing': 6393,
 'atp/field/opening_hours/missing': 25,
 'atp/field/operator/missing': 6393,
 'atp/field/operator_wikidata/missing': 6393,
 'atp/field/phone/invalid': 2,
 'atp/field/twitter/missing': 6393,
 'atp/nsi/perfect_match': 6393,
 'downloader/request_bytes': 2620002,
 'downloader/request_count': 6446,
 'downloader/request_method_count/GET': 6446,
 'downloader/response_bytes': 173366762,
 'downloader/response_count': 6446,
 'downloader/response_status_count/200': 6445,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 1739.231421,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 13, 37, 58, 881084, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 6013,
 'httpcache/hit': 433,
 'httpcache/miss': 6013,
 'httpcache/store': 6013,
 'httpcompression/response_bytes': 814054851,
 'httpcompression/response_count': 6445,
 'item_scraped_count': 6393,
 'log_count/INFO': 38,
 'log_count/WARNING': 1,
 'memusage/max': 334458880,
 'memusage/startup': 146993152,
 'request_depth_max': 2,
 'response_received_count': 6445,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6445,
 'scheduler/dequeued/memory': 6445,
 'scheduler/enqueued': 6445,
 'scheduler/enqueued/memory': 6445,
 'start_time': datetime.datetime(2024, 1, 22, 13, 8, 59, 649663, tzinfo=datetime.timezone.utc)}
```