### PR TITLE
Record days with closed hours

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -830,9 +830,6 @@ class OpeningHours:
     def _parse_opening_hours(self, rule: str, time_format: str):
         days, time_ranges = rule.split(" ", 1)
 
-        # if "-" not in time_ranges:
-        # return
-
         for time_range in time_ranges.split(","):
             if time_ranges.lower() in ["closed", "off"]:
                 start_time = end_time = "closed"

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -709,6 +709,9 @@ class OpeningHours:
         self.day_hours = defaultdict(set)
         self.days_closed = set()
 
+    def __bool__(self):
+        return bool(self.day_hours or self.days_closed)
+
     def add_days_range(self, days: [str], open_time, close_time, time_format="%H:%M"):
         for day in days:
             self.add_range(day, open_time, close_time, time_format=time_format)

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -707,6 +707,7 @@ def sanitise_day(day: str, days: {} = DAYS_EN) -> str:
 class OpeningHours:
     def __init__(self):
         self.day_hours = defaultdict(set)
+        self.days_closed = set()
 
     def add_days_range(self, days: [str], open_time, close_time, time_format="%H:%M"):
         for day in days:
@@ -720,6 +721,14 @@ class OpeningHours:
 
         if not open_time or not close_time:
             return
+        if (
+            isinstance(open_time, str)
+            and isinstance(close_time, str)
+            and open_time.lower() == "closed"
+            and close_time.lower() == "closed"
+        ):
+            self.day_hours.pop(day, None)
+            self.days_closed.add(day)
         if isinstance(open_time, str):
             if open_time.lower() == "closed":
                 return
@@ -733,6 +742,7 @@ class OpeningHours:
         if not isinstance(close_time, time.struct_time):
             close_time = time.strptime(close_time, time_format)
 
+        self.days_closed.discard(day)
         self.day_hours[day].add((open_time, close_time))
 
     def as_opening_hours(self) -> str:
@@ -740,14 +750,17 @@ class OpeningHours:
         this_day_group = None
 
         for day in DAYS:
-            hours = ",".join(
-                "%s-%s"
-                % (
-                    time.strftime("%H:%M", h[0]),
-                    time.strftime("%H:%M", h[1]).replace("23:59", "24:00"),
+            if day in self.days_closed:
+                hours = "closed"
+            else:
+                hours = ",".join(
+                    "%s-%s"
+                    % (
+                        time.strftime("%H:%M", h[0]),
+                        time.strftime("%H:%M", h[1]).replace("23:59", "24:00"),
+                    )
+                    for h in sorted(self.day_hours[day])
                 )
-                for h in sorted(self.day_hours[day])
-            )
 
             if not this_day_group:
                 this_day_group = {"from_day": day, "to_day": day, "hours": hours}
@@ -814,11 +827,14 @@ class OpeningHours:
     def _parse_opening_hours(self, rule: str, time_format: str):
         days, time_ranges = rule.split(" ", 1)
 
-        if "-" not in time_ranges:
-            return
+        # if "-" not in time_ranges:
+        # return
 
         for time_range in time_ranges.split(","):
-            start_time, end_time = time_range.split("-")
+            if time_ranges.lower() in ["closed", "off"]:
+                start_time = end_time = "closed"
+            else:
+                start_time, end_time = time_range.split("-")
 
             start_time = start_time.strip()
             end_time = end_time.strip()

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -94,7 +94,7 @@ class CheckItemPropertiesPipeline:
 
         if opening_hours := item.get("opening_hours"):
             if isinstance(opening_hours, OpeningHours):
-                if opening_hours.day_hours:
+                if opening_hours:
                     item["opening_hours"] = opening_hours.as_opening_hours()
                 else:
                     item["opening_hours"] = None

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -333,6 +333,44 @@ def test_ld_parse_opening_hours_array_with_commas():
     assert o.as_opening_hours() == "Mo-Su 00:00-01:00,04:00-24:00"
 
 
+def test_ld_parse_opening_hours_closed():
+    o = OpeningHours()
+    o.from_linked_data(
+        json.loads(
+            """
+            {
+                "@context": "https://schema.org",
+                "openingHours": [
+                    "Mo Closed",
+                    "Tu Closed",
+                    "We Closed",
+                    "Th Closed",
+                    "Fr Closed",
+                    "Sa Closed",
+                    "Su Closed"
+                ]
+            }
+            """
+        )
+    )
+    assert o.as_opening_hours() == "Mo-Su closed"
+
+
+def test_ld_parse_opening_hours_closed_range():
+    o = OpeningHours()
+    o.from_linked_data(
+        json.loads(
+            """
+            {
+                "@context": "https://schema.org",
+                "openingHours": ["Mo-Su Closed"]
+            }
+            """
+        )
+    )
+    assert o.as_opening_hours() == "Mo-Su closed"
+
+
 def test_ld_parse_time_format():
     o = OpeningHours()
     o.from_linked_data(


### PR DESCRIPTION
My comment in #8626: For the locations with explicitly closed hours, e.g. `<tr itemprop="openingHours" content="Mo Closed">` (etc.), I would much prefer to see the output contain `"opening_hours":"Mo-Su closed"`.

For the issue of KFC specifically, this isn't actually interesting, since all 373 items lacking opening hours do say Mo-Su closed in the microdata, but it's generally useful and would allow consumers to confidently filter out these items, such as for the MapRoulette case of creating missing POIs.

In the stats counters, we might also want to distinguish "opening_hours/missing" from "opening_hours/always_closed" or some such.
