### PR TITLE
[hsbc_tw] Added HSBC in Taiwan (26 items)

### DIFF
--- a/locations/spiders/hsbc_tw.py
+++ b/locations/spiders/hsbc_tw.py
@@ -1,0 +1,23 @@
+import scrapy
+from requests_cache import Response
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class HSBCSpider(StructuredDataSpider):
+    name = "hsbc_tw"
+    item_attributes = {"brand": "HSBC", "brand_wikidata": "Q190464", "extras": Categories.BANK.value}
+    start_urls = ["https://www.hsbc.com.tw/en-tw/ways-to-bank/branch/"]
+
+    def parse(self, response: Response, **kwargs):
+        for branch in response.xpath(r'//*[@class="desktop"]//td[2]').xpath("normalize-space()").getall():
+            url = "https://www.hsbc.com.tw/en-tw/branch-list/" + branch.lower().replace(
+                "taoyuan branch", "tahsin branch"
+            ).replace(" (bilingual branch)", "").replace(" ", "-")
+            yield scrapy.Request(url=url, callback=self.parse_sd)
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        for service in ld_data["hasOfferCatalog"]["itemListElement"]:
+            apply_yes_no(Extras.ATM, item, "atm" in service["itemOffered"]["name"].lower())
+        yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/HSBC': 26,
 'atp/brand_wikidata/Q190464': 26,
 'atp/category/amenity/bank': 26,
 'atp/field/email/missing': 26,
 'atp/field/image/dropped': 26,
 'atp/field/image/missing': 26,
 'atp/field/operator/missing': 26,
 'atp/field/operator_wikidata/missing': 26,
 'atp/field/phone/missing': 26,
 'atp/field/state/missing': 26,
 'atp/field/twitter/missing': 26,
 'atp/nsi/cc_match': 26,
 'downloader/request_bytes': 33188,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 538535,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 28,
 'downloader/response_status_count/301': 26,
 'elapsed_time_seconds': 66.582598,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 10, 12, 15, 26, 335147, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3779856,
 'httpcompression/response_count': 28,
 'item_scraped_count': 26,
 'log_count/DEBUG': 91,
 'log_count/INFO': 10,
 'memusage/max': 301506560,
 'memusage/startup': 155090944,
 'request_depth_max': 1,
 'response_received_count': 28,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 53,
 'scheduler/dequeued/memory': 53,
 'scheduler/enqueued': 53,
 'scheduler/enqueued/memory': 53,
 'start_time': datetime.datetime(2024, 6, 10, 12, 14, 19, 752549, tzinfo=datetime.timezone.utc)}
```
</details>