### PR TITLE
[societe_generale] fix spider

### DIFF
--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -8,7 +8,7 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
     name = "societe_generale"
     item_attributes = {"brand_wikidata": "Q270363"}
     allowed_domains = ["societegenerale.com", "agences.sg.fr"]
-    sitemap_urls = ["https://agences.societegenerale.fr/banque-assurance/sitemap_agence_pois.xml"]
+    sitemap_urls = ["https://agences.sg.fr/banque-assurance/sitemap_agence_pois.xml"]
     sitemap_rules = [("", "parse_sd")]
     download_delay = 0.5
 


### PR DESCRIPTION
Previous sitemap URL was redirecting to another domain which was not present in `allowed_domains`.