### PR TITLE
[Aarons] Fix spider

### DIFF
--- a/locations/spiders/aarons.py
+++ b/locations/spiders/aarons.py
@@ -33,6 +33,7 @@ class AaronsSpider(SitemapSpider, StructuredDataSpider):
                     "/sony",
                     "/televisions",
                     "/washer-dryer",
+                    "/woodhaven",
                 ]
             ):
                 continue

--- a/locations/spiders/aarons.py
+++ b/locations/spiders/aarons.py
@@ -1,13 +1,39 @@
+from scrapy.spiders import SitemapSpider
+
 from locations.categories import Categories
-from locations.storefinders.yext import YextSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class Aarons(YextSpider):
+class AaronsSpider(SitemapSpider, StructuredDataSpider):
     name = "aarons"
+    sitemap_urls = ["https://locations.aarons.com/robots.txt"]
+    sitemap_rules = [(r"\.com/\w\w/\w\w/[^/]+/[^/]+$", "parse")]
     item_attributes = {"brand": "Aaron's", "brand_wikidata": "Q10397787", "extras": Categories.SHOP_FURNITURE.value}
-    api_key = "62158b834ca95fa3ef64cf0e8327c9c5"
+    drop_attributes = {"name", "image"}
+    wanted_types = ["Store"]
+    search_for_twitter = False
 
-    def parse_item(self, item, location):
-        item.pop("twitter", None)
-        item["extras"].pop("contact:instagram", None)
-        yield item
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            if any(
+                entry["loc"].endswith(s)
+                for s in [
+                    "/ashley-furniture",
+                    "/bedroom-furniture",
+                    "/computers",
+                    "/gaming",
+                    "/ge",
+                    "/hp",
+                    "/lg",
+                    "/living-room-furniture",
+                    "/mattresses",
+                    "/refrigerators",
+                    "/samsung",
+                    "/service-area",
+                    "/sony",
+                    "/televisions",
+                    "/washer-dryer",
+                ]
+            ):
+                continue
+            yield entry


### PR DESCRIPTION
```python
{"atp/brand/Aaron's": 1234,
 'atp/brand_wikidata/Q10397787': 1234,
 'atp/category/shop/furniture': 1234,
 'atp/cdn/cloudflare/response_count': 1237,
 'atp/cdn/cloudflare/response_status_count/200': 1237,
 'atp/field/email/missing': 1234,
 'atp/field/image/missing': 1234,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 1234,
 'atp/field/operator_wikidata/missing': 1234,
 'atp/field/twitter/missing': 1234,
 'atp/nsi/perfect_match': 1234,
 'downloader/request_bytes': 549242,
 'downloader/request_count': 1237,
 'downloader/request_method_count/GET': 1237,
 'downloader/response_bytes': 66352513,
 'downloader/response_count': 1237,
 'downloader/response_status_count/200': 1237,
 'elapsed_time_seconds': 29.450292,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 27, 13, 26, 46, 342240, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1237,
 'httpcompression/response_bytes': 407395885,
 'httpcompression/response_count': 1237,
 'item_scraped_count': 1234,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 166264832,
 'memusage/startup': 166264832,
 'request_depth_max': 2,
 'response_received_count': 1237,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1236,
 'scheduler/dequeued/memory': 1236,
 'scheduler/enqueued': 1236,
 'scheduler/enqueued/memory': 1236,
 'start_time': datetime.datetime(2024, 6, 27, 13, 26, 16, 891948, tzinfo=datetime.timezone.utc)}
```