### PR TITLE
[kfc_nl] add spider (90 locations)

### DIFF
--- a/locations/spiders/kfc_nl.py
+++ b/locations/spiders/kfc_nl.py
@@ -1,0 +1,48 @@
+import scrapy
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.spiders.kfc import KFC_SHARED_ATTRIBUTES
+
+
+class KfcNLSpider(scrapy.Spider):
+    name = "kfc_nl"
+    start_urls = ["https://api.menu.app/api/directory/search"]
+    item_attributes = KFC_SHARED_ATTRIBUTES
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://api.menu.app/api/directory/search",
+            headers={"Application": "6a800bd9ae7e75ead64fc04c02a3f21a"},
+            data={
+                "latitude": "52.0907",
+                "longitude": "5.1214",
+                "order_types": [4, 6],
+                "view": "search",
+                "per_page": 500,
+            },
+            callback=self.parse,
+        )
+
+    def parse(self, response):
+        for poi in response.json()["data"]["venues"]["data"]:
+            poi = poi["venue"]
+            item = DictParser.parse(poi)
+            item.pop("state")
+            item["street_address"] = item.pop("addr_full")
+            self.parse_hours(item, poi)
+            apply_category(Categories.FAST_FOOD, item)
+            yield item
+
+    def parse_hours(self, item, poi):
+        days_map = {1: "Mo", 2: "Tu", 3: "We", 4: "Th", 5: "Fr", 6: "Sa", 0: "Su"}
+        hours = poi.get("serving_times")
+        if not hours:
+            return
+        oh = OpeningHours()
+        for serving_time in hours:
+            for day in serving_time.get("days", []):
+                oh.add_range(days_map.get(day), serving_time.get("time_from"), serving_time.get("time_to"))
+        item["opening_hours"] = oh.as_opening_hours()


### PR DESCRIPTION
Individual urls per POI seems available (e.g. https://www.kfc.nl/locaties/sontplein-3/?id=625), but they don't work when I try to open them in a new tab.

Stats:

```json
{
 "atp/brand/KFC": 90,
 "atp/brand_wikidata/Q524757": 90,
 "atp/category/amenity/fast_food": 90,
 "atp/field/country/from_spider_name": 90,
 "atp/field/email/missing": 90,
 "atp/field/image/missing": 90,
 "atp/field/operator/missing": 90,
 "atp/field/operator_wikidata/missing": 90,
 "atp/field/phone/missing": 90,
 "atp/field/state/missing": 90,
 "atp/field/twitter/missing": 90,
 "atp/field/website/missing": 90,
 "atp/nsi/cc_match": 90,
 "downloader/request_bytes": 783,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 1,
 "downloader/request_method_count/POST": 1,
 "downloader/response_bytes": 9525,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 0.50466,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-03-27T14:30:22.620099+00:00",
 "httpcache/hit": 2,
 "httpcompression/response_bytes": 82301,
 "httpcompression/response_count": 1,
 "item_scraped_count": 90,
 "log_count/INFO": 10,
 "memusage/max": 158875648,
 "memusage/startup": 158875648,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-03-27T14:30:22.115439+00:00"
}
```