### PR TITLE
[Ingo DK] Add spider

### DIFF
--- a/locations/spiders/ingo_dk.py
+++ b/locations/spiders/ingo_dk.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class IngoDKSpider(SitemapSpider, StructuredDataSpider):
+    name = "ingo_dk"
+    item_attributes = {"brand": "Ingo", "brand_wikidata": "Q17048617"}
+    sitemap_urls = ["https://www.ingo.dk/stations/sitemap.xml"]
+    wanted_types = ["GasStation"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("INGO ")
+        extract_google_position(item, response)
+        apply_category(Categories.FUEL_STATION, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Ingo': 196,
 'atp/brand_wikidata/Q17048617': 196,
 'atp/category/amenity/fuel': 196,
 'atp/field/email/missing': 196,
 'atp/field/image/missing': 196,
 'atp/field/opening_hours/missing': 192,
 'atp/field/operator/missing': 196,
 'atp/field/operator_wikidata/missing': 196,
 'atp/field/state/missing': 196,
 'atp/field/twitter/missing': 196,
 'atp/nsi/category_match': 196,
 'downloader/request_bytes': 73235,
 'downloader/request_count': 198,
 'downloader/request_method_count/GET': 198,
 'downloader/response_bytes': 1652707,
 'downloader/response_count': 198,
 'downloader/response_status_count/200': 198,
 'elapsed_time_seconds': 1.418007,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 7, 11, 10, 5, 8963, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 198,
 'httpcompression/response_bytes': 6665564,
 'httpcompression/response_count': 198,
 'item_scraped_count': 196,
 'log_count/INFO': 9,
 'log_count/WARNING': 192,
 'memusage/max': 160112640,
 'memusage/startup': 160112640,
 'request_depth_max': 1,
 'response_received_count': 198,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 197,
 'scheduler/dequeued/memory': 197,
 'scheduler/enqueued': 197,
 'scheduler/enqueued/memory': 197,
 'start_time': datetime.datetime(2024, 4, 7, 11, 10, 3, 590956, tzinfo=datetime.timezone.utc)}
```