### PR TITLE
[subway_kr] Created spider for Subway in KR (580 items)

### DIFF
--- a/locations/spiders/subway_kr.py
+++ b/locations/spiders/subway_kr.py
@@ -21,7 +21,7 @@ class Subwaykrpider(scrapy.Spider):
 
     def parse(self, response: Response, **kwargs):
         links = self.link_extractor.extract_links(response)
-        if len(links) == 1:
+        if len(links) == 0:
             return
         else:
             next_page = response.meta["page"] + 1

--- a/locations/spiders/subway_kr.py
+++ b/locations/spiders/subway_kr.py
@@ -1,0 +1,43 @@
+import chompjs
+import scrapy
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+
+from locations.dict_parser import DictParser
+from locations.spiders.subway import SubwaySpider
+from locations.spiders.vapestore_gb import clean_address
+
+
+class Subwaykrpider(scrapy.Spider):
+    name = "subway_kr"
+    item_attributes = SubwaySpider.item_attributes
+    link_extractor = LinkExtractor(allow="/storeDetail?")
+
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self):
+        yield Request("https://www.subway.co.kr/storeSearch?page=1", meta={"page": 1})
+
+    def parse(self, response: Response, **kwargs):
+        links = self.link_extractor.extract_links(response)
+        if len(links) == 1:
+            return
+        else:
+            next_page = response.meta["page"] + 1
+            yield Request(f"https://www.subway.co.kr/storeSearch?page={next_page}", meta={"page": next_page})
+
+            for link in links:
+                yield Request(link.url, callback=self.parse_store)
+
+    def parse_store(self, response, **kwargs):
+        data = chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "var storeInfo")]/text()').re_first(r"var storeInfo = (\{.*\});")
+        )
+        data.update(data.pop("franchiseDetail"))
+        item = DictParser.parse(data)
+        item["name"] = data.get("storNm")
+        item["addr_full"] = clean_address(",".join([data.get("storAddr1"), data.get("storAddr2")]))
+        item["phone"] = data.get("storTel")
+        item["ref"] = item["website"] = response.url
+        yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Subway': 580,
 'atp/brand_wikidata/Q244457': 580,
 'atp/category/amenity/fast_food': 580,
 'atp/field/city/missing': 580,
 'atp/field/country/from_spider_name': 580,
 'atp/field/email/missing': 580,
 'atp/field/image/missing': 580,
 'atp/field/lat/missing': 11,
 'atp/field/lon/missing': 11,
 'atp/field/opening_hours/missing': 580,
 'atp/field/operator/missing': 580,
 'atp/field/operator_wikidata/missing': 580,
 'atp/field/phone/invalid': 9,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 580,
 'atp/field/state/missing': 580,
 'atp/field/street_address/missing': 580,
 'atp/field/twitter/missing': 580,
 'atp/geometry/null_island': 8,
 'atp/nsi/cc_match': 580,
 'downloader/request_bytes': 400317,
 'downloader/request_count': 639,
 'downloader/request_method_count/GET': 639,
 'downloader/response_bytes': 14649153,
 'downloader/response_count': 639,
 'downloader/response_status_count/200': 639,
 'elapsed_time_seconds': 778.419245,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 23, 12, 38, 38, 142166, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 580,
 'log_count/INFO': 21,
 'memusage/max': 275660800,
 'memusage/startup': 137785344,
 'request_depth_max': 58,
 'response_received_count': 639,
 'scheduler/dequeued': 639,
 'scheduler/dequeued/memory': 639,
 'scheduler/enqueued': 639,
 'scheduler/enqueued/memory': 639,
 'start_time': datetime.datetime(2024, 1, 23, 12, 25, 39, 722921, tzinfo=datetime.timezone.utc)}
```
</details>