### PR TITLE
[Gov Osservaprezzi Carburanti IT] Clean up names

### DIFF
--- a/locations/spiders/gov_osservaprezzi_carburanti_it.py
+++ b/locations/spiders/gov_osservaprezzi_carburanti_it.py
@@ -15,8 +15,6 @@ class GovOsservaprezziCarburantiITSpider(Spider):
     dataset_attributes = {"source": "api", "api": "carburanti.mise.gov.it"}
 
     custom_settings = {
-        "HTTPCACHE_ENABLED": True,
-        "HTTPCACHE_EXPIRATION_SECS": 1800,
         "DOWNLOAD_DELAY": 0.1,
     }
 

--- a/locations/spiders/gov_osservaprezzi_carburanti_it.py
+++ b/locations/spiders/gov_osservaprezzi_carburanti_it.py
@@ -53,8 +53,6 @@ class GovOsservaprezziCarburantiITSpider(Spider):
         "Beyfin": {"brand": "Beyfin", "brand_wikidata": "Q3639256"},
         "Costantin": {"brand": "Costantin", "brand_wikidata": "Q48800790"},
         "Lukoil": {"brand": "Lukoil", "brand_wikidata": "Q329347"},
-        # "brand" used by non-branded stations
-        "PompeBianche": {},
     }
 
     def get_price_tag(self, fuel_tag):
@@ -117,8 +115,11 @@ class GovOsservaprezziCarburantiITSpider(Spider):
                     self.crawler.stats.inc_value(f"atp/gov_osservaprezzi_carburanti_it/unmapped_price/{charged_fuel}")
 
             if (brand := result["brand"]) in self.BRANDS:
+                item["name"] = None  # Use NSI name
                 item.update(self.BRANDS[brand])
+            elif result["brand"] == "PompeBianche":  # "brand" used by non-branded stations
+                pass
             else:
-                item["brand"] = brand
+                item["brand"] = item["name"] = brand  # Use the brand as the name as well
                 self.crawler.stats.inc_value(f"atp/gov_osservaprezzi_carburanti_it/unmapped_brand/{brand}")
             yield item


### PR DESCRIPTION
The names coming out of this are quite bad, I wouldn't be surprised if they are operators/legal entities, eg `EUROPAM CASTELNUOVO BOCCA D'ADDA`.

I propose, we use the NSI name when possible, and use the supplied brand as the name otherwise. That just leaves the independent POIs with unappealing names.