### PR TITLE
[avia_pl][avia_de] add spiders, use shared attributes, add map_payment utility

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = boto3,botocore,chompjs,cryptography,geonamescache,ijson,json5,lxml,parsel,phonenumbers,phpserialize,pycountry,pygeohash,pyproj,requests,requests_cache,reverse_geocoder,scrapy,unidecode,xmltodict
+known_third_party = boto3,botocore,chompjs,cryptography,geonamescache,ijson,json5,lxml,parsel,phonenumbers,phpserialize,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,unidecode,xmltodict

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = boto3,botocore,chompjs,cryptography,geonamescache,ijson,json5,lxml,parsel,phonenumbers,phpserialize,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,unidecode,xmltodict
+known_third_party = boto3,botocore,chompjs,cryptography,geonamescache,ijson,json5,lxml,parsel,phonenumbers,phpserialize,pycountry,pygeohash,pyproj,requests,requests_cache,reverse_geocoder,scrapy,unidecode,xmltodict

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+from locations.dict_parser import DictParser
 from locations.items import Feature
 
 
@@ -736,3 +737,22 @@ def apply_healthcare_specialities(specialities: [HealthcareSpecialities], item: 
     """
     for s in specialities:
         apply_category({"healthcare:speciality": s.value}, item)
+
+
+# TODO: something similar for fuel types
+def map_payment(item: Feature, payment_method: str, enum: PaymentMethods | FuelCards):
+    """Apply appropriate payment method tag to an item if given string is found in an enum."""
+    if not payment_method:
+        return
+    map = {}
+    for payment in enum:
+        variations = DictParser.get_variations(payment.name.replace("_", "-"))
+        variations.add(payment.name.replace("_", " ").lower())
+        variations.add(payment.name.replace("_", " ").title())
+        variations.add(payment.name.replace("_", " ").upper())
+        for variation in variations:
+            map[variation] = payment.name
+
+    if payment := map.get(payment_method):
+        apply_yes_no(enum[payment], item, True)
+        return True

--- a/locations/spiders/avia_de.py
+++ b/locations/spiders/avia_de.py
@@ -1,0 +1,65 @@
+import scrapy
+
+from locations.categories import Categories, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no, map_payment
+from locations.dict_parser import DictParser
+
+AVIA_SHARED_ATTRIBUTES = {
+    "brand": "Avia",
+    "brand_wikidata": "Q300147",
+}
+
+FUEL_TYPES_MAPPING = {
+    "AdBlue (Gebinde)": Fuel.ADBLUE,
+    "AdBlue Säule (LKW)": Fuel.ADBLUE,
+    "AdBlue Säule (PKW)": Fuel.ADBLUE,
+    "Blue Diesel": Fuel.DIESEL,
+    "CNG/Erdgas": Fuel.CNG,
+    "Diesel": Fuel.DIESEL,
+    "LKW-Diesel": Fuel.HGV_DIESEL,
+    "LPG/Autogas": Fuel.LPG,
+    "Stromladesäule": Fuel.ELECTRIC,
+    "Super E10": Fuel.E10,
+    "Super E5": Fuel.E5,
+    "Super Plus": Fuel.OCTANE_98,
+}
+
+
+class AviaDESpider(scrapy.Spider):
+    name = "avia_de"
+    allowed_domains = ["www.avia.de"]
+    start_urls = ["https://www.avia.de/index.php?eID=tsfindergetdata&datatype=allstations"]
+    BRANDS_MAPPING = {
+        "AVIA Automatentankstelle": AVIA_SHARED_ATTRIBUTES,
+        "AVIA Tankstelle": AVIA_SHARED_ATTRIBUTES,
+        "AVIA XPress": AVIA_SHARED_ATTRIBUTES,
+        "tankpoint Tankstelle": {"brand": "Tank Point"},
+    }
+
+    def parse(self, response):
+        for poi in response.json():
+            poi.update(poi.pop("addressData"))
+            poi.update(poi.pop("contactData"))
+            poi.update(poi.pop("geoData"))
+            item = DictParser.parse(poi)
+            item.update(self.BRANDS_MAPPING.get(poi.get("facilityTitle"), {}))
+
+            if payment := poi.get("optionalData", {}).get("paymentMethods", {}):
+                for paymentMethod in payment.values():
+                    if not map_payment(item, paymentMethod, PaymentMethods):
+                        self.crawler.stats.inc_value(f"atp/avia_de/payment/fail/{paymentMethod}")
+
+            if fuel_cards := poi.get("optionalData", {}).get("fuelCards", {}):
+                for fuelCard in fuel_cards.values():
+                    if not map_payment(item, fuelCard, FuelCards):
+                        self.crawler.stats.inc_value(f"atp/avia_de/fuelCard/fail/{fuelCard}")
+
+            for fuel in poi.get("optionalData", {}).get("fuelTypes", []):
+                if tag := FUEL_TYPES_MAPPING.get(fuel):
+                    apply_yes_no(tag, item, True)
+                else:
+                    self.crawler.stats.inc_value(f"atp/avia_de/fuel/fail/{fuel}")
+
+            apply_category(Categories.FUEL_STATION, item)
+
+            # TODO: Opening hours
+            yield item

--- a/locations/spiders/avia_de.py
+++ b/locations/spiders/avia_de.py
@@ -1,6 +1,16 @@
 import scrapy
 
-from locations.categories import Categories, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no, map_payment
+from locations.categories import (
+    Access,
+    Categories,
+    Extras,
+    Fuel,
+    FuelCards,
+    PaymentMethods,
+    apply_category,
+    apply_yes_no,
+    map_payment,
+)
 from locations.dict_parser import DictParser
 
 AVIA_SHARED_ATTRIBUTES = {
@@ -23,6 +33,32 @@ FUEL_TYPES_MAPPING = {
     "Super Plus": Fuel.OCTANE_98,
 }
 
+SERVICES_MAPPING = {
+    "Anhängervermietung": None,
+    "Backshop": None,
+    "Bistro": Extras.FAST_FOOD,
+    "Dusche": Extras.SHOWERS,
+    "Erdgas": None,
+    "Geldautomat": Extras.ATM,
+    "Getränkemarkt": None,
+    "LKW-Hochleistungssäule": Access.HGV,
+    "LOTTO": None,
+    "Portalwaschanlage": Extras.CAR_WASH,
+    "Prima Bistro": Extras.FAST_FOOD,
+    "Reinigungsannahme": None,
+    "SB-Sauger": Extras.VACUUM_CLEANER,
+    "SB-Waschbox": None,
+    "SB-Öltheke": None,
+    "Segafredo Kaffee": None,
+    "Shop": None,
+    "Stromladesäule": Fuel.ELECTRIC,
+    "Tankautomat": "automated",
+    "TÜV / AU": None,
+    "Unbemannte Automatenstation": None,
+    "Waschstrasse": Extras.CAR_WASH,
+    "Werkstatt": None,
+}
+
 
 class AviaDESpider(scrapy.Spider):
     name = "avia_de"
@@ -36,6 +72,9 @@ class AviaDESpider(scrapy.Spider):
     }
 
     def parse(self, response):
+        def dict_to_list(d):
+            return d.values() if d else []
+
         for poi in response.json():
             poi.update(poi.pop("addressData"))
             poi.update(poi.pop("contactData"))
@@ -43,23 +82,30 @@ class AviaDESpider(scrapy.Spider):
             item = DictParser.parse(poi)
             item.update(self.BRANDS_MAPPING.get(poi.get("facilityTitle"), {}))
 
-            if payment := poi.get("optionalData", {}).get("paymentMethods", {}):
-                for paymentMethod in payment.values():
-                    if not map_payment(item, paymentMethod, PaymentMethods):
-                        self.crawler.stats.inc_value(f"atp/avia_de/payment/fail/{paymentMethod}")
+            payments = dict_to_list(poi.get("optionalData", {}).get("paymentMethods"))
+            fuel_cards = dict_to_list(poi.get("optionalData", {}).get("fuelCards", {}))
+            gas_types = dict_to_list(poi.get("optionalData", {}).get("gasTypes", {}))
+            services = dict_to_list(poi.get("optionalData", {}).get("services", {}))
 
-            if fuel_cards := poi.get("optionalData", {}).get("fuelCards", {}):
-                for fuelCard in fuel_cards.values():
-                    if not map_payment(item, fuelCard, FuelCards):
-                        self.crawler.stats.inc_value(f"atp/avia_de/fuelCard/fail/{fuelCard}")
+            for payment in payments:
+                if not map_payment(item, payment, PaymentMethods):
+                    self.crawler.stats.inc_value(f"atp/avia_de/payment/fail/{payment}")
 
-            for fuel in poi.get("optionalData", {}).get("fuelTypes", []):
-                if tag := FUEL_TYPES_MAPPING.get(fuel):
-                    apply_yes_no(tag, item, True)
-                else:
-                    self.crawler.stats.inc_value(f"atp/avia_de/fuel/fail/{fuel}")
+            for fuel_card in fuel_cards:
+                if not map_payment(item, fuel_card, FuelCards):
+                    self.crawler.stats.inc_value(f"atp/avia_de/fuelCard/fail/{fuel_card}")
+
+            self.parse_attribute(item, gas_types, "gasTypes", FUEL_TYPES_MAPPING)
+            self.parse_attribute(item, services, "services", SERVICES_MAPPING)
 
             apply_category(Categories.FUEL_STATION, item)
 
             # TODO: Opening hours
             yield item
+
+    def parse_attribute(self, item, values: list, attribute_name, mapping: dict):
+        for value in values:
+            if tag := mapping.get(value):
+                apply_yes_no(tag, item, True)
+            else:
+                self.crawler.stats.inc_value(f"atp/avia_de/{attribute_name}/fail/{value}")

--- a/locations/spiders/avia_hu.py
+++ b/locations/spiders/avia_hu.py
@@ -7,11 +7,12 @@ from scrapy.http import Response
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
 
 
 class AviaHUSpider(Spider):
     name = "avia_hu"
-    item_attributes = {"brand": "Avia", "brand_wikidata": "Q300147"}
+    item_attributes = AVIA_SHARED_ATTRIBUTES
     start_urls = ["https://www.avia.hu/kapcsolat/toltoallomasok/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 
 from locations.categories import Access, Categories, Extras, Fuel, FuelCards, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
 from locations.spiders.vapestore_gb import clean_address
 from locations.structured_data_spider import extract_phone
 
@@ -36,7 +37,7 @@ FUELS_AND_SERVICES_MAPPING = {
 
 class AviaPLSpider(Spider):
     name = "avia_pl"
-    item_attributes = {"brand": "Avia", "brand_wikidata": "Q300147"}
+    item_attributes = AVIA_SHARED_ATTRIBUTES
     start_urls = ["https://aviastacjapaliw.pl/mapa-2/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -1,0 +1,65 @@
+import re
+from typing import Any
+
+from scrapy import Selector, Spider
+from scrapy.http import Response
+
+from locations.categories import Access, Categories, Extras, Fuel, FuelCards, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.spiders.vapestore_gb import clean_address
+from locations.structured_data_spider import extract_phone
+
+FUELS_AND_SERVICES_MAPPING = {
+    # Fuels
+    "AdBluePompa": Fuel.ADBLUE,
+    "Diesel": Fuel.DIESEL,
+    "DieselGold": Fuel.DIESEL,
+    "DieselONTIR": Fuel.DIESEL,
+    "Benzyna98": Fuel.OCTANE_98,
+    "Benzyna95": Fuel.OCTANE_95,
+    "LPG": Fuel.LPG,
+    # Services
+    "Gastro": Extras.FAST_FOOD,
+    "HS": Access.HGV,
+    "Myjnia": Extras.CAR_WASH,
+    "Myjniatir": Extras.CAR_WASH,
+    "Wjazdtir": Access.HGV,
+    "Parkingtir": Access.HGV,
+    # Fuel cards
+    "Eurowag": FuelCards.EUROWAG,
+    "Dkv": FuelCards.DKV,
+    "Uta": FuelCards.UTA,
+    "Aviacard": FuelCards.AVIA,
+    "e100": FuelCards.E100,
+}
+
+
+class AviaPLSpider(Spider):
+    name = "avia_pl"
+    item_attributes = {"brand": "Avia", "brand_wikidata": "Q300147"}
+    start_urls = ["https://aviastacjapaliw.pl/mapa-2/"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for lat, lon, name, html_blob in re.findall(
+            r"\[{ lat: (-?\d+\.\d+), ?lng:\s+(-?\d+\.\d+)\s+}, \"(.+?)\", \"(.+?)\"],", response.text
+        ):
+            item = Feature()
+            item["lat"] = lat
+            item["lon"] = lon
+            item["branch"] = name.removeprefix("AVIA ")
+
+            sel = Selector(text=html_blob)
+            item["ref"] = item["website"] = sel.xpath("//a/@href").get().strip('\\"')
+            item["addr_full"] = clean_address(sel.xpath('//div[@class="content"]/text()').getall())
+            extract_phone(item, sel)
+
+            for key, tag in FUELS_AND_SERVICES_MAPPING.items():
+                if sel.xpath(f'//div[contains(text(), "+{key}+")]').get():
+                    apply_yes_no(tag, item, True)
+
+            if sel.xpath('//div[contains(text(), "+h24+")]').get():
+                item["opening_hours"] = "24/7"
+
+            apply_category(Categories.FUEL_STATION, item)
+
+            yield item

--- a/locations/spiders/avia_rs.py
+++ b/locations/spiders/avia_rs.py
@@ -5,11 +5,12 @@ from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
 
 
 class AviaRSSpider(Spider):
     name = "avia_rs"
-    item_attributes = {"brand": "Avia", "brand_wikidata": "Q300147"}
+    item_attributes = AVIA_SHARED_ATTRIBUTES
     start_urls = [
         "https://radunavia.rs/en/avia-petrol-stations",
     ]

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,13 +1,17 @@
+import pytest
+
 from locations.categories import (
     Categories,
     Clothes,
     Fuel,
     HealthcareSpecialities,
+    PaymentMethods,
     apply_category,
     apply_clothes,
     apply_healthcare_specialities,
     apply_yes_no,
     get_category_tags,
+    map_payment,
 )
 from locations.items import Feature
 
@@ -110,3 +114,29 @@ def test_healthcare_specialities():
 
     apply_healthcare_specialities([HealthcareSpecialities.OCCUPATIONAL], item)
     assert item["extras"] == {"healthcare:speciality": "occupational"}
+
+
+@pytest.fixture
+def payment_methods_enum():
+    return PaymentMethods
+
+
+@pytest.fixture
+def item():
+    return Feature()
+
+
+@pytest.mark.parametrize(
+    "input_payment, expected_tag",
+    [
+        ("americanexpress", "payment:american_express"),
+        ("american express", "payment:american_express"),
+        ("American Express", "payment:american_express"),
+        ("american_express", "payment:american_express"),
+        ("American_Express", None),  # TODO: fix this
+    ],
+)
+def test_map_payment(item, payment_methods_enum, input_payment, expected_tag):
+    map_payment(item, input_payment, payment_methods_enum)
+    if expected_tag:
+        assert item["extras"].get(expected_tag)

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,5 +1,3 @@
-import pytest
-
 from locations.categories import (
     Categories,
     Clothes,
@@ -116,27 +114,23 @@ def test_healthcare_specialities():
     assert item["extras"] == {"healthcare:speciality": "occupational"}
 
 
-@pytest.fixture
-def payment_methods_enum():
-    return PaymentMethods
+def test_map_payment():
+    item = Feature()
+    map_payment(item, "americanexpress", PaymentMethods)
+    assert item["extras"].get("payment:american_express")
 
+    item = Feature()
+    map_payment(item, "american express", PaymentMethods)
+    assert item["extras"].get("payment:american_express")
 
-@pytest.fixture
-def item():
-    return Feature()
+    item = Feature()
+    map_payment(item, "American Express", PaymentMethods)
+    assert item["extras"].get("payment:american_express")
 
+    item = Feature()
+    map_payment(item, "american_express", PaymentMethods)
+    assert item["extras"].get("payment:american_express")
 
-@pytest.mark.parametrize(
-    "input_payment, expected_tag",
-    [
-        ("americanexpress", "payment:american_express"),
-        ("american express", "payment:american_express"),
-        ("American Express", "payment:american_express"),
-        ("american_express", "payment:american_express"),
-        ("American_Express", None),  # TODO: fix this
-    ],
-)
-def test_map_payment(item, payment_methods_enum, input_payment, expected_tag):
-    map_payment(item, input_payment, payment_methods_enum)
-    if expected_tag:
-        assert item["extras"].get(expected_tag)
+    item = Feature()
+    map_payment(item, "American_Express", PaymentMethods)
+    assert not item["extras"].get("payment:american_express")


### PR DESCRIPTION
<details><summary> avia_pl stats</summary>

```json
{
 "atp/brand/Avia": 127,
 "atp/brand_wikidata/Q300147": 127,
 "atp/category/amenity/fuel": 127,
 "atp/field/city/missing": 127,
 "atp/field/country/from_spider_name": 127,
 "atp/field/email/missing": 127,
 "atp/field/image/missing": 127,
 "atp/field/opening_hours/missing": 52,
 "atp/field/operator/missing": 127,
 "atp/field/operator_wikidata/missing": 127,
 "atp/field/phone/invalid": 1,
 "atp/field/phone/missing": 54,
 "atp/field/postcode/missing": 127,
 "atp/field/state/missing": 127,
 "atp/field/street_address/missing": 127,
 "atp/field/twitter/missing": 127,
 "atp/nsi/category_match": 127,
 "downloader/request_bytes": 1233,
 "downloader/request_count": 4,
 "downloader/request_method_count/GET": 4,
 "downloader/response_bytes": 41954,
 "downloader/response_count": 4,
 "downloader/response_status_count/200": 1,
 "downloader/response_status_count/500": 3,
 "elapsed_time_seconds": 3.914104,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-03-06T16:16:56.245761+00:00",
 "httpcompression/response_bytes": 232320,
 "httpcompression/response_count": 1,
 "item_scraped_count": 127,
 "log_count/ERROR": 1,
 "log_count/INFO": 10,
 "memusage/max": 135020544,
 "memusage/startup": 135020544,
 "response_received_count": 2,
 "retry/count": 2,
 "retry/max_reached": 1,
 "retry/reason_count/500 Internal Server Error": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/500": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-03-06T16:16:52.331657+00:00"
}
```

</details>

<details><summary> avia_de stats</summary>

```json
{
 "atp/avia_de/fuelCard/fail/AVIA G-CARD": 221,
 "atp/avia_de/fuelCard/fail/AVIACARD": 868,
 "atp/avia_de/fuelCard/fail/AVIACARD NL": 789,
 "atp/avia_de/fuelCard/fail/AVIACARD Prepaid": 757,
 "atp/avia_de/fuelCard/fail/BayWa Tankkarte": 848,
 "atp/avia_de/fuelCard/fail/LogPay": 860,
 "atp/avia_de/fuelCard/fail/Novofleet": 861,
 "atp/avia_de/fuelCard/fail/TND-Card": 212,
 "atp/avia_de/fuelCard/fail/Total Card Deutschland": 840,
 "atp/avia_de/fuelCard/fail/Westfalen Service Card": 853,
 "atp/avia_de/fuelCard/fail/euroShell Card Multi": 801,
 "atp/avia_de/payment/fail/AMEXCO": 827,
 "atp/avia_de/payment/fail/EC / Girocard": 868,
 "atp/avia_de/payment/fail/Mastercard": 848,
 "atp/avia_de/services/fail/Anh\u00e4ngervermietung": 6,
 "atp/avia_de/services/fail/Backshop": 304,
 "atp/avia_de/services/fail/Erdgas": 33,
 "atp/avia_de/services/fail/Getr\u00e4nkemarkt": 76,
 "atp/avia_de/services/fail/LOTTO": 85,
 "atp/avia_de/services/fail/Reinigungsannahme": 14,
 "atp/avia_de/services/fail/SB-Waschbox": 100,
 "atp/avia_de/services/fail/SB-\u00d6ltheke": 89,
 "atp/avia_de/services/fail/Segafredo Kaffee": 306,
 "atp/avia_de/services/fail/Shop": 635,
 "atp/avia_de/services/fail/T\u00dcV / AU": 256,
 "atp/avia_de/services/fail/Unbemannte Automatenstation": 224,
 "atp/avia_de/services/fail/Werkstatt": 360,
 "atp/brand/Avia": 845,
 "atp/brand/Tank Point": 37,
 "atp/brand_wikidata/Q300147": 845,
 "atp/category/amenity/fuel": 882,
 "atp/field/brand_wikidata/missing": 37,
 "atp/field/country/from_spider_name": 882,
 "atp/field/email/invalid": 5,
 "atp/field/email/missing": 120,
 "atp/field/image/missing": 882,
 "atp/field/name/missing": 37,
 "atp/field/opening_hours/missing": 882,
 "atp/field/operator/missing": 882,
 "atp/field/operator_wikidata/missing": 882,
 "atp/field/phone/invalid": 5,
 "atp/field/phone/missing": 17,
 "atp/field/twitter/missing": 882,
 "atp/field/website/invalid": 11,
 "atp/field/website/missing": 637,
 "atp/nsi/category_match": 845,
 "downloader/request_bytes": 644,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 115830,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 9.194173,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-03-06T18:04:18.589300+00:00",
 "httpcompression/response_bytes": 1278316,
 "httpcompression/response_count": 2,
 "item_scraped_count": 882,
 "log_count/INFO": 10,
 "memusage/max": 143523840,
 "memusage/startup": 143507456,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-03-06T18:04:09.395127+00:00"
}
```

</details>

`map_payment` utility helps to map some payments and fuel cards without explicit mapping dict in a spider. Not ideal, but it gives some quick wins.