### PR TITLE
[burger_king_tw] Added Burger King in Taiwan (95 itmes)

### DIFF
--- a/locations/spiders/burger_king_tw.py
+++ b/locations/spiders/burger_king_tw.py
@@ -1,0 +1,32 @@
+import json
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
+
+
+class BurgerKingTWSpider(Spider):
+    name = "burger_king_tw"
+    item_attributes = BURGER_KING_SHARED_ATTRIBUTES
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://www.burgerking.com.tw/AJhandler/frontierHandler.ashx",
+            data={"what": "getDeliveryInfo", "args": 520000, "list": {"type": 20, "view": 1}, "args2": ""},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["args"]["branchList"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["opening_hours"] = OpeningHours()
+            for rule in json.loads(location["openHours"]):
+                if not rule["isopen"]:
+                    continue
+                item["opening_hours"].add_range(DAYS[rule["week"] - 1], rule["openTime"], rule["closeTime"])
+            item["website"] = "https://www.burgerking.com.tw/map"
+            yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Burger King': 95,
 'atp/brand_wikidata/Q177054': 95,
 'atp/category/amenity/fast_food': 95,
 'atp/field/country/from_spider_name': 95,
 'atp/field/email/missing': 95,
 'atp/field/image/missing': 95,
 'atp/field/operator_wikidata/missing': 95,
 'atp/field/state/missing': 95,
 'atp/field/street_address/missing': 95,
 'atp/field/twitter/missing': 95,
 'atp/nsi/cc_match': 95,
 'atp/operator/家城股份有限公司': 95,
 'downloader/request_bytes': 921,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 30601,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.356421,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 10, 12, 11, 47, 66599, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 210386,
 'httpcompression/response_count': 1,
 'item_scraped_count': 95,
 'log_count/DEBUG': 108,
 'log_count/INFO': 9,
 'memusage/max': 154013696,
 'memusage/startup': 154013696,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 10, 12, 11, 43, 710178, tzinfo=datetime.timezone.utc)}
```
</details>