### PR TITLE
[vhlDE] Add Spider (2916 locations)

### DIFF
--- a/locations/spiders/vlh_de.py
+++ b/locations/spiders/vlh_de.py
@@ -1,0 +1,39 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.hours import DAYS_DE, OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class vhlDESpider(SitemapSpider, StructuredDataSpider):
+    name = "vhl_de"
+    item_attributes = {"brand": "Vereinigte Lohnsteuerhilfe e.V.", "brand_wikidata": "Q15852617"}
+    sitemap_urls = [
+        "https://www.vlh.de/sitemap.bst.xml",
+    ]
+    sitemap_rules = [(r"/\d+/Oeffnungszeiten.html$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data):
+        item.pop("image", None)
+        item["phone"] = ld_data["telephone"]
+        item["website"] = item["website"].replace("Oeffnungszeiten.html", "")
+        item["name"] = response.xpath("/html/head/title/text()").get().replace("Öffnungszeiten | ", "")
+
+        opening_hours = self.parse_opening_hours(response)
+
+        if opening_hours:
+            item["opening_hours"] = opening_hours
+        yield item
+
+    def parse_opening_hours(self, response):
+        opening_hours = OpeningHours()
+
+        table = response.xpath('//table[@id="office-hours-table"]')
+        for row in table.xpath("./tr"):
+            day = row.xpath("./td/text()").extract()[0]
+            times = row.xpath("./td/text()").extract()[1:]
+
+            for time in times:
+                open_time, close_time = time.split(" - ")
+                opening_hours.add_range(DAYS_DE.get(day.title()), open_time.strip(), close_time.strip())
+
+        return opening_hours


### PR DESCRIPTION
Add spider for german tax advisor: Vereinigte Lohnsteuerhilfe e.V.

```
{'atp/brand/Vereinigte Lohnsteuerhilfe e.V.': 2916,
 'atp/brand_wikidata/Q15852617': 2916,
 'atp/category/office/tax_advisor': 2916,
 'atp/field/country/from_spider_name': 2916,
 'atp/field/image/missing': 2916,
 'atp/field/opening_hours/missing': 1624,
 'atp/field/operator/missing': 2916,
 'atp/field/operator_wikidata/missing': 2916,
 'atp/field/phone/missing': 37,
 'atp/field/state/missing': 2916,
 'atp/field/twitter/missing': 2916,
 'atp/nsi/perfect_match': 2916,
 'downloader/request_bytes': 1065305,
 'downloader/request_count': 2918,
 'downloader/request_method_count/GET': 2918,
 'downloader/response_bytes': 42586355,
 'downloader/response_count': 2918,
 'downloader/response_status_count/200': 2918,
 'elapsed_time_seconds': 3567.42462,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 26, 23, 13, 46, 737625, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1882389,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2916,
 'log_count/DEBUG': 5845,
 'log_count/INFO': 69,
 'memusage/max': 289398784,
 'memusage/startup': 146317312,
 'request_depth_max': 1,
 'response_received_count': 2918,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2917,
 'scheduler/dequeued/memory': 2917,
 'scheduler/enqueued': 2917,
 'scheduler/enqueued/memory': 2917,
 'start_time': datetime.datetime(2024, 2, 26, 22, 14, 19, 313005, tzinfo=datetime.timezone.utc)}
```