### PR TITLE
Add Real (HU) and a MapsMarkerPro Store Locator

### DIFF
--- a/locations/spiders/real_hu.py
+++ b/locations/spiders/real_hu.py
@@ -1,0 +1,9 @@
+from locations.storefinders.maps_marker_pro import MapsMarkerProSpider
+from locations.hours import DAYS_HU
+
+
+class RealHU(MapsMarkerProSpider):
+    name = "real_hu"
+    allowed_domains = ["real.hu"]
+    days = DAYS_HU
+    item_attributes = {"brand": "Real", "brand_wikidata": "Q100741414"}

--- a/locations/spiders/real_hu.py
+++ b/locations/spiders/real_hu.py
@@ -1,5 +1,5 @@
-from locations.storefinders.maps_marker_pro import MapsMarkerProSpider
 from locations.hours import DAYS_HU
+from locations.storefinders.maps_marker_pro import MapsMarkerProSpider
 
 
 class RealHU(MapsMarkerProSpider):

--- a/locations/storefinders/maps_marker_pro.py
+++ b/locations/storefinders/maps_marker_pro.py
@@ -1,0 +1,68 @@
+import scrapy
+
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.geo import point_locations
+from locations.hours import DAYS_BY_FREQUENCY, OpeningHours, sanitise_day
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+from scrapy.http import HtmlResponse
+
+# Similar to many other wordpress based spiders, supply an allowed domain or start_urls
+# Explicity specify days
+
+
+class MapsMarkerProSpider(Spider):
+    headers = {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
+    days = None
+
+    def start_requests(self):
+        payload = "action=mmp_map_markers&type=map"
+        if len(self.start_urls) == 0 and hasattr(self, "allowed_domains"):
+            for domain in self.allowed_domains:
+                url = "https://{domain}/wp-admin/admin-ajax.php"
+                yield scrapy.Request(url=url, headers=self.headers, method="POST", body=payload, callback=self.parse)
+        elif len(self.start_urls) != 0:
+            for url in self.start_urls:
+                yield scrapy.Request(url=url, headers=self.headers, method="POST", body=payload, callback=self.parse)
+
+    def parse(self, response, **kwargs):
+        # Response is a GeoJSON object
+        ids = []
+        for location in response.json()["data"]["features"]:
+            ids.append(location["properties"]["id"])
+
+        payload = "action=mmp_marker_popups&id=" + ",".join(ids) + "&lang="
+        yield scrapy.Request(
+            url=response.url,
+            headers=self.headers,
+            method="POST",
+            body=payload,
+            callback=self.parse_popups,
+            cb_kwargs=dict(features=response.json()["data"]["features"]),
+        )
+
+    def parse_popups(self, response, features, **kwargs):
+        for location in features:
+            item = DictParser.parse(location["properties"])
+            item["lat"], item["lon"] = location["geometry"]["coordinates"]
+
+            for popup in response.json()["data"]:
+                if popup["id"] == location["properties"]["id"]:
+                    html_fragment = HtmlResponse(url="#", body=popup["popup"], encoding="utf-8")
+                    item = self.parse_popup_html(item, location, html_fragment)
+
+            yield from self.parse_item(item, location)
+
+    def parse_popup_html(self, item: Feature, location: dict, html_fragment: HtmlResponse):
+        item["opening_hours"] = OpeningHours()
+        for hours in html_fragment.xpath("//div[contains(@class, 'real-opening-hours')]/ul/li/text()").getall():
+            item["opening_hours"].add_ranges_from_string(hours, days=self.days)
+
+        item["website"] = html_fragment.xpath("//a/@href").get()
+        return item
+
+    def parse_item(self, item: Feature, location: dict, **kwargs):
+        yield item

--- a/locations/storefinders/maps_marker_pro.py
+++ b/locations/storefinders/maps_marker_pro.py
@@ -8,6 +8,7 @@ from locations.items import Feature
 
 # Similar to many other wordpress based spiders, supply an allowed domain or start_urls
 # Explicity specify days
+# TODO: Auto detection of an ajaxy request with mmp_* to a wordpress endpoint
 
 
 class MapsMarkerProSpider(Spider):

--- a/locations/storefinders/maps_marker_pro.py
+++ b/locations/storefinders/maps_marker_pro.py
@@ -1,14 +1,10 @@
 import scrapy
-
-
 from scrapy import Spider
+from scrapy.http import HtmlResponse
 
 from locations.dict_parser import DictParser
-from locations.geo import point_locations
-from locations.hours import DAYS_BY_FREQUENCY, OpeningHours, sanitise_day
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
-from scrapy.http import HtmlResponse
 
 # Similar to many other wordpress based spiders, supply an allowed domain or start_urls
 # Explicity specify days


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/7976

{'atp/brand/Real': 707,
 'atp/brand_wikidata/Q100741414': 707,
 'atp/category/missing': 707,
 'atp/field/city/missing': 707,
 'atp/field/country/from_spider_name': 707,
 'atp/field/email/missing': 707,
 'atp/field/image/missing': 707,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 26,
 'atp/field/operator/missing': 707,
 'atp/field/operator_wikidata/missing': 707,
 'atp/field/phone/missing': 707,
 'atp/field/postcode/missing': 707,
 'atp/field/state/missing': 707,
 'atp/field/street_address/missing': 707,
 'atp/field/twitter/missing': 707,
 'atp/field/website/missing': 6,
 'atp/geometry/null_island': 4,
 'atp/nsi/match_failed': 707,
 'downloader/request_bytes': 4699,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 59657,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 9.591962,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 23, 4, 2, 11, 160215, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 958593,
 'httpcompression/response_count': 3,
 'item_scraped_count': 707,
 'log_count/DEBUG': 721,
 'log_count/INFO': 9,
 'memusage/max': 159272960,
 'memusage/startup': 159272960,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 3, 23, 4, 2, 1, 568253, tzinfo=datetime.timezone.utc)}
2024-03-23 04:02:11 [scrapy.core.engine] INFO: Spider closed (finished)