### PR TITLE
Cadera (DE) (shop/bakery) (Wordpress) 

### DIFF
--- a/locations/spiders/cadera_de.py
+++ b/locations/spiders/cadera_de.py
@@ -1,5 +1,5 @@
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 from locations.hours import DAYS_DE
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class CaderaDESpider(WPStoreLocatorSpider):

--- a/locations/spiders/cadera_de.py
+++ b/locations/spiders/cadera_de.py
@@ -1,0 +1,14 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+from locations.hours import DAYS_DE
+
+
+class CaderaDESpider(WPStoreLocatorSpider):
+    name = "cadera_de"
+    item_attributes = {
+        "brand_wikidata": "Q62086410",
+        "brand": "Cadera",
+    }
+    allowed_domains = [
+        "cadera.de",
+    ]
+    days = DAYS_DE


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7298

```
{'atp/brand/Cadera': 25,
 'atp/brand_wikidata/Q62086410': 25,
 'atp/category/shop/bakery': 25,
 'atp/field/country/from_spider_name': 25,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 25,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 25,
 'atp/field/twitter/missing': 25,
 'atp/nsi/perfect_match': 25,
 'downloader/request_bytes': 659,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 48594,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.638495,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 21, 12, 33, 46, 724675, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 25,
 'log_count/DEBUG': 38,
 'log_count/INFO': 9,
 'memusage/max': 149889024,
 'memusage/startup': 149889024,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 21, 12, 33, 42, 86180, tzinfo=datetime.timezone.utc)}
2024-02-21 12:33:46 [scrapy.core.engine] INFO: Spider closed (finished)
```