### PR TITLE
[seven_eleven_ph] add spider (3k locations)

### DIFF
--- a/locations/spiders/seven_eleven_ph.py
+++ b/locations/spiders/seven_eleven_ph.py
@@ -1,0 +1,58 @@
+import scrapy
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import DAYS_EN, OpeningHours
+from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
+
+
+class SevenElevenPhSpider(scrapy.Spider):
+    name = "seven_eleven_ph"
+    allowed_domains = ["www.7-eleven.com.ph"]
+    item_attributes = SEVEN_ELEVEN_SHARED_ATTRIBUTES
+
+    def start_requests(self):
+        for city in city_locations("PH"):
+            lat = city.get("latitude")
+            lon = city.get("longitude")
+            yield JsonRequest(
+                f"https://www.7-eleven.com.ph/wp-admin/admin-ajax.php?action=store_search&lat={lat}&lng={lon}&max_results=100&search_radius=500&filter=62",
+            )
+
+    def parse(self, response: Response):
+        for poi in response.json():
+            item = DictParser.parse(poi)
+            item["branch"] = poi.get("store")
+            self.parse_hours(item, poi)
+            if "[PERMANENT CLOSED]" in item["addr_full"]:
+                item["extras"]["end_date"] = "yes"
+            self.clean_address(item)
+            yield item
+
+    def parse_hours(self, item, poi):
+        hours = poi.get("hours")
+        if not hours:
+            return
+        try:
+            days = scrapy.Selector(text=hours).xpath("//tr")
+            oh = OpeningHours()
+            for day in days:
+                day_name = day.xpath("td[1]/text()").get()
+                times = day.xpath("td[2]/time/text()").get()
+                if not day_name or not times:
+                    continue
+                if "Closed" in times:
+                    continue
+                open_time, close_time = times.split(" - ")
+                oh.add_range(DAYS_EN.get(day_name), open_time, close_time, "%I:%M %p")
+            item["opening_hours"] = oh.as_opening_hours()
+        except Exception as e:
+            self.logger.warning(f"Error parsing hours: {e}", exc_info=True)
+            self.crawler.stats.inc_value("atp/hours/failed")
+
+    def clean_address(self, item):
+        for term in ["[OPEN]", "[TEMPORARY CLOSED]", "[PERMANENT CLOSED]"]:
+            if term in item["addr_full"]:
+                item["addr_full"] = item["addr_full"].replace(term, "").strip()
+                break

--- a/locations/spiders/seven_eleven_ph.py
+++ b/locations/spiders/seven_eleven_ph.py
@@ -1,4 +1,5 @@
 import scrapy
+from scrapy import Selector
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
@@ -35,7 +36,7 @@ class SevenElevenPhSpider(scrapy.Spider):
         if not hours:
             return
         try:
-            days = scrapy.Selector(text=hours).xpath("//tr")
+            days = Selector(text=hours).xpath("//tr")
             oh = OpeningHours()
             for day in days:
                 day_name = day.xpath("td[1]/text()").get()


### PR DESCRIPTION
The spider is geo-based, but amount of requests is acceptable I hope.

Stats:

```json
{
 "atp/brand/7-Eleven": 3344,
 "atp/brand_wikidata/Q259340": 3344,
 "atp/category/missing": 3344,
 "atp/closed_poi": 118,
 "atp/field/city/missing": 424,
 "atp/field/country/from_spider_name": 3344,
 "atp/field/email/missing": 3344,
 "atp/field/image/missing": 3344,
 "atp/field/name/missing": 3344,
 "atp/field/operator/missing": 3344,
 "atp/field/operator_wikidata/missing": 3344,
 "atp/field/phone/invalid": 1237,
 "atp/field/phone/missing": 2048,
 "atp/field/postcode/missing": 3344,
 "atp/field/street_address/missing": 3344,
 "atp/field/twitter/missing": 3344,
 "atp/field/website/missing": 3344,
 "atp/nsi/match_failed": 3344,
 "downloader/request_bytes": 197037,
 "downloader/request_count": 461,
 "downloader/request_method_count/GET": 461,
 "downloader/response_bytes": 3606847,
 "downloader/response_count": 461,
 "downloader/response_status_count/200": 460,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 31.018201,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-03-27T13:20:27.319079+00:00",
 "httpcache/hit": 461,
 "httpcompression/response_bytes": 41932538,
 "httpcompression/response_count": 461,
 "item_dropped_count": 42456,
 "item_dropped_reasons_count/DropItem": 42456,
 "item_scraped_count": 3344,
 "log_count/INFO": 10,
 "memusage/max": 153911296,
 "memusage/startup": 153911296,
 "response_received_count": 461,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 460,
 "scheduler/dequeued/memory": 460,
 "scheduler/enqueued": 460,
 "scheduler/enqueued/memory": 460,
 "start_time": "2024-03-27T13:19:56.300878+00:00"
}
```