### PR TITLE
Fix Yext Answers API website extraction

### DIFF
--- a/locations/storefinders/yext_answers.py
+++ b/locations/storefinders/yext_answers.py
@@ -57,6 +57,12 @@ class YextAnswersSpider(Spider):
             item["extras"]["ref:google"] = location["data"].get("googlePlaceId")
             item["facebook"] = location["data"].get("facebookPageUrl")
 
+            if website_url_dict := location["data"].get("websiteUrl"):
+                if website_url_dict.get("preferDisplayUrl"):
+                    item["website"] = website_url_dict.get("displayUrl")
+                else:
+                    item["website"] = website_url_dict.get("url")
+
             if (
                 not isinstance(item["lat"], float)
                 or not isinstance(item["lon"], float)


### PR DESCRIPTION
While working on converting data to parquet, the conversion tool complained about inconsistent column types. The website is normally a string, but every once and a while a spider emits a dict instead. It looks like all/most of these cases are the Yext Answers spider pulling out the container dict instead of using a null.

In the case of a missing URL, the `websiteUrl` property looks like:

```json
{
  "websiteUrl":{
    "preferDisplayUrl":false
  }
}
```

In the normal case:

```json
{
  "websiteUrl":{
    "url":"https://restaurantes.fiveguys.es/comunidad-de-madrid/paseo-de-la-castellana-259-e",
    "displayUrl":"https://restaurantes.fiveguys.es/comunidad-de-madrid/paseo-de-la-castellana-259-e",
    "preferDisplayUrl":false
  }
}
```

This adjusts the Yext Answers API spider to handle this situation.