### PR TITLE
[LaAnonima AR] Fix name

### DIFF
--- a/locations/spiders/la_anonima_ar.py
+++ b/locations/spiders/la_anonima_ar.py
@@ -3,7 +3,7 @@ from scrapy import Spider
 from locations.dict_parser import DictParser
 
 
-class LaAnonimaAR(Spider):
+class LaAnonimaARSpider(Spider):
     name = "la_anonima_ar"
     start_urls = ["https://www.laanonima.com.ar/contents/themes/evolucionamos/bin/get_all_sucursales.php"]
     item_attributes = {"brand_wikidata": "Q6135985"}
@@ -13,6 +13,6 @@ class LaAnonimaAR(Spider):
             item = DictParser.parse(location)
             item["phone"] = location["telefono"]
             item["addr_full"] = location["direccion"]
-            item["name"] = location["nombre"]
+            item["extras"]["ref:branch"], item["branch"] = location["nombre"].split(" - ", 1)
             item["website"] = "https://www.laanonima.com.ar/" + location["url"]
             yield item


### PR DESCRIPTION
At some point in the future, we may need to discus refs. For us `ref`, it's a unique id per spider, that then gets turned into a `id` which is unique across ATP. However not all refs are equal, some like this are seen by the users, they are essentially advertised. (I think CVS is an example in the US). Some of our refs are slugs or urls or even uuids from the source, they aren't advertised, they shouldn't make it into OSMs `ref`, however there are examples of it happening. And they shouldn't be shown to end users.

Right now, I wouldn't advise anyone who shows ATP data to end users to show any of our `ref`s, however I could see a world where someone wants to show some refs (CVS, or this).

I've used `ref:branch` here, but only because I didn't want to needlessly break the `id` as it's different from the current `ref`. I am not using `ref:branch`, I'm happy for specifics to be changed when we actually have the conversation. This PR is actually about `name`.