### PR TITLE
[DeutscheTelekomDE] Add spider

### DIFF
--- a/locations/spiders/deutsche_telekom_de.py
+++ b/locations/spiders/deutsche_telekom_de.py
@@ -1,0 +1,48 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import set_closed
+
+
+class DeutscheTelekomDESpider(Spider):
+    name = "deutsche_telekom_de"
+    item_attributes = {"brand": "Deutsche Telekom", "brand_wikidata": "Q9396"}
+
+    def make_request(self, page: int) -> JsonRequest:
+        return JsonRequest(url="https://shopseite.telekom.de/api/shops?_page={}".format(page))
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(1)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            if location["type"] != "tsg":
+                # Seems type = "ivs" are not branded locations.
+                # Also kind = "pa", "tp", "ts"?
+                continue
+
+            item = DictParser.parse(location)
+            item["lat"] = location["address"]["latitude"]
+            item["lon"] = location["address"]["longitude"]
+            item["housenumber"] = location["address"]["street_number"]
+            item["image"] = location["images"]["original"]
+            item["website"] = location["properties"]["store_url"]
+
+            item["opening_hours"] = OpeningHours()
+            for day, times in location["opening_times"]["opening_hours"].items():
+                for time in times:
+                    item["opening_hours"].add_range(day, time[0], time[1])
+
+            item["extras"]["start_date"] = location["properties"]["initial_opening_date"]
+            if location["closed"]:
+                set_closed(item)
+
+            yield item
+
+        paginator = response.json()["meta"]
+        if paginator["current_page"] < paginator["total_pages"]:
+            yield self.make_request(paginator["current_page"] + 1)


### PR DESCRIPTION
```python
{'atp/brand/Deutsche Telekom': 534,
 'atp/brand_wikidata/Q9396': 534,
 'atp/category/missing': 534,
 'atp/closed_poi': 5,
 'atp/field/country/from_spider_name': 534,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 534,
 'atp/field/operator_wikidata/missing': 534,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 534,
 'atp/field/street_address/missing': 534,
 'atp/field/twitter/missing': 534,
 'atp/nsi/match_failed': 534,
 'downloader/request_bytes': 94503,
 'downloader/request_count': 241,
 'downloader/request_method_count/GET': 241,
 'downloader/response_bytes': 661555,
 'downloader/response_count': 241,
 'downloader/response_status_count/200': 240,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 25.398611,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 14, 25, 20, 604316, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 241,
 'httpcompression/response_bytes': 4414895,
 'httpcompression/response_count': 240,
 'item_scraped_count': 534,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 147202048,
 'memusage/startup': 147202048,
 'request_depth_max': 238,
 'response_received_count': 240,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 239,
 'scheduler/dequeued/memory': 239,
 'scheduler/enqueued': 239,
 'scheduler/enqueued/memory': 239,
 'start_time': datetime.datetime(2024, 1, 22, 14, 24, 55, 205705, tzinfo=datetime.timezone.utc)}
```