### PR TITLE
[latagliatella_es] add spider (223 locations)

### DIFF
--- a/locations/spiders/latagliatella_es.py
+++ b/locations/spiders/latagliatella_es.py
@@ -1,0 +1,15 @@
+from locations.storefinders.amrest_eu import AmrestEUSpider
+
+
+class LaTagliatellaESSpider(AmrestEUSpider):
+    name = "latagliatella_es"
+    base_urls = ["https://api.amrest.eu/amdv/ordering-api/TAG_ES/"]  # https://www.latagliatella.es/restaurantes
+    item_attributes = {
+        "brand": "La Tagliatella",
+        "brand_wikidata": "Q113426257",
+    }
+
+    def parse_item(self, item, feature, **kwargs):
+        # storeLocatorUrl format vary for other Amrest brands
+        item["website"] = feature.get("storeLocatorUrl")
+        yield item

--- a/locations/storefinders/amrest_eu.py
+++ b/locations/storefinders/amrest_eu.py
@@ -34,7 +34,7 @@ class AmrestEUSpider(Spider):
         match self.item_attributes["brand"]:
             case "KFC":
                 return f"{root_url}{self.restaurants_url}details/{restaurant['id']}"
-            case "Pizza Hut" | "Burger King":
+            case "Pizza Hut" | "Burger King" | "La Tagliatella":
                 for channel_key, channel in self.CHANNELS.items():
                     if restaurant.get(channel_key):
                         return f"{root_url}{self.restaurants_url}{restaurant['id']}/{channel}"


### PR DESCRIPTION
Stats:

```json
{
 "atp/brand/La Tagliatella": 223,
 "atp/brand_wikidata/Q113426257": 223,
 "atp/category/amenity/restaurant": 223,
 "atp/field/country/from_spider_name": 223,
 "atp/field/email/missing": 223,
 "atp/field/image/missing": 223,
 "atp/field/operator/missing": 223,
 "atp/field/operator_wikidata/missing": 223,
 "atp/field/state/missing": 223,
 "atp/field/street_address/missing": 223,
 "atp/field/twitter/missing": 223,
 "atp/field/website/missing": 1,
 "atp/nsi/perfect_match": 223,
 "downloader/request_bytes": 236971,
 "downloader/request_count": 226,
 "downloader/request_method_count/GET": 225,
 "downloader/request_method_count/POST": 1,
 "downloader/response_bytes": 553970,
 "downloader/response_count": 226,
 "downloader/response_status_count/200": 225,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 278.481494,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-02-05T09:52:34.588204+00:00",
 "httpcompression/response_bytes": 1797995,
 "httpcompression/response_count": 225,
 "item_scraped_count": 223,
 "log_count/INFO": 14,
 "memusage/max": 319127552,
 "memusage/startup": 140935168,
 "request_depth_max": 2,
 "response_received_count": 226,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 225,
 "scheduler/dequeued/memory": 225,
 "scheduler/enqueued": 225,
 "scheduler/enqueued/memory": 225,
 "start_time": "2024-02-05T09:47:56.106710+00:00"
}
```