### PR TITLE
Add Alltown (US)

### DIFF
--- a/locations/spiders/alltown_us.py
+++ b/locations/spiders/alltown_us.py
@@ -1,0 +1,13 @@
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class AlltownUSSpider(WPStoreLocatorSpider):
+    name = "alltown_us"
+    item_attributes = {
+        "brand_wikidata": "Q119586667",
+        "brand": "Alltown",
+    }
+    allowed_domains = [
+        "alltown.com",
+    ]
+    time_format = "%I:%M %p"


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7500

Note: 
The URL does https://www.alltown.com/wp-admin/admin-ajax.php?action=store_search&....&max_results=100&search_radius=1000&skip_cache=1

So the 50 results I think is just... 50 results.

{'atp/brand/Alltown': 50,
 'atp/brand_wikidata/Q119586667': 50,
 'atp/category/missing': 50,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 50,
 'atp/field/image/missing': 50,
 'atp/field/opening_hours/missing': 50,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/twitter/missing': 50,
 'atp/nsi/match_failed': 50,
 'downloader/request_bytes': 1303,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 5448,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 4.031125,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 2, 2, 34, 59, 797300, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 45183,
 'httpcompression/response_count': 2,
 'item_scraped_count': 50,
 'log_count/DEBUG': 64,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 150716416,
 'memusage/startup': 150716416,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 2, 2, 34, 55, 766175, tzinfo=datetime.timezone.utc)}
