### PR TITLE
Add Van Wall (US) 31 locations

### DIFF
--- a/locations/spiders/van_wall_us.py
+++ b/locations/spiders/van_wall_us.py
@@ -1,0 +1,13 @@
+from locations.categories import Categories
+from locations.hours import DAYS_EN
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class VanWallUSSpider(WPStoreLocatorSpider):
+    item_attributes = {"brand": "Van Wall", "extras": Categories.SHOP_PLANT_HIRE.value }
+    days = DAYS_EN
+    name = "van_wall_us"
+    allowed_domains = [
+        "vanwall.com",
+    ]
+    time_format = "%I:%M %p"

--- a/locations/spiders/van_wall_us.py
+++ b/locations/spiders/van_wall_us.py
@@ -4,7 +4,7 @@ from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class VanWallUSSpider(WPStoreLocatorSpider):
-    item_attributes = {"brand": "Van Wall", "extras": Categories.SHOP_PLANT_HIRE.value }
+    item_attributes = {"brand": "Van Wall", "extras": Categories.SHOP_PLANT_HIRE.value}
     days = DAYS_EN
     name = "van_wall_us"
     allowed_domains = [


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/1674

No wikidata entry

2024-03-03 03:12:35 [scrapy.core.engine] INFO: Closing spider (finished)
2024-03-03 03:12:35 [locations.pipelines.duplicates] INFO: Dropped 0 duplicate items
2024-03-03 03:12:35 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Van Wall': 31,
 'atp/category/shop/plant_hire': 31,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/brand_wikidata/missing': 31,
 'atp/field/email/missing': 31,
 'atp/field/image/missing': 31,
 'atp/field/operator/missing': 31,
 'atp/field/operator_wikidata/missing': 31,
 'atp/field/twitter/missing': 31,
 'downloader/request_bytes': 734,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4312,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.479064,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 3, 3, 12, 35, 743236, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 28095,
 'httpcompression/response_count': 2,
 'item_scraped_count': 31,
 'log_count/DEBUG': 34,
 'log_count/INFO': 9,
 'memusage/max': 150499328,
 'memusage/startup': 150499328,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 3, 3, 12, 33, 264172, tzinfo=datetime.timezone.utc)}
2024-03-03 03:12:35 [scrapy.core.engine] INFO: Spider closed (finished)