### PR TITLE
Cache Python dependencies to S3 for CodeBuild to run faster

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -33,6 +33,7 @@ phases:
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
           pip install --upgrade pip pipenv
+          echo "Pipenv is installed at $(which pipenv)"
           pipenv sync --system
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -12,7 +12,6 @@ phases:
     runtime-versions:
       python: 3.11
   pre_build:
-    on-failure: ABORT
     commands:
       - |
         # calculate a hash of the pipenv lockfile
@@ -34,7 +33,7 @@ phases:
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
           pip install --user --upgrade pip pipenv
-          pipenv install --deploy
+          pipenv sync --deploy
 
           # install playwright dependencies too
           pipenv run playwright install-deps

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -34,6 +34,10 @@ phases:
           pip install --upgrade pip pipenv
           pipenv install --deploy
 
+          # install playwright dependencies too
+          pipenv run playwright install-deps
+          pipenv run playwright install firefox
+
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
           tar -czf ${PIPENV_HASH}.tar.gz .venv
           aws s3 --only-show-errors cp ${PIPENV_HASH}.tar.gz $REMOTE_CACHE_LOCATION

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -32,12 +32,12 @@ phases:
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
-          pip install --upgrade pip pipenv
+          pip install -qq --upgrade pip pipenv
           echo "Pipenv is installed at $(which pipenv)"
           pipenv sync --system
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
-          tar -czf ${PIPENV_HASH}.tar.gz .venv
+          tar -czf "${PIPENV_HASH}.tar.gz" "${PYTHON_INSTALL_LOCATION}"
           aws s3 --only-show-errors cp ${PIPENV_HASH}.tar.gz $REMOTE_CACHE_LOCATION
         fi
   build:

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -30,7 +30,7 @@ phases:
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
           mkdir -p ${PYTHON_INSTALL_LOCATION}
-          tar -xzf ${PIPENV_HASH}.tar.gz -C ${PYTHON_INSTALL_LOCATION}
+          tar -xzf ${PIPENV_HASH}.tar.gz -C /
           ls -la ${PYTHON_INSTALL_LOCATION}/**/*
         else
           # if the cache does not exist, install dependencies and save the cache to S3

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -11,9 +11,33 @@ phases:
   install:
     runtime-versions:
       python: 3.11
+  pre_build:
+    on-failure: ABORT
     commands:
-      - pip install pipenv
-      - pipenv --bare install --deploy
+      - |
+        # calculate a hash of the pipenv lockfile
+        # this is used to cache the pipenv environment
+        # if the lockfile changes, the cache will be invalidated
+        PIPENV_HASH=$(sha256sum Pipfile.lock | cut -d ' ' -f 1)
+
+        # output where pip is installing stuff to help with debugging
+        echo "Pip install location: $(python -m site --user-base)/lib/python3.11/site-packages"
+
+        # check if the cache exists on S3
+        REMOTE_CACHE_LOCATION="s3://${BUCKET}/pipenv-cache/${PIPENV_HASH}.tar.gz"
+        if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
+          # if the cache exists, extract it
+          tar -xzf ${PIPENV_HASH}.tar.gz
+        else
+          # if the cache does not exist, install dependencies and save the cache to S3
+          echo "Cache not found. Installing dependencies."
+          pip install --upgrade pip pipenv
+          pipenv install --deploy
+
+          echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
+          tar -czf ${PIPENV_HASH}.tar.gz .venv
+          aws s3 --only-show-errors cp ${PIPENV_HASH}.tar.gz $REMOTE_CACHE_LOCATION
+        fi
   build:
     commands:
       - pipenv run scrapy check

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -46,7 +46,7 @@ phases:
         fi
   build:
     commands:
-      - pipenv run scrapy check
+      - scrapy check
       - |
         env
         PR_COMMENT_BODY="I ran the spiders in this pull request and got these results:\\n\\n|Spider|Results|Log|\\n|---|---|---|\\n"
@@ -86,8 +86,8 @@ phases:
 
         if grep PLAYWRIGHT -q -m 1 $SPIDERS; then
             echo "Playwright detected. Installing requirements."
-            pipenv run playwright install-deps
-            pipenv run playwright install firefox
+            playwright install-deps
+            playwright install firefox
         fi
 
         RUN_DIR="/tmp/output"
@@ -109,7 +109,7 @@ phases:
             LOGFILE="${SPIDER_RUN_DIR}/log.txt"
             OUTFILE="${SPIDER_RUN_DIR}/output.geojson"
 
-            pipenv run scrapy runspider \
+            scrapy runspider \
                 -o "file://${OUTFILE}:geojson" \
                 --loglevel=INFO \
                 --logfile="${LOGFILE}" \

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -29,6 +29,7 @@ phases:
         if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
