### PR TITLE
Argos - Flag for proxy

### DIFF
--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -14,6 +14,7 @@ class ArgosSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.argos.co.uk/stores_sitemap.xml"]
     sitemap_rules = [(r"https://www.argos.co.uk/stores/([\d]+)-([\w-]+)", "parse")]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if item["name"].startswith("Closed - "):


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3063

Works when I run it.

Partial run:
```
{'atp/brand/Argos': 83,
 'atp/brand_wikidata/Q4789707': 83,
 'atp/category/shop/catalogue': 83,
 'atp/field/country/from_website_url': 83,
 'atp/field/email/missing': 83,
 'atp/field/image/missing': 83,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 83,
 'atp/field/operator_wikidata/missing': 83,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 83,
 'atp/nsi/perfect_match': 83,
 'downloader/request_bytes': 105724,
 'downloader/request_count': 88,
 'downloader/request_method_count/GET': 88,
 'downloader/response_bytes': 4170305,
 'downloader/response_count': 88,
 'downloader/response_status_count/200': 85,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 107.746291,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2024, 3, 10, 6, 25, 27, 125695, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 26254724,
 'httpcompression/response_count': 84,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 83,
 'log_count/DEBUG': 182,
 'log_count/INFO': 12,
 'memusage/max': 287174656,
 'memusage/startup': 151322624,
 'request_depth_max': 1,
 'response_received_count': 86,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 87,
 'scheduler/dequeued/memory': 87,
 'scheduler/enqueued': 1304,
 'scheduler/enqueued/memory': 1304,
 'start_time': datetime.datetime(2024, 3, 10, 6, 23, 39, 379404, tzinfo=datetime.timezone.utc)}

```