### PR TITLE
fix mcdonalds_cz name attribute

### DIFF
--- a/locations/spiders/mcdonalds_cz.py
+++ b/locations/spiders/mcdonalds_cz.py
@@ -28,6 +28,7 @@ class McDonaldsCZSpider(scrapy.Spider):
     def parse(self, response):
         pois = response.json().get("restaurants")
         for poi in pois:
+            poi.pop("name")
             poi["street_address"] = poi.pop("address")
             item = DictParser.parse(poi)
             item["website"] = response.urljoin(poi["slug"])


### PR DESCRIPTION
The `name` tag contained the address instead of the actual name. It seems that this is the case for other McDonald's scrapers as well but there are exceptions, for example `mcdonalds_hr`.