### PR TITLE
[KrispyKrunchyChicken US] Add spider (2.9k locations)

### DIFF
--- a/locations/spiders/krispy_krunchy_chicken_us.py
+++ b/locations/spiders/krispy_krunchy_chicken_us.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class KrispyKrunchyChickenUSSpider(SitemapSpider):
+    name = "krispy_krunchy_chicken_us"
+    item_attributes = {"brand_wikidata": "Q65087447"}
+    sitemap_urls = ["https://www.krispykrunchy.com/robots.txt"]
+    sitemap_follow = ["wpsl_stores"]
+    sitemap_rules = [(r"/locations/([^/]+)/$", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = chompjs.parse_js_object(
+            response.xpath('//script[@id="wpsl-js-js-extra"]/text()').re_first(r"wpslMap_0 = ({.+})")
+        )
+        for location in data["locations"]:
+            item = DictParser.parse(location)
+            item["addr_full"] = None
+            item["street_address"] = merge_address_lines([location["address"], location["address2"]])
+            item["branch"] = location["store"]
+            item["website"] = response.url
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Krispy Krunchy Chicken': 2918,
 'atp/brand_wikidata/Q65087447': 2918,
 'atp/category/amenity/fast_food': 2918,
 'atp/cdn/cloudflare/response_count': 2924,
 'atp/cdn/cloudflare/response_status_count/200': 2924,
 'atp/field/country/from_spider_name': 2806,
 'atp/field/email/missing': 2918,
 'atp/field/image/missing': 2918,
 'atp/field/opening_hours/missing': 2918,
 'atp/field/operator/missing': 2918,
 'atp/field/operator_wikidata/missing': 2918,
 'atp/field/phone/missing': 2918,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 2918,
 'atp/nsi/perfect_match': 2918,
 'downloader/request_bytes': 1165758,
 'downloader/request_count': 2924,
 'downloader/request_method_count/GET': 2924,
 'downloader/response_bytes': 50355521,
 'downloader/response_count': 2924,
 'downloader/response_status_count/200': 2924,
 'dupefilter/filtered': 4,
 'elapsed_time_seconds': 2501.297422,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 19, 16, 0, 1, 274085, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 2041,
 'httpcache/hit': 883,
 'httpcache/miss': 2041,
 'httpcache/store': 2041,
 'httpcompression/response_bytes': 248809232,
 'httpcompression/response_count': 2924,
 'item_scraped_count': 2918,
 'log_count/INFO': 51,
 'log_count/WARNING': 1,
 'memusage/max': 486674432,
 'memusage/startup': 165998592,
 'request_depth_max': 3,
 'response_received_count': 2924,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2923,
 'scheduler/dequeued/memory': 2923,
 'scheduler/enqueued': 2923,
 'scheduler/enqueued/memory': 2923,
 'start_time': datetime.datetime(2024, 6, 19, 15, 18, 19, 976663, tzinfo=datetime.timezone.utc)}
```