### PR TITLE
[bricofer_it] Added bricofer_it (100 items)

### DIFF
--- a/locations/spiders/bricofer_it.py
+++ b/locations/spiders/bricofer_it.py
@@ -1,0 +1,8 @@
+from locations.storefinders.woosmap import WoosmapSpider
+
+
+class BricoferITSpider(WoosmapSpider):
+    name = "bricofer_it"
+    item_attributes = {"brand": "Bricofer", "brand_wikidata": "Q126012596"}
+    key = "woos-be159326-28cf-36ca-b940-616359889dba"
+    origin = "https://www.bricofer.it"

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -10,6 +10,7 @@ from locations.hours import DAYS, OpeningHours
 # with 'woos-' followed by a UUID. Also supply a value for 'origin'
 # which is the HTTP 'Origin' header value, typically similar to
 # 'https://www.brandname.example'.
+from locations.pipelines.address_clean_up import clean_address
 
 
 class WoosmapSpider(Spider):
@@ -29,7 +30,7 @@ class WoosmapSpider(Spider):
             for feature in features:
                 item = DictParser.parse(feature["properties"])
 
-                item["street_address"] = ", ".join(filter(None, feature["properties"]["address"]["lines"]))
+                item["street_address"] = clean_address(feature["properties"]["address"]["lines"])
                 item["geometry"] = feature["geometry"]
 
                 item["opening_hours"] = OpeningHours()

--- a/locations/storefinders/woosmap.py
+++ b/locations/storefinders/woosmap.py
@@ -3,6 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+from locations.pipelines.address_clean_up import clean_address
 
 # Documentation available at https://developers.woosmap.com/products/search-api/get-started/
 #
@@ -10,7 +11,6 @@ from locations.hours import DAYS, OpeningHours
 # with 'woos-' followed by a UUID. Also supply a value for 'origin'
 # which is the HTTP 'Origin' header value, typically similar to
 # 'https://www.brandname.example'.
-from locations.pipelines.address_clean_up import clean_address
 
 
 class WoosmapSpider(Spider):


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Bricofer': 100,
 'atp/brand_wikidata/Q126012596': 100,
 'atp/category/shop/doityourself': 100,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 100,
 'atp/field/operator/missing': 100,
 'atp/field/operator_wikidata/missing': 100,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 100,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 100,
 'atp/nsi/perfect_match': 100,
 'downloader/request_bytes': 728,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13098,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.646548,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 7, 13, 59, 2, 395092, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 174844,
 'httpcompression/response_count': 1,
 'item_scraped_count': 100,
 'log_count/INFO': 9,
 'memusage/max': 155701248,
 'memusage/startup': 155701248,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 7, 13, 58, 59, 748544, tzinfo=datetime.timezone.utc)}
```
</details>