### PR TITLE
[carlsjr_es] Added Carls Jr in Spain (44 items)

### DIFF
--- a/locations/spiders/carlsjr_es.py
+++ b/locations/spiders/carlsjr_es.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.spiders.carlsjr_us import CarlsJrUSSpider
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CarlsJrESSpider(SitemapSpider, StructuredDataSpider):
+    name = "carlsjr_es"
+    item_attributes = CarlsJrUSSpider.item_attributes
+    sitemap_urls = ["https://carlsjr.es/ubicaciones-sitemap.xml"]
+    sitemap_rules = [(r"/ubicaciones/", "parse_sd")]
+    wanted_types = ["WebPage"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = item["name"].removesuffix(" - Carls Jr.")
+        item["addr_full"] = response.xpath('//*[@itemprop="text"]/p/text()').get()
+        item["email"] = None
+        item["extras"]["check_date"] = (ld_data.get("dateModified") or ld_data.get("datePublished")).split("T", 1)[0]
+        yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{"atp/brand/Carl's Jr.": 44,
 'atp/brand_wikidata/Q1043486': 44,
 'atp/category/amenity/fast_food': 44,
 'atp/field/city/missing': 44,
 'atp/field/country/from_spider_name': 44,
 'atp/field/email/missing': 44,
 'atp/field/image/missing': 44,
 'atp/field/lat/missing': 44,
 'atp/field/lon/missing': 44,
 'atp/field/opening_hours/missing': 44,
 'atp/field/operator/missing': 44,
 'atp/field/operator_wikidata/missing': 44,
 'atp/field/phone/missing': 44,
 'atp/field/postcode/missing': 44,
 'atp/field/state/missing': 44,
 'atp/field/street_address/missing': 44,
 'atp/nsi/perfect_match': 44,
 'downloader/request_bytes': 17118,
 'downloader/request_count': 46,
 'downloader/request_method_count/GET': 46,
 'downloader/response_bytes': 1392374,
 'downloader/response_count': 46,
 'downloader/response_status_count/200': 46,
 'elapsed_time_seconds': 57.978529,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 12, 44, 158361, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8411398,
 'httpcompression/response_count': 46,
 'item_scraped_count': 44,
 'log_count/INFO': 9,
 'memusage/max': 151699456,
 'memusage/startup': 151699456,
 'request_depth_max': 1,
 'response_received_count': 46,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 45,
 'scheduler/dequeued/memory': 45,
 'scheduler/enqueued': 45,
 'scheduler/enqueued/memory': 45,
 'start_time': datetime.datetime(2024, 4, 25, 13, 11, 46, 179832, tzinfo=datetime.timezone.utc)}
```
</details>