### PR TITLE
[starbucks_pe] Created Spider (116 items)

### DIFF
--- a/locations/spiders/starbucks_pe.py
+++ b/locations/spiders/starbucks_pe.py
@@ -1,0 +1,37 @@
+import scrapy
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.spiders.starbucks import HEADERS, STORELOCATOR, StarbucksSpider
+
+
+class StarbucksPESpider(scrapy.Spider):
+    name = "starbucks_pe"
+    item_attributes = StarbucksSpider.item_attributes
+
+    def start_requests(self):
+        for city in city_locations("PE", 15000):
+            yield JsonRequest(
+                url=STORELOCATOR.format(city["latitude"], city["longitude"]),
+                headers=HEADERS,
+            )
+
+    def parse(self, response, **kwargs):
+        for store in response.json()["stores"]:
+            item = DictParser.parse(store)
+            item["street_address"] = ", ".join(
+                filter(
+                    None,
+                    [
+                        store["address"].get("streetAddressLine1"),
+                        store["address"].get("streetAddressLine2"),
+                        store["address"].get("streetAddressLine3"),
+                    ],
+                )
+            )
+            item["state"] = store["address"].get("countrySubdivisionCode")
+            item["website"] = f'https://www.starbucks.com/store-locator/store/{store["id"]}/{store["slug"]}'
+            item["extras"]["number"] = store.get("storeNumber")
+            item["extras"]["ownership_type"] = store.get("ownershipTypeCode")
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Starbucks': 116,
 'atp/brand_wikidata/Q37158': 116,
 'atp/category/amenity/cafe': 116,
 'atp/field/email/missing': 116,
 'atp/field/image/missing': 116,
 'atp/field/opening_hours/missing': 116,
 'atp/field/operator/missing': 116,
 'atp/field/operator_wikidata/missing': 116,
 'atp/field/phone/invalid': 11,
 'atp/field/phone/missing': 105,
 'atp/field/twitter/missing': 116,
 'atp/nsi/match_failed': 116,
 'downloader/request_bytes': 58363,
 'downloader/request_count': 132,
 'downloader/request_method_count/GET': 132,
 'downloader/response_bytes': 808100,
 'downloader/response_count': 132,
 'downloader/response_status_count/200': 132,
 'elapsed_time_seconds': 164.492468,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 30, 14, 0, 22, 929320, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 648,
 'item_dropped_reasons_count/DropItem': 648,
 'item_scraped_count': 116,
 'log_count/DEBUG': 915,
 'log_count/INFO': 11,
 'memusage/max': 658997248,
 'memusage/startup': 138256384,
 'response_received_count': 132,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 131,
 'scheduler/dequeued/memory': 131,
 'scheduler/enqueued': 131,
 'scheduler/enqueued/memory': 131,
 'start_time': datetime.datetime(2024, 1, 30, 13, 57, 38, 436852, tzinfo=datetime.timezone.utc)}
```
</details>