### PR TITLE
Fix double slashes in URLs in The Food Warehouse spider output

### DIFF
--- a/locations/spiders/the_food_warehouse_gb.py
+++ b/locations/spiders/the_food_warehouse_gb.py
@@ -21,7 +21,7 @@ class TheFoodWarehouseGBSpider(Spider):
             if "CLOSED" in item["name"].upper() or "COMING SOON" in item["name"].upper():
                 continue
             item["ref"] = store["storeNo"]
-            item["website"] = "https://www.thefoodwarehouse.com/" + store["url"]
+            item["website"] = "https://www.thefoodwarehouse.com" + store["url"]
             item["phone"] = store.get("store-number")
             item["addr_full"] = (
                 item["addr_full"].replace("<br>", "").replace("<br />", "").replace("<p>", "").replace("</p>", "")


### PR DESCRIPTION
The text in store["url"] already includes the initial forward-slash, so also including one at the end of the prepended domain results in a double slash in the 'website' URL in the putput.