### PR TITLE
[obi_ru] add spider (29 locations)

### DIFF
--- a/locations/spiders/obi_de.py
+++ b/locations/spiders/obi_de.py
@@ -6,7 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class ObiDESpider(CrawlSpider, StructuredDataSpider):
     name = "obi_de"
-    item_attributes = {"brand": "Obi", "brand_wikidata": "Q300518"}
+    item_attributes = {"brand": "OBI", "brand_wikidata": "Q300518"}
     allowed_domains = ["www.obi.de"]
     start_urls = ["https://www.obi.de/markt/index.html"]
     rules = [Rule(LinkExtractor(allow="https://www.obi.de/markt/.*"), callback="parse_sd")]

--- a/locations/spiders/obi_ru.py
+++ b/locations/spiders/obi_ru.py
@@ -1,0 +1,31 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_RU, NAMED_DAY_RANGES_RU, NAMED_TIMES_RU, OpeningHours
+from locations.spiders.obi_de import ObiDESpider
+
+
+class ObiRUSpider(scrapy.Spider):
+    name = "obi_ru"
+    allowed_domains = ["obi.ru"]
+    item_attributes = ObiDESpider.item_attributes
+    start_urls = ["https://obi.ru/graphql?hash=2872797852"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = "RU"
+
+    def parse(self, response):
+        for poi in response.json()["data"]["offlineStores"]:
+            if poi["source_code"] in ["668", "default"]:
+                # Exclude test pois
+                continue
+            item = DictParser.parse(poi)
+            item["ref"] = poi["source_code"]
+            if not poi["enabled"]:
+                item["extras"]["end_date"] = "yes"
+            try:
+                oh = OpeningHours()
+                oh.add_ranges_from_string(poi.get("schedule"), DAYS_RU, NAMED_DAY_RANGES_RU, NAMED_TIMES_RU)
+                item["opening_hours"] = oh.as_opening_hours()
+            except Exception as e:
+                self.logger.warning(f'Fail to parse hours: {poi.get("schedule")}, {e}')
+            yield item


### PR DESCRIPTION
Only 29 stores, but these stores are large and popular.

Stats:
```json
{
 "atp/brand/OBI": 29,
 "atp/brand_wikidata/Q300518": 29,
 "atp/category/shop/doityourself": 29,
 "atp/closed_poi": 5,
 "atp/field/country/from_spider_name": 29,
 "atp/field/image/missing": 29,
 "atp/field/opening_hours/missing": 1,
 "atp/field/operator/missing": 29,
 "atp/field/operator_wikidata/missing": 29,
 "atp/field/phone/invalid": 24,
 "atp/field/street_address/missing": 29,
 "atp/field/twitter/missing": 29,
 "atp/field/website/missing": 29,
 "atp/nsi/perfect_match": 29,
 "downloader/request_bytes": 310,
 "downloader/request_count": 1,
 "downloader/request_method_count/GET": 1,
 "downloader/response_bytes": 355086,
 "downloader/response_count": 1,
 "downloader/response_status_count/200": 1,
 "elapsed_time_seconds": 1.518221,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-02-25T22:34:33.159090+00:00",
 "httpcompression/response_bytes": 3094808,
 "httpcompression/response_count": 1,
 "item_scraped_count": 29,
 "log_count/INFO": 10,
 "memusage/max": 143982592,
 "memusage/startup": 143982592,
 "response_received_count": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-02-25T22:34:31.640869+00:00"
}
```