### PR TITLE
[Aerie] Add spider

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -47,7 +47,6 @@ phases:
     commands:
       - scrapy check
       - |
-        env
         PR_COMMENT_BODY="I ran the spiders in this pull request and got these results:\\n\\n|Spider|Results|Log|\\n|---|---|---|\\n"
 
         # Check if the build is triggered by a pull request
@@ -119,7 +118,7 @@ phases:
                 $spider
 
             FAILURE_REASON="success"
-            if [ $? -eq 124 ]; then
+            if [ ! $? -eq 0 ]; then
                 (>&2 echo "${spider} hit shell timeout")
                 EXIT_CODE=1
                 FAILURE_REASON="timeout"

--- a/locations/spiders/aerie.py
+++ b/locations/spiders/aerie.py
@@ -1,0 +1,23 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+# We have to parse city pages to ensure we only scrap Aerie locations
+
+
+class AerieSpider(SitemapSpider, StructuredDataSpider):
+    name = "aerie"
+    item_attributes = {"brand": "Aerie", "brand_wikidata": "Q25351619"}
+    sitemap_urls = ["https://storelocations.ae.com/sitemap.xml"]
+    sitemap_rules = [(r"https://storelocations.ae.com/\w\w/[^/]+/[^/]+.html$", "parse")]
+    wanted_types = ["ClothingStore"]
+
+    def parse(self, response: Response, **kwargs):
+        for link in response.xpath('//span[@class="LocationName-brand"][text()="Aerie Store"]/../../@href').getall():
+            yield response.follow(link, self.parse_sd)
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Aerie Store ")
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9328

```python
{'atp/brand/Aerie': 182,
 'atp/brand_wikidata/Q25351619': 182,
 'atp/category/shop/clothes': 182,
 'atp/cdn/cloudflare/response_count': 1108,
 'atp/cdn/cloudflare/response_status_count/200': 1108,
 'atp/field/email/missing': 182,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 182,
 'atp/field/operator_wikidata/missing': 182,
 'atp/field/postcode/missing': 4,
 'atp/field/state/missing': 3,
 'atp/field/twitter/missing': 182,
 'atp/nsi/perfect_match': 182,
 'downloader/request_bytes': 423013,
 'downloader/request_count': 1109,
 'downloader/request_method_count/GET': 1109,
 'downloader/response_bytes': 18658932,
 'downloader/response_count': 1109,
 'downloader/response_status_count/200': 1109,
 'elapsed_time_seconds': 10.486538,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 26, 22, 43, 37, 476287, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1109,
 'httpcompression/response_bytes': 146114301,
 'httpcompression/response_count': 1108,
 'item_scraped_count': 182,
 'log_count/INFO': 9,
 'memusage/max': 185778176,
 'memusage/startup': 185778176,
 'request_depth_max': 2,
 'response_received_count': 1109,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1108,
 'scheduler/dequeued/memory': 1108,
 'scheduler/enqueued': 1108,
 'scheduler/enqueued/memory': 1108,
 'start_time': datetime.datetime(2024, 3, 26, 22, 43, 26, 989749, tzinfo=datetime.timezone.utc)}
```