### PR TITLE
[FleetPride US] Add spider

### DIFF
--- a/locations/spiders/fleet_pride_us.py
+++ b/locations/spiders/fleet_pride_us.py
@@ -1,0 +1,14 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class FleetPrideUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "fleet_pride_us"
+    item_attributes = {"brand": "FleetPride", "brand_wikidata": "Q121436710"}
+    sitemap_urls = ["https://branches.fleetpride.com/robots.txt"]
+    sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+(?<!-sc)\.html$", "parse")]
+    wanted_types = ["AutoPartsStore"]
+
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data["name"] = None


### PR DESCRIPTION
```python
{'atp/brand/FleetPride': 371,
 'atp/brand_wikidata/Q121436710': 371,
 'atp/category/shop/car_parts': 371,
 'atp/field/country/from_spider_name': 371,
 'atp/field/image/dropped': 371,
 'atp/field/image/missing': 371,
 'atp/field/opening_hours/missing': 71,
 'atp/field/operator/missing': 371,
 'atp/field/operator_wikidata/missing': 371,
 'atp/field/twitter/missing': 371,
 'atp/nsi/perfect_match': 371,
 'downloader/request_bytes': 150525,
 'downloader/request_count': 375,
 'downloader/request_method_count/GET': 375,
 'downloader/response_bytes': 8712798,
 'downloader/response_count': 375,
 'downloader/response_status_count/200': 375,
 'elapsed_time_seconds': 3.437974,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 2, 15, 13, 25, 284299, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 375,
 'httpcompression/response_bytes': 55439479,
 'httpcompression/response_count': 374,
 'item_scraped_count': 371,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 180002816,
 'memusage/startup': 180002816,
 'request_depth_max': 3,
 'response_received_count': 375,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 374,
 'scheduler/dequeued/memory': 374,
 'scheduler/enqueued': 374,
 'scheduler/enqueued/memory': 374,
 'start_time': datetime.datetime(2024, 2, 2, 15, 13, 21, 846325, tzinfo=datetime.timezone.utc)}
```