### PR TITLE
[teboil_ru] add spider (334 locations)

### DIFF
--- a/locations/spiders/teboil_ru.py
+++ b/locations/spiders/teboil_ru.py
@@ -1,0 +1,45 @@
+from typing import Iterable
+
+from scrapy import FormRequest, Request, Spider
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
+
+FUEL_MAPING = {
+    "100plus": Fuel.OCTANE_100,
+    "92": Fuel.OCTANE_92,
+    "95": Fuel.OCTANE_95,
+    "95plus": Fuel.OCTANE_95,
+    "DT": Fuel.DIESEL,
+    "DTplus": Fuel.DIESEL,
+}
+
+
+class TeboilRuSpider(Spider):
+    name = "teboil_ru"
+    item_attributes = {"brand_wikidata": "Q7692079"}
+    allowed_domains = ["azs.teboil.ru"]
+
+    def start_requests(self) -> Iterable[Request]:
+        yield FormRequest(
+            url="https://azs.teboil.ru/map/ajax/map.php",
+            formdata={"cityId[]": ""},
+        )
+
+    def parse(self, response):
+        for poi in response.json()["data"][0]["shops"]:
+            item = Feature()
+            # data is a bit messy, 'telephone' in most cases has has POI id
+            item["ref"] = poi.get("externalCode") if poi.get("externalCode") != "" else poi.get("telephone")
+            item["addr_full"] = poi["adr"]
+            item["lat"], item["lon"] = poi["coordinates"]
+            apply_category(Categories.FUEL_STATION, item)
+            yield item
+
+    def parse_fuel(self, item, poi):
+        if fuels := poi.get("fuel"):
+            for fuel in fuels:
+                if tag := FUEL_MAPING.get(fuel["fuelId"]):
+                    apply_yes_no(tag, item, True)
+                else:
+                    self.crawler.stats.inc_value(f'atp/teboil_ru/fuel/unknown/{fuel["fuelId"]}')


### PR DESCRIPTION
TODO -> include RU in NSI: https://nsi.guide/index.html?t=brands&tt=teboil

Stats:

```json
{
 "atp/brand_wikidata/Q7692079": 334,
 "atp/category/amenity/fuel": 334,
 "atp/field/brand/missing": 334,
 "atp/field/city/missing": 334,
 "atp/field/country/from_spider_name": 334,
 "atp/field/email/missing": 334,
 "atp/field/image/missing": 334,
 "atp/field/name/missing": 334,
 "atp/field/opening_hours/missing": 334,
 "atp/field/operator/missing": 334,
 "atp/field/operator_wikidata/missing": 334,
 "atp/field/phone/missing": 334,
 "atp/field/postcode/missing": 334,
 "atp/field/state/missing": 334,
 "atp/field/street_address/missing": 334,
 "atp/field/twitter/missing": 334,
 "atp/field/website/missing": 334,
 "atp/nsi/match_failed": 334,
 "downloader/request_bytes": 677,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 1,
 "downloader/request_method_count/POST": 1,
 "downloader/response_bytes": 17151,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 1.880042,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-02-19T18:04:49.320367+00:00",
 "httpcompression/response_bytes": 126632,
 "httpcompression/response_count": 2,
 "item_scraped_count": 334,
 "log_count/INFO": 10,
 "memusage/max": 145408000,
 "memusage/startup": 145408000,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-02-19T18:04:47.440325+00:00"
}
```