### PR TITLE
Fix Spar (NO)

### DIFF
--- a/locations/spiders/spar_no.py
+++ b/locations/spiders/spar_no.py
@@ -1,75 +1,7 @@
-import scrapy
+from locations.storefinders.sylinder import SylinderSpider
 
-from locations.items import Feature
-
-DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
-
-
-class SparNoSpider(scrapy.Spider):
+class SparNoSpider(SylinderSpider):
     name = "spar_no"
     item_attributes = {"brand": "Spar", "brand_wikidata": "Q610492"}
-    allowed_domains = ["spar.no"]
-    start_urls = ("https://spar.no/Finn-butikk/",)
-
-    def parse(self, response):
-        shops = response.xpath('//div[@id="js_subnav"]//li[@class="level-1"]/a/@href')
-        for shop in shops:
-            yield scrapy.Request(response.urljoin(shop.extract()), callback=self.parse_shop)
-
-    def parse_shop(self, response):
-        props = {}
-
-        ref = response.xpath('//h1[@itemprop="name"]/text()').extract_first()
-
-        if ref:  # some links redirects back to list page
-            props["ref"] = ref.strip("\n").strip()
-        else:
-            return
-
-        days = response.xpath('//div[@itemprop="openingHoursSpecification"]')
-        if days:
-            for day in days:
-                day_list = day.xpath('.//link[@itemprop="dayOfWeek"]/@href').extract()
-                first = 0
-                last = 0
-            for d in day_list:
-                st = d.replace("https://purl.org/goodrelations/v1#", "")[:2]
-                first = DAYS.index(st) if first > DAYS.index(st) else first
-                last = DAYS.index(st) if first > DAYS.index(st) else first
-            props["opening_hours"] = (
-                DAYS[first]
-                + "-"
-                + DAYS[last]
-                + " "
-                + day.xpath('.//meta[@itemprop="opens"]/@content').extract_first()
-                + " "
-                + day.xpath('.//meta[@itemprop="closes"]/@content').extract_first()
-            )
-
-        phone = response.xpath('//a[@itemprop="telephone"]/text()').extract_first()
-        if phone:
-            props["phone"] = phone
-
-        addr_full = response.xpath('//div[@itemprop="streetAddress"]/text()').extract_first()
-        if addr_full:
-            props["addr_full"] = addr_full
-
-        postcode = response.xpath('//span[@itemprop="postalCode"]/text()').extract_first()
-        if postcode:
-            props["postcode"] = postcode
-
-        city = response.xpath('//span[@itemprop="addressLocality"]/text()').extract_first()
-        if city:
-            props["city"] = city.strip()
-
-        props["country"] = "NO"
-
-        lat = response.xpath('//meta[@itemprop="latitude"]/@content').extract_first()
-        lon = response.xpath('//meta[@itemprop="longitude"]/@content').extract_first()
-        if lat and lon:
-            props["lat"] = float(lat)
-            props["lon"] = float(lon)
-
-        props["website"] = response.url
-
-        yield Feature(**props)
+    app_key = "1210"
+    base_url = "https://spar.no/Finn-butikk/"

--- a/locations/spiders/spar_no.py
+++ b/locations/spiders/spar_no.py
@@ -1,5 +1,6 @@
 from locations.storefinders.sylinder import SylinderSpider
 
+
 class SparNoSpider(SylinderSpider):
     name = "spar_no"
     item_attributes = {"brand": "Spar", "brand_wikidata": "Q610492"}


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/2923
{'atp/brand/Spar': 288,
 'atp/brand_wikidata/Q610492': 288,
 'atp/category/missing': 288,
 'atp/field/country/from_spider_name': 288,
 'atp/field/image/missing': 288,
 'atp/field/opening_hours/missing': 288,
 'atp/field/operator/missing': 288,
 'atp/field/operator_wikidata/missing': 288,
 'atp/field/phone/invalid': 2,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 288,
 'atp/nsi/match_failed': 288,
 'downloader/request_bytes': 655,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 232705,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.04131,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 16, 0, 13, 2, 86704, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 288,
 'log_count/DEBUG': 302,
 'log_count/INFO': 9,
 'memusage/max': 159453184,
 'memusage/startup': 159453184,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 16, 0, 12, 58, 45394, tzinfo=datetime.timezone.utc)}
2024-03-16 00:13:02 [scrapy.core.engine] INFO: Spider closed (finished)