### PR TITLE
[BenchmarkHospitality] Add category

### DIFF
--- a/locations/spiders/benchmark_hospitality.py
+++ b/locations/spiders/benchmark_hospitality.py
@@ -55,7 +55,7 @@ class BenchmarkHospitalitySpider(scrapy.Spider):
 
         item["ref"] = re.search(r".com/+(?:meeting/+)?(.+?)//?", response.url + "/").group(1)
         item["addr_full"] = address.strip() if "Reservations" not in address else None
-        item["phone"] = (phone.strip(),)
+        item["phone"] = phone.strip()
         item["website"] = response.url
 
         if "Resort" in item["name"]:

--- a/locations/spiders/benchmark_hospitality.py
+++ b/locations/spiders/benchmark_hospitality.py
@@ -2,6 +2,7 @@ import re
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -36,6 +37,11 @@ class BenchmarkHospitalitySpider(scrapy.Spider):
             return
         properties = response.meta["properties"]
 
+        item = Feature()
+        item["lat"] = properties["lat"]
+        item["lon"] = properties["lon"]
+        item["name"] = properties["name"]
+
         p = response.xpath('//p[@class="brand-cap"]/following-sibling::p/text()').extract_first()
 
         if p:
@@ -47,13 +53,15 @@ class BenchmarkHospitalitySpider(scrapy.Spider):
             address = p[0]
             phone = ""
 
-        properties.update(
-            {
-                "ref": re.search(r".com/+(?:meeting/+)?(.+?)//?", response.url + "/").group(1),
-                "addr_full": address.strip() if "Reservations" not in address else None,
-                "phone": phone.strip(),
-                "website": response.url,
-            }
-        )
+        item["ref"] = re.search(r".com/+(?:meeting/+)?(.+?)//?", response.url + "/").group(1)
+        item["addr_full"] = address.strip() if "Reservations" not in address else None
+        item["phone"] = (phone.strip(),)
 
-        yield Feature(**properties)
+        if "Resort" in item["name"]:
+            apply_category(Categories.LEISURE_RESORT, item)
+        elif "Center" in item["name"]:
+            apply_category({"amenity": "conference_centre"}, item)
+        else:
+            apply_category(Categories.HOTEL, item)
+
+        yield item

--- a/locations/spiders/benchmark_hospitality.py
+++ b/locations/spiders/benchmark_hospitality.py
@@ -56,6 +56,7 @@ class BenchmarkHospitalitySpider(scrapy.Spider):
         item["ref"] = re.search(r".com/+(?:meeting/+)?(.+?)//?", response.url + "/").group(1)
         item["addr_full"] = address.strip() if "Reservations" not in address else None
         item["phone"] = (phone.strip(),)
+        item["website"] = response.url
 
         if "Resort" in item["name"]:
             apply_category(Categories.LEISURE_RESORT, item)


### PR DESCRIPTION
{'atp/category/amenity/conference_centre': 4,
 'atp/category/leisure/resort': 23,
 'atp/category/tourism/hotel': 32,
 'atp/field/brand/missing': 59,
 'atp/field/brand_wikidata/missing': 59,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 59,
 'atp/field/email/missing': 59,
 'atp/field/image/missing': 59,
 'atp/field/opening_hours/missing': 59,
 'atp/field/operator/missing': 59,
 'atp/field/operator_wikidata/missing': 59,
 'atp/field/phone/wrong_type': 118,
 'atp/field/postcode/missing': 59,
 'atp/field/street_address/missing': 59,
 'atp/field/twitter/missing': 59,
 'downloader/request_bytes': 98341,
 'downloader/request_count': 108,
 'downloader/request_method_count/GET': 108,
 'downloader/response_bytes': 4793356,
 'downloader/response_count': 108,
 'downloader/response_status_count/200': 64,
 'downloader/response_status_count/301': 4,
 'downloader/response_status_count/302': 40,
 'elapsed_time_seconds': 127.92389,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 26, 10, 57, 33, 383226, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 59,
 'log_count/DEBUG': 177,
 'log_count/ERROR': 59,
 'log_count/INFO': 11,
 'memusage/max': 279396352,
 'memusage/startup': 137523200,
 'offsite/domains': 9,
 'offsite/filtered': 9,
 'request_depth_max': 1,
 'response_received_count': 64,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 104,
 'scheduler/dequeued/memory': 104,
 'scheduler/enqueued': 104,
 'scheduler/enqueued/memory': 104,
 'start_time': datetime.datetime(2024, 1, 26, 10, 55, 25, 459336, tzinfo=datetime.timezone.utc)}

