### PR TITLE
Sanders Backstube (DE) (shop/bakery) (24 locations)

### DIFF
--- a/locations/spiders/sanders_backstube_de.py
+++ b/locations/spiders/sanders_backstube_de.py
@@ -1,0 +1,14 @@
+from locations.hours import DAYS_DE
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class sandersbackstubeDESpider(WPStoreLocatorSpider):
+    name = "sanders_backstube_de"
+    item_attributes = {
+        "brand_wikidata": "Q66207337",
+        "brand": "sander's backstube",
+    }
+    allowed_domains = [
+        "sanders-backstube.de",
+    ]
+    days = DAYS_DE

--- a/locations/spiders/sanders_backstube_de.py
+++ b/locations/spiders/sanders_backstube_de.py
@@ -2,7 +2,7 @@ from locations.hours import DAYS_DE
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class sandersbackstubeDESpider(WPStoreLocatorSpider):
+class SandersBackstubeDESpider(WPStoreLocatorSpider):
     name = "sanders_backstube_de"
     item_attributes = {
         "brand_wikidata": "Q66207337",


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7297

2024-02-20 22:22:19 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{"atp/brand/sander's backstube": 24,
 'atp/brand_wikidata/Q66207337': 24,
 'atp/category/shop/bakery': 24,
 'atp/field/country/from_spider_name': 24,
 'atp/field/email/missing': 24,
 'atp/field/image/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/phone/invalid': 21,
 'atp/field/state/missing': 24,
 'atp/field/twitter/missing': 24,
 'atp/field/website/missing': 24,
 'atp/nsi/perfect_match': 24,
 'downloader/request_bytes': 727,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3512,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.410161,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 20, 22, 22, 19, 906466, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 37858,
 'httpcompression/response_count': 2,
 'item_scraped_count': 24,
 'log_count/DEBUG': 37,
 'log_count/INFO': 9,
 'memusage/max': 150745088,
 'memusage/startup': 150745088,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 20, 22, 22, 16, 496305, tzinfo=datetime.timezone.utc)}