### PR TITLE
[peugeot_nl_fr] Create peugeot spider for NL and FR (2266 items)

### DIFF
--- a/locations/spiders/peugeot_nl_fr.py
+++ b/locations/spiders/peugeot_nl_fr.py
@@ -1,0 +1,37 @@
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class PeugeotNLFRSpider(scrapy.Spider):
+    name = "peugeot_nl_fr"
+    start_urls = [
+        "https://www.peugeot.nl/apps/atomic/DealersServlet?distance=30000&latitude=52.36993&longitude=4.90787&maxResults=40000&orderResults=false&path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvbmV0aGVybGFuZHMvbmw%3D&searchType=latlong",
+        "https://www.peugeot.fr/apps/atomic/DealersServlet?path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvZnJhbmNlL2ZyX2Zy&searchType=latlong",
+    ]
+
+    item_attributes = {"brand": "Peugeot", "brand_wikidata": "Q6742"}
+
+    def parse(self, response, **kwargs):
+        for store in response.json().get("payload").get("dealers"):
+            address_details = store.get("address")
+            coordinates = store.get("geolocation")
+            contact_details = store.get("generalContact")
+            item = Feature(
+                {
+                    "ref": store.get("siteGeo"),
+                    "name": store.get("dealerName"),
+                    "street_address": address_details.get("addresssLine1"),
+                    "phone": contact_details.get("phone1"),
+                    "email": contact_details.get("email"),
+                    "postcode": address_details.get("postalCode"),
+                    "city": address_details.get("cityName"),
+                    "state": address_details.get("county"),
+                    "website": store.get("dealerUrl"),
+                    "lat": float(coordinates.get("latitude")),
+                    "lon": float(coordinates.get("longitude")),
+                }
+            )
+            apply_category(Categories.SHOP_CAR, item)
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Peugeot': 2266,
 'atp/brand_wikidata/Q6742': 2266,
 'atp/category/shop/car': 2266,
 'atp/field/country/from_reverse_geocoding': 123,
 'atp/field/country/from_website_url': 2143,
 'atp/field/email/missing': 21,
 'atp/field/image/missing': 2266,
 'atp/field/opening_hours/missing': 2266,
 'atp/field/operator/missing': 2266,
 'atp/field/operator_wikidata/missing': 2266,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 764,
 'atp/field/street_address/missing': 2266,
 'atp/field/twitter/missing': 2266,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 121,
 'atp/nsi/cc_match': 2266,
 'downloader/request_bytes': 1517,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 325028,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 6.213433,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 11, 12, 25, 59, 482363, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3822109,
 'httpcompression/response_count': 4,
 'item_scraped_count': 2266,
 'log_count/DEBUG': 2281,
 'log_count/INFO': 9,
 'memusage/max': 151265280,
 'memusage/startup': 151265280,
 'response_received_count': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 4, 11, 12, 25, 53, 268930, tzinfo=datetime.timezone.utc)}
```
</details>