### PR TITLE
[REWE DE] Fix spider

### DIFF
--- a/locations/spiders/rewe_de.py
+++ b/locations/spiders/rewe_de.py
@@ -1,17 +1,24 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class REWEDESpider(SitemapSpider, StructuredDataSpider):
     name = "rewe_de"
-    item_attributes = {"brand": "REWE", "brand_wikidata": "Q16968817", "extras": Categories.SHOP_SUPERMARKET.value}
+    item_attributes = {"name": "REWE", "brand": "REWE", "brand_wikidata": "Q16968817"}
     allowed_domains = ["www.rewe.de"]
     sitemap_urls = ["https://www.rewe.de/sitemaps/sitemap-maerkte.xml"]
-    sitemap_rules = [(r"^https:\/\/www\.rewe\.de\/marktseite\/[\w\-]+\/\d+\/[\w\-]+\/$", "parse_sd")]
+    sitemap_rules = [(r"/marktseite/[^/]+/(\d+)/[^/]+/$", "parse_sd")]
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item, response, ld_data):
+        item["name"] = None
         item["street_address"] = item["street_address"].removesuffix(" null")
         item.pop("image", None)
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/REWE': 3732,
 'atp/brand_wikidata/Q16968817': 3732,
 'atp/category/shop/supermarket': 3732,
 'atp/field/country/from_spider_name': 3732,
 'atp/field/email/missing': 3732,
 'atp/field/image/missing': 3732,
 'atp/field/lat/missing': 5,
 'atp/field/lon/missing': 5,
 'atp/field/opening_hours/missing': 29,
 'atp/field/operator/missing': 3732,
 'atp/field/operator_wikidata/missing': 3732,
 'atp/field/phone/missing': 7,
 'atp/field/twitter/missing': 3732,
 'atp/geometry/null_island': 5,
 'atp/nsi/match_failed': 3732,
 'downloader/request_bytes': 5874817,
 'downloader/request_count': 3737,
 'downloader/request_method_count/GET': 3737,
 'downloader/response_bytes': 1635732012,
 'downloader/response_count': 3737,
 'downloader/response_status_count/200': 3734,
 'downloader/response_status_count/502': 3,
 'elapsed_time_seconds': 55.022841,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 28, 11, 37, 17, 793108, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 3737,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/502': 1,
 'item_scraped_count': 3732,
 'log_count/ERROR': 1,
 'log_count/INFO': 13,
 'log_count/WARNING': 24,
 'memusage/max': 169115648,
 'memusage/startup': 169115648,
 'request_depth_max': 1,
 'response_received_count': 3735,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/502 Bad Gateway': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3736,
 'scheduler/dequeued/memory': 3736,
 'scheduler/enqueued': 3736,
 'scheduler/enqueued/memory': 3736,
 'start_time': datetime.datetime(2024, 6, 28, 11, 36, 22, 770267, tzinfo=datetime.timezone.utc)}
```