### PR TITLE
[fiat_dk] Added fiat dealerships in Denmark (35 items)

### DIFF
--- a/locations/spiders/fiat_dk.py
+++ b/locations/spiders/fiat_dk.py
@@ -1,0 +1,16 @@
+import scrapy
+
+from locations.dict_parser import DictParser
+
+
+class FiatDKSpider(scrapy.Spider):
+    name = "fiat_dk"
+    item_attributes = {"brand": "Fiat", "brand_wikidata": "Q27597"}
+    start_urls = [
+        "https://interaction.fiat.dk/wp-admin/admin-ajax.php?action=asl_load_stores&nonce=f01f079120&lang=&load_all=1&layout=1"
+    ]
+
+    def parse(self, response, **kwargs):
+        for dealer in response.json():
+            item = DictParser.parse(dealer)
+            yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Fiat': 35,
 'atp/brand_wikidata/Q27597': 35,
 'atp/category/missing': 35,
 'atp/field/email/missing': 4,
 'atp/field/image/missing': 35,
 'atp/field/opening_hours/missing': 35,
 'atp/field/operator/missing': 35,
 'atp/field/operator_wikidata/missing': 35,
 'atp/field/state/missing': 35,
 'atp/field/street_address/missing': 35,
 'atp/field/twitter/missing': 35,
 'atp/field/website/missing': 1,
 'atp/nsi/match_failed': 35,
 'downloader/request_bytes': 699,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4564,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.906065,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 20, 33, 280880, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24615,
 'httpcompression/response_count': 2,
 'item_scraped_count': 35,
 'log_count/INFO': 9,
 'memusage/max': 151330816,
 'memusage/startup': 151330816,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 25, 13, 20, 30, 374815, tzinfo=datetime.timezone.utc)}
```
</details>