### PR TITLE
Add Gall & Gall

### DIFF
--- a/locations/spiders/gall_and_gall_nl.py
+++ b/locations/spiders/gall_and_gall_nl.py
@@ -1,0 +1,31 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_NL, OpeningHours
+
+
+class GallAndGallSpider(Spider):
+    name = "gall_and_gall"
+    item_attributes = {"brand": "Gall & Gall", "brand_wikidata": "Q13639185"}
+    allowed_domains = ["www.gall.nl"]
+    start_urls = [
+        "https://www.gall.nl/on/demandware.store/Sites-gall-nl-Site/nl_NL/Stores-GetAll",
+    ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url)
+
+    def parse(self, response):
+        for location in response.json()["stores"]:
+            item = DictParser.parse(location)
+            item["website"] = "https://www.gall.nl/" + item["website"]
+
+            item["opening_hours"] = OpeningHours()
+
+            for day in location["storeHoursJSON"]:
+                item["opening_hours"].add_ranges_from_string(day["day"] + " " + day["time"], days=DAYS_NL)
+
+            yield item

--- a/locations/spiders/gall_and_gall_nl.py
+++ b/locations/spiders/gall_and_gall_nl.py
@@ -22,6 +22,7 @@ class GallAndGallSpider(Spider):
         for location in response.json()["stores"]:
             item = DictParser.parse(location)
             item["website"] = "https://www.gall.nl/" + item["website"]
+            item["housenumber"] = location["houseNr"] + location["houseNrAdditional"]
 
             item["opening_hours"] = OpeningHours()
 


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7002
{'atp/brand/Gall & Gall': 636,
 'atp/brand_wikidata/Q13639185': 636,
 'atp/category/shop/alcohol': 636,
 'atp/field/email/missing': 636,
 'atp/field/image/missing': 636,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 636,
 'atp/field/operator_wikidata/missing': 636,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 636,
 'atp/field/twitter/missing': 636,
 'atp/nsi/perfect_match': 636,
 'downloader/request_bytes': 365,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 61969,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.268416,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 11, 3, 7, 21, 755634, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 613540,
 'httpcompression/response_count': 1,
 'item_scraped_count': 636,
 'log_count/DEBUG': 648,
 'log_count/INFO': 9,
 'memusage/max': 149995520,
 'memusage/startup': 149995520,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 11, 3, 7, 17, 487218, tzinfo=datetime.timezone.utc)}
2024-03-11 03:07:21 [scrapy.core.engine] INFO: Spider closed (finished)