### PR TITLE
[FamilyShopper GB] Add spider

### DIFF
--- a/locations/spiders/family_shopper_gb.py
+++ b/locations/spiders/family_shopper_gb.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.open_graph_parser import OpenGraphParser
+
+
+class FamilyShopperGBSpider(SitemapSpider):
+    name = "family_shopper_gb"
+    item_attributes = {"brand": "Family Shopper", "brand_wikidata": "Q122731426"}
+    sitemap_urls = ["https://www.familyshopperstores.co.uk/sitemap.xml"]
+    sitemap_rules = [("/our-stores/", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = OpenGraphParser.parse(response)
+        item["branch"] = (
+            item.pop("name").removeprefix("Family Shopper").strip(" -").removeprefix("Family Shopper").strip(" -")
+        )
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/commit/ffb7a14c8e1541cbf244e6b6b9173e31ec928f60

```python
{'atp/brand/Family Shopper': 229,
 'atp/brand_wikidata/Q122731426': 229,
 'atp/category/missing': 229,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 229,
 'atp/field/image/missing': 229,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/name/missing': 229,
 'atp/field/opening_hours/missing': 229,
 'atp/field/operator/missing': 229,
 'atp/field/operator_wikidata/missing': 229,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 88,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 72,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 229,
 'atp/nsi/brand_missing': 229,
 'downloader/request_bytes': 95050,
 'downloader/request_count': 237,
 'downloader/request_method_count/GET': 237,
 'downloader/response_bytes': 7671134,
 'downloader/response_count': 237,
 'downloader/response_status_count/200': 231,
 'downloader/response_status_count/500': 6,
 'elapsed_time_seconds': 1.57787,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 4, 29, 7, 43, 55, 558584, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 237,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/500': 2,
 'item_scraped_count': 229,
 'log_count/ERROR': 2,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 164020224,
 'memusage/startup': 164020224,
 'request_depth_max': 1,
 'response_received_count': 233,
 'retry/count': 4,
 'retry/max_reached': 2,
 'retry/reason_count/500 Internal Server Error': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 236,
 'scheduler/dequeued/memory': 236,
 'scheduler/enqueued': 236,
 'scheduler/enqueued/memory': 236,
 'start_time': datetime.datetime(2024, 4, 29, 7, 43, 53, 980714, tzinfo=datetime.timezone.utc)}
```