### PR TITLE
[bankofcyprus_cy] add spider (111 locations)

### DIFF
--- a/locations/spiders/bank_of_cyprus_cp.py
+++ b/locations/spiders/bank_of_cyprus_cp.py
@@ -1,0 +1,37 @@
+import html
+
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class BankOfCyprusCYSpider(scrapy.Spider):
+    name = "bankofcyprus_cy"
+    item_attributes = {"brand_wikidata": "Q806678"}
+    start_urls = ["https://www.bankofcyprus.com/home-gr/bank_gr/storespage-gr/"]
+
+    def parse(self, response):
+        cities = response.xpath("//li[@class='cityMap']/@data-value").getall()
+        for city in cities:
+            yield scrapy.Request(
+                f"https://www.bankofcyprus.com/ajax/StoresPage/GetFilteredStores?IsATMForeignCurrency=true&IsATMWithdrawals=true&IsATMDepositWithdrawals=true&IsStore=true&IsBCS=true&IsNotesCoins=true&isCoinDeposit=true&isCoinDispenser=true&Region={city}&SearchString=&Country=CY&Language=el",
+                callback=self.parse_pois,
+                cb_kwargs=dict(city=city),
+            )
+
+    def parse_pois(self, response, city):
+        for poi in response.xpath("//li/div[@class='result-item']"):
+            item = Feature()
+            item["ref"] = poi.xpath('.//span[@class="number"]/text()').get().replace("\u00a0", "")
+            item["street_address"] = poi.xpath(".//@data-address").get()
+            item["city"] = city
+            item["branch"] = html.unescape(poi.xpath(".//@data-name").get())
+            item["lat"] = poi.xpath(".//@data-lat").get()
+            item["lon"] = poi.xpath(".//@data-long").get()
+            item["phone"] = poi.xpath(".//@data-phone").get()
+            if "ATM" in item["branch"]:
+                apply_category(Categories.ATM, item)
+            else:
+                apply_category(Categories.BANK, item)
+            yield item


### PR DESCRIPTION
Stats:

```python
{'atp/brand/Bank of Cyprus': 111,
 'atp/brand_wikidata/Q806678': 111,
 'atp/category/amenity/atm': 12,
 'atp/category/amenity/bank': 99,
 'atp/field/country/from_spider_name': 111,
 'atp/field/email/missing': 111,
 'atp/field/image/missing': 111,
 'atp/field/name/missing': 12,
 'atp/field/opening_hours/missing': 111,
 'atp/field/operator/missing': 99,
 'atp/field/operator_wikidata/missing': 99,
 'atp/field/phone/missing': 111,
 'atp/field/postcode/missing': 111,
 'atp/field/state/missing': 111,
 'atp/field/twitter/missing': 111,
 'atp/field/website/missing': 111,
 'atp/nsi/category_match': 111,
 'atp/operator/Bank of Cyprus': 12,
 'atp/operator_wikidata/Q806678': 12,
 'downloader/request_bytes': 5650,
 'downloader/request_count': 7,
 'downloader/request_method_count/GET': 7,
 'downloader/response_bytes': 91711,
 'downloader/response_count': 7,
 'downloader/response_status_count/200': 7,
 'elapsed_time_seconds': 11.000438,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 3, 27, 11, 11, 59, 850251, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 509368,
 'httpcompression/response_count': 7,
 'item_scraped_count': 111,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 168546304,
 'memusage/startup': 168546304,
 'request_depth_max': 1,
 'response_received_count': 7,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6,
 'scheduler/dequeued/memory': 6,
 'scheduler/enqueued': 6,
 'scheduler/enqueued/memory': 6,
 'start_time': datetime.datetime(2024, 3, 27, 11, 11, 48, 849813, tzinfo=datetime.timezone.utc)}
```