### PR TITLE
[USGS monitoring station] Add spider

### DIFF
--- a/locations/spiders/usgs_monitoring_station.py
+++ b/locations/spiders/usgs_monitoring_station.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.items import Feature
+
+
+class UsgsMonitoringStationUSSpider(Spider):
+    name = "usgs_monitoring_station_us"
+    item_attributes = {
+        "operator": "United States Geological Survey",
+        "operator_wikidata": "Q193755",
+        "extras": {"man_made": "monitoring_station"},
+        "nsi_id": "N/A",
+    }
+    start_urls = [
+        "https://dashboard.waterdata.usgs.gov/service/cwis/1.0/odata/CurrentConditions?$top=15000&$filter=(AccessLevelCode%20eq%20%27P%27)%20and%20(SiteTypeCode%20%20in%20(%27ST%27%2C%27ST-CA%27%2C%27ST-DCH%27%2C%27ST-TS%27))%20and%20(ParameterCode%20in%20(%2730208%27%2C%2730209%27%2C%2750042%27%2C%2750050%27%2C%2750051%27%2C%2772137%27%2C%2772138%27%2C%2772139%27%2C%2772177%27%2C%2772243%27%2C%2774072%27%2C%2781395%27%2C%2799060%27%2C%2799061%27%2C%2700056%27%2C%2700058%27%2C%2700059%27%2C%2700060%27%2C%2700061%27))&$select=AgencyCode,SiteNumber,SiteName,SiteTypeCode,Latitude,Longitude,CurrentConditionID,ParameterCode,TimeLocal,TimeZoneCode,Value,ValueFlagCode,RateOfChangeUnitPerHour,StatisticStatusCode,FloodStageStatusCode&$orderby=SiteNumber,AgencyCode,ParameterCode,TimeLocal%20desc&caller=National%20Water%20Dashboard%20default"
+    ]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["value"]:
+            item = Feature()
+            item["ref"] = location["SiteNumber"]
+            item["name"] = location["SiteName"]
+            item["lat"] = location["Latitude"]
+            item["lon"] = location["Longitude"]
+            item["website"] = "https://waterdata.usgs.gov/monitoring-location/{}/".format(location["SiteNumber"])
+            item["extras"]["SiteTypeCode"] = location["SiteTypeCode"]
+
+            yield item
+            self.crawler.stats.inc_value("z/SiteTypeCode/{}".format(location["SiteTypeCode"]))


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/9705

```python
{'atp/category/man_made/monitoring_station': 8850,
 'atp/field/brand/missing': 8850,
 'atp/field/brand_wikidata/missing': 8850,
 'atp/field/city/missing': 8850,
 'atp/field/country/from_spider_name': 8850,
 'atp/field/email/missing': 8850,
 'atp/field/image/missing': 8850,
 'atp/field/opening_hours/missing': 8850,
 'atp/field/phone/missing': 8850,
 'atp/field/postcode/missing': 8850,
 'atp/field/state/from_reverse_geocoding': 8850,
 'atp/field/state/missing': 153,
 'atp/field/street_address/missing': 8850,
 'atp/field/twitter/missing': 8850,
 'atp/operator/United States Geological Survey': 8850,
 'atp/operator_wikidata/Q193755': 8850,
 'downloader/request_bytes': 1424,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 3527722,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.721708,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 9, 16, 1, 0, 813317, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'item_dropped_count': 67,
 'item_dropped_reasons_count/DropItem': 67,
 'item_scraped_count': 8850,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 171880448,
 'memusage/startup': 171880448,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 9, 16, 0, 58, 91609, tzinfo=datetime.timezone.utc),
 'z/SiteTypeCode/ST': 8679,
 'z/SiteTypeCode/ST-CA': 163,
 'z/SiteTypeCode/ST-DCH': 36,
 'z/SiteTypeCode/ST-TS': 39}
```