### PR TITLE
[NHS England] Fix GPs

### DIFF
--- a/locations/spiders/nhs_england_gb.py
+++ b/locations/spiders/nhs_england_gb.py
@@ -7,7 +7,6 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class NhsEnglandGBSpider(SitemapSpider, StructuredDataSpider):
     name = "nhs_england_gb"
-    item_attributes = {"brand": "NHS England", "brand_wikidata": "Q16251481"}
     sitemap_urls = [
         # The following is an enormous general service file, too fiddly to pick things out for now!
         # "https://www.nhs.uk/sitemaps/sitemap-GDOSprofile.xml",
@@ -16,7 +15,7 @@ class NhsEnglandGBSpider(SitemapSpider, StructuredDataSpider):
         "https://www.nhs.uk/sitemaps/sitemap-GPBprofile.xml",
         # TODO: opticians, pharmacies and hospitals are exposed via a search interface
     ]
-    wanted_types = ["Dentist", "GP", "LocalBusiness"]
+    wanted_types = ["Dentist", "Physician", "LocalBusiness"]
 
     def pre_process_data(self, ld_data, **kwargs):
         for rule in ld_data.get("openingHoursSpecification", []):


### PR DESCRIPTION
```python
{'atp/category/amenity/dentist': 6132,
 'atp/category/amenity/doctors': 8558,
 'atp/category/multiple': 14690,
 'atp/cdn/akamai/response_count': 9,
 'atp/cdn/akamai/response_status_count/403': 9,
 'atp/closed_check': 1,
 'atp/field/brand/missing': 14690,
 'atp/field/brand_wikidata/missing': 14690,
 'atp/field/city/missing': 14690,
 'atp/field/country/from_spider_name': 14690,
 'atp/field/email/invalid': 14,
 'atp/field/email/missing': 6898,
 'atp/field/image/missing': 14690,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 846,
 'atp/field/operator/missing': 14690,
 'atp/field/operator_wikidata/missing': 14690,
 'atp/field/phone/invalid': 20,
 'atp/field/phone/missing': 623,
 'atp/field/state/missing': 14690,
 'atp/field/street_address/missing': 14690,
 'atp/field/twitter/missing': 14690,
 'atp/field/website/invalid': 26,
 'downloader/exception_count': 16,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 16,
 'downloader/request_bytes': 7467220,
 'downloader/request_count': 18518,
 'downloader/request_method_count/GET': 18518,
 'downloader/response_bytes': 120062145,
 'downloader/response_count': 18502,
 'downloader/response_status_count/200': 15045,
 'downloader/response_status_count/302': 3019,
 'downloader/response_status_count/403': 9,
 'downloader/response_status_count/404': 429,
 'elapsed_time_seconds': 22570.047362,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 14, 19, 26, 27, 372228, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 18490,
 'httpcache/hit': 12,
 'httpcache/miss': 18506,
 'httpcache/store': 18490,
 'httpcompression/response_bytes': 384337950,
 'httpcompression/response_count': 15472,
 'httperror/response_ignored_count': 438,
 'httperror/response_ignored_status_count/403': 9,
 'httperror/response_ignored_status_count/404': 429,
 'item_scraped_count': 14690,
 'log_count/INFO': 824,
 'log_count/WARNING': 2,
 'memusage/max': 215011328,
 'memusage/startup': 150482944,
 'request_depth_max': 1,
 'response_received_count': 15483,
 'retry/count': 16,
 'retry/reason_count/twisted.internet.error.TimeoutError': 16,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 18517,
 'scheduler/dequeued/memory': 18517,
 'scheduler/enqueued': 18517,
 'scheduler/enqueued/memory': 18517,
 'start_time': datetime.datetime(2024, 3, 14, 13, 10, 17, 324866, tzinfo=datetime.timezone.utc)}
```