### PR TITLE
[BangkokBank] Fix spider

### DIFF
--- a/locations/spiders/bangkok_bank_th.py
+++ b/locations/spiders/bangkok_bank_th.py
@@ -5,13 +5,21 @@ from scrapy.http import JsonRequest
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.user_agents import CHROME_LATEST
 
 
 class BangkokBankSpider(scrapy.Spider):
     name = "bangkok_bank"
     allowed_domains = ["www.bangkokbank.com"]
     item_attributes = {"brand_wikidata": "Q806483"}
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Ocp-Apim-Subscription-Key": "7d1b09abe2ea413cbf95b2d99782ed37"}}
+    user_agent = CHROME_LATEST
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": {
+            "Ocp-Apim-Subscription-Key": "7d1b09abe2ea413cbf95b2d99782ed37",
+            "X-Requested-With": "XMLHttpRequest",
+        },
+        "ROBOTSTXT_OBEY": False,
+    }
     base_url = "https://www.bangkokbank.com/api/locationsearchservice/"
 
     def start_requests(self):


### PR DESCRIPTION
```python
{'atp/brand/Bangkok Bank': 13,
 'atp/brand/ธนาคารกรุงเทพ': 6742,
 'atp/brand/盤谷銀行 Bangkok Bank': 1,
 'atp/brand_wikidata/Q806483': 6756,
 'atp/category/amenity/atm': 5928,
 'atp/category/amenity/bank': 828,
 'atp/field/city/missing': 6756,
 'atp/field/email/missing': 6756,
 'atp/field/image/missing': 6756,
 'atp/field/lat/missing': 1995,
 'atp/field/lon/missing': 1995,
 'atp/field/name/missing': 5928,
 'atp/field/opening_hours/missing': 6756,
 'atp/field/operator/missing': 828,
 'atp/field/operator_wikidata/missing': 828,
 'atp/field/phone/invalid': 6692,
 'atp/field/postcode/missing': 7,
 'atp/field/twitter/missing': 6756,
 'atp/field/website/missing': 6756,
 'atp/nsi/cc_match': 6756,
 'atp/operator/ธนาคารกรุงเทพ': 5928,
 'atp/operator_wikidata/Q806483': 5928,
 'downloader/request_bytes': 227667,
 'downloader/request_count': 170,
 'downloader/request_method_count/GET': 170,
 'downloader/response_bytes': 1120574,
 'downloader/response_count': 170,
 'downloader/response_status_count/200': 170,
 'elapsed_time_seconds': 212.248834,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 21, 14, 18, 38, 209859, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 170,
 'httpcache/miss': 170,
 'httpcache/store': 170,
 'httpcompression/response_bytes': 5270435,
 'httpcompression/response_count': 170,
 'item_dropped_count': 830,
 'item_dropped_reasons_count/DropItem': 830,
 'item_scraped_count': 6756,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'memusage/max': 298065920,
 'memusage/startup': 166043648,
 'request_depth_max': 1,
 'response_received_count': 170,
 'scheduler/dequeued': 170,
 'scheduler/dequeued/memory': 170,
 'scheduler/enqueued': 170,
 'scheduler/enqueued/memory': 170,
 'start_time': datetime.datetime(2024, 6, 21, 14, 15, 5, 961025, tzinfo=datetime.timezone.utc)}
```