### PR TITLE
Add SuperBioMarkt (DE) and fix issue with empty hours

### DIFF
--- a/locations/spiders/super_bio_markt_de.py
+++ b/locations/spiders/super_bio_markt_de.py
@@ -1,0 +1,12 @@
+from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+
+
+class SuperBioMarktDESpider(AgileStoreLocatorSpider):
+    name = "super_bio_markt_de"
+    item_attributes = {
+        "brand_wikidata": "Q2367009",
+        "brand": "SuperBioMarkt",
+    }
+    allowed_domains = [
+        "www.superbiomarkt.de",
+    ]

--- a/locations/storefinders/agile_store_locator.py
+++ b/locations/storefinders/agile_store_locator.py
@@ -44,6 +44,10 @@ class AgileStoreLocatorSpider(Spider):
         if location.get("open_hours"):
             item["opening_hours"] = OpeningHours()
             hours_json = json.loads(location["open_hours"])
+
+            if hours_json == []:
+                return item
+
             for day_name, hours_ranges in hours_json.items():
                 for hours_range in hours_ranges:
                     hours_range = hours_range.upper()


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/8114

2024-04-24 08:29:16 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/SuperBioMarkt': 26,
 'atp/brand_wikidata/Q2367009': 26,
 'atp/category/shop/supermarket': 26,
 'atp/field/country/from_spider_name': 26,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 26,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 26,
 'atp/field/operator_wikidata/missing': 26,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 26,
 'atp/field/website/missing': 1,
 'atp/nsi/perfect_match': 26,
 'downloader/request_bytes': 684,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3597,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 9.164394,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 24, 8, 29, 16, 990923, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 19806,
 'httpcompression/response_count': 2,
 'item_scraped_count': 26,
 'log_count/DEBUG': 45,
 'log_count/INFO': 9,
 'memusage/max': 160296960,
 'memusage/startup': 160296960,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 24, 8, 29, 7, 826529, tzinfo=datetime.timezone.utc)}
2024-04-24 08:29:16 [scrapy.core.engine] INFO: Spider closed (finished)