### PR TITLE
[ToomBaumarkt DE] Sync brand string with NSI

### DIFF
--- a/locations/spiders/toom_baumarkt_de.py
+++ b/locations/spiders/toom_baumarkt_de.py
@@ -3,9 +3,14 @@ from scrapy.spiders import SitemapSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class ToomBaumarktDeSpider(SitemapSpider, StructuredDataSpider):
+class ToomBaumarktDESpider(SitemapSpider, StructuredDataSpider):
     name = "toom_baumarkt_de"
-    item_attributes = {"brand": "Toom Baumarkt", "brand_wikidata": "Q2442970"}
+    item_attributes = {"brand": "toom Baumarkt", "brand_wikidata": "Q2442970"}
     sitemap_urls = ["https://static.toom.de/sitemap/cms.xml"]
     sitemap_follow = ["newmarkets"]
     json_parser = "chompjs"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").split(" in ", 1)[1]
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/toom Baumarkt': 293,
 'atp/brand_wikidata/Q2442970': 293,
 'atp/category/shop/doityourself': 293,
 'atp/field/country/from_spider_name': 13,
 'atp/field/image/missing': 293,
 'atp/field/operator/missing': 293,
 'atp/field/operator_wikidata/missing': 293,
 'atp/field/state/missing': 286,
 'atp/field/twitter/missing': 293,
 'atp/nsi/perfect_match': 293,
 'downloader/request_bytes': 115083,
 'downloader/request_count': 297,
 'downloader/request_method_count/GET': 297,
 'downloader/response_bytes': 21832900,
 'downloader/response_count': 297,
 'downloader/response_status_count/200': 297,
 'elapsed_time_seconds': 4.803786,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 8, 12, 34, 18, 770622, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 297,
 'httpcompression/response_bytes': 129796370,
 'httpcompression/response_count': 296,
 'item_scraped_count': 293,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 160243712,
 'memusage/startup': 160243712,
 'request_depth_max': 2,
 'response_received_count': 297,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 295,
 'scheduler/dequeued/memory': 295,
 'scheduler/enqueued': 295,
 'scheduler/enqueued/memory': 295,
 'start_time': datetime.datetime(2024, 4, 8, 12, 34, 13, 966836, tzinfo=datetime.timezone.utc)}
```