### PR TITLE
[AniCura] Add spider

### DIFF
--- a/locations/spiders/anicura.py
+++ b/locations/spiders/anicura.py
@@ -1,0 +1,46 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.google_url import extract_google_position
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class AnicuraSpider(SitemapSpider, StructuredDataSpider):
+    name = "anicura"
+    item_attributes = {"brand": "AniCura", "brand_wikidata": "Q21100245"}
+    sitemap_urls = [
+        "https://www.anicura.at/robots.txt",
+        "https://www.anicura.be/robots.txt",
+        "https://www.anicura.dk/robots.txt",
+        "https://www.anicura.fr/robots.txt",
+        "https://www.anicura.de/robots.txt",
+        "https://www.anicura.it/robots.txt",
+        "https://www.anicura.no/robots.txt",
+        "https://www.anicura.pt/robots.txt",
+        "https://www.anicura.es/robots.txt",
+        "https://www.anicura.se/robots.txt",
+        "https://www.anicura.ch/robots.txt",
+        "https://www.anicura.nl/robots.txt",
+        "https://www.anicura.pl/robots.txt",
+    ]
+    sitemap_rules = [
+        (r"at/standorte/[^/]+/$", "parse"),
+        (r"be/klinieken/[^/]+/[^/]+/$", "parse"),
+        (r"dk/klinikker/[^/]+/$", "parse"),
+        (r"fr/cliniques/[^/]+/$", "parse"),
+        (r"de/standorte/[^/]+/$", "parse"),
+        (r"it/cliniche/[^/]+/$", "parse"),
+        (r"no/klinikker/[^/]+/$", "parse"),
+        (r"pt/clinicas-veterinarias/[^/]+/$", "parse"),
+        (r"es/clinicas/[^/]+/$", "parse"),
+        (r"se/hitta-klinik/[^/]+/$", "parse"),
+        (r"ch/standorte/[^/]+/$", "parse"),
+        (r"nl/klinieken/[^/]+/[^/]+/$", "parse"),
+        (r"pl/clinicas-veterinarias/[^/]+/$", "parse"),
+    ]
+    wanted_types = ["VeterinaryCare"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("AniCura ")
+        extract_google_position(item, response)
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/commit/79c982bc10d93d60c3ede5e49ed7cdcc23e4efb7
```python
{'atp/brand/AniCura': 436,
 'atp/brand_wikidata/Q21100245': 436,
 'atp/category/missing': 436,
 'atp/cdn/cloudflare/response_count': 501,
 'atp/cdn/cloudflare/response_status_count/200': 500,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/city/missing': 3,
 'atp/field/country/from_website_url': 255,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 55,
 'atp/field/image/missing': 436,
 'atp/field/lat/missing': 11,
 'atp/field/lon/missing': 11,
 'atp/field/name/missing': 436,
 'atp/field/opening_hours/missing': 436,
 'atp/field/operator/missing': 436,
 'atp/field/operator_wikidata/missing': 436,
 'atp/field/phone/invalid': 16,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 21,
 'atp/field/state/missing': 330,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 413,
 'atp/geometry/null_island': 11,
 'atp/nsi/brand_missing': 436,
 'downloader/request_bytes': 330271,
 'downloader/request_count': 506,
 'downloader/request_method_count/GET': 506,
 'downloader/response_bytes': 19909311,
 'downloader/response_count': 506,
 'downloader/response_status_count/200': 500,
 'downloader/response_status_count/301': 5,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 5,
 'elapsed_time_seconds': 95.954354,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 26, 12, 27, 25, 59151, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 95,
 'httpcache/hit': 411,
 'httpcache/miss': 95,
 'httpcache/store': 95,
 'httpcompression/response_bytes': 76355614,
 'httpcompression/response_count': 501,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 436,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 324534272,
 'memusage/startup': 163688448,
 'request_depth_max': 2,
 'response_received_count': 501,
 'robotstxt/request_count': 13,
 'robotstxt/response_count': 13,
 'robotstxt/response_status_count/200': 13,
 'scheduler/dequeued': 493,
 'scheduler/dequeued/memory': 493,
 'scheduler/enqueued': 493,
 'scheduler/enqueued/memory': 493,
 'start_time': datetime.datetime(2024, 4, 26, 12, 25, 49, 104797, tzinfo=datetime.timezone.utc)}
```