### PR TITLE
[Oshkosh US] Add spider

### DIFF
--- a/locations/spiders/oshkosh_us.py
+++ b/locations/spiders/oshkosh_us.py
@@ -1,0 +1,18 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+# Sitemap is currently out of date
+class OshkoshUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "oshkosh_us"
+    item_attributes = {"brand": "OshKosh B'gosh", "brand_wikidata": "Q1417347"}
+    start_urls = ["https://locations.oshkosh.com/"]
+    rules = [
+        Rule(LinkExtractor(r"\.com/\w\w/$")),
+        Rule(LinkExtractor(r"\.com/\w\w/[^/]+/$")),
+        Rule(LinkExtractor(r"\.com/\w\w/[^/]+/[^/]+$"), "parse"),
+    ]
+    wanted_types = ["LocalBusiness"]
+    search_for_twitter = False

--- a/locations/spiders/oshkosh_us.py
+++ b/locations/spiders/oshkosh_us.py
@@ -2,6 +2,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 # Sitemap is currently out of date
@@ -16,3 +17,4 @@ class OshkoshUSSpider(CrawlSpider, StructuredDataSpider):
     ]
     wanted_types = ["LocalBusiness"]
     search_for_twitter = False
+    user_agent = BROWSER_DEFAULT

--- a/locations/spiders/oshkosh_us.py
+++ b/locations/spiders/oshkosh_us.py
@@ -2,7 +2,6 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 # Sitemap is currently out of date
@@ -17,4 +16,3 @@ class OshkoshUSSpider(CrawlSpider, StructuredDataSpider):
     ]
     wanted_types = ["LocalBusiness"]
     search_for_twitter = False
-    user_agent = BROWSER_DEFAULT


### PR DESCRIPTION
```python
{"atp/brand/OshKosh B'gosh": 466,
 'atp/brand_wikidata/Q1417347': 466,
 'atp/category/shop/clothes': 466,
 'atp/field/country/from_spider_name': 42,
 'atp/field/email/missing': 466,
 'atp/field/image/missing': 466,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 466,
 'atp/field/operator_wikidata/missing': 466,
 'atp/field/twitter/missing': 466,
 'atp/nsi/perfect_match': 466,
 'downloader/request_bytes': 417285,
 'downloader/request_count': 943,
 'downloader/request_method_count/GET': 943,
 'downloader/response_bytes': 227578159,
 'downloader/response_count': 943,
 'downloader/response_status_count/200': 943,
 'dupefilter/filtered': 1212,
 'elapsed_time_seconds': 1139.843153,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 25, 14, 47, 25, 856668, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 923,
 'httpcache/hit': 20,
 'httpcache/miss': 923,
 'httpcache/store': 923,
 'httpcompression/response_bytes': 898496107,
 'httpcompression/response_count': 943,
 'item_scraped_count': 466,
 'log_count/INFO': 28,
 'log_count/WARNING': 1,
 'memusage/max': 570970112,
 'memusage/startup': 155058176,
 'request_depth_max': 4,
 'response_received_count': 943,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 942,
 'scheduler/dequeued/memory': 942,
 'scheduler/enqueued': 942,
 'scheduler/enqueued/memory': 942,
 'start_time': datetime.datetime(2024, 1, 25, 14, 28, 26, 13515, tzinfo=datetime.timezone.utc)}
```