+          mkdir -p ${PYTHON_INSTALL_LOCATION}
           tar -xzf ${PIPENV_HASH}.tar.gz -C ${PYTHON_INSTALL_LOCATION}
         else
           # if the cache does not exist, install dependencies and save the cache to S3

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -21,17 +21,19 @@ phases:
         PIPENV_HASH=$(sha256sum Pipfile.lock | cut -d ' ' -f 1)
 
         # output where pip is installing stuff to help with debugging
-        echo "Pip install location: $(python -m site --user-base)/lib/python3.11/site-packages"
+        PYTHON_INSTALL_LOCATION=$(python -m site --user-site)
+        echo "Pip install location: ${PYTHON_INSTALL_LOCATION}"
 
         # check if the cache exists on S3
         REMOTE_CACHE_LOCATION="s3://${BUCKET}/pipenv-cache/${PIPENV_HASH}.tar.gz"
         if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
-          # if the cache exists, extract it
-          tar -xzf ${PIPENV_HASH}.tar.gz
+          # if the cache exists, extract it to the install location
+          echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
+          tar -xzf ${PIPENV_HASH}.tar.gz -C ${PYTHON_INSTALL_LOCATION}
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
-          pip install --upgrade pip pipenv
+          pip install --user --upgrade pip pipenv
           pipenv install --deploy
 
           # install playwright dependencies too

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -32,12 +32,8 @@ phases:
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
-          pip install --user --upgrade pip pipenv
-          pipenv sync --deploy
-
-          # install playwright dependencies too
-          pipenv run playwright install-deps
-          pipenv run playwright install firefox
+          pip install --upgrade pip pipenv
+          pipenv sync --system
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
           tar -czf ${PIPENV_HASH}.tar.gz .venv

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -32,7 +32,7 @@ phases:
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
           mkdir -p ${PYTHON_INSTALL_LOCATION}
-          tar -xzf ${PIPENV_HASH}.tar.gz -C /
+          tar -xzf "${CACHE_FILE_NAME}" -C /
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -33,8 +33,10 @@ phases:
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
           pip install -qq --upgrade pip pipenv
-          echo "Pipenv is installed at $(which pipenv)"
           pipenv sync --system
+          echo "Pipenv is installed at $(which pipenv)"
+          echo "Python is installed at $(which python)"
+          echo "Scrapy is installed at $(which scrapy)"
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
           tar -czf "${PIPENV_HASH}.tar.gz" "${PYTHON_INSTALL_LOCATION}"

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     BUCKET: alltheplaces.openaddresses.io
+    CODEBUILD_CACHE_BUCKET: codebuild-cache.openaddresses.io
   secrets-manager:
     ZYTE_API_KEY: "alltheplaces:ZYTE_API_KEY"
     GITHUB_TOKEN: "alltheplaces:GITHUB_TOKEN"
@@ -24,7 +25,7 @@ phases:
         echo "Pip install location: ${PYTHON_INSTALL_LOCATION}"
 
         # check if the cache exists on S3
-        REMOTE_CACHE_LOCATION="s3://${BUCKET}/pipenv-cache/${PIPENV_HASH}.tar.gz"
+        REMOTE_CACHE_LOCATION="s3://${CODEBUILD_CACHE_BUCKET}/atp-pipenv-cache/${PIPENV_HASH}.tar.gz"
         if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -20,13 +20,14 @@ phases:
         # if the lockfile changes, the cache will be invalidated
         PIPENV_HASH=$(sha256sum Pipfile.lock | cut -d ' ' -f 1)
         PLATFORM=$(uname -m)
+        CACHE_FILE_NAME="${PIPENV_HASH}-${PLATFORM}.tar.gz"
 
         # output where pip is installing stuff to help with debugging
         PYTHON_INSTALL_LOCATION="/tmp/opt/python/site-packages"
         echo "Pip install location: ${PYTHON_INSTALL_LOCATION}"
 
         # check if the cache exists on S3
-        REMOTE_CACHE_LOCATION="s3://${CODEBUILD_CACHE_BUCKET}/atp-pipenv-cache/${PIPENV_HASH}-${PLATFORM}.tar.gz"
+        REMOTE_CACHE_LOCATION="s3://${CODEBUILD_CACHE_BUCKET}/atp-pipenv-cache/${CACHE_FILE_NAME}"
         if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
