### PR TITLE
United Rentals: Add spider (1472 locations)

### DIFF
--- a/locations/spiders/united_rentals.py
+++ b/locations/spiders/united_rentals.py
@@ -1,0 +1,28 @@
+from urllib.parse import urljoin
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+
+
+class UnitedRentalsSpider(Spider):
+    name = "united_rentals"
+    item_attributes = {"brand": "United Rentals", "brand_wikidata": "Q7889101"}
+    start_urls = ["https://www.unitedrentals.com/api/v4/locations"]
+
+    def parse(self, response):
+        for location in response.json()["data"]:
+            item = DictParser.parse(location)
+
+            # The URL in the response is relative
+            item["website"] = urljoin(response.url, location["url"])
+
+            # The public "branch ID" is found at the end of the URL
+            item["ref"] = item["branch"] = location["url"].split("/")[-1].upper()
+
+            # The "name" key in the response is the facility type
+            item["name"] = "United Rentals"
+
+            # The opening hours can be found on the branch webpage, but it's not really worth scraping
+
+            yield item

--- a/locations/spiders/united_rentals.py
+++ b/locations/spiders/united_rentals.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin
-
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
@@ -15,7 +13,7 @@ class UnitedRentalsSpider(Spider):
             item = DictParser.parse(location)
 
             # The URL in the response is relative
-            item["website"] = urljoin(response.url, location["url"])
+            item["website"] = response.urljoin(location["url"])
 
             # The public "branch ID" is found at the end of the URL
             item["ref"] = item["branch"] = location["url"].split("/")[-1].upper()


### PR DESCRIPTION
Stats:
```py
{'atp/brand/United Rentals': 1472,
 'atp/brand_wikidata/Q7889101': 1472,
 'atp/category/shop/plant_hire': 1472,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_reverse_geocoding': 1472,
 'atp/field/email/missing': 1472,
 'atp/field/image/missing': 1472,
 'atp/field/opening_hours/missing': 1472,
 'atp/field/operator/missing': 1472,
 'atp/field/operator_wikidata/missing': 1472,
 'atp/field/phone/invalid': 34,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/twitter/missing': 1472,
 'atp/nsi/perfect_match': 1472,
 'downloader/request_bytes': 818,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 105328,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.987079,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 2, 0, 10, 32, 154660, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 672468,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1472,
 'log_count/DEBUG': 1485,
 'log_count/INFO': 10,
 'memusage/max': 155455488,
 'memusage/startup': 155455488,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 5, 2, 0, 10, 29, 167581, tzinfo=datetime.timezone.utc)}
```