### PR TITLE
[Europam IT] Add Spider

### DIFF
--- a/locations/spiders/europam_it.py
+++ b/locations/spiders/europam_it.py
@@ -1,0 +1,20 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class EuropamITSpider(SitemapSpider, StructuredDataSpider):
+    name = "europam_it"
+    item_attributes = {"brand": "Europam", "brand_wikidata": "Q115268198"}
+    sitemap_urls = ["https://europam.it/robots.txt"]
+    sitemap_rules = [("/stazioni-di-servizio/mappa-distributori/", "parse")]
+    wanted_types = ["GasStation"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = None  # Address
+        extract_google_position(item, response)
+        apply_category(Categories.FUEL_STATION, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Europam': 208,
 'atp/brand_wikidata/Q115268198': 208,
 'atp/category/amenity/fuel': 208,
 'atp/cdn/cloudflare/response_count': 214,
 'atp/cdn/cloudflare/response_status_count/200': 214,
 'atp/field/country/from_spider_name': 208,
 'atp/field/email/missing': 208,
 'atp/field/opening_hours/missing': 208,
 'atp/field/operator/missing': 208,
 'atp/field/operator_wikidata/missing': 208,
 'atp/field/phone/missing': 208,
 'atp/field/state/missing': 208,
 'atp/field/twitter/missing': 208,
 'atp/nsi/category_match': 208,
 'downloader/request_bytes': 89465,
 'downloader/request_count': 217,
 'downloader/request_method_count/GET': 217,
 'downloader/response_bytes': 5685899,
 'downloader/response_count': 217,
 'downloader/response_status_count/200': 214,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 171.747361,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 7, 16, 33, 55, 110497, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 137,
 'httpcache/hit': 80,
 'httpcache/miss': 137,
 'httpcache/store': 137,
 'httpcompression/response_bytes': 21440996,
 'httpcompression/response_count': 214,
 'item_scraped_count': 208,
 'log_count/DEBUG': 438,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 304656384,
 'memusage/startup': 150687744,
 'request_depth_max': 3,
 'response_received_count': 214,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 216,
 'scheduler/dequeued/memory': 216,
 'scheduler/enqueued': 216,
 'scheduler/enqueued/memory': 216,
 'start_time': datetime.datetime(2024, 3, 7, 16, 31, 3, 363136, tzinfo=datetime.timezone.utc)}
```