### PR TITLE
[carlsjr_nz] Added Carls Jr in New Zealand (17 items)

### DIFF
--- a/locations/spiders/carlsjr_nz.py
+++ b/locations/spiders/carlsjr_nz.py
@@ -1,0 +1,27 @@
+import json
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.spiders.carlsjr_us import CarlsJrUSSpider
+
+
+class CarlsJrNZSpider(Spider):
+    name = "carlsjr_nz"
+    item_attributes = CarlsJrUSSpider.item_attributes
+    start_urls = ["https://www.carlsjr.co.nz/stores"]
+    no_refs = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.xpath("//@data-block-json").getall():
+            store = json.loads(location)["location"]
+            item = Feature()
+            item["name"] = store.get("addressTitle")
+            item["lat"] = store.get("mapLat")
+            item["lon"] = store.get("mapLng")
+            item["addr_full"] = merge_address_lines([store.get("addressLine1"), store.get("addressLine2")])
+            item["website"] = response.url
+            yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{"atp/brand/Carl's Jr.": 17,
 'atp/brand_wikidata/Q1043486': 17,
 'atp/category/amenity/fast_food': 17,
 'atp/field/city/missing': 17,
 'atp/field/country/from_spider_name': 17,
 'atp/field/email/missing': 17,
 'atp/field/image/missing': 17,
 'atp/field/opening_hours/missing': 17,
 'atp/field/operator/missing': 17,
 'atp/field/operator_wikidata/missing': 17,
 'atp/field/phone/missing': 17,
 'atp/field/postcode/missing': 17,
 'atp/field/state/missing': 17,
 'atp/field/street_address/missing': 17,
 'atp/field/twitter/missing': 17,
 'atp/nsi/perfect_match': 17,
 'downloader/request_bytes': 680,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 26883,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.550873,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 7, 9, 263641, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 141285,
 'httpcompression/response_count': 2,
 'item_scraped_count': 17,
 'log_count/INFO': 9,
 'memusage/max': 149184512,
 'memusage/startup': 149184512,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 25, 13, 7, 3, 712768, tzinfo=datetime.timezone.utc)}
```
</details>