### PR TITLE
Add skechers

### DIFF
--- a/locations/spiders/skechers.py
+++ b/locations/spiders/skechers.py
@@ -1,0 +1,13 @@
+from locations.storefinders.where2getit import Where2GetItSpider
+
+
+class SkechersSpider(Where2GetItSpider):
+    name = "skechers"
+    item_attributes = {
+        "brand_wikidata": "Q2945643",
+        "brand": "Skechers",
+    }
+    allowed_domains = [
+        "local.skechers.com",
+    ]
+    api_key = "8C3F989C-6D95-11E1-9DE0-BB3690553863"


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7560
```
2024-03-02 15:13:04 [scrapy.core.scraper] DEBUG: Scraped from <200 https://hosted.where2getit.com//rest/getlist>
{'brand': 'Skechers',
 'brand_wikidata': 'Q2945643',
 'city': 'Niagara Falls',
 'country': 'US',
 'email': None,
 'extras': {'@spider': 'skechers', 'shop': 'shoes'},
 'geometry': {'coordinates': [-78.9811362, 43.0880235], 'type': 'Point'},
 'housenumber': None,
 'name': 'SKECHERS Niagara Consumer Square',
 'nsi_id': 'skechers-9b62dc',
 'phone': '+1 716-402-5052',
 'postcode': '14304',
 'ref': 'Store 1365',
 'state': 'NY',
 'street': None,
 'street_address': '7260 Niagara Falls Blvd',
 'website': None}
2024-03-02 15:13:04 [scrapy.core.engine] INFO: Closing spider (finished)
2024-03-02 15:13:04 [locations.pipelines.duplicates] INFO: Dropped 2 duplicate items
2024-03-02 15:13:04 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Skechers': 5425,
 'atp/brand_wikidata/Q2945643': 5425,
 'atp/category/shop/shoes': 5425,
 'atp/field/email/missing': 5425,
 'atp/field/image/missing': 5425,
 'atp/field/lat/missing': 15,
 'atp/field/lon/missing': 15,
 'atp/field/opening_hours/missing': 5425,
 'atp/field/operator/missing': 5425,
 'atp/field/operator_wikidata/missing': 5425,
 'atp/field/phone/invalid': 47,
 'atp/field/phone/missing': 4005,
 'atp/field/postcode/missing': 3397,
 'atp/field/state/from_reverse_geocoding': 629,
 'atp/field/state/missing': 1341,
 'atp/field/street_address/missing': 69,
 'atp/field/twitter/missing': 5425,
 'atp/field/website/missing': 5425,
 'atp/nsi/perfect_match': 5425,
 'downloader/request_bytes': 454,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 762154,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 22.28455,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 2, 15, 13, 4, 396049, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9444250,
 'httpcompression/response_count': 1,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 5425,
 'log_count/DEBUG': 5439,
 'log_count/INFO': 9,
 'memusage/max': 150245376,
 'memusage/startup': 150245376,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 2, 15, 12, 42, 111499, tzinfo=datetime.timezone.utc)}
2024-03-02 15:13:04 [scrapy.core.engine] INFO: Spider closed (finished)
```

Multiple countries.
I may need to check how many of these are simply resellers, as 5000 stores is... a lot.