### PR TITLE
[ihg_hotels] Fixed IHG Hotels spider (5687 items)

### DIFF
--- a/locations/spiders/ihg_hotels.py
+++ b/locations/spiders/ihg_hotels.py
@@ -8,8 +8,10 @@ class IHGHotelsSpider(SitemapSpider, StructuredDataSpider):
     name = "ihg_hotels"
     allowed_domains = ["ihg.com"]
     sitemap_urls = ["https://www.ihg.com/bin/sitemapindex.xml"]
-    sitemap_rules = [(r".*/us/en/.*/hoteldetail$", "parse")]
+    sitemap_follow = ["en.hoteldetail"]
+    sitemap_rules = [(r"/hotels/us/en/[-\w]+/[-\w]+/hoteldetail$", "parse")]
     wanted_types = ["Hotel"]
+    json_parser = "chompjs"
     requires_proxy = True
 
     my_brands = {
@@ -32,7 +34,13 @@ class IHGHotelsSpider(SitemapSpider, StructuredDataSpider):
         "voco": ("Voco Hotels", "Q60750454"),
     }
 
+    def parse(self, response, **kwargs):
+        if response.url.endswith("hoteldetail"):
+            yield from self.parse_sd(response)
+
     def post_process_item(self, item, response, ld_data):
+        if not item.get("street_address"):
+            return
         item["name"] = item["name"].strip("\n").strip("\t")
 
         if (hotel_type := response.url.split("/")[3]) in self.my_brands:


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Army Hotels': 71,
 'atp/brand/Avid Hotels': 51,
 'atp/brand/Candlewood Suites': 356,
 'atp/brand/Crowne Plaza': 371,
 'atp/brand/Even Hotels': 22,
 'atp/brand/Holiday Inn': 1074,
 'atp/brand/Holiday Inn Express': 2950,
 'atp/brand/Hotel Indigo': 128,
 'atp/brand/InterContinental': 213,
 'atp/brand/Kimpton': 62,
 'atp/brand/Staybridge Suites': 307,
 'atp/brand/Voco Hotels': 6,
 'atp/brand_wikidata/Q16994722': 71,
 'atp/brand_wikidata/Q1825730': 213,
 'atp/brand_wikidata/Q2717882': 1074,
 'atp/brand_wikidata/Q2746220': 371,
 'atp/brand_wikidata/Q5032010': 356,
 'atp/brand_wikidata/Q5416522': 22,
 'atp/brand_wikidata/Q5880423': 2950,
 'atp/brand_wikidata/Q5911596': 128,
 'atp/brand_wikidata/Q60749907': 51,
 'atp/brand_wikidata/Q60750454': 6,
 'atp/brand_wikidata/Q6410248': 62,
 'atp/brand_wikidata/Q7605116': 307,
 'atp/category/tourism/hotel': 5687,
 'atp/field/brand/missing': 76,
 'atp/field/brand_wikidata/missing': 76,
 'atp/field/country/from_reverse_geocoding': 547,
 'atp/field/country/invalid': 1,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 136,
 'atp/field/image/invalid': 1,
 'atp/field/image/missing': 206,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 5687,
 'atp/field/operator/missing': 5687,
 'atp/field/operator_wikidata/missing': 5687,
 'atp/field/phone/invalid': 27,
 'atp/field/postcode/missing': 74,
 'atp/field/state/from_reverse_geocoding': 5,
 'atp/field/state/missing': 1009,
 'atp/nsi/brand_missing': 71,
 'atp/nsi/match_failed': 2950,
 'atp/nsi/perfect_match': 2590,
 'downloader/exception_count': 72,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 72,
 'downloader/request_bytes': 12464858,
 'downloader/request_count': 7199,
 'downloader/request_method_count/GET': 7199,
 'downloader/response_bytes': 1169689204,
 'downloader/response_count': 7127,
 'downloader/response_status_count/200': 5887,
 'downloader/response_status_count/301': 1206,
 'downloader/response_status_count/302': 6,
 'downloader/response_status_count/404': 28,
 'dupefilter/filtered': 211,
 'elapsed_time_seconds': 8771.703019,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 25, 15, 44, 0, 48528, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3624027207,
 'httpcompression/response_count': 5887,
 'httperror/response_ignored_count': 28,
 'httperror/response_ignored_status_count/404': 28,
 'item_dropped_count': 25,
 'item_dropped_reasons_count/DropItem': 25,
 'item_scraped_count': 5687,
 'log_count/ERROR': 2,
 'log_count/INFO': 183,
 'memusage/max': 638812160,
 'memusage/startup': 151552000,
 'request_depth_max': 2,
 'response_received_count': 5915,
 'retry/count': 71,
 'retry/max_reached': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 71,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7198,
 'scheduler/dequeued/memory': 7198,
 'scheduler/enqueued': 7198,
 'scheduler/enqueued/memory': 7198,
 'start_time': datetime.datetime(2024, 4, 25, 13, 17, 48, 345509, tzinfo=datetime.timezone.utc)}
```
</details>