### PR TITLE
[carrefour_es] Created spider for carrefour_es (1765 items)

### DIFF
--- a/locations/spiders/carrefour_es.py
+++ b/locations/spiders/carrefour_es.py
@@ -1,0 +1,64 @@
+import scrapy
+import xmltodict
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.spiders.carrefour_fr import CARREFOUR_EXPRESS, CARREFOUR_MARKET, CARREFOUR_SUPERMARKET
+from locations.spiders.vapestore_gb import clean_address
+
+CARREFOUR_BIO = {
+    "brand": "Carrefour BIO",
+    "brand_wikidata": "Q55221138",
+    "category": Categories.SHOP_SUPERMARKET,
+}
+CARREFOUR_VIAJES = {
+    "brand": "Carrefour Viajes",
+    "brand_wikidata": "Q116483791",
+    "category": Categories.SHOP_TRAVEL_AGENCY,
+}
+
+
+class CarrefourESSpider(scrapy.Spider):
+    name = "carrefour_es"
+    item_attributes = {"brand": "Carrefour", "brand_wikidata": "Q217599"}
+    brands = {
+        "hipermercado": CARREFOUR_SUPERMARKET,
+        "market": CARREFOUR_MARKET,
+        "express": CARREFOUR_EXPRESS,
+        "bio": CARREFOUR_BIO,
+        "agencia de viajes": CARREFOUR_VIAJES,
+    }
+    start_urls = ["https://www.carrefour.es/tiendas-carrefour/buscador-de-tiendas/locations.aspx"]
+    no_refs = True
+
+    def parse(self, response, **kwargs):
+        for store_data in xmltodict.parse(response.text)["markers"]["marker"]:
+            store = {key.removeprefix("@"): value for key, value in store_data.items()}
+            store["street-address"] = clean_address([store.pop("address", ""), store.pop("address2", "")])
+            item = DictParser.parse(store)
+            item["website"] = response.urljoin(store["web"]) if store.get("web") else response.url
+            location_category = store.get("category", "").lower()
+            if "estación de servicio" in location_category:
+                apply_category(Categories.FUEL_STATION, item)
+            else:
+                for brand_key, brand_info in self.brands.items():
+                    if brand_key in location_category:
+                        item["brand"] = brand_info["brand"]
+                        item["brand_wikidata"] = brand_info["brand_wikidata"]
+                        apply_category(brand_info["category"], item)
+                        break
+            if "cepsa" in location_category:
+                item["located_in"] = "Cepsa"
+                item["located_in_wikidata"] = "Q608819"
+            if services := store.get("features", "").lower():
+                apply_yes_no(Extras.ATM, item, "cajeros automáticos" in services)
+                apply_yes_no(Extras.WIFI, item, "wifi gratis" in services)
+                apply_yes_no(Extras.DELIVERY, item, "entrega a domicilio" in services)
+                apply_yes_no(Extras.DRIVE_THROUGH, item, "carrefour drive" in services)
+                apply_yes_no(Extras.SELF_CHECKOUT, item, "cajas de autopago" in services)
+                apply_yes_no(Extras.CAR_WASH, item, "lavado de coches" in services)
+                apply_yes_no(Extras.BABY_CHANGING_TABLE, item, "cambiador de bebé" in services)
+                apply_yes_no("amenity:parking", item, "aparcamiento" in services)
+                # TODO: more services
+
+            yield item


### PR DESCRIPTION
Getting benefit of Sitemap-StructuredData combination doesn't look feasible here, as it require about 1 minute of download_delay (mentioned in robots.txt file) between two requests, any value less than that will result in loss of POI pages, because server sends captcha page. (Keeping in mind we have more than 1700 POIs.)

<details><summary>Stats</summary>

```python
{'atp/brand/Carrefour': 367,
 'atp/brand/Carrefour BIO': 2,
 'atp/brand/Carrefour Express': 1053,
 'atp/brand/Carrefour Market': 152,
 'atp/brand/Carrefour Viajes': 193,
 'atp/brand_wikidata/Q116483791': 193,
 'atp/brand_wikidata/Q217599': 367,
 'atp/brand_wikidata/Q2689639': 152,
 'atp/brand_wikidata/Q2940190': 1053,
 'atp/brand_wikidata/Q55221138': 2,
 'atp/category/amenity/fuel': 147,
 'atp/category/shop/convenience': 1053,
 'atp/category/shop/supermarket': 374,
 'atp/category/shop/travel_agency': 193,
 'atp/field/email/missing': 1767,
 'atp/field/image/missing': 1767,
 'atp/field/opening_hours/missing': 1767,
 'atp/field/operator/missing': 1767,
 'atp/field/operator_wikidata/missing': 1767,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 11,
 'atp/field/twitter/missing': 1767,
 'atp/nsi/brand_missing': 195,
 'atp/nsi/category_match': 519,
 'atp/nsi/perfect_match': 1053,
 'downloader/request_bytes': 899,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 149350,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 10.420511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 22, 17, 6, 54, 843467, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 936746,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1767,
 'log_count/DEBUG': 1788,
 'log_count/INFO': 9,
 'memusage/max': 138190848,
 'memusage/startup': 138190848,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 22, 17, 6, 44, 422956, tzinfo=datetime.timezone.utc)}
```
</details>