### PR TITLE
[vhl_de] fix spider, use name from NSI

### DIFF
--- a/locations/spiders/vlh_de.py
+++ b/locations/spiders/vlh_de.py
@@ -1,6 +1,8 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_DE, OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -10,30 +12,42 @@ class vhlDESpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = [
         "https://www.vlh.de/sitemap.bst.xml",
     ]
-    sitemap_rules = [(r"/\d+/Oeffnungszeiten.html$", "parse_sd")]
+    sitemap_rules = [(r"\/bst\/\d+\/*$", "parse_sd")]
 
-    def post_process_item(self, item, response, ld_data):
+    def post_process_item(self, item: Feature, response: Response, ld_data):
         item.pop("image", None)
         item["phone"] = ld_data["telephone"]
-        item["website"] = item["website"].replace("Oeffnungszeiten.html", "")
-        item["name"] = response.xpath("/html/head/title/text()").get().replace("Öffnungszeiten | ", "")
-
-        opening_hours = self.parse_opening_hours(response)
-
-        if opening_hours:
-            item["opening_hours"] = opening_hours
+        item["name"] = None  # It's cleaner to just use name from NSI
+        self.parse_opening_hours(item, response)
         yield item
 
-    def parse_opening_hours(self, response):
-        opening_hours = OpeningHours()
+    def parse_opening_hours(self, item: Feature, response: Response):
+        try:
+            table = response.xpath('//table[@class="table time-table"]')
+            if table:
+                # It can be two tables, first is actual hours, second is phone availability hours
+                table = table[0]
+            else:
+                return
 
-        table = response.xpath('//table[@id="office-hours-table"]')
-        for row in table.xpath("./tr"):
-            day = row.xpath("./td/text()").extract()[0]
-            times = row.xpath("./td/text()").extract()[1:]
+            oh = OpeningHours()
 
-            for time in times:
-                open_time, close_time = time.split(" - ")
-                opening_hours.add_range(DAYS_DE.get(day.title()), open_time.strip(), close_time.strip())
+            for row in table.xpath("./tr"):
+                day = row.xpath("./td/text()").extract()[0]
+                times = row.xpath("./td/text()").extract()[1:]
 
-        return opening_hours
+                for time in times:
+                    time.strip()
+                    time = time.replace("Uhr", "")
+                    if not time:
+                        continue
+
+                    open_time, close_time = time.split(" - ")
+                    day = day.replace(":", "")
+                    oh.add_range(DAYS_DE.get(day.title()), open_time.strip(), close_time.strip())
+
+            item["opening_hours"] = oh.as_opening_hours()
+
+        except Exception as e:
+            self.logger.warning(f'Failed to parse opening hours for {item["ref"]}, {e}')
+            self.crawler.stats.inc_value(f"atp/{self.name}/hours/failed")


### PR DESCRIPTION
Sitemap was changed as well as some html tags on individual pages. I also preferred name from NSI, <title> has it just as brand name + address e.g. `Beratungsstelle der Vereinigten Lohnsteuerhilfe  Apolda 99510, Goldgasse 7`.

```json
{
 "atp/brand/Vereinigte Lohnsteuerhilfe": 2950,
 "atp/brand_wikidata/Q15852617": 2950,
 "atp/category/office/tax_advisor": 2950,
 "atp/field/country/from_spider_name": 2950,
 "atp/field/image/missing": 2950,
 "atp/field/opening_hours/missing": 1296,
 "atp/field/operator/missing": 2950,
 "atp/field/operator_wikidata/missing": 2950,
 "atp/field/phone/missing": 33,
 "atp/field/state/missing": 2950,
 "atp/field/twitter/missing": 2950,
 "atp/nsi/perfect_match": 2950,
 "downloader/request_bytes": 1018717,
 "downloader/request_count": 2952,
 "downloader/request_method_count/GET": 2952,
 "downloader/response_bytes": 40004924,
 "downloader/response_count": 2952,
 "downloader/response_status_count/200": 2952,
 "elapsed_time_seconds": 3063.913824,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-07-01T16:35:57.257508+00:00",
 "httpcache/firsthand": 2514,
 "httpcache/hit": 438,
 "httpcache/miss": 2514,
 "httpcache/store": 2514,
 "httpcompression/response_bytes": 214381343,
 "httpcompression/response_count": 2952,
 "item_scraped_count": 2950,
 "log_count/INFO": 61,
 "memusage/max": 326008832,
 "memusage/startup": 161923072,
 "request_depth_max": 1,
 "response_received_count": 2952,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2951,
 "scheduler/dequeued/memory": 2951,
 "scheduler/enqueued": 2951,
 "scheduler/enqueued/memory": 2951,
 "start_time": "2024-07-01T15:44:53.343684+00:00"
}
```