### PR TITLE
[Zaxbys US] Drop opening hours

### DIFF
--- a/locations/spiders/zaxbys_us.py
+++ b/locations/spiders/zaxbys_us.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -11,6 +12,8 @@ class ZaxbysUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"\/locations\/[a-z]{2}\/[\w\-]+\/[\w\-]+\/?$", "parse_sd")]
     wanted_types = ["Restaurant"]
     custom_settings = {"REDIRECT_ENABLED": False}
+    search_for_facebook = False
+    search_for_twitter = False
 
     def sitemap_filter(self, entries):
         for entry in entries:
@@ -20,7 +23,10 @@ class ZaxbysUSSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data):
         if "undefined" in item["website"]:
             return
+        if "Closed" in item["name"]:
+            set_closed(item)
+        item["branch"] = item.pop("name")
         item.pop("image")
-        item.pop("facebook")
-        item.pop("twitter")
+        item.pop("opening_hours")
+
         yield item


### PR DESCRIPTION
Fixes #8806

The data in the ld is always `opening_hours=Mo-Su 10:30-23:00`. Probably a templating issue with them. Actual opening hours are only available via an API call to `https://zapi.zaxbys.com/v1/stores/174855/calendars?from=2024-07-10&to=2024-07-16`