### PR TITLE
[kia_at_fr_de] Created spider for kia in AT, FR, DE (857 items)

### DIFF
--- a/locations/spiders/kia_at_fr_de.py
+++ b/locations/spiders/kia_at_fr_de.py
@@ -1,0 +1,31 @@
+import scrapy
+
+from locations.items import Feature
+
+
+class KiaATFRDESpider(scrapy.Spider):
+    name = "kia_at_fr_de"
+    item_attributes = {"brand": "Kia", "brand_wikidata": "Q35349"}
+    start_urls = [
+        "https://www.kia.com/api/bin/dealer?locale=at-de&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=fr-fr&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=de-de&program=dealerLocatorSearch",
+    ]
+
+    def parse(self, response, **kwargs):
+        for store in response.json()["list"]:
+            item = Feature()
+            item["name"] = store.get("dealerName")
+            item["street_address"] = store.get("dealerAddress")
+            item["postcode"] = store.get("dealerPostcode")
+            item["city"] = store.get("dealerResidence")
+            item["lat"] = store.get("dealerLatitude")
+            item["lon"] = store.get("dealerLongitude")
+            item["phone"] = store.get("dealerPhone")
+            item["email"] = store.get("dealerEmail")
+            if store.get("websiteUrl") not in ["None", ""]:
+                item["website"] = store.get("websiteUrl")
+            else:
+                item["website"] = "https://www.kia.com/"
+            item["ref"] = store.get("dealerSeq")
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Kia': 857,
 'atp/brand_wikidata/Q35349': 857,
 'atp/category/shop/car': 857,
 'atp/field/country/from_reverse_geocoding': 348,
 'atp/field/country/from_website_url': 509,
 'atp/field/email/invalid': 17,
 'atp/field/email/missing': 233,
 'atp/field/image/missing': 857,
 'atp/field/opening_hours/missing': 857,
 'atp/field/operator/missing': 857,
 'atp/field/operator_wikidata/missing': 857,
 'atp/field/phone/invalid': 47,
 'atp/field/phone/missing': 8,
 'atp/field/state/missing': 509,
 'atp/field/twitter/missing': 857,
 'atp/field/website/invalid': 7,
 'atp/nsi/perfect_match': 857,
 'downloader/request_bytes': 1343,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 245169,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 5.707653,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 15, 14, 45, 43, 182294, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3368341,
 'httpcompression/response_count': 3,
 'item_scraped_count': 857,
 'log_count/DEBUG': 872,
 'log_count/INFO': 9,
 'memusage/max': 151183360,
 'memusage/startup': 151183360,
 'response_received_count': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 4, 15, 14, 45, 37, 474641, tzinfo=datetime.timezone.utc)}
```
</details>