### PR TITLE
Add Petland (US) 234 locations

### DIFF
--- a/locations/spiders/petland_us.py
+++ b/locations/spiders/petland_us.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class PetlandUSSpider(WPStoreLocatorSpider):
+    name = "petland_us"
+    item_attributes = {
+        "brand_wikidata": "Q17111474",
+        "brand": "Petland",
+    }
+    allowed_domains = [
+        "petland.com",
+    ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7517

{'atp/brand/Petland': 234,
 'atp/brand_wikidata/Q17111474': 234,
 'atp/category/shop/pet': 234,
 'atp/field/city/missing': 5,
 'atp/field/email/missing': 231,
 'atp/field/image/missing': 234,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 179,
 'atp/field/operator/missing': 234,
 'atp/field/operator_wikidata/missing': 234,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 65,
 'atp/field/postcode/missing': 67,
 'atp/field/street_address/missing': 10,
 'atp/field/twitter/missing': 234,
 'atp/field/website/missing': 7,
 'atp/nsi/perfect_match': 234,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 19099,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.763008,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 7, 55, 36, 707446, tzinfo=datetime.timezone.utc),