### PR TITLE
new command to show spiders sharing hard coded wikidata information

### DIFF
--- a/locations/commands/duplicate_wikidata.py
+++ b/locations/commands/duplicate_wikidata.py
@@ -1,0 +1,56 @@
+import logging
+import os
+import re
+import sys
+
+from scrapy.commands import ScrapyCommand
+
+from locations.exporters.geojson import find_spider_class
+
+logger = logging.getLogger(__name__)
+
+
+class DuplicateWikidataCommand(ScrapyCommand):
+    """
+    Look for the same wikidata code appearing in multiple spider files. In many cases
+    this provides the nudge for the attribute value to be shared between spiders
+    where the duplication is very simple i.e. the same brand in multiple countries
+    (e.g. vodafone_de and vodafone_it).
+    """
+
+    requires_project = True
+    default_settings = {"LOG_ENABLED": True}
+
+    def short_desc(self):
+        return "Look for wikidata code duplication across spiders"
+
+    def add_options(self, parser):
+        ScrapyCommand.add_options(self, parser)
+
+    @staticmethod
+    def spider_properties(name):
+        spider = find_spider_class(name)
+        filename = sys.modules[spider.__module__].__file__
+        filename = filename.replace(".pyc", ".py")
+        filename = os.path.relpath(filename)
+        wikidata_codes = set()
+        with open(filename) as f:
+            for line in f.readlines():
+                codes = re.findall("[\"|'](Q[0-9]*)[\"|']", line)
+                for code in codes:
+                    wikidata_codes.add(code)
+        return {"name": name, "filename": filename, "wikidata_codes": wikidata_codes}
+
+    def run(self, args, opts):
+        codes = dict()
+        for spider_name in self.crawler_process.spider_loader.list():
+            props = self.spider_properties(spider_name)
+            for code in props["wikidata_codes"]:
+                code_spiders = codes.get(code, set())
+                code_spiders.add(props["filename"])
+                codes[code] = code_spiders
+
+        # Now look for wikidata codes appearing in multiple spiders.
+        for code, code_spiders in codes.items():
+            if len(code_spiders) > 1:
+                logger.info("%s -> %s", code, code_spiders)

--- a/locations/spiders/vodafone_de.py
+++ b/locations/spiders/vodafone_de.py
@@ -5,13 +5,12 @@ import scrapy
 from locations.hours import OpeningHours
 from locations.items import Feature
 
+VODAFONE_SHARED_ATTRIBUTES = {"brand": "Vodafone", "brand_wikidata": "Q122141"}
+
 
 class VodafoneDeSpider(scrapy.Spider):
     name = "vodafone_de"
-    item_attributes = {
-        "brand": "Vodafone",
-        "brand_wikidata": "Q122141",
-    }
+    item_attributes = VODAFONE_SHARED_ATTRIBUTES
     allowed_domains = ["vodafone.de"]
     start_urls = ["https://shops.vodafone.de"]
 

--- a/locations/spiders/vodafone_es.py
+++ b/locations/spiders/vodafone_es.py
@@ -1,16 +1,13 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.spiders.vodafone_de import VODAFONE_SHARED_ATTRIBUTES
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class VodafoneEsSpider(SitemapSpider, StructuredDataSpider):
     name = "vodafone_es"
-    item_attributes = {
-        "brand": "Vodafone",
-        "brand_wikidata": "Q122141",
-    }
+    item_attributes = VODAFONE_SHARED_ATTRIBUTES
     allowed_domains = ["vodafone.es"]
     sitemap_urls = ["https://tiendas.vodafone.es/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/tiendas.vodafone.es\/tiendas\/.+\/.+\/.+", "parse_sd")]
-
     wanted_types = ["MobilePhoneStore"]

--- a/locations/spiders/vodafone_it.py
+++ b/locations/spiders/vodafone_it.py
@@ -1,8 +1,9 @@
+from locations.spiders.vodafone_de import VODAFONE_SHARED_ATTRIBUTES
 from locations.storefinders.yext import YextSpider
 
 
 class VodafoneITSpider(YextSpider):
     name = "vodafone_it"
-    item_attributes = {"brand": "Vodafone", "brand_wikidata": "Q122141"}
+    item_attributes = VODAFONE_SHARED_ATTRIBUTES
     api_key = "07377ddb3ff87208d4fb4d14fed7c6ff"
     api_version = "20220511"


### PR DESCRIPTION
Command can give some insight into the relationship between spiders and their wikidata codes. It can help us move towards being a little more DRY where it makes sense. For example in the proposed tidy up to the vodafone_* spiders. Where the relationship is more more complex e.g.

