### PR TITLE
Add Outdoor Supply Hardware spider (14 locations)

### DIFF
--- a/locations/spiders/outdoor_supply_hardware_us.py
+++ b/locations/spiders/outdoor_supply_hardware_us.py
@@ -1,0 +1,40 @@
+import json
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+def decode_email(s):
+    s = bytes.fromhex(s)
+    return "".join(chr(c ^ s[0]) for c in s[1:])
+
+
+class OutdoorSupplyHardwareUSSpider(Spider):
+    name = "outdoor_supply_hardware_us"
+    item_attributes = {"brand": "Outdoor Supply Hardware", "brand_wikidata": "Q119104427"}
+    start_urls = ["https://www.outdoorsupplyhardware.com/Locations"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response, **kwargs):
+        root = response.xpath('//*[@id="hiddenLocationData"]')[0].root
+
+        for el in root:
+            el.text = decode_email(el.get("data-cfemail"))
+
+        for location in json.loads(root.text_content()):
+            item = DictParser.parse(location)
+            del item["street"]
+
+            item["name"] = location["branchName"]
+            item["ref"] = location["branchId"]
+            item["street_address"] = location["street"]
+            item["extras"]["fax"] = location["faxNum"]
+
+            hours = OpeningHours()
+            for line in location["workHour"][len("<p>") : -len("</p>")].split("</br>"):
+                hours.add_ranges_from_string(line)
+            item["opening_hours"] = hours.as_opening_hours()
+
+            yield item


### PR DESCRIPTION
### Brand name

Outdoor Supply Hardware

Hardware store chain in the United States
### Wikidata ID

Q119104427 https://www.wikidata.org/wiki/Q119104427
### Store finder url(s)

https://www.outdoorsupplyhardware.com/Locations

### Stats
```py
{'atp/brand/Outdoor Supply Hardware': 14,
 'atp/brand_wikidata/Q119104427': 14,
 'atp/category/shop/hardware': 14,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/image/missing': 14,
 'atp/field/operator/missing': 14,
 'atp/field/operator_wikidata/missing': 14,
 'atp/field/twitter/missing': 14,
 'atp/field/website/missing': 14,
 'atp/nsi/perfect_match': 14,
 'downloader/request_bytes': 319,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 53912,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.211959,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 21, 22, 27, 40, 953892, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 271291,
 'httpcompression/response_count': 1,
 'item_scraped_count': 14,
 'log_count/DEBUG': 26,
 'log_count/INFO': 10,
 'memusage/max': 141856768,
 'memusage/startup': 141856768,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 21, 22, 27, 39, 741933, tzinfo=datetime.timezone.utc)}
```