### PR TITLE
[sony_tw] Add sony tw (64 items)

### DIFF
--- a/locations/spiders/sony_tw.py
+++ b/locations/spiders/sony_tw.py
@@ -1,0 +1,66 @@
+from scrapy import Spider
+
+from locations.hours import DAYS_CN, OpeningHours, day_range
+from locations.items import Feature
+
+
+class AmpolAUSpider(Spider):
+    name = "sony_tw"
+    item_attributes = {"brand": "Sony", "brand_wikidata": "Q41187"}
+    start_urls = ["https://store.sony.com.tw/channelStore/index?area=all&productId=&type=direct&isType=Y"]
+
+    # def start_requests(self):
+    #     yield Request(
+    #         url="https://store.sony.com.tw/channelStore/index?area=all&productId=&type=direct&isType=Y",
+    #     )
+
+    def parse(self, response):
+        stores = response.xpath('//figure[@class="cell store__list"]')  # .getall()
+        for store in stores:
+            # print()
+            # print(store)
+            item = {}
+
+            # Ref
+            item["ref"] = store.xpath("./a/@href").get()
+
+            # Name
+            item["name"] = store.xpath('./a/div/p[@class="h5"]/strong/text()').get()
+
+            # Address, Phone, Opening Hours
+            # info_keys = store.xpath('./a/div/p[@class="h6"]/strong/text()').getall()
+            info_values = store.xpath('./a/div/p[@class="text-gary"]').getall()
+            for index in range(0, len(info_values)):
+                info_values[index] = info_values[index].replace('<p class="text-gary">', "").replace("</p>", "")
+                info_values[index] = (
+                    info_values[index].replace("<br>", ",").replace("\n", "").replace("\t", "").replace(" ", "")
+                )
+            item["addr_full"] = info_values[0]
+            item["phone"] = info_values[1].split("(")[0]
+            self.parse_opening_hours(item, info_values[2][:-1])
+
+            yield Feature(**item)
+
+    def parse_opening_hours(self, item, hours):
+        try:
+            item["opening_hours"] = OpeningHours()
+            for hour in hours.split(","):
+                if "例假日" in hour:  # Holidays
+                    continue
+                elif "平日" in hour:  # Weekdays
+                    day_range_start = "Mo"
+                    day_range_end = "Fr"
+                elif "週末" in hour:  # Weekends
+                    day_range_start = "Sa"
+                    day_range_end = "Su"
+                else:
+                    day_range_start = DAYS_CN.get(hour.split("~")[0])
+                    day_range_end = DAYS_CN.get(hour.split(":", 1)[0].split("~")[1])
+                if not day_range_start or not day_range_end:
+                    continue
+                days = day_range(day_range_start, day_range_end)
+                open_time = hour.split(":", 1)[1].split("~")[0]
+                close_time = hour.split(":", 1)[1].split("~")[1]
+                item["opening_hours"].add_days_range(days, open_time, close_time)
+        except Exception:
+            self.crawler.stats.inc_value("failed_hours_parse")

--- a/locations/spiders/sony_tw.py
+++ b/locations/spiders/sony_tw.py
@@ -7,7 +7,10 @@ from locations.items import Feature
 class AmpolAUSpider(Spider):
     name = "sony_tw"
     item_attributes = {"brand": "Sony", "brand_wikidata": "Q41187"}
-    start_urls = ["https://store.sony.com.tw/channelStore/index?area=all&productId=&type=direct&isType=Y"]
+    start_urls = [
+        "https://store.sony.com.tw/channelStore/index?area=all&productId=&type=direct&isType=Y",
+        "https://store.sony.com.tw/channelStore/index?area=all&productId=&type=special&isType=Y&max=100",
+    ]
 
     # def start_requests(self):
     #     yield Request(

--- a/locations/spiders/sony_tw.py
+++ b/locations/spiders/sony_tw.py
@@ -4,7 +4,7 @@ from locations.hours import DAYS_CN, OpeningHours, day_range
 from locations.items import Feature
 
 
-class AmpolAUSpider(Spider):
+class SonyTWSpider(Spider):
     name = "sony_tw"
     item_attributes = {"brand": "Sony", "brand_wikidata": "Q41187"}
     start_urls = [
@@ -12,16 +12,9 @@ class AmpolAUSpider(Spider):
         "https://store.sony.com.tw/channelStore/index?area=all&productId=&type=special&isType=Y&max=100",
     ]
 
-    # def start_requests(self):
-    #     yield Request(
-    #         url="https://store.sony.com.tw/channelStore/index?area=all&productId=&type=direct&isType=Y",
-    #     )
-
     def parse(self, response):
-        stores = response.xpath('//figure[@class="cell store__list"]')  # .getall()
+        stores = response.xpath('//figure[@class="cell store__list"]')
         for store in stores:
-            # print()
-            # print(store)
             item = {}
 
             # Ref


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Sony': 64,
 'atp/brand_wikidata/Q41187': 64,
 'atp/category/shop/electronics': 64,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/city/missing': 64,
 'atp/field/country/from_spider_name': 64,
 'atp/field/email/missing': 64,
 'atp/field/image/missing': 64,
 'atp/field/lat/missing': 64,
 'atp/field/lon/missing': 64,
 'atp/field/opening_hours/missing': 36,
 'atp/field/operator/missing': 64,
 'atp/field/operator_wikidata/missing': 64,
 'atp/field/postcode/missing': 64,
 'atp/field/state/missing': 64,
 'atp/field/street_address/missing': 64,
 'atp/field/twitter/missing': 64,
 'atp/field/website/missing': 64,
 'atp/nsi/perfect_match': 64,
 'downloader/request_bytes': 1031,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 35588,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 7.537151,
 'failed_hours_parse': 40,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 10, 7, 17, 20, 971494, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 304974,
 'httpcompression/response_count': 3,
 'item_scraped_count': 64,
 'log_count/INFO': 9,
 'memusage/max': 155205632,
 'memusage/startup': 155205632,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 6, 10, 7, 17, 13, 434343, tzinfo=datetime.timezone.utc)}
```
</details>