### PR TITLE
[KFC GB] Require proxy

### DIFF
--- a/locations/spiders/kfc_gb.py
+++ b/locations/spiders/kfc_gb.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from scrapy import Spider
 
 from locations.categories import Extras, apply_yes_no
@@ -25,8 +27,8 @@ class KFCGBSpider(Spider):
             location["id"] = location.pop("storeid")
 
             item = DictParser.parse(location)
-
-            item["website"] = "https://www.kfc.co.uk" + location["link"]
+            if slug := location.get("link"):
+                item["website"] = urljoin("https://www.kfc.co.uk/", slug)
 
             for h in location["hours"]:
                 if h["type"] == "Standard":

--- a/locations/spiders/kfc_gb.py
+++ b/locations/spiders/kfc_gb.py
@@ -9,11 +9,12 @@ from locations.spiders.vets4pets_gb import set_located_in
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class KFCGB(Spider):
+class KFCGBSpider(Spider):
     name = "kfc_gb"
     item_attributes = KFC_SHARED_ATTRIBUTES
     start_urls = ["https://www.kfc.co.uk/cms/api/data/restaurants_all"]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         for location in response.json():


### PR DESCRIPTION
```python
{'atp/brand/KFC': 1040,
 'atp/brand_wikidata/Q524757': 1040,
 'atp/category/amenity/fast_food': 1040,
 'atp/field/email/missing': 1040,
 'atp/field/image/missing': 1040,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 1040,
 'atp/field/operator_wikidata/missing': 1040,
 'atp/field/phone/missing': 1040,
 'atp/field/state/missing': 6,
 'atp/field/twitter/missing': 1040,
 'atp/field/website/missing': 2,
 'atp/nsi/cc_match': 1040,
 'downloader/request_bytes': 534,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3696381,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.572946,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 22, 13, 30, 30, 830028, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 88,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1040,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 196169728,
 'memusage/startup': 196169728,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 22, 13, 30, 29, 257082, tzinfo=datetime.timezone.utc)}
```