### PR TITLE
[RisparmioCasa IT] Add spider

### DIFF
--- a/locations/spiders/risparmio_casa_it.py
+++ b/locations/spiders/risparmio_casa_it.py
@@ -1,0 +1,43 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class RisparmioCasaITSpider(Spider):
+    name = "risparmio_casa_it"
+    item_attributes = {"brand": "Risparmio Casa", "brand_wikidata": "Q125936928"}
+
+    def make_request(self, page: int) -> JsonRequest:
+        return JsonRequest(
+            url="https://www.risparmiocasa.com/wp-json/wp/v2/stores?per_page=100&page={}".format(page),
+            meta={"page": page},
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(1)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for page in response.json():
+            yield Request(page["link"], self.parse_page)
+
+        if len(response.json()) == 100:
+            yield self.make_request(response.meta["page"] + 1)
+
+    def parse_page(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["website"] = item["ref"] = response.url
+        item["lat"] = response.xpath("//@data-lat").get()
+        item["lon"] = response.xpath("//@data-lng").get()
+        item["addr_full"] = merge_address_lines(
+            response.xpath('//div[@class="store_locator_single_address"]/text()').getall()
+        )
+        item["phone"] = response.xpath('//div[@class="phone_container"]/a/@href').get()
+        self.crawler.stats.inc_value(
+            "{}/{}".format(self.name, response.xpath('//div[@class="store_locator_single_categories"]/text()').get())
+        )
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9495

```python
{'atp/brand/Risparmio Casa': 164,
 'atp/brand_wikidata/Q125936928': 164,
 'atp/category/missing': 164,
 'atp/field/city/missing': 164,
 'atp/field/country/from_spider_name': 164,
 'atp/field/email/missing': 164,
 'atp/field/image/missing': 164,
 'atp/field/name/missing': 164,
 'atp/field/opening_hours/missing': 164,
 'atp/field/operator/missing': 164,
 'atp/field/operator_wikidata/missing': 164,
 'atp/field/phone/invalid': 18,
 'atp/field/phone/missing': 12,
 'atp/field/postcode/missing': 164,
 'atp/field/state/missing': 164,
 'atp/field/street_address/missing': 164,
 'atp/field/twitter/missing': 164,
 'atp/nsi/brand_missing': 164,
 'downloader/request_bytes': 67119,
 'downloader/request_count': 167,
 'downloader/request_method_count/GET': 167,
 'downloader/response_bytes': 4448127,
 'downloader/response_count': 167,
 'downloader/response_status_count/200': 167,
 'elapsed_time_seconds': 1.543213,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 18, 9, 0, 51, 669529, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 167,
 'httpcompression/response_bytes': 24397674,
 'httpcompression/response_count': 166,
 'item_scraped_count': 164,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 163315712,
 'memusage/startup': 163315712,
 'request_depth_max': 2,
 'response_received_count': 167,
 'risparmio_casa_it/Iper': 40,
 'risparmio_casa_it/Logo': 96,
 'risparmio_casa_it/Mega': 25,
 'risparmio_casa_it/Shop': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 166,
 'scheduler/dequeued/memory': 166,
 'scheduler/enqueued': 166,
 'scheduler/enqueued/memory': 166,
 'start_time': datetime.datetime(2024, 5, 18, 9, 0, 50, 126316, tzinfo=datetime.timezone.utc)}
```