### PR TITLE
[UnitedPetroleum AU] Seperate Pie Face and Quick Stop POIs

### DIFF
--- a/locations/spiders/united_petroleum_au.py
+++ b/locations/spiders/united_petroleum_au.py
@@ -1,9 +1,16 @@
+from urllib.parse import urljoin
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
+
+SUB_TENANTS = {
+    "pieFace": ({"brand": "Pie Face", "brand_wikidata": "Q18166370"}, Categories.COFFEE_SHOP),
+    "quickStop": ({"brand": "Quick Stop", "name": "Quick Stop"}, Categories.SHOP_CONVENIENCE),
+}
 
 
 class UnitedPetroleumAUSpider(Spider):
@@ -14,7 +21,7 @@ class UnitedPetroleumAUSpider(Spider):
     # possible to determine whether a location is "Astron" or
     # "United" branded, but in all but seemingly < 5 cases, United
     # is almost always used.
-    item_attributes = {"brand": "United Petroleum", "brand_wikidata": "Q28224393"}
+    UNITED = {"brand": "United", "brand_wikidata": "Q28224393"}
     allowed_domains = ["servicestations.unitedpetroleum.com.au"]
     start_urls = ["https://servicestations.unitedpetroleum.com.au/api/find"]
 
@@ -37,9 +44,22 @@ class UnitedPetroleumAUSpider(Spider):
     def parse(self, response):
         for location in response.json():
             item = DictParser.parse(location)
-            item["addr_full"] = " ".join(
+            item["addr_full"] = ", ".join(
                 filter(None, [location["address1"], location["address2"], location["address3"]])
             )
+
+            if food_and_drinks := location.get("foodAndDrinks"):
+                for tenant_key, (brand, cat) in SUB_TENANTS.items():
+                    if food_and_drinks.get(tenant_key) is True:
+                        tenant = item.deepcopy()
+                        tenant["name"] = None
+                        tenant["ref"] = "{}-{}".format(item["ref"], tenant_key)
+                        tenant.update(brand)
+                        apply_category(cat, tenant)
+                        yield tenant
+
+            item.update(self.UNITED)
+            item["website"] = urljoin("https://servicestations.unitedpetroleum.com.au/location/", location["slug"])
             item["phone"] = location["publicPhoneNumber"]
             item["opening_hours"] = OpeningHours()
             for day_name in DAYS_FULL:
@@ -81,22 +101,5 @@ class UnitedPetroleumAUSpider(Spider):
             apply_yes_no(Extras.SHOWERS, item, location["facilitiesAndServices"]["showers"], False)
             apply_yes_no(Extras.ATM, item, location["facilitiesAndServices"]["atm"], False)
             apply_yes_no(Extras.CAR_WASH, item, location["facilitiesAndServices"]["carWash"], False)
-            if location.get("foodAndDrinks"):
-                apply_yes_no(Extras.DRIVE_THROUGH, item, location["foodAndDrinks"]["driveThru"], False)
-                if location["foodAndDrinks"]["roadhouse"]:
-                    apply_category(Categories.RESTAURANT, item)
-                    apply_yes_no(Extras.INDOOR_SEATING, item, True)
-                if location["foodAndDrinks"]["quickStop"]:
-                    apply_category(Categories.SHOP_CONVENIENCE, item)
-                if location["foodAndDrinks"]["pieFace"] or location["foodAndDrinks"]["baristaCoffee"]:
-                    apply_category(Categories.FAST_FOOD, item)
-                    apply_yes_no(Extras.TAKEAWAY, item, True)
-                    cuisine = ""
-                    if location["foodAndDrinks"]["pieFace"] and location["foodAndDrinks"]["baristaCoffee"]:
-                        cuisine = "pie;coffee_shop"
-                    elif location["foodAndDrinks"]["pieFace"]:
-                        cuisine = "pie"
-                    elif location["foodAndDrinks"]["baristaCoffee"]:
-                        cuisine = "coffee_shop"
-                    apply_category({"cuisine": cuisine}, item)
+
             yield item


### PR DESCRIPTION
I know you have some concerns over outputting multiple POIs at one location, but outputting:
```
name=United Wynyard
amenity=fast_food;fuel;restaurant
shop=convenience
```

For [this](https://www.google.com/maps/place/United+Petroleum+Wynyard+(Pie+Face)/@-40.9897012,145.723124,3a,75y,178.48h,86.72t/data=!3m7!1e1!3m5!1sBkFzYZWTWucmpMjAnMImeA!2e0!6shttps:%2F%2Fstreetviewpixels-pa.googleapis.com%2Fv1%2Fthumbnail%3Fpanoid%3DBkFzYZWTWucmpMjAnMImeA%26cb_client%3Dmaps_sv.tactile.gps%26w%3D203%26h%3D100%26yaw%3D110.145294%26pitch%3D0%26thumbfov%3D100!7i16384!8i8192!4m7!3m6!1s0xaa7bf3d5b0c609f3:0x350b13086e92c7f4!8m2!3d-40.9898671!4d145.7231398!10e5!16s%2Fg%2F11b6ntfml_?entry=ttu) isn't usable. If you really don't want to output these, I'd vote to drop them, not merge them into the fuel station.