### PR TITLE
Add Bolo da Madre (BR)

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -302,14 +302,22 @@ DAYS_PL = {
     "Niedziela": "Su",
 }
 DAYS_PT = {
+    # Feriado Holidays
     # "Se": "Mo",
+    "Segunda": "Mo",
     "Te": "Tu",
+    "Terça": "Tu",
     # "Qu": "We",
+    "Quarta": "We",
     # "Qu": "Th",
+    "Quinta": "Th",
     # "Se": "Fr",
+    "Sexta": "Fr",
+    "Sábado": "Sa",
     "Sa": "Sa",
     "Sá": "Sa",
     "Do": "Su",
+    "Domingo": "Su"
 }
 DAYS_SK = {
     "Po": "Mo",

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -317,7 +317,7 @@ DAYS_PT = {
     "Sa": "Sa",
     "Sá": "Sa",
     "Do": "Su",
-    "Domingo": "Su"
+    "Domingo": "Su",
 }
 DAYS_SK = {
     "Po": "Mo",

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -302,7 +302,7 @@ DAYS_PL = {
     "Niedziela": "Su",
 }
 DAYS_PT = {
-    # Feriado Holidays
+    # "Feriado": "PH",
     # "Se": "Mo",
     "Segunda": "Mo",
     "Te": "Tu",
@@ -558,6 +558,14 @@ DELIMITERS_ES = [
     "-",
     "a",
     "y",
+    "de",
+]
+
+DELIMITERS_PT = [
+    "-",
+    "a",
+    "das",
+    "às",
     "de",
 ]
 

--- a/locations/spiders/bolo_da_madre_br.py
+++ b/locations/spiders/bolo_da_madre_br.py
@@ -1,0 +1,39 @@
+from scrapy import Spider, Request
+
+from locations.items import Feature
+from locations.hours import DAYS_PT, DELIMITERS_PT, OpeningHours
+
+
+class BoloDaMadreBRSpider(Spider):
+    name = "bolo_da_madre_br"
+    item_attributes = {"brand": "Bolo da Madre", "brand_wikidata": "Q121322483"}
+    # allowed_domains = ["www.a1.net"]
+    start_urls = ["https://bolodamadre.com.br/onde-encontrar/"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield Request(url=url, callback=self.parse_store_list)
+
+    def parse_store_list(self, response):
+        locations = response.xpath("//div[contains(@class, 'list-places')]/div[contains(@class, 'place')]")
+        for location in locations:
+            name = location.xpath("h3/strong/text()").get()
+
+            address_hours = location.xpath("div[@class='address-hours']/p/text()").getall()
+
+            oh = OpeningHours()
+            oh.add_ranges_from_string(address_hours[3], days=DAYS_PT, delimiters=DELIMITERS_PT)
+            if 4 in address_hours:
+                oh.add_ranges_from_string(address_hours[4], days=DAYS_PT, delimiters=DELIMITERS_PT)
+            if 5 in address_hours:
+                oh.add_ranges_from_string(address_hours[5], days=DAYS_PT, delimiters=DELIMITERS_PT)
+
+            yield Feature(
+                {
+                    "ref": name,
+                    "name": name,
+                    "addr_full": ", ".join([address_hours[0], address_hours[1]]),
+                    "phone": location.xpath("p/span[@class='whats-phone']/a/text()").get(),
+                    "opening_hours": oh,
+                }
+            )

--- a/locations/spiders/bolo_da_madre_br.py
+++ b/locations/spiders/bolo_da_madre_br.py
@@ -1,7 +1,7 @@
-from scrapy import Spider, Request
+from scrapy import Request, Spider
 
-from locations.items import Feature
 from locations.hours import DAYS_PT, DELIMITERS_PT, OpeningHours
+from locations.items import Feature
 
 
 class BoloDaMadreBRSpider(Spider):


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7668
{'atp/brand/Bolo da Madre': 29,
 'atp/brand_wikidata/Q121322483': 29,
 'atp/category/shop/pastry': 29,
 'atp/field/city/missing': 29,
 'atp/field/country/missing': 29,
 'atp/field/email/missing': 29,
 'atp/field/image/missing': 29,
 'atp/field/lat/missing': 29,
 'atp/field/lon/missing': 29,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/phone/invalid': 23,
 'atp/field/phone/missing': 6,
 'atp/field/postcode/missing': 29,
 'atp/field/state/missing': 29,
 'atp/field/street_address/missing': 29,
 'atp/field/twitter/missing': 29,
 'atp/field/website/missing': 29,
 'atp/nsi/perfect_match': 29,
 'downloader/request_bytes': 669,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23393,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.303312,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 1, 4, 51, 840964, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 91677,
 'httpcompression/response_count': 1,
 'item_dropped_count': 49,
 'item_dropped_reasons_count/DropItem': 49,
 'item_scraped_count': 29,
 'log_count/DEBUG': 91,
 'log_count/INFO': 9,
 'memusage/max': 150634496,
 'memusage/startup': 150634496,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 10, 1, 4, 49, 537652, tzinfo=datetime.timezone.utc)}