### PR TITLE
[PapaJohns GB] Enable proxy

### DIFF
--- a/locations/pipelines/drop_logo.py
+++ b/locations/pipelines/drop_logo.py
@@ -7,7 +7,7 @@ class DropLogoPipeline:
     def process_item(self, item: Feature, spider: Spider):
         if image := item.get("image"):
             if isinstance(image, str):
-                if "logo" in image:
+                if "logo" in image or "favicon" in image:
                     item["image"] = None
                     spider.crawler.stats.inc_value("atp/field/image/dropped")
 

--- a/locations/spiders/papa_johns_gb.py
+++ b/locations/spiders/papa_johns_gb.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
@@ -9,8 +11,11 @@ class PapaJohnsGBSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.papajohns.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.papajohns\.co\.uk\/stores\/([-.\w]+)$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data):
-        # extract_google_position(item, response)
-        item["website"] = response.url
+        item["branch"] = item.pop("name")
+        if m := re.search(r"\"latitude\":(-?\d+\.\d+),\"longitude\":(-?\d+\.\d+)", response.text):
+            item["lat"], item["lon"] = m.groups()
+
         yield item


### PR DESCRIPTION
```python
 {"atp/brand/Papa John's": 458,
 'atp/brand_wikidata/Q2759586': 458,
 'atp/category/amenity/fast_food': 458,
 'atp/cdn/cloudflare/response_count': 468,
 'atp/cdn/cloudflare/response_status_count/200': 458,
 'atp/cdn/cloudflare/response_status_count/404': 10,
 'atp/field/email/missing': 458,
 'atp/field/image/dropped': 458,
 'atp/field/image/missing': 458,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 458,
 'atp/field/operator_wikidata/missing': 458,
 'atp/nsi/cc_match': 458,
 'downloader/request_bytes': 621083,
 'downloader/request_count': 470,
 'downloader/request_method_count/GET': 470,
 'downloader/response_bytes': 14285708,
 'downloader/response_count': 470,
 'downloader/response_status_count/200': 460,
 'downloader/response_status_count/404': 10,
 'elapsed_time_seconds': 5.01562,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 20, 10, 37, 38, 160661, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 470,
 'httpcompression/response_bytes': 36829823,
 'httpcompression/response_count': 470,
 'httperror/response_ignored_count': 10,
 'httperror/response_ignored_status_count/404': 10,
 'item_scraped_count': 458,
 'log_count/INFO': 20,
 'log_count/WARNING': 1,
 'memusage/max': 218415104,
 'memusage/startup': 218415104,
 'request_depth_max': 1,
 'response_received_count': 470,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 469,
 'scheduler/dequeued/memory': 469,
 'scheduler/enqueued': 469,
 'scheduler/enqueued/memory': 469,
 'start_time': datetime.datetime(2024, 2, 20, 10, 37, 33, 145041, tzinfo=datetime.timezone.utc)}
```