### PR TITLE
Add Kennards Self Storage (NZ)  (shop/storage_rental) (10 locations)

### DIFF
--- a/locations/spiders/kennards_self_storage_nz.py
+++ b/locations/spiders/kennards_self_storage_nz.py
@@ -2,9 +2,9 @@ from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
 
+
 class KennardsSelfStorageNZSpider(SitemapSpider, StructuredDataSpider):
     name = "kennards_self_storage_nz"
     item_attributes = {"brand": "Kennards Self Storage", "brand_wikidata": "Q115565997"}
     sitemap_urls = ["https://www.kennards.co.nz/sitemap.xml"]
     sitemap_rules = [("locations/(.*)$", "parse_sd")]
-

--- a/locations/spiders/kennards_self_storage_nz.py
+++ b/locations/spiders/kennards_self_storage_nz.py
@@ -1,0 +1,10 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+class KennardsSelfStorageNZSpider(SitemapSpider, StructuredDataSpider):
+    name = "kennards_self_storage_nz"
+    item_attributes = {"brand": "Kennards Self Storage", "brand_wikidata": "Q115565997"}
+    sitemap_urls = ["https://www.kennards.co.nz/sitemap.xml"]
+    sitemap_rules = [("locations/(.*)$", "parse_sd")]
+


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/6545

```
{'atp/brand/Kennards Self Storage': 10,
 'atp/brand_wikidata/Q115565997': 10,
 'atp/category/shop/storage_rental': 10,
 'atp/field/operator/missing': 10,
 'atp/field/operator_wikidata/missing': 10,
 'atp/field/twitter/invalid': 10,
 'atp/nsi/perfect_match': 10,
 'downloader/request_bytes': 9536,
 'downloader/request_count': 18,
 'downloader/request_method_count/GET': 18,
 'downloader/response_bytes': 2956458,
 'downloader/response_count': 18,
 'downloader/response_status_count/200': 18,
 'elapsed_time_seconds': 21.487144,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 12, 8, 34, 53, 940520, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 10,
 'log_count/DEBUG': 52,
 'log_count/INFO': 9,
 'memusage/max': 146636800,
 'memusage/startup': 146636800,
 'request_depth_max': 1,
 'response_received_count': 18,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 17,
 'scheduler/dequeued/memory': 17,
 'scheduler/enqueued': 17,
 'scheduler/enqueued/memory': 17,
 'start_time': datetime.datetime(2024, 2, 12, 8, 34, 32, 453376, tzinfo=datetime.timezone.utc)}
2024-02-12 08:34:53 [scrapy.core.engine] INFO: Spider closed (finished)
```