### PR TITLE
[Costco CA] Add spider

### DIFF
--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -1,0 +1,18 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class CostcoCASpider(SitemapSpider, StructuredDataSpider):
+    name = "costco_ca"
+    item_attributes = {"name": "Costco", "brand": "Costco", "brand_wikidata": "Q715583"}
+    sitemap_urls = ["https://www.costco.ca/robots.txt"]
+    sitemap_rules = [("/warehouse-locations/", "parse")]
+    wanted_types = ["Store"]
+    user_agent = BROWSER_DEFAULT
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_WHOLESALE, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Costco': 108,
 'atp/brand_wikidata/Q715583': 108,
 'atp/category/shop/wholesale': 108,
 'atp/field/country/from_spider_name': 108,
 'atp/field/email/missing': 108,
 'atp/field/image/missing': 108,
 'atp/field/opening_hours/missing': 108,
 'atp/field/operator/missing': 108,
 'atp/field/operator_wikidata/missing': 108,
 'atp/field/twitter/missing': 108,
 'atp/nsi/match_failed': 108,
 'downloader/request_bytes': 432914,
 'downloader/request_count': 119,
 'downloader/request_method_count/GET': 119,
 'downloader/response_bytes': 11841509,
 'downloader/response_count': 119,
 'downloader/response_status_count/200': 117,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 4.47827,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 20, 17, 4, 0, 554103, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 119,
 'httpcompression/response_bytes': 60107748,
 'httpcompression/response_count': 118,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/404': 2,
 'item_scraped_count': 108,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 159039488,
 'memusage/startup': 159039488,
 'request_depth_max': 3,
 'response_received_count': 119,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 118,
 'scheduler/dequeued/memory': 118,
 'scheduler/enqueued': 118,
 'scheduler/enqueued/memory': 118,
 'start_time': datetime.datetime(2024, 3, 20, 17, 3, 56, 75833, tzinfo=datetime.timezone.utc)}
```