### PR TITLE
[Wagamama GB] Fix spider

### DIFF
--- a/locations/spiders/wagamama_gb.py
+++ b/locations/spiders/wagamama_gb.py
@@ -1,18 +1,31 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from typing import Any
 
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
+from locations.structured_data_spider import extract_phone
+
+# 2024-02-20 - Site has microdata, but it is broken :(
 
 
-class WagamamaGBSpider(CrawlSpider):
+class WagamamaGBSpider(SitemapSpider):
     name = "wagamama_gb"
     item_attributes = {"brand": "Wagamama", "brand_wikidata": "Q503715"}
     allowed_domains = ["wagamama.com"]
-    start_urls = ["https://www.wagamama.com/restaurants/"]
-    rules = [Rule(LinkExtractor(allow="/restaurants/"), callback="parse", follow=True)]
-    download_delay = 0.5
+    sitemap_urls = ["https://www.wagamama.com/sitemap.xml"]
+    sitemap_rules = [("/restaurants/[^/]+/[^/]+$", "parse")]
 
-    def parse(self, response):
-        MicrodataParser.convert_to_json_ld(response)
-        yield LinkedDataParser.parse(response, "Restaurant")
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["ref"] = item["website"] = response.url
+
+        item["addr_full"] = clean_address(response.xpath("//address//text()").getall())
+        item["street_address"] = response.xpath('//meta[@itemprop="streetAddress"]/@content').get()
+        item["city"] = response.xpath('//meta[@itemprop="addressLocality"]/@content').get()
+
+        extract_google_position(item, response)
+        extract_phone(item, response)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Wagamama': 172,
 'atp/brand_wikidata/Q503715': 172,
 'atp/category/amenity/restaurant': 172,
 'atp/field/country/from_spider_name': 172,
 'atp/field/email/missing': 172,
 'atp/field/image/missing': 172,
 'atp/field/opening_hours/missing': 172,
 'atp/field/operator/missing': 172,
 'atp/field/operator_wikidata/missing': 172,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 172,
 'atp/field/twitter/missing': 172,
 'atp/nsi/perfect_match': 172,
 'downloader/request_bytes': 63429,
 'downloader/request_count': 175,
 'downloader/request_method_count/GET': 175,
 'downloader/response_bytes': 15539819,
 'downloader/response_count': 175,
 'downloader/response_status_count/200': 173,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 3.776303,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 22, 12, 57, 12, 22165, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 175,
 'httpcompression/response_bytes': 108687424,
 'httpcompression/response_count': 175,
 'item_scraped_count': 172,
 'log_count/DEBUG': 531,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 195420160,
 'memusage/startup': 195420160,
 'request_depth_max': 1,
 'response_received_count': 175,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 173,
 'scheduler/dequeued/memory': 173,
 'scheduler/enqueued': 173,
 'scheduler/enqueued/memory': 173,
 'start_time': datetime.datetime(2024, 2, 22, 12, 57, 8, 245862, tzinfo=datetime.timezone.utc)}
```