### PR TITLE
[Mitre10NZ] Add category

### DIFF
--- a/locations/spiders/mitre_10_nz.py
+++ b/locations/spiders/mitre_10_nz.py
@@ -1,13 +1,14 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
 class Mitre10NZSpider(Spider):
     name = "mitre_10_nz"
-    item_attributes = {"brand": "Mitre 10", "brand_wikidata": "Q6882394"}
+    item_attributes = {"brand": "Mitre 10", "brand_wikidata": "Q6882394", "extras": Categories.SHOP_DOITYOURSELF.value}
     allowed_domains = ["www.mitre10.co.nz"]
     start_urls = [
         "https://ccapi.mitre10.co.nz/mitre10webservices/v2/mitre10/geolocation/store-locator?fields=FULL&page=0&pageSize=1000&storeCode=28&lang=en&curr=NZD"


### PR DESCRIPTION
{'atp/brand/Mitre 10': 88,
 'atp/brand_wikidata/Q6882394': 88,
 'atp/category/shop/doityourself': 88,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/image/missing': 88,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 88,
 'atp/field/operator_wikidata/missing': 88,
 'atp/field/state/missing': 88,
 'atp/field/twitter/missing': 88,
 'atp/nsi/match_failed': 88,
 'downloader/request_bytes': 906,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29008,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.629911,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 26, 15, 16, 47, 777914, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 589869,
 'httpcompression/response_count': 2,
 'item_scraped_count': 88,
 'log_count/DEBUG': 102,
 'log_count/INFO': 9,
 'memusage/max': 136749056,
 'memusage/startup': 136749056,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 26, 15, 16, 44, 148003, tzinfo=datetime.timezone.utc)}
