### PR TITLE
[SwingKitchen] Add spider (14 locations)

### DIFF
--- a/locations/spiders/swing_kitchen.py
+++ b/locations/spiders/swing_kitchen.py
@@ -1,0 +1,17 @@
+from locations.categories import Categories
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class SwingKitchenSpider(WPStoreLocatorSpider):
+    name = "swing_kitchen"
+    item_attributes = {"brand": "Swing Kitchen", "brand_wikidata": "Q116943226", "extras": Categories.FAST_FOOD.value}
+    allowed_domains = [
+        "www.swingkitchen.com",
+    ]
+
+    def parse_item(self, item: Feature, location: dict, **kwargs):
+        del item["addr_full"]
+        del item["phone"]
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Swing Kitchen': 14,
 'atp/brand_wikidata/Q116943226': 14,
 'atp/category/amenity/fast_food': 14,
 'atp/field/country/from_reverse_geocoding': 12,
 'atp/field/email/missing': 14,
 'atp/field/image/missing': 14,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 14,
 'atp/field/operator_wikidata/missing': 14,
 'atp/field/phone/missing': 14,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 14,
 'atp/nsi/perfect_match': 14,
 'downloader/request_bytes': 681,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 2170,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.903173,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 20, 22, 0, 5, 366714, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14980,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 14,
 'log_count/DEBUG': 28,
 'log_count/INFO': 9,
 'memusage/max': 145043456,
 'memusage/startup': 145043456,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 20, 21, 59, 59, 463541, tzinfo=datetime.timezone.utc)}
```