### PR TITLE
[Virsi LV] Add spider

### DIFF
--- a/locations/spiders/virsi_lv.py
+++ b/locations/spiders/virsi_lv.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class VirsiLVSpider(Spider):
+    name = "virsi_lv"
+    item_attributes = {"brand": "Virši", "brand_wikidata": "Q50378789"}
+    start_urls = ["https://www.virsi.lv/en/private/gas-stations/data"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["stations"]:
+            item = DictParser.parse(location)
+            item["state"] = None
+            item["branch"] = item.pop("name").removeprefix("Virši ")
+
+            services = [s["title"] for s in location["services"]]
+
+            apply_yes_no(Fuel.CNG, item, "CNG" in services)
+            apply_yes_no(Fuel.OCTANE_98, item, "98" in services)
+            apply_yes_no(Fuel.OCTANE_95, item, "95E" in services)
+            apply_yes_no(Fuel.DIESEL, item, "Diesel" in services)
+            apply_yes_no(Fuel.ADBLUE, item, "AdBlue" in services)
+            apply_yes_no(Extras.CAR_WASH, item, "Car wash" in services)
+            apply_yes_no(Extras.TOILETS, item, "WC" in services)
+            apply_yes_no(Extras.WIFI, item, "WiFi" in services)
+            apply_yes_no(Extras.COMPRESSED_AIR, item, "Air" in services)
+
+            apply_category(Categories.FUEL_STATION, item)
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9660

```python
{'atp/brand/Virši': 78,
 'atp/brand_wikidata/Q50378789': 78,
 'atp/category/amenity/fuel': 78,
 'atp/field/city/missing': 78,
 'atp/field/country/from_spider_name': 78,
 'atp/field/email/missing': 77,
 'atp/field/image/missing': 78,
 'atp/field/name/missing': 78,
 'atp/field/opening_hours/missing': 78,
 'atp/field/operator/missing': 78,
 'atp/field/operator_wikidata/missing': 78,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 78,
 'atp/field/state/missing': 78,
 'atp/field/street_address/missing': 78,
 'atp/field/twitter/missing': 78,
 'atp/field/website/missing': 78,
 'atp/nsi/brand_missing': 78,
 'downloader/request_bytes': 624,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 45513,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.544172,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 2, 7, 1, 27, 743583, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 332456,
 'httpcompression/response_count': 1,
 'item_scraped_count': 78,
 'log_count/DEBUG': 92,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 164343808,
 'memusage/startup': 164343808,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 2, 7, 1, 27, 199411, tzinfo=datetime.timezone.utc)}
```