### PR TITLE
fix Castorama names

### DIFF
--- a/locations/spiders/castorama_pl.py
+++ b/locations/spiders/castorama_pl.py
@@ -16,3 +16,12 @@ class CastoramaPLSpider(CrawlSpider, StructuredDataSpider):
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["image"] = None
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "name" in item:
+            item["extras"]["web_listing_name"] = item["name"]
+        if "brand" in item:
+            item["name"] = item["brand"]
+        else:
+            item["name"] = "Castorama"
+        yield item


### PR DESCRIPTION
fixes #8658 - and closes #8608 as it would be treated as a mistake

I though about putting them into `branch` but these, as far as I checked, are not even real branch names

I guess that just dropping them would be possible?