### PR TITLE
[toyota_eu] Fixed toyota eu and added CZ (2381 items)

### DIFF
--- a/locations/spiders/toyota_eu.py
+++ b/locations/spiders/toyota_eu.py
@@ -39,12 +39,13 @@ class ToyotaEUSpider(scrapy.Spider):
         "it",
         "rs",
         "bg",
+        "cz",
     ]
 
     def start_requests(self):
         for country in self.available_countries:
             yield scrapy.Request(
-                f"https://kong-proxy-aws.toyota-europe.com/dxp/dealers/api/toyota/{country}/{country}/drive/2.344148/48.862893?count=1000&extraCountries=&isCurrentLocation=false",
+                f"https://kong-proxy-aws.toyota-europe.com/dxp/dealers/api/toyota/{country}/cs/all?extraCountries=&services=&randomize=false",
                 callback=self.parse,
             )
 
@@ -53,7 +54,7 @@ class ToyotaEUSpider(scrapy.Spider):
             address_details = store["address"]
             coordinates = address_details["geo"]
             item = DictParser.parse(store)
-            item["ref"] = store["uuid"]
+            item["ref"] = store["id"]
             item["email"] = store["eMail"]
             item["lat"] = coordinates["lat"]
             item["lon"] = coordinates["lon"]


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Toyota': 2381,
 'atp/brand_wikidata/Q53268': 2381,
 'atp/category/shop/car': 2381,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 62,
 'atp/field/image/missing': 2381,
 'atp/field/lat/missing': 27,
 'atp/field/lon/missing': 27,
 'atp/field/opening_hours/missing': 2381,
 'atp/field/operator/missing': 2381,
 'atp/field/operator_wikidata/missing': 2381,
 'atp/field/phone/invalid': 30,
 'atp/field/phone/missing': 44,
 'atp/field/state/missing': 461,
 'atp/field/twitter/missing': 2381,
 'atp/field/website/invalid': 13,
 'atp/field/website/missing': 575,
 'atp/geometry/null_island': 27,
 'atp/nsi/cc_match': 2381,
 'downloader/request_bytes': 11546,
 'downloader/request_count': 30,
 'downloader/request_method_count/GET': 30,
 'downloader/response_bytes': 7963824,
 'downloader/response_count': 30,
 'downloader/response_status_count/200': 29,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 35.134626,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 42, 21, 524546, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2381,
 'log_count/INFO': 9,
 'memusage/max': 151343104,
 'memusage/startup': 151343104,
 'response_received_count': 30,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 29,
 'scheduler/dequeued/memory': 29,
 'scheduler/enqueued': 29,
 'scheduler/enqueued/memory': 29,
 'start_time': datetime.datetime(2024, 4, 25, 13, 41, 46, 389920, tzinfo=datetime.timezone.utc)}
```
</details>