### PR TITLE
Add NSW National Parks and Wildlife Service (AU) (452 locations)

### DIFF
--- a/locations/spiders/nsw_national_parks_and_wildlife_service_au.py
+++ b/locations/spiders/nsw_national_parks_and_wildlife_service_au.py
@@ -1,0 +1,57 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NSWNationalParksAndWildlifeServiceAUSpider(SitemapSpider, StructuredDataSpider):
+    name = "nsw_national_parks_and_wildlife_service_au"
+    item_attributes = {"state": "New South Wales", "operator": "NSW National Parks and Wildlife Service", "operator_wikidata": "Q108872274"}
+    allowed_domains = ["www.nationalparks.nsw.gov.au"]
+    sitemap_urls = ["https://www.nationalparks.nsw.gov.au/sitemap.xml"]
+    sitemap_rules = [(r"^https:\/\/www\.nationalparks\.nsw\.gov\.au\/camping-and-accommodation\/(?:accommodation|campgrounds)\/[\w\-]+$", "parse_sd")]
+    wanted_types = ["Accommodation", "Campground"]
+
+    def post_process_item(self, item, response, ld_data):
+        item.pop("email", None)
+        item.pop("facebook", None)
+        item.pop("twitter", None)
+        if "/campgrounds/" in response.url:
+            apply_category(Categories.TOURISM_CAMP_SITE, item)
+            apply_category({"reservation": "required"}, item)
+            for campground_detail in response.xpath('//table[contains(@class, "itemDetails")]/tr'):
+                if campground_detail.xpath('./th[contains(text(), "Number of campsites")]'):
+                    capacity = campground_detail.xpath('./td/text()').get()
+                    apply_category({"capacity:pitches": capacity}, item)
+                elif campground_detail.xpath('./th[contains(text(), "Camping type")]'):
+                    camping_types = campground_detail.xpath('./td/text()').get().lower()
+                    apply_yes_no("tents", item, "tent" in camping_types or "camping beside my vehicle" in camping_types, False)
+                    apply_yes_no("caravans", item, "camper trailer site" in camping_types or "caravan site" in camping_types, False)
+                    apply_yes_no("motor_vehicle", item, "camping beside my vehicle" in camping_types or "camper trailer site" in camping_types or "caravan site" in camping_types, False)
+                elif campground_detail.xpath('./th[contains(text(), "Facilities")]'):
+                    facilities = campground_detail.xpath('./td/text()').get().lower()
+                    apply_yes_no("bbq", item, "barbecue facilities" in facilities, False)
+                    apply_yes_no("picnic_table", item, "picnic tables" in facilities, False)
+                    apply_yes_no("toilets", item, "toilets" in facilities, False)
+                    apply_yes_no("drinking_water", item, "drinking water" in facilities, False)
+                    apply_yes_no("shower", item, "showers" in facilities, False)
+        else:
+            # Other types of accommodation are extremely varied and
+            # are difficult to tag accurately:
+            # * One cabin, house or hut without an on-site manager.
+            # * A cabin, house or hut with multiple rooms where
+            #   each room can be booked separately. There could be
+            #   common facilities and an on-site manager.
+            # * A group of cabins or huts. There could be common
+            #   facilities and an on-site manager.
+            # * A hotel.
+            # * Lightstation cottages that may have an on-site
+            #   manager to provide services.
+            # * And more!
+            # Due to this complexity and very basic accommodation
+            # tagging standards of OSM, an attempt is not yet made
+            # to capture details about these other accommodation
+            # types.
+            apply_category({"tourism": "yes"}, item)
+            apply_category({"reservation": "required"}, item)
+        yield item

--- a/locations/spiders/nsw_national_parks_and_wildlife_service_au.py
+++ b/locations/spiders/nsw_national_parks_and_wildlife_service_au.py
@@ -6,10 +6,19 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class NSWNationalParksAndWildlifeServiceAUSpider(SitemapSpider, StructuredDataSpider):
     name = "nsw_national_parks_and_wildlife_service_au"
