### PR TITLE
[krispy_kreme_mx] Add krispy kreme mexico (250 items)

### DIFF
--- a/locations/spiders/krispy_kreme_mx.py
+++ b/locations/spiders/krispy_kreme_mx.py
@@ -9,12 +9,12 @@ class KrispyKremeMXSpider(Spider):
     name = "krispy_kreme_mx"
     item_attributes = {"brand": "Krispy Kreme", "brand_wikidata": "Q1192805", "extras": Categories.FAST_FOOD.value}
     start_urls = ["https://www.krispykreme.mx/directorio-tiendas/"]
+    no_refs = True
 
     def parse(self, response):
         locations = response.xpath('//tbody[@id="myTable"]/tr')
         for index in range(0, len(locations)):
             item = {}
-            item["ref"] = f"krispy_kreme_mx_{index}"
             # item["name"] = locations[index].xpath('./td[1]/text()').get() # Seems to be name of owner or something. Thus use NSI Name tag
             item["addr_full"] = clean_address(locations[index].xpath("./td[2]/text()").get())
             if phone := locations[index].xpath("./a/text()").get():

--- a/locations/spiders/krispy_kreme_mx.py
+++ b/locations/spiders/krispy_kreme_mx.py
@@ -1,0 +1,23 @@
+from scrapy import Spider
+
+from locations.categories import Categories
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class KrispyKremeMXSpider(Spider):
+    name = "krispy_kreme_mx"
+    item_attributes = {"brand": "Krispy Kreme", "brand_wikidata": "Q1192805", "extras": Categories.FAST_FOOD.value}
+    start_urls = ["https://www.krispykreme.mx/directorio-tiendas/"]
+
+    def parse(self, response):
+        locations = response.xpath('//tbody[@id="myTable"]/tr')
+        for index in range(0, len(locations)):
+            item = {}
+            item["ref"] = f"krispy_kreme_mx_{index}"
+            # item["name"] = locations[index].xpath('./td[1]/text()').get() # Seems to be name of owner or something. Thus use NSI Name tag
+            item["addr_full"] = clean_address(locations[index].xpath("./td[2]/text()").get())
+            if phone := locations[index].xpath("./a/text()").get():
+                item["phone"] = phone
+
+            yield Feature(**item)


### PR DESCRIPTION
Might not have great attribution. But I did spot check some of the addresses and they are at them. Thus, I think it could still be useful even if it was just to use some reverse geocoding to get the latitude and longitude.

<details><summary>Stats</summary>

```python
{'atp/brand/Krispy Kreme': 250,
 'atp/brand_wikidata/Q1192805': 250,
 'atp/category/amenity/fast_food': 250,
 'atp/field/city/missing': 250,
 'atp/field/country/from_spider_name': 250,
 'atp/field/email/missing': 250,
 'atp/field/image/missing': 250,
 'atp/field/lat/missing': 250,
 'atp/field/lon/missing': 250,
 'atp/field/opening_hours/missing': 250,
 'atp/field/operator/missing': 250,
 'atp/field/operator_wikidata/missing': 250,
 'atp/field/phone/missing': 250,
 'atp/field/postcode/missing': 250,
 'atp/field/state/missing': 250,
 'atp/field/street_address/missing': 250,
 'atp/field/twitter/missing': 250,
 'atp/field/website/missing': 250,
 'atp/nsi/cc_match': 250,
 'downloader/request_bytes': 627,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 31228,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.924861,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 11, 12, 4, 30, 650011, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 165269,
 'httpcompression/response_count': 2,
 'item_scraped_count': 250,
 'log_count/DEBUG': 263,
 'log_count/INFO': 9,
 'memusage/max': 155611136,
 'memusage/startup': 155611136,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 11, 12, 4, 27, 725150, tzinfo=datetime.timezone.utc)}
```
</details>