### PR TITLE
Add Linde Gas & Equipment (US) (formerly Praxis)

### DIFF
--- a/locations/spiders/linde_direct_us.py
+++ b/locations/spiders/linde_direct_us.py
@@ -1,4 +1,3 @@
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.storefinders.rio_seo_spider import RioSeoSpider
 
 
@@ -8,5 +7,3 @@ class LindeDirectUSSpider(RioSeoSpider):
     start_urls = [
         "https://maps.stores.lindedirect.com/api/getAsyncLocations?template=search&level=search&search=Kansas%20City,%20KS,%20US&radius=100000&limit=100000"
     ]
-
-    

--- a/locations/spiders/linde_direct_us.py
+++ b/locations/spiders/linde_direct_us.py
@@ -1,0 +1,12 @@
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.storefinders.rio_seo_spider import RioSeoSpider
+
+
+class LindeDirectUSSpider(RioSeoSpider):
+    name = "linde_direct_us"
+    item_attributes = {"brand": "Linde Gas & Equipment", "brand_wikidata": "Q902780"}
+    start_urls = [
+        "https://maps.stores.lindedirect.com/api/getAsyncLocations?template=search&level=search&search=Kansas%20City,%20KS,%20US&radius=100000&limit=100000"
+    ]
+
+    


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/810
{'atp/brand/Linde Gas & Equipment': 325,
 'atp/brand_wikidata/Q902780': 325,
 'atp/category/missing': 325,
 'atp/field/country/from_spider_name': 325,
 'atp/field/email/missing': 325,
 'atp/field/image/missing': 325,
 'atp/field/operator/missing': 325,
 'atp/field/operator_wikidata/missing': 325,
 'atp/field/street_address/missing': 325,
 'atp/field/twitter/missing': 325,
 'atp/nsi/brand_missing': 325,
 'downloader/request_bytes': 736,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 132503,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.959334,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 17, 8, 0, 19, 641402, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4014071,
 'httpcompression/response_count': 2,
 'item_scraped_count': 325,
 'log_count/DEBUG': 338,
 'log_count/INFO': 9,
 'memusage/max': 157728768,
 'memusage/startup': 157728768,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 3, 17, 8, 0, 16, 682068, tzinfo=datetime.timezone.utc)}
2024-03-17 08:00:19 [scrapy.core.engine] INFO: Spider closed (finished)

Suggestions welcome for category!