-    item_attributes = {"state": "New South Wales", "operator": "NSW National Parks and Wildlife Service", "operator_wikidata": "Q108872274"}
+    item_attributes = {
+        "state": "New South Wales",
+        "operator": "NSW National Parks and Wildlife Service",
+        "operator_wikidata": "Q108872274",
+    }
     allowed_domains = ["www.nationalparks.nsw.gov.au"]
     sitemap_urls = ["https://www.nationalparks.nsw.gov.au/sitemap.xml"]
-    sitemap_rules = [(r"^https:\/\/www\.nationalparks\.nsw\.gov\.au\/camping-and-accommodation\/(?:accommodation|campgrounds)\/[\w\-]+$", "parse_sd")]
+    sitemap_rules = [
+        (
+            r"^https:\/\/www\.nationalparks\.nsw\.gov\.au\/camping-and-accommodation\/(?:accommodation|campgrounds)\/[\w\-]+$",
+            "parse_sd",
+        )
+    ]
     wanted_types = ["Accommodation", "Campground"]
 
     def post_process_item(self, item, response, ld_data):
@@ -21,15 +30,29 @@ class NSWNationalParksAndWildlifeServiceAUSpider(SitemapSpider, StructuredDataSp
             apply_category({"reservation": "required"}, item)
             for campground_detail in response.xpath('//table[contains(@class, "itemDetails")]/tr'):
                 if campground_detail.xpath('./th[contains(text(), "Number of campsites")]'):
-                    capacity = campground_detail.xpath('./td/text()').get()
+                    capacity = campground_detail.xpath("./td/text()").get()
                     apply_category({"capacity:pitches": capacity}, item)
                 elif campground_detail.xpath('./th[contains(text(), "Camping type")]'):
-                    camping_types = campground_detail.xpath('./td/text()').get().lower()
-                    apply_yes_no("tents", item, "tent" in camping_types or "camping beside my vehicle" in camping_types, False)
-                    apply_yes_no("caravans", item, "camper trailer site" in camping_types or "caravan site" in camping_types, False)
-                    apply_yes_no("motor_vehicle", item, "camping beside my vehicle" in camping_types or "camper trailer site" in camping_types or "caravan site" in camping_types, False)
+                    camping_types = campground_detail.xpath("./td/text()").get().lower()
+                    apply_yes_no(
+                        "tents", item, "tent" in camping_types or "camping beside my vehicle" in camping_types, False
+                    )
+                    apply_yes_no(
+                        "caravans",
+                        item,
+                        "camper trailer site" in camping_types or "caravan site" in camping_types,
+                        False,
+                    )
+                    apply_yes_no(
+                        "motor_vehicle",
+                        item,
+                        "camping beside my vehicle" in camping_types
+                        or "camper trailer site" in camping_types
+                        or "caravan site" in camping_types,
+                        False,
+                    )
                 elif campground_detail.xpath('./th[contains(text(), "Facilities")]'):
-                    facilities = campground_detail.xpath('./td/text()').get().lower()
+                    facilities = campground_detail.xpath("./td/text()").get().lower()
                     apply_yes_no("bbq", item, "barbecue facilities" in facilities, False)
                     apply_yes_no("picnic_table", item, "picnic tables" in facilities, False)
                     apply_yes_no("toilets", item, "toilets" in facilities, False)

--- a/locations/spiders/seven_eleven_dk.py
+++ b/locations/spiders/seven_eleven_dk.py
@@ -1,4 +1,3 @@
-
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category, apply_yes_no


### PR DESCRIPTION
 'atp/category/tourism/camp_site': 360,
 'atp/category/tourism/yes': 92,

tourism=yes sites are not readily taggable, but are various types of accommodation ranging from lodging, chatels, remote huts, hotels, ensuite cabins, etc. See justification in source file for lack of detailed tagging.