### PR TITLE
Rewrite SentryFoods as FreshOp

### DIFF
--- a/locations/spiders/sentryfoods.py
+++ b/locations/spiders/sentryfoods.py
@@ -1,43 +1,7 @@
-import scrapy
-
-from locations.items import Feature
+from locations.storefinders.freshop import FreshopSpider
 
 
-class SentryFoodsSpider(scrapy.Spider):
+class SentryFoodsSpider(FreshopSpider):
     name = "sentryfoods"
-    item_attributes = {"brand": "Sentry Foods"}
-    allowed_domains = ["sentryfoods.com"]
-    start_urls = ("https://www.sentryfoods.com/stores/search-stores.html",)
-
-    def parse(self, response):
-        response.selector.remove_namespaces()
-        city_urls = response.xpath('//div[@class="searchbystate parbase section"]/div/div/*/ul/li/a/@href').extract()
-        for path in city_urls:
-            yield scrapy.Request(
-                "https://www.sentryfoods.com" + path.strip() + "&displayCount=100",
-                callback=self.parse_state,
-            )
-
-    def parse_state(self, response):
-        response.selector.remove_namespaces()
-        store_elems = response.xpath('//div[@class="store-search-results"]/ul/li')
-        for store_elem in store_elems:
-            url = response.urljoin(store_elem.xpath('.//a[@class="store-detail"]/@href').extract_first())
-            city_state_zip = store_elem.xpath('.//p[@class="store-city-state-zip"]/text()').extract_first()
-            city, state_zip = city_state_zip.split(",", 1)
-            state, zipcode = state_zip.split(" ", 1)
-
-            props = {
-                "website": url,
-                "ref": store_elem.xpath(".//@data-storeid").extract_first(),
-                "lat": store_elem.xpath(".//@data-storelat").extract_first(),
-                "lon": store_elem.xpath(".//@data-storelng").extract_first(),
-                "name": store_elem.xpath('.//h6[@class="store-display-name"]/text()').extract_first(),
-                "addr_full": store_elem.xpath('.//p[@class="store-address"]/text()').extract_first(),
-                "phone": store_elem.xpath('.//p[@class="store-main-phone"]/span/text()').extract_first().strip(),
-                "opening_hours": store_elem.xpath('.//ul[@class="store-regular-hours"]/li/text()').extract_first(),
-                "city": city,
-                "state": state,
-                "postcode": zipcode,
-            }
-            yield Feature(**props)
+    item_attributes = {"brand": "Sentry Foods", "brand_wikidata": "Q7451397"}
+    app_key = "sentry_stores"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3102

{'atp/brand/Sentry Foods': 9,
 'atp/brand_wikidata/Q7451397': 9,
 'atp/category/missing': 9,
 'atp/field/email/missing': 9,
 'atp/field/image/missing': 9,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/nsi/brand_missing': 9,
 'downloader/request_bytes': 647,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3907,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.271459,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 6, 7, 3, 295120, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 28707,
 'httpcompression/response_count': 2,
 'item_scraped_count': 9,
 'log_count/DEBUG': 22,
 'log_count/INFO': 9,
 'memusage/max': 150839296,
 'memusage/startup': 150839296,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 10, 6, 7, 1, 23661, tzinfo=datetime.timezone.utc)}