### PR TITLE
[karstadt -> galeria] change brand and rename the spider

### DIFF
--- a/locations/spiders/galeria_de.py
+++ b/locations/spiders/galeria_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.uberall import UberallSpider
+
+
+class GaleriaDESpider(UberallSpider):
+    name = "galeria_de"
+    item_attributes = {"brand": "Galeria", "brand_wikidata": "Q80220059"}
+    key = "yQ7AVSxcAEpMdcx1mMWkSEwH8SenmY"

--- a/locations/spiders/karstadt_de.py
+++ b/locations/spiders/karstadt_de.py
@@ -1,7 +1,0 @@
-from locations.storefinders.uberall import UberallSpider
-
-
-class KarstadtDESpider(UberallSpider):
-    name = "karstadt_de"
-    item_attributes = {"brand": "Karstadt", "brand_wikidata": "Q182910"}
-    key = "yQ7AVSxcAEpMdcx1mMWkSEwH8SenmY"

--- a/locations/spiders/wiener_feinbacker_heberer_de.py
+++ b/locations/spiders/wiener_feinbacker_heberer_de.py
@@ -5,8 +5,8 @@ from scrapy import Selector
 
 from locations.categories import Categories
 from locations.hours import DAYS_DE, OpeningHours
+from locations.spiders.galeria_de import GaleriaDESpider
 from locations.spiders.hit_de import HITDESpider
-from locations.spiders.karstadt_de import KarstadtDESpider
 from locations.spiders.kaufland import KauflandSpider
 from locations.spiders.rewe_de import REWEDESpider
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
@@ -35,8 +35,8 @@ class WienerFeinbackerHebererDESpider(WPStoreLocatorSpider):
                 item["located_in"] = HITDESpider.item_attributes["brand"]
                 item["located_in_wikidata"] = HITDESpider.item_attributes["brand_wikidata"]
             elif re.search(r"\WKarstadt\W", located_in_tag, flags=re.IGNORECASE):
-                item["located_in"] = KarstadtDESpider.item_attributes["brand"]
-                item["located_in_wikidata"] = KarstadtDESpider.item_attributes["brand_wikidata"]
+                item["located_in"] = GaleriaDESpider.item_attributes["brand"]
+                item["located_in_wikidata"] = GaleriaDESpider.item_attributes["brand_wikidata"]
             elif re.search(r"\WKaufland\W", located_in_tag, flags=re.IGNORECASE):
                 item["located_in"] = KauflandSpider.item_attributes["brand"]
                 item["located_in_wikidata"] = KauflandSpider.item_attributes["brand_wikidata"]


### PR DESCRIPTION
All Karstadts are Galerias now, POIs on the website were rebranded:

- https://www.galeria.de/filialen
- https://en.wikipedia.org/wiki/Galeria_Karstadt_Kaufhof
- https://nsi.guide/index.html?t=brands&k=shop&v=department_store&tt=karstadt%20