### PR TITLE
Add Ohio CAT (US)

### DIFF
--- a/locations/spiders/ohio_cat_us.py
+++ b/locations/spiders/ohio_cat_us.py
@@ -10,3 +10,4 @@ class OhioCATUSSpider(WPStoreLocatorSpider):
     allowed_domains = [
         "ohiocat.com",
     ]
+    time_format = "%I:%M %p"

--- a/locations/spiders/ohio_cat_us.py
+++ b/locations/spiders/ohio_cat_us.py
@@ -1,0 +1,12 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class OhioCATUSSpider(WPStoreLocatorSpider):
+    name = "ohio_cat_us"
+    item_attributes = {
+        "brand_wikidata": "Q115486235",
+        "brand": "Ohio CAT",
+    }
+    allowed_domains = [
+        "ohiocat.com",
+    ]


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7486

{'atp/brand/Ohio CAT': 13,
 'atp/brand_wikidata/Q115486235': 13,
 'atp/category/shop/trade': 13,
 'atp/field/email/missing': 13,
 'atp/field/image/missing': 13,
 'atp/field/operator/missing': 13,
 'atp/field/operator_wikidata/missing': 13,
 'atp/field/phone/missing': 12,
 'atp/field/twitter/missing': 13,
 'atp/nsi/perfect_match': 13,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 64117,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.169997,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 25, 21, 19, 13, 745162, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 13,
 'log_count/DEBUG': 26,
 'log_count/INFO': 9,
 'memusage/max': 150142976,
 'memusage/startup': 150142976,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 25, 21, 19, 10, 575165, tzinfo=datetime.timezone.utc)}
2024-02-25 21:19:13 [scrapy.core.engine] INFO: Spider closed (finished)