### PR TITLE
[carlsjr_fr] Added carls jr for france (7 items)

### DIFF
--- a/locations/spiders/carlsjr_fr.py
+++ b/locations/spiders/carlsjr_fr.py
@@ -1,0 +1,29 @@
+import re
+
+from scrapy import Spider
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address, merge_address_lines
+from locations.spiders.carlsjr_us import CarlsJrUSSpider
+
+
+class CarlsJrFRSpider(Spider):
+    name = "carlsjr_fr"
+    item_attributes = CarlsJrUSSpider.item_attributes
+    start_urls = ["https://www.carlsjr.fr/build/front-mainController.min.513861e5.js"]
+
+    def parse(self, response, **kwargs):
+        for store_url in re.findall(r"document\.location\.href[=\s]+\"(.+?)\"", response.text):
+            yield response.follow(url=store_url, callback=self.parse_store)
+
+    def parse_store(self, response, **kwargs):
+        item = Feature()
+        location = response.xpath('//*[contains(text(),"Tel:")]/parent::p')
+        address_1 = clean_address(location.xpath("./strong[1]/text()").getall())
+        address_2 = clean_address(location.xpath("./text()").getall())
+        item["addr_full"] = merge_address_lines([address_1, address_2])
+        item["phone"] = response.xpath('//*[contains(text(),"Tel:")]/text()').get()
+        item["ref"] = item["website"] = response.url
+        extract_google_position(item, response)
+        yield item


### PR DESCRIPTION

<details><summary>Stats</summary>

```python
{"atp/brand/Carl's Jr.": 7,
 'atp/brand_wikidata/Q1043486': 7,
 'atp/category/amenity/fast_food': 7,
 'atp/field/city/missing': 7,
 'atp/field/country/from_spider_name': 7,
 'atp/field/email/missing': 7,
 'atp/field/image/missing': 7,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 7,
 'atp/field/operator_wikidata/missing': 7,
 'atp/field/postcode/missing': 7,
 'atp/field/state/missing': 7,
 'atp/field/street_address/missing': 7,
 'atp/field/twitter/missing': 7,
 'atp/nsi/perfect_match': 7,
 'downloader/request_bytes': 3419,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 139492,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 9.941078,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 11, 12, 16, 13, 733344, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 7,
 'log_count/DEBUG': 27,
 'log_count/INFO': 9,
 'memusage/max': 151252992,
 'memusage/startup': 151252992,
 'request_depth_max': 1,
 'response_received_count': 9,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2024, 4, 11, 12, 16, 3, 792266, tzinfo=datetime.timezone.utc)}
```
</details>