### PR TITLE
[Kinki NL] Add spider

### DIFF
--- a/locations/spiders/kinki_nl.py
+++ b/locations/spiders/kinki_nl.py
@@ -1,0 +1,16 @@
+from urllib.parse import urljoin
+
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class KinkiNLSpider(WPStoreLocatorSpider):
+    name = "kinki_nl"
+    item_attributes = {"brand": "Kinki Kappers", "brand_wikidata": "Q124152910"}
+    allowed_domains = ["www.kinki.nl"]
+
+    def parse_item(self, item: Feature, location: dict, **kwargs):
+        item["addr_full"] = None
+        item["branch"] = item.pop("name")
+        item["website"] = urljoin("https://www.kinki.nl/", location["url"])
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9185
```python
{'atp/brand/Kinki Kappers': 41,
 'atp/brand_wikidata/Q124152910': 41,
 'atp/category/missing': 41,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_spider_name': 41,
 'atp/field/email/missing': 41,
 'atp/field/image/missing': 41,
 'atp/field/name/missing': 41,
 'atp/field/opening_hours/missing': 41,
 'atp/field/operator/missing': 41,
 'atp/field/operator_wikidata/missing': 41,
 'atp/field/state/missing': 41,
 'atp/field/twitter/missing': 41,
 'atp/nsi/brand_missing': 41,
 'downloader/request_bytes': 722,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5229,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.299749,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 23, 15, 56, 31, 13004, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 20252,
 'httpcompression/response_count': 2,
 'item_scraped_count': 41,
 'log_count/DEBUG': 55,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 147451904,
 'memusage/startup': 147451904,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 23, 15, 56, 29, 713255, tzinfo=datetime.timezone.utc)}
```