### PR TITLE
[Epaka] Add category

### DIFF
--- a/locations/spiders/epaka.py
+++ b/locations/spiders/epaka.py
@@ -1,12 +1,13 @@
 from scrapy import Spider
 
+from locations.categories import Categories
 from locations.hours import DAYS_PL, OpeningHours
 from locations.items import Feature
 
 
 class EPakaPLSpider(Spider):
     name = "epaka_pl"
-    item_attributes = {"brand": "Epaka.pl", "brand_wikidata": "Q123028724"}
+    item_attributes = {"brand": "Epaka.pl", "brand_wikidata": "Q123028724", "extras": Categories.POST_OFFICE.value}
     start_urls = ["https://www.epaka.pl/api/getPoints.xml"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 

--- a/locations/spiders/seven_eleven_dk.py
+++ b/locations/spiders/seven_eleven_dk.py
@@ -1,4 +1,3 @@
-
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category, apply_yes_no

--- a/locations/spiders/seven_eleven_dk.py
+++ b/locations/spiders/seven_eleven_dk.py
@@ -1,8 +1,10 @@
 from scrapy import Spider
 
-from locations.categories import Categories, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
+from locations.spiders.shell import ShellSpider
 
 
 class SevenElevenDKSpider(Spider):
@@ -12,16 +14,31 @@ class SevenElevenDKSpider(Spider):
 
     def parse(self, response, **kwargs):
         for location in response.json():
-            location["street_address"] = location.pop("address")
-
             item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full")
+            item["branch"] = item.pop("name")
+            item["postcode"] = str(item.pop("postcode"))
 
             item["ref"] = location["storeNumber"]
 
-            if location["type"] == "shell":
-                apply_category(Categories.FUEL_STATION, item)
-                apply_yes_no("car_wash", item, location["hasCarwash"])
-            else:
-                apply_category(Categories.SHOP_CONVENIENCE, item)
+            item["opening_hours"] = OpeningHours()
+            for day in map(str.lower, DAYS_FULL):
+                if location["{}ClosedAllDay".format(day)]:
+                    continue
+                item["opening_hours"].add_range(
+                    day,
+                    location["{}OpeningTime".format(day)].replace(".", ":"),
+                    location["{}ClosingTime".format(day)].replace(".", ":"),
+                )
+
+            if location["storeChainName"] == "Shell / 7-Eleven":
+                fuel = item.deepcopy()
+                fuel["ref"] = "{}-shell".format(fuel["ref"])
+                fuel.update(ShellSpider.item_attributes)
+                apply_category(Categories.FUEL_STATION, fuel)
+                apply_yes_no(Extras.CAR_WASH, fuel, location["hasCarwash"])
+                yield fuel
+
+            apply_category(Categories.SHOP_CONVENIENCE, item)
 
             yield item


### PR DESCRIPTION
{'atp/brand/Epaka.pl': 360,
 'atp/brand_wikidata/Q123028724': 360,
 'atp/category/amenity/post_office': 360,
 'atp/field/country/from_spider_name': 360,
 'atp/field/image/missing': 360,
 'atp/field/name/missing': 360,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 360,
 'atp/field/operator_wikidata/missing': 360,
 'atp/field/state/missing': 360,
 'atp/field/street_address/missing': 360,
 'atp/field/twitter/missing': 360,
 'atp/nsi/brand_missing': 360,
 'downloader/request_bytes': 310,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 32516,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.602628,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 24, 10, 15, 52, 254926, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 498823,
 'httpcompression/response_count': 1,
 'item_scraped_count': 360,
 'log_count/DEBUG': 372,
 'log_count/INFO': 9,
 'memusage/max': 135688192,
 'memusage/startup': 135688192,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 24, 10, 15, 47, 652298, tzinfo=datetime.timezone.utc)}
