### PR TITLE
Add Naturalia (FR)

### DIFF
--- a/locations/spiders/naturalia_fr.py
+++ b/locations/spiders/naturalia_fr.py
@@ -1,0 +1,11 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NaturaliaFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "naturalia_fr"
+    item_attributes = {"brand": "Naturalia", "brand_wikidata": "Q3337081"}
+    sitemap_urls = ["https://magasins.naturalia.fr/sitemap.xml"]
+    sitemap_rules = [(r"https://magasins.naturalia.fr/naturalia/fr/store/.*", "parse_sd")]
+

--- a/locations/spiders/naturalia_fr.py
+++ b/locations/spiders/naturalia_fr.py
@@ -8,4 +8,3 @@ class NaturaliaFRSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Naturalia", "brand_wikidata": "Q3337081"}
     sitemap_urls = ["https://magasins.naturalia.fr/sitemap.xml"]
     sitemap_rules = [(r"https://magasins.naturalia.fr/naturalia/fr/store/.*", "parse_sd")]
-


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7885

Partial run:
2024-03-17 01:46:15 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Naturalia': 156,
 'atp/brand_wikidata/Q3337081': 156,
 'atp/category/shop/supermarket': 156,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 156,
 'atp/field/operator/missing': 156,
 'atp/field/operator_wikidata/missing': 156,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 156,
 'atp/nsi/perfect_match': 156,
 'downloader/request_bytes': 81697,
 'downloader/request_count': 160,
 'downloader/request_method_count/GET': 160,
 'downloader/response_bytes': 2647618,
 'downloader/response_count': 160,
 'downloader/response_status_count/200': 159,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 194.933244,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2024, 3, 17, 1, 46, 15, 735526, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18675289,
 'httpcompression/response_count': 159,
 'item_scraped_count': 156,
 'log_count/DEBUG': 327,
 'log_count/INFO': 13,
 'memusage/max': 287506432,
 'memusage/startup': 157265920,
 'request_depth_max': 1,
 'response_received_count': 159,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 159,
 'scheduler/dequeued/memory': 159,
 'scheduler/enqueued': 234,
 'scheduler/enqueued/memory': 234,
 'start_time': datetime.datetime(2024, 3, 17, 1, 43, 0, 802282, tzinfo=datetime.timezone.utc)}
2024-03-17 01:46:15 [scrapy.core.engine] INFO: Spider closed (shutdown)