### PR TITLE
Unify instagram tagging

### DIFF
--- a/locations/spiders/crunch_fitness.py
+++ b/locations/spiders/crunch_fitness.py
@@ -1,6 +1,6 @@
 import scrapy
 
-from locations.items import Feature
+from locations.items import Feature, SocialMedia, set_social_media
 
 
 class CrunchFitnessSpider(scrapy.Spider):
@@ -22,10 +22,11 @@ class CrunchFitnessSpider(scrapy.Spider):
                 "phone": club.get("phone"),
                 "email": club.get("email"),
                 "facebook": club.get("facebook_url"),
-                "extras": {"instagram": club.get("instagram_url")},
                 "website": "https://www.crunch.com/locations/" + club["slug"],
                 "lat": float(club["latitude"]),
                 "lon": float(club["longitude"]),
             }
+            item = Feature(**properties)
+            set_social_media(item, SocialMedia.INSTAGRAM, club.get("instagram_url"))
 
-            yield Feature(**properties)
+            yield item

--- a/locations/spiders/the_cheesecake_shop.py
+++ b/locations/spiders/the_cheesecake_shop.py
@@ -3,6 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import SocialMedia, set_social_media
 
 
 class TheCheesecakeShopSpider(Spider):
@@ -57,8 +58,8 @@ class TheCheesecakeShopSpider(Spider):
                 item["postcode"] = item["postcode"].strip()
                 item["phone"] = store.get("store_phone")
                 item["email"] = store.get("store_email")
-                item["facebook"] = store.get("store_facebook")
-                item["extras"]["instagram"] = store.get("store_instagram")
+                set_social_media(item, SocialMedia.FACEBOOK, store.get("store_facebook"))
+                set_social_media(item, SocialMedia.INSTAGRAM, store.get("store_instagram"))
                 if ".com.au" in response.url:
                     item["website"] = "https://www.cheesecake.com.au/find-bakery/" + store["store_identifier"] + "/"
                 elif ".co.nz" in response.url:

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -3,7 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.items import Feature, SocialMedia, set_social_media
 
 
 class StoreRocketSpider(Spider):
@@ -24,9 +24,9 @@ class StoreRocketSpider(Spider):
 
             item["street_address"] = ", ".join(filter(None, [location["address_line_1"], location["address_line_2"]]))
 
-            item["facebook"] = location.get("facebook")
-            item["extras"]["instagram"] = location.get("instagram")
-            item["twitter"] = location.get("twitter")
+            set_social_media(item, SocialMedia.FACEBOOK, location.get("facebook"))
+            set_social_media(item, SocialMedia.INSTAGRAM, location.get("instagram"))
+            set_social_media(item, SocialMedia.TWITTER, location.get("twitter"))
 
             if self.base_url:
                 item["website"] = f'{self.base_url}?location={location["slug"]}'


### PR DESCRIPTION
5 spiders were outputting `instagram` not `contact:instagram`. https://taginfo.openstreetmap.org/search?q=instagram#keys