### PR TITLE
Improve Wendy's hours parsing

### DIFF
--- a/locations/spiders/wendys.py
+++ b/locations/spiders/wendys.py
@@ -17,14 +17,18 @@ class WendysSpider(SitemapSpider, StructuredDataSpider):
         item["website"] = ld_data.get("url")
 
         # Opening hours for the drive-through seem to get included with regular hours, so clean that up
-        item["opening_hours"] = self.clean_hours(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]')[0])
-        item["extras"]["opening_hours:drive_through"] = self.clean_hours(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]')[1])
+        item["opening_hours"] = self.clean_hours(
+            response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]')[0]
+        )
+        item["extras"]["opening_hours:drive_through"] = self.clean_hours(
+            response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]')[1]
+        )
 
         yield item
 
     @staticmethod
     def clean_hours(hours_div):
-        days = hours_div.xpath('.//@data-days').extract_first()
+        days = hours_div.xpath(".//@data-days").extract_first()
         days = json.loads(days)
 
         oh = OpeningHours()

--- a/locations/spiders/wendys.py
+++ b/locations/spiders/wendys.py
@@ -23,14 +23,16 @@ class WendysSpider(SitemapSpider, StructuredDataSpider):
         if len(opening_hours_divs) > 1:
             item["extras"]["opening_hours:drive_through"] = self.clean_hours(opening_hours_divs[1])
 
-        if breakfast_hours_divs := response.xpath('//div[@class="LocationInfo-breakfastInfo js-breakfastInfo"]/span[@class="c-location-hours-today js-location-hours"]'):
+        if breakfast_hours_divs := response.xpath(
+            '//div[@class="LocationInfo-breakfastInfo js-breakfastInfo"]/span[@class="c-location-hours-today js-location-hours"]'
+        ):
             item["extras"]["breakfast"] = self.clean_hours(breakfast_hours_divs[0])
 
         yield item
 
     @staticmethod
     def clean_hours(hours_div):
-        days = hours_div.xpath('.//@data-days').extract_first()
+        days = hours_div.xpath(".//@data-days").extract_first()
         days = json.loads(days)
 
         oh = OpeningHours()

--- a/locations/spiders/wendys.py
+++ b/locations/spiders/wendys.py
@@ -1,10 +1,40 @@
+import json
+
 from scrapy.spiders import SitemapSpider
 
+from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class WendysSpider(SitemapSpider, StructuredDataSpider):
     name = "wendys"
     item_attributes = {"brand": "Wendy's", "brand_wikidata": "Q550258"}
+    wanted_types = ["FastFoodRestaurant"]
     sitemap_urls = ["https://locations.wendys.com/sitemap.xml"]
     sitemap_rules = [(r"https://locations.wendys.com/.+/\w\w/.+/.+", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["website"] = ld_data.get("url")
+
+        # Opening hours for the drive-through seem to get included with regular hours, so clean that up
+        item["opening_hours"] = self.clean_hours(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]').first())
+        item["opening_hours:drive_through"] = self.clean_hours(response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]').last())
+
+        return item
+
+    @staticmethod
+    def clean_hours(hours_div):
+        days = hours_div.xpath('.//@data-days').extract()
+        days = json.loads(days)
+
+        oh = OpeningHours()
+
+        for day in days:
+            day = day["day"]
+            for interval in day["intervals"]:
+                open_time = interval["start"]
+                close_time = interval["end"]
+
+                oh.add_range(day=day.titlecase()[:2], open_time=open_time, close_time=close_time)
+
+        return oh.as_opening_hours()


### PR DESCRIPTION
Fixes #8373 

The default structured data parser was mixing standard store opening hours with breakfast hours (and sometimes drive-through hours). I added post-processing to be more explicit about these two sets of hours.