### PR TITLE
Add Spitalfields Crypt Trust (GB) (shop/charity) (Wordpress) 11 locations

### DIFF
--- a/locations/spiders/sct.py
+++ b/locations/spiders/sct.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class SCTSpider(WPStoreLocatorSpider):
+    name = "sct"
+    item_attributes = {
+        "brand_wikidata": "Q107463316",
+        "brand": "Spitalfields Crypt Trust",
+    }
+    allowed_domains = [
+        "www.sct.org.uk",
+    ]
+    time_format = "%I:%M %p"

--- a/locations/spiders/sct_gb.py
+++ b/locations/spiders/sct_gb.py
@@ -1,8 +1,8 @@
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class SCTSpider(WPStoreLocatorSpider):
-    name = "sct"
+class SCTGBSpider(WPStoreLocatorSpider):
+    name = "sct_gb"
     item_attributes = {
         "brand_wikidata": "Q107463316",
         "brand": "Spitalfields Crypt Trust",


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7301
{'atp/brand/Spitalfields Crypt Trust': 11,
 'atp/brand_wikidata/Q107463316': 11,
 'atp/category/shop/charity': 11,
 'atp/field/email/missing': 9,
 'atp/field/image/missing': 11,
 'atp/field/operator/missing': 11,
 'atp/field/operator_wikidata/missing': 11,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 9,
 'atp/field/twitter/missing': 11,
 'atp/field/website/missing': 11,
 'atp/nsi/perfect_match': 11,
 'downloader/request_bytes': 669,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 2069,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.681129,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 24, 3, 15, 58, 951635, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9217,
 'httpcompression/response_count': 2,
 'item_scraped_count': 11,
 'log_count/DEBUG': 24,
 'log_count/INFO': 9,
 'memusage/max': 149766144,
 'memusage/startup': 149766144,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 24, 3, 15, 56, 270506, tzinfo=datetime.timezone.utc)}
2024-02-24 03:15:58 [scrapy.core.engine] INFO: Spider closed (finished)