### PR TITLE
[seven_eleven_mx] fix spider

### DIFF
--- a/locations/spiders/seven_eleven_mx.py
+++ b/locations/spiders/seven_eleven_mx.py
@@ -1,33 +1,25 @@
 from typing import Any
 
+import w3lib
 from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.dict_parser import DictParser
 from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
 
 
 class SevenElevenMXSpider(Spider):
     name = "seven_eleven_mx"
     item_attributes = SEVEN_ELEVEN_SHARED_ATTRIBUTES
-    start_urls = ["https://app.7-eleven.com.mx:8443/web/services/tiendas"]
+    start_urls = ["https://7-eleven.com.mx/wp-json/wpgmza/v1/features/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["results"]:
-            item = Feature()
-            item["ref"] = location["id"]
-            item["addr_full"] = location["full_address"]
-            item["branch"] = location["name"]
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-
-            if location["open_hours"].lower() == "24 horas":
-                item["opening_hours"] = "24/7"
-
-            if location["type"] == 1:
-                apply_category(Categories.FUEL_STATION, item)
-            else:
-                apply_category(Categories.SHOP_CONVENIENCE, item)
-
+        for location in response.json()["markers"]:
+            if location["map_id"] == "7":
+                # Skip duplicates with different map_id, it's not clear from the website how they are used
+                continue
+            item = DictParser.parse(location)
+            item["addr_full"] = w3lib.html.remove_tags(item.get("addr_full", ""))
+            apply_category(Categories.SHOP_CONVENIENCE, item)
             yield item


### PR DESCRIPTION

There is a new API on a website where I haven't noticed any fuel stations.

```json
{
 "atp/brand/7-Eleven": 1829,
 "atp/brand_wikidata/Q259340": 1829,
 "atp/category/shop/convenience": 1829,
 "atp/field/city/missing": 1829,
 "atp/field/country/from_spider_name": 1829,
 "atp/field/email/missing": 1829,
 "atp/field/image/missing": 1829,
 "atp/field/opening_hours/missing": 1829,
 "atp/field/operator/missing": 1829,
 "atp/field/operator_wikidata/missing": 1829,
 "atp/field/phone/missing": 1829,
 "atp/field/postcode/missing": 1829,
 "atp/field/state/missing": 1829,
 "atp/field/street_address/missing": 1829,
 "atp/field/twitter/missing": 1829,
 "atp/field/website/missing": 1829,
 "atp/nsi/cc_match": 1829,
 "atp/seven_eleven_mx/skip": 503,
 "downloader/request_bytes": 629,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 114052,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 1.176898,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-06-25T13:35:22.934580+00:00",
 "httpcache/hit": 2,
 "httpcompression/response_bytes": 926029,
 "httpcompression/response_count": 2,
 "item_scraped_count": 1829,
 "log_count/INFO": 10,
 "memusage/max": 161726464,
 "memusage/startup": 161726464,
 "response_received_count": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1,
 "scheduler/dequeued/memory": 1,
 "scheduler/enqueued": 1,
 "scheduler/enqueued/memory": 1,
 "start_time": "2024-06-25T13:35:21.757682+00:00"
}
```