### PR TITLE
[Exporters] Swicth email key

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -42,7 +42,7 @@ Each GeoJSON feature will have a `properties` object with as many of the followi
 | **Contact**           | _Contact information for the venue_
 | `phone`               | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
 | `website`             | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
-| `contact:email`       | The email address for the venue. We try to make this an email specific to the venue and not a generic email for the brand that is operating the venue.
+| `email`               | The email address for the venue. We try to make this an email specific to the venue and not a generic email for the brand that is operating the venue.
 | `contact:twitter`     | The twitter account for the venue. We try to make this specific to the venue and not generic for the brand that is operating the venue.
 | `contact:facebook`    | The facebook account for the venue. We try to make this specific to the venue and not generic for the brand that is operating the venue.
 | **Other**             | _Other information about the venue_

--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -28,7 +28,7 @@ mapping = (
     ("website", "website"),
     ("twitter", "contact:twitter"),
     ("facebook", "contact:facebook"),
-    ("email", "contact:email"),
+    ("email", "email"),
     ("opening_hours", "opening_hours"),
     ("image", "image"),
     ("brand", "brand"),


### PR DESCRIPTION
To some degree, this is just noise. Anyone consuming OSM data has to be able to consume both. However `email` is more popular, with double the usage of `contact:email`. When I added email (`contact:email`), relatively recently, I was fighting the `contact` namespace fight is OSM, that fight is over. No namespace has won, we may as well fall in line with the de facto.

Social media (eg `contact:facebook`) is still far more popular than the none namespaced equivalent, lets stick with the popular version.