### PR TITLE
[NHSScotlandGB] Fix long run time

### DIFF
--- a/locations/spiders/nhs_scotland_gb.py
+++ b/locations/spiders/nhs_scotland_gb.py
@@ -1,5 +1,3 @@
-import re
-
 from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
@@ -63,9 +61,19 @@ class NHSScotlandGBSpider(Spider):
     def parse(self, response, service):
         for link in response.xpath('//h2[@class="nhsuk-heading-m"]/a/@href').getall():
             yield Request(link, callback=self.parse_service, cb_kwargs=dict(service=service))
+
+        page_link = response.url.split("?page=")
+        new_page_number = str(int(page_link[1].split("&")[0]) + 1)
+        new_link = page_link[0] + "?page=" + new_page_number
+        # Don't request all links, since they then all request duplicate links
+        # Just kick off next page link only if it exists in the links carousel
+        found = False
         for link in response.xpath('//a[contains(@class, "pagination__link")]/@href').getall():
-            link = re.sub(r"\?page=\d+&page=", "?page=", link)
-            yield Request(link, callback=self.parse, cb_kwargs=dict(service=service))
+            if new_page_number in link:
+                found = True
+                break
+        if found:
+            yield Request(new_link, callback=self.parse, cb_kwargs=dict(service=service))
 
     def parse_service(self, response, service):
         item = Feature()


### PR DESCRIPTION
regex was failing due to additional request parameters added.
Was in loop because of way link carousel has been redesigned.
Was running for 8+ hrs. Now 
{'atp/category/amenity/clinic': 66,
 'atp/category/amenity/dentist': 1014,
 'atp/category/amenity/doctors': 30,
 'atp/category/amenity/hospital': 141,
 'atp/category/amenity/pharmacy': 1140,
 'atp/category/multiple': 2391,
 'atp/category/shop/optician': 39,
 'atp/field/brand/missing': 2430,
 'atp/field/brand_wikidata/missing': 2430,
 'atp/field/city/missing': 2430,
 'atp/field/country/from_spider_name': 2430,
 'atp/field/email/missing': 2430,
 'atp/field/image/missing': 2430,
 'atp/field/lat/missing': 1688,
 'atp/field/lon/missing': 1688,
 'atp/field/name/missing': 1678,
 'atp/field/opening_hours/missing': 1696,
 'atp/field/operator/missing': 2430,
 'atp/field/operator_wikidata/missing': 2430,
 'atp/field/phone/missing': 2430,
 'atp/field/postcode/missing': 1686,
 'atp/field/state/missing': 2430,
 'atp/field/street_address/missing': 2430,
 'atp/field/twitter/missing': 2430,
 'downloader/exception_count': 350,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 350,
 'downloader/request_bytes': 1776381,
 'downloader/request_count': 3157,
 'downloader/request_method_count/GET': 3157,
 'downloader/response_bytes': 59668895,
 'downloader/response_count': 2807,
 'downloader/response_status_count/200': 2807,
 'elapsed_time_seconds': 2317.854142,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 24, 11, 42, 3, 921023, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 2807,
 'httpcache/miss': 3157,
 'httpcache/store': 2807,
 'httpcompression/response_bytes': 292483340,
 'httpcompression/response_count': 2807,
 'item_scraped_count': 2430,
 'log_count/INFO': 48,
 'memusage/max': 208027648,
 'memusage/startup': 167116800,
 'request_depth_max': 125,
 'response_received_count': 2807,
 'retry/count': 350,
 'retry/reason_count/twisted.internet.error.TimeoutError': 350,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3156,
 'scheduler/dequeued/memory': 3156,
 'scheduler/enqueued': 3156,
 'scheduler/enqueued/memory': 3156,
 'start_time': datetime.datetime(2024, 6, 24, 11, 3, 26, 66881, tzinfo=datetime.timezone.utc)}
