### PR TITLE
Add USAVE (GB) 245 locations

### DIFF
--- a/locations/spiders/usave_gb.py
+++ b/locations/spiders/usave_gb.py
@@ -1,0 +1,12 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class USaveGBSpider(WPStoreLocatorSpider):
+    name = "usave_gb"
+    item_attributes = {
+        "brand_wikidata": "Q121435010",
+        "brand": "USave",
+    }
+    allowed_domains = [
+        "www.usave.org.uk",
+    ]

--- a/locations/spiders/usave_gb.py
+++ b/locations/spiders/usave_gb.py
@@ -10,3 +10,4 @@ class USaveGBSpider(WPStoreLocatorSpider):
     allowed_domains = [
         "www.usave.org.uk",
     ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7502

{'atp/brand/USave': 245,
 'atp/brand_wikidata/Q121435010': 245,
 'atp/category/shop/convenience': 245,
 'atp/field/city/missing': 109,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 245,
 'atp/field/image/missing': 245,
 'atp/field/lat/missing': 12,
 'atp/field/lon/missing': 12,
 'atp/field/opening_hours/missing': 239,
 'atp/field/operator/missing': 245,
 'atp/field/operator_wikidata/missing': 245,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 123,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 245,
 'atp/field/twitter/missing': 245,
 'atp/field/website/missing': 245,
 'atp/nsi/perfect_match': 245,
 'downloader/request_bytes': 725,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12335,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.273761,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 7, 19, 14, 327576, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 75598,
 'httpcompression/response_count': 2,
 'item_scraped_count': 245,
 'log_count/DEBUG': 258,
 'log_count/INFO': 9,
 'memusage/max': 150380544,
 'memusage/startup': 150380544,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 25, 7, 19, 9, 53815, tzinfo=datetime.timezone.utc)}

One pesky store with a street address  of BLANK that might be worth filtering out.