### PR TITLE
[puma_tw] Created puma taiwan spider (38 items)

### DIFF
--- a/locations/spiders/puma_tw.py
+++ b/locations/spiders/puma_tw.py
@@ -1,0 +1,38 @@
+import chompjs
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_WEEKDAY, DAYS_WEEKEND, OpeningHours
+
+
+class PumaTWSpider(SitemapSpider):
+    name = "puma_tw"
+    item_attributes = {
+        "brand": "Puma",
+        "brand_wikidata": "Q157064",
+    }
+
+    # Note, /api/search is forbidden by robots.txt
+    sitemap_urls = ["https://tw.puma.com/Sitemap/40187/Sitemap_Index.xml"]
+    sitemap_rules = [
+        (r"/Shop/StoreDetail/[^/]+/[^/]+$", "parse"),
+    ]
+
+    def parse(self, response):
+        store = chompjs.parse_js_object(
+            response.xpath('//script[contains(text(),"nineyi.ServerData")]/text()').extract_first()
+        )
+        item = DictParser.parse(store)
+        item["opening_hours"] = OpeningHours()
+        self.opening_hours_add(DAYS_WEEKDAY, store.get("NormalTime"), item)
+        self.opening_hours_add(DAYS_WEEKEND, store.get("WeekendTime"), item)
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item
+
+    def opening_hours_add(self, days, store_hours, item):
+        for day in days:
+            open = store_hours.split("~")[0]
+            close = store_hours.split("~")[1]
+            item["opening_hours"].add_range(day, open, close)


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Puma': 38,
 'atp/brand_wikidata/Q157064': 38,
 'atp/category/shop/clothes': 38,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 38,
 'atp/field/email/missing': 38,
 'atp/field/image/missing': 38,
 'atp/field/lat/missing': 38,
 'atp/field/lon/missing': 38,
 'atp/field/name/missing': 1,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 38,
 'atp/field/state/missing': 38,
 'atp/field/street_address/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/field/website/missing': 38,
 'atp/nsi/match_failed': 38,
 'downloader/request_bytes': 18536,
 'downloader/request_count': 46,
 'downloader/request_method_count/GET': 46,
 'downloader/response_bytes': 501930,
 'downloader/response_count': 46,
 'downloader/response_status_count/200': 46,
 'elapsed_time_seconds': 54.009626,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 7, 18, 18, 38, 383382, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1103021,
 'httpcompression/response_count': 40,
 'item_scraped_count': 38,
 'log_count/INFO': 9,
 'memusage/max': 155353088,
 'memusage/startup': 155353088,
 'request_depth_max': 2,
 'response_received_count': 46,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 45,
 'scheduler/dequeued/memory': 45,
 'scheduler/enqueued': 45,
 'scheduler/enqueued/memory': 45,
 'start_time': datetime.datetime(2024, 6, 7, 18, 17, 44, 373756, tzinfo=datetime.timezone.utc)}
```
</details>