### PR TITLE
moneygram: fix spider

### DIFF
--- a/locations/spiders/moneygram.py
+++ b/locations/spiders/moneygram.py
@@ -9,7 +9,7 @@ class MoneyGramSpider(Where2GetItSpider):
     item_attributes = {"brand": "MoneyGram", "brand_wikidata": "Q1944412"}
     api_brand_name = "moneygram"
     api_key = "46493320-D5C3-11E1-A25A-4A6F97B4DA77"
-    api_filter_admin_level = 1
+    api_filter_admin_level = 2
 
     def parse_item(self, item, location):
         # MoneyGram compiles location information provided by

--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -136,8 +136,9 @@ class Where2GetItSpider(Spider):
     def parse_country_list(self, response, **kwargs):
         for country in response.json()["response"]["collection"]:
             country_code = country["name"]
-            if self.api_filter_admin_level > 1:
-                for state in pycountry.subdivisions.get(country_code=country_code):
+            subdivisions = pycountry.subdivisions.get(country_code=country_code)
+            if self.api_filter_admin_level > 1 and subdivisions:
+                for state in subdivisions:
                     state_code = state.code[-2:]
                     if state.type == "Province":
                         yield from self.make_request(country_code=country_code, province_code=state_code)


### PR DESCRIPTION
Timeouts seem to necessitate filtering at a lower subdivision level to ensure that the server doesn't get too busy returning many results at once.