### PR TITLE
John Lewis - Mark as needing proxy

### DIFF
--- a/locations/spiders/johnlewis.py
+++ b/locations/spiders/johnlewis.py
@@ -21,6 +21,7 @@ class JohnLewisSpider(CrawlSpider):
     ]
     custom_settings = {"REDIRECT_ENABLED": False}
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def parse_stores(self, response):
         item = Feature()


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3087 maybe

Works happily when I run it, so assume proxy issue.

{'atp/brand/John Lewis': 36,
 'atp/brand_wikidata/Q1918981': 36,
 'atp/category/shop/department_store': 36,
 'atp/field/country/from_reverse_geocoding': 36,
 'atp/field/email/missing': 36,
 'atp/field/image/missing': 36,
 'atp/field/operator/missing': 36,
 'atp/field/operator_wikidata/missing': 36,
 'atp/field/street_address/missing': 36,
 'atp/field/twitter/missing': 36,
 'atp/nsi/perfect_match': 36,
 'downloader/request_bytes': 104526,
 'downloader/request_count': 46,
 'downloader/request_method_count/GET': 46,
 'downloader/response_bytes': 1435631,
 'downloader/response_count': 46,
 'downloader/response_status_count/200': 38,
 'downloader/response_status_count/303': 8,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 54.685936,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 6, 19, 44, 136925, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10343676,
 'httpcompression/response_count': 38,
 'item_scraped_count': 36,
 'log_count/DEBUG': 94,
 'log_count/INFO': 9,
 'memusage/max': 151334912,
 'memusage/startup': 151334912,
 'request_depth_max': 2,
 'response_received_count': 46,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 45,
 'scheduler/dequeued/memory': 45,
 'scheduler/enqueued': 45,
 'scheduler/enqueued/memory': 45,
 'start_time': datetime.datetime(2024, 3, 10, 6, 18, 49, 450989, tzinfo=datetime.timezone.utc)}