### PR TITLE
Fix KPMG

### DIFF
--- a/locations/spiders/kpmg.py
+++ b/locations/spiders/kpmg.py
@@ -8,8 +8,8 @@ from locations.items import Feature
 class KpmgSpider(SitemapSpider):
     name = "kpmg"
     item_attributes = {"brand": "KPMG", "brand_wikidata": "Q493751"}
-    allowed_domains = ["home.kpmg"]
-    sitemap_urls = ["https://home.kpmg/sitemap-index.xml"]
+    allowed_domains = ["kpmg.com", ""]
+    sitemap_urls = ["https://kpmg.com/sitemap-index.xml"]
     sitemap_rules = [("/offices/", "parse")]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/3367

Partial run:

{'atp/brand/KPMG': 56,
 'atp/brand_wikidata/Q493751': 56,
 'atp/category/office/consulting': 56,
 'atp/field/email/missing': 56,
 'atp/field/image/missing': 56,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 56,
 'atp/field/operator/missing': 56,
 'atp/field/operator_wikidata/missing': 56,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 56,
 'atp/field/twitter/missing': 56,
 'atp/nsi/perfect_match': 56,
 'downloader/request_bytes': 35067,
 'downloader/request_count': 96,
 'downloader/request_method_count/GET': 96,
 'downloader/response_bytes': 4023777,
 'downloader/response_count': 96,
 'downloader/response_status_count/200': 96,
 'elapsed_time_seconds': 117.525674,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2024, 3, 10, 8, 5, 47, 760923, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27424028,
 'httpcompression/response_count': 96,
 'item_scraped_count': 56,
 'log_count/DEBUG': 163,
 'log_count/INFO': 11,
 'memusage/max': 281202688,
 'memusage/startup': 150716416,
 'request_depth_max': 2,
 'response_received_count': 96,
 'scheduler/dequeued': 96,
 'scheduler/dequeued/memory': 96,
 'scheduler/enqueued': 256,
 'scheduler/enqueued/memory': 256,
 'start_time': datetime.datetime(2024, 3, 10, 8, 3, 50, 235249, tzinfo=datetime.timezone.utc)}