### PR TITLE
[kia] Added ES and NL to Kia (1208 items)

### DIFF
--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -3,13 +3,15 @@ import scrapy
 from locations.items import Feature
 
 
-class KiaATFRDESpider(scrapy.Spider):
-    name = "kia_at_fr_de"
+class KiaSpider(scrapy.Spider):
+    name = "kia"
     item_attributes = {"brand": "Kia", "brand_wikidata": "Q35349"}
     start_urls = [
         "https://www.kia.com/api/bin/dealer?locale=at-de&program=dealerLocatorSearch",
         "https://www.kia.com/api/bin/dealer?locale=fr-fr&program=dealerLocatorSearch",
         "https://www.kia.com/api/bin/dealer?locale=de-de&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=es-es&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=nl-nl&program=dealerLocatorSearch",
     ]
 
     def parse(self, response, **kwargs):


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Kia': 1208,
 'atp/brand_wikidata/Q35349': 1208,
 'atp/category/shop/car': 1208,
 'atp/field/country/from_reverse_geocoding': 699,
 'atp/field/country/from_website_url': 509,
 'atp/field/email/invalid': 23,
 'atp/field/email/missing': 236,
 'atp/field/image/missing': 1208,
 'atp/field/opening_hours/missing': 1208,
 'atp/field/operator/missing': 1208,
 'atp/field/operator_wikidata/missing': 1208,
 'atp/field/phone/invalid': 49,
 'atp/field/phone/missing': 9,
 'atp/field/state/missing': 509,
 'atp/field/twitter/missing': 1208,
 'atp/field/website/invalid': 30,
 'atp/field/website/missing': 108,
 'atp/nsi/perfect_match': 1208,
 'downloader/request_bytes': 2037,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 305195,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 7.861079,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 46, 57, 959088, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4547730,
 'httpcompression/response_count': 5,
 'item_scraped_count': 1208,
 'log_count/INFO': 9,
 'memusage/max': 151441408,
 'memusage/startup': 151441408,
 'response_received_count': 6,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2024, 4, 25, 13, 46, 50, 98009, tzinfo=datetime.timezone.utc)}
```
</details>