### PR TITLE
[bp] Add more tags for bp (17884 items)

### DIFF
--- a/locations/spiders/bp.py
+++ b/locations/spiders/bp.py
@@ -1,4 +1,14 @@
-from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.categories import (
+    Access,
+    Categories,
+    Extras,
+    Fuel,
+    FuelCards,
+    PaymentMethods,
+    apply_category,
+    apply_yes_no,
+)
+from locations.hours import DAYS, OpeningHours
 from locations.storefinders.geo_me import GeoMeSpider
 
 
@@ -15,15 +25,40 @@ class BPSpider(GeoMeSpider):
         item["brand"], item["brand_wikidata"] = self.brands.get(location["site_brand"], self.brands["BP"])
         products = location["products"]
         facilities = location["facilities"]
+
+        if "bp_connect_store" in facilities:
+            bp_connect_item = item.deepcopy()
+            bp_connect_item["ref"] = item.get("ref") + "-attachecd-bp-connect-shop"
+            bp_connect_item["name"] = "BP Connect"
+            bp_connect_item["brand"] = "BP Connect"
+            bp_connect_item["brand_wikidata"] = "Q152057"
+            if "shop_open_24_hours" in facilities:
+                item["opening_hours"] = OpeningHours()
+                item["opening_hours"].add_days_range(DAYS, "00:00", "23:59")
+            apply_category(Categories.SHOP_CONVENIENCE, bp_connect_item)
+            yield bp_connect_item
+
         apply_category(Categories.FUEL_STATION, item)
         if "shop" in facilities:
-            apply_category(Categories.SHOP_CONVENIENCE, item)
-        apply_yes_no("amenity:chargingstation", item, "electricity" in products)
-        apply_yes_no("amenity:toilets", item, "toilet" in facilities)
-        apply_yes_no("atm", item, "cash_point" in facilities)
-        apply_yes_no("car_wash", item, "car_wash" in facilities)
-        apply_yes_no("hgv", item, any("truck" in f for f in facilities))
-        apply_yes_no("wheelchair", item, "disabled_facilities" in facilities)
+            apply_yes_no("shop", item, True)
+        if "restaurant" in facilities:
+            apply_yes_no("food", item, True)
+
+        if "electric_charging" in facilities or "electricity" in products:
+            apply_yes_no("fuel:electricity", item, True)
+
+        apply_yes_no(Extras.TOILETS, item, any("toilet" in a for a in facilities))
+        apply_yes_no(Extras.SHOWERS, item, "shower" in facilities)
+        apply_yes_no(Extras.ATM, item, "cash_point" in facilities)
+        apply_yes_no(
+            Extras.CAR_WASH,
+            item,
+            "car_wash" in facilities or "car_wash_self_service" in facilities or "super_wash" in facilities,
+        )
+        apply_yes_no(Extras.VACUUM_CLEANER, item, "vacuum_cleaner" in facilities)
+        apply_yes_no(Extras.WIFI, item, "wifi" in facilities)
+        apply_yes_no(Access.HGV, item, any("truck" in f for f in facilities))
+        apply_yes_no(Extras.WHEELCHAIR, item, "disabled_facilities" in facilities)
         apply_yes_no(Fuel.ADBLUE, item, any("ad_blue" in p for p in products))
         apply_yes_no(Fuel.DIESEL, item, any("diesel" in p for p in products))
         apply_yes_no(Fuel.COLD_WEATHER_DIESEL, item, "diesel_frost" in products)
@@ -39,4 +74,9 @@ class BPSpider(GeoMeSpider):
         apply_yes_no(Fuel.OCTANE_95, item, "unlead" in products or any("unleaded_95" in p for p in products))
         apply_yes_no(Fuel.OCTANE_98, item, "ultimate_unleaded" in products or any("98" in p for p in products))
         apply_yes_no(Fuel.UNTAXED_DIESEL, item, "red_diesel" in products)
+        apply_yes_no(PaymentMethods.VISA, item, "visa" in facilities)
+        apply_yes_no(PaymentMethods.MASTER_CARD, item, "mastercard" in facilities)
+        apply_yes_no(FuelCards.BP, item, "bp_fuel_card" in facilities or "euroshell_card" in facilities)
+        apply_yes_no(FuelCards.DKV, item, "dkv" in facilities)
+        apply_yes_no(FuelCards.UTA, item, "uta" in facilities)
         yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/BP': 17846,
 'atp/brand/BP Connect': 38,
 'atp/brand_wikidata/Q152057': 17884,
 'atp/category/amenity/fuel': 17846,
 'atp/category/shop/convenience': 38,
 'atp/closed_check': 5,
 'atp/field/email/missing': 17884,
 'atp/field/image/missing': 17884,
 'atp/field/opening_hours/missing': 989,
 'atp/field/operator/missing': 17615,
 'atp/field/operator_wikidata/missing': 17615,
 'atp/field/phone/invalid': 212,
 'atp/field/phone/missing': 530,
 'atp/field/postcode/missing': 269,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 8115,
 'atp/field/twitter/missing': 17884,
 'atp/field/website/missing': 15551,
 'atp/nsi/cc_match': 17847,
 'atp/nsi/match_failed': 37,
 'atp/operator/BP': 269,
 'atp/operator_wikidata/Q152057': 269,
 'downloader/request_bytes': 728485,
 'downloader/request_count': 1366,
 'downloader/request_method_count/GET': 1366,
 'downloader/response_bytes': 35173004,
 'downloader/response_count': 1366,
 'downloader/response_status_count/200': 1365,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 1684.997662,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 15, 18, 52, 15, 461344, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 17842,
 'item_dropped_reasons_count/DropItem': 17842,
 'item_scraped_count': 17884,
 'log_count/INFO': 37,
 'log_count/WARNING': 5,
 'memusage/max': 371843072,
 'memusage/startup': 150941696,
 'request_depth_max': 712,
 'response_received_count': 1366,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1365,
 'scheduler/dequeued/memory': 1365,
 'scheduler/enqueued': 1365,
 'scheduler/enqueued/memory': 1365,
 'start_time': datetime.datetime(2024, 4, 15, 18, 24, 10, 463682, tzinfo=datetime.timezone.utc)}
```
</details>