### PR TITLE
Yext - Add detection

### DIFF
--- a/locations/storefinders/yext.py
+++ b/locations/storefinders/yext.py
@@ -9,7 +9,6 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.structured_data_spider import clean_facebook
 
-
 # Documentation for the Yext API is available at:
 # 1. https://hitchhikers.yext.com/docs/contentdeliveryapis/introduction/overview-policies-and-conventions/
 # 2. https://hitchhikers.yext.com/docs/contentdeliveryapis/legacy/entities

--- a/locations/storefinders/yext.py
+++ b/locations/storefinders/yext.py
@@ -92,9 +92,16 @@ class YextSpider(Spider, AutomaticSpiderGenerator):
         # "https://cdn.yextapis.com/v2/accounts/me/entities?api_key=
         if response.xpath('//script[contains(text(), "window.Yext")]').get():
             return True
+
         # https://locations.cariboucoffee.com/
         if response.xpath('//script[contains(text(), "locator-google")]').get():
             return True
+
+        # https://www.fnb-online.com/atm-branch-locator
+        # As per https://hitchhikers.yext.com/guides/add-searchbar-guide/01-intializethelibrary/
+        if response.xpath('//script[contains(@src, "answers-search-bar")]').get():
+            return True
+
         return False
 
     def extract_spider_attributes(response: Response) -> dict | Request:

--- a/locations/storefinders/yext.py
+++ b/locations/storefinders/yext.py
@@ -92,6 +92,9 @@ class YextSpider(Spider, AutomaticSpiderGenerator):
         # "https://cdn.yextapis.com/v2/accounts/me/entities?api_key=
         if response.xpath('//script[contains(text(), "window.Yext")]').get():
             return True
+        # https://locations.cariboucoffee.com/
+        if response.xpath('//script[contains(text(), "locator-google")]').get():
+            return True
         return False
 
     def extract_spider_attributes(response: Response) -> dict | Request:


### PR DESCRIPTION
Tested on: 
* https://locations.citizensbank.com/index.html
* BWS AU - no longer uses Yext API?
* https://locations.cariboucoffee.com/
* https://www.fnb-online.com/atm-branch-locator

Unfortunately as this library has about 50 different ways to deliver itself and ultimately make an API request to the back end, I'd like to find multiple examples of each technique.
I'm not 100% on the locator-google one.