### PR TITLE
Add Animates(NZ) and a base class for the Aheadworks Storefinder

### DIFF
--- a/locations/spiders/animates_nz.py
+++ b/locations/spiders/animates_nz.py
@@ -1,9 +1,11 @@
 import json
+
 from chompjs import parse_js_object
 from scrapy import Spider
+
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.categories import Categories
 
 
 class AnimatesNZSpider(Spider):
@@ -31,7 +33,7 @@ class AnimatesNZSpider(Spider):
             item["opening_hours"] = OpeningHours()
             for day, hours in json.loads(location["hoursofoperation"])["hoursofoperation"].items():
                 item["opening_hours"].add_range(day, hours[0], hours[1])
-            
+
             item["extras"] = Categories.SHOP_PET.value
 
             yield item

--- a/locations/spiders/animates_nz.py
+++ b/locations/spiders/animates_nz.py
@@ -1,39 +1,13 @@
 import json
 
-from chompjs import parse_js_object
-from scrapy import Spider
-
 from locations.categories import Categories
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.storefinders.aheadworks import AheadworksSpider
 
 
-class AnimatesNZSpider(Spider):
+class AnimatesNZSpider(AheadworksSpider):
     name = "animates_nz"
     allowed_domains = [
         "www.animates.co.nz",
     ]
     start_urls = ["https://www.animates.co.nz/store-finder"]
-    item_attributes = {"brand": "Animates", "brand_wikidata": "Q110299350"}
-
-    def parse(self, response):
-        locations_js = response.xpath(
-            '//script[contains(text(), "Aheadworks_StoreLocator/js/view/location-list") and contains(text(), "locationRawItems")]/text()'
-        ).get()
-        locations = parse_js_object(locations_js)["#aw-storelocator-navigation"]["Magento_Ui/js/core/app"][
-            "components"
-        ]["locationList"]["locationRawItems"]
-
-        for tab in locations:
-            location = tab["tabs"][0]
-
-            item = DictParser.parse(location)
-            item["website"] = "https://www.animates.co.nz/store-finder/" + location["slug"]
-            item["street_address"] = item.pop("street")
-            item["opening_hours"] = OpeningHours()
-            for day, hours in json.loads(location["hoursofoperation"])["hoursofoperation"].items():
-                item["opening_hours"].add_range(day, hours[0], hours[1])
-
-            item["extras"] = Categories.SHOP_PET.value
-
-            yield item
+    item_attributes = {"brand": "Animates", "brand_wikidata": "Q110299350", "extras": Categories.SHOP_PET.value}

--- a/locations/spiders/animates_nz.py
+++ b/locations/spiders/animates_nz.py
@@ -1,0 +1,37 @@
+import json
+from chompjs import parse_js_object
+from scrapy import Spider
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.categories import Categories
+
+
+class AnimatesNZSpider(Spider):
+    name = "animates_nz"
+    allowed_domains = [
+        "www.animates.co.nz",
+    ]
+    start_urls = ["https://www.animates.co.nz/store-finder"]
+    item_attributes = {"brand": "Animates", "brand_wikidata": "Q110299350"}
+
+    def parse(self, response):
+        locations_js = response.xpath(
+            '//script[contains(text(), "Aheadworks_StoreLocator/js/view/location-list") and contains(text(), "locationRawItems")]/text()'
+        ).get()
+        locations = parse_js_object(locations_js)["#aw-storelocator-navigation"]["Magento_Ui/js/core/app"][
+            "components"
+        ]["locationList"]["locationRawItems"]
+
+        for tab in locations:
+            location = tab["tabs"][0]
+
+            item = DictParser.parse(location)
+            item["website"] = "https://www.animates.co.nz/store-finder/" + location["slug"]
+            item["street_address"] = item.pop("street")
+            item["opening_hours"] = OpeningHours()
+            for day, hours in json.loads(location["hoursofoperation"])["hoursofoperation"].items():
+                item["opening_hours"].add_range(day, hours[0], hours[1])
+            
+            item["extras"] = Categories.SHOP_PET.value
+
+            yield item

--- a/locations/spiders/animates_nz.py
+++ b/locations/spiders/animates_nz.py
@@ -1,5 +1,3 @@
-import json
-
 from locations.categories import Categories
 from locations.storefinders.aheadworks import AheadworksSpider
 

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -1,0 +1,39 @@
+import json
+
+from chompjs import parse_js_object
+from scrapy import Spider
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+#
+# A spider for the embedded behaviours of
+#
+# https://aheadworks.com/store-locator-extension-for-magento-1
+# https://aheadworks.com/store-locator-extension-for-magento-2
+#
+# TODO: Autodetection
+# TODO: Find more examples of this in the wild
+#
+class AheadworksSpider(Spider):
+    def parse(self, response):
+        locations_js = response.xpath(
+            '//script[contains(text(), "Aheadworks_StoreLocator/js/view/location-list") and contains(text(), "locationRawItems")]/text()'
+        ).get()
+        locations = parse_js_object(locations_js)["#aw-storelocator-navigation"]["Magento_Ui/js/core/app"][
+            "components"
+        ]["locationList"]["locationRawItems"]
+
+        for tab in locations:
+            location = tab["tabs"][0]
+
+            item = DictParser.parse(location)
+            item["website"] = self.start_urls[0] + location["slug"]
+            item["street_address"] = item.pop("street")
+            item["opening_hours"] = OpeningHours()
+            for day, hours in json.loads(location["hoursofoperation"])["hoursofoperation"].items():
+                item["opening_hours"].add_range(day, hours[0], hours[1])
+
+            yield item

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -3,7 +3,6 @@ import json
 from chompjs import parse_js_object
 from scrapy import Spider
 
-from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7663

{'atp/brand/Animates': 53,
 'atp/brand_wikidata/Q110299350': 53,
 'atp/category/shop/pet': 53,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 53,
 'atp/field/operator/missing': 53,
 'atp/field/operator_wikidata/missing': 53,
 'atp/field/twitter/missing': 53,
 'atp/nsi/category_match': 53,
 'downloader/request_bytes': 620,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 923750,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.095533,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 17, 2, 50, 45, 364818, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1867,
 'httpcompression/response_count': 1,
 'item_scraped_count': 53,
 'log_count/DEBUG': 66,
 'log_count/INFO': 9,
 'memusage/max': 157569024,
 'memusage/startup': 157569024,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 17, 2, 50, 42, 269285, tzinfo=datetime.timezone.utc)}
2024-03-17 02:50:45 [scrapy.core.engine] INFO: Spider closed (finished)