### PR TITLE
[KFC DE] Fix spider

### DIFF
--- a/locations/spiders/kfc_de.py
+++ b/locations/spiders/kfc_de.py
@@ -4,7 +4,7 @@ from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.spiders.kfc import KFC_SHARED_ATTRIBUTES
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 SERVICES_MAPPING = {
     "click_collect": Extras.TAKEAWAY,
@@ -20,12 +20,15 @@ class KFCDESpider(Spider):
     item_attributes = KFC_SHARED_ATTRIBUTES
     start_urls = ["https://api.kfc.de/find-a-kfc/allrestaurant"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
-    user_agent = BROWSER_DEFAULT
+    user_agent = FIREFOX_LATEST
 
     def parse(self, response, **kwargs):
         for location in response.json():
+            if location["name"].endswith(" - COMING SOON"):
+                continue
             location["street_address"] = location.pop("address")
             item = DictParser.parse(location)
+            item["name"] = None
             item["ref"] = location["id"]
             item["website"] = "https://www.kfc.de/find-a-kfc/" + location["urlName"]
             oh = OpeningHours()
@@ -40,4 +43,6 @@ class KFCDESpider(Spider):
                     apply_yes_no(tags, item, True, True)
                 else:
                     self.logger.warning(f"Unknown service {service}")
+
+            apply_yes_no(Extras.INDOOR_SEATING, item, "dinein" in location["dispositions"])
             yield item


### PR DESCRIPTION
```python
{'atp/brand/KFC': 206,
 'atp/brand_wikidata/Q524757': 206,
 'atp/category/amenity/fast_food': 206,
 'atp/field/country/from_spider_name': 206,
 'atp/field/email/missing': 206,
 'atp/field/image/missing': 206,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 206,
 'atp/field/operator_wikidata/missing': 206,
 'atp/field/phone/missing': 206,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 206,
 'atp/field/twitter/missing': 206,
 'atp/nsi/cc_match': 206,
 'downloader/request_bytes': 274,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 40967,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.562306,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 10, 15, 28, 36, 646742, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1,
 'httpcompression/response_bytes': 585134,
 'httpcompression/response_count': 1,
 'item_scraped_count': 206,
 'log_count/INFO': 10,
 'log_count/WARNING': 357,
 'memusage/max': 160038912,
 'memusage/startup': 160038912,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 10, 15, 28, 36, 84436, tzinfo=datetime.timezone.utc)}
```

Switching from Firefox ESR to normal Firefox user agent is the key bit here, we may want to switch BROWSER_DEFAULT at some point, but I kind of imagine it will be more maintenance. idk.