### PR TITLE
Add Anti-Bot Detection middleware

### DIFF
--- a/locations/middlewares/anti_bot_detection.py
+++ b/locations/middlewares/anti_bot_detection.py
@@ -1,0 +1,84 @@
+from enum import Enum
+
+from scrapy import Request, Spider
+from scrapy.downloadermiddlewares.httpcompression import HttpCompressionMiddleware
+from scrapy.http import HtmlResponse, Response
+
+
+# As a temporary transition to use of AntiBotDetectionMiddleware,
+# assume that Zyte API is capable of bypassing all anti-bot
+# methods. This list will need to be amended after testing of Zyte
+# API ability to bypass various anti-bot methods. This list will
+# need to be frequently updated depending on the effectiveness of
+# Zyte API's ability to rapidly bypass new/revised anti-bot methods.
+class AntiBotMethods(Enum):
+    AZURE_WAF = {"name": "Azure WAF", "zyte_bypassable": True}
+    CLOUDFLARE = {"name": "Cloudflare", "zyte_bypassable": True}
+    DATADOME = {"name": "DataDome", "zyte_bypassable": True}
+    HUMAN = {"name": "HUMAN", "zyte_bypassable": True}
+    IMPERVA = {"name": "Imperva", "zyte_bypassable": True}
+    QRATOR = {"name": "Qrator", "zyte_bypassable": True}
+
+
+class AntiBotDetectionMiddleware:
+    def __init__(self, crawler):
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def process_response(self, request: Request, response: Response, spider: Spider):
+        if response.headers.get("cf-mitigated"):
+            self.add_anti_bot_method(AntiBotMethods.CLOUDFLARE, spider)
+
+        if response.headers.get("x-datadome"):
+            self.add_anti_bot_method(AntiBotMethods.DATADOME, spider)
+
+        if server := response.headers.get("server"):
+            server_utf8 = self.decode_http_header_value(server)
+            if server_utf8.upper() == "QRATOR":
+                self.add_anti_bot_method(AntiBotMethods.QRATOR, spider)
+            if response.status == 403 and server_utf8.upper() == "MICROSOFT-AZURE-APPLICATION-GATEWAY/V2":
+                self.add_anti_bot_method(AntiBotMethods.AZURE_WAF, spider)
+
+        if cookies := response.headers.getlist("set-cookie"):
+            for cookie in cookies:
+                cookie_utf8 = self.decode_http_header_value(cookie)
+                if cookie_utf8.startswith("visid_incap_") or cookie_utf8.startswith("incap_ses_"):
+                    self.add_anti_bot_method(AntiBotMethods.IMPERVA, spider)
+
+        if response.status == 403:
+            # We may need to decompress the response body before it
+            # can be parsed to detect anti-bot methods. This is
+            # necessary because HttpErrorMiddleware is ordered
+            # before HttpCompressionMiddleware per:
+            # 1. https://docs.scrapy.org/en/latest/topics/settings.html#spider-middlewares-base
+            # 2. https://docs.scrapy.org/en/latest/topics/settings.html#downloader-middlewares-base
+            # It is probably not a good idea to reorder these
+            # default middleware orders.
+            httpcm = HttpCompressionMiddleware.from_crawler(spider.crawler)
+            decompressed_response = httpcm.process_response(request, response, spider)
+            html_response = HtmlResponse(decompressed_response.url, body=decompressed_response.body)
+            if html_response.xpath('//meta[@name="description" and @content="px-captcha"]'):
+                self.add_anti_bot_method(AntiBotMethods.HUMAN, spider)
+
+        return response
+
+    @staticmethod
+    def decode_http_header_value(raw_header_value: bytes) -> str:
+        # It's not quite so simple to decode HTTP header values.
+        # The below approach is simple and will most likely work due
+        # to the encoding of HTTP header values being expected to be
+        # set by anti-bot systems. It is not expected that anti-bot
+        # systems would use different encodings for different sites.
+        return raw_header_value.decode("utf-8")
+
+    @staticmethod
+    def add_anti_bot_method(anti_bot_method: AntiBotMethods, spider: Spider):
+        if not getattr(spider, "anti_bot_methods", None):
+            setattr(spider, "anti_bot_methods", [])
+        if anti_bot_method not in spider.anti_bot_methods:
+            anti_bot_name = anti_bot_method.value["name"]
+            spider.logger.info(f"{anti_bot_name} anti-bot protection has been detected when executing spider {spider.name}.")
+            spider.anti_bot_methods.append(anti_bot_method)

