### PR TITLE
Add Daylight Donuts (US) (and fix small but important wordpress regression)

### DIFF
--- a/locations/spiders/daylight_donuts_us.py
+++ b/locations/spiders/daylight_donuts_us.py
@@ -1,0 +1,15 @@
+from locations.hours import DAYS_EN
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class DaylightDonutsUSSpider(WPStoreLocatorSpider):
+    days = DAYS_EN
+    name = "daylight_donuts_us"
+    item_attributes = {
+        "brand_wikidata": "Q48970508",
+        "brand": "Daylight Donuts",
+    }
+    allowed_domains = [
+        "daylightdonuts.com",
+    ]
+    time_format = "%I:%M %p"

--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -94,6 +94,7 @@ class WPStoreLocatorSpider(Spider):
                     item["opening_hours"] = self.parse_opening_hours(location, days)
                     if item["opening_hours"] is not None:
                         self.days = days
+                        break
 
             yield from self.parse_item(item, location) or []
 


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/941
```
{'atp/brand/Daylight Donuts': 323,
 'atp/brand_wikidata/Q48970508': 323,
 'atp/category/amenity/fast_food': 323,
 'atp/closed_check': 2,
 'atp/field/country/from_spider_name': 217,
 'atp/field/email/missing': 264,
 'atp/field/image/missing': 323,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 323,
 'atp/field/operator_wikidata/missing': 323,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 323,
 'atp/field/website/missing': 317,
 'atp/nsi/perfect_match': 323,
 'downloader/request_bytes': 851,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 85413,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.613202,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 3, 2, 53, 15, 2801, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 278879,
 'httpcompression/response_count': 2,
 'item_scraped_count': 323,
 'log_count/DEBUG': 336,
 'log_count/INFO': 9,
 'log_count/WARNING': 2,
 'memusage/max': 150167552,
 'memusage/startup': 150167552,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 3, 2, 53, 10, 389599, tzinfo=datetime.timezone.utc)}
2024-03-03 02:53:15 [scrapy.core.engine] INFO: Spider closed (finished)
```