### PR TITLE
[pizza_hut_hk] Created pizzahut hk spider (97 items)

### DIFF
--- a/locations/spiders/pizza_hut_hk.py
+++ b/locations/spiders/pizza_hut_hk.py
@@ -1,0 +1,26 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+
+
+class PizzaHutHKSpider(scrapy.Spider):
+    name = "pizza_hut_hk"
+    item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
+
+    start_urls = [
+        "https://jrgapp.aigens.com/api/v1/store/store.json?brandId=599961624702976",
+    ]
+
+    def parse(self, response, **kwargs):
+        for store in response.json()["data"]:
+            item = DictParser.parse(store)
+            item["addr_full"] = store.get("location").get("line")
+            item["website"] = "https://www.pizzahut.com.hk/"
+            item["opening_hours"] = OpeningHours()
+            for day_time in store.get("openings").get("weekdays"):
+                day = day_time.get("weekday")
+                start_time = day_time.get("startTime")
+                close_time = day_time.get("endTime")
+                item["opening_hours"].add_range(day=DAYS_FULL[day], open_time=start_time, close_time=close_time)
+            yield item


### PR DESCRIPTION
<details><summary>stats</summary>

```python
{'atp/brand/Pizza Hut': 97,
 'atp/brand_wikidata/Q191615': 97,
 'atp/category/amenity/restaurant': 97,
 'atp/field/city/missing': 97,
 'atp/field/country/from_spider_name': 97,
 'atp/field/email/missing': 97,
 'atp/field/image/missing': 97,
 'atp/field/operator/missing': 97,
 'atp/field/operator_wikidata/missing': 97,
 'atp/field/postcode/missing': 97,
 'atp/field/state/missing': 97,
 'atp/field/street_address/missing': 97,
 'atp/field/twitter/missing': 97,
 'atp/nsi/cc_match': 97,
 'downloader/request_bytes': 653,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5445849,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 7.51293,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 1, 31, 15, 42, 11, 951358, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 194,
 'httpcompression/response_count': 1,
 'item_scraped_count': 97,
 'log_count/INFO': 9,
 'memusage/max': 138452992,
 'memusage/startup': 138452992,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 1, 31, 15, 42, 4, 438428, tzinfo=datetime.timezone.utc)}
```
</details>