--- a/locations/middlewares/anti_bot_stop_crawl.py
+++ b/locations/middlewares/anti_bot_stop_crawl.py
@@ -1,0 +1,38 @@
+from scrapy import Request, Spider
+from scrapy.exceptions import IgnoreRequest
+from scrapy.http import Response
+
+from locations.middlewares.anti_bot_detection import AntiBotDetectionMiddleware, AntiBotMethods
+
+class AntiBotStopCrawlMiddleware:
+    def __init__(self, crawler):
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def process_response(self, request: Request, response: Response, spider: Spider):
+        if anti_bot_methods := getattr(spider, "anti_bot_methods", None):
+            nonbypassable_anti_bot_methods = [anti_bot_method for anti_bot_method in anti_bot_methods if not anti_bot_method.value["zyte_bypassable"]]
+            if len(nonbypassable_anti_bot_methods) > 0 or not getattr(spider, "requires_proxy", None):
+                self.close_spider(anti_bot_methods, spider)
+        return response
+
+    @staticmethod
+    def close_spider(anti_bot_methods: list[AntiBotMethods], spider: Spider):
+        anti_bot_names = " and ".join([anti_bot_method.value["name"] for anti_bot_method in anti_bot_methods])
+        error_string = f"{anti_bot_names} anti-bot protection has been detected when executing spider {spider.name}. This spider has been halted as no bypass is currently implemented."
+        spider.logger.error(error_string)
+        # The CloseSpider exception doesn't work from middlewares
+        # as this is not implemented in Scrapy per:
+        # https://github.com/scrapy/scrapy/issues/2578
+        # Instead, the following workaround makes a deferred
+        # request to stop the spider. Note that many requests may
+        # already have been made and this deferred request won't
+        # stop those requests being handled by Scrapy. The deferred
+        # stop request prevents new requests being scheduled.
+        # The process_response method is then expected to raise an
+        # IgnoreRequest exception.
+        spider.crawler.engine.close_spider(spider, reason=error_string)
+        raise IgnoreRequest(error_string)

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -69,6 +69,13 @@ TELNETCONSOLE_ENABLED = False
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {}
 
+# Anti Bot Detection middleware must execute prior to
+# scrapy.spidermiddlewares.httperror.HttpErrorMiddleware
+# Refer to SPIDER_MIDDLEWARES_BASE at:
+# https://doc.scrapy.org/en/latest/topics/settings.html#std-setting-SPIDER_MIDDLEWARES_BASE
+DOWNLOADER_MIDDLEWARES["locations.middlewares.anti_bot_detection.AntiBotDetectionMiddleware"] = 40
+DOWNLOADER_MIDDLEWARES["locations.middlewares.anti_bot_stop_crawl.AntiBotStopCrawlMiddleware"] = 45
+
 if os.environ.get("ZYTE_API_KEY"):
     DOWNLOAD_HANDLERS = {
         "http": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",


### PR DESCRIPTION
This new middleware is in two parts:

1. Middleware to detect use of anti-bot methods such as Cloudflare Captchas, and various other Web Application Firewalls (WAF) implementing the likes of TLS fingerprinting, browser JS challenges, etc.

2. Middleware to stop a spider from generating more requests, leading to quick (but still deferred) stopping of a crawl once anti-bot methods have been detected.

Spiders can implement a new attribute "anti_bot_methods" which is a list of AntiBotMethod as specified in
locations/middlewares/anti_bot_detection.py

AntiBotDetectionMiddleware will automatically set the attribute if anti-bot method(s) are discovered.

If a particular anti-bot method is unexpected or if Zyte API is not available to use for bypassing the anti-bot method, AntiBotStopCrawl will automatically shut down the crawl in a graceful way, generally after all requests already sent have been received and parsed.