### PR TITLE
aaa: fix spider

### DIFF
--- a/locations/spiders/aaa.py
+++ b/locations/spiders/aaa.py
@@ -26,7 +26,7 @@ class AAASpider(scrapy.Spider):
                 "radius": "5000",
                 "format": "json",
                 "ident": "AAACOM",
-                "destination": ",".join([lat, lon]),
+                "destination": f"{lat},{lon}",
             }
             yield scrapy.http.Request("https://tdr.aaa.com/tdrl/search.jsp?" + urlencode(params))
 


### PR DESCRIPTION
b90e2c1ad54c1f5496a63ba25fa07d89095b7557 changed the point_locations function to return floats for lat and lon, rather than strings. The AAA spider needs to concatenate the two floats into a single string sent in a request to the server.