### PR TITLE
Add Kennards Self Storage (AU) (shop/storage_rental) (104 locations)

### DIFF
--- a/locations/spiders/kennards_self_storage_au.py
+++ b/locations/spiders/kennards_self_storage_au.py
@@ -2,9 +2,9 @@ from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
 
+
 class KennardsSelfStorageAUSpider(SitemapSpider, StructuredDataSpider):
     name = "kennards_self_storage_au"
     item_attributes = {"brand": "Kennards Self Storage", "brand_wikidata": "Q115565997"}
     sitemap_urls = ["https://www.kss.com.au/sitemap.xml"]
     sitemap_rules = [("locations/(.*)$", "parse_sd")]
-

--- a/locations/spiders/kennards_self_storage_au.py
+++ b/locations/spiders/kennards_self_storage_au.py
@@ -1,0 +1,10 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+class KennardsSelfStorageAUSpider(SitemapSpider, StructuredDataSpider):
+    name = "kennards_self_storage_au"
+    item_attributes = {"brand": "Kennards Self Storage", "brand_wikidata": "Q115565997"}
+    sitemap_urls = ["https://www.kss.com.au/sitemap.xml"]
+    sitemap_rules = [("locations/(.*)$", "parse_sd")]
+


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/6545
Related: https://github.com/alltheplaces/alltheplaces/pull/7164

```
{'atp/brand/Kennards Self Storage': 104,
 'atp/brand_wikidata/Q115565997': 104,
 'atp/category/shop/storage_rental': 104,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/invalid': 104,
 'atp/nsi/perfect_match': 104,
 'downloader/request_bytes': 91482,
 'downloader/request_count': 140,
 'downloader/request_method_count/GET': 140,
 'downloader/response_bytes': 36502921,
 'downloader/response_count': 140,
 'downloader/response_status_count/200': 140,
 'elapsed_time_seconds': 169.873442,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 12, 8, 39, 3, 489332, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 104,
 'log_count/DEBUG': 268,
 'log_count/INFO': 11,
 'memusage/max': 277544960,
 'memusage/startup': 146247680,
 'request_depth_max': 1,
 'response_received_count': 140,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 139,
 'scheduler/dequeued/memory': 139,
 'scheduler/enqueued': 139,
 'scheduler/enqueued/memory': 139,
 'start_time': datetime.datetime(2024, 2, 12, 8, 36, 13, 615890, tzinfo=datetime.timezone.utc)}
2024-02-12 08:39:03 [scrapy.core.engine] INFO: Spider closed (finished)
```