### PR TITLE
[Claires] Switch to RioSEO Spider

### DIFF
--- a/locations/spiders/claires.py
+++ b/locations/spiders/claires.py
@@ -1,26 +1,15 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
 
-from locations.spiders.pandora import PandoraSpider
+from locations.items import Feature
+from locations.storefinders.rio_seo import RioSeoSpider
 
 
-class ClairesSpider(SitemapSpider):
+class ClairesSpider(RioSeoSpider):
     name = "claires"
     item_attributes = {"brand_wikidata": "Q2974996"}
-    allowed_domains = ["claires.com"]
-    sitemap_urls = ["https://stores.claires.com/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/stores\.claires\.com\/.+\/([-\w]+\/\d+)\.html$",
-            "parse_store",
-        )
-    ]
-    download_delay = 0.2
+    end_point = "https://maps.stores.claires.com/api/"
 
-    def parse_store(self, response):
-        item = PandoraSpider.parse_item(response, self.sitemap_rules[0][0])
-        item["branch"] = (
-            item.pop("name")
-            .removeprefix("Shop Ear Piercings & Jewellery at ")
-            .removeprefix("Shop Ear Piercings & Jewelry at ")
-        )
-        yield item
+    def post_process_feature(self, feature: Feature, location: dict) -> Iterable[Feature]:
+        feature["branch"] = feature.pop("name")
+
+        yield feature

--- a/locations/storefinders/rio_seo.py
+++ b/locations/storefinders/rio_seo.py
@@ -1,7 +1,9 @@
 import json
-from typing import Iterable
+from typing import Any, Iterable
+from urllib.parse import urljoin
 
-from scrapy import Spider
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
 from scrapy.selector import Selector
 
 from locations.dict_parser import DictParser
@@ -12,6 +14,27 @@ from locations.pipelines.address_clean_up import merge_address_lines
 
 class RioSeoSpider(Spider):
     dataset_attributes = {"source": "api", "api": "rio_seo"}
+
+    end_point: str = None
+    radius: int = 10000
+    limit: int = 3000
+
+    def start_requests(self) -> Iterable[Request]:
+        if self.start_urls:
+            for url in self.start_urls:
+                yield JsonRequest(url=url)
+        else:
+            yield JsonRequest(url=urljoin(self.end_point, "getAutocompleteData"), callback=self.parse_autocomplete)
+
+    def parse_autocomplete(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            url=urljoin(
+                self.end_point,
+                "getAsyncLocations?template=search&level=search&search={}&radius={}&limit={}".format(
+                    response.json()["data"][0], self.radius, self.limit
+                ),
+            )
+        )
 
     def parse(self, response, **kwargs):
         map_list = response.json()["maplist"]


### PR DESCRIPTION
There is an issue with RioSEO hosted sitemaps and Canadian URLs, eg: https://stores.claires.com/ca/mb/brandon/2544.html is in the sitemap, but gets redirected to https://stores.claires.com/us/ca/ when it should be/go to https://stores.claires.com/mb/brandon/2544.html

I expect this issues is in other sitemap spiders on sites hosted by RioSEO.