### PR TITLE
Add Wheel Works spider (28 locations)

### DIFF
--- a/locations/spiders/wheel_works_us.py
+++ b/locations/spiders/wheel_works_us.py
@@ -1,0 +1,33 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WheelWorksUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "wheel_works_us"
+    item_attributes = {"brand": "Wheel Works", "brand_wikidata": "Q121088283"}
+    allowed_domains = ["www.wheelworks.net", "local.wheelworks.net"]
+    start_urls = ["https://www.wheelworks.net/site-map/"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"^https:\/\/local\.wheelworks\.net/.+"),
+            callback="parse_sd",
+            follow=False,
+        ),
+    ]
+
+    def post_process_item(self, item, response, ld_data):
+        additional_properties = {
+            prop["propertyID"]: prop["value"]
+            for prop in ld_data.get("additionalProperty", [])
+            if "propertyID" in prop and "value" in prop
+        }
+        item["image"] = additional_properties.get("storeImage")
+        item["street"] = additional_properties.get("street")
+
+        hours = OpeningHours()
+        hours.from_linked_data(ld_data, "%H:%M:%S")
+        item["opening_hours"] = hours.as_opening_hours()
+        yield item


### PR DESCRIPTION
### Brand name

Wheel Works

Tire retailer in California, US
### Wikidata ID

Q121088283 https://www.wikidata.org/wiki/Q121088283
### Store finder url(s)

https://www.wheelworks.net/locate/display-map/ 
https://www.wheelworks.net/site-map/

### Stats
```py
{'atp/brand/Wheel Works': 28,
 'atp/brand_wikidata/Q121088283': 28,
 'atp/category/shop/tyres': 28,
 'atp/field/email/missing': 28,
 'atp/field/image/invalid': 2,
 'atp/field/operator/missing': 28,
 'atp/field/operator_wikidata/missing': 28,
 'atp/field/twitter/missing': 28,
 'atp/nsi/perfect_match': 28,
 'downloader/request_bytes': 40313,
 'downloader/request_count': 82,
 'downloader/request_method_count/GET': 82,
 'downloader/response_bytes': 581618,
 'downloader/response_count': 82,
 'downloader/response_status_count/200': 31,
 'downloader/response_status_count/301': 42,
 'downloader/response_status_count/404': 9,
 'elapsed_time_seconds': 98.400876,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 21, 22, 13, 7, 412247, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3664461,
 'httpcompression/response_count': 40,
 'item_scraped_count': 28,
 'log_count/DEBUG': 231,
 'log_count/INFO': 11,
 'memusage/max': 282185728,
 'memusage/startup': 141471744,
 'request_depth_max': 1,
 'response_received_count': 40,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 79,
 'scheduler/dequeued/memory': 79,
 'scheduler/enqueued': 79,
 'scheduler/enqueued/memory': 79,
 'start_time': datetime.datetime(2024, 2, 21, 22, 11, 29, 11371, tzinfo=datetime.timezone.utc)}
```