### PR TITLE
[shell] Create convenience POI when shop is in amenitites (63876 items)

### DIFF
--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -25,6 +25,7 @@ class ShellSpider(GeoMeSpider):
         # As we know the name of the shop attached we create its own POI
         if "selectshop" in amenities:
             select_shop_item = item.deepcopy()
+            item["ref"] = item.get("ref") + "-attached-shop"
             item["name"] = "Shell Select"
             item["brand"] = "Shell Select"
             item["brand_wikidata"] = "Q110716465"

--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -1,4 +1,5 @@
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
 from locations.storefinders.geo_me import GeoMeSpider
 
 
@@ -13,7 +14,21 @@ class ShellSpider(GeoMeSpider):
         fuels = location["fuels"]
         apply_category(Categories.FUEL_STATION, item)
         if "shop" in amenities:
-            apply_category(Categories.SHOP_CONVENIENCE, item)
+            shop_item = Feature()
+            shop_item["ref"] = item.get("ref") + "-attached-shop"
+            shop_item["lat"] = item.get("lat")
+            shop_item["lon"] = item.get("lon")
+            shop_item["addr_full"] = item.get("addr_full")
+            shop_item["phone"] = item.get("phone")
+            shop_item["street"] = item.get("street")
+            shop_item["housenumber"] = item.get("housenumber")
+            shop_item["street_address"] = item.get("street_address")
+            shop_item["city"] = item.get("city")
+            shop_item["state"] = item.get("state")
+            shop_item["postcode"] = item.get("postcode")
+            shop_item["country"] = item.get("country")
+            apply_category(Categories.SHOP_CONVENIENCE, shop_item)
+            yield shop_item
         apply_yes_no("amenity:chargingstation", item, "electric_charging_other" in fuels or "shell_recharge" in fuels)
         apply_yes_no("toilets", item, "toilet" in amenities)
         apply_yes_no("atm", item, "atm" in amenities)

--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -25,10 +25,10 @@ class ShellSpider(GeoMeSpider):
         # As we know the name of the shop attached we create its own POI
         if "selectshop" in amenities:
             select_shop_item = item.deepcopy()
-            item["ref"] = item.get("ref") + "-attached-shop"
-            item["name"] = "Shell Select"
-            item["brand"] = "Shell Select"
-            item["brand_wikidata"] = "Q110716465"
+            select_shop_item["ref"] = item.get("ref") + "-attached-shop"
+            select_shop_item["name"] = "Shell Select"
+            select_shop_item["brand"] = "Shell Select"
+            select_shop_item["brand_wikidata"] = "Q110716465"
             apply_category(Categories.SHOP_CONVENIENCE, select_shop_item)
             yield select_shop_item
 

--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -9,7 +9,6 @@ from locations.categories import (
     apply_yes_no,
 )
 from locations.hours import DAYS, OpeningHours
-from locations.items import Feature
 from locations.storefinders.geo_me import GeoMeSpider
 
 
@@ -22,14 +21,17 @@ class ShellSpider(GeoMeSpider):
         # Definitions extracted from https://shellgsllocator.geoapp.me/config/published/retail/prod/en_US.json?format=json
         amenities = location["amenities"]
         fuels = location["fuels"]
-        apply_category(Categories.FUEL_STATION, item)
 
         # As we know the name of the shop attached we create its own POI
         if "selectshop" in amenities:
-            select_shop_item = self.copy_address_coord_info(item)
+            select_shop_item = item.deepcopy()
             item["name"] = "Shell Select"
+            item["brand"] = "Shell Select"
+            item["brand_wikidata"] = "Q110716465"
             apply_category(Categories.SHOP_CONVENIENCE, select_shop_item)
             yield select_shop_item
+
+        apply_category(Categories.FUEL_STATION, item)
 
         # As we do not know the name of shop/restaurant attached, we apply to main item
         if "shop" in amenities:
@@ -85,19 +87,3 @@ class ShellSpider(GeoMeSpider):
         apply_yes_no(FuelCards.ESSO_NATIONAL, item, "fleet_card_esso" in amenities)
         apply_yes_no(FuelCards.UTA, item, "fleet_card_uta" in amenities)
         yield item
-
-    def copy_address_coord_info(self, item):
-        new_item = Feature()
-        new_item["ref"] = item.get("ref") + "-attached-shop"
-        new_item["lat"] = item.get("lat")
-        new_item["lon"] = item.get("lon")
-        new_item["addr_full"] = item.get("addr_full")
-        new_item["phone"] = item.get("phone")
-        new_item["street"] = item.get("street")
-        new_item["housenumber"] = item.get("housenumber")
-        new_item["street_address"] = item.get("street_address")
-        new_item["city"] = item.get("city")
-        new_item["state"] = item.get("state")
-        new_item["postcode"] = item.get("postcode")
-        new_item["country"] = item.get("country")
-        return new_item


### PR DESCRIPTION
Whenever there is a shop attached to the shell fuel station I think we should add a separate POI with the same address and coords. As a lot of the times it is not a shell convenience store that is attached. Now we do not know the name of the shop but we can still add it. Curious at peoples thoughts about this.

<details><summary>New Stats</summary>

```python
{'atp/brand/Shell': 63876,
 'atp/brand_wikidata/Q110716465': 63876,
 'atp/category/amenity/fuel': 41602,
 'atp/category/shop/convenience': 22274,
 'atp/field/city/missing': 1137,
 'atp/field/email/missing': 63876,
 'atp/field/image/missing': 63876,
 'atp/field/name/missing': 22274,
 'atp/field/opening_hours/missing': 39389,
 'atp/field/operator/missing': 63876,
 'atp/field/operator_wikidata/missing': 63876,
 'atp/field/phone/invalid': 778,
 'atp/field/phone/missing': 10146,
 'atp/field/postcode/missing': 12320,
 'atp/field/state/missing': 4990,
 'atp/field/street_address/missing': 800,
 'atp/field/twitter/missing': 63876,
 'atp/field/website/missing': 25436,
 'atp/nsi/category_match': 41602,
 'atp/nsi/match_failed': 22274,
 'downloader/request_bytes': 2063504,
 'downloader/request_count': 3827,
 'downloader/request_method_count/GET': 3827,
 'downloader/response_bytes': 137625363,
 'downloader/response_count': 3827,
 'downloader/response_status_count/200': 3826,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 4830.349677,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 2, 29, 21, 33, 9, 179277, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 80763,
 'item_dropped_reasons_count/DropItem': 80763,
 'item_scraped_count': 63876,
 'log_count/INFO': 89,
 'memusage/max': 280088576,
 'memusage/startup': 140107776,
 'request_depth_max': 1878,
 'response_received_count': 3827,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 3826,
 'scheduler/dequeued/memory': 3826,
 'scheduler/enqueued': 3826,
 'scheduler/enqueued/memory': 3826,
 'start_time': datetime.datetime(2024, 2, 29, 20, 12, 38, 829600, tzinfo=datetime.timezone.utc)}
```
</details>