### PR TITLE
[TotalEnergies] Fix flipped coordinates

### DIFF
--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -1,3 +1,5 @@
+import reverse_geocoder
+
 from locations.categories import (
     Access,
     Categories,
@@ -8,6 +10,7 @@ from locations.categories import (
     apply_category,
     apply_yes_no,
 )
+from locations.items import get_lat_lon, set_lat_lon
 from locations.storefinders.woosmap import WoosmapSpider
 
 
@@ -114,12 +117,20 @@ class TotalEnergiesSpider(WoosmapSpider):
 
         if brand := self.BRANDS.get(feature["properties"]["user_properties"]["brand"]):
             item.update(brand)
-            # Agip gas stations (Germany) have flipped coordinates in the source data.
-            if brand["brand"] == "Agip":
-                item["geometry"]["coordinates"].reverse()
         else:
             self.crawler.stats.inc_value(
                 f'atp/total_energies/unknown_brand/{feature["properties"]["user_properties"]["brand"]}'
             )
+
+        # Some locations have flipped coordinates - all gas stations of certain brands (Agip) and
+        # some, but not all stations of other brands (Cepsa).
+
+        lat, lon = get_lat_lon(item)
+        coords_country = reverse_geocoder.get((lat, lon), mode=1, verbose=False)["cc"]
+        flipped_coords_country = reverse_geocoder.get((lon, lat), mode=1, verbose=False)["cc"]
+        expected_country = item["country"]
+
+        if expected_country == flipped_coords_country and expected_country != coords_country:
+            set_lat_lon(item, lon, lat)
 
         yield item

--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -114,7 +114,7 @@ class TotalEnergiesSpider(WoosmapSpider):
 
         if brand := self.BRANDS.get(feature["properties"]["user_properties"]["brand"]):
             item.update(brand)
-            #Agip gas stations (Germany) have flipped coordinates in the source data.
+            # Agip gas stations (Germany) have flipped coordinates in the source data.
             if brand["brand"] == "Agip":
                 item["geometry"]["coordinates"].reverse()
         else:

--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -114,6 +114,9 @@ class TotalEnergiesSpider(WoosmapSpider):
 
         if brand := self.BRANDS.get(feature["properties"]["user_properties"]["brand"]):
             item.update(brand)
+            #Agip gas stations (Germany) have flipped coordinates in the source data.
+            if brand["brand"] == "Agip":
+                item["geometry"]["coordinates"].reverse()
         else:
             self.crawler.stats.inc_value(
                 f'atp/total_energies/unknown_brand/{feature["properties"]["user_properties"]["brand"]}'


### PR DESCRIPTION
Agip gas stations in Germany have incorrect location:

![Agip gas stations](https://github.com/alltheplaces/alltheplaces/assets/104327272/da10a264-4b6e-43c8-a8e9-a8a0dc4b30b5)

Flipping the coordinates fixes this, other gas stations in Germany are located correctly.
