### PR TITLE
[hot_pot_buffet_th] Added a spider for hot_pot_buffet_th (60 items)

### DIFF
--- a/locations/spiders/hot_pot_buffet_th.py
+++ b/locations/spiders/hot_pot_buffet_th.py
@@ -1,0 +1,32 @@
+import json
+
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class HermesSpider(scrapy.Spider):
+    name = "hot_pot_buffet_th"
+    item_attributes = {
+        "brand": "HOT POT Buffet",
+        "brand_wikidata": "Q125919341",
+    }
+    allowed_domains = ["hermes.com"]
+    start_urls = ["http://www.hotpotmember.com/branch/search"]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+
+    def parse(self, response):
+        data_js = json.loads(
+            response.xpath('//body/script[contains(text(), "__INITIAL_STATE__")]/text()')
+            .get()
+            .split("__INITIAL_STATE__=", 1)[1]
+        )
+        for brand_item in data_js.get("branch").get("all"):
+            if brand_item.get("category") == "Hot Pot Inter Buffet":
+                for store in brand_item.get("branch"):
+                    item = DictParser.parse(store)
+                    item["name"] = "HOT POT Buffet"
+                    item["phone"] = store.get("mobile")
+
+                    yield item

--- a/locations/spiders/hot_pot_buffet_th.py
+++ b/locations/spiders/hot_pot_buffet_th.py
@@ -6,7 +6,7 @@ from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class HermesSpider(scrapy.Spider):
+class HotPotBuffetTHSpider(scrapy.Spider):
     name = "hot_pot_buffet_th"
     item_attributes = {
         "brand": "HOT POT Buffet",


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/HOT POT Buffet': 60,
 'atp/brand_wikidata/Q125919341': 60,
 'atp/category/missing': 60,
 'atp/field/city/missing': 60,
 'atp/field/country/from_spider_name': 60,
 'atp/field/email/missing': 60,
 'atp/field/image/missing': 60,
 'atp/field/opening_hours/missing': 60,
 'atp/field/operator/missing': 60,
 'atp/field/operator_wikidata/missing': 60,
 'atp/field/postcode/missing': 60,
 'atp/field/state/missing': 60,
 'atp/field/street_address/missing': 60,
 'atp/field/twitter/missing': 60,
 'atp/field/website/missing': 60,
 'atp/nsi/brand_missing': 60,
 'downloader/request_bytes': 268,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 13488,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.782718,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 15, 18, 2, 1, 737983, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 66859,
 'httpcompression/response_count': 1,
 'item_scraped_count': 60,
 'log_count/DEBUG': 72,
 'log_count/INFO': 9,
 'memusage/max': 154779648,
 'memusage/startup': 154779648,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 5, 15, 18, 1, 59, 955265, tzinfo=datetime.timezone.utc)}
```
</details>

The do give where the store is located, as most are at a shopping mall or airport. But they do not give an address not sure if there is a tag for something like that.