### PR TITLE
[taco_bell_nl] Added taco bell to NL (10 items)

### DIFF
--- a/locations/spiders/taco_bell_nl.py
+++ b/locations/spiders/taco_bell_nl.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import Spider
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.spiders.taco_bell import TACO_BELL_SHARED_ATTRIBUTES
+
+
+class TacoBellNLSpider(Spider):
+    name = "taco_bell_nl"
+    item_attributes = TACO_BELL_SHARED_ATTRIBUTES
+    start_urls = ["https://tacobell.nl/en/locations/"]
+    no_refs = True
+
+    def parse(self, response, **kwargs):
+        for restaurant in response.xpath(r'//*[@class="find-Us-Branches"]'):
+            item = Feature()
+            item["name"] = restaurant.xpath('.//*[@class = "storename"]/text()').get()
+            item["addr_full"] = restaurant.xpath('.//*[@class = "findus_addr"]/text()').get()
+            item["phone"] = restaurant.xpath('.//*[@class = "store-mobile"]//text()').get()
+            item["website"] = "https://tacobell.nl/"
+            extract_google_position(item, response)
+            yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Taco Bell': 10,
 'atp/brand_wikidata/Q752941': 10,
 'atp/category/amenity/fast_food': 10,
 'atp/field/city/missing': 10,
 'atp/field/country/from_spider_name': 10,
 'atp/field/email/missing': 10,
 'atp/field/image/missing': 10,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 10,
 'atp/field/operator_wikidata/missing': 10,
 'atp/field/postcode/missing': 10,
 'atp/field/state/missing': 10,
 'atp/field/street_address/missing': 10,
 'atp/field/twitter/missing': 10,
 'atp/nsi/perfect_match': 10,
 'downloader/request_bytes': 632,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 36181,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.491042,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 53, 45, 421218, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 150087,
 'httpcompression/response_count': 2,
 'item_scraped_count': 10,
 'log_count/INFO': 9,
 'memusage/max': 151199744,
 'memusage/startup': 151199744,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 4, 25, 13, 53, 37, 930176, tzinfo=datetime.timezone.utc)}
```
</details>