### PR TITLE
Add contacts attribute on spider

### DIFF
--- a/locations/spiders/tomtom.py
+++ b/locations/spiders/tomtom.py
@@ -4,3 +4,4 @@ from locations.storefinders.alltheplaces import AllThePlacesSpider
 class TomTomSpider(AllThePlacesSpider):
     name = "tomtom"
     start_urls = ["https://download.tomtom.com/open/fcd/pois.json"]
+    contacts = ["office-pois@groups.tomtom.com"]


### PR DESCRIPTION
I've been vocal in that some brands should be looking after their own spiders, when they are, we should document a contact method for them. In theory it could be plumed in to email them automatically when there is an issue with a spider.