### PR TITLE
Add Second Cup (CA)

### DIFF
--- a/locations/spiders/second_cup_ca.py
+++ b/locations/spiders/second_cup_ca.py
@@ -1,8 +1,6 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import SitemapSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_FR
-from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 

--- a/locations/spiders/second_cup_ca.py
+++ b/locations/spiders/second_cup_ca.py
@@ -14,8 +14,6 @@ class SecondCupCASpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"^https://secondcup\.com/location/.*/$", "parse_sd"),
     ]
-    # wanted_types = ["Restaurant"]
-    # time_format = "%I:%M %p"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "openingHours" in ld_data:

--- a/locations/spiders/second_cup_ca.py
+++ b/locations/spiders/second_cup_ca.py
@@ -1,0 +1,26 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import SitemapSpider, Rule
+
+from locations.hours import DAYS_FR
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SecondCupCASpider(SitemapSpider, StructuredDataSpider):
+    name = "second_cup_ca"
+    item_attributes = {
+        "brand": "Second Cup",
+        "brand_wikidata": "Q862180",
+    }
+    sitemap_urls = ["https://secondcup.com/sitemap_index.xml"]
+    sitemap_rules = [
+        (r"^https://secondcup\.com/location/.*/$", "parse_sd"),
+    ]
+    # wanted_types = ["Restaurant"]
+    # time_format = "%I:%M %p"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "openingHours" in ld_data:
+            item["opening_hours"].add_ranges_from_string(ld_data["openingHours"], days=DAYS_FR)
+
+        return super().post_process_item(item, response, ld_data, **kwargs)


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/67

{'atp/brand/Second Cup': 170,
 'atp/brand_wikidata/Q862180': 170,
 'atp/category/amenity/cafe': 170,
 'atp/field/email/missing': 170,
 'atp/field/image/missing': 170,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 88,
 'atp/field/operator/missing': 170,
 'atp/field/operator_wikidata/missing': 170,
 'atp/field/phone/missing': 6,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/state/missing': 3,
 'atp/geometry/null_island': 2,
 'atp/nsi/perfect_match': 170,
 'downloader/request_bytes': 71893,
 'downloader/request_count': 191,
 'downloader/request_method_count/GET': 191,
 'downloader/response_bytes': 5715917,
 'downloader/response_count': 191,
 'downloader/response_status_count/200': 190,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 237.224985,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 9, 6, 57, 48, 39604, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 37091283,
 'httpcompression/response_count': 191,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 170,
 'log_count/DEBUG': 372,
 'log_count/INFO': 13,
 'memusage/max': 389767168,
 'memusage/startup': 151076864,
 'request_depth_max': 2,
 'response_received_count': 191,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 190,
 'scheduler/dequeued/memory': 190,
 'scheduler/enqueued': 190,
 'scheduler/enqueued/memory': 190,
 'start_time': datetime.datetime(2024, 3, 9, 6, 53, 50, 814619, tzinfo=datetime.timezone.utc)}
2024-03-09 06:57:48 [scrapy.core.engine] INFO: Spider closed (finished)