### PR TITLE
[Arbys] Fix spider

### DIFF
--- a/locations/spiders/arbys_ca.py
+++ b/locations/spiders/arbys_ca.py
@@ -8,5 +8,5 @@ class ArbysCASpider(SitemapSpider, StructuredDataSpider):
     name = "arbys_ca"
     item_attributes = ArbysUSSpider.item_attributes
     sitemap_urls = ["https://locations.arbys.ca/sitemap.xml"]
-    sitemap_rules = [("ca/\w\w/[^/]+/[^/]+.html", "parse")]
+    sitemap_rules = [(r"ca/\w\w/[^/]+/[^/]+.html", "parse")]
     wanted_types = ["Restaurant"]

--- a/locations/spiders/arbys_ca.py
+++ b/locations/spiders/arbys_ca.py
@@ -1,0 +1,12 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.spiders.arbys_us import ArbysUSSpider
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ArbysCASpider(SitemapSpider, StructuredDataSpider):
+    name = "arbys_ca"
+    item_attributes = ArbysUSSpider.item_attributes
+    sitemap_urls = ["https://locations.arbys.ca/sitemap.xml"]
+    sitemap_rules = [("ca/\w\w/[^/]+/[^/]+.html", "parse")]
+    wanted_types = ["Restaurant"]

--- a/locations/spiders/arbys_us.py
+++ b/locations/spiders/arbys_us.py
@@ -1,10 +1,52 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any, Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class ArbysUSSpider(SitemapSpider, StructuredDataSpider):
+class ArbysUSSpider(Spider):
     name = "arbys_us"
     item_attributes = {"brand": "Arby's", "brand_wikidata": "Q630866"}
-    sitemap_urls = ["https://locations.arbys.com/sitemap.xml"]
-    sitemap_rules = [(r"\.html$", "parse_sd")]
+
+    def make_request(self, page: int) -> JsonRequest:
+        return JsonRequest(
+            url="https://api.arbys.com/arb/web-exp-api/v1/location?latitude=0&longitude=0&radius=500000&limit=100&page={}".format(
+                page
+            )
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(0)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["locations"]:
+            if location["contactDetails"]["address"]["countryCode"] == "KR":
+                continue  # ArbysCASpider
+            item = Feature()
+            item["ref"] = location["id"]
+            item["branch"] = location["displayName"]
+            item["street_address"] = merge_address_lines(
+                [
+                    location["contactDetails"]["address"]["line1"],
+                    location["contactDetails"]["address"]["line2"],
+                    location["contactDetails"]["address"]["line3"],
+                ]
+            )
+            item["postcode"] = location["contactDetails"]["address"]["postalCode"]
+            item["state"] = location["contactDetails"]["address"]["stateProvinceCode"]
+            item["country"] = location["contactDetails"]["address"]["countryCode"]
+            item["city"] = location["contactDetails"]["address"]["city"]
+            item["phone"] = location["contactDetails"]["phone"]
+            item["website"] = "https://www.arbys.com/locations/{}/".format(location["url"])
+            item["lat"] = location["details"]["latitude"]
+            item["lon"] = location["details"]["longitude"]
+
+            yield item
+
+        metadata = response.json()["metadata"]
+        if metadata["isLastPage"] is False:
+            yield self.make_request(metadata["pageNumber"] + 1)


### PR DESCRIPTION
CA:
```python
{"atp/brand/Arby's": 56,
 'atp/brand_wikidata/Q630866': 56,
 'atp/category/amenity/fast_food': 56,
 'atp/field/country/from_spider_name': 56,
 'atp/field/email/missing': 56,
 'atp/field/image/dropped': 56,
 'atp/field/image/missing': 56,
 'atp/field/operator/missing': 56,
 'atp/field/operator_wikidata/missing': 56,
 'atp/field/twitter/missing': 56,
 'atp/nsi/perfect_match': 56,
 'downloader/request_bytes': 22124,
 'downloader/request_count': 58,
 'downloader/request_method_count/GET': 58,
 'downloader/response_bytes': 684615,
 'downloader/response_count': 58,
 'downloader/response_status_count/200': 58,
 'elapsed_time_seconds': 71.044544,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 21, 16, 20, 29, 853152, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 58,
 'httpcache/miss': 58,
 'httpcache/store': 58,
 'httpcompression/response_bytes': 4002681,
 'httpcompression/response_count': 58,
 'item_scraped_count': 56,
 'log_count/DEBUG': 126,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'memusage/max': 289525760,
 'memusage/startup': 166416384,
 'request_depth_max': 1,
 'response_received_count': 58,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 57,
 'scheduler/dequeued/memory': 57,
 'scheduler/enqueued': 57,
 'scheduler/enqueued/memory': 57,
 'start_time': datetime.datetime(2024, 6, 21, 16, 19, 18, 808608, tzinfo=datetime.timezone.utc)}
```
US:
```python
{"atp/brand/Arby's": 3440,
 'atp/brand_wikidata/Q630866': 3440,
 'atp/category/amenity/fast_food': 3440,
 'atp/cdn/cloudflare/response_count': 36,
 'atp/cdn/cloudflare/response_status_count/200': 35,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 3440,
 'atp/field/image/missing': 3440,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 3440,
 'atp/field/operator/missing': 3440,
 'atp/field/operator_wikidata/missing': 3440,
 'atp/field/phone/missing': 14,
 'atp/field/twitter/missing': 3440,
 'atp/geometry/null_island': 1,
 'atp/nsi/perfect_match': 3440,
 'downloader/request_bytes': 21974,
 'downloader/request_count': 36,
 'downloader/request_method_count/GET': 36,
 'downloader/response_bytes': 730854,
 'downloader/response_count': 36,
 'downloader/response_status_count/200': 35,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.90722,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 21, 16, 21, 59, 840858, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 36,
 'httpcompression/response_bytes': 13965359,
 'httpcompression/response_count': 36,
 'item_scraped_count': 3440,
 'log_count/DEBUG': 3489,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 166268928,
 'memusage/startup': 166268928,
 'request_depth_max': 34,
 'response_received_count': 36,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 35,
 'scheduler/dequeued/memory': 35,
 'scheduler/enqueued': 35,
 'scheduler/enqueued/memory': 35,
 'start_time': datetime.datetime(2024, 6, 21, 16, 21, 53, 933638, tzinfo=datetime.timezone.utc)}
```