### PR TITLE
[DockxBE] Add category

### DIFF
--- a/locations/spiders/dockx_be.py
+++ b/locations/spiders/dockx_be.py
@@ -2,6 +2,7 @@ import json
 
 import scrapy
 
+from locations.categories import Categories
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 
@@ -10,7 +11,7 @@ class DockxBESpider(scrapy.Spider):
     name = "dockx_be"
     start_urls = ["https://www.dockx.be/en/locations"]
 
-    item_attributes = {"brand": "Dockx"}
+    item_attributes = {"brand": "Dockx", "extras": Categories.CAR_RENTAL.value}
 
     def parse(self, response, **kwargs):
         raw = (


### PR DESCRIPTION
{'atp/brand/Dockx': 24,
 'atp/category/amenity/car_rental': 24,
 'atp/field/brand_wikidata/missing': 24,
 'atp/field/image/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/state/missing': 24,
 'atp/field/twitter/missing': 24,
 'downloader/request_bytes': 651,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 67006,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.032939,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 26, 14, 20, 54, 791188, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 278654,
 'httpcompression/response_count': 2,
 'item_scraped_count': 24,
 'log_count/DEBUG': 27,
 'log_count/INFO': 9,
 'memusage/max': 136015872,
 'memusage/startup': 136015872,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 26, 14, 20, 52, 758249, tzinfo=datetime.timezone.utc)}
