### PR TITLE
Add Storcash (NO)

### DIFF
--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -20,7 +20,7 @@ class StorcashNoSpider(SylinderSpider):
     ]
 
     def start_requests(self):
-        yield JsonRequest(url=f"https://api.ngdata.no/sylinder/stores/v1/extended-info")
+        yield JsonRequest(url="https://api.ngdata.no/sylinder/stores/v1/extended-info")
 
     def parse(self, response, **kwargs):
         for location in response.json():

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -1,10 +1,12 @@
-from locations.storefinders.sylinder import SylinderSpider
 from scrapy.http import JsonRequest
+
+from locations.storefinders.sylinder import SylinderSpider
+from locations.categories import Categories
 
 
 class StorcashNoSpider(SylinderSpider):
     name = "storcash_no"
-    item_attributes = {"brand": "Storcash"}
+    item_attributes = {"brand": "Storcash", "extras": Categories.SHOP_WHOLESALE.value}
     base_url = "https://storcash.no/#"  # Note: Doesn't use the same storefinder
     app_keys = [
         "5000",  # Bergen Storcash Storcash (NO)

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -6,14 +6,14 @@ class StorcashNoSpider(SylinderSpider):
     item_attributes = {"brand": "Storcash"}
     base_url = "https://storcash.no/#"  # Note: Doesn't use the same storefinder
     app_keys = [
-        "5000", # Bergen Storcash Storcash (NO)
-        "5020", # Sola Storcash
-        "5030", # Haugaland Storcash
-        "5040", # Kjørbekk Storcash
-        "5060", # Tiller Storcash
-        "5070", # Sørlandet Storcash
-        "5080", # Buskerud Storcash
-        "5090", # Bodø Storcash
+        "5000",  # Bergen Storcash Storcash (NO)
+        "5020",  # Sola Storcash
+        "5030",  # Haugaland Storcash
+        "5040",  # Kjørbekk Storcash
+        "5060",  # Tiller Storcash
+        "5070",  # Sørlandet Storcash
+        "5080",  # Buskerud Storcash
+        "5090",  # Bodø Storcash
     ]
 
     def start_requests(self):
@@ -25,5 +25,3 @@ class StorcashNoSpider(SylinderSpider):
                 continue
 
             yield from parse_location(location) or []
-
-

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -1,0 +1,29 @@
+from locations.storefinders.sylinder import SylinderSpider
+
+
+class StorcashNoSpider(SylinderSpider):
+    name = "storcash_no"
+    item_attributes = {"brand": "Storcash"}
+    base_url = "https://storcash.no/#"  # Note: Doesn't use the same storefinder
+    app_keys = [
+        "5000", # Bergen Storcash Storcash (NO)
+        "5020", # Sola Storcash
+        "5030", # Haugaland Storcash
+        "5040", # Kjørbekk Storcash
+        "5060", # Tiller Storcash
+        "5070", # Sørlandet Storcash
+        "5080", # Buskerud Storcash
+        "5090", # Bodø Storcash
+    ]
+
+    def start_requests(self):
+        yield JsonRequest(url=f"https://api.ngdata.no/sylinder/stores/v1/extended-info")
+
+    def parse(self, response, **kwargs):
+        for location in response.json():
+            if not location["chainId"] in self.app_keys:
+                continue
+
+            yield from parse_location(location) or []
+
+

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -1,4 +1,5 @@
 from locations.storefinders.sylinder import SylinderSpider
+from scrapy.http import JsonRequest
 
 
 class StorcashNoSpider(SylinderSpider):
@@ -21,7 +22,7 @@ class StorcashNoSpider(SylinderSpider):
 
     def parse(self, response, **kwargs):
         for location in response.json():
-            if not location["chainId"] in self.app_keys:
+            if not location["storeDetails"]["chainId"] in self.app_keys:
                 continue
 
-            yield from parse_location(location) or []
+            yield from self.parse_location(location) or []

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -1,7 +1,7 @@
 from scrapy.http import JsonRequest
 
-from locations.storefinders.sylinder import SylinderSpider
 from locations.categories import Categories
+from locations.storefinders.sylinder import SylinderSpider
 
 
 class StorcashNoSpider(SylinderSpider):

--- a/locations/storefinders/sylinder.py
+++ b/locations/storefinders/sylinder.py
@@ -24,7 +24,7 @@ class SylinderSpider(Spider):
 
     def parse(self, response, **kwargs):
         for location in response.json():
-            yield from parse_location(location) or []
+            yield from self.parse_location(location) or []
 
     def parse_location(self, location):
         item = DictParser.parse(location["storeDetails"])


### PR DESCRIPTION
Fixes #7908.
Unfortunately tricky to avoid the hardcoding of chains unless I match the store names.

{'atp/brand/Storcash': 8,
 'atp/category/shop/wholesale': 8,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/image/missing': 8,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/twitter/missing': 8,
 'downloader/request_bytes': 645,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 10483540,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 34.937097,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 17, 3, 31, 55, 297047, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 8,
 'log_count/DEBUG': 12,
 'log_count/INFO': 9,
 'memusage/max': 157630464,
 'memusage/startup': 157630464,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 17, 3, 31, 20, 359950, tzinfo=datetime.timezone.utc)}
2024-03-17 03:31:55 [scrapy.core.engine] INFO: Spider closed (finished)