### PR TITLE
[Box Now] Requeire proxy

### DIFF
--- a/locations/spiders/box_now.py
+++ b/locations/spiders/box_now.py
@@ -7,12 +7,12 @@ from locations.dict_parser import DictParser
 class BoxNowSpider(Spider):
     name = "box_now"
     item_attributes = {"brand": "Box Now"}
-    allowed_domains = ["boxlockersloadfilesbg.blob.core.windows.net"]
     start_urls = [
         "https://boxlockersloadfilesbg.blob.core.windows.net/lockerslargenavigate/all.json",
         "https://boxlockersloadfiles.blob.core.windows.net/lockerslargenavigate/all.json",
         "https://boxlockersloadfilescr.blob.core.windows.net/lockerslargenavigate/all.json",
     ]
+    requires_proxy = True
 
     def start_requests(self):
         for url in self.start_urls:


### PR DESCRIPTION
I can't really debug this one. It runs fine from my GB ip, and my US vpn, however something is happening in the weekly.

```python
{'atp/brand/Box Now': 2771,
 'atp/brand_wikidata/Q117195372': 580,
 'atp/brand_wikidata/Q117195375': 613,
 'atp/brand_wikidata/Q117195376': 1578,
 'atp/category/amenity/parcel_locker': 2771,
 'atp/field/city/missing': 2771,
 'atp/field/email/missing': 2771,
 'atp/field/image/missing': 2771,
 'atp/field/opening_hours/missing': 2771,
 'atp/field/operator/missing': 2771,
 'atp/field/operator_wikidata/missing': 2771,
 'atp/field/phone/missing': 2771,
 'atp/field/postcode/missing': 2771,
 'atp/field/state/missing': 2771,
 'atp/field/street_address/missing': 2771,
 'atp/field/twitter/missing': 2771,
 'atp/field/website/missing': 2771,
 'atp/nsi/perfect_match': 2771,
 'downloader/request_bytes': 2102,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 572754,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/400': 3,
 'elapsed_time_seconds': 2.943951,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 20, 10, 45, 51, 486369, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 6,
 'httpcache/miss': 6,
 'httpcache/store': 6,
 'item_scraped_count': 2771,
 'log_count/INFO': 9,
 'memusage/max': 164720640,
 'memusage/startup': 164720640,
 'response_received_count': 6,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/400': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 6, 20, 10, 45, 48, 542418, tzinfo=datetime.timezone.utc)}
```