### PR TITLE
[RiteAid US] Collect pharmacy opening hours

### DIFF
--- a/locations/spiders/rite_aid_us.py
+++ b/locations/spiders/rite_aid_us.py
@@ -2,34 +2,36 @@ import re
 
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class RiteAidUSSpider(SitemapSpider, StructuredDataSpider):
     name = "rite_aid_us"
     item_attributes = {"brand": "Rite Aid", "brand_wikidata": "Q3433273"}
-    allowed_domains = ["locations2.riteaid.com.yext-cdn.com"]
-    sitemap_urls = ("https://locations2.riteaid.com.yext-cdn.com/sitemap.xml",)
-    sitemap_rules = [
-        (r"^https://locations2.riteaid.com.yext-cdn.com/[^/]+/[^/]+/[^/]+.html$", "parse_sd"),
-    ]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,
-    }
+    sitemap_urls = ["https://www.riteaid.com/robots.txt"]
+    sitemap_follow = ["locations"]
+    sitemap_rules = [(r"^https://www.riteaid.com/locations/[^/]+/[^/]+/[^/]+.html$", "parse_sd")]
     wanted_types = ["Store"]
 
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            if "www.riteaid.com/locations/" in entry.get("loc"):
-                entry["loc"] = entry["loc"].replace(
-                    "www.riteaid.com/locations/", "locations2.riteaid.com.yext-cdn.com/"
-                )
-                yield entry
-
     def post_process_item(self, item, response, ld_data):
-        if m := re.match(r"^Rite Aid #(\d+)\s", item["name"]):
+        if m := re.match(r"^Rite Aid #(\d+)\s", item.pop("name")):
             item["ref"] = m.group(1)
-        item["website"] = item["website"].replace("www.riteaid.com/locations/", "locations2.riteaid.com.yext-cdn.com/")
+
         item.pop("image")
         item.pop("twitter")
+
+        for department in ld_data.get("department", []):
+            if department.get("@type") == "Pharmacy":
+                pharmacy = item.deepcopy()
+                pharmacy["ref"] = "{}-pharmacy".format(item["ref"])
+                pharmacy["phone"] = department["telephone"]
+                pharmacy["opening_hours"] = OpeningHours()
+                pharmacy["opening_hours"].from_linked_data(department)
+                apply_category(Categories.PHARMACY, pharmacy)
+                yield pharmacy
+                break
+
+        apply_category(Categories.SHOP_CHEMIST, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Rite Aid': 3212,
 'atp/brand_wikidata/Q3433273': 3212,
 'atp/category/amenity/pharmacy': 1606,
 'atp/category/multiple': 1606,
 'atp/category/shop/chemist': 1606,
 'atp/cdn/cloudflare/response_count': 1606,
 'atp/cdn/cloudflare/response_status_count/200': 1606,
 'atp/field/email/missing': 3212,
 'atp/field/image/missing': 3212,
 'atp/field/opening_hours/missing': 34,
 'atp/field/operator/missing': 3212,
 'atp/field/operator_wikidata/missing': 3212,
 'atp/field/twitter/missing': 3212,
 'atp/nsi/cc_match': 3212,
 'downloader/request_bytes': 648527,
 'downloader/request_count': 1610,
 'downloader/request_method_count/GET': 1610,
 'downloader/response_bytes': 67199387,
 'downloader/response_count': 1610,
 'downloader/response_status_count/200': 1610,
 'elapsed_time_seconds': 1965.771078,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 19, 7, 31, 2, 597785, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1609,
 'httpcache/hit': 1,
 'httpcache/miss': 1609,
 'httpcache/store': 1609,
 'httpcompression/response_bytes': 623236621,
 'httpcompression/response_count': 1610,
 'item_scraped_count': 3212,
 'log_count/DEBUG': 4834,
 'log_count/INFO': 42,
 'log_count/WARNING': 1,
 'memusage/max': 428314624,
 'memusage/startup': 164761600,
 'request_depth_max': 3,
 'response_received_count': 1610,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1609,
 'scheduler/dequeued/memory': 1609,
 'scheduler/enqueued': 1609,
 'scheduler/enqueued/memory': 1609,
 'start_time': datetime.datetime(2024, 6, 19, 6, 58, 16, 826707, tzinfo=datetime.timezone.utc)}
```