### PR TITLE
moneygram: fix spider

### DIFF
--- a/locations/spiders/moneygram.py
+++ b/locations/spiders/moneygram.py
@@ -9,7 +9,12 @@ class MoneyGramSpider(Where2GetItSpider):
     item_attributes = {"brand": "MoneyGram", "brand_wikidata": "Q1944412"}
     api_brand_name = "moneygram"
     api_key = "46493320-D5C3-11E1-A25A-4A6F97B4DA77"
-    api_filter_admin_level = 2
+    api_filter_admin_level = 1
+    download_delay = 0.2
+    custom_settings = {
+        "DOWNLOAD_WARNSIZE": 134217728,  # 128 MiB needed as some results are ~ 90 MiB
+        "DOWNLOAD_TIMEOUT": 60,  # Some countries have large result sets and responses are slow
+    }
 
     def parse_item(self, item, location):
         # MoneyGram compiles location information provided by

--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -4,6 +4,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 
 # To use this storefinder, supply an api_brand_name value as would
 # be found in the following URL template:
@@ -155,9 +156,7 @@ class Where2GetItSpider(Spider):
             item = DictParser.parse(location)
             if not item["ref"]:
                 item["ref"] = location["clientkey"]
-            item["street_address"] = ", ".join(
-                filter(None, [location.get("address1"), location.get("address2"), location.get("address3")])
-            )
+            item["street_address"] = clean_address([location.get("address1"), location.get("address2"), location.get("address3")])
             yield from self.parse_item(item, location)
 
     def parse_item(self, item: Feature, location: dict, **kwargs):


### PR DESCRIPTION
State/province level filtering didn't work because MoneyGram has null state/province fields for most countries.

Instead, increasing timeouts allows the server to respond with all locations per country, which is sometimes up to 90 MiB per country in one returned set of locations.