### PR TITLE
Add Kitchen Connection (AU) 22 locations

### DIFF
--- a/locations/spiders/kitchen_connection_au.py
+++ b/locations/spiders/kitchen_connection_au.py
@@ -1,0 +1,12 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class KitchenConnectionAUSpider(WPStoreLocatorSpider):
+    name = "kitchen_connection_au"
+    item_attributes = {
+        "brand_wikidata": "Q111081406",
+        "brand": "Kitchen Connection",
+    }
+    allowed_domains = [
+        "kitchenconnection.com.au",
+    ]


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7515

Again, hours are available but weird:
```
"hours": "    <div class=\"showroom-hours-section\">\n                    <header>\n                <h4>Casula</h4>\n                <h6>Opening Hours</h6>\n            </header>\n                <table class=\"showroom-hours\">\n            <tbody>\n                        <tr>\n                <th>Mon - Wed:</th>\n                <td>9.00am - 5.30pm</td>\n                            <tr>\n                <th>Thursday:</th>\n                <td>9.00am - 7.00pm</td>\n                            <tr>\n                <th>Friday:</th>\n                <td>9.00am - 5.30pm</td>\n                            <tr>\n                <th>Saturday:</th>\n                <td>9.00am - 5.00pm</td>\n                            <tr>\n                <th>Sunday:</th>\n                <td>10.00am - 5.00pm</td>\n                            </tr>\n            </tbody>\n        </table>\n    </div>\n    ",
"url": ""
```

{'atp/brand/Kitchen Connection': 22,
 'atp/brand_wikidata/Q111081406': 22,
 'atp/category/shop/kitchen': 22,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 22,
 'atp/field/image/missing': 22,
 'atp/field/opening_hours/missing': 22,
 'atp/field/operator/missing': 22,
 'atp/field/operator_wikidata/missing': 22,
 'atp/field/twitter/missing': 22,
 'atp/nsi/perfect_match': 22,
 'downloader/request_bytes': 854,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3851,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.785595,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 7, 52, 37, 67127, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25521,
 'httpcompression/response_count': 2,
 'item_scraped_count': 22,
 'log_count/DEBUG': 35,
 'log_count/INFO': 9,
 'memusage/max': 150188032,
 'memusage/startup': 150188032,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 25, 7, 52, 34, 281532, tzinfo=datetime.timezone.utc)}