### PR TITLE
Add Refuel and Double Quick (US) (227 locations)

### DIFF
--- a/locations/spiders/refuel_double_quick_us.py
+++ b/locations/spiders/refuel_double_quick_us.py
@@ -1,0 +1,18 @@
+from locations.categories import Categories
+from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+
+
+class RefuelDoubleQuickUSSpider(AgileStoreLocatorSpider):
+    name = "refuel_double_quick_us"
+    item_attributes = {"extras": Categories.SHOP_CONVENIENCE.value}
+    allowed_domains = ["www.refuelmarket.com"]
+
+    def parse_item(self, item, location):
+        if location["title"].startswith("Refuel "):
+            item["brand"] = "Refuel"
+            item["brand_wikidata"] = "Q124987140"
+        elif location["title"].startswith("Double Quick "):
+            item["brand"] = "Double Quick"
+            item["brand_wikidata"] = "Q124987186"
+        item["ref"] = location["title"].split(" ")[-1]
+        yield item


### PR DESCRIPTION
 'atp/brand/Double Quick': 50,
 'atp/brand/Refuel': 177,

Fixes #7982