### PR TITLE
[Circle K PL] Add spider

### DIFF
--- a/locations/spiders/circle_k_pl.py
+++ b/locations/spiders/circle_k_pl.py
@@ -5,16 +5,10 @@ from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKSESpider(SitemapSpider, StructuredDataSpider):
-    name = "circle_k_se"
+class CircleKPLSpider(SitemapSpider, StructuredDataSpider):
+    name = "circle_k_pl"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
-    sitemap_urls = ["https://www.circlek.se/stations/sitemap.xml"]
-    sitemap_rules = [("/station/circle-k-", "parse")]
-
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            entry["loc"] = entry["loc"].replace("172.16.34.158", "www.circlek.se")
-            yield entry
+    sitemap_urls = ["https://www.circlek.pl/stations/sitemap.xml"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         extract_google_position(item, response)


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 409,
 'atp/brand_wikidata/Q3268010': 409,
 'atp/category/amenity/fuel': 409,
 'atp/field/email/missing': 409,
 'atp/field/image/missing': 409,
 'atp/field/opening_hours/missing': 386,
 'atp/field/operator/missing': 409,
 'atp/field/operator_wikidata/missing': 409,
 'atp/field/phone/missing': 54,
 'atp/field/state/missing': 409,
 'atp/field/twitter/missing': 409,
 'atp/nsi/category_match': 409,
 'downloader/request_bytes': 157731,
 'downloader/request_count': 411,
 'downloader/request_method_count/GET': 411,
 'downloader/response_bytes': 4601272,
 'downloader/response_count': 411,
 'downloader/response_status_count/200': 411,
 'elapsed_time_seconds': 509.172883,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 23, 10, 20, 8, 41367, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 411,
 'httpcache/miss': 411,
 'httpcache/store': 411,
 'httpcompression/response_bytes': 27459847,
 'httpcompression/response_count': 411,
 'item_scraped_count': 409,
 'log_count/DEBUG': 832,
 'log_count/INFO': 18,
 'log_count/WARNING': 1,
 'memusage/max': 271917056,
 'memusage/startup': 147361792,
 'request_depth_max': 1,
 'response_received_count': 411,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 410,
 'scheduler/dequeued/memory': 410,
 'scheduler/enqueued': 410,
 'scheduler/enqueued/memory': 410,
 'start_time': datetime.datetime(2024, 1, 23, 10, 11, 38, 868484, tzinfo=datetime.timezone.utc)}
```