### PR TITLE
[JackInTheBox] Collect opening hours

### DIFF
--- a/locations/spiders/jackinthebox.py
+++ b/locations/spiders/jackinthebox.py
@@ -7,6 +7,12 @@ class JackInTheBoxSpider(SitemapSpider, StructuredDataSpider):
     name = "jackinthebox"
     item_attributes = {"brand": "Jack in the Box", "brand_wikidata": "Q1538507"}
     sitemap_urls = ["https://locations.jackinthebox.com/sitemap.xml"]
-    sitemap_rules = [("", "parse_sd")]
+    sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+/[^/]+$", "parse_sd")]
     download_delay = 0.5
     json_parser = "chompjs"
+    time_format = "%I:%M %p"
+
+    def pre_process_data(self, ld_data, **kwargs):
+        for rule in ld_data.get("openingHoursSpecification", []):
+            rule["opens"] = rule.get("opens", "").replace(".", "")
+            rule["closes"] = rule.get("closes", "").replace(".", "")


### PR DESCRIPTION
```python
{'atp/brand/Jack in the Box': 2204,
 'atp/brand_wikidata/Q1538507': 2204,
 'atp/category/amenity/fast_food': 2204,
 'atp/field/email/missing': 2204,
 'atp/field/image/missing': 2204,
 'atp/field/opening_hours/missing': 23,
 'atp/field/operator/missing': 2204,
 'atp/field/operator_wikidata/missing': 2204,
 'atp/nsi/perfect_match': 2204,
 'downloader/request_bytes': 1254806,
 'downloader/request_count': 2206,
 'downloader/request_method_count/GET': 2206,
 'downloader/response_bytes': 27270055,
 'downloader/response_count': 2206,
 'downloader/response_status_count/200': 2206,
 'elapsed_time_seconds': 14.429617,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 26, 13, 42, 23, 832364, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2206,
 'httpcompression/response_bytes': 127791823,
 'httpcompression/response_count': 2206,
 'item_scraped_count': 2204,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 180170752,
 'memusage/startup': 180170752,
 'request_depth_max': 1,
 'response_received_count': 2206,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2205,
 'scheduler/dequeued/memory': 2205,
 'scheduler/enqueued': 2205,
 'scheduler/enqueued/memory': 2205,
 'start_time': datetime.datetime(2024, 2, 26, 13, 42, 9, 402747, tzinfo=datetime.timezone.utc)}
```