### PR TITLE
[hyundai_se_dk] Added Germany to Hyundai SE spider (105 items)

### DIFF
--- a/locations/spiders/hyundai_se_dk.py
+++ b/locations/spiders/hyundai_se_dk.py
@@ -5,9 +5,12 @@ from locations.hours import OpeningHours
 from locations.items import Feature
 
 
-class HyundaiSESpider(scrapy.Spider):
-    name = "hyundai_se"
-    start_urls = ["https://www.hyundai.se/api/elastic-locations/contextual?category=retail"]
+class HyundaiSEDKSpider(scrapy.Spider):
+    name = "hyundai_se_dk"
+    start_urls = [
+        "https://www.hyundai.se/api/elastic-locations/contextual?category=retail",
+        "https://www.hyundai.dk/api/elastic-locations/contextual?category=retail",
+    ]
 
     item_attributes = {"brand": "Hyundai", "brand_wikidata": "Q55931"}
 


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Hyundai': 105,
 'atp/brand_wikidata/Q55931': 105,
 'atp/category/shop/car': 105,
 'atp/cdn/cloudflare/response_count': 4,
 'atp/cdn/cloudflare/response_status_count/200': 4,
 'atp/field/country/from_reverse_geocoding': 105,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 104,
 'atp/field/image/missing': 105,
 'atp/field/operator/missing': 105,
 'atp/field/operator_wikidata/missing': 105,
 'atp/field/twitter/missing': 105,
 'atp/field/website/missing': 105,
 'atp/nsi/cc_match': 105,
 'downloader/request_bytes': 1296,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 18853,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 2.277063,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 25, 7, 120482, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 174004,
 'httpcompression/response_count': 4,
 'item_scraped_count': 105,
 'log_count/INFO': 9,
 'memusage/max': 151429120,
 'memusage/startup': 151429120,
 'response_received_count': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 4, 25, 13, 25, 4, 843419, tzinfo=datetime.timezone.utc)}
```
</details>