### PR TITLE
[AMC US] Fix spider

### DIFF
--- a/locations/spiders/amc_theatres_us.py
+++ b/locations/spiders/amc_theatres_us.py
@@ -1,14 +1,18 @@
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+
+AMC = {"brand": "AMC", "brand_wikidata": "Q294721"}
 
 
 class AMCTheatresUSSpider(Spider):
     name = "amc_theatres_us"
-    item_attributes = {"brand": "AMC Theaters", "brand_wikidata": "Q294721"}
     allowed_domains = ["www.amctheatres.com"]
     start_urls = ["https://www.amctheatres.com/sitemaps/sitemap-theatres.xml"]
-    requires_proxy = "US"
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response):
         response.selector.remove_namespaces()
@@ -16,7 +20,6 @@ class AMCTheatresUSSpider(Spider):
         for theater_elem in response.xpath("//url"):
             properties = {
                 "website": theater_elem.xpath(".//loc/text()").extract_first(),
-                "name": theater_elem.xpath('.//Attribute[@name="title"]/text()').extract_first(),
                 "ref": theater_elem.xpath('.//Attribute[@name="theatreId"]/text()').extract_first(),
                 "street_address": theater_elem.xpath('.//Attribute[@name="addressLine1"]/text()').extract_first(),
                 "city": theater_elem.xpath('.//Attribute[@name="city"]/text()').extract_first(),
@@ -25,5 +28,27 @@ class AMCTheatresUSSpider(Spider):
                 "lat": theater_elem.xpath('.//Attribute[@name="latitude"]/text()').extract_first(),
                 "lon": theater_elem.xpath('.//Attribute[@name="longitude"]/text()').extract_first(),
             }
+
+            label = theater_elem.xpath('.//Attribute[@name="title"]/text()').get()
+            screens = label.rsplit(" ", 1)[1]
+            if screens.isnumeric():
+                properties["extras"] = {"screen": screens}
+                label = label.rsplit(" ", 1)[0]
+
+            if label.startswith("AMC"):
+                properties.update(AMC)
+            if label.startswith("AMC CLASSIC "):
+                properties["name"] = "AMC Classic"
+                properties["branch"] = label.removeprefix("AMC CLASSIC ")
+            elif label.startswith("AMC DINE-IN "):
+                properties["name"] = "AMC Dine-In"
+                properties["branch"] = label.removeprefix("AMC DINE-IN ")
+            elif label.startswith("AMC "):
+                properties["name"] = "AMC"
+                properties["branch"] = label.removeprefix("AMC ")
+            else:
+                properties["name"] = label
+
+            apply_category(Categories.CINEMA, properties)
 
             yield Feature(**properties)


### PR DESCRIPTION
```python
{'atp/brand/AMC': 555,
 'atp/brand_wikidata/Q294721': 555,
 'atp/category/amenity/cinema': 557,
 'atp/field/brand/missing': 2,
 'atp/field/brand_wikidata/missing': 2,
 'atp/field/country/from_spider_name': 557,
 'atp/field/email/missing': 557,
 'atp/field/image/missing': 557,
 'atp/field/opening_hours/missing': 557,
 'atp/field/operator/missing': 557,
 'atp/field/operator_wikidata/missing': 557,
 'atp/field/phone/missing': 557,
 'atp/field/twitter/missing': 557,
 'atp/nsi/perfect_match': 555,
 'downloader/request_bytes': 639,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 465396,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.812337,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 11, 14, 31, 22, 632184, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'item_scraped_count': 557,
 'log_count/DEBUG': 574,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 163491840,
 'memusage/startup': 163491840,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 11, 14, 31, 16, 819847, tzinfo=datetime.timezone.utc)}
```