### PR TITLE
[Oreilly US] Drop duplicates

### DIFF
--- a/locations/spiders/oreilly_auto.py
+++ b/locations/spiders/oreilly_auto.py
@@ -5,9 +5,20 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class OreillyAutoSpider(SitemapSpider, StructuredDataSpider):
     name = "oreilly"
-    item_attributes = {"brand": "O'Reilly Auto Parts", "brand_wikidata": "Q7071951"}
+    item_attributes = {"brand": "O'Reilly Auto Parts", "brand_wikidata": "Q7071951", "country": "US"}
     allowed_domains = ["locations.oreillyauto.com"]
     sitemap_urls = ["https://locations.oreillyauto.com/sitemap.xml"]
-    sitemap_rules = [(r"[0-9]+.html$", "parse_sd")]
+    sitemap_rules = [(r"autoparts-([0-9]+).html$", "parse_sd")]
     wanted_types = ["AutoPartsStore"]
+    search_for_twitter = False
     requires_proxy = True
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = None
+        item["extras"]["website:en"] = response.url
+        item["extras"]["website:es"] = response.xpath('//a[@class="translate-link ga-link"]/@href').get()
+        item["facebook"] = (
+            response.xpath('//a[@class="ga-link"][contains(@href, "https://www.facebook.com/")]/@href').get() or ""
+        ).removesuffix("/reviews/?ref=page_internal")
+
+        yield item


### PR DESCRIPTION
The spider was also parsing the [Spanish](https://locations.oreillyauto.com/ak/juneau/autopartes-3826.html) page, and services pages such as [Battery Testing](https://locations.oreillyauto.com/ak/juneau/battery-testing-3826.html) and [Windshield Wiper Blade Installation](https://locations.oreillyauto.com/ak/juneau/wiper-installation-3826.html)

```python
{"atp/brand/O'Reilly Auto Parts": 6141,
 'atp/brand_wikidata/Q7071951': 6141,
 'atp/category/shop/car_parts': 6141,
 'atp/field/email/missing': 6141,
 'atp/field/image/dropped': 6141,
 'atp/field/image/missing': 6141,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 6141,
 'atp/field/operator_wikidata/missing': 6141,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 6141,
 'atp/nsi/perfect_match': 6141,
 'downloader/request_bytes': 2416012,
 'downloader/request_count': 6143,
 'downloader/request_method_count/GET': 6143,
 'downloader/response_bytes': 334649469,
 'downloader/response_count': 6143,
 'downloader/response_status_count/200': 6143,
 'elapsed_time_seconds': 51.1551,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 6, 11, 36, 55, 553493, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 6143,
 'httpcompression/response_bytes': 1427974934,
 'httpcompression/response_count': 6143,
 'item_scraped_count': 6141,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 160182272,
 'memusage/startup': 160182272,
 'request_depth_max': 1,
 'response_received_count': 6143,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6142,
 'scheduler/dequeued/memory': 6142,
 'scheduler/enqueued': 6142,
 'scheduler/enqueued/memory': 6142,
 'start_time': datetime.datetime(2024, 4, 6, 11, 36, 4, 398393, tzinfo=datetime.timezone.utc)}
```