### PR TITLE
[Tier] Add spider

### DIFF
--- a/locations/pipelines/apply_nsi_categories.py
+++ b/locations/pipelines/apply_nsi_categories.py
@@ -15,7 +15,7 @@ class ApplyNSICategoriesPipeline:
         if not code:
             return item
 
-        if not self.wikidata_cache.get(code):
+        if code not in self.wikidata_cache:
             # wikidata_cache will usually only hold one thing, but can contain more with more complex spiders
             # The key thing is that we don't have to call nsi.iter_nsi on every process_item
             self.wikidata_cache[code] = list(self.nsi.iter_nsi(code))

--- a/locations/spiders/tier.py
+++ b/locations/spiders/tier.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class TierSpider(Spider):
     name = "tier"
-    item_attributes = {"name": "Tier", "brand": "Tier", "brand_wikidata": "Q63386916"}
+    item_attributes = {"name": "Tier", "operator": "Tier", "operator_wikidata": "Q63386916"}
 
     def start_requests(self) -> Iterable[Request]:
         yield JsonRequest(

--- a/locations/spiders/tier.py
+++ b/locations/spiders/tier.py
@@ -1,0 +1,38 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.items import Feature
+
+
+class TierSpider(Spider):
+    name = "tier"
+    item_attributes = {"name": "Tier", "brand": "Tier", "brand_wikidata": "Q63386916"}
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            "https://platform.tier-services.io/v1/zone",
+            headers={"X-Api-Key": "bpEUTJEBTf74oGRWxaIcW7aeZMzDDODe1yBoSxi2"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            if location["attributes"]["zoneType"] != "parking":
+                continue
+
+            item = Feature()
+            item["ref"] = location["id"]
+            # Names are bad in most zones
+            # item["name"] = location["attributes"]["name"]
+
+            item["lat"] = location["attributes"]["lat"]
+            item["lon"] = location["attributes"]["lng"]
+            item["country"] = location["attributes"]["country"]
+
+            # TODO: we could do with the vehicles types, then add OSM tags
+            # eg amenity=bicycle_rental, amenity=kick-scooter_rental, amenity=motorcycle_rental, amenity=car_rental
+            # but until then, we can do a white lie and call it public transit
+            item["extras"]["public_transport"] = "stop_position"
+
+            yield item


### PR DESCRIPTION
I just want to have another think about the pipeline change, make sure I'm not breaking anything.

Brands that aren't in NSI end up with `wikidata_cache["q123"] = []`. This fails the existing `not wikidata_cache.get`, so we loop NSI on every POI, causing quite a slow down on this spider.