### PR TITLE
[LabCorp US] Add spider

### DIFF
--- a/locations/spiders/lab_corp_us.py
+++ b/locations/spiders/lab_corp_us.py
@@ -1,0 +1,34 @@
+import json
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.linked_data_parser import LinkedDataParser
+from locations.spiders.tesco_gb import set_located_in
+from locations.spiders.walgreens import WalgreensSpider
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LabCorpUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "lab_corp_us"
+    item_attributes = {"brand": "LabCorp", "brand_wikidata": "Q6466630"}
+    sitemap_urls = ["https://locations.labcorp.com/robots.txt"]
+    sitemap_rules = [(r"/\w\w/[^/]+/(\d+)/", "parse")]
+    wanted_types = ["MedicalBusiness"]
+
+    def parse(self, response: Response, **kwargs):
+        # Remove comments from JSON
+        json_blob = ""
+        for line in (
+            response.xpath('//script[@type="application/ld+json"][contains(text(), "MedicalBusiness")]/text()')
+            .get()
+            .splitlines()
+        ):
+            json_blob += line.split(" //", 1)[0]
+
+        item = LinkedDataParser.parse_ld(json.loads(json_blob))
+        if item.get("name", "").upper().endswith("WALGREENS"):
+            set_located_in(WalgreensSpider.WALGREENS, item)
+        item["name"] = None
+
+        yield item

--- a/locations/spiders/lab_corp_us.py
+++ b/locations/spiders/lab_corp_us.py
@@ -6,15 +6,13 @@ from scrapy.spiders import SitemapSpider
 from locations.linked_data_parser import LinkedDataParser
 from locations.spiders.tesco_gb import set_located_in
 from locations.spiders.walgreens import WalgreensSpider
-from locations.structured_data_spider import StructuredDataSpider
 
 
-class LabCorpUSSpider(SitemapSpider, StructuredDataSpider):
+class LabCorpUSSpider(SitemapSpider):
     name = "lab_corp_us"
     item_attributes = {"brand": "LabCorp", "brand_wikidata": "Q6466630"}
     sitemap_urls = ["https://locations.labcorp.com/robots.txt"]
     sitemap_rules = [(r"/\w\w/[^/]+/(\d+)/", "parse")]
-    wanted_types = ["MedicalBusiness"]
 
     def parse(self, response: Response, **kwargs):
         # Remove comments from JSON


### PR DESCRIPTION
```python
{'atp/brand/LabCorp': 2116,
 'atp/brand_wikidata/Q6466630': 2116,
 'atp/category/healthcare/laboratory': 2116,
 'atp/field/email/missing': 2116,
 'atp/field/image/dropped': 2116,
 'atp/field/image/missing': 2116,
 'atp/field/lat/invalid': 8,
 'atp/field/lat/missing': 8,
 'atp/field/lon/invalid': 2,
 'atp/field/lon/missing': 8,
 'atp/field/opening_hours/missing': 2116,
 'atp/field/operator/missing': 2116,
 'atp/field/operator_wikidata/missing': 2116,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 2116,
 'atp/nsi/perfect_match': 2116,
 'downloader/request_bytes': 796479,
 'downloader/request_count': 2119,
 'downloader/request_method_count/GET': 2119,
 'downloader/response_bytes': 58822323,
 'downloader/response_count': 2119,
 'downloader/response_status_count/200': 2119,
 'elapsed_time_seconds': 21.231058,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 12, 15, 24, 37, 657131, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2119,
 'httpcompression/response_bytes': 435817680,
 'httpcompression/response_count': 2118,
 'item_scraped_count': 2116,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 150614016,
 'memusage/startup': 150614016,
 'request_depth_max': 2,
 'response_received_count': 2119,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2118,
 'scheduler/dequeued/memory': 2118,
 'scheduler/enqueued': 2118,
 'scheduler/enqueued/memory': 2118,
 'start_time': datetime.datetime(2024, 3, 12, 15, 24, 16, 426073, tzinfo=datetime.timezone.utc)}
```