### PR TITLE
[a101_tr] add spider (5k locations)

### DIFF
--- a/locations/spiders/a101.py
+++ b/locations/spiders/a101.py
@@ -1,0 +1,31 @@
+import json
+from base64 import b64encode
+from typing import Iterable
+
+import scrapy
+from pygeohash import encode
+
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+
+
+class A101TRSpider(scrapy.Spider):
+    # TODO: the spider is giving an incomplete output, 5k locations instead of 13k, due to a hard limit of 20 locations per request
+    name = "a101_tr"
+    item_attributes = {"brand": "A101", "brand_wikidata": "Q6034496"}
+
+    def start_requests(self) -> Iterable[scrapy.Request]:
+        for city in city_locations("TR"):
+            data = {"geoHash": encode(city.get("latitude"), city.get("longitude"), precision=5)}
+            data = b64encode(json.dumps(data).encode("utf-8"))
+            data = data.decode("utf-8")  # convert bytes back to string
+            self.logger.info(f"{data}")
+            url_template = "https://api-bp.a101prod.retter.io/dbmk89vnr/CALL/StoreContentManager/nearestStores/default?__culture=tr-TR&__platform=web&data={}&__isbase64=true"
+            # TODO: /dbmk89vnr/ part of the url may not be constant
+            yield scrapy.Request(url=url_template.format(data), callback=self.parse)
+
+    def parse(self, response):
+        for poi in response.json().get("stores", []):
+            item = DictParser.parse(poi)
+            item["street_address"] = item.pop("addr_full")
+            yield item

--- a/locations/spiders/a101.py
+++ b/locations/spiders/a101.py
@@ -10,7 +10,9 @@ from locations.geo import city_locations
 
 
 class A101TRSpider(scrapy.Spider):
-    # TODO: the spider is giving an incomplete output, 5k locations instead of 13k, due to a hard limit of 20 locations per request
+    # TODO: due to a hard limit of 20 locations per request
+    #       the spider is giving an incomplete output,
+    #       5k locations instead of 13k.
     name = "a101_tr"
     item_attributes = {"brand": "A101", "brand_wikidata": "Q6034496"}
 


### PR DESCRIPTION
I'll comeback at some point to try to collect more locations.

```json
{
 "atp/brand/A101": 5545,
 "atp/brand_wikidata/Q6034496": 5545,
 "atp/category/shop/supermarket": 5545,
 "atp/field/email/missing": 5545,
 "atp/field/image/missing": 5545,
 "atp/field/opening_hours/missing": 5545,
 "atp/field/operator/missing": 5545,
 "atp/field/operator_wikidata/missing": 5545,
 "atp/field/phone/missing": 5545,
 "atp/field/postcode/missing": 5545,
 "atp/field/state/missing": 2,
 "atp/field/twitter/missing": 5545,
 "atp/field/website/missing": 5545,
 "atp/nsi/perfect_match": 5545,
 "downloader/request_bytes": 177740,
 "downloader/request_count": 395,
 "downloader/request_method_count/GET": 395,
 "downloader/response_bytes": 729082,
 "downloader/response_count": 395,
 "downloader/response_status_count/200": 392,
 "downloader/response_status_count/500": 3,
 "elapsed_time_seconds": 477.383197,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-07-10T15:45:20.613549+00:00",
 "httpcache/firsthand": 392,
 "httpcache/hit": 3,
 "httpcache/miss": 392,
 "httpcache/store": 392,
 "httpcompression/response_bytes": 1634914,
 "httpcompression/response_count": 392,
 "item_dropped_count": 2046,
 "item_dropped_reasons_count/DropItem": 2046,
 "item_scraped_count": 5545,
 "log_count/ERROR": 1,
 "log_count/INFO": 17,
 "memusage/max": 457818112,
 "memusage/startup": 160743424,
 "response_received_count": 393,
 "retry/count": 2,
 "retry/max_reached": 1,
 "retry/reason_count/500 Internal Server Error": 2,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/500": 1,
 "scheduler/dequeued": 392,
 "scheduler/dequeued/memory": 392,
 "scheduler/enqueued": 392,
 "scheduler/enqueued/memory": 392,
 "start_time": "2024-07-10T15:37:23.230352+00:00"
}
```