### PR TITLE
Kvickly (DK)

### DIFF
--- a/locations/spiders/kvickly_coop_dk.py
+++ b/locations/spiders/kvickly_coop_dk.py
@@ -1,0 +1,31 @@
+from typing import Any, Iterable
+
+from scrapy import FormRequest, Request, Spider
+from scrapy.http import Response
+
+from locations.items import Feature
+
+
+class KvicklyCoopDKSpider(Spider):
+    name = "kvickly_coop_dk"
+    item_attributes = {"brand": "Kvickly", "brand_wikidata": "Q7061148"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self) -> Iterable[Request]:
+        yield FormRequest(
+            "https://kvickly.coop.dk/umbraco/api/Chains/GetAllStores",
+            formdata={"pageId": "3418", "chainsToShowStoresFrom": "", "hideClosedStores": "false"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = Feature()
+            item["name"] = location["Name"]
+            item["street_address"] = location["Address"]
+            item["city"] = location["City"]
+            item["postcode"] = str(location["Zipcode"])
+            item["lon"], item["lat"] = location["Location"]
+            item["phone"] = location["PhoneNumber"]
+            item["ref"] = item["website"] = "https://kvickly.coop.dk/find-butik/{}".format(location["UrlName"])
+
+            yield item


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/7681
{'atp/brand/Kvickly': 65,
 'atp/brand_wikidata/Q7061148': 65,
 'atp/category/shop/supermarket': 65,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/country/from_spider_name': 65,
 'atp/field/email/missing': 65,
 'atp/field/image/missing': 65,
 'atp/field/opening_hours/missing': 65,
 'atp/field/operator/missing': 65,
 'atp/field/operator_wikidata/missing': 65,
 'atp/field/state/missing': 65,
 'atp/field/twitter/missing': 65,
 'atp/nsi/perfect_match': 65,
 'downloader/request_bytes': 435,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 5663,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.099777,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 8, 9, 31, 46, 353374, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 42580,
 'httpcompression/response_count': 1,
 'item_scraped_count': 65,
 'log_count/DEBUG': 77,
 'log_count/INFO': 9,
 'memusage/max': 150192128,
 'memusage/startup': 150192128,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 8, 9, 31, 45, 253597, tzinfo=datetime.timezone.utc)}
2024-03-08 09:31:46 [scrapy.core.engine] INFO: Spider closed (finished)