@@ -39,7 +40,7 @@ phases:
           pipenv sync --system
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
-          tar -czf "${PIPENV_HASH}.tar.gz" "${PYTHON_INSTALL_LOCATION}"
+          tar -czf "${CACHE_FILE_NAME}" "${PYTHON_INSTALL_LOCATION}"
           aws s3 --only-show-errors cp ${PIPENV_HASH}.tar.gz $REMOTE_CACHE_LOCATION
         fi
   build:

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -20,7 +20,7 @@ phases:
         PIPENV_HASH=$(sha256sum Pipfile.lock | cut -d ' ' -f 1)
 
         # output where pip is installing stuff to help with debugging
-        PYTHON_INSTALL_LOCATION=$(python -m site --user-site)
+        PYTHON_INSTALL_LOCATION="/tmp/opt/python/site-packages"
         echo "Pip install location: ${PYTHON_INSTALL_LOCATION}"
 
         # check if the cache exists on S3
@@ -37,6 +37,7 @@ phases:
           echo "Pipenv is installed at $(which pipenv)"
           echo "Python is installed at $(which python)"
           echo "Scrapy is installed at $(which scrapy)"
+          echo "Playwright is installed at $(which playwright)"
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
           tar -czf "${PIPENV_HASH}.tar.gz" "${PYTHON_INSTALL_LOCATION}"

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -19,28 +19,24 @@ phases:
         # this is used to cache the pipenv environment
         # if the lockfile changes, the cache will be invalidated
         PIPENV_HASH=$(sha256sum Pipfile.lock | cut -d ' ' -f 1)
+        PLATFORM=$(uname -m)
 
         # output where pip is installing stuff to help with debugging
         PYTHON_INSTALL_LOCATION="/tmp/opt/python/site-packages"
         echo "Pip install location: ${PYTHON_INSTALL_LOCATION}"
 
         # check if the cache exists on S3
-        REMOTE_CACHE_LOCATION="s3://${CODEBUILD_CACHE_BUCKET}/atp-pipenv-cache/${PIPENV_HASH}.tar.gz"
+        REMOTE_CACHE_LOCATION="s3://${CODEBUILD_CACHE_BUCKET}/atp-pipenv-cache/${PIPENV_HASH}-${PLATFORM}.tar.gz"
         if aws s3 --only-show-errors cp $REMOTE_CACHE_LOCATION .; then
           # if the cache exists, extract it to the install location
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
           mkdir -p ${PYTHON_INSTALL_LOCATION}
           tar -xzf ${PIPENV_HASH}.tar.gz -C /
-          ls -la ${PYTHON_INSTALL_LOCATION}/**/*
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."
           pip install -qq --upgrade pip pipenv
           pipenv sync --system
-          echo "Pipenv is installed at $(which pipenv)"
-          echo "Python is installed at $(which python)"
-          echo "Scrapy is installed at $(which scrapy)"
-          echo "Playwright is installed at $(which playwright)"
 
           echo "Caching pipenv environment to $REMOTE_CACHE_LOCATION"
           tar -czf "${PIPENV_HASH}.tar.gz" "${PYTHON_INSTALL_LOCATION}"

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -31,6 +31,7 @@ phases:
           echo "Cache found. Extracting ${REMOTE_CACHE_LOCATION} to ${PYTHON_INSTALL_LOCATION}"
           mkdir -p ${PYTHON_INSTALL_LOCATION}
           tar -xzf ${PIPENV_HASH}.tar.gz -C ${PYTHON_INSTALL_LOCATION}
+          ls -la ${PYTHON_INSTALL_LOCATION}/**/*
         else
           # if the cache does not exist, install dependencies and save the cache to S3
           echo "Cache not found. Installing dependencies."

--- a/locations/spiders/amc_theatres_us.py
+++ b/locations/spiders/amc_theatres_us.py
@@ -13,7 +13,7 @@ class AMCTheatresUSSpider(Spider):
     def parse(self, response):
         response.selector.remove_namespaces()
 
-        for theater_elem in response.xpath("//ur l"):
+        for theater_elem in response.xpath("//url"):
             properties = {
                 "website": theater_elem.xpath(".//loc/text()").extract_first(),
                 "name": theater_elem.xpath('.//Attribute[@name="title"]/text()').extract_first(),

--- a/locations/spiders/amc_theatres_us.py
+++ b/locations/spiders/amc_theatres_us.py
@@ -13,7 +13,7 @@ class AMCTheatresUSSpider(Spider):
     def parse(self, response):
         response.selector.remove_namespaces()
 
-        for theater_elem in response.xpath("//url"):
+        for theater_elem in response.xpath("//ur l"):
             properties = {
                 "website": theater_elem.xpath(".//loc/text()").extract_first(),
                 "name": theater_elem.xpath('.//Attribute[@name="title"]/text()').extract_first(),


### PR DESCRIPTION
This adds a step to cache Python dependencies to S3 so that install of dependencies doesn't take ~60 seconds every time.