### PR TITLE
Add Tasmanian Government Free WiFi (AU) (121 hotspots)

### DIFF
--- a/locations/spiders/tasmanian_government_free_wifi_au.py
+++ b/locations/spiders/tasmanian_government_free_wifi_au.py
@@ -12,6 +12,7 @@ class TasmanianGovernmentFreeWiFiAUSpider(Spider):
     item_attributes = {"operator": "Government of Tasmania", "operator_wikidata": "Q3112571"}
     allowed_domains = ["freewifi.tas.gov.au"]
     start_urls = ["https://freewifi.tas.gov.au/api/application.json"]
+    no_refs = True
 
     def start_requests(self):
         for url in self.start_urls:
@@ -23,7 +24,6 @@ class TasmanianGovernmentFreeWiFiAUSpider(Spider):
                 if hotspot["disabled"]:
                     continue
                 properties = {
-                    "ref": sha1("{},{}".format(hotspot["latitude"], hotspot["longitude"]).encode("UTF-8")).hexdigest(),
                     "name": hotspot["label"],
                     "lat": hotspot["latitude"],
                     "lon": hotspot["longitude"],

--- a/locations/spiders/tasmanian_government_free_wifi_au.py
+++ b/locations/spiders/tasmanian_government_free_wifi_au.py
@@ -1,4 +1,3 @@
-
 from scrapy import Spider
 from scrapy.http import JsonRequest
 

--- a/locations/spiders/tasmanian_government_free_wifi_au.py
+++ b/locations/spiders/tasmanian_government_free_wifi_au.py
@@ -1,4 +1,3 @@
-from hashlib import sha1
 
 from scrapy import Spider
 from scrapy.http import JsonRequest

--- a/locations/spiders/tasmanian_government_free_wifi_au.py
+++ b/locations/spiders/tasmanian_government_free_wifi_au.py
@@ -3,7 +3,7 @@ from hashlib import sha1
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -35,7 +35,7 @@ class TasmanianGovernmentFreeWiFiAUSpider(Spider):
                         "internet_access:operator": "Telstra",
                         "internet_access:operator:wikidata": "Q721162",
                         "internet_access:ssid": "TasGov_Free",
-                    }
+                    },
                 }
                 apply_category(Categories.ANTENNA, properties)
                 yield Feature(**properties)

--- a/locations/spiders/tasmanian_government_free_wifi_au.py
+++ b/locations/spiders/tasmanian_government_free_wifi_au.py
@@ -1,0 +1,41 @@
+from hashlib import sha1
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import apply_category, Categories
+from locations.items import Feature
+
+
+class TasmanianGovernmentFreeWiFiAUSpider(Spider):
+    name = "tasmanian_government_free_wifi_au"
+    item_attributes = {"operator": "Government of Tasmania", "operator_wikidata": "Q3112571"}
+    allowed_domains = ["freewifi.tas.gov.au"]
+    start_urls = ["https://freewifi.tas.gov.au/api/application.json"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url)
+
+    def parse(self, response):
+        for location in response.json()["locations"]:
+            for hotspot in location.get("hotspots", []):
+                if hotspot["disabled"]:
+                    continue
+                properties = {
+                    "ref": sha1("{},{}".format(hotspot["latitude"], hotspot["longitude"]).encode("UTF-8")).hexdigest(),
+                    "name": hotspot["label"],
+                    "lat": hotspot["latitude"],
+                    "lon": hotspot["longitude"],
+                    "city": location["title"]["en"],
+                    "state": "Tasmania",
+                    "extras": {
+                        "internet_access": "wlan",
+                        "internet_access:fee": "no",
+                        "internet_access:operator": "Telstra",
+                        "internet_access:operator:wikidata": "Q721162",
+                        "internet_access:ssid": "TasGov_Free",
+                    }
+                }
+                apply_category(Categories.ANTENNA, properties)
+                yield Feature(**properties)


### PR DESCRIPTION
Reference/source data: https://freewifi.tas.gov.au/