### PR TITLE
[peugeot_se_cz_es] Added Peugeot CZ, ES to Peugeot SE (500 items)

### DIFF
--- a/locations/spiders/peugeot_se_cz_es.py
+++ b/locations/spiders/peugeot_se_cz_es.py
@@ -4,10 +4,12 @@ from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
-class PeugeotSESpider(scrapy.Spider):
-    name = "peugeot_se"
+class PeugeotSECZESSpider(scrapy.Spider):
+    name = "peugeot_se_cz_es"
     start_urls = [
-        "https://www.peugeot.se/apps/atomic/DealersServlet?distance=30000&latitude=59.33257&longitude=18.06682&maxResults=4000&orderResults=false&path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvc3dlZGVuL3Nl&searchType=latlong"
+        "https://www.peugeot.se/apps/atomic/DealersServlet?distance=30000&latitude=59.33257&longitude=18.06682&maxResults=4000&orderResults=false&path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvc3dlZGVuL3Nl&searchType=latlong",
+        "https://www.peugeot.cz/apps/atomic/DealersServlet?distance=300&latitude=50.07914&longitude=14.43299&maxResults=40000&orderResults=false&path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvY3plY2hfcmVwdWJsaWMvY3o%3D&searchType=latlong",
+        "https://www.peugeot.es/apps/atomic/DealersServlet?distance=300&latitude=40.41955&longitude=-3.69197&maxResults=40&orderResults=false&path=L2NvbnRlbnQvcGV1Z2VvdC93b3JsZHdpZGUvc3BhaW4vZXM%3D&searchType=latlong",
     ]
 
     item_attributes = {"brand": "Peugeot", "brand_wikidata": "Q6742"}
@@ -19,7 +21,7 @@ class PeugeotSESpider(scrapy.Spider):
             contact_details = store.get("generalContact")
             item = Feature(
                 {
-                    "ref": store.get("rrdi"),
+                    "ref": store.get("siteGeo"),
                     "name": store.get("dealerName"),
                     "street_address": address_details.get("addresssLine1"),
                     "phone": contact_details.get("phone1"),
@@ -43,5 +45,4 @@ class PeugeotSESpider(scrapy.Spider):
                 apply_category(Categories.SHOP_CAR_REPAIR, item)
             elif "Parts" in service_names:
                 apply_category(Categories.SHOP_CAR_PARTS, item)
-
             yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Peugeot': 500,
 'atp/brand_wikidata/Q6742': 500,
 'atp/category/missing': 419,
 'atp/category/shop/car': 63,
 'atp/category/shop/car_repair': 18,
 'atp/field/country/from_reverse_geocoding': 2,
 'atp/field/country/from_website_url': 498,
 'atp/field/email/missing': 128,
 'atp/field/image/missing': 500,
 'atp/field/opening_hours/missing': 500,
 'atp/field/operator/missing': 500,
 'atp/field/operator_wikidata/missing': 500,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 82,
 'atp/field/street_address/missing': 500,
 'atp/field/twitter/missing': 500,
 'atp/field/website/invalid': 1,
 'atp/nsi/cc_match': 81,
 'atp/nsi/match_failed': 419,
 'downloader/request_bytes': 2369,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 83939,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 2.43569,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 36, 54, 221484, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 961770,
 'httpcompression/response_count': 6,
 'item_scraped_count': 500,
 'log_count/INFO': 9,
 'memusage/max': 151760896,
 'memusage/startup': 151760896,
 'response_received_count': 6,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 4, 25, 13, 36, 51, 785794, tzinfo=datetime.timezone.utc)}
```
</details>