### PR TITLE
[BurgerKing CZ] Fix allowed domains

### DIFF
--- a/locations/spiders/burger_king_cz.py
+++ b/locations/spiders/burger_king_cz.py
@@ -14,7 +14,7 @@ from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 class BurgerKingCZSpider(Spider):
     name = "burger_king_cz"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    allowed_domains = ["burgerking.cz"]
+    allowed_domains = ["czqk28jt.api.sanity.io"]
     db = "prod_bk_cz"
     base = "https://burgerking.cz/store-locator/store/"
 


### PR DESCRIPTION
Weirdly `allowed_domains` isn't enforced in `start_requests` for me locally, however it appears that's not the case in the weekly.