### PR TITLE
Maison de la Literie (FR) (shop/bed) (145 locations)

### DIFF
--- a/locations/spiders/maisondelaliterie.py
+++ b/locations/spiders/maisondelaliterie.py
@@ -1,0 +1,38 @@
+from locations.dict_parser import DictParser
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+from typing import Any, Iterable
+from locations.hours import OpeningHours, DAYS_FR
+
+
+class MaisonDeLaLiterieSpider(Spider):
+    name = "maison_de_la_literie_fr"
+    item_attributes = {"brand": "Maison de la Literie", "brand_wikidata": "Q80955776"}
+    start_urls = ["https://www.maisondelaliterie.fr/magasins?ajax=1&p=1&n=500&all=1"]
+    time_format = "%Hh%M"
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]["stores"]:
+            item = DictParser.parse(location)
+            # Unfortunately, the opening hours are expressed in a variety of
+            # formats:
+            # "10h - 19h"
+            # "10h-12h et 14h-19h"
+            # ""
+            # For now, commenting out but leaving as example for any later contributors
+            # oh = OpeningHours()
+
+            # for specific_day in location["business_hours"]:
+            #     for hours in specific_day["hours"]:
+            #         oh.add_range(
+            #             day=DAYS_FR[specific_day["day"]],
+            #             open_time=hours.split("-")[0],
+            #             close_time=hours.split("-")[1],
+            #             time_format=self.time_format,
+            #         )
+
+            # item["opening_hours"] = oh
+
+            item["website"] = "https://www.maisondelaliterie.fr/magasin/" + location["link_rewrite"]
+
+            yield item

--- a/locations/spiders/maisondelaliterie.py
+++ b/locations/spiders/maisondelaliterie.py
@@ -1,8 +1,9 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
 from locations.dict_parser import DictParser
-from scrapy import Request, Spider
-from scrapy.http import JsonRequest, Response
-from typing import Any, Iterable
-from locations.hours import OpeningHours, DAYS_FR
 
 
 class MaisonDeLaLiterieSpider(Spider):


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7121

{'atp/brand/Maison de la Literie': 145,
 'atp/brand_wikidata/Q80955776': 145,
 'atp/category/shop/bed': 145,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_website_url': 5,
 'atp/field/image/missing': 145,
 'atp/field/opening_hours/missing': 145,
 'atp/field/operator/missing': 145,
 'atp/field/operator_wikidata/missing': 145,
 'atp/field/phone/invalid': 3,
 'atp/field/state/missing': 138,
 'atp/field/twitter/missing': 145,
 'atp/nsi/perfect_match': 145,
 'downloader/request_bytes': 651,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 42338,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.255952,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 18, 10, 12, 44, 380335, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 351878,
 'httpcompression/response_count': 2,
 'item_scraped_count': 145,
 'log_count/DEBUG': 158,
 'log_count/INFO': 9,
 'memusage/max': 148074496,
 'memusage/startup': 148074496,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 18, 10, 12, 39, 124383, tzinfo=datetime.timezone.utc)}
2024-02-18 10:12:44 [scrapy.core.engine] INFO: Spider closed (finished)