### PR TITLE
[Core] Make _parse_opening_hours_specification safer

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -715,7 +715,7 @@ class OpeningHours:
     # }
     # See https://schema.org/OpeningHoursSpecification for further examples.
     def _parse_opening_hours_specification(self, rule: dict, time_format: str):
-        if not rule.get("dayOfWeek") or not rule.get("opens") or not rule.get("closes"):
+        if not rule.get("dayOfWeek") or not type(rule.get("opens")) == str or not type(rule.get("closes")) == str:
             return
 
         days = rule["dayOfWeek"]

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -715,7 +715,11 @@ class OpeningHours:
     # }
     # See https://schema.org/OpeningHoursSpecification for further examples.
     def _parse_opening_hours_specification(self, rule: dict, time_format: str):
-        if not rule.get("dayOfWeek") or not type(rule.get("opens")) == str or not type(rule.get("closes")) == str:
+        if (
+            not type(rule.get("dayOfWeek")) in [list, str]
+            or not type(rule.get("opens")) == str
+            or not type(rule.get("closes")) == str
+        ):
             return
 
         days = rule["dayOfWeek"]


### PR DESCRIPTION
This has been causing some errors in unexpected places. Traditionally `from_linked_data` was safe, (but `add_range` was never safe).