### PR TITLE
[MediaMarkt] Rename spider to media_markt_de

### DIFF
--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -5,8 +5,8 @@ from scrapy.http import Request
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class MediaMarktSpider(StructuredDataSpider):
-    name = "media_markt"
+class MediaMarktDESpider(StructuredDataSpider):
+    name = "media_markt_de"
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
     start_urls = ["https://www.mediamarkt.de/de/store/store-finder"]
 


### PR DESCRIPTION
This is a country-specific spider, see e.g. the number of countries for brand MediaMarkt at https://www.alltheplaces.xyz/wikidata