### PR TITLE
bucees_us: fix spider

### DIFF
--- a/locations/spiders/bucees_us.py
+++ b/locations/spiders/bucees_us.py
@@ -31,7 +31,7 @@ class BuceesUSSpider(WPStoreLocatorSpider):
 
         yield item
 
-    def parse_opening_hours(self, location: dict, **kwargs) -> OpeningHours:
+    def parse_opening_hours(self, location: dict, days: dict, **kwargs) -> OpeningHours:
         sel = Selector(text=location["hours"])
         oh = OpeningHours()
         for rule in sel.xpath("//tr"):


### PR DESCRIPTION
3818d225b6ac75d0b551ebe9e85146e45a96aa83 introduced a new attribute to parse_opening_hours() of WPStoreLocatorSpider. BuceesUSSpider thus needs to accomodate this new attribute when overriding parse_opening_hours()