### PR TITLE
Add Spa World (AU, NZ) (shop/swimming_pool? for spa) (20 locations)

### DIFF
--- a/locations/spiders/spa_world_au_nz.py
+++ b/locations/spiders/spa_world_au_nz.py
@@ -1,0 +1,18 @@
+from locations.categories import Categories
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SpawWorldAUNZSpider(SitemapSpider, StructuredDataSpider):
+    name = "spa_world_au_nz"
+    item_attributes = {
+        "brand": "Spa World",
+        "brand_wikidata": "Q124003802",
+        "extras": {"shop": "swimming_pool"},
+    }
+    sitemap_urls = [
+        "https://www.spaworld.com.au/sitemap/sitemap-index.xml",
+        "https://www.spaworld.co.nz/sitemap/sitemap-index.xml",
+    ]
+    sitemap_rules = [("find-a-showroom/(.*)", "parse_sd")]

--- a/locations/spiders/spa_world_au_nz.py
+++ b/locations/spiders/spa_world_au_nz.py
@@ -1,4 +1,3 @@
-from locations.categories import Categories
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/6543
```
{'atp/brand/Spa World': 20,
 'atp/brand_wikidata/Q124003802': 20,
 'atp/category/shop/swimming_pool': 20,
 'atp/field/email/missing': 14,
 'atp/field/lat/missing': 20,
 'atp/field/lon/missing': 20,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 20,
 'atp/field/operator_wikidata/missing': 20,
 'atp/field/postcode/wrong_type': 20,
 'atp/nsi/brand_missing': 20,
 'downloader/request_bytes': 19465,
 'downloader/request_count': 50,
 'downloader/request_method_count/GET': 50,
 'downloader/response_bytes': 3379371,
 'downloader/response_count': 50,
 'downloader/response_status_count/200': 50,
 'elapsed_time_seconds': 45.427371,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 12, 21, 49, 57, 185529, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 23128398,
 'httpcompression/response_count': 46,
 'item_scraped_count': 20,
 'log_count/DEBUG': 81,
 'log_count/ERROR': 20,
 'log_count/INFO': 9,
 'memusage/max': 147726336,
 'memusage/startup': 147726336,
 'request_depth_max': 2,
 'response_received_count': 50,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 48,
 'scheduler/dequeued/memory': 48,
 'scheduler/enqueued': 48,
 'scheduler/enqueued/memory': 48,
 'start_time': datetime.datetime(2024, 2, 12, 21, 49, 11, 758158, tzinfo=datetime.timezone.utc)}
2024-02-12 21:49:57 [scrapy.core.engine] INFO: Spider closed (finished)
```