### PR TITLE
[BestAndLess AU] Fix spider

### DIFF
--- a/locations/spiders/best_and_less_au.py
+++ b/locations/spiders/best_and_less_au.py
@@ -1,6 +1,7 @@
+from typing import Iterable
 from urllib.parse import quote
 
-from scrapy import Spider
+from scrapy import Request, Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
@@ -11,19 +12,19 @@ from locations.pipelines.address_clean_up import clean_address
 class BestAndLessAUSpider(Spider):
     name = "best_and_less_au"
     item_attributes = {"brand": "Best & Less", "brand_wikidata": "Q4896542"}
-    allowed_domains = ["www.bestandless.com.au"]
-    start_urls = [
-        f"https://prodapi.bestandless.com.au/occ/v2/bnlsite/stores/location/{state}?fields=FULL"
-        for state in ["ACT", "NSW", "NT", "QLD", "SA", "TAS", "VIC", "WA"]
-    ]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def make_request(self, page: int) -> JsonRequest:
+        return JsonRequest(
+            url="https://prodapi.bestandless.com.au/occ/v2/bnlsite/stores?fields=FULL&currentPage={}".format(page)
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(0)
 
     def parse(self, response):
         for location in response.json()["stores"]:
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
             item["ref"] = location["address"]["id"]
             item["addr_full"] = location["address"].get("formattedAddress")
             item["street_address"] = clean_address([location["address"].get("line1"), location["address"].get("line2")])
@@ -44,3 +45,7 @@ class BestAndLessAUSpider(Spider):
                     "%I:%M %p",
                 )
             yield item
+
+        pagination = response.json()["pagination"]
+        if pagination["currentPage"] < pagination["totalPages"]:
+            yield self.make_request(pagination["currentPage"] + 1)


### PR DESCRIPTION
```python
{'atp/brand/Best & Less': 190,
 'atp/brand_wikidata/Q4896542': 190,
 'atp/category/shop/clothes': 190,
 'atp/field/email/missing': 187,
 'atp/field/image/missing': 190,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 190,
 'atp/field/operator_wikidata/missing': 190,
 'atp/field/twitter/missing': 190,
 'atp/nsi/perfect_match': 190,
 'downloader/request_bytes': 5307,
 'downloader/request_count': 12,
 'downloader/request_method_count/GET': 12,
 'downloader/response_bytes': 44348,
 'downloader/response_count': 12,
 'downloader/response_status_count/200': 11,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.761716,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 6, 28, 14, 22, 11, 164318, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 12,
 'httpcompression/response_bytes': 731182,
 'httpcompression/response_count': 11,
 'item_scraped_count': 190,
 'log_count/DEBUG': 215,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 165588992,
 'memusage/startup': 165588992,
 'request_depth_max': 10,
 'response_received_count': 12,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 11,
 'scheduler/dequeued/memory': 11,
 'scheduler/enqueued': 11,
 'scheduler/enqueued/memory': 11,
 'start_time': datetime.datetime(2024, 6, 28, 14, 22, 9, 402602, tzinfo=datetime.timezone.utc)}
```