### PR TITLE
[Circle K NO] Add spider

### DIFF
--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CircleKNOSpider(SitemapSpider, StructuredDataSpider):
+    name = "circle_k_no"
+    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
+    sitemap_urls = ["https://www.circlek.no/stations/sitemap.xml"]
+    sitemap_rules = [("/station/circle-k-", "parse")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        extract_google_position(item, response)
+        apply_category(Categories.FUEL_STATION, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 462,
 'atp/brand_wikidata/Q3268010': 462,
 'atp/category/amenity/fuel': 462,
 'atp/field/email/missing': 462,
 'atp/field/image/missing': 462,
 'atp/field/opening_hours/missing': 283,
 'atp/field/operator/missing': 462,
 'atp/field/operator_wikidata/missing': 462,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 462,
 'atp/field/twitter/missing': 462,
 'atp/nsi/category_match': 462,
 'downloader/request_bytes': 303670,
 'downloader/request_count': 464,
 'downloader/request_method_count/GET': 464,
 'downloader/response_bytes': 5595718,
 'downloader/response_count': 464,
 'downloader/response_status_count/200': 464,
 'elapsed_time_seconds': 558.655768,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 23, 10, 36, 53, 527597, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 464,
 'httpcache/miss': 464,
 'httpcache/store': 464,
 'httpcompression/response_bytes': 35752321,
 'httpcompression/response_count': 464,
 'item_scraped_count': 462,
 'log_count/DEBUG': 938,
 'log_count/INFO': 19,
 'log_count/WARNING': 1,
 'memusage/max': 280399872,
 'memusage/startup': 149688320,
 'request_depth_max': 1,
 'response_received_count': 464,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 463,
 'scheduler/dequeued/memory': 463,
 'scheduler/enqueued': 463,
 'scheduler/enqueued/memory': 463,
 'start_time': datetime.datetime(2024, 1, 23, 10, 27, 34, 871829, tzinfo=datetime.timezone.utc)}
```