### PR TITLE
[nespresso] Added Austria and Denmark to countries list (480 items)

### DIFF
--- a/locations/spiders/nespresso.py
+++ b/locations/spiders/nespresso.py
@@ -9,7 +9,7 @@ class NespressoSpider(scrapy.Spider):
     item_attributes = {"brand": "Nespresso", "brand_wikidata": "Q301301"}
 
     def start_requests(self):
-        countries = ["US", "CA", "FR", "NL", "GB", "DE", "CH", "IT", "ZA"]
+        countries = ["AT", "CA", "CH", "DE", "DK", "FR", "GB", "IT", "NL", "US", "ZA"]
 
         base_url = "https://www.nespresso.com/storelocator/app/find_poi-v4.php?country={country}&lang=EN"
 


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Nespresso': 480,
 'atp/brand_wikidata/Q301301': 480,
 'atp/category/shop/coffee': 480,
 'atp/field/email/missing': 480,
 'atp/field/image/missing': 480,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 480,
 'atp/field/operator/missing': 480,
 'atp/field/operator_wikidata/missing': 480,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 286,
 'atp/field/postcode/missing': 3,
 'atp/field/state/from_reverse_geocoding': 74,
 'atp/field/state/missing': 406,
 'atp/field/twitter/missing': 480,
 'atp/field/website/missing': 480,
 'atp/nsi/perfect_match': 480,
 'downloader/request_bytes': 5192,
 'downloader/request_count': 12,
 'downloader/request_method_count/GET': 12,
 'downloader/response_bytes': 73012,
 'downloader/response_count': 12,
 'downloader/response_status_count/200': 12,
 'elapsed_time_seconds': 13.66333,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 11, 16, 5, 13, 274980, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 368580,
 'httpcompression/response_count': 12,
 'item_scraped_count': 480,
 'log_count/INFO': 9,
 'memusage/max': 151470080,
 'memusage/startup': 151470080,
 'response_received_count': 12,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 11,
 'scheduler/dequeued/memory': 11,
 'scheduler/enqueued': 11,
 'scheduler/enqueued/memory': 11,
 'start_time': datetime.datetime(2024, 4, 11, 16, 4, 59, 611650, tzinfo=datetime.timezone.utc)}
```
</details>