### PR TITLE
Add O'Briens (IE) (shop/alcohol) (storemapper) (35 stores)

### DIFF
--- a/locations/spiders/obriens_ie.py
+++ b/locations/spiders/obriens_ie.py
@@ -1,0 +1,7 @@
+from locations.storefinders.storemapper import StoremapperSpider
+
+
+class ObriensIESpider(StoremapperSpider):
+    name = "obriens_ie"
+    item_attributes = {"brand": "O'Briens", "brand_wikidata": "Q113151266"}
+    key = "5830"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7024
```
2024-02-12 07:41:56 [scrapy.core.scraper] DEBUG: Scraped from <200 https://storemapper-herokuapp-com.global.ssl.fastly.net/api/users/5830/stores.js>
{'addr_full': '178 Templeogue Road, Templeogue, Dublin 6W',
 'brand': "O'Briens",
 'brand_wikidata': 'Q113151266',
 'city': None,
 'country': 'IE',
 'email': 'templeogue@obrienswine.ie',
 'extras': {'@spider': 'obriens_ie', 'shop': 'alcohol'},
 'geometry': {'coordinates': [-6.3031479, 53.29836], 'type': 'Point'},
 'housenumber': None,
 'name': 'Templeogue',
 'nsi_id': 'obriens-986e1f',
 'phone': '+353 1 492 0334',
 'postcode': None,
 'ref': 11844016,
 'state': None,
 'street': None,
 'street_address': None,
 'website': None}
2024-02-12 07:41:56 [scrapy.core.engine] INFO: Closing spider (finished)
2024-02-12 07:41:56 [locations.pipelines.duplicates] INFO: Dropped 0 duplicate items
```

```
2024-02-12 07:41:56 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{"atp/brand/O'Briens": 35,
 'atp/brand_wikidata/Q113151266': 35,
 'atp/category/shop/alcohol': 35,
 'atp/field/city/missing': 35,
 'atp/field/country/from_spider_name': 35,
 'atp/field/image/missing': 35,
 'atp/field/opening_hours/missing': 35,
 'atp/field/operator/missing': 35,
 'atp/field/operator_wikidata/missing': 35,
 'atp/field/postcode/missing': 28,
 'atp/field/state/missing': 35,
 'atp/field/street_address/missing': 35,
 'atp/field/twitter/missing': 35,
 'atp/field/website/missing': 35,
 'atp/nsi/perfect_match': 35,
 'downloader/request_bytes': 367,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 4693,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.927387,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 12, 7, 41, 56, 907202, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 36320,
 'httpcompression/response_count': 1,
 'item_scraped_count': 35,
 'log_count/DEBUG': 47,
 'log_count/INFO': 9,
 'memusage/max': 145711104,
 'memusage/startup': 145711104,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 12, 7, 41, 54, 979815, tzinfo=datetime.timezone.utc)}
```