### PR TITLE
[LasikPlus US] Add spider

### DIFF
--- a/locations/spiders/lasik_plus_us.py
+++ b/locations/spiders/lasik_plus_us.py
@@ -1,0 +1,24 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.items import SocialMedia, get_social_media, set_social_media
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LasikPlusUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "lasik_plus_us"
+    item_attributes = {"brand": "LasikPlus", "brand_wikidata": "Q126111242"}
+    sitemap_urls = ["https://www.lasikplus.com/robots.txt"]
+    sitemap_follow = ["lasik_location.xml"]
+    sitemap_rules = [(r"/location/([^/]+-lasik-center)/$", "parse")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["website"] = response.url
+
+        if get_social_media(item, SocialMedia.FACEBOOK) == "https://www.facebook.com/LasikPlus/":
+            return  # SEO spam
+
+        yelp, fb, *_ = get_social_media(item, SocialMedia.FACEBOOK).split(", ")
+        set_social_media(item, SocialMedia.YELP, yelp)
+        set_social_media(item, SocialMedia.FACEBOOK, fb)
+
+        yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/6211
```python
{'atp/brand/LasikPlus': 52,
 'atp/brand_wikidata/Q126111242': 52,
 'atp/category/amenity/clinic': 52,
 'atp/category/multiple': 52,
 'atp/cdn/cloudflare/response_count': 140,
 'atp/cdn/cloudflare/response_status_count/200': 140,
 'atp/field/email/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/field/state/from_reverse_geocoding': 52,
 'atp/nsi/perfect_match': 52,
 'downloader/request_bytes': 55980,
 'downloader/request_count': 140,
 'downloader/request_method_count/GET': 140,
 'downloader/response_bytes': 8905348,
 'downloader/response_count': 140,
 'downloader/response_status_count/200': 140,
 'elapsed_time_seconds': 3.883534,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 5, 28, 12, 6, 49, 29501, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 140,
 'httpcompression/response_bytes': 52244505,
 'httpcompression/response_count': 140,
 'item_scraped_count': 52,
 'log_count/DEBUG': 204,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 165380096,
 'memusage/startup': 165380096,
 'request_depth_max': 3,
 'response_received_count': 140,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 139,
 'scheduler/dequeued/memory': 139,
 'scheduler/enqueued': 139,
 'scheduler/enqueued/memory': 139,
 'start_time': datetime.datetime(2024, 5, 28, 12, 6, 45, 145967, tzinfo=datetime.timezone.utc)}
```