### PR TITLE
Add Alltown Fresh (US)

### DIFF
--- a/locations/spiders/alltown_fresh_us.py
+++ b/locations/spiders/alltown_fresh_us.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class AlltownFreshUSSpider(WPStoreLocatorSpider):
+    name = "alltown_fresh_us"
+    item_attributes = {
+        "brand_wikidata": "Q119591365",
+        "brand": "Alltown Fresh",
+    }
+    allowed_domains = [
+        "alltownfresh.com",
+    ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7495

Note: There's a seperate one for alltown carwashes (self service) and alltown service stations it seems

{'atp/brand/Alltown Fresh': 16,
 'atp/brand_wikidata/Q119591365': 16,
 'atp/category/shop/convenience': 16,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 16,
 'atp/field/image/missing': 16,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 16,
 'atp/field/operator_wikidata/missing': 16,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 16,
 'atp/nsi/perfect_match': 16,
 'downloader/request_bytes': 840,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4020,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.567525,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 2, 2, 22, 23, 990020, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25224,
 'httpcompression/response_count': 2,
 'item_scraped_count': 16,
 'log_count/DEBUG': 29,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 150593536,
 'memusage/startup': 150593536,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 2, 2, 22, 20, 422495, tzinfo=datetime.timezone.utc)}
2024-03-02 02:22:23 [scrapy.core.engine] INFO: Spider closed (finished)