### PR TITLE
western_union: fix spider

### DIFF
--- a/locations/geo.py
+++ b/locations/geo.py
@@ -68,11 +68,19 @@ def point_locations(areas_csv_file: str, area_field_filter: list[str] = None) ->
                 try:
                     lat, lon = float(row["latitude"]), float(row["longitude"])
                 except ValueError:
-                    raise Exception("Invalid latitude/longitude in searchable points file {} where latitude = {} and longitude = {}.".format(csv_file, row["latitude"], row["longitude"]))
+                    raise Exception(
+                        "Invalid latitude/longitude in searchable points file {} where latitude = {} and longitude = {}.".format(
+                            csv_file, row["latitude"], row["longitude"]
+                        )
+                    )
                 area = get_key(row, ["country", "territory", "state"])
                 if area_field_filter:
                     if not area:
-                        raise Exception("Searchable points file {} does support support area field filters (columns named 'country', 'territory' and 'state').".format(csv_file))
+                        raise Exception(
+                            "Searchable points file {} does support support area field filters (columns named 'country', 'territory' and 'state').".format(
+                                csv_file
+                            )
+                        )
                     if area not in area_field_filter:
                         continue
                 yield lat, lon

--- a/locations/geo.py
+++ b/locations/geo.py
@@ -65,13 +65,14 @@ def point_locations(areas_csv_file: str, area_field_filter: list[str] = None) ->
     for csv_file in areas_csv_file:
         with open_searchable_points("{}".format(csv_file)) as file:
             for row in csv.DictReader(file):
-                lat, lon = float(row["latitude"]), float(row["longitude"])
-                if not lat or not lon:
-                    raise Exception("missing lat/lon in file")
+                try:
+                    lat, lon = float(row["latitude"]), float(row["longitude"])
+                except ValueError:
+                    raise Exception(f"Invalid latitude/longitude in searchable points file {} where latitude = {} and longitude = {}.".format(csv_file, row["latitude"], row["longitude"]))
                 area = get_key(row, ["country", "territory", "state"])
                 if area_field_filter:
                     if not area:
-                        raise Exception("trying to perform area filter on file with no area support")
+                        raise Exception(f"Searchable points file {} does support support area field filters (columns named 'country', 'territory' and 'state').".format(csv_file))
                     if area not in area_field_filter:
                         continue
                 yield lat, lon

--- a/locations/geo.py
+++ b/locations/geo.py
@@ -68,11 +68,11 @@ def point_locations(areas_csv_file: str, area_field_filter: list[str] = None) ->
                 try:
                     lat, lon = float(row["latitude"]), float(row["longitude"])
                 except ValueError:
-                    raise Exception(f"Invalid latitude/longitude in searchable points file {} where latitude = {} and longitude = {}.".format(csv_file, row["latitude"], row["longitude"]))
+                    raise Exception("Invalid latitude/longitude in searchable points file {} where latitude = {} and longitude = {}.".format(csv_file, row["latitude"], row["longitude"]))
                 area = get_key(row, ["country", "territory", "state"])
                 if area_field_filter:
                     if not area:
-                        raise Exception(f"Searchable points file {} does support support area field filters (columns named 'country', 'territory' and 'state').".format(csv_file))
+                        raise Exception("Searchable points file {} does support support area field filters (columns named 'country', 'territory' and 'state').".format(csv_file))
                     if area not in area_field_filter:
                         continue
                 yield lat, lon


### PR DESCRIPTION
point_locations was treating coordinates of +/-0.0000000 as invalid coordinates, when these are valid coordinates. Instead of using a loose if(lat) and if(lon) check that fails for floating point values of 0, only consider coordinates to be invalid if they can't be converted to a floating point type.