### PR TITLE
Add Leader(BR)

### DIFF
--- a/locations/spiders/leader_br.py
+++ b/locations/spiders/leader_br.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class LeaderBRSpider(WPStoreLocatorSpider):
+    name = "leader_br"
+    item_attributes = {
+        "brand_wikidata": "Q10316732",
+        "brand": "Leader",
+    }
+    allowed_domains = [
+        "institucional.lojasleader.com.br",
+    ]
+    time_format = "%I:%M %p"

--- a/locations/spiders/leader_br.py
+++ b/locations/spiders/leader_br.py
@@ -1,5 +1,5 @@
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 from locations.hours import DAYS_EN
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class LeaderBRSpider(WPStoreLocatorSpider):

--- a/locations/spiders/leader_br.py
+++ b/locations/spiders/leader_br.py
@@ -1,8 +1,10 @@
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+from locations.hours import DAYS_EN
 
 
 class LeaderBRSpider(WPStoreLocatorSpider):
     name = "leader_br"
+    days = DAYS_EN
     item_attributes = {
         "brand_wikidata": "Q10316732",
         "brand": "Leader",


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7505

2024-02-29 11:20:30 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Leader': 23,
 'atp/brand_wikidata/Q10316732': 23,
 'atp/category/shop/department_store': 23,
 'atp/field/country/from_spider_name': 6,
 'atp/field/email/missing': 23,
 'atp/field/image/missing': 23,
 'atp/field/opening_hours/missing': 23,
 'atp/field/operator/missing': 23,
 'atp/field/operator_wikidata/missing': 23,
 'atp/field/phone/missing': 6,
 'atp/field/twitter/missing': 23,
 'atp/field/website/missing': 23,
 'atp/nsi/perfect_match': 23,
 'downloader/request_bytes': 705,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3045,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.478856,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 29, 11, 20, 30, 355155, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18636,
 'httpcompression/response_count': 2,
 'item_scraped_count': 23,
 'log_count/DEBUG': 36,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 150409216,
 'memusage/startup': 150409216,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 2, 29, 11, 20, 27, 876299, tzinfo=datetime.timezone.utc)}
2024-02-29 11:20:30 [scrapy.core.engine] INFO: Spider closed (finished)