### PR TITLE
[NatWest GB] Add spider

### DIFF
--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -1,0 +1,64 @@
+import json
+from typing import Any, Iterable
+from urllib.parse import urlencode
+
+from scrapy import Request, Spider
+from scrapy.exceptions import CloseSpider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import postal_regions
+from locations.hours import OpeningHours
+
+
+class NatWestGBSpider(Spider):
+    name = "natwest_gb"
+    item_attributes = {"brand": "NatWest", "brand_wikidata": "Q2740021"}
+    total_pois = -1
+    seen_refs = set()
+
+    def start_requests(self) -> Iterable[Request]:
+        for region in postal_regions("GB"):
+            yield JsonRequest(
+                url="https://www.natwest.com/content/natwest_com/en_uk/personal/search-results/locator/jcr:content/root/responsivegrid/locator/results.blapi.search.json?{}".format(
+                    urlencode(
+                        {
+                            "search_term": region["postal_region"],
+                            "search_limit": "50",
+                            "search_radius": "2000",
+                            "filter": json.dumps(
+                                {"$and": [{"c_brand": {"$eq": "NatWest"}}, {"c_launch": {"$eq": "ACTIVE_BRANCH"}}]}
+                            ),
+                        }
+                    ),
+                )
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        resp = response.json()["response"]
+        self.total_pois = max([self.total_pois, resp["count"]])
+        for location, dist in zip(resp["entities"], resp["distances"]):
+            location["location"] = location["displayCoordinate"]
+            item = DictParser.parse(location)
+            item["ref"] = dist["id"]
+            item["branch"] = location["geomodifier"]
+            item["website"] = location["c_listing_URL"].replace("/personal", "")
+            item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
+            item["extras"]["ref:facebook"] = location.get("" "facebookPageUrl", "").split("/")[-1]
+            item["extras"]["ref:google"] = location["googlePlaceId"]
+
+            item["opening_hours"] = OpeningHours()
+            for day, rule in location["hours"].items():
+                if rule.get("isClosed"):
+                    continue
+                for time in rule["openIntervals"]:
+                    item["opening_hours"].add_range(day, time["start"], time["end"])
+
+            apply_category(Categories.BANK, item)
+
+            yield item
+            self.seen_refs.add(item["ref"])
+
+        if len(self.seen_refs) == self.total_pois:
+            raise CloseSpider()


### PR DESCRIPTION
Fixes #5782

```python
{'atp/brand/NatWest': 446,
 'atp/brand_wikidata/Q2740021': 446,
 'atp/category/amenity/bank': 446,
 'atp/field/email/missing': 446,
 'atp/field/image/missing': 446,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 446,
 'atp/field/operator_wikidata/missing': 446,
 'atp/field/phone/missing': 446,
 'atp/field/twitter/missing': 446,
 'atp/nsi/category_match': 446,
 'downloader/request_bytes': 771457,
 'downloader/request_count': 989,
 'downloader/request_method_count/GET': 989,
 'downloader/response_bytes': 19182624,
 'downloader/response_count': 989,
 'downloader/response_status_count/200': 989,
 'elapsed_time_seconds': 49.007578,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'cancelled',
 'finish_time': datetime.datetime(2024, 3, 3, 10, 1, 31, 178685, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 989,
 'httpcompression/response_bytes': 367577136,
 'httpcompression/response_count': 989,
 'item_dropped_count': 46004,
 'item_dropped_reasons_count/DropItem': 46004,
 'item_scraped_count': 446,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 196034560,
 'memusage/startup': 196034560,
 'response_received_count': 989,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 988,
 'scheduler/dequeued/memory': 988,
 'scheduler/enqueued': 989,
 'scheduler/enqueued/memory': 989,
 'start_time': datetime.datetime(2024, 3, 3, 10, 0, 42, 171107, tzinfo=datetime.timezone.utc)}
```