### PR TITLE
Add Nærbutikken (NO)

### DIFF
--- a/locations/spiders/narbutikken_no.py
+++ b/locations/spiders/narbutikken_no.py
@@ -1,0 +1,8 @@
+from locations.storefinders.sylinder import SylinderSpider
+
+
+class NarbutikkenNO(SylinderSpider):
+    name = "narbutikken_no"
+    item_attributes = {"brand": "Nærbutikken", "brand_wikidata": "Q108810007"}
+    app_key = "1270"
+    base_url = "https://narbutikken.no/Finn-butikk/"


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7880
{'atp/brand/Nærbutikken': 141,
 'atp/brand_wikidata/Q108810007': 141,
 'atp/category/shop/supermarket': 141,
 'atp/field/country/from_spider_name': 141,
 'atp/field/image/missing': 141,
 'atp/field/opening_hours/missing': 141,
 'atp/field/operator/missing': 141,
 'atp/field/operator_wikidata/missing': 141,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 141,
 'atp/nsi/perfect_match': 141,
 'downloader/request_bytes': 655,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 110904,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.786184,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 16, 0, 6, 36, 210713, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 141,
 'log_count/DEBUG': 155,
 'log_count/INFO': 9,
 'memusage/max': 159432704,
 'memusage/startup': 159432704,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 16, 0, 6, 31, 424529, tzinfo=datetime.timezone.utc)}
2024-03-16 00:06:36 [scrapy.core.engine] INFO: Spider closed (finished)