### PR TITLE
bar_burrito_ca: fix spider and parse opening hours

### DIFF
--- a/locations/spiders/bar_burrito_ca.py
+++ b/locations/spiders/bar_burrito_ca.py
@@ -1,20 +1,37 @@
-import html
+from html import unescape
+from phpserialize import unserialize
 
+from locations.categories import Categories
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
 class BarBurritoCASpider(WPStoreLocatorSpider):
     name = "bar_burrito_ca"
-    item_attributes = {"brand": "BarBurrito", "brand_wikidata": "Q104844862"}
+    item_attributes = {"brand": "BarBurrito", "brand_wikidata": "Q104844862", "extras": Categories.FAST_FOOD.value}
     allowed_domains = ["www.barburrito.ca"]
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
-        item["branch"] = html.unescape(item.pop("name"))
+        item["branch"] = unescape(item.pop("name"))
         del item["addr_full"]
 
         yield item
 
-    def parse_opening_hours(self, location: dict, **kwargs):
-        # TODO: php serialized format
-        return None
+    def parse_opening_hours(self, location: dict, days: dict, **kwargs):
+        # Reference: https://www.php.net/manual/en/function.unserialize.php
+        php_serialized_string = location.get("hours", "").encode("utf-8")
+        unserialized_object = unserialize(php_serialized_string)
+        unserialized_dict = {
+            k.decode(): v.decode() if isinstance(v, bytes) else v for k, v in unserialized_object.items()
+        }
+        unserialized_dict = {
+            k: list(map(bytes.decode, v.values())) for k, v in unserialized_dict.items()
+        }
+        hours_string = ""
+        for day_name, hour_ranges in unserialized_dict.items():
+            for hour_range in hour_ranges:
+                hours_string = "{} {}: {} - {}".format(hours_string, day_name, hour_range.split(",", 1)[0], hour_range.split(",", 1)[1])
+        oh = OpeningHours()
+        oh.add_ranges_from_string(hours_string)
+        return oh

--- a/locations/spiders/bar_burrito_ca.py
+++ b/locations/spiders/bar_burrito_ca.py
@@ -1,4 +1,5 @@
 from html import unescape
+
 from phpserialize import unserialize
 
 from locations.categories import Categories
@@ -25,13 +26,13 @@ class BarBurritoCASpider(WPStoreLocatorSpider):
         unserialized_dict = {
             k.decode(): v.decode() if isinstance(v, bytes) else v for k, v in unserialized_object.items()
         }
-        unserialized_dict = {
-            k: list(map(bytes.decode, v.values())) for k, v in unserialized_dict.items()
-        }
+        unserialized_dict = {k: list(map(bytes.decode, v.values())) for k, v in unserialized_dict.items()}
         hours_string = ""
         for day_name, hour_ranges in unserialized_dict.items():
             for hour_range in hour_ranges:
-                hours_string = "{} {}: {} - {}".format(hours_string, day_name, hour_range.split(",", 1)[0], hour_range.split(",", 1)[1])
+                hours_string = "{} {}: {} - {}".format(
+                    hours_string, day_name, hour_range.split(",", 1)[0], hour_range.split(",", 1)[1]
+                )
         oh = OpeningHours()
         oh.add_ranges_from_string(hours_string)
         return oh


### PR DESCRIPTION
3818d225b6ac75d0b551ebe9e85146e45a96aa83 introduced a new attribute to parse_opening_hours() of WPStoreLocatorSpider. BarBurritoCASpider thus needs to accomodate this new attribute when overriding parse_opening_hours()

This change also implements parse_opening_hours(), as this overridden function was previously just a placeholder.