### PR TITLE
Add Nothing Bundt Cakes (US, CA)

### DIFF
--- a/locations/spiders/nothing_bundt_cakes_us_ca.py
+++ b/locations/spiders/nothing_bundt_cakes_us_ca.py
@@ -1,0 +1,23 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NothingBundtCakesUSCASpider(CrawlSpider, StructuredDataSpider):
+    name = "nothing_bundt_cakes_us_ca"
+    item_attributes = {"brand": "Nothing Bundt Cakes", "brand_wikidata": "Q62082526"}
+    allowed_domains = ["www.nothingbundtcakes.com"]
+    start_urls = ["https://www.nothingbundtcakes.com/find-a-bakery/"]
+    rules = [
+        # Example: https://www.nothingbundtcakes.com/find-a-bakery/al/
+        Rule(LinkExtractor(allow=r"https://www\.nothingbundtcakes\.com/find-a-bakery/[\w]+/$")),
+        # Example: https://www.nothingbundtcakes.com/find-a-bakery/al/madison/
+        Rule(LinkExtractor(allow=r"https://www\.nothingbundtcakes\.com/find-a-bakery/[\w]+/[\w]+/$")),
+        # Example: https://www.nothingbundtcakes.com/find-a-bakery/mi/okemos/bakery-478.html
+        Rule(
+            LinkExtractor(allow=r"https://www\.nothingbundtcakes\.com/find-a-bakery/[\w]+/[\w]+/bakery-\d+\.html$"),
+            callback="parse_sd",
+        ),
+    ]
+    wanted_types = ["Bakery"]

--- a/locations/spiders/nothing_bundt_cakes_us_ca.py
+++ b/locations/spiders/nothing_bundt_cakes_us_ca.py
@@ -24,5 +24,5 @@ class NothingBundtCakesUSCASpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data):
         # Example: 'Weslaco TX Bakery & Cake Shop | Wedding & Birthday Celebration Cakes',
-        item["name"] = item["name"].replace(" | Wedding & Birthday Celebration Cakes", "").replace("  ", " ")
+        item["name"] = item["name"].replace(" | Wedding & Birthday Celebration Cakes", "")
         yield item

--- a/locations/spiders/nothing_bundt_cakes_us_ca.py
+++ b/locations/spiders/nothing_bundt_cakes_us_ca.py
@@ -24,5 +24,5 @@ class NothingBundtCakesUSCASpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data):
         # Example: 'Weslaco TX Bakery & Cake Shop | Wedding & Birthday Celebration Cakes',
-        item["name"] = item["name"].replace(' | Wedding & Birthday Celebration Cakes', '').replace('  ', ' ')
+        item["name"] = item["name"].replace(" | Wedding & Birthday Celebration Cakes", "").replace("  ", " ")
         yield item

--- a/locations/spiders/nothing_bundt_cakes_us_ca.py
+++ b/locations/spiders/nothing_bundt_cakes_us_ca.py
@@ -21,3 +21,8 @@ class NothingBundtCakesUSCASpider(CrawlSpider, StructuredDataSpider):
         ),
     ]
     wanted_types = ["Bakery"]
+
+    def post_process_item(self, item, response, ld_data):
+        # Example: 'Weslaco TX Bakery & Cake Shop | Wedding & Birthday Celebration Cakes',
+        item["name"] = item["name"].replace('| Wedding & Birthday Celebration Cakes', '')
+        yield item

--- a/locations/spiders/nothing_bundt_cakes_us_ca.py
+++ b/locations/spiders/nothing_bundt_cakes_us_ca.py
@@ -24,5 +24,5 @@ class NothingBundtCakesUSCASpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data):
         # Example: 'Weslaco TX Bakery & Cake Shop | Wedding & Birthday Celebration Cakes',
-        item["name"] = item["name"].replace('| Wedding & Birthday Celebration Cakes', '')
+        item["name"] = item["name"].replace(' | Wedding & Birthday Celebration Cakes', '').replace('  ', ' ')
         yield item


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/1665
```
{'brand': 'Nothing Bundt Cakes',
 'brand_wikidata': 'Q62082526',
 'city': 'Santa Fe',
 'country': 'US',
 'email': 'SantaFe-NM@nothingbundtcakes.com',
 'extras': {'@spider': 'nothing_bundt_cakes_us_ca', 'shop': 'pastry'},
 'facebook': 'https://www.facebook.com/nothingbundtcakes/',
 'geometry': {'coordinates': [-105.9522934, 35.6726808], 'type': 'Point'},
 'image': None,
 'name': 'Santa Fe NM Bakery & Cake Shop',
 'nsi_id': 'nothingbundtcakes-e06bde',
 'opening_hours': 'Mo-Fr 09:00-18:00; Sa 10:00-18:00',
 'phone': '+1 505-230-1325',
 'postcode': '87505',
 'ref': 'https://www.nothingbundtcakes.com/find-a-bakery/nm/santafe/bakery-471.html',
 'state': 'NM',
 'street_address': '524A W Cordova Rd',
 'website': 'https://www.nothingbundtcakes.com/find-a-bakery/nm/santafe/bakery-471.html'}
```

```
{'atp/brand/Nothing Bundt Cakes': 597,
 'atp/brand_wikidata/Q62082526': 597,
 'atp/category/shop/pastry': 597,
 'atp/field/country/from_reverse_geocoding': 597,
 'atp/field/email/missing': 18,
 'atp/field/image/dropped': 597,
 'atp/field/image/missing': 597,
 'atp/field/opening_hours/missing': 26,
 'atp/field/operator/missing': 597,
 'atp/field/operator_wikidata/missing': 597,
 'atp/field/phone/invalid': 17,
 'atp/field/twitter/missing': 597,
 'atp/nsi/perfect_match': 597,
 'downloader/request_bytes': 480975,
 'downloader/request_count': 1183,
 'downloader/request_method_count/GET': 1183,
 'downloader/response_bytes': 225737492,
 'downloader/response_count': 1183,
 'downloader/response_status_count/200': 1183,
 'dupefilter/filtered': 540,
 'elapsed_time_seconds': 1448.446676,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 2, 2, 35, 41, 182332, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2290,
 'httpcompression/response_count': 1,
 'item_scraped_count': 597,
 'log_count/DEBUG': 1792,
 'log_count/INFO': 33,
 'memusage/max': 389136384,
 'memusage/startup': 150720512,
 'request_depth_max': 3,
 'response_received_count': 1183,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1182,
 'scheduler/dequeued/memory': 1182,
 'scheduler/enqueued': 1182,
 'scheduler/enqueued/memory': 1182,
 'start_time': datetime.datetime(2024, 3, 2, 2, 11, 32, 735656, tzinfo=datetime.timezone.utc)}
2024-03-02 02:35:41 [scrapy.core.engine] INFO: Spider closed (finished)
```