### PR TITLE
[Well GB] Add spider

### DIFF
--- a/locations/spiders/well_gb.py
+++ b/locations/spiders/well_gb.py
@@ -1,0 +1,21 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WellGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "well_gb"
+    item_attributes = {"brand": "Well Pharmacy", "brand_wikidata": "Q7726524"}
+    sitemap_urls = ["https://finder.well.co.uk/robots.txt"]
+    sitemap_rules = [("/store/", "parse")]
+    wanted_types = ["Pharmacy"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["website"] = response.url
+        item["image"] = item["email"] = None
+
+        if postcode := item.get("postcode"):
+            if " " not in postcode:
+                item["postcode"] = "{} {}".format(postcode[: len(postcode) - 3], postcode[len(postcode) - 3 :])
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Well Pharmacy': 736,
 'atp/brand_wikidata/Q7726524': 736,
 'atp/category/amenity/pharmacy': 736,
 'atp/category/multiple': 736,
 'atp/cdn/cloudflare/response_count': 740,
 'atp/cdn/cloudflare/response_status_count/200': 740,
 'atp/field/email/missing': 736,
 'atp/field/image/missing': 736,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 736,
 'atp/field/operator_wikidata/missing': 736,
 'atp/field/state/missing': 6,
 'atp/nsi/perfect_match': 736,
 'downloader/request_bytes': 398529,
 'downloader/request_count': 740,
 'downloader/request_method_count/GET': 740,
 'downloader/response_bytes': 13370068,
 'downloader/response_count': 740,
 'downloader/response_status_count/200': 740,
 'elapsed_time_seconds': 4.482592,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 5, 16, 6, 31, 569495, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 740,
 'httpcompression/response_bytes': 52842936,
 'httpcompression/response_count': 740,
 'item_scraped_count': 736,
 'log_count/DEBUG': 1488,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 180121600,
 'memusage/startup': 180121600,
 'request_depth_max': 3,
 'response_received_count': 740,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 739,
 'scheduler/dequeued/memory': 739,
 'scheduler/enqueued': 739,
 'scheduler/enqueued/memory': 739,
 'start_time': datetime.datetime(2024, 2, 5, 16, 6, 27, 86903, tzinfo=datetime.timezone.utc)}
```