### PR TITLE
[foodlion_us] Simplified Foodlion (1172 items)

### DIFF
--- a/locations/spiders/foodlion_us.py
+++ b/locations/spiders/foodlion_us.py
@@ -1,50 +1,11 @@
-import json
-import re
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-from scrapy.http import JsonRequest
-
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, day_range
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FoodLionUSSpider(scrapy.Spider):
+class FoodLionUSSpider(SitemapSpider, StructuredDataSpider):
     name = "foodlion_us"
     item_attributes = {"brand": "Food Lion", "brand_wikidata": "Q1435950"}
-    allowed_domains = ["www.foodlion.com"]
-    start_urls = ["https://www.foodlion.com/stores/"]
+    sitemap_urls = ["https://stores.foodlion.com/sitemap.xml"]
+    sitemap_rules = [(r"https://stores.foodlion.com/\w{2}/[-\w]+/[-\w]+", "parse_sd")]
     requires_proxy = True
-
-    def start_requests(self):
-        for state in ["GA", "SC", "NC", "MD", "TN", "VA"]:
-            yield JsonRequest(url=f"https://www.foodlion.com/bin/foodlion/search/storelocator.json?state={state}")
-
-    @staticmethod
-    def parse_hours(hours: [str]) -> OpeningHours:
-        oh = OpeningHours()
-        for rule in hours:
-            if rule == "Open 24 Hours":
-                return "24/7"
-            if m := re.match(
-                r"(\w+)(?:-(\w+))?: (\d+:\d\d)\s*([ap]m)\s*-\s*(\d+:\d\d)\s*([ap]m)", rule.replace(".", "")
-            ):
-                start_day, end_day, start_time, start_zone, end_time, end_zone = m.groups()
-                if not end_day:
-                    end_day = start_day
-                oh.add_days_range(
-                    day_range(start_day, end_day),
-                    f"{start_time} {start_zone}",
-                    f"{end_time} {end_zone}",
-                    time_format="%I:%M %p",
-                )
-        return oh
-
-    def parse(self, response, **kwargs):
-        for store in json.loads(response.json()["result"]):
-            store["street_address"] = store.pop("address")
-            item = DictParser.parse(store)
-            item["website"] = f'https://www.foodlion.com{store["href"]}'
-
-            item["opening_hours"] = self.parse_hours(store["hours"])
-
-            yield item


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Food Lion': 1172,
 'atp/brand_wikidata/Q1435950': 1172,
 'atp/category/shop/supermarket': 1172,
 'atp/cdn/cloudflare/response_count': 1174,
 'atp/cdn/cloudflare/response_status_count/200': 1174,
 'atp/field/city/missing': 1172,
 'atp/field/country/from_spider_name': 1172,
 'atp/field/email/missing': 1172,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 1172,
 'atp/field/operator_wikidata/missing': 1172,
 'atp/nsi/perfect_match': 1172,
 'downloader/request_bytes': 643784,
 'downloader/request_count': 1174,
 'downloader/request_method_count/GET': 1174,
 'downloader/response_bytes': 31900011,
 'downloader/response_count': 1174,
 'downloader/response_status_count/200': 1174,
 'elapsed_time_seconds': 1435.657082,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 7, 14, 4, 59, 819839, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 294253070,
 'httpcompression/response_count': 1174,
 'item_scraped_count': 1172,
 'log_count/INFO': 32,
 'memusage/max': 308183040,
 'memusage/startup': 155467776,
 'request_depth_max': 1,
 'response_received_count': 1174,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1173,
 'scheduler/dequeued/memory': 1173,
 'scheduler/enqueued': 1173,
 'scheduler/enqueued/memory': 1173,
 'start_time': datetime.datetime(2024, 6, 7, 13, 41, 4, 162757, tzinfo=datetime.timezone.utc)}
```
</details>