### PR TITLE
[Core] Fix clean_address with new lines

### DIFF
--- a/locations/pipelines/address_clean_up.py
+++ b/locations/pipelines/address_clean_up.py
@@ -14,6 +14,8 @@ _multiple_spaces = re.compile(r" +")
 
 
 def clean_address(address: list[str] | str) -> str:
+    if not address:
+        return ""
     if isinstance(address, list):
         address = merge_address_lines(address)
     address_list = (

--- a/locations/pipelines/address_clean_up.py
+++ b/locations/pipelines/address_clean_up.py
@@ -10,12 +10,14 @@ def merge_address_lines(address_lines: [str]) -> str:
     return ", ".join(filter(None, [line.strip() if line else None for line in address_lines]))
 
 
+_multiple_spaces = re.compile(r" +")
+
+
 def clean_address(address: list[str] | str) -> str:
     if isinstance(address, list):
         address = merge_address_lines(address)
-
     address_list = (
-        re.sub(r"\s+", " ", unescape(address))
+        re.sub(_multiple_spaces, " ", unescape(address))
         .replace("\n", ",")
         .replace("\r", ",")
         .replace("\t", ",")


### PR DESCRIPTION
Apparently `\s` includes `\n`, so when #8320 replaced them with ` `, and the tests started failing.