### PR TITLE
[BurgerKing FR] Use new API

### DIFF
--- a/locations/spiders/burger_king_fr.py
+++ b/locations/spiders/burger_king_fr.py
@@ -1,39 +1,32 @@
 import scrapy
-from scrapy.http import JsonRequest
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
 
 class BurgerKingFRSpider(scrapy.Spider):
     name = "burger_king_fr"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    start_urls = ["https://webapi.burgerking.fr/blossom/api/v12/public/store-locator/all"]
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-application": "WEBSITE"}}
-    requires_proxy = True
+    start_urls = ["https://ecoceabkstorageprdnorth.blob.core.windows.net/static/restaurants.json"]
 
     def parse(self, response):
-        for location in response.json():
-            yield JsonRequest(
-                url=f'https://webapi.burgerking.fr/blossom/api/v12/public/restaurant{location["pageUrl"]}/page',
-                callback=self.parse_store,
-            )
+        for location in response.json()["restaurants"].values():
+            yield self.parse_store(location)
 
-    def parse_store(self, response):
-        location = response.json()["restaurant"]
+    def parse_store(self, location: dict) -> Feature:
         item = DictParser.parse(location)
         item["branch"] = item.pop("name", "").upper().removeprefix("BURGER KING ").title()
-        item["website"] = response.json()["metaData"]["canonicalURL"]
-        item["image"] = location["image"][0]
-        oh = OpeningHours()
-        open_hours = location["openHours"]
-        for hours in open_hours:
-            if hours["room"] is not None:
-                start, end = hours["room"].split("-", maxsplit=1)
-                oh.add_range(hours["day"], start.strip(), end.strip(), time_format="%H:%M")
-        item["opening_hours"] = oh
+        item["website"] = location["canonicalURL"]
+
+        if rules := location["openings"].get("room"):
+            item["opening_hours"] = self.parse_opening_hours(rules)
+
+        if rules := location["openings"].get("drive"):
+            item["extras"]["opening_hours:drive_through"] = self.parse_opening_hours(rules).as_opening_hours()
+
         apply_yes_no(Extras.AIR_CONDITIONING, item, "AIR_COND" in location["services"])
         apply_yes_no(Extras.OUTDOOR_SEATING, item, "TERRACE" in location["services"])
         apply_yes_no(Extras.TAKEAWAY, item, "TAKEAWAY" in location["services"])
@@ -41,4 +34,10 @@ class BurgerKingFRSpider(scrapy.Spider):
         apply_yes_no(Extras.DRIVE_THROUGH, item, "DRIVE" in location["services"])
         apply_yes_no(Extras.WIFI, item, "FREE_WIFI" in location["services"])
 
-        yield item
+        return item
+
+    def parse_opening_hours(self, rules: dict) -> OpeningHours:
+        oh = OpeningHours()
+        for day, times in rules.items():
+            oh.add_range(day, times["opening"], times["closing"])
+        return oh


### PR DESCRIPTION
The old code was working fine for me locally, without a VPN. However it was having [issues](https://www.alltheplaces.xyz/spiders.html?search=burger_king_fr) in the weekly, with or without a VPN. I wanna try this API, the [store finder](https://burgerking.fr/restaurants) fetches both datasets, not totally sure why.

```python
{'atp/brand/Burger King': 532,
 'atp/brand_wikidata/Q177054': 532,
 'atp/category/amenity/fast_food': 532,
 'atp/field/city/missing': 532,
 'atp/field/country/from_spider_name': 532,
 'atp/field/email/missing': 532,
 'atp/field/image/missing': 532,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 532,
 'atp/field/operator_wikidata/missing': 532,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 532,
 'atp/field/state/missing': 532,
 'atp/field/street_address/missing': 532,
 'atp/field/twitter/missing': 532,
 'atp/field/website/invalid': 1,
 'atp/nsi/cc_match': 532,
 'downloader/request_bytes': 685,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 122670,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/400': 1,
 'elapsed_time_seconds': 2.280481,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 20, 14, 52, 37, 631902, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2115940,
 'httpcompression/response_count': 1,
 'item_scraped_count': 532,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 166006784,
 'memusage/startup': 166006784,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/400': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 6, 20, 14, 52, 35, 351421, tzinfo=datetime.timezone.utc)}
```