### PR TITLE
[pandaexpress] Added a user agent and delay for pandaexpress (2138 items)

### DIFF
--- a/locations/spiders/pandaexpress.py
+++ b/locations/spiders/pandaexpress.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class PandaExpressSpider(SitemapSpider, StructuredDataSpider):
@@ -10,3 +11,4 @@ class PandaExpressSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.pandaexpress.com/sitemap.xml"]
     sitemap_rules = [(r"/locations/\w{2}/[-\w]+/\d+", "parse_sd")]
     time_format = "%I:%M %p"
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT, "DOWNLOAD_DELAY": 0.5}


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Panda Express': 2138,
 'atp/brand_wikidata/Q1358690': 2138,
 'atp/category/amenity/fast_food': 2138,
 'atp/cdn/cloudflare/response_count': 2156,
 'atp/cdn/cloudflare/response_status_count/200': 2140,
 'atp/cdn/cloudflare/response_status_count/403': 16,
 'atp/field/email/missing': 2138,
 'atp/field/image/dropped': 2138,
 'atp/field/image/missing': 2138,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 2138,
 'atp/field/operator_wikidata/missing': 2138,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 45,
 'atp/nsi/perfect_match': 2138,
 'downloader/request_bytes': 809758,
 'downloader/request_count': 2434,
 'downloader/request_method_count/GET': 2434,
 'downloader/response_bytes': 68088563,
 'downloader/response_count': 2434,
 'downloader/response_status_count/200': 2140,
 'downloader/response_status_count/301': 278,
 'downloader/response_status_count/403': 16,
 'dupefilter/filtered': 277,
 'elapsed_time_seconds': 1489.643631,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 14, 16, 59, 34, 838167, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 246523247,
 'httpcompression/response_count': 2156,
 'httperror/response_ignored_count': 16,
 'httperror/response_ignored_status_count/403': 16,
 'item_scraped_count': 2138,
 'log_count/DEBUG': 4584,
 'log_count/INFO': 49,
 'log_count/WARNING': 4,
 'memusage/max': 297803776,
 'memusage/startup': 155267072,
 'request_depth_max': 1,
 'response_received_count': 2156,
 'scheduler/dequeued': 2434,
 'scheduler/dequeued/memory': 2434,
 'scheduler/enqueued': 2434,
 'scheduler/enqueued/memory': 2434,
 'start_time': datetime.datetime(2024, 5, 14, 16, 34, 45, 194536, tzinfo=datetime.timezone.utc)}
```
</details>