### PR TITLE
Fix Goddard School

### DIFF
--- a/locations/spiders/goddard_school.py
+++ b/locations/spiders/goddard_school.py
@@ -9,6 +9,10 @@ class GoddardSchoolSpider(scrapy.Spider):
     item_attributes = {"brand": "Goddard School", "brand_wikidata": "Q5576260"}
     allowed_domains = ["goddardschool.com"]
     start_urls = ["https://www.goddardschool.com/apps/gsi/api/v1/schools"]
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+    }
+
 
     def parse(self, response):
         for data in response.json().get("items"):

--- a/locations/spiders/goddard_school.py
+++ b/locations/spiders/goddard_school.py
@@ -13,7 +13,6 @@ class GoddardSchoolSpider(scrapy.Spider):
         "ROBOTSTXT_OBEY": False,
     }
 
-
     def parse(self, response):
         for data in response.json().get("items"):
             item = DictParser.parse(data.get("address1"))


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/2166
{'atp/brand/Goddard School': 648,
 'atp/brand_wikidata/Q5576260': 648,
 'atp/category/amenity/kindergarten': 648,
 'atp/field/country/from_reverse_geocoding': 648,
 'atp/field/image/missing': 648,
 'atp/field/operator/missing': 648,
 'atp/field/operator_wikidata/missing': 648,
 'atp/field/phone/invalid': 3,
 'atp/field/twitter/missing': 648,
 'atp/nsi/perfect_match': 648,
 'downloader/request_bytes': 325,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 115400,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 30.901684,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 4, 51, 58, 588141, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 995866,
 'httpcompression/response_count': 1,
 'item_scraped_count': 648,
 'log_count/DEBUG': 660,
 'log_count/INFO': 9,
 'memusage/max': 151064576,
 'memusage/startup': 151064576,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 10, 4, 51, 27, 686457, tzinfo=datetime.timezone.utc)}
2024-03-10 04:51:58 [scrapy.core.engine] INFO: Spider closed (finished)