### PR TITLE
[seat] Added PL to seat spider (1953 items)

### DIFF
--- a/locations/spiders/seat.py
+++ b/locations/spiders/seat.py
@@ -21,6 +21,7 @@ class SeatSpider(scrapy.Spider):
         "mx": "concesionarias",
         "ch": "de/haendlersuche",
         "se": "hitta-aterforsaljare",
+        "pl": "mapa-dealerow-i-serwisow",
     }
 
     def start_requests(self):


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/SEAT': 1953,
 'atp/brand_wikidata/Q188217': 1953,
 'atp/category/shop/car': 1953,
 'atp/closed_check': 4,
 'atp/field/email/invalid': 23,
 'atp/field/email/missing': 228,
 'atp/field/image/missing': 1953,
 'atp/field/opening_hours/missing': 1953,
 'atp/field/operator/missing': 1953,
 'atp/field/operator_wikidata/missing': 1953,
 'atp/field/phone/invalid': 72,
 'atp/field/phone/missing': 6,
 'atp/field/state/missing': 1953,
 'atp/field/twitter/missing': 1953,
 'atp/field/website/invalid': 856,
 'atp/field/website/missing': 617,
 'atp/nsi/perfect_match': 1953,
 'downloader/request_bytes': 8548,
 'downloader/request_count': 20,
 'downloader/request_method_count/GET': 20,
 'downloader/response_bytes': 5016034,
 'downloader/response_count': 20,
 'downloader/response_status_count/200': 20,
 'elapsed_time_seconds': 8.478161,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 13, 58, 40, 189911, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1953,
 'log_count/INFO': 9,
 'log_count/WARNING': 4,
 'memusage/max': 151474176,
 'memusage/startup': 151474176,
 'response_received_count': 20,
 'robotstxt/request_count': 10,
 'robotstxt/response_count': 10,
 'robotstxt/response_status_count/200': 10,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2024, 4, 25, 13, 58, 31, 711750, tzinfo=datetime.timezone.utc)}
```
</details>