### PR TITLE
[CircleK Ireland] Add Spider

### DIFF
--- a/locations/spiders/circle_k_ie.py
+++ b/locations/spiders/circle_k_ie.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CircleKIESpider(SitemapSpider, StructuredDataSpider):
+    name = "circle_k_ie"
+    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
+    sitemap_urls = ["https://www.circlek.ie/stations/sitemap.xml"]
+    sitemap_rules = [("/station/circle-k-", "parse")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        extract_google_position(item, response)
+        apply_category(Categories.FUEL_STATION, item)
+        yield item

--- a/locations/spiders/circle_k_ireland.py
+++ b/locations/spiders/circle_k_ireland.py
@@ -5,8 +5,8 @@ from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKIESpider(SitemapSpider, StructuredDataSpider):
-    name = "circle_k_ie"
+class CircleKIrelandSpider(SitemapSpider, StructuredDataSpider):
+    name = "circle_k_ireland"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     sitemap_urls = ["https://www.circlek.ie/stations/sitemap.xml"]
     sitemap_rules = [("/station/circle-k-", "parse")]


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 410,
 'atp/brand_wikidata/Q3268010': 410,
 'atp/category/amenity/fuel': 410,
 'atp/field/email/missing': 410,
 'atp/field/image/missing': 410,
 'atp/field/opening_hours/missing': 410,
 'atp/field/operator/missing': 410,
 'atp/field/operator_wikidata/missing': 410,
 'atp/field/phone/missing': 234,
 'atp/field/state/missing': 410,
 'atp/nsi/category_match': 410,
 'downloader/request_bytes': 157141,
 'downloader/request_count': 412,
 'downloader/request_method_count/GET': 412,
 'downloader/response_bytes': 3669928,
 'downloader/response_count': 412,
 'downloader/response_status_count/200': 412,
 'elapsed_time_seconds': 504.615983,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 2, 15, 35, 21, 335104, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 412,
 'httpcache/miss': 412,
 'httpcache/store': 412,
 'httpcompression/response_bytes': 20996288,
 'httpcompression/response_count': 412,
 'item_scraped_count': 410,
 'log_count/DEBUG': 834,
 'log_count/INFO': 18,
 'log_count/WARNING': 1,
 'memusage/max': 306577408,
 'memusage/startup': 180555776,
 'request_depth_max': 1,
 'response_received_count': 412,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 411,
 'scheduler/dequeued/memory': 411,
 'scheduler/enqueued': 411,
 'scheduler/enqueued/memory': 411,
 'start_time': datetime.datetime(2024, 2, 2, 15, 26, 56, 719121, tzinfo=datetime.timezone.utc)}
```