### PR TITLE
[starbucks] fix spider, add hours

### DIFF
--- a/locations/spiders/starbucks.py
+++ b/locations/spiders/starbucks.py
@@ -1,11 +1,11 @@
 import csv
-import json
 from collections import defaultdict
 from math import sqrt
 
 import scrapy
 
 from locations.categories import Categories
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.searchable_points import open_searchable_points
 
@@ -38,14 +38,15 @@ class StarbucksSpider(scrapy.Spider):
                     yield request
 
     def parse(self, response):
-        response_json = json.loads(response.body)
-        stores = response_json["stores"]
+        stores = response.json()
 
-        for store in stores:
-            store_lat = store["coordinates"]["latitude"]
-            store_lon = store["coordinates"]["longitude"]
+        for poi in stores:
+            store = poi["store"]
+            store_lat = store.get("coordinates", {}).get("latitude")
+            store_lon = store.get("coordinates", {}).get("longitude")
             properties = {
                 "name": store["name"],
+                "branch": store["name"],
                 "street_address": ", ".join(
                     filter(
                         None,
@@ -64,19 +65,19 @@ class StarbucksSpider(scrapy.Spider):
                 "ref": store["id"],
                 "lon": store_lon,
                 "lat": store_lat,
-                "brand": store["brandName"],
                 "website": f'https://www.starbucks.com/store-locator/store/{store["id"]}/{store["slug"]}',
                 "extras": {"number": store["storeNumber"], "ownership_type": store["ownershipTypeCode"]},
             }
-            yield Feature(**properties)
+            item = Feature(**properties)
+            self.parse_hours(item, store)
+            yield item
 
         # Get lat and lng from URL
         pairs = response.url.split("?")[-1].split("&")
         # Center is lng, lat
         center = [float(pairs[1].split("=")[1]), float(pairs[0].split("=")[1])]
 
-        paging = response_json["paging"]
-        if paging["returned"] > 0 and paging["limit"] == paging["returned"]:
+        if stores:
             if response.meta["distance"] > 0.15:
                 next_distance = response.meta["distance"] / 2
                 # Create four new coordinate pairs
@@ -106,14 +107,19 @@ class StarbucksSpider(scrapy.Spider):
                 for ii in range(additional_stores):
                     # Find distance between current center and all stores
                     for jj, store in enumerate(stores):
-                        store_lat = store["coordinates"]["latitude"]
-                        store_lon = store["coordinates"]["longitude"]
+                        store_lat = store.get("coordinates", {}).get("latitude")
+                        store_lon = store.get("coordinates", {}).get("longitude")
+                        if store_lat is None or store_lon is None:
+                            continue
                         store_distances[jj].append(
                             sqrt((current_center[1] - store_lat) ** 2 + (current_center[0] - store_lon) ** 2)
                         )
 
                     # Find total distance from each store to each center point
                     total_distances = {key: sum(val) for key, val in store_distances.items()}
+
+                    if not total_distances:
+                        continue
 
                     # Find store furthest away
                     max_store = max(total_distances, key=total_distances.get)
@@ -135,3 +141,27 @@ class StarbucksSpider(scrapy.Spider):
                     request = scrapy.Request(url=url, headers=HEADERS, callback=self.parse)
                     request.meta["distance"] = next_distance
                     yield request
+
+    def parse_hours(self, item: Feature, poi: dict):
+        if schedule := poi.get("schedule"):
+            try:
+                oh = OpeningHours()
+                for day in schedule:
+                    if not day.get("open"):
+                        continue
+                    day_name = day.get("dayOfWeek", "")
+                    hours_formatted = day.get("hoursFormatted", "")
+                    if hours_formatted == "Open 24 hours":
+                        oh.add_range(day=DAYS_EN.get(day_name.title()), open_time="00:00", close_time="23:59")
+                    else:
+                        hours = hours_formatted.split(" to ")
+                        oh.add_range(
+                            day=DAYS_EN.get(day_name.title()),
+                            open_time=hours[0],
+                            close_time=hours[1],
+                            time_format="%I:%M %p",
+                        )
+                item["opening_hours"] = oh.as_opening_hours()
+            except Exception as e:
+                self.logger.warning(f"Failed to parse hours for {schedule}: {e}")
+                self.crawler.stats.inc_value(f"atp/{self.name}/hours/failed")


### PR DESCRIPTION
Output format of the API was changed, they got rid of `paging`.
I haven't run spider till completion but it worked for ~6k POIs.

```json
{
 "atp/brand/Starbucks": 5855,
 "atp/brand_wikidata/Q37158": 5855,
 "atp/category/amenity/cafe": 5855,
 "atp/field/email/missing": 5855,
 "atp/field/image/missing": 5855,
 "atp/field/opening_hours/missing": 66,
 "atp/field/operator/missing": 5855,
 "atp/field/operator_wikidata/missing": 5855,
 "atp/field/phone/invalid": 3,
 "atp/field/phone/missing": 61,
 "atp/field/twitter/missing": 5855,
 "atp/nsi/match_failed": 5855,
 "downloader/request_bytes": 3005673,
 "downloader/request_count": 5871,
 "downloader/request_method_count/GET": 5871,
 "downloader/response_bytes": 199111907,
 "downloader/response_count": 5871,
 "downloader/response_status_count/200": 5871,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "shutdown",
 "item_dropped_count": 78646,
 "item_dropped_reasons_count/DropItem": 78646,
 "item_scraped_count": 5855,
 "log_count/DEBUG": 93461,
 "log_count/INFO": 12,
}
```