### PR TITLE
Fix Dick Blick

### DIFF
--- a/locations/spiders/dick_blick.py
+++ b/locations/spiders/dick_blick.py
@@ -9,7 +9,7 @@ class DickBlickSpider(SitemapSpider, StructuredDataSpider):
     name = "dick_blick"
     item_attributes = {"brand": "Dick Blick", "brand_wikidata": "Q5272692"}
     allowed_domains = ["www.dickblick.com"]
-    sitemap_urls = ["https://www.dickblick.com/sitemap.aspx"]
+    sitemap_urls = ["https://www.dickblick.com/robots.txt"]
     sitemap_rules = [(r"/stores/[-\w]+/[-\w]+/$", "parse_sd")]
     wanted_types = ["HobbyShop"]
     user_agent = BROWSER_DEFAULT


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/2729

{'atp/brand/Dick Blick': 64,
 'atp/brand_wikidata/Q5272692': 64,
 'atp/category/missing': 64,
 'atp/closed_check': 3,
 'atp/field/city/missing': 57,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 64,
 'atp/field/operator_wikidata/missing': 64,
 'atp/field/state/from_reverse_geocoding': 56,
 'atp/nsi/brand_missing': 64,
 'downloader/request_bytes': 24942,
 'downloader/request_count': 75,
 'downloader/request_method_count/GET': 75,
 'downloader/response_bytes': 15349783,
 'downloader/response_count': 75,
 'downloader/response_status_count/200': 75,
 'elapsed_time_seconds': 93.344526,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 10, 7, 26, 34, 118392, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11233224,
 'httpcompression/response_count': 71,
 'item_scraped_count': 64,
 'log_count/DEBUG': 150,
 'log_count/INFO': 10,
 'log_count/WARNING': 3,
 'memusage/max': 382066688,
 'memusage/startup': 150671360,
 'request_depth_max': 3,
 'response_received_count': 75,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 74,
 'scheduler/dequeued/memory': 74,
 'scheduler/enqueued': 74,
 'scheduler/enqueued/memory': 74,
 'start_time': datetime.datetime(2024, 3, 10, 7, 25, 0, 773866, tzinfo=datetime.timezone.utc)}
2024-03-10 07:26:34 [scrapy.core.engine] INFO: Spider closed (finished)