### PR TITLE
Add Sanel NAPA (shop/car_parts) (Wordpress)

### DIFF
--- a/locations/spiders/sanel_napa.py
+++ b/locations/spiders/sanel_napa.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class SanelNAPASpider(WPStoreLocatorSpider):
+    name = "sanel_napa"
+    item_attributes = {
+        "brand_wikidata": "Q122564780",
+        "brand": "Sanel NAPA",
+    }
+    allowed_domains = [
+        "sanelnapa.com",
+    ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7372
{'atp/brand/Sanel NAPA': 46,
 'atp/brand_wikidata/Q122564780': 46,
 'atp/category/shop/car_parts': 46,
 'atp/field/email/missing': 46,
 'atp/field/image/missing': 46,
 'atp/field/opening_hours/missing': 46,
 'atp/field/operator/missing': 46,
 'atp/field/operator_wikidata/missing': 46,
 'atp/field/twitter/missing': 46,
 'atp/nsi/perfect_match': 46,
 'downloader/request_bytes': 667,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4672,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.79168,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 29, 11, 5, 13, 633860, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 43431,
 'httpcompression/response_count': 1,
 'item_scraped_count': 46,
 'log_count/DEBUG': 59,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 150712320,
 'memusage/startup': 150712320,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,