### PR TITLE
[suzuki_fr] Create Spider for Suzuki France (219 items)

### DIFF
--- a/locations/spiders/suzuki_fr.py
+++ b/locations/spiders/suzuki_fr.py
@@ -1,0 +1,24 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class SuzukiFRSpider(SitemapSpider):
+    name = "suzuki_fr"
+    item_attributes = {"brand": "Suzuki", "brand_wikidata": "Q181642"}
+    sitemap_urls = [
+        "https://www.suzuki.fr/sitemap.xml",
+    ]
+    sitemap_rules = [("/show/", "parse")]
+
+    def parse(self, response, **kwargs):
+        item = Feature()
+        item["name"] = response.xpath(r"//title/text()").get().replace("|", "-")
+        item["street_address"] = clean_address(response.xpath(r'//*[@class = "uppercase"]/text()').get().strip())
+        item["addr_full"] = (
+            item["street_address"] + ", " + clean_address(response.xpath(r'//*[@class = "uppercase"]/text()[2]').get())
+        )
+        item["phone"] = response.xpath(r'//*[contains(@href,"tel:")]/text()').get().replace(".", "")
+        item["ref"] = item["website"] = response.url
+        yield item

--- a/locations/spiders/suzuki_fr.py
+++ b/locations/spiders/suzuki_fr.py
@@ -14,6 +14,8 @@ class SuzukiFRSpider(SitemapSpider):
 
     def parse(self, response, **kwargs):
         item = Feature()
+        item["lat"] = response.xpath(r'//div[@id = "store-locator-map"]/@data-store-lat').get()
+        item["lon"] = response.xpath(r'//div[@id = "store-locator-map"]/@data-store-lng').get()
         item["name"] = response.xpath(r"//title/text()").get().replace("|", "-")
         item["street_address"] = clean_address(response.xpath(r'//*[@class = "uppercase"]/text()').get().strip())
         item["addr_full"] = (


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Suzuki': 219,
 'atp/brand_wikidata/Q181642': 219,
 'atp/category/missing': 219,
 'atp/field/city/missing': 219,
 'atp/field/country/from_spider_name': 219,
 'atp/field/email/missing': 219,
 'atp/field/image/missing': 219,
 'atp/field/lat/missing': 219,
 'atp/field/lon/missing': 219,
 'atp/field/opening_hours/missing': 219,
 'atp/field/operator/missing': 219,
 'atp/field/operator_wikidata/missing': 219,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 219,
 'atp/field/state/missing': 219,
 'atp/field/twitter/missing': 219,
 'atp/nsi/match_failed': 219,
 'downloader/request_bytes': 84665,
 'downloader/request_count': 221,
 'downloader/request_method_count/GET': 221,
 'downloader/response_bytes': 72108108,
 'downloader/response_count': 221,
 'downloader/response_status_count/200': 221,
 'elapsed_time_seconds': 273.357544,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 11, 12, 34, 52, 543217, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 85,
 'httpcompression/response_count': 1,
 'item_scraped_count': 219,
 'log_count/DEBUG': 451,
 'log_count/INFO': 13,
 'memusage/max': 321396736,
 'memusage/startup': 151146496,
 'request_depth_max': 1,
 'response_received_count': 221,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 220,
 'scheduler/dequeued/memory': 220,
 'scheduler/enqueued': 220,
 'scheduler/enqueued/memory': 220,
 'start_time': datetime.datetime(2024, 4, 11, 12, 30, 19, 185673, tzinfo=datetime.timezone.utc)}
```
</details>