### PR TITLE
O'Rielly Auto Parts - Flag for Proxy

### DIFF
--- a/locations/spiders/oreilly_auto.py
+++ b/locations/spiders/oreilly_auto.py
@@ -10,3 +10,4 @@ class OreillyAutoSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://locations.oreillyauto.com/sitemap.xml"]
     sitemap_rules = [(r"[0-9]+.html$", "parse_sd")]
     wanted_types = ["AutoPartsStore"]
+    requires_proxy = True


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3015

Works for me when I run it
```2024-03-10 06:26:59 [scrapy.core.scraper] DEBUG: Scraped from <200 https://locations.oreillyauto.com/al/evergreen/autoparts-2286.html>
{'brand': "O'Reilly Auto Parts",
 'brand_wikidata': 'Q7071951',
 'city': 'Evergreen',
 'country': 'US',
 'email': None,
 'extras': {'@spider': 'oreilly', 'shop': 'car_parts'},
 'facebook': 'https://www.facebook.com/OreillyAutoParts',
 'geometry': {'coordinates': [-86.957833, 31.432002], 'type': 'Point'},
 'image': None,
 'name': "Your Evergreen O'Reilly Auto Parts Store",
 'nsi_id': 'oreillyautoparts-bb9baa',
 'opening_hours': 'Mo-Sa 07:00-20:00; Su 08:00-19:00',
 'phone': '+1 251-578-1610',
 'postcode': '36401',
 'ref': 'https://locations.oreillyauto.com/al/evergreen/autoparts-2286.html',
 'state': 'AL',
 'street_address': '218 West Front Street',
 'twitter': 'OReillyAuto',
 'website': 'https://locations.oreillyauto.com/al/evergreen/autoparts-2286.html'}
^C2024-03-10 06:27:00 [scrapy.crawler] INFO: Received SIGINT, shutting down gracefully. Send again to force 
```