### PR TITLE
JCPenney - Flag for proxy

### DIFF
--- a/locations/spiders/jcpenney.py
+++ b/locations/spiders/jcpenney.py
@@ -25,3 +25,4 @@ class JCPenneySpider(CrawlSpider, StructuredDataSpider):
     ]
     user_agent = BROWSER_DEFAULT
     wanted_types = ["DepartmentStore"]
+    requires_proxy = True


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3082

Another one where it works when I run it, so proxy likely the issue.

Partial run:
```
{'atp/brand/JCPenney': 192,
 'atp/brand_wikidata/Q920037': 192,
 'atp/category/shop/department_store': 192,
 'atp/cdn/cloudflare/response_count': 210,
 'atp/cdn/cloudflare/response_status_count/200': 210,
 'atp/field/email/missing': 192,
 'atp/field/operator/missing': 192,
 'atp/field/operator_wikidata/missing': 192,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 192,
 'atp/nsi/category_match': 191,
 'atp/nsi/match_failed': 1,
 'downloader/request_bytes': 309207,
 'downloader/request_count': 217,
 'downloader/request_method_count/GET': 217,
 'downloader/response_bytes': 11466611,
 'downloader/response_count': 217,
 'downloader/response_status_count/200': 212,
 'downloader/response_status_count/301': 5,
 'dupefilter/filtered': 759,
 'elapsed_time_seconds': 260.157248,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2024, 3, 10, 6, 25, 26, 594446, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 48044498,
 'httpcompression/response_count': 212,
 'item_scraped_count': 192,
 'log_count/DEBUG': 421,
 'log_count/INFO': 14,
 'memusage/max': 287457280,
 'memusage/startup': 150728704,
 'request_depth_max': 10,
 'response_received_count': 212,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 212,
 'scheduler/dequeued/memory': 212,
 'scheduler/enqueued': 314,
 'scheduler/enqueued/memory': 314,
 'start_time': datetime.datetime(2024, 3, 10, 6, 21, 6, 437198, tzinfo=datetime.timezone.utc)}
```