```
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q25172225 -> {'locations/spiders/tesco_gb.py', 'locations/spiders/visionexpress_gb.py'}
```

.. I would not propose sharing the definition at present.

Full output at present:

```
2024-01-22 18:00:44 [scrapy.utils.log] INFO: Scrapy 2.11.0 started (bot: locations)
2024-01-22 18:00:44 [scrapy.utils.log] INFO: Versions: lxml 5.0.0.0, libxml2 2.12.3, cssselect 1.2.0, parsel 1.8.1, w3lib 2.1.2, Twisted 22.10.0, Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0], pyOpenSSL 23.3.0 (OpenSSL 3.1.4 24 Oct 2023), cryptography 41.0.7, Platform Linux-5.15.0-91-generic-x86_64-with-glibc2.35
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q688755 -> {'locations/spiders/a1_at.py', 'locations/spiders/a1_hr.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q920166 -> {'locations/spiders/ibis_nl.py', 'locations/spiders/accor.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2470307 -> {'locations/spiders/guess_au.py', 'locations/spiders/aje.py', 'locations/spiders/guess.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q41171373 -> {'locations/spiders/aldi_nord_be.py', 'locations/spiders/aldi_nord_pt.py', 'locations/spiders/aldi_nord_dk.py', 'locations/spiders/aldi_nord_de.py', 'locations/spiders/aldi_nord_es.py', 'locations/spiders/aldi_nord_nl.py', 'locations/spiders/aldi_nord_fr.py', 'locations/spiders/aldi_nord_lu.py', 'locations/spiders/aldi_nord_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q41171672 -> {'locations/spiders/aldi_sud_cn.py', 'locations/spiders/aldi_sud_de.py', 'locations/spiders/aldi_sud_au.py', 'locations/spiders/aldi_sud_it.py', 'locations/spiders/aldi_sud_hu.py', 'locations/spiders/aldi_sud_gb.py', 'locations/spiders/aldi_sud_us.py', 'locations/spiders/aldi_sud_ch.py', 'locations/spiders/aldi_sud_ie.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q876811 -> {'locations/spiders/alnatura_de.py', 'locations/spiders/migros_ch.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q4773903 -> {'locations/spiders/anthropologie.py', 'locations/spiders/urbn.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q7178908 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/applegreen.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q297410 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/asda_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q4805437 -> {'locations/spiders/ashley_homestore.py', 'locations/spiders/ashley_furniture.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q327247 -> {'locations/spiders/asics_us.py', 'locations/spiders/asics_eu.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q23317 -> {'locations/spiders/audi.py', 'locations/spiders/audi_be.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q246655 -> {'locations/spiders/bash_za.py', 'locations/spiders/next.py', 'locations/spiders/tui_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1484081 -> {'locations/spiders/bash_za.py', 'locations/spiders/g_star_raw.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q584601 -> {'locations/spiders/baskin_robbins_ca.py', 'locations/spiders/baskin_robbins_in.py', 'locations/spiders/baskin_robbins_gb_ie_je.py', 'locations/spiders/baskin_robbins_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q810773 -> {'locations/spiders/bathandbodyworks_us.py', 'locations/spiders/bathandbodyworks.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q116232 -> {'locations/spiders/bmw_group.py', 'locations/spiders/mini_be.py', 'locations/spiders/mini_se.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q117744569 -> {'locations/spiders/bnp_paribas_bank_pl.py', 'locations/spiders/credit_agricole_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5412010 -> {'locations/spiders/bnp_paribas_bank_pl.py', 'locations/spiders/credit_agricole_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q6123139 -> {'locations/spiders/boots.py', 'locations/spiders/boots_no.py', 'locations/spiders/boots_th.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q152057 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/bp.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q565734 -> {'locations/spiders/bp.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q177054 -> {'locations/spiders/burger_king_it.py', 'locations/spiders/burger_king_es_pt.py', 'locations/spiders/burger_king.py', 'locations/spiders/burger_king_ru.py', 'locations/spiders/burger_king_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5928422 -> {'locations/spiders/caffe_nero.py', 'locations/spiders/game.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q675808 -> {'locations/spiders/caffe_nero.py', 'locations/spiders/caffe_nero_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q117156437 -> {'locations/spiders/carpet_court_au.py', 'locations/spiders/carpet_court_nz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2689639 -> {'locations/spiders/carrefour_fr.py', 'locations/spiders/carrefour_tw.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2948688 -> {'locations/spiders/champion.py', 'locations/spiders/champion_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5096393 -> {'locations/spiders/chicos_offtherack.py', 'locations/spiders/chicos.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q110127908 -> {'locations/spiders/salad_and_go_us.py', 'locations/spiders/childcare_network_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q117155570 -> {'locations/spiders/choices_flooring_nz.py', 'locations/spiders/choices_flooring_au.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q3268010 -> {'locations/spiders/circle_k_se.py', 'locations/spiders/circle_k_vn.py', 'locations/spiders/circle_k.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q727697 -> {'locations/spiders/coach_us.py', 'locations/spiders/coach_ca.py', 'locations/spiders/coach_au_nz.py', 'locations/spiders/coach.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q3277439 -> {'locations/spiders/coop_food_gb.py', 'locations/spiders/the_cooperative_group.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q64411347 -> {'locations/spiders/coopers_hawk.py', 'locations/spiders/old_chicago_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q686643 -> {'locations/spiders/cora_be.py', 'locations/spiders/cora_fr.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q608845 -> {'locations/spiders/costa_coffee_gg_gb_im_je.py', 'locations/spiders/costacoffee_pl.py', 'locations/spiders/costa_coffee.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q113556385 -> {'locations/spiders/costa_coffee_gg_gb_im_je.py', 'locations/spiders/costa_coffee.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q590952 -> {'locations/spiders/credit_agricole.py', 'locations/spiders/credit_agricole_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q926699 -> {'locations/spiders/crocs_es.py', 'locations/spiders/crocs_eu.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1143685 -> {'locations/spiders/cumberland_farms.py', 'locations/spiders/eg_america_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q489815 -> {'locations/spiders/dhl_express_de.py', 'locations/spiders/dhl_express_us_ca.py', 'locations/spiders/dhl_express_gb.py', 'locations/spiders/dhl_express_fr.py', 'locations/spiders/dhl_express_es.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q62390177 -> {'locations/spiders/edeka_de.py', 'locations/spiders/diska_de.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q839466 -> {'locations/spiders/dominos_pizza_au.py', 'locations/spiders/dominos_pizza_fr.py', 'locations/spiders/dominos_pizza_mx.py', 'locations/spiders/dominos_pizza.py', 'locations/spiders/dominos_pizza_jp.py', 'locations/spiders/dominos_pizza_nl.py', 'locations/spiders/dominos_pizza_be.py', 'locations/spiders/dominos_pizza_in.py', 'locations/spiders/dominos_pizza_gb.py', 'locations/spiders/dominos_pizza_de.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q847743 -> {'locations/spiders/dunkin_de.py', 'locations/spiders/dunkin_be_nl.py', 'locations/spiders/dunkin_ch.py', 'locations/spiders/dunkin_us.py', 'locations/spiders/dunkin_at.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q120669167 -> {'locations/spiders/dusk_nz.py', 'locations/spiders/dusk_au.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5329759 -> {'locations/spiders/lincolnshire_cooperative.py', 'locations/spiders/east_of_england_coop.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q117324848 -> {'locations/spiders/eg_america_us.py', 'locations/spiders/fastrac_cafe_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q3060668 -> {'locations/spiders/euromaster_fr.py', 'locations/spiders/euromaster_nl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q867662 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/exxonmobil.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q8 -> {'locations/spiders/f24.py', 'locations/spiders/q8.py', 'locations/spiders/q8_italia.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1634762 -> {'locations/spiders/f24.py', 'locations/spiders/q8.py', 'locations/spiders/q8_italia.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5430910 -> {'locations/spiders/fairway_market.py', 'locations/spiders/fairway_market_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q938615 -> {'locations/spiders/ford.py', 'locations/spiders/mercedes_benz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q44294 -> {'locations/spiders/ford.py', 'locations/spiders/ford_dealers_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1060537 -> {'locations/spiders/forever21_ca.py', 'locations/spiders/forever21_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1493667 -> {'locations/spiders/gant.py', 'locations/spiders/gant_au.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q620875 -> {'locations/spiders/goodyear_autocare_au_nz.py', 'locations/spiders/goodyear_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q99891702 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/gov_mot_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q152096 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/sainsburys.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q110716465 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/total_energies.py', 'locations/spiders/shell.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q487494 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/tesco_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q922344 -> {'locations/spiders/gov_cma_fuel_gb.py', 'locations/spiders/morrisons_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1419438 -> {'locations/spiders/great_western_railway_gb.py', 'locations/spiders/national_rail_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5564162 -> {'locations/spiders/greene_king_pubs_gb.py', 'locations/spiders/greene_king_inns_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5617505 -> {'locations/spiders/gulf_pr_us.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5628558 -> {'locations/spiders/signet_jewelers.py', 'locations/spiders/h_samuel_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q7140896 -> {'locations/spiders/halloweencity.py', 'locations/spiders/party_city.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q188326 -> {'locations/spiders/hm_nl.py', 'locations/spiders/hm.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q15815751 -> {'locations/spiders/hofer_at.py', 'locations/spiders/hofer_si.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q864407 -> {'locations/spiders/homedepot.py', 'locations/spiders/homedepot_ca.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5887941 -> {'locations/spiders/homegoods.py', 'locations/spiders/tjx.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q16844433 -> {'locations/spiders/homesense.py', 'locations/spiders/tjx.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q151954 -> {'locations/spiders/ich_tanke_strom.py', 'locations/spiders/lidl_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q478214 -> {'locations/spiders/ich_tanke_strom.py', 'locations/spiders/tesla.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q17089620 -> {'locations/spiders/ich_tanke_strom.py', 'locations/spiders/tesla.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q666888 -> {'locations/spiders/intersport_nl.py', 'locations/spiders/intersport_au.py', 'locations/spiders/intersport_se.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q6375797 -> {'locations/spiders/kate_spade.py', 'locations/spiders/kate_spade_au_nz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q524757 -> {'locations/spiders/kfc_ph.py', 'locations/spiders/kfc.py', 'locations/spiders/kfc_amrest.py', 'locations/spiders/kfc_au.py', 'locations/spiders/kfc_jp.py', 'locations/spiders/kfc_ca.py', 'locations/spiders/kfc_my.py', 'locations/spiders/kfc_nz.py', 'locations/spiders/kfc_sg.py', 'locations/spiders/kfc_ru.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q3196447 -> {'locations/spiders/kiehls_de.py', 'locations/spiders/kiehls_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1783759 -> {'locations/spiders/kookai_nz.py', 'locations/spiders/kookai_au.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q493751 -> {'locations/spiders/kpmg.py', 'locations/spiders/kpmg_fr.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q629269 -> {'locations/spiders/lenscrafters.py', 'locations/spiders/macys.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q889624 -> {'locations/spiders/leroy_merlin_pl.py', 'locations/spiders/leroy_merlin.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q111764460 -> {'locations/spiders/lilly_gr.py', 'locations/spiders/lilly_bg.py', 'locations/spiders/lilly_rs.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q7300856 -> {'locations/spiders/real_canadian_superstore.py', 'locations/spiders/loblaws.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1869471 -> {'locations/spiders/longchamp.py', 'locations/spiders/longchamp_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q782200 -> {'locations/spiders/marriott_hotels.py', 'locations/spiders/ritzcarlton.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q513977 -> {'locations/spiders/match_fr.py', 'locations/spiders/match_be.py', 'locations/spiders/match_lu.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2381223 -> {'locations/spiders/mediamarkt_be.py', 'locations/spiders/mediamarkt.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q156490 -> {'locations/spiders/smart.py', 'locations/spiders/mercedes_benz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q104870732 -> {'locations/spiders/metro_diner_us.py', 'locations/spiders/metrodiner.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q300518 -> {'locations/spiders/migros_ch.py', 'locations/spiders/obi_de.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q549181 -> {'locations/spiders/mol.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1587563 -> {'locations/spiders/mol.py', 'locations/spiders/total_energies.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q3472954 -> {'locations/spiders/nandos_om.py', 'locations/spiders/nandos_my.py', 'locations/spiders/nandos_pk.py', 'locations/spiders/nandos_sg.py', 'locations/spiders/nandos_bh.py', 'locations/spiders/nandos_qa.py', 'locations/spiders/nandos_zw.py', 'locations/spiders/nandos_zm.py', 'locations/spiders/nandos.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q18356161 -> {'locations/spiders/national_rail_gb.py', 'locations/spiders/scotrail_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1696490 -> {'locations/spiders/southeastern_railway_gb.py', 'locations/spiders/national_rail_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q85789775 -> {'locations/spiders/national_rail_gb.py', 'locations/spiders/northern_railway_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q104878180 -> {'locations/spiders/national_rail_gb.py', 'locations/spiders/transport_for_wales_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q332477 -> {'locations/spiders/next.py', 'locations/spiders/victoriassecret.py', 'locations/spiders/victoriassecret_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q20716793 -> {'locations/spiders/next.py', 'locations/spiders/victoriassecret_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q120669012 -> {'locations/spiders/novo_au.py', 'locations/spiders/novo_nz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q168238 -> {'locations/spiders/total_energies.py', 'locations/spiders/omv.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2759586 -> {'locations/spiders/papa_johns.py', 'locations/spiders/papa_johns_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q6742 -> {'locations/spiders/peugeot_se.py', 'locations/spiders/peugeot_nl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q191615 -> {'locations/spiders/pizza_hut_amrest.py', 'locations/spiders/pizza_hut_us.py', 'locations/spiders/pizza_hut_gb.py', 'locations/spiders/pizza_hut_be.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q137023 -> {'locations/spiders/primark_gb.py', 'locations/spiders/primark.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1806948 -> {'locations/spiders/q8.py', 'locations/spiders/q8_italia.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q965845 -> {'locations/spiders/remax_es.py', 'locations/spiders/remax_de.py', 'locations/spiders/remax_fr.py', 'locations/spiders/remax_gb.py', 'locations/spiders/remax_it.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q174747 -> {'locations/spiders/repsol_mx.py', 'locations/spiders/repsol_es.py', 'locations/spiders/repsol_pt.py', 'locations/spiders/repsol_pe.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q316004 -> {'locations/spiders/rossmann_pl.py', 'locations/spiders/rossmann_de.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q1972120 -> {'locations/spiders/sams_club_mx.py', 'locations/spiders/sams_club.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q69926963 -> {'locations/spiders/sears_hometown.py', 'locations/spiders/sears.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q188217 -> {'locations/spiders/seat_de.py', 'locations/spiders/seat_es.py', 'locations/spiders/seat_gb.py', 'locations/spiders/seat_fr.py', 'locations/spiders/seat_it.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q2408041 -> {'locations/spiders/sephora_br.py', 'locations/spiders/sephora_mx.py', 'locations/spiders/sephora_us_ca.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q259340 -> {'locations/spiders/seven_eleven_ca.py', 'locations/spiders/seven_eleven_se.py', 'locations/spiders/seven_eleven_au.py', 'locations/spiders/seven_eleven_us.py', 'locations/spiders/seven_eleven_dk.py', 'locations/spiders/seven_eleven_mx.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q7511598 -> {'locations/spiders/sierra.py', 'locations/spiders/tjx.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q5185959 -> {'locations/spiders/smatch_be.py', 'locations/spiders/smatch_lu.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q610492 -> {'locations/spiders/spar_gb.py', 'locations/spiders/spar_northern_ireland_gb.py', 'locations/spiders/spar_nl.py', 'locations/spiders/spar_fr.py', 'locations/spiders/spar_no.py', 'locations/spiders/spar_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q12309283 -> {'locations/spiders/spar_northern_ireland_gb.py', 'locations/spiders/spar_pl.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q6938433 -> {'locations/spiders/stadt_zuerich_ch.py', 'locations/spiders/winterthur_ch.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q37158 -> {'locations/spiders/starbucks_eu.py', 'locations/spiders/starbucks_au.py', 'locations/spiders/starbucks.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q244457 -> {'locations/spiders/subway_tw.py', 'locations/spiders/subway.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q136311 -> {'locations/spiders/sunglass_hut_1.py', 'locations/spiders/sunglass_hut_2.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q611115 -> {'locations/spiders/swarovski_eu.py', 'locations/spiders/swarovski_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q752941 -> {'locations/spiders/tacobell.py', 'locations/spiders/taco_bell_au.py', 'locations/spiders/taco_bell_fi.py', 'locations/spiders/taco_bell_in.py', 'locations/spiders/taco_bell_es.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q7673969 -> {'locations/spiders/taco_time.py', 'locations/spiders/taco_time_ca.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q919641 -> {'locations/spiders/tcc_us.py', 'locations/spiders/verizon_us.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q25172225 -> {'locations/spiders/tesco_gb.py', 'locations/spiders/visionexpress_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q152784 -> {'locations/spiders/the_north_face_au_nz.py', 'locations/spiders/the_north_face_eu.py', 'locations/spiders/the_north_face.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q175106 -> {'locations/spiders/tim_hortons.py', 'locations/spiders/tim_hortons_gb.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q634881 -> {'locations/spiders/tommy_hilfiger.py', 'locations/spiders/tommy_hilfiger_au_nz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q53268 -> {'locations/spiders/toyota_us.py', 'locations/spiders/toyota_eu.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q95923071 -> {'locations/spiders/toyworld_au.py', 'locations/spiders/toyworld_nz.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q668687 -> {'locations/spiders/usps_collection_boxes.py', 'locations/spiders/usps.py'}
2024-01-22 18:01:39 [locations.commands.duplicate_wikidata] INFO: Q483551 -> {'locations/spiders/walmart_us.py', 'locations/spiders/walmart_ca.py'}
```