### PR TITLE
Add Bricks and Minifigs (CA, US) 123 Locations

### DIFF
--- a/locations/spiders/bricks_minifigs_ca_us.py
+++ b/locations/spiders/bricks_minifigs_ca_us.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class BricksMinifigsCAUSSpider(WPStoreLocatorSpider):
+    name = "bricks_minifigs_ca_us"
+    item_attributes = {
+        "brand_wikidata": "Q109329121",
+        "brand": "Bricks & Minifigs",
+    }
+    allowed_domains = [
+        "bricksandminifigs.com",
+    ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7485

{'atp/brand/Bricks & Minifigs': 123,
 'atp/brand_wikidata/Q109329121': 123,
 'atp/category/shop/toys': 123,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 107,
 'atp/field/image/missing': 123,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 123,
 'atp/field/operator_wikidata/missing': 123,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 76,
 'atp/field/postcode/missing': 10,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 123,
 'atp/field/website/missing': 19,
 'atp/nsi/perfect_match': 123,
 'downloader/request_bytes': 683,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 11917,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.317125,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 8, 0, 15, 629910, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 120798,
 'httpcompression/response_count': 2,
 'item_scraped_count': 123,
 'log_count/DEBUG': 136,
 'log_count/INFO': 9,
 'memusage/max': 150601728,
 'memusage/startup': 150601728,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 25, 8, 0, 10, 312785, tzinfo=datetime.timezone.utc)}
2024-02-25 08:00:15 [scrapy.core.engine] INFO: Spider closed (finished)