### PR TITLE
Add Hizi Hair (NL)

### DIFF
--- a/locations/spiders/hizi_hair_nl.py
+++ b/locations/spiders/hizi_hair_nl.py
@@ -1,11 +1,10 @@
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 from locations.hours import DAYS_NL
-
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class HiziHairNLSpider(WPStoreLocatorSpider):
     name = "hizi_hair_nl"
-    days = DAYS_NL # Not supplied, but if they ever are
+    days = DAYS_NL  # Not supplied, but if they ever are
     item_attributes = {
         "brand_wikidata": "Q122903761",
         "brand": "Hizi Hair",

--- a/locations/spiders/hizi_hair_nl.py
+++ b/locations/spiders/hizi_hair_nl.py
@@ -1,0 +1,15 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+from locations.hours import DAYS_NL
+
+
+
+class HiziHairNLSpider(WPStoreLocatorSpider):
+    name = "hizi_hair_nl"
+    days = DAYS_NL # Not supplied, but if they ever are
+    item_attributes = {
+        "brand_wikidata": "Q122903761",
+        "brand": "Hizi Hair",
+    }
+    allowed_domains = [
+        "www.hizihair.nl",
+    ]


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7519

{'atp/brand/Hizi Hair': 75,
 'atp/brand_wikidata/Q122903761': 75,
 'atp/category/shop/hairdresser': 75,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_spider_name': 6,
 'atp/field/image/missing': 75,
 'atp/field/opening_hours/missing': 75,
 'atp/field/operator/missing': 75,
 'atp/field/operator_wikidata/missing': 75,
 'atp/field/state/missing': 75,
 'atp/field/twitter/missing': 75,
 'atp/field/website/invalid': 68,
 'atp/nsi/perfect_match': 75,
 'downloader/request_bytes': 671,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7346,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.016797,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 29, 10, 35, 41, 458615, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 26536,
 'httpcompression/response_count': 2,
 'item_scraped_count': 75,
 'log_count/DEBUG': 88,
 'log_count/INFO': 9,
 'memusage/max': 150761472,
 'memusage/startup': 150761472,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 29, 10, 35, 37, 441818, tzinfo=datetime.timezone.utc)}
2024-02-29 10:35:41 [scrapy.core.engine] INFO: Spider closed (finished)