### PR TITLE
Update chorten_pl.py

### DIFF
--- a/locations/spiders/chorten_pl.py
+++ b/locations/spiders/chorten_pl.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class ChortenPLSpider(CrawlSpider):
     name = "chorten_pl"
-    item_attributes = {"brand": "Chorten", "brand_wikidata": "Q48843988"}
+    item_attributes = {}
     start_urls = ["https://chorten.com.pl/sklepy/lista/"]
     rules = [
         Rule(LinkExtractor(allow=[r"/sklepy/lista/p\d+?$"])),

--- a/locations/spiders/chorten_pl.py
+++ b/locations/spiders/chorten_pl.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 
 class ChortenPLSpider(CrawlSpider):
     name = "chorten_pl"
-    item_attributes = {}
+    item_attributes = {"shop": "yes"}
     start_urls = ["https://chorten.com.pl/sklepy/lista/"]
     rules = [
         Rule(LinkExtractor(allow=[r"/sklepy/lista/p\d+?$"])),


### PR DESCRIPTION
not all shops from Chorten franchise are branded

based on 

(a) checking some supposed `brand=Chorten` shops, none was Chorten-branded or having clear indicator of being Chorten franchise

(b) https://pl.wikipedia.org/wiki/Chorten which mentions that shops may keep their names ("jest to tak zwana „miękka [franczyza](https://pl.wikipedia.org/wiki/Franczyza)”[[8]](https://pl.wikipedia.org/wiki/Chorten#cite_note-8). Właściciele sklepów otrzymują wizualizację sklepu wraz z szyldami, ale jednocześnie zachowują własną nazwę sklepu.")