### PR TITLE
fix #8740 - keep shared phone out of phone tag

### DIFF
--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -47,9 +47,9 @@ class NatWestGBSpider(Spider):
             item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
             item["extras"]["ref:facebook"] = location.get("" "facebookPageUrl", "").split("/")[-1]
             item["extras"]["ref:google"] = location["googlePlaceId"]
+
             if "phone" in item and item["phone"].startswith("+443"):
                 # not a phone number specific to given branch
-                item["extras"]["callcenter_phone"] = item["phone"]
                 item["phone"] = None
 
             item["opening_hours"] = OpeningHours()

--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -47,6 +47,10 @@ class NatWestGBSpider(Spider):
             item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
             item["extras"]["ref:facebook"] = location.get("" "facebookPageUrl", "").split("/")[-1]
             item["extras"]["ref:google"] = location["googlePlaceId"]
+            if "phone" in item and item["phone"].startswith("+443"):
+                # not a phone number specific to given branch
+                item["extras"]["callcenter_phone"] = item["phone"]
+                item["phone"] = None
 
             item["opening_hours"] = OpeningHours()
             for day, rule in location["hours"].items():


### PR DESCRIPTION
"The telephone number for the venue" in https://github.com/alltheplaces/alltheplaces/blob/master/DATA_FORMAT.md promises venue-specific one

Note: `callcenter_phone` is something that I invented on the spot