### PR TITLE
Add Reformhaus Bacher (DE)

### DIFF
--- a/locations/spiders/reformhaus_bacher_de.py
+++ b/locations/spiders/reformhaus_bacher_de.py
@@ -1,0 +1,12 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class ReformhausBacherDESpider(WPStoreLocatorSpider):
+    name = "reformhaus_bacher_de"
+    item_attributes = {
+        "brand_wikidata": "Q19816424",
+        "brand": "Reformhaus Bacher",
+    }
+    allowed_domains = [
+        "www.reformhaus-bacher.de",
+    ]


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7514

{'atp/brand/Reformhaus Bacher': 50,
 'atp/brand_wikidata/Q19816424': 50,
 'atp/category/shop/health_food': 50,
 'atp/field/country/from_spider_name': 50,
 'atp/field/email/missing': 50,
 'atp/field/image/missing': 50,
 'atp/field/opening_hours/missing': 50,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 50,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 1,
 'atp/nsi/perfect_match': 50,
 'downloader/request_bytes': 689,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 19421,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.199085,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 21, 16, 2, 788843, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 50,
 'log_count/DEBUG': 63,
 'log_count/INFO': 9,
 'memusage/max': 149999616,
 'memusage/startup': 149999616,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 25, 21, 15, 59, 589758, tzinfo=datetime.timezone.utc)}
2024-02-25 21:16:02 [scrapy.core.engine] INFO: Spider closed (finished)

No actual hours for once.