### PR TITLE
[sushi_express_tw] Added Sushi Express (281 items)

### DIFF
--- a/locations/spiders/sushi_express_tw.py
+++ b/locations/spiders/sushi_express_tw.py
@@ -1,7 +1,7 @@
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import DAYS, OpeningHours
 
 
 class SushiExpressTW(Spider):
@@ -13,16 +13,18 @@ class SushiExpressTW(Spider):
         stores = response.json()
         for store in stores:
             item = DictParser.parse(store)
-            item["state"] = store.get("District")
-            item["fax"] = store.get("faxNumber")
+            item["state"] = store.get("district")
+            item["extras"]["fax"] = store.get("faxNumber")
             self.parse_opening_hours(item, store.get("openingHours"))
 
             yield item
 
-    def parse_opening_hours(self, item, hours):
+    def parse_opening_hours(self, item, full_hours):
         try:
+            full_hours = full_hours.replace("~", "-")
             item["opening_hours"] = OpeningHours()
-            hours = hours.split("(")[0]
+            hours = full_hours.split("（")[0]  # Has weird character in string. Shows hours and last order hour?
+            item["opening_hours"].add_days_range(DAYS, hours.split("-")[0], hours.split("-")[1])
 
         except Exception:
             self.crawler.stats.inc_value("failed_hours_parse")

--- a/locations/spiders/sushi_express_tw.py
+++ b/locations/spiders/sushi_express_tw.py
@@ -1,0 +1,28 @@
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class SushiExpressTW(Spider):
+    name = "sushi_express_tw"
+    item_attributes = {"brand": "Sushi Express", "brand_wikidata": "Q15920674"}
+    start_urls = ["https://www.sushiexpress.com.tw/WCF/getSpot.ashx"]
+
+    def parse(self, response):
+        stores = response.json()
+        for store in stores:
+            item = DictParser.parse(store)
+            item["state"] = store.get("District")
+            item["fax"] = store.get("faxNumber")
+            self.parse_opening_hours(item, store.get("openingHours"))
+
+            yield item
+
+    def parse_opening_hours(self, item, hours):
+        try:
+            item["opening_hours"] = OpeningHours()
+            hours = hours.split("(")[0]
+
+        except Exception:
+            self.crawler.stats.inc_value("failed_hours_parse")


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Sushi Express': 281,
 'atp/brand_wikidata/Q15920674': 281,
 'atp/category/amenity/restaurant': 281,
 'atp/field/country/from_spider_name': 281,
 'atp/field/email/missing': 281,
 'atp/field/image/missing': 281,
 'atp/field/opening_hours/missing': 24,
 'atp/field/operator/missing': 281,
 'atp/field/operator_wikidata/missing': 281,
 'atp/field/street_address/missing': 281,
 'atp/field/twitter/missing': 281,
 'atp/field/website/missing': 281,
 'atp/nsi/cc_match': 281,
 'downloader/request_bytes': 634,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 252789,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.418889,
 'failed_hours_parse': 24,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 12, 15, 3, 11, 374343, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 281,
 'log_count/INFO': 9,
 'memusage/max': 155348992,
 'memusage/startup': 155348992,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 12, 15, 3, 6, 955454, tzinfo=datetime.timezone.utc)}

```
</details>