### PR TITLE
Add Harveys Supermarkets (US)

### DIFF
--- a/locations/spiders/harveys_supermarkets_us.py
+++ b/locations/spiders/harveys_supermarkets_us.py
@@ -1,0 +1,43 @@
+import scrapy
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories
+from locations.items import Feature
+
+
+class HarveysSupermarketsUSSpider(scrapy.Spider):
+    # Note: This is winndixie and harveys are owned by the same parent (Southeastern Grocers: https://www.segrocers.com/)
+    # and appear to use the same APIs.
+    # At a later point we may consolidate the spiders
+    name = "harveys_supermarkets_us"
+    item_attributes = {
+        "brand": "Harveys Supermarkets",
+        "brand_wikidata": "Q5677767",
+        "extras": Categories.SHOP_SUPERMARKET.value,
+    }
+    allowed_domains = ["harveyssupermarkets.com"]
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://www.harveyssupermarkets.com/V2/storelocator/getStores?search=jacksonville,%20fl&strDefaultMiles=1000&filter=",
+        )
+
+    def parse(self, response):
+        jsonresponse = response.json()
+        for store in jsonresponse:
+            properties = {
+                "name": store["StoreName"],
+                "ref": store["StoreCode"],
+                "addr_full": store["Address"]["AddressLine2"],
+                "city": store["Address"]["City"],
+                "state": store["Address"]["State"],
+                "postcode": store["Address"]["Zipcode"],
+                "country": store["Address"]["Country"],
+                "phone": store["Phone"],
+                "lat": float(store["Location"]["Latitude"]),
+                "lon": float(store["Location"]["Longitude"]),
+            }
+            slug = f'{properties["city"]}/{properties["state"]}?search={properties["ref"]}'.lower()
+            properties["website"] = f"https://www.harveyssupermarkets.com/storedetails/{slug}"
+
+            yield Feature(**properties)


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/876
2024-03-02 23:29:45 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Harveys Supermarkets': 25,
 'atp/brand_wikidata/Q5677767': 25,
 'atp/category/shop/supermarket': 25,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 25,
 'atp/field/name/missing': 17,
 'atp/field/opening_hours/missing': 25,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/street_address/missing': 25,
 'atp/field/twitter/missing': 25,
 'atp/field/website/invalid': 2,
 'atp/nsi/brand_missing': 25,
 'downloader/request_bytes': 721,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8759,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.539624,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 2, 23, 29, 45, 223815, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 38979,
 'httpcompression/response_count': 2,
 'item_scraped_count': 25,
 'log_count/DEBUG': 38,
 'log_count/INFO': 9,
 'memusage/max': 150433792,
 'memusage/startup': 150433792,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 2, 23, 29, 42, 684191, tzinfo=datetime.timezone.utc)}
2024-03-02 23:29:45 [scrapy.core.engine] INFO: Spider closed (finished)