### PR TITLE
[Hooters] Fix spider

### DIFF
--- a/locations/spiders/hooters.py
+++ b/locations/spiders/hooters.py
@@ -1,68 +1,38 @@
-import re
+from typing import Any
 
 import scrapy
+from scrapy.http import JsonRequest, Response
 
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
 
 
 class HootersSpider(scrapy.Spider):
     name = "hooters"
     item_attributes = {"brand": "Hooters", "brand_wikidata": "Q1025921"}
     allowed_domains = ["www.hooters.com"]
-    start_urls = ("https://www.hooters.com/api/search_locations.json",)
+    start_urls = ["https://www.hooters.com/api/location_names.php"]
 
-    day_mapping = {
-        "sun": "Su",
-        "mon": "Mo",
-        "tue": "Tu",
-        "wed": "We",
-        "thu": "Th",
-        "fri": "Fr",
-        "sat": "Sa",
-    }
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            yield JsonRequest(
+                url="https://www.hooters.com/api/set_my_location.php?id={}".format(location["id"]),
+                callback=self.parse_location,
+            )
 
-    def parse_store(self, store_json):
-        city = None
-        state = None
-        postcode = None
-        country = None
-        addr_full = store_json["address"]["line-1"]
-        # Only US addresses on line-2 end with a zipcode in the format "Addison, TX 75240"
-        if re.search(r"\d+$", store_json["address"]["line-2"]):
-            city = store_json["address"]["line-2"].split(",")[0].strip()
-            state = store_json["address"]["line-2"].split(",")[1].strip()[:2].strip()
-            postcode = store_json["address"]["line-2"][-5:].strip()  # Get last five characters in string
-            country = "US"
-        # Canadian address have the format "Edmonton, AB Canada"
-        elif "Canada" in store_json["address"]["line-2"]:
-            city = store_json["address"]["line-2"].split(",")[0].strip()
-            state = store_json["address"]["line-2"].split(",")[1].strip()[:2]
-            country = "CA"
-        else:
-            # For an international address just concate line-1 and line-2
-            addr_full = " ".join([addr_full, store_json["address"]["line-2"]])
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        location = response.json()["location"]
+        item = DictParser.parse(location)
+        item["branch"] = item.pop("name")
+        item["website"] = response.urljoin(location["detailsUrl"])
+        item["street_address"] = location["address"]["line-1"]
+        item["addr_full"] = clean_address([location["address"]["line-1"], location["address"]["line-2"]])
 
-        # Opening hours
-        opening_hours = OpeningHours()
-        for day, times in (store_json["hours"] or {}).items():
-            opening_hours.add_range(day, times["open"], times["close"], time_format="%H:%M:%S")
+        item["opening_hours"] = OpeningHours()
+        for day, times in (location["hours"] or {}).items():
+            item["opening_hours"].add_range(
+                day, times["open"], times["close"], "%H:%M" if len(times["open"]) == 5 else "%H:%M:%S"
+            )
 
-        return Feature(
-            lat=store_json["latitude"],
-            lon=store_json["longitude"],
-            name=store_json["name"],
-            addr_full=addr_full,
-            city=city,
-            state=state,
-            country=country,
-            postcode=postcode,
-            phone=store_json["phone"],
-            opening_hours=opening_hours,
-            ref=store_json["id"],
-        )
-
-    def parse(self, response):
-        response_dictionary = response.json()
-        stores_array = response_dictionary["locations"]
-        return list(map(self.parse_store, stores_array))
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Hooters': 375,
 'atp/brand_wikidata/Q1025921': 375,
 'atp/category/amenity/restaurant': 375,
 'atp/field/city/missing': 54,
 'atp/field/country/from_reverse_geocoding': 375,
 'atp/field/email/missing': 375,
 'atp/field/image/missing': 375,
 'atp/field/opening_hours/missing': 31,
 'atp/field/operator/missing': 375,
 'atp/field/operator_wikidata/missing': 375,
 'atp/field/phone/invalid': 16,
 'atp/field/phone/missing': 29,
 'atp/field/postcode/missing': 374,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 375,
 'atp/nsi/perfect_match': 375,
 'downloader/request_bytes': 220479,
 'downloader/request_count': 377,
 'downloader/request_method_count/GET': 377,
 'downloader/response_bytes': 585886,
 'downloader/response_count': 377,
 'downloader/response_status_count/200': 377,
 'elapsed_time_seconds': 366.878793,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 23, 0, 51, 22, 680758, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 306,
 'httpcache/hit': 71,
 'httpcache/miss': 306,
 'httpcache/store': 306,
 'httpcompression/response_bytes': 1063883,
 'httpcompression/response_count': 377,
 'item_scraped_count': 375,
 'log_count/INFO': 16,
 'log_count/WARNING': 1,
 'memusage/max': 430358528,
 'memusage/startup': 197898240,
 'request_depth_max': 1,
 'response_received_count': 377,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 376,
 'scheduler/dequeued/memory': 376,
 'scheduler/enqueued': 376,
 'scheduler/enqueued/memory': 376,
 'start_time': datetime.datetime(2024, 2, 23, 0, 45, 15, 801965, tzinfo=datetime.timezone.utc)}
```