### PR TITLE
[ShoeCarnival US] Add spider

### DIFF
--- a/locations/spiders/shoe_carnival_us.py
+++ b/locations/spiders/shoe_carnival_us.py
@@ -1,0 +1,16 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ShoeCarnivalUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "shoe_carnival_us"
+    item_attributes = {"brand": "Shoe Carnival", "brand_wikidata": "Q7500007"}
+    sitemap_urls = ["https://stores.shoecarnival.com/robots.txt"]
+    sitemap_rules = [(r"com/\w\w/[^/]+/shoe-store-.+-(\d+)\.html$", "parse")]
+    wanted_types = ["ShoeStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("name")
+        item["branch"] = response.xpath('//span[@class="loc-name"]/a/text()').get()
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Shoe Carnival': 373,
 'atp/brand_wikidata/Q7500007': 373,
 'atp/category/shop/shoes': 373,
 'atp/field/country/from_spider_name': 373,
 'atp/field/email/missing': 373,
 'atp/field/operator/missing': 373,
 'atp/field/operator_wikidata/missing': 373,
 'atp/nsi/perfect_match': 373,
 'downloader/request_bytes': 156444,
 'downloader/request_count': 378,
 'downloader/request_method_count/GET': 378,
 'downloader/response_bytes': 14258401,
 'downloader/response_count': 378,
 'downloader/response_status_count/200': 378,
 'elapsed_time_seconds': 350.461103,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 23, 14, 0, 29, 313924, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 290,
 'httpcache/hit': 88,
 'httpcache/miss': 290,
 'httpcache/store': 290,
 'httpcompression/response_bytes': 86382745,
 'httpcompression/response_count': 376,
 'item_scraped_count': 373,
 'log_count/INFO': 15,
 'log_count/WARNING': 1,
 'memusage/max': 336474112,
 'memusage/startup': 147546112,
 'request_depth_max': 3,
 'response_received_count': 378,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 377,
 'scheduler/dequeued/memory': 377,
 'scheduler/enqueued': 377,
 'scheduler/enqueued/memory': 377,
 'start_time': datetime.datetime(2024, 1, 23, 13, 54, 38, 852821, tzinfo=datetime.timezone.utc)}
```