### PR TITLE
Add Golden Discs (IE)

### DIFF
--- a/locations/spiders/golden_discs_ie.py
+++ b/locations/spiders/golden_discs_ie.py
@@ -1,0 +1,7 @@
+from locations.storefinders.storemapper import StoremapperSpider
+
+
+class GoldenDiscsIESpider(StoremapperSpider):
+    name = "golden_discs_ie"
+    item_attributes = {"brand": "Golden Discs", "brand_wikidata": "Q5579324"}
+    key = "4298"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7738

{'atp/brand/Golden Discs': 19,
 'atp/brand_wikidata/Q5579324': 19,
 'atp/category/shop/music': 19,
 'atp/field/city/missing': 19,
 'atp/field/country/from_spider_name': 19,
 'atp/field/image/missing': 19,
 'atp/field/opening_hours/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 18,
 'atp/field/state/missing': 19,
 'atp/field/street_address/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/nsi/perfect_match': 19,
 'downloader/request_bytes': 367,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 3155,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.813667,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 0, 30, 11, 63091, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 16937,
 'httpcompression/response_count': 1,
 'item_scraped_count': 19,
 'log_count/DEBUG': 31,
 'log_count/INFO': 9,
 'memusage/max': 150200320,
 'memusage/startup': 150200320,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 10, 0, 30, 9, 249424, tzinfo=datetime.timezone.utc)}