### PR TITLE
Add Davi Nails (US) (shop/beauty) (WPStoreLocator) (180/330 locations)

### DIFF
--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -21,5 +21,5 @@ class DaViNailsCAUSSpider(WPStoreLocatorSpider):
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
         item["city"] = item["city"].strip(",")
-        item["name"] = re.sub(" inside WM #\d+", "", item["name"])
+        item["name"] = re.sub(r" inside WM #\d+", "", item["name"])
         yield item

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -6,6 +6,7 @@ from locations.categories import Categories
 from locations.items import Feature
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
+
 class DaViNailsCAUSSpider(WPStoreLocatorSpider):
     name = "davi_nails_ca_us"
     item_attributes = {
@@ -16,10 +17,9 @@ class DaViNailsCAUSSpider(WPStoreLocatorSpider):
     allowed_domains = [
         "davinails.com",
     ]
-    searchable_points_files = {
-        "us_centroids_100mile_radius.csv"
-    }
-    search_radius = 100
+    searchable_points_files = ["us_centroids_100mile_radius.csv"]
+    search_radius = 10000
+    max_results = 10000
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
         item["city"] = item["city"].strip(",")

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -1,6 +1,5 @@
 import re
 
-from scrapy import Request
 
 from locations.categories import Categories
 from locations.items import Feature

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -17,10 +17,10 @@ class DaViNailsCAUSSpider(WPStoreLocatorSpider):
         "davinails.com",
     ]
     searchable_points_files = ["us_centroids_25mile_radius_state.csv"]
-    search_radius = 50
+    search_radius = 25
     max_results = 100
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
         item["city"] = item["city"].strip(",")
-        item["name"] = re.sub(" inside WM \#\d+", "", item["name"])
+        item["name"] = re.sub(" inside WM #\d+", "", item["name"])
         yield item

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -1,6 +1,5 @@
 import re
 
-
 from locations.categories import Categories
 from locations.items import Feature
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -1,6 +1,10 @@
-from locations.categories import Categories
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+import re
 
+from scrapy import Request
+
+from locations.categories import Categories
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 class DaViNailsCAUSSpider(WPStoreLocatorSpider):
     name = "davi_nails_ca_us"
@@ -12,3 +16,12 @@ class DaViNailsCAUSSpider(WPStoreLocatorSpider):
     allowed_domains = [
         "davinails.com",
     ]
+    searchable_points_files = {
+        "us_centroids_100mile_radius.csv"
+    }
+    search_radius = 100
+
+    def parse_item(self, item: Feature, location: dict, **kwargs):
+        item["city"] = item["city"].strip(",")
+        item["name"] = re.sub(" inside WM \#\d+", "", item["name"])
+        yield item

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -1,0 +1,14 @@
+from locations.categories import Categories
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class DaViNailsCAUSSpider(WPStoreLocatorSpider):
+    name = "davi_nails_ca_us"
+    item_attributes = {
+        "brand_wikidata": "Q108726836",
+        "brand": "DaVi Nails",
+        "extras": Categories.SHOP_BEAUTY.value,
+    }
+    allowed_domains = [
+        "davinails.com",
+    ]

--- a/locations/spiders/davi_nails_ca_us.py
+++ b/locations/spiders/davi_nails_ca_us.py
@@ -17,9 +17,9 @@ class DaViNailsCAUSSpider(WPStoreLocatorSpider):
     allowed_domains = [
         "davinails.com",
     ]
-    searchable_points_files = ["us_centroids_100mile_radius.csv"]
-    search_radius = 10000
-    max_results = 10000
+    searchable_points_files = ["us_centroids_25mile_radius_state.csv"]
+    search_radius = 50
+    max_results = 100
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
         item["city"] = item["city"].strip(",")


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7128

Interestingly, they have some kind of graphql endpoint that gives us the list of stores in one query.

```
{'addr_full': '5601 East Ramon Road',
 'brand': 'DaVi Nails',
 'brand_wikidata': 'Q108726836',
 'city': 'Palm Springs',
 'country': 'US',
 'email': None,
 'extras': {'@spider': 'davi_nails_ca_us', 'beauty': 'nails', 'shop': 'beauty'},
 'geometry': {'coordinates': [-116.488071, 33.815336], 'type': 'Point'},
 'housenumber': None,
 'name': 'DaVi Nails',
 'nsi_id': 'davinails-4be8e1',
 'opening_hours': None,
 'phone': '+1 760-322-3181',
 'postcode': '92262',
 'ref': '218123',
 'state': 'CA',
 'street': None,
 'street_address': '5601 East Ramon Road',
 'website': None}
```


```
2024-02-14 09:19:44 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/DaVi Nails': 109,
 'atp/brand_wikidata/Q108726836': 109,
 'atp/category/shop/beauty': 109,
 'atp/field/email/missing': 109,
 'atp/field/image/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/phone/missing': 9,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/twitter/missing': 109,
 'atp/field/website/missing': 109,
 'atp/nsi/perfect_match': 109,
 'downloader/request_bytes': 2784104,
 'downloader/request_count': 5868,
 'downloader/request_method_count/GET': 5868,
 'downloader/response_bytes': 2858435,
 'downloader/response_count': 5868,
 'downloader/response_status_count/200': 5868,
 'dupefilter/filtered': 1021,
 'elapsed_time_seconds': 7340.92206,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 14, 9, 19, 44, 470345, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 73171,
 'httpcompression/response_count': 5868,
 'item_dropped_count': 74,
 'item_dropped_reasons_count/DropItem': 74,
 'item_scraped_count': 109,
 'log_count/DEBUG': 6063,
 'log_count/INFO': 131,
 'memusage/max': 349982720,
 'memusage/startup': 147369984,
 'response_received_count': 5868,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5867,
 'scheduler/dequeued/memory': 5867,
 'scheduler/enqueued': 5867,
 'scheduler/enqueued/memory': 5867,
 'start_time': datetime.datetime(2024, 2, 14, 7, 17, 23, 548285, tzinfo=datetime.timezone.utc)}
2024-02-14 09:19:44 [scrapy.core.engine] INFO: Spider closed (finished)
```