### PR TITLE
DictParser: fix reference keys

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -2,18 +2,27 @@ from locations.items import Feature
 
 
 class DictParser:
+    # Variations can't handle capitalised acronyms such as "ID" so
+    # the common variants of case including such acronyms need to
+    # all be listed below.
     ref_keys = [
         "ref",
         "id",
         "identifier",
         "store-id",
+        "StoreID",
+        "storeID",
         "store-number",
         "shop-number",
         "location-id",
+        "LocationID",
+        "locationID",
         "location-number",
         "slug",
         "store-code",
         "item-id",
+        "ItemID",
+        "itemID",
     ]
 
     name_keys = ["name", "store-name", "display-name", "title", "business-name", "item-name", "location-name"]

--- a/tests/test_dict_parser.py
+++ b/tests/test_dict_parser.py
@@ -202,6 +202,7 @@ def test_get_variations():
 
     assert any("Postcode" in DictParser.get_variations(key) for key in DictParser.postcode_keys)
 
+
 def test_get_first_key():
     ref_keys = [
         "storeid",

--- a/tests/test_dict_parser.py
+++ b/tests/test_dict_parser.py
@@ -201,3 +201,38 @@ def test_get_variations():
         assert variation in variations
 
     assert any("Postcode" in DictParser.get_variations(key) for key in DictParser.postcode_keys)
+
+def test_get_first_key():
+    ref_keys = [
+        "storeid",
+        "storeID",
+        "StoreID",
+        "storeId",
+        "StoreId",
+        "id",
+        "Id",
+        "ID",
+        "locationid",
+        "locationID",
+        "LocationID",
+        "locationId",
+        "LocationID",
+        "store_id",
+        "store_ID",
+        "Store_ID",
+        "store_Id",
+        "Store_Id",
+        "store-id",
+        "store-ID",
+        "Store-ID",
+        "store-Id",
+        "Store-Id",
+    ]
+    for ref_key in ref_keys:
+        location_dict = {
+            "sTOREID": "0000",
+            ref_key: "1234",
+            "identifier": "9999",
+        }
+        assert DictParser.get_first_key(location_dict, ref_keys) == "1234"
+        assert DictParser.get_first_key(location_dict, ["lOCATION_ID"]) is None


### PR DESCRIPTION
Commit e3ecda5778fdff7ba8261ca4fd3a2cc678abfde7 tried to standardise case of reference keys. The idea was that the variation function would try all possibilities of case for each key (camel case, title case, uppercase, lowercase, etc).

Unfortunately it was forgotten that the "ID" acronym in reference keys cannot be handled well by the variations function. It is common for a reference key to always capitalise acronyms, particularly "ID", whilst using some other case for everything else.

This change should fix a number of spiders that were returning 0 or 1 result due to lack of ability to set unique references for each location scraped.