### PR TITLE
WPStoreLocator: Attempt to detect days by frequency

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -462,6 +462,41 @@ DAYS_SR = {
     "Недеља": "Su",
 }
 
+# See https://github.com/alltheplaces/alltheplaces/issues/7360
+# A list orded by Languages most frequently used for web content as of January 2024, by share of websites.
+# See WPStoreLocator for example usage.
+DAYS_BY_FREQUENCY = [
+    DAYS_EN,
+    DAYS_ES,
+    DAYS_DE,
+    DAYS_RU,
+    # Japanese missing
+    DAYS_FR,
+    DAYS_PT,
+    DAYS_IT,
+    # Turkish missing
+    DAYS_DK,
+    DAYS_PL,
+    # Persian
+    DAYS_CZ,
+    # And everything else
+    DAYS_AT,
+    DAYS_BG,
+    DAYS_CH,
+    DAYS_FI,
+    DAYS_GR,
+    DAYS_HU,
+    DAYS_IL,
+    DAYS_NL,
+    DAYS_NO,
+    DAYS_RO,
+    DAYS_RS,
+    DAYS_SE,
+    DAYS_SI,
+    DAYS_SK,
+    DAYS_SR,
+]
+
 NAMED_DAY_RANGES_DK = {
     "Hverdage": ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],  # Weekdays
 }

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -1,3 +1,4 @@
+import logging
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest
 
@@ -85,7 +86,7 @@ class WPStoreLocatorSpider(Spider):
                 item["opening_hours"] = self.parse_opening_hours(location, self.days)
             else:
                 # Otherwise, iterate over the possibilities until we get a first match
-                logging.warn(
+                logging.warning(
                     "Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning"
                 )
                 for days in self.possible_days:

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -85,6 +85,7 @@ class WPStoreLocatorSpider(Spider):
                 item["opening_hours"] = self.parse_opening_hours(location, self.days)
             else:
                 # Otherwise, iterate over the possibilities until we get a first match
+                logging.warning(f"Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning")
                 for days in self.possible_days:
                     item["opening_hours"] = self.parse_opening_hours(location, days)
                     if item["opening_hours"] is not None:

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -85,8 +85,8 @@ class WPStoreLocatorSpider(Spider):
                 item["opening_hours"] = self.parse_opening_hours(location, self.days)
             else:
                 # Otherwise, iterate over the possibilities until we get a first match
-                logging.warning(
-                    f"Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning"
+                logging.warn(
+                    "Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning"
                 )
                 for days in self.possible_days:
                     item["opening_hours"] = self.parse_opening_hours(location, days)

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -85,7 +85,9 @@ class WPStoreLocatorSpider(Spider):
                 item["opening_hours"] = self.parse_opening_hours(location, self.days)
             else:
                 # Otherwise, iterate over the possibilities until we get a first match
-                logging.warning(f"Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning")
+                logging.warning(
+                    f"Attempting to detect opening hours - specify self.days = DAYS_EN or the appropriate language code to suppress this warning"
+                )
                 for days in self.possible_days:
                     item["opening_hours"] = self.parse_opening_hours(location, days)
                     if item["opening_hours"] is not None:

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -1,4 +1,5 @@
 import logging
+
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest
 

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -3,7 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.geo import point_locations
-from locations.hours import DAYS_EN, OpeningHours, sanitise_day
+from locations.hours import DAYS_BY_FREQUENCY, OpeningHours, sanitise_day
 from locations.items import Feature
 from locations.spiders.vapestore_gb import clean_address
 
@@ -42,11 +42,12 @@ from locations.spiders.vapestore_gb import clean_address
 
 
 class WPStoreLocatorSpider(Spider):
-    days = DAYS_EN
+    days = None
     time_format = "%H:%M"
     searchable_points_files = []
     search_radius = 0
     max_results = 0
+    possible_days = DAYS_BY_FREQUENCY
 
     def start_requests(self):
         if len(self.start_urls) == 0 and hasattr(self, "allowed_domains"):
@@ -79,19 +80,28 @@ class WPStoreLocatorSpider(Spider):
             item = DictParser.parse(location)
             item["street_address"] = clean_address([location.get("address"), location.get("address2")])
             item["name"] = location["store"]
-            item["opening_hours"] = self.parse_opening_hours(location)
+            # If we have preconfigured the exact days to use, start there
+            if self.days is not None:
+                item["opening_hours"] = self.parse_opening_hours(location, self.days)
+            else:
+                # Otherwise, iterate over the possibilities until we get a first match
+                for days in self.possible_days:
+                    item["opening_hours"] = self.parse_opening_hours(location, days)
+                    if item["opening_hours"] is not None:
+                        self.days = days
+
             yield from self.parse_item(item, location) or []
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
         yield item
 
-    def parse_opening_hours(self, location: dict, **kwargs) -> OpeningHours:
+    def parse_opening_hours(self, location: dict, days: dict, **kwargs) -> OpeningHours:
         if not location.get("hours"):
             return
         sel = Selector(text=location["hours"])
         oh = OpeningHours()
         for rule in sel.xpath("//tr"):
-            day = sanitise_day(rule.xpath("./td/text()").get(), days=self.days)
+            day = sanitise_day(rule.xpath("./td/text()").get(), days)
             times = rule.xpath("./td/time/text()").get()
             if not day or not times:
                 continue


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7360

I feel this is slightly better for wordpress instances as:

- English is still tried first
- As soon as a match is detected the assumption is made spider wide that everything else will be in that language, so the iteration cost is only for the first few matches
- Existing spiders that have set the days to a particular value remain unchanged/that is the way to optimise this.

I've only done it to the wpstorelocator spider for now as it tends to hit mainly one url / it's an API.
But this approach should be applicable more widely.

