### PR TITLE
[Hours] Add set_closed function

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -716,6 +716,15 @@ class OpeningHours:
         for day in days:
             self.add_range(day, open_time, close_time, time_format=time_format)
 
+    def set_closed(self, days: str | list[str]):
+        for day in [days] if isinstance(days, str) else days:
+            day = sanitise_day(day)
+
+            if day not in DAYS:
+                raise ValueError(f"day must be one of {DAYS}, not {day!r}")
+            self.day_hours.pop(day, None)
+            self.days_closed.add(day)
+
     def add_range(self, day, open_time, close_time, time_format="%H:%M"):
         day = sanitise_day(day)
 
@@ -732,6 +741,7 @@ class OpeningHours:
         ):
             self.day_hours.pop(day, None)
             self.days_closed.add(day)
+            return
         if isinstance(open_time, str):
             if open_time.lower() == "closed":
                 return

--- a/locations/spiders/aldi_sud_au.py
+++ b/locations/spiders/aldi_sud_au.py
@@ -21,7 +21,7 @@ class AldiSudAUSpider(SitemapSpider, StructuredDataSpider):
         if data := response.xpath("//@data-days").get():
             for rule in json.loads(data):
                 if rule["isClosed"]:
-                    continue
+                    item["opening_hours"].set_closed(rule["day"])
                 for time in rule["intervals"]:
                     item["opening_hours"].add_range(
                         rule["day"], str(time["start"]).zfill(4), str(time["end"]).zfill(4), "%H%M"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -333,6 +333,14 @@ def test_ld_parse_opening_hours_array_with_commas():
     assert o.as_opening_hours() == "Mo-Su 00:00-01:00,04:00-24:00"
 
 
+def test_opening_hours_closed():
+    oh = OpeningHours()
+    oh.set_closed("Su")
+    assert oh.as_opening_hours() == "Su closed"
+    oh.set_closed(DAYS)
+    assert oh.as_opening_hours() == "Mo-Su closed"
+
+
 def test_ld_parse_opening_hours_closed():
     o = OpeningHours()
     o.from_linked_data(


### PR DESCRIPTION
I have the same worries about `closed` as I did about `off` in the `apply_yes_no` discussion. I don't think we should set negative attributes when we aren't certain. If we incorrectly say someone is closed on Sunday, or doesn't have a drive through it's a lot more drama than just leaving it null.

That being said, `apply_yes_no` has a safer way to handle this, I'm OK with opening hours having it too, when we are careful.

(Bad)
```python
item["extras"]["drive_through"] = "yes" if services.get("Drive Through") else "no"
```
If they changed `Drive Through` to `drive-through`, or anything, we'd be outputting `drive_through=no` on everything.

(Safe)
```python
apply_yes_no(Extras.DT, item, services.get("Drive Through") is True)
```
We'd be outputting nothing.

(Safe negative)
```python
apply_yes_no(Extras.DT, item, services.get("Drive Through") is True, "Drive Through" not in services)
```
We output `yes/no` or null.

Anyway, opening hours. I don't think any of us want write `oh.add_range(day, "closed", "closed")`. `oh.set_closed("Su")` or `oh.set_closed(["Mo", "Tu"])` seems better.