### PR TITLE
Handle non-fuel stations operated by Orlen

### DIFF
--- a/locations/spiders/orlen.py
+++ b/locations/spiders/orlen.py
@@ -135,5 +135,9 @@ class OrlenSpider(scrapy.Spider):
                 item["opening_hours"] = OpeningHours()
                 item["opening_hours"].add_days_range(DAYS, match.group(1) + ":00", match.group(2) + ":00")
 
-        apply_category(Categories.FUEL_STATION, item)
+        if len(gas_names) > 0 or len(cards_names) == 0:
+            # note that some listed locations are not providing any fuel
+            # but also, some places are not having any detail provided at all
+            # in such cases lets assume that these are fuel stations
+            apply_category(Categories.FUEL_STATION, item)
         yield item


### PR DESCRIPTION
fixes #6964

run before/after spiders and looked at sample of changes

it actually removes more cases like this, like case in https://www.openstreetmap.org/#map=18/52.17961/18.12293 - there is one fuel station there, one of two points listed is separate entry for selling food/drinks

![screen03](https://github.com/alltheplaces/alltheplaces/assets/899988/5fbdc90e-410a-417c-8f12-9902f5e5b044)
