### PR TITLE
Add La Vie Claire (FR)

### DIFF
--- a/locations/spiders/lavieclare_fr.py
+++ b/locations/spiders/lavieclare_fr.py
@@ -9,4 +9,3 @@ class LaVieClaireFRSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://magasins.lavieclaire.com/sitemap.xml"]
     sitemap_rules = [(r"https://magasins.lavieclaire.com/lavieclaire/fr/store/.*/\d+$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
-

--- a/locations/spiders/lavieclare_fr.py
+++ b/locations/spiders/lavieclare_fr.py
@@ -1,0 +1,12 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LaVieClaireFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "lavieclaire_fr"
+    item_attributes = {"brand": "La Vie Claire", "brand_wikidata": "Q3213589"}
+    sitemap_urls = ["https://magasins.lavieclaire.com/sitemap.xml"]
+    sitemap_rules = [(r"https://magasins.lavieclaire.com/lavieclaire/fr/store/.*/\d+$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7780

Partial run:
```
{'brand': 'La Vie Claire',
 'brand_wikidata': 'Q3213589',
 'city': 'Paris',
 'country': 'FR',
 'email': None,
 'extras': {'@spider': 'lavieclaire_fr'},
 'facebook': 'https://www.facebook.com/Lavieclaire/',
 'geometry': {'coordinates': [2.378632, 48.85606], 'type': 'Point'},
 'image': 'https://magasins.lavieclaire.com/uploads/other/image-60643d04450c24.60763451.jpeg',
 'name': 'Magasin bio La Vie Claire Paris Ledru Rollin',
 'opening_hours': 'Mo-Sa 09:30-20:00; Su 09:00-12:30',
 'phone': '+33 1 40 09 09 42',
 'postcode': '75011',
 'ref': 'https://magasins.lavieclaire.com/lavieclaire/fr/store/france/ile-de-france/paris/paris/paris-ledru-rollin/17521',
 'state': None,
 'street_address': '163, avenue Ledru Rollin',
 'twitter': '_LaVieClaire',
 'website': 'https://magasins.lavieclaire.com/lavieclaire/fr/store/france/ile-de-france/paris/paris/paris-ledru-rollin/17521'}
2024-03-11 02:47:04 [locations.pipelines.duplicates] INFO: Dropped 0 duplicate items
2024-03-11 02:47:04 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/La Vie Claire': 104,
 'atp/brand_wikidata/Q3213589': 104,
 'atp/category/missing': 104,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 104,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/state/missing': 104,
 'atp/nsi/match_failed': 104,
 'downloader/request_bytes': 55076,
 'downloader/request_count': 106,
 'downloader/request_method_count/GET': 106,
 'downloader/response_bytes': 1680338,
 'downloader/response_count': 106,
 'downloader/response_status_count/200': 106,
 'elapsed_time_seconds': 129.639391,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2024, 3, 11, 2, 47, 4, 131569, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8147040,
 'httpcompression/response_count': 106,
 'item_scraped_count': 104,
 'log_count/DEBUG': 221,
 'log_count/INFO': 12,
 'memusage/max': 284069888,
 'memusage/startup': 153395200,
 'request_depth_max': 1,
 'response_received_count': 106,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 105,
 'scheduler/dequeued/memory': 105,
 'scheduler/enqueued': 333,
 'scheduler/enqueued/memory': 333,
 'start_time': datetime.datetime(2024, 3, 11, 2, 44, 54, 492178, tzinfo=datetime.timezone.utc)}
```