### PR TITLE
[chevrolet] added canada to chevrolet spider (2876 items)

### DIFF
--- a/locations/spiders/chevrolet.py
+++ b/locations/spiders/chevrolet.py
@@ -20,12 +20,16 @@ class ChevroletSpider(scrapy.Spider):
             "clientapplicationid": "quantum",
             "locale": "en-US",
         }
-        point_files = "us_centroids_100mile_radius_state.csv"
-        for lat, lon in point_locations(point_files):
-            yield scrapy.Request(
-                url=f"https://www.chevrolet.com/bypass/pcf/quantum-dealer-locator/v1/getDealers?desiredCount=1000&distance=1200&makeCodes=001&latitude={lat}&longitude={lon}&searchType=latLongSearch",
-                headers=headers,
-            )
+        point_files = [
+            "us_centroids_100mile_radius_state.csv",
+            "ca_centroids_100mile_radius_territory.csv",
+        ]
+        for point_file in point_files:
+            for lat, lon in point_locations(point_file):
+                yield scrapy.Request(
+                    url=f"https://www.chevrolet.com/bypass/pcf/quantum-dealer-locator/v1/getDealers?desiredCount=1000&distance=500&makeCodes=001&latitude={lat}&longitude={lon}&searchType=latLongSearch",
+                    headers=headers,
+                )
 
     def parse(self, response):
         for data in response.json().get("payload", {}).get("dealers"):


### PR DESCRIPTION
<details><summary>New Stats</summary>

```python
{'atp/brand/Chevrolet': 2876,
 'atp/brand_wikidata/Q29570': 2876,
 'atp/category/shop/car': 2876,
 'atp/field/city/missing': 3,
 'atp/field/email/missing': 2876,
 'atp/field/image/missing': 2876,
 'atp/field/opening_hours/missing': 64,
 'atp/field/operator/missing': 2876,
 'atp/field/operator_wikidata/missing': 2876,
 'atp/field/postcode/missing': 3,
 'atp/field/state/from_reverse_geocoding': 13,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 2876,
 'atp/field/website/missing': 100,
 'atp/nsi/cc_match': 2876,
 'downloader/exception_count': 5,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 5,
 'downloader/request_bytes': 3060939,
 'downloader/request_count': 1575,
 'downloader/request_method_count/GET': 1575,
 'downloader/response_bytes': 87361355,
 'downloader/response_count': 1570,
 'downloader/response_status_count/200': 1569,
 'downloader/response_status_count/500': 1,
 'dupefilter/filtered': 680,
 'elapsed_time_seconds': 1909.610567,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 7, 14, 18, 37, 688381, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 16693,
 'item_dropped_reasons_count/DropItem': 16693,
 'item_scraped_count': 2876,
 'log_count/INFO': 40,
 'memusage/max': 383102976,
 'memusage/startup': 155348992,
 'response_received_count': 1569,
 'retry/count': 6,
 'retry/reason_count/500 Internal Server Error': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 5,
 'scheduler/dequeued': 1575,
 'scheduler/dequeued/memory': 1575,
 'scheduler/enqueued': 1575,
 'scheduler/enqueued/memory': 1575,
 'start_time': datetime.datetime(2024, 6, 7, 13, 46, 48, 77814, tzinfo=datetime.timezone.utc)}
```
</details>