### PR TITLE
[upsstore] fix spider, convert to SitemapSpider

### DIFF
--- a/locations/spiders/upsstore.py
+++ b/locations/spiders/upsstore.py
@@ -8,4 +8,5 @@ class UpsStoreSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "UPS Store", "brand_wikidata": "Q7771029"}
     allowed_domains = ["locations.theupsstore.com"]
     sitemap_urls = ["https://locations.theupsstore.com/sitemap.xml"]
-    sitemap_rules = [(r"\/[a-z]{2}\/[a-z]+\/\d+-[a-z-]+$", "parse_sd")]
+    sitemap_rules = [(r"https:\/\/locations.theupsstore.com\/[a-z]{2}\/[a-z]+\/\d+-[a-z-]+$", "parse_sd")]
+    download_delay = 0.5

--- a/locations/spiders/upsstore.py
+++ b/locations/spiders/upsstore.py
@@ -1,103 +1,11 @@
-import json
-import re
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import Feature
-
-DAY_MAPPING = {
-    "MONDAY": "Mo",
-    "TUESDAY": "Tu",
-    "WEDNESDAY": "We",
-    "THURSDAY": "Th",
-    "FRIDAY": "Fr",
-    "SATURDAY": "Sa",
-    "SUNDAY": "Su",
-}
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class UpsStoreSpider(scrapy.Spider):
+class UpsStoreSpider(SitemapSpider, StructuredDataSpider):
     name = "upsstore"
     item_attributes = {"brand": "UPS Store", "brand_wikidata": "Q7771029"}
-    allowed_domains = ["theupsstore.com"]
-    download_delay = 0.1
-    start_urls = ("https://locations.theupsstore.com/",)
-
-    def parse_hours(self, hours):
-        """
-        :param hours:
-        :return:
-        """
-        hours = json.loads(hours)
-        o = OpeningHours()
-
-        for day in hours["hours"]["days"]:
-            if not day["isClosed"]:
-                interval = day["intervals"][0]
-
-                o.add_range(
-                    DAY_MAPPING[day["day"]],
-                    open_time=str(interval["start"]),
-                    close_time=str(interval["end"]),
-                    time_format="%H%M",
-                )
-        return o.as_opening_hours()
-
-    def parse_store(self, response):
-        if "Permanently Closed" in response.text:
-            return
-
-        ref = response.xpath('//input[@id="store_id"]/@value').extract_first()
-        if not ref:
-            ref = re.search(
-                r"store(\d+)@theupsstore.com",
-                response.xpath('//a[@itemprop="email"]/text()').extract_first(),
-            ).group(0)
-
-        properties = {
-            "name": response.xpath('//span[@class="LocationName-geo"]/text()').extract_first(),
-            "phone": response.xpath('//span[@itemprop="telephone"]/text()').extract_first(),
-            "addr_full": response.xpath('//meta[@itemprop="streetAddress"]/@content').extract_first(),
-            "city": response.xpath('//meta[@itemprop="addressLocality"]/@content').extract_first(),
-            "state": response.xpath('//abbr[@itemprop="addressRegion"]/text()').extract_first(),
-            "country": response.xpath('//abbr[@itemprop="addressCountry"]/text()').extract_first(),
-            "postcode": response.xpath('//span[@itemprop="postalCode"]/text()').extract_first(),
-            "ref": ref,
-            "website": response.url,
-            "lat": float(response.xpath('//meta[@itemprop="latitude"]/@content').extract_first()),
-            "lon": float(response.xpath('//meta[@itemprop="longitude"]/@content').extract_first()),
-        }
-
-        hours = response.xpath('//script[@id="location_info_hours"]/text()').extract_first()
-        try:
-            hours = self.parse_hours(hours)
-            if hours:
-                properties["opening_hours"] = hours
-        except Exception:
-            pass
-
-        yield Feature(**properties)
-
-    def parse(self, response):
-        urls = response.xpath('//a[@class="Directory-listLink"]/@href').extract()
-
-        if urls:
-            for url in urls:
-                if len(url.split("/")) == 3:
-                    callback = self.parse_store
-                else:
-                    callback = self.parse
-
-                yield scrapy.Request(
-                    response.urljoin(url),
-                    callback=callback,
-                )
-
-        else:
-            urls = response.xpath('//a[@class="Link"]/@href').extract()
-            for url in urls:
-                yield scrapy.Request(
-                    response.urljoin(url),
-                    callback=self.parse_store,
-                )
+    allowed_domains = ["locations.theupsstore.com"]
+    sitemap_urls = ["https://locations.theupsstore.com/sitemap.xml"]
+    sitemap_rules = [(r"\/[a-z]{2}\/[a-z]+\/\d+-[a-z-]+$", "parse_sd")]


### PR DESCRIPTION
I did a quick check and was not able to find any stores that are closed, so assume that the website gives only operational stores.

Stats:

```json
{
 "atp/brand/UPS Store": 3221,
 "atp/brand_wikidata/Q7771029": 3221,
 "atp/category/amenity/post_office": 3221,
 "atp/category/multiple": 3221,
 "atp/cdn/cloudflare/response_count": 3258,
 "atp/cdn/cloudflare/response_status_count/200": 3258,
 "atp/closed_check": 1,
 "atp/field/lat/missing": 7,
 "atp/field/lon/missing": 7,
 "atp/field/operator/missing": 3221,
 "atp/field/operator_wikidata/missing": 3221,
 "atp/field/phone/missing": 129,
 "atp/field/twitter/missing": 46,
 "atp/nsi/perfect_match": 3221,
 "downloader/request_bytes": 1824991,
 "downloader/request_count": 3258,
 "downloader/request_method_count/GET": 3258,
 "downloader/response_bytes": 145656195,
 "downloader/response_count": 3258,
 "downloader/response_status_count/200": 3258,
 "elapsed_time_seconds": 1969.901533,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-07-10T09:19:10.320700+00:00",
 "httpcache/firsthand": 3221,
 "httpcache/hit": 37,
 "httpcache/miss": 3221,
 "httpcache/store": 3221,
 "httpcompression/response_bytes": 810766440,
 "httpcompression/response_count": 3258,
 "item_scraped_count": 3221,
 "log_count/INFO": 42,
 "log_count/WARNING": 1,
 "memusage/max": 638599168,
 "memusage/startup": 157974528,
 "request_depth_max": 2,
 "response_received_count": 3258,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 3257,
 "scheduler/dequeued/memory": 3257,
 "scheduler/enqueued": 3257,
 "scheduler/enqueued/memory": 3257,
 "start_time": "2024-07-10T08:46:20.419167+00:00"
}
```