### PR TITLE
[PureGym GB] Fix spider

### DIFF
--- a/locations/spiders/puregym_gb.py
+++ b/locations/spiders/puregym_gb.py
@@ -1,28 +1,28 @@
+from urllib.parse import parse_qs, urlparse
+
 from scrapy.spiders import SitemapSpider
 
-from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class PureGymGBSpider(SitemapSpider, StructuredDataSpider):
     name = "puregym_gb"
-    item_attributes = {
-        "brand": "PureGym",
-        "brand_wikidata": "Q18345898",
-        "country": "GB",
-    }
+    item_attributes = {"brand": "PureGym", "brand_wikidata": "Q18345898", "country": "GB"}
     allowed_domains = ["www.puregym.com"]
     sitemap_urls = ["https://www.puregym.com/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/www\.puregym\.com\/gyms\/([\w-]+)\/$",
-            "parse_sd",
-        ),
-    ]
+    sitemap_rules = [(r"/gyms/([^/]+)/$", "parse_sd")]
     wanted_types = ["HealthClub"]
 
-    def inspect_item(self, item, response):
-        item["ref"] = response.xpath('//meta[@itemprop="gymId"]/@content').get()
-        extract_google_position(item, response)
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data["address"] = ld_data.get("location", {}).get("address")
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name")
+        item["image"] = None
+
+        if img := response.xpath('//img[contains(@src, "tiles.stadiamaps.com")]/@src').get():
+            q = parse_qs(urlparse(img)[4])
+            if "center" in q:
+                item["lat"], item["lon"] = q["center"][0].split(",", 1)
 
         yield item


### PR DESCRIPTION
Fixes #8339
```python
{'atp/brand/PureGym': 399,
 'atp/brand_wikidata/Q18345898': 399,
 'atp/category/leisure/fitness_centre': 399,
 'atp/cdn/cloudflare/response_count': 401,
 'atp/cdn/cloudflare/response_status_count/200': 401,
 'atp/field/image/missing': 399,
 'atp/field/opening_hours/missing': 399,
 'atp/field/operator/missing': 399,
 'atp/field/operator_wikidata/missing': 399,
 'atp/field/state/missing': 399,
 'atp/nsi/perfect_match': 399,
 'downloader/request_bytes': 172813,
 'downloader/request_count': 401,
 'downloader/request_method_count/GET': 401,
 'downloader/response_bytes': 14408548,
 'downloader/response_count': 401,
 'downloader/response_status_count/200': 401,
 'elapsed_time_seconds': 3.824414,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 14, 11, 17, 57, 365148, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 401,
 'httpcompression/response_bytes': 66695607,
 'httpcompression/response_count': 401,
 'item_scraped_count': 399,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 166096896,
 'memusage/startup': 166096896,
 'request_depth_max': 1,
 'response_received_count': 401,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 400,
 'scheduler/dequeued/memory': 400,
 'scheduler/enqueued': 400,
 'scheduler/enqueued/memory': 400,
 'start_time': datetime.datetime(2024, 5, 14, 11, 17, 53, 540734, tzinfo=datetime.timezone.utc)}
```