### PR TITLE
[BoxNow] Switch to local proxy

### DIFF
--- a/locations/spiders/box_now.py
+++ b/locations/spiders/box_now.py
@@ -12,7 +12,7 @@ class BoxNowSpider(Spider):
         "https://boxlockersloadfiles.blob.core.windows.net/lockerslargenavigate/all.json",
         "https://boxlockersloadfilescr.blob.core.windows.net/lockerslargenavigate/all.json",
     ]
-    requires_proxy = "BG"
+    # requires_proxy = "BG"
 
     def start_requests(self):
         for url in self.start_urls:

--- a/locations/spiders/box_now.py
+++ b/locations/spiders/box_now.py
@@ -12,7 +12,7 @@ class BoxNowSpider(Spider):
         "https://boxlockersloadfiles.blob.core.windows.net/lockerslargenavigate/all.json",
         "https://boxlockersloadfilescr.blob.core.windows.net/lockerslargenavigate/all.json",
     ]
-    requires_proxy = True
+    requires_proxy = "BG"
 
     def start_requests(self):
         for url in self.start_urls:


### PR DESCRIPTION
This runs fine from my residential GB ip, but `requires_proxy = True` will default to US, it's probably the wrong location for a EU spider.

```python
{'atp/brand/Box Now': 2780,
 'atp/brand_wikidata/Q117195372': 564,
 'atp/brand_wikidata/Q117195375': 618,
 'atp/brand_wikidata/Q117195376': 1598,
 'atp/category/amenity/parcel_locker': 2780,
 'atp/field/city/missing': 2780,
 'atp/field/email/missing': 2780,
 'atp/field/image/missing': 2780,
 'atp/field/opening_hours/missing': 2780,
 'atp/field/operator/missing': 2780,
 'atp/field/operator_wikidata/missing': 2780,
 'atp/field/phone/missing': 2780,
 'atp/field/postcode/missing': 2780,
 'atp/field/state/missing': 2780,
 'atp/field/street_address/missing': 2780,
 'atp/field/twitter/missing': 2780,
 'atp/field/website/missing': 2780,
 'atp/nsi/perfect_match': 2780,
 'downloader/request_bytes': 2102,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 574333,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/400': 3,
 'elapsed_time_seconds': 3.460085,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 27, 12, 25, 7, 649417, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 6,
 'httpcache/miss': 6,
 'httpcache/store': 6,
 'item_scraped_count': 2780,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 166158336,
 'memusage/startup': 166158336,
 'response_received_count': 6,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/400': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 6, 27, 12, 25, 4, 189332, tzinfo=datetime.timezone.utc)}
```