### PR TITLE
[585 Gold RU] Add spider

### DIFF
--- a/locations/spiders/zoloto_585_ru.py
+++ b/locations/spiders/zoloto_585_ru.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class Zoloto585RUSpider(SitemapSpider):
+    name = "zoloto_585_ru"
+    item_attributes = {"brand_wikidata": "Q125730875"}
+    sitemap_urls = ["https://zoloto585.ru/robots.txt"]
+    sitemap_rules = [(r"/about/address/[^/]+/[^/]+/$", "parse")]
+    user_agent = BROWSER_DEFAULT
+    custom_settings = {"DOWNLOAD_TIMEOUT": 30}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["ref"] = item["website"] = response.url
+        item["lat"], item["lon"] = response.xpath("//@data-geo").get().split(",")
+        item["street_address"] = response.xpath(
+            '//div[@class="shop-info__item shop-info__item--address"]/span/text()'
+        ).get()
+        item["image"] = response.urljoin(
+            response.xpath('//div[contains(@class, "address-block__shop-gallery")]/img/@src').get()
+        )
+        yield item


### PR DESCRIPTION
```python
{'atp/brand_wikidata/Q125730875': 211,
 'atp/category/missing': 211,
 'atp/field/brand/missing': 211,
 'atp/field/city/missing': 211,
 'atp/field/country/from_spider_name': 211,
 'atp/field/email/missing': 211,
 'atp/field/image/invalid': 5,
 'atp/field/name/missing': 211,
 'atp/field/opening_hours/missing': 211,
 'atp/field/operator/missing': 211,
 'atp/field/operator_wikidata/missing': 211,
 'atp/field/phone/missing': 211,
 'atp/field/postcode/missing': 211,
 'atp/field/state/missing': 211,
 'atp/field/twitter/missing': 211,
 'atp/nsi/brand_missing': 211,
 'downloader/request_bytes': 170739,
 'downloader/request_count': 240,
 'downloader/request_method_count/GET': 240,
 'downloader/response_bytes': 10010035,
 'downloader/response_count': 240,
 'downloader/response_status_count/200': 214,
 'downloader/response_status_count/404': 2,
 'downloader/response_status_count/502': 24,
 'elapsed_time_seconds': 2.647451,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 1, 16, 40, 22, 660951, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 240,
 'httpcompression/response_bytes': 82953787,
 'httpcompression/response_count': 216,
 'httperror/response_ignored_count': 10,
 'httperror/response_ignored_status_count/404': 2,
 'httperror/response_ignored_status_count/502': 8,
 'item_scraped_count': 211,
 'log_count/ERROR': 8,
 'log_count/INFO': 19,
 'memusage/max': 166883328,
 'memusage/startup': 166883328,
 'request_depth_max': 2,
 'response_received_count': 224,
 'retry/count': 16,
 'retry/max_reached': 8,
 'retry/reason_count/502 Bad Gateway': 16,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 239,
 'scheduler/dequeued/memory': 239,
 'scheduler/enqueued': 239,
 'scheduler/enqueued/memory': 239,
 'start_time': datetime.datetime(2024, 5, 1, 16, 40, 20, 13500, tzinfo=datetime.timezone.utc)}
```