### PR TITLE
[gap_tw] Added Gap TW (15 items)

### DIFF
--- a/locations/spiders/gap_tw.py
+++ b/locations/spiders/gap_tw.py
@@ -1,0 +1,26 @@
+import scrapy
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+
+
+class GapTWSpider(scrapy.Spider):
+    name = "gap_tw"
+    item_attributes = {"brand": "Gap", "brand_wikidata": "Q420822"}
+
+    def start_requests(self):
+        url = "https://api.gap.tw/store/queryStoreLocation"
+        yield JsonRequest(
+            url=url,
+            method="POST",
+            headers={"Content-Type": "application/json;charset=UTF-8"},
+            data={"id": 1, "locationIdentifier": "Gap"},
+        )
+
+    def parse(self, response, **kwargs):
+        for city in response.json()["data"][0]["cityList"]:
+            for store in city["storeLocations"]:
+                item = DictParser.parse(store)
+                item["country"] = "TW"
+                item["website"] = "https://www.gap.tw/"
+                yield item


### PR DESCRIPTION
<details><summary>Stats</summary>

```python
{'atp/brand/Gap': 15,
 'atp/brand_wikidata/Q420822': 15,
 'atp/category/missing': 15,
 'atp/field/email/missing': 15,
 'atp/field/image/missing': 15,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 15,
 'atp/field/operator/missing': 15,
 'atp/field/operator_wikidata/missing': 15,
 'atp/field/postcode/missing': 15,
 'atp/field/street_address/missing': 15,
 'atp/field/twitter/missing': 15,
 'atp/nsi/match_failed': 15,
 'downloader/request_bytes': 763,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 3431,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.149474,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 10, 12, 17, 47, 260118, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12727,
 'httpcompression/response_count': 1,
 'item_scraped_count': 15,
 'log_count/DEBUG': 28,
 'log_count/INFO': 9,
 'memusage/max': 155881472,
 'memusage/startup': 155881472,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 10, 12, 17, 43, 110644, tzinfo=datetime.timezone.utc)}
```
</details>