### PR TITLE
Add A3 Sport (CZ)

### DIFF
--- a/locations/spiders/a3_sport_cz.py
+++ b/locations/spiders/a3_sport_cz.py
@@ -1,0 +1,31 @@
+import json
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class A3SportCZSpider(Spider):
+    name = "a3_sport_cz"
+    item_attributes = {"brand": "A3 Sport", "brand_wikidata": "Q58170961"}
+    allowed_domains = ["www.a3sport.cz"]
+    start_urls = ["https://www.a3sport.cz/prodejny?type=json&ver=1"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url)
+
+    def parse(self, response):
+        for location in response.json()["stores"]:
+            item = DictParser.parse(location)
+            item["name"] = location["name"].replace(", ", " ")
+            item["lat"], item["lon"] = location["coordinatesGoogleMap"].split(",")
+            if location["workingHoursObject"]:
+                item["opening_hours"] = OpeningHours()
+                opening_hours = json.loads(location["workingHoursObject"])
+                for day, hours in opening_hours.items():
+                    item["opening_hours"].add_range(day, hours["from"], hours["to"], "%H:%M:%S")
+
+            yield item


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7920
{'atp/brand/A3 Sport': 43,
 'atp/brand_wikidata/Q58170961': 43,
 'atp/category/shop/sports': 43,
 'atp/field/country/from_website_url': 43,
 'atp/field/image/missing': 43,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 43,
 'atp/field/operator_wikidata/missing': 43,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 43,
 'atp/field/street_address/missing': 43,
 'atp/field/twitter/missing': 43,
 'atp/nsi/perfect_match': 43,
 'downloader/request_bytes': 639,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17590,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.009077,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 17, 0, 38, 47, 760431, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 288601,
 'httpcompression/response_count': 2,
 'item_scraped_count': 43,
 'log_count/DEBUG': 56,
 'log_count/INFO': 9,
 'memusage/max': 158015488,
 'memusage/startup': 158015488,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 17, 0, 38, 43, 751354, tzinfo=datetime.timezone.utc)}
2024-03-17 00:38:47 [scrapy.core.engine] INFO: Spider closed (finished)