### PR TITLE
Sync brand strings with NSI

### DIFF
--- a/locations/spiders/allianz_de.py
+++ b/locations/spiders/allianz_de.py
@@ -5,7 +5,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class AllianzDESpider(SitemapSpider, StructuredDataSpider):
     name = "allianz_de"
-    item_attributes = {"brand": "Allianz SE", "brand_wikidata": "Q487292"}
+    item_attributes = {"brand": "Allianz", "brand_wikidata": "Q487292"}
     sitemap_urls = [
         "https://vertretung.allianz.de/sitemap.xml",
     ]

--- a/locations/spiders/applebees.py
+++ b/locations/spiders/applebees.py
@@ -5,12 +5,12 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class ApplebeesSpider(SitemapSpider, StructuredDataSpider):
     name = "applebees"
-    item_attributes = {"brand": "Applebees", "brand_wikidata": "Q621532"}
+    item_attributes = {"brand_wikidata": "Q621532"}
     sitemap_urls = ["https://restaurants.applebees.com/robots.txt"]
     sitemap_rules = [(r"https://restaurants\.applebees\.com/en-us/\w\w/[-\w]+/[-.\w]+\d+$", "parse_sd")]
     wanted_types = ["Restaurant"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["name"] = response.xpath("//h3/text()").get()
+        item["name"] = None
 
         yield item

--- a/locations/spiders/asics_us.py
+++ b/locations/spiders/asics_us.py
@@ -3,7 +3,7 @@ from locations.storefinders.locally import LocallySpider
 
 class AsicsUsSpider(LocallySpider):
     name = "asics_us"
-    item_attributes = {"brand": "asics", "brand_wikidata": "Q327247"}
+    item_attributes = {"brand": "ASICS", "brand_wikidata": "Q327247"}
     allowed_domains = ["www.asics.com"]
     start_urls = [
         "https://www.locally.com/stores/conversion_data?has_data=true&company_id=1682&store_mode=&style=&color=&upc=&category=&inline=1&show_links_in_list=&parent_domain=&map_center_lat=31.945163222857545&map_center_lng=-96.352774663203&map_distance_diag=2692.1535387671056&sort_by=proximity&no_variants=0&only_retailer_id=&dealers_company_id=&only_store_id=false&uses_alt_coords=false&q=false&zoom_level=5"

--- a/locations/spiders/bp_pulse_gb.py
+++ b/locations/spiders/bp_pulse_gb.py
@@ -7,7 +7,7 @@ from locations.items import Feature
 
 class BPPulseGBSpider(Spider):
     name = "bp_pulse_gb"
-    item_attributes = {"brand": "bp pulse", "brand_wikidata": "Q39057719"}
+    item_attributes = {"brand_wikidata": "Q39057719"}
 
     @staticmethod
     def make_request(page: int) -> JsonRequest:

--- a/locations/spiders/cic.py
+++ b/locations/spiders/cic.py
@@ -9,7 +9,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class CiceSpider(CrawlSpider, StructuredDataSpider):
     name = "cic"
-    item_attributes = {"brand": "cic", "brand_wikidata": "Q746525"}
+    item_attributes = {"brand_wikidata": "Q746525"}
     start_urls = ["https://www.cic.fr/fr/banques/entreprises/agences-et-distributeurs/BrowseSubdivision.aspx"]
     allowed_domains = ["cic.fr"]
     rules = [

--- a/locations/spiders/citizens_us.py
+++ b/locations/spiders/citizens_us.py
@@ -4,7 +4,7 @@ from locations.storefinders.yext import YextSpider
 
 class CitizensUSSpider(YextSpider):
     name = "citizens_us"
-    item_attributes = {"brand": "Citizens", "brand_wikidata": "Q5122694"}
+    item_attributes = {"brand_wikidata": "Q5122694"}
     api_key = "d4d6be17717272573aeece729fdbec0c"
     wanted_types = ["location", "atm"]
 

--- a/locations/spiders/claires.py
+++ b/locations/spiders/claires.py
@@ -5,7 +5,7 @@ from locations.spiders.pandora import PandoraSpider
 
 class ClairesSpider(SitemapSpider):
     name = "claires"
-    item_attributes = {"brand": "Claire's", "brand_wikidata": "Q2974996"}
+    item_attributes = {"brand_wikidata": "Q2974996"}
     allowed_domains = ["claires.com"]
     sitemap_urls = ["https://stores.claires.com/sitemap.xml"]
     sitemap_rules = [
@@ -17,4 +17,10 @@ class ClairesSpider(SitemapSpider):
     download_delay = 0.2
 
     def parse_store(self, response):
-        yield PandoraSpider.parse_item(response, self.sitemap_rules[0][0])
+        item = PandoraSpider.parse_item(response, self.sitemap_rules[0][0])
+        item["branch"] = (
+            item.pop("name")
+            .removeprefix("Shop Ear Piercings & Jewellery at ")
+            .removeprefix("Shop Ear Piercings & Jewelry at ")
+        )
+        yield item

--- a/locations/spiders/croix_rouge_francaise_fr.py
+++ b/locations/spiders/croix_rouge_francaise_fr.py
@@ -7,7 +7,7 @@ from locations.hours import DAYS_FR, OpeningHours, sanitise_day
 
 class CroixRougeFrancaiseFRSpider(Spider):
     name = "croix_rouge_francaise_fr"
-    item_attributes = {"brand": "Croix-Rouge française", "brand_wikidata": "Q3003244"}
+    item_attributes = {"brand": "Croix-Rouge Française", "brand_wikidata": "Q3003244"}
     allowed_domains = ["backend.structure.croix-rouge.fr"]
     start_urls = ["https://backend.structure.croix-rouge.fr/graphql"]
 

--- a/locations/spiders/dairy_queen_us.py
+++ b/locations/spiders/dairy_queen_us.py
@@ -12,6 +12,7 @@ class DairyQueenUSSpider(Spider):
     allowed_domains = ["prod-dairyqueen.dotcmscloud.com"]
     start_urls = ["https://prod-dairyqueen.dotcmscloud.com/api/es/search"]
     custom_settings = {"ROBOTSTXT_OBEY": False}  # Missing robots.txt
+    item_attributes = {"nsi_id": "N/A"}
     brands = {
         "Food and Treat": {
             "brand": "DQ Grill & Chill",
@@ -40,7 +41,8 @@ class DairyQueenUSSpider(Spider):
                 item["brand_wikidata"] = self.brands[location["conceptType"]]["brand_wikidata"]
                 for tag_key, tag_value in self.brands[location["conceptType"]]["extras"].items():
                     apply_category({tag_key: tag_value}, item)
-            item["name"] = re.sub(r"^\d+ : ", "", item["name"])
+            item["branch"] = re.sub(r"^\d+ : ", "", item["name"])
+            item["name"] = item["brand"]
             item["street_address"] = location.get("address3")
             item["website"] = "https://www.dairyqueen.com" + location.get("urlTitle")
             yield item

--- a/locations/spiders/dominos_pizza_in.py
+++ b/locations/spiders/dominos_pizza_in.py
@@ -5,10 +5,11 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class DominiosINSpider(SitemapSpider, StructuredDataSpider):
     name = "dominos_pizza_in"
-    item_attributes = {"brand": "Domino's Pizza", "brand_wikidata": "Q839466"}
+    item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     sitemap_urls = ["https://www.dominos.co.in/store-locations/sitemap_store.xml"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["addr_full"] = item.pop("street_address")
+        item["name"] = None
 
         yield item

--- a/locations/spiders/dominos_pizza_jp.py
+++ b/locations/spiders/dominos_pizza_jp.py
@@ -9,7 +9,6 @@ from locations.user_agents import BROWSER_DEFAULT
 class DominosPizzaJPSpider(scrapy.Spider):
     name = "dominos_pizza_jp"
     item_attributes = {
-        "brand": "Domino's",
         "brand_wikidata": "Q839466",
         "country": "JP",
     }

--- a/locations/spiders/dominos_pizza_mx.py
+++ b/locations/spiders/dominos_pizza_mx.py
@@ -10,7 +10,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class DominiosMXSpider(Spider):
     name = "dominos_pizza_mx"
-    item_attributes = {"brand": "Domino's Pizza", "brand_wikidata": "Q839466"}
+    item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
     user_agent = BROWSER_DEFAULT
 

--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -8,7 +8,7 @@ from locations.dict_parser import DictParser
 
 class EnterpriseSpider(Spider):
     name = "enterprise"
-    item_attributes = {"brand": "Enterprise Rent-A-Car", "brand_wikidata": "Q17085454"}
+    item_attributes = {"brand": "Enterprise", "brand_wikidata": "Q17085454"}
     allowed_domains = ["prd.location.enterprise.com", "int1.location.enterprise.com"]
 
     def start_requests(self):

--- a/locations/spiders/familymart_tw.py
+++ b/locations/spiders/familymart_tw.py
@@ -9,7 +9,6 @@ from locations.user_agents import BROWSER_DEFAULT
 class FamilyMartTWSpider(Spider):
     name = "familymart_tw"
     item_attributes = {
-        "brand": "FamilyMart",
         "brand_wikidata": "Q10891564",
         "extras": Categories.SHOP_CONVENIENCE.value,
     }

--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -8,7 +8,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class FordDealersUSSpider(CrawlSpider, StructuredDataSpider):
     name = "ford_dealers_us"
     item_attributes = {
-        "brand": "Ford Motor Company",
+        "brand": "Ford",
         "brand_wikidata": "Q44294",
     }
     start_urls = ["https://www.ford.com/dealerships/dealer-directory/browse-all/"]

--- a/locations/spiders/kfc_jp.py
+++ b/locations/spiders/kfc_jp.py
@@ -5,12 +5,11 @@ from scrapy import Request, Spider
 from locations.categories import Extras, PaymentMethods, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.spiders.kfc import KFC_SHARED_ATTRIBUTES
 
 
 class KFCJPSpider(Spider):
     name = "kfc_jp"
-    item_attributes = KFC_SHARED_ATTRIBUTES
+    item_attributes = {"brand_wikidata": "Q524757"}
     allowed_domains = ["search.kfc.co.jp"]
     start_urls = ["https://search.kfc.co.jp/api/point?b=31,129,46,146"]
 

--- a/locations/spiders/marriott_hotels.py
+++ b/locations/spiders/marriott_hotels.py
@@ -36,7 +36,7 @@ class MarriottHotelsSpider(scrapy.Spider):
         "BA": ["Marriott Beach Apartments", "Q3918608"],
         "BG": ["Bulgari Hotels", "Q91602871"],
         "BR": ["Renaissance Hotels", "Q2143252"],
-        "CY": ["Courtyard by Marriott", "Q1053170"],
+        "CY": ["Courtyard", "Q1053170"],
         "DE": ["Delta Hotels", "Q5254663"],
         "DS": ["Design Hotels", "Q5264274"],
         "EB": ["Edition Hotels", "Q91218404"],

--- a/locations/spiders/mcdonalds_jp.py
+++ b/locations/spiders/mcdonalds_jp.py
@@ -1,12 +1,11 @@
 import scrapy
 
 from locations.items import Feature
-from locations.spiders.mcdonalds import McDonaldsSpider
 
 
 class McDonaldsJPSpider(scrapy.Spider):
     name = "mcdonalds_jp"
-    item_attributes = McDonaldsSpider.item_attributes
+    item_attributes = {"brand_wikidata": "Q38076"}
     start_urls = (
         "https://map.mcdonalds.co.jp/api/poi?uuid=91b35ff7-e1ca-47b5-a0c0-377c41a6c3f2&bounds=-11.17840187371178%2C56.25%2C70.61261423801925%2C-146.25&_=1513674348668",
     )

--- a/locations/spiders/millennium_bank_pl.py
+++ b/locations/spiders/millennium_bank_pl.py
@@ -10,7 +10,7 @@ from locations.hours import OpeningHours
 
 class MillenniumBankPLSpider(Spider):
     name = "millennium_bank_pl"
-    item_attributes = {"brand": "Bank Millennium", "brand_wikidata": "Q4855947"}
+    item_attributes = {"brand": "Millennium Bank", "brand_wikidata": "Q4855947"}
     start_urls = ["https://www.bankmillennium.pl/en/about-the-bank/branches-and-atms"]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class PaczkomatInpostPLSpider(Spider):
     name = "paczkomat_inpost_pl"
-    item_attributes = {"brand": "Paczkomat", "brand_wikidata": "Q110970254"}
+    item_attributes = {"brand": "Paczkomat InPost", "brand_wikidata": "Q110970254"}
     allowed_domains = ["inpost.pl"]
     start_urls = ["https://inpost.pl/sites/default/files/points.json"]
 

--- a/locations/spiders/papa_johns.py
+++ b/locations/spiders/papa_johns.py
@@ -5,7 +5,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class PapaJohnsSpider(SitemapSpider, StructuredDataSpider):
     name = "papa_johns"
-    item_attributes = {"brand": "Papa John's Pizza", "brand_wikidata": "Q2759586"}
+    item_attributes = {"brand": "Papa John's", "brand_wikidata": "Q2759586"}
     allowed_domains = ["papajohns.com"]
     sitemap_urls = ["https://locations.papajohns.com/sitemap.xml"]
     sitemap_rules = [

--- a/locations/spiders/penny_de.py
+++ b/locations/spiders/penny_de.py
@@ -6,7 +6,7 @@ from locations.hours import DAYS_FULL, OpeningHours
 
 class PennyDESpider(scrapy.Spider):
     name = "penny_de"
-    item_attributes = {"brand": "Penny", "brand_wikidata": "Q284688"}
+    item_attributes = {"brand_wikidata": "Q284688"}
     allowed_domains = ["penny.de"]
     start_urls = ("https://www.penny.de/.rest/market",)
 
@@ -23,7 +23,7 @@ class PennyDESpider(scrapy.Spider):
     def parse(self, response, **kwargs):
         for location in response.json():
             item = DictParser.parse(location)
-            item["name"] = location["marketName"]
+            item["branch"] = location["marketName"].removeprefix("Penny ")
             item["street_address"] = location["streetWithHouseNumber"]
             item["website"] = response.urljoin(
                 "/".join(["/markt", location["citySlug"], location["wwIdent"], location["slug"]])

--- a/locations/spiders/penske.py
+++ b/locations/spiders/penske.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 from scrapy.spiders import SitemapSpider
@@ -7,7 +8,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class PenskeSpider(SitemapSpider, StructuredDataSpider):
     name = "penske"
-    item_attributes = {"brand": "Penske", "brand_wikidata": "Q81234570"}
+    item_attributes = {"brand_wikidata": "Q81234570"}
     allowed_domains = ["pensketruckrental.com"]
     sitemap_urls = ["https://www.pensketruckrental.com/sitemap.xml"]
     sitemap_rules = [(r"/locations/us/[-\w]+/[-\w]+/[0-9]+/$", "parse_sd")]
@@ -16,5 +17,6 @@ class PenskeSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data):
         item["ref"] = re.findall("[0-9]+", response.url)[0]
         item.pop("email", None)
+        item["branch"] = html.unescape(item.pop("name"))
 
         yield item

--- a/locations/spiders/pnc.py
+++ b/locations/spiders/pnc.py
@@ -7,7 +7,7 @@ from locations.geo import point_locations
 
 class PNCSpider(scrapy.Spider):
     name = "pnc"
-    item_attributes = {"brand": "PNC", "brand_wikidata": "Q38928", "country": "US"}
+    item_attributes = {"brand": "PNC Bank", "brand_wikidata": "Q38928", "country": "US"}
     allowed_domains = ["www.pnc.com"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 

--- a/locations/spiders/ross_dress_for_less_us.py
+++ b/locations/spiders/ross_dress_for_less_us.py
@@ -4,7 +4,7 @@ from locations.storefinders.where2getit import Where2GetItSpider
 
 class RossDressForLessUSSpider(Where2GetItSpider):
     name = "ross_dress_for_less_us"
-    item_attributes = {"brand": "Ross Dress for Less", "brand_wikidata": "Q3442791"}
+    item_attributes = {"brand": "Ross", "brand_wikidata": "Q3442791"}
     api_brand_name = "rossdressforless"
     api_key = "1F663E4E-1B64-11E5-B356-3DAF58203F82"
 

--- a/locations/spiders/skoda.py
+++ b/locations/spiders/skoda.py
@@ -5,7 +5,7 @@ from locations.items import Feature
 
 class SkodaSpider(scrapy.Spider):
     name = "skoda"
-    item_attributes = {"brand": "Skoda", "brand_wikidata": "Q29637"}
+    item_attributes = {"brand": "Škoda", "brand_wikidata": "Q29637"}
 
     available_countries = {
         260: "CZ",

--- a/locations/spiders/the_courier_guy.py
+++ b/locations/spiders/the_courier_guy.py
@@ -6,6 +6,7 @@ from locations.dict_parser import DictParser
 
 class TheCourierGuySpider(scrapy.Spider):
     name = "the_courier_guy"
+    PUDO = {"brand": "pudo", "brand_wikidata": "Q116753323"}
     item_attributes = {"brand": "The Courier Guy", "brand_wikidata": "Q116753262"}
     allowed_domains = ["wp-admin.thecourierguy.co.za", "ksttcgzafunctionsv2-candidate.azurewebsites.net"]
 
@@ -51,4 +52,5 @@ class TheCourierGuySpider(scrapy.Spider):
             item = DictParser.parse(locker)
             item["postcode"] = locker.get("place", {}).get("postalCode")
             apply_category(Categories.PARCEL_LOCKER, item)
+            item.update(self.PUDO)
             yield item

--- a/locations/spiders/ubitricity.py
+++ b/locations/spiders/ubitricity.py
@@ -1,13 +1,14 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class UbitricitySpider(Spider):
     name = "ubitricity"
-    item_attributes = {"brand": "Ubitricity", "brand_wikidata": "Q113699692", "extras": {"amenity": "charging_station"}}
+    item_attributes = {"brand": "ubitricity", "brand_wikidata": "Q113699692"}
 
     def start_requests(self):
         yield JsonRequest(
@@ -22,4 +23,7 @@ class UbitricitySpider(Spider):
                 [location["address"].pop("street"), location["address"].pop("street2")]
             )
             location["ref"] = location["ssoId"]
-            yield DictParser.parse(location)
+
+            item = DictParser.parse(location)
+            apply_category(Categories.CHARGING_STATION, item)
+            yield item

--- a/locations/spiders/us_bank.py
+++ b/locations/spiders/us_bank.py
@@ -11,7 +11,7 @@ class UsBankSpider(SitemapSpider):
     name = "us_bank"
     download_delay = 0.5
     concurrent_requests = 3
-    item_attributes = {"brand": "US Bank", "brand_wikidata": "Q739084"}
+    item_attributes = {"brand": "U.S. Bank", "brand_wikidata": "Q739084"}
     allowed_domains = ["usbank.com"]
     sitemap_urls = [
         "https://www.usbank.com/locations/sitemap.xml",

--- a/locations/spiders/vlh_de.py
+++ b/locations/spiders/vlh_de.py
@@ -6,7 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class vhlDESpider(SitemapSpider, StructuredDataSpider):
     name = "vhl_de"
-    item_attributes = {"brand": "Vereinigte Lohnsteuerhilfe e.V.", "brand_wikidata": "Q15852617"}
+    item_attributes = {"brand": "Vereinigte Lohnsteuerhilfe", "brand_wikidata": "Q15852617"}
     sitemap_urls = [
         "https://www.vlh.de/sitemap.bst.xml",
     ]


### PR DESCRIPTION
These are the bigger spiders where our brand string is different to NSI. Some of ours looks like Wikidata/old NSI ones eg Allianz SE. I've removed some as well, as long as we match NSI we'll still get them in the output, eg Applebees, where I think NSI should change, Penny VS PENNY which seem controversial in NSI so may change again in the future and FamilyMart which NSI has in Japanese.