### PR TITLE
[SparFR] Add spider

### DIFF
--- a/locations/spiders/spar_fr.py
+++ b/locations/spiders/spar_fr.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class SparFRSpider(Spider):
+    name = "spar_fr"
+    item_attributes = {"brand": "Spar", "brand_wikidata": "Q610492"}
+    start_urls = ["https://magasins.spar.fr/api/v3/locations"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["lat"] = location["address"]["latitude"]
+            item["lon"] = location["address"]["longitude"]
+            item["website"] = location["contact"]["url"]
+
+            item["opening_hours"] = OpeningHours()
+            for rule in location["businessHours"]:
+                item["opening_hours"].add_range(
+                    DAYS[rule["startDay"] - 1], rule["openTimeFormat"], rule["closeTimeFormat"]
+                )
+
+            if location["brand"] == "SPAR-Supermarche":
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+            else:
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Spar': 825,
 'atp/brand_wikidata/Q610492': 825,
 'atp/category/shop/convenience': 651,
 'atp/category/shop/supermarket': 174,
 'atp/field/email/missing': 825,
 'atp/field/image/missing': 825,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 825,
 'atp/field/operator_wikidata/missing': 825,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 24,
 'atp/field/state/missing': 825,
 'atp/field/street_address/missing': 825,
 'atp/field/twitter/missing': 825,
 'atp/field/website/invalid': 1,
 'atp/nsi/category_match': 174,
 'atp/nsi/match_failed': 651,
 'downloader/request_bytes': 672,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 206515,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.225565,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 14, 46, 8, 729540, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 2902842,
 'httpcompression/response_count': 2,
 'item_scraped_count': 825,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 147554304,
 'memusage/startup': 147554304,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 22, 14, 46, 7, 503975, tzinfo=datetime.timezone.utc)}
```