### PR TITLE
[champs_sports_us] add spider (410 locations)

### DIFF
--- a/locations/spiders/champs_sports_us.py
+++ b/locations/spiders/champs_sports_us.py
@@ -1,0 +1,11 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ChampsSportsUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "champs_sports_us"
+    item_attributes = {"brand": "Champs Sports", "brand_wikidata": "Q2955924"}
+    sitemap_urls = ["https://stores.champssports.com/sitemap.xml"]
+    sitemap_rules = [(r".html$", "parse_sd")]
+    wanted_types = ["ShoeStore"]


### PR DESCRIPTION
 A US sports shop brand:

'atp/brand/Champs Sports': 410,
 'atp/brand_wikidata/Q2955924': 410,
 'atp/category/shop/sports': 410,
 'atp/field/country/from_spider_name': 410,
 'atp/field/email/missing': 410,
 'atp/field/image/dropped': 410,
 'atp/field/image/missing': 410,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 25,
 'atp/field/operator/missing': 410,
 'atp/field/operator_wikidata/missing': 410,
 'atp/field/twitter/missing': 410,
 'atp/nsi/perfect_match': 410