### PR TITLE
drop clearly broken leroy_merlin_pl locations

### DIFF
--- a/locations/spiders/leroy_merlin_pl.py
+++ b/locations/spiders/leroy_merlin_pl.py
@@ -21,8 +21,8 @@ class LeroyMerlinPLSpider(Spider):
             item["phone"] = poi["informationPointPhone"]
             item["website"] = urljoin("https://www.leroymerlin.pl", poi.get("wwwUrl"))
             # TODO: figure out opening hours
-            if item['lat'] < 48.99 or item['lat'] > 54.87 or item['lon'] < 14.07 or item['lon'] > 24.13:
+            if item["lat"] < 48.99 or item["lat"] > 54.87 or item["lon"] < 14.07 or item["lon"] > 24.13:
                 # clearly outside Poland, some locations were claimed to be in the Middle East
-                del item['lat']
-                del item['lon']
+                del item["lat"]
+                del item["lon"]
             yield item

--- a/locations/spiders/leroy_merlin_pl.py
+++ b/locations/spiders/leroy_merlin_pl.py
@@ -21,4 +21,8 @@ class LeroyMerlinPLSpider(Spider):
             item["phone"] = poi["informationPointPhone"]
             item["website"] = urljoin("https://www.leroymerlin.pl", poi.get("wwwUrl"))
             # TODO: figure out opening hours
+            if item['lat'] < 48.99 or item['lat'] > 54.87 or item['lon'] < 14.07 or item['lon'] > 24.13:
+                # clearly outside Poland, some locations were claimed to be in the Middle East
+                del item['lat']
+                del item['lon']
             yield item


### PR DESCRIPTION
some locations are in Yemen/ocean near Oman, and as Poland has no colonies this is clearly broken. Address data present there confirms that coordinates are garbage (general area looks like switched lat-lons, but not tried confirming this theory)

I am not entirely sure how to best do it, other spiders are likely to be also affected (look at ATP global map, note supposed POIs in the middle of oceans). Maybe it should be separate pipeline, however these are defined?

It would be also possible for data consumers to do nothing and keep this claims as stated. And each data consumer skipping these data manually, I guess, but that seems overall vastly significant effort and keeping known trap for data users.