### PR TITLE
tjx: fix spider

### DIFF
--- a/locations/spiders/tjx.py
+++ b/locations/spiders/tjx.py
@@ -34,8 +34,8 @@ class TjxSpider(scrapy.Spider):
                     formdata={
                         "chain": ",".join(chains),
                         "lang": "en",
-                        "geolat": lat,
-                        "geolong": lon,
+                        "geolat": str(lat),
+                        "geolong": str(lon),
                     },
                     headers={"Accept": "application/json"},
                 )


### PR DESCRIPTION
b90e2c1ad54c1f5496a63ba25fa07d89095b7557 changed the point_locations function to return floats for lat and lon, rather than strings. The TJX spider needs to send lat and lon as strings not integers in FormRequest.