### PR TITLE
[Hours] Update regex pattern to allow closed days

### DIFF
--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -36,7 +36,7 @@ class CheckItemPropertiesPipeline:
         r"^Q[0-9]+$",
     )
     opening_hours_regex = re.compile(
-        r"^(?:(?:Mo|Tu|We|Th|Fr|Sa|Su)(?:-(?:Mo|Tu|We|Th|Fr|Sa|Su))? (?:,?[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2})+(?:; )?)+$"
+        r"^(?:(?:Mo|Tu|We|Th|Fr|Sa|Su)(?:-(?:Mo|Tu|We|Th|Fr|Sa|Su))? (?:,?[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}|closed|off)+(?:; )?)+$"
     )
     min_lat = -90.0
     max_lat = 90.0


### PR DESCRIPTION
There has been an increase of `atp/field/opening_hours/invalid`, not because we output more broken hours (still just wellsfargo, vivacom_bg and fantastiko_bg), but because we now output closed days. I've updated the regex, but this is regex and OSM opening hours are far more complex. Up until now I've had a soft preference for outputting `OpeningHours` directly, not a string, so we can skip the regex test. I want this to now be a strong recommendation for everyone, no more `.as_opening_hours()` without a good reason.