### PR TITLE
[nespresso] Added hungary to nespresso spider (487 items)

### DIFF
--- a/locations/spiders/nespresso.py
+++ b/locations/spiders/nespresso.py
@@ -9,7 +9,7 @@ class NespressoSpider(scrapy.Spider):
     item_attributes = {"brand": "Nespresso", "brand_wikidata": "Q301301"}
 
     def start_requests(self):
-        countries = ["AT", "CA", "CH", "DE", "DK", "FR", "GB", "IT", "NL", "US", "ZA"]
+        countries = ["AT", "CA", "CH", "DE", "DK", "FR", "GB", "HU", "IT", "NL", "US", "ZA"]
 
         base_url = "https://www.nespresso.com/storelocator/app/find_poi-v4.php?country={country}&lang=EN"
 


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Nespresso': 487,
 'atp/brand_wikidata/Q301301': 487,
 'atp/category/shop/coffee': 487,
 'atp/field/email/missing': 487,
 'atp/field/image/missing': 487,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 487,
 'atp/field/operator/missing': 487,
 'atp/field/operator_wikidata/missing': 487,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 293,
 'atp/field/postcode/missing': 3,
 'atp/field/state/from_reverse_geocoding': 74,
 'atp/field/state/missing': 413,
 'atp/field/twitter/missing': 487,
 'atp/field/website/missing': 487,
 'atp/nsi/perfect_match': 487,
 'downloader/request_bytes': 5648,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 75925,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 13,
 'elapsed_time_seconds': 14.918667,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 12, 15, 57, 29, 19021, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 373355,
 'httpcompression/response_count': 13,
 'item_scraped_count': 487,
 'log_count/INFO': 9,
 'memusage/max': 150523904,
 'memusage/startup': 150523904,
 'response_received_count': 13,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2024, 4, 12, 15, 57, 14, 100354, tzinfo=datetime.timezone.utc)}
```
</details>