### PR TITLE
[Biogroup FR] Add spider

### DIFF
--- a/locations/spiders/biogroup_fr.py
+++ b/locations/spiders/biogroup_fr.py
@@ -1,0 +1,11 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BiogroupFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "biogroup_fr"
+    item_attributes = {"brand": "Biogroup", "brand_wikidata": "Q101559741"}
+    sitemap_urls = ["https://laboratoires.biogroup.fr/robots.txt"]
+    sitemap_rules = [(r"fr/[^/]+/[^/]+/[^/]+$", "parse")]
+    wanted_types = ["MedicalClinic"]


### PR DESCRIPTION
```python
{'atp/brand/Biogroup': 908,
 'atp/brand_wikidata/Q101559741': 908,
 'atp/category/healthcare/laboratory': 908,
 'atp/cdn/cloudflare/response_count': 911,
 'atp/cdn/cloudflare/response_status_count/200': 911,
 'atp/field/city/missing': 907,
 'atp/field/country/from_spider_name': 908,
 'atp/field/email/missing': 12,
 'atp/field/image/missing': 32,
 'atp/field/opening_hours/missing': 373,
 'atp/field/operator/missing': 908,
 'atp/field/operator_wikidata/missing': 908,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 908,
 'atp/nsi/perfect_match': 908,
 'downloader/request_bytes': 515426,
 'downloader/request_count': 911,
 'downloader/request_method_count/GET': 911,
 'downloader/response_bytes': 29036798,
 'downloader/response_count': 911,
 'downloader/response_status_count/200': 911,
 'elapsed_time_seconds': 1103.887477,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 15, 15, 39, 410442, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 902,
 'httpcache/hit': 9,
 'httpcache/miss': 902,
 'httpcache/store': 902,
 'httpcompression/response_bytes': 260504534,
 'httpcompression/response_count': 911,
 'item_scraped_count': 908,
 'log_count/INFO': 28,
 'log_count/WARNING': 1,
 'memusage/max': 305332224,
 'memusage/startup': 147279872,
 'request_depth_max': 2,
 'response_received_count': 911,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 910,
 'scheduler/dequeued/memory': 910,
 'scheduler/enqueued': 910,
 'scheduler/enqueued/memory': 910,
 'start_time': datetime.datetime(2024, 1, 22, 14, 57, 15, 522965, tzinfo=datetime.timezone.utc)}
```