### PR TITLE
[Hours] Drop empty OpeningHours before DEBUG logging and the exporter

### DIFF
--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -92,12 +92,13 @@ class CheckItemPropertiesPipeline:
         else:
             spider.crawler.stats.inc_value("atp/field/twitter/missing")
 
-        if opening_hours := item.get("opening_hours"):
+        opening_hours = item.get("opening_hours")
+        if opening_hours is not None:
             if isinstance(opening_hours, OpeningHours):
                 if opening_hours:
                     item["opening_hours"] = opening_hours.as_opening_hours()
                 else:
-                    item["opening_hours"] = None
+                    del item["opening_hours"]
                     spider.crawler.stats.inc_value("atp/field/opening_hours/missing")
             elif not isinstance(opening_hours, str):
                 spider.crawler.stats.inc_value("atp/field/opening_hours/wrong_type")


### PR DESCRIPTION
For a while now, we've been able to output either a string or a `OpeningHours` object. Using the object allows us to skip validation in the pipeline. However recently empty `OpeningHours` have been showing up as a class in DEBUG output:

```python
{'extras': {'@spider': 'test_1'},
 'opening_hours': <locations.hours.OpeningHours object at 0x738cf5f9bfe0>,
 'ref': 'none_null'}
```

In #8631 `OpeningHours` was given `__bool__`. This is good, and behaves as I'd expect, False when there is no data, and True when there is someing to output. However it also tricks me, eg the following exception will never happen:

```python
        item["opening_hours"] = OpeningHours()
        if item.get("opening_hours"):
            raise Exception()  # Never gonna happen
```

It also tricks the pipeline, empty `OpeningHours` fails the `if` (was line 95), triggers the `atp/field/opening_hours/missing` stat (was line 107), but we wipe the empty class so it goes through the debug log and out to the exporter.

With this patch, we step into the `if` on 96, then again on 97, but then we fail 98, so count `atp/field/opening_hours/missing` and the `OpeningHours` object is gone before the debug log or exporter.

```python
{'extras': {'@spider': 'test_1'}, 'ref': 'none_null'}
```