### PR TITLE
western_union: fix spider

### DIFF
--- a/locations/spiders/western_union.py
+++ b/locations/spiders/western_union.py
@@ -41,9 +41,10 @@ class WesternUnionSpider(Spider):
             "query": "query locations($req:LocationInput) { locations(input: $req) }",
             "variables": {
                 "req": {
-                    "longitude": longitude,
-                    "latitude": latitude,
+                    "longitude": str(longitude),
+                    "latitude": str(latitude),
                     "country": "US",  # Seemingly has no effect.
+                    "brand": "wu",
                     "openNow": "",
                     "services": [],
                     "sortOrder": "Distance",


### PR DESCRIPTION
b90e2c1ad54c1f5496a63ba25fa07d89095b7557 changed the point_locations function to return floats for lat and lon, rather than strings. The Western Union spider needs to send lat and lon as JSON strings, not JSON floats.