### PR TITLE
[carlsjr_ca] Added Carls Jr to Canada (19 items)

### DIFF
--- a/locations/spiders/carlsjr_ca.py
+++ b/locations/spiders/carlsjr_ca.py
@@ -1,0 +1,26 @@
+import re
+
+import scrapy
+
+from locations.items import Feature
+from locations.spiders.carlsjr_us import CarlsJrUSSpider
+
+
+class CarlsJrCASpider(scrapy.Spider):
+    name = "carlsjr_ca"
+    item_attributes = CarlsJrUSSpider.item_attributes
+    start_urls = ["https://www.carlsjr.ca/locations"]
+
+    def parse(self, response, **kwargs):
+        for location in response.xpath("//div[@id][@data-testid]//p"):
+            location_text = location.xpath(".//span//text()").get(default="").strip()
+            if re.match(r"\d+", location_text) or "Airport" in location_text.title():
+                item = Feature()
+                item["ref"] = item["street_address"] = location_text
+                item["phone"] = location.xpath('./following-sibling::p//span[contains(text(),"PH:")]/text()').get()
+                hours = location.xpath('./following-sibling::p//span[contains(text(),"HOURS:")]/text()').get()
+                if not hours:  # not a valid location
+                    continue
+                # opening hours ignored because of inconsistent data
+                item["website"] = response.url
+                yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{"atp/brand/Carl's Jr.": 19,
 'atp/brand_wikidata/Q1043486': 19,
 'atp/category/amenity/fast_food': 19,
 'atp/field/city/missing': 19,
 'atp/field/country/from_spider_name': 19,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 19,
 'atp/field/lat/missing': 19,
 'atp/field/lon/missing': 19,
 'atp/field/opening_hours/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 19,
 'atp/field/state/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/nsi/perfect_match': 19,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 2,
 'downloader/request_bytes': 1218,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 156340,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 52.860653,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 14, 8, 37, 565603, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 498210,
 'httpcompression/response_count': 1,
 'item_scraped_count': 19,
 'log_count/INFO': 9,
 'memusage/max': 151576576,
 'memusage/startup': 151576576,
 'response_received_count': 2,
 'retry/count': 2,
 'retry/reason_count/twisted.internet.error.TimeoutError': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 4, 25, 14, 7, 44, 704950, tzinfo=datetime.timezone.utc)}
```
</details>