### PR TITLE
[CareOneUS] Add category

### DIFF
--- a/locations/spiders/careone_us.py
+++ b/locations/spiders/careone_us.py
@@ -1,3 +1,4 @@
+from locations.categories import Categories, apply_category
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
@@ -9,4 +10,8 @@ class CareOneUSSpider(WPStoreLocatorSpider):
 
     def parse_item(self, item, location):
         item.pop("addr_full", None)
+        if "Assisted Living" in item.get("name"):
+            apply_category({"amenity": "social_facility", "social_facility": "assisted_living"}, item)
+        else:
+            apply_category(Categories.NURSING_HOME, item)
         yield item


### PR DESCRIPTION
{'atp/brand/CareOne': 58,
 'atp/brand_wikidata/Q25108589': 58,
 'atp/category/amenity/social_facility': 58,
 'atp/field/email/missing': 58,
 'atp/field/image/missing': 58,
 'atp/field/opening_hours/missing': 53,
 'atp/field/operator/missing': 58,
 'atp/field/operator_wikidata/missing': 58,
 'atp/field/twitter/missing': 58,
 'atp/field/website/missing': 58,
 'atp/nsi/brand_missing': 58,
 'downloader/request_bytes': 706,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 69191,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.947493,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 25, 10, 39, 35, 555236, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 174,
 'httpcompression/response_count': 1,
 'item_scraped_count': 58,
 'log_count/DEBUG': 71,
 'log_count/INFO': 9,
 'memusage/max': 136880128,
 'memusage/startup': 136880128,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 25, 10, 39, 32, 607743, tzinfo=datetime.timezone.utc)}
