### PR TITLE
[Van Dal NL] Add spider

### DIFF
--- a/locations/spiders/van_dal_nl.py
+++ b/locations/spiders/van_dal_nl.py
@@ -1,0 +1,20 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class VanDalNLSpider(SitemapSpider, StructuredDataSpider):
+    name = "van_dal_nl"
+    item_attributes = {"brand": "Van Dal", "brand_wikidata": "Q125580449"}
+    sitemap_urls = ["https://www.vdal.nl/robots.txt"]
+    sitemap_follow = ["branches"]
+    sitemap_rules = [(r"winkels/(\d+)/van-dal-[^\.]+\.html$", "parse")]
+    wanted_types = ["Store"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Van Dal ")
+        item["extras"]["website:nl"] = response.xpath('//link[@rel="alternate"][@hreflang="nl-NL"]/@href').get()
+        item["extras"]["website:de"] = response.xpath('//link[@rel="alternate"][@hreflang="de-DE"]/@href').get()
+        # item["extras"]["website:nl"] = response.xpath('//link[@rel="alternate"][hreflang="nl-BE"]/@href').get()
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/commit/ccb95b2680c164479af5c8310dfd0823382848cd
```python
{'atp/brand/Van Dal': 39,
 'atp/brand_wikidata/Q125580449': 39,
 'atp/category/missing': 39,
 'atp/cdn/cloudflare/response_count': 43,
 'atp/cdn/cloudflare/response_status_count/200': 43,
 'atp/field/country/from_website_url': 39,
 'atp/field/email/missing': 39,
 'atp/field/image/missing': 39,
 'atp/field/name/missing': 39,
 'atp/field/opening_hours/missing': 39,
 'atp/field/operator/missing': 39,
 'atp/field/operator_wikidata/missing': 39,
 'atp/field/state/missing': 39,
 'atp/field/twitter/missing': 39,
 'atp/nsi/brand_missing': 39,
 'downloader/request_bytes': 20816,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 43,
 'downloader/response_bytes': 1103526,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'elapsed_time_seconds': 1.05214,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 26, 12, 36, 27, 424252, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 43,
 'httpcompression/response_bytes': 2844145,
 'httpcompression/response_count': 43,
 'item_scraped_count': 39,
 'log_count/DEBUG': 94,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 163700736,
 'memusage/startup': 163700736,
 'request_depth_max': 3,
 'response_received_count': 43,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 42,
 'scheduler/dequeued/memory': 42,
 'scheduler/enqueued': 42,
 'scheduler/enqueued/memory': 42,
 'start_time': datetime.datetime(2024, 4, 26, 12, 36, 26, 372112, tzinfo=datetime.timezone.utc)}
```