### PR TITLE
remove amenity=post_office from general GLS entries

### DIFF
--- a/locations/spiders/general_logistics_systems.py
+++ b/locations/spiders/general_logistics_systems.py
@@ -18,7 +18,6 @@ class GeneralLogisticsSystemsSpider(scrapy.Spider):
         "brand": "General Logistics Systems",
         "brand_wikidata": "Q46495823",
         "country": "DE",
-        "extras": Categories.POST_OFFICE.value,
     }
 
     def start_requests(self):


### PR DESCRIPTION
not all GLS POIs listed in ATP are dedicated post offices many are just a shelf in some shop where packages are waiting for pickup

note that there are many ways to solve this:

- declare that shelf with waiting parcels in say electronics/honey/ticket shop and dedicated post office will not be distnguished
- prefer to have false positive with nonexisting post offices reported as full post offices rather than not listing some real post offices
- more advanced processing to distinguish this caes somehow
- expect data consumers to spot such bad data on their own (with either curated list of valid spiders or by treating all post office data from ATP as likely false)
- add additional field indicating likely quality issues such as data_quality:poi_category=likely_false
- ????