### PR TITLE
[ProMedicaUS] Add category

### DIFF
--- a/locations/spiders/promedica_us.py
+++ b/locations/spiders/promedica_us.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import XMLFeedSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -12,19 +13,22 @@ class ProMedicaUSSpider(XMLFeedSpider):
     itertag = "marker"
 
     def parse_node(self, response, node):
-        properties = {
-            "ref": node.xpath(".//@web").get(),
-            "name": node.xpath(".//@name").get(),
-            "lat": node.xpath(".//@lat").get(),
-            "lon": node.xpath(".//@lng").get(),
-            "street_address": ", ".join(
-                filter(None, [node.xpath(".//@address").get(), node.xpath(".//@address2").get()])
-            ),
-            "city": node.xpath(".//@city").get(),
-            "state": node.xpath(".//@state").get(),
-            "postcode": node.xpath(".//@postal").get(),
-            "phone": node.xpath(".//@phone").get(),
-            "website": node.xpath(".//@web").get(),
-            "image": "https://promedicaseniorcare.org" + node.xpath(".//@image").get(),
-        }
-        yield Feature(**properties)
+        item = Feature()
+        item["ref"] = node.xpath(".//@web").get()
+        item["name"] = node.xpath(".//@name").get()
+        item["lat"] = node.xpath(".//@lat").get()
+        item["lon"] = node.xpath(".//@lng").get()
+        item["street_address"] = ", ".join(
+            filter(None, [node.xpath(".//@address").get(), node.xpath(".//@address2").get()])
+        )
+        item["city"] = node.xpath(".//@city").get()
+        item["state"] = node.xpath(".//@state").get()
+        item["postcode"] = node.xpath(".//@postal").get()
+        item["phone"] = node.xpath(".//@phone").get()
+        item["website"] = node.xpath(".//@web").get()
+        item["image"] = "https://promedicaseniorcare.org" + node.xpath(".//@image").get()
+        if "Community" in item["name"]:
+            apply_category({"amenity": "social_facility", "social_facility": "assisted_living"}, item)
+        else:
+            apply_category(Categories.NURSING_HOME, item)
+        yield item


### PR DESCRIPTION
{'atp/brand/ProMedica': 138,
 'atp/brand_wikidata/Q7246673': 138,
 'atp/category/amenity/social_facility': 138,
 'atp/field/country/from_spider_name': 138,
 'atp/field/email/missing': 138,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 138,
 'atp/field/operator_wikidata/missing': 138,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/twitter/missing': 138,
 'atp/nsi/brand_missing': 138,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 15697,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.821786,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 25, 13, 36, 26, 236785, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 62691,
 'httpcompression/response_count': 2,
 'item_scraped_count': 138,
 'log_count/DEBUG': 151,
 'log_count/INFO': 9,
 'memusage/max': 136040448,
 'memusage/startup': 136040448,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 25, 13, 36, 22, 414999, tzinfo=datetime.timezone.utc)}
