### PR TITLE
storefinders/kibo: improve hours extraction

### DIFF
--- a/locations/storefinders/kibo.py
+++ b/locations/storefinders/kibo.py
@@ -30,12 +30,19 @@ class KiboSpider(Spider):
             if not item["phone"] and "phoneNumber" in location["shippingOriginContact"]:
                 item["phone"] = location["shippingOriginContact"]["phoneNumber"]
 
-            oh = OpeningHours()
+            item["opening_hours"] = OpeningHours()
+            hours_string = ""
             for day in DAYS_FULL:
                 hours_for_day = location["regularHours"][day.lower()]
-                if not hours_for_day["isClosed"]:
-                    oh.add_range(day, hours_for_day["openTime"], hours_for_day["closeTime"])
-            item["opening_hours"] = oh.as_opening_hours()
+                if hours_for_day["isClosed"]:
+                    continue
+                if hours_for_day.get("openTime") and hours_for_day.get("closeTime"):
+                    open_time = hours_for_day["openTime"]
+                    close_time = hours_for_day["closeTime"]
+                    hours_string = f"{hours_string} {day}: {open_time} - {close_time}"
+                elif hours_label := hours_for_day.get("label"):
+                    hours_string = f"{hours_string} {day}: {hours_label}"
+            item["opening_hours"].add_ranges_from_string(hours_string)
 
             yield from self.parse_item(item, location) or []
 


### PR DESCRIPTION
Sometimes, only a label is supplied, rather than an open time and close time. The label is a text version of the time range the store is open on a given day.