### PR TITLE
Add 99 bikes (AU) (shop/bike) (62 locations)

### DIFF
--- a/locations/spiders/99_bikes.py
+++ b/locations/spiders/99_bikes.py
@@ -1,9 +1,8 @@
 from scrapy import Spider
 
+from locations.categories import Categories
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
-from locations.dict_parser import DictParser
-from locations.categories import Categories, apply_category
 
 
 class NinetyNineBikesAUSpider(Spider):

--- a/locations/spiders/99_bikes.py
+++ b/locations/spiders/99_bikes.py
@@ -1,0 +1,40 @@
+from scrapy import Spider
+
+from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.categories import Categories, apply_category
+
+
+class NinetyNineBikesAUSpider(Spider):
+    name = "99_bikes_au"
+    item_attributes = {"brand": "99 Bikes", "brand_wikidata": "Q110288298", "extras": Categories.SHOP_BICYCLE.value}
+    allowed_domains = ["www.99bikes.com.au"]
+    start_urls = ["https://www.99bikes.com.au//rest/V1/clickandcollect_getalllocations"]
+
+    def parse(self, response):
+        for item in response.xpath("item"):
+            store = {}
+            store["ref"] = item.xpath("id/text()").get()
+            store["name"] = item.xpath("store_name/text()").get()
+            store["email"] = item.xpath("email/text()").get()
+            # store["fax"] = item.xpath("fax/text()").get()
+
+            store["lat"] = item.xpath("latitude/text()").get()
+            store["lon"] = item.xpath("longitude/text()").get()
+
+            store["city"] = item.xpath("city/text()").get()
+            store["phone"] = item.xpath("phone/text()").get()
+
+            store["state"] = item.xpath("state/text()").get()
+            store["postcode"] = item.xpath("postcode/text()").get()
+            store["street_address"] = item.xpath("address/text()").get()
+
+            store["opening_hours"] = OpeningHours()
+            for opening_time in item.xpath("extension_attributes/opening_time/item"):
+                day = opening_time.xpath("day/text()").get()
+                open_time = opening_time.xpath("open_time/text()").get()
+                close_time = opening_time.xpath("close_time/text()").get()
+
+                store["opening_hours"].add_range(DAYS_EN[day], open_time, close_time, "%H:%M%p")
+            yield Feature(**store)


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7037 (I'm not going to bother with the NZ store, as it doesn't have this API)

```
{'brand': '99 Bikes',
 'brand_wikidata': 'Q110288298',
 'city': 'Upper Coomera',
 'country': 'AU',
 'email': 'coomera@99bikes.com.au',
 'extras': {'@spider': '99_bikes_au', 'shop': 'bicycle'},
 'geometry': {'coordinates': [153.30186651, -27.85163952], 'type': 'Point'},
 'name': 'Coomera',
 'nsi_id': '99bikes-0d00fa',
 'opening_hours': 'Mo-Fr 09:00-05:30; Sa 09:00-05:00; Su 10:00-04:00',
 'phone': '+61 7 5648 3758',
 'postcode': '4209',
 'ref': '91',
 'state': 'QLD',
 'street_address': '8/15 City Centre Drive'}
2024-02-13 10:21:46 [scrapy.core.engine] INFO: Closing spider (finished)
2024-02-13 10:21:46 [locations.pipelines.duplicates] INFO: Dropped 0 duplicate items
2024-02-13 10:21:46 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/99 Bikes': 62,
 'atp/brand_wikidata/Q110288298': 62,
 'atp/category/shop/bicycle': 62,
 'atp/field/country/from_reverse_geocoding': 62,
 'atp/field/image/missing': 62,
 'atp/field/operator/missing': 62,
 'atp/field/operator_wikidata/missing': 62,
 'atp/field/twitter/missing': 62,
 'atp/field/website/missing': 62,
 'atp/nsi/perfect_match': 62,
 'downloader/request_bytes': 648,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1064632,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.066968,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 13, 10, 21, 46, 786577, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2311,
 'httpcompression/response_count': 1,
 'item_scraped_count': 62,
 'log_count/DEBUG': 75,
 'log_count/INFO': 9,
 'memusage/max': 147587072,
 'memusage/startup': 147587072,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 13, 10, 21, 43, 719609, tzinfo=datetime.timezone.utc)}
 ```