### PR TITLE
[Hours] Stop outputting 24/7

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -786,22 +786,17 @@ class OpeningHours:
         day_groups.append(this_day_group)
 
         opening_hours = ""
-        if len(day_groups) == 1 and day_groups[0]["hours"] in (
-            "00:00-24:00",
-            "00:00-00:00",
-        ):
-            opening_hours = "24/7"
-        else:
-            for day_group in day_groups:
-                if not day_group["hours"]:
-                    continue
-                elif day_group["from_day"] == day_group["to_day"]:
-                    opening_hours += "{from_day} {hours}; ".format(**day_group)
-                elif day_group["from_day"] == "Su" and day_group["to_day"] == "Sa":
-                    opening_hours += "{hours}; ".format(**day_group)
-                else:
-                    opening_hours += "{from_day}-{to_day} {hours}; ".format(**day_group)
-            opening_hours = opening_hours[:-2]
+
+        for day_group in day_groups:
+            if not day_group["hours"]:
+                continue
+            elif day_group["from_day"] == day_group["to_day"]:
+                opening_hours += "{from_day} {hours}; ".format(**day_group)
+            elif day_group["from_day"] == "Su" and day_group["to_day"] == "Sa":
+                opening_hours += "{hours}; ".format(**day_group)
+            else:
+                opening_hours += "{from_day}-{to_day} {hours}; ".format(**day_group)
+        opening_hours = opening_hours[:-2]
 
         return opening_hours
 

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -528,3 +528,17 @@ def test_add_ranges_from_string():
         DAYS_PL,
     )
     assert o.as_opening_hours() == "Mo-Fr 08:00-19:00; Sa 09:00-15:00"
+
+
+def test_oh_as_bool():
+    # https://github.com/alltheplaces/alltheplaces/pull/8779#issue-2395034394
+    o = OpeningHours()
+    assert not o
+
+    o = OpeningHours()
+    o.add_range("Mo", "09:00", "17:00")
+    assert o
+
+    o = OpeningHours()
+    o.set_closed("Mo")
+    assert o

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -99,7 +99,7 @@ def test_twentyfour_seven():
     o.add_range("Sa", "0:00", "23:59")
     o.add_range("Su", "0:00", "23:59")
 
-    assert o.as_opening_hours() == "24/7"
+    assert o.as_opening_hours() == "Mo-Su 00:00-24:00"
 
 
 def test_no_opening_hours():
@@ -458,7 +458,7 @@ def test_add_ranges_from_string():
 
     o = OpeningHours()
     o.add_ranges_from_string("Monday - Sunday: 00:00 - 23:59")
-    assert o.as_opening_hours() == "24/7"
+    assert o.as_opening_hours() == "Mo-Su 00:00-24:00"
 
     o = OpeningHours()
     o.add_ranges_from_string("Monday: 08:00 - Midday, 14:00 - Midnight   tue-sat: Midnight-0800")


### PR DESCRIPTION
Fixes #6537

As mentioned before `opening_hours=24/7` actually means `opening_hours=Mo-Su,PH 00:00-24:00`, but we don't (and never will) collect `PH`. We probably will collect specific days in the future.