### PR TITLE
[KwikTrip] Collect opening hours and more attributes

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -398,6 +398,7 @@ class Fuel(Enum):
     E20 = "fuel:e20"
     E30 = "fuel:e30"
     E85 = "fuel:e85"
+    E88 = "fuel:e88"
     ETHANOL_FREE = "fuel:ethanol_free"
     METHANOL = "fuel:methanol"
     BIOGAS = "fuel:biogas"


### PR DESCRIPTION
```python
{'atp/brand/Kwik Star': 131,
 'atp/brand/Kwik Trip': 743,
 'atp/brand_wikidata/Q123269534': 131,
 'atp/brand_wikidata/Q6450420': 743,
 'atp/category/amenity/fuel': 847,
 'atp/category/shop/convenience': 14,
 'atp/category/shop/tobacco': 13,
 'atp/field/country/from_reverse_geocoding': 874,
 'atp/field/email/missing': 874,
 'atp/field/image/missing': 874,
 'atp/field/operator/missing': 874,
 'atp/field/operator_wikidata/missing': 874,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 874,
 'atp/nsi/category_match': 861,
 'atp/nsi/match_failed': 13,
 'downloader/request_bytes': 759912,
 'downloader/request_count': 879,
 'downloader/request_method_count/GET': 879,
 'downloader/response_bytes': 1295660,
 'downloader/response_count': 879,
 'downloader/response_status_count/200': 878,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.995247,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 19, 16, 50, 53, 106608, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 879,
 'httpcompression/response_bytes': 2864600,
 'httpcompression/response_count': 879,
 'item_scraped_count': 874,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 159367168,
 'memusage/startup': 159367168,
 'request_depth_max': 1,
 'response_received_count': 879,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 878,
 'scheduler/dequeued/memory': 878,
 'scheduler/enqueued': 878,
 'scheduler/enqueued/memory': 878,
 'start_time': datetime.datetime(2024, 3, 19, 16, 50, 49, 111361, tzinfo=datetime.timezone.utc)}
```