### PR TITLE
[starbucks_ar_cl] Created spider for starbucks_ar_cl (280 items)

### DIFF
--- a/locations/spiders/starbucks_ar_cl.py
+++ b/locations/spiders/starbucks_ar_cl.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import DAYS, OpeningHours
+from locations.spiders.vapestore_gb import clean_address
+
+
+class StarbucksARCLSpider(Spider):
+    name = "starbucks_ar_cl"
+    item_attributes = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
+
+    def start_requests(self):
+        for country, base_url, min_population in [
+            ("AR", "https://www.starbucks.com.ar", 100000),
+            ("CL", "https://www.starbucks.cl", 15000),
+        ]:
+            for city in city_locations(country, min_population):
+                yield JsonRequest(
+                    url=f"{base_url}/api/getStores",
+                    data=[city["latitude"], city["longitude"], "100000"],
+                )
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            store = location.get("store")
+            item = DictParser.parse(store)
+            item["street_address"] = clean_address(
+                [store["address"].get("streetAddressLine1"), store["address"].get("streetAddressLine2")]
+            )
+            item["state"] = store["address"].get("countrySubdivisionCode")
+            if item["phone"] == "null":
+                item["phone"] = None
+            oh = OpeningHours()
+            for rule in store.get("hoursNext7Days", {}).get("dailySchedule", []):
+                day = datetime.strptime(rule.get("date").split(".")[0], "%Y-%m-%dT%H:%M:%S").weekday()
+                if rule.get("openTime") and rule.get("closeTime"):
+                    oh.add_range(DAYS[day], rule["openTime"], rule["closeTime"], "%H:%M:%S")
+            item["opening_hours"] = oh.as_opening_hours()
+            item["website"] = response.url.replace("/api/getStores", "/stores")
+
+            if services := store.get("features", {}).get("feature"):
+                service_codes = [service.get("code") for service in services]
+                apply_yes_no(Extras.WIFI, item, "WF" in service_codes)
+                apply_yes_no(Extras.DELIVERY, item, "DE" in service_codes)
+                apply_yes_no(Extras.DRIVE_THROUGH, item, "DT" in service_codes)
+                apply_yes_no(Extras.TOILETS, item, "WC" in service_codes)
+            apply_category(Categories.COFFEE_SHOP, item)
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Starbucks': 280,
 'atp/brand_wikidata/Q37158': 280,
 'atp/category/amenity/cafe': 280,
 'atp/field/email/missing': 280,
 'atp/field/image/missing': 280,
 'atp/field/operator/missing': 280,
 'atp/field/operator_wikidata/missing': 280,
 'atp/field/phone/missing': 280,
 'atp/field/twitter/missing': 280,
 'atp/nsi/match_failed': 280,
 'downloader/request_bytes': 51213,
 'downloader/request_count': 143,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 141,
 'downloader/response_bytes': 344526,
 'downloader/response_count': 143,
 'downloader/response_status_count/200': 143,
 'elapsed_time_seconds': 152.380076,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 24, 16, 25, 35, 362875, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4513972,
 'httpcompression/response_count': 88,
 'item_dropped_count': 1819,
 'item_dropped_reasons_count/DropItem': 1819,
 'item_scraped_count': 280,
 'log_count/INFO': 11,
 'memusage/max': 317562880,
 'memusage/startup': 138104832,
 'response_received_count': 143,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 141,
 'scheduler/dequeued/memory': 141,
 'scheduler/enqueued': 141,
 'scheduler/enqueued/memory': 141,
 'start_time': datetime.datetime(2024, 1, 24, 16, 23, 2, 982799, tzinfo=datetime.timezone.utc)}
```
</details>