### PR TITLE
[dominos_pizza_in] Fixed spider as all store pages keep return 500 (588 items)

### DIFF
--- a/locations/spiders/dominos_pizza_in.py
+++ b/locations/spiders/dominos_pizza_in.py
@@ -1,15 +1,68 @@
+import logging
+
+from scrapy import Request
 from scrapy.spiders import SitemapSpider
+from scrapy.utils.sitemap import Sitemap
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+
+logger = logging.getLogger(__name__)
 
 
-class DominiosINSpider(SitemapSpider, StructuredDataSpider):
+class DominiosINSpider(SitemapSpider):
     name = "dominos_pizza_in"
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     sitemap_urls = ["https://www.dominos.co.in/store-locations/sitemap_store.xml"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["addr_full"] = item.pop("street_address")
-        item["name"] = None
+    def _parse_sitemap(self, response):
+        body = self._get_sitemap_body(response)
+        if body is None:
+            logger.warning(
+                "Ignoring invalid sitemap: %(response)s",
+                {"response": response},
+                extra={"spider": self},
+            )
+            return
+
+        s = Sitemap(body)
+        it = self.sitemap_filter(s)
+
+        if s.type == "sitemapindex":
+            for loc in iterloc(it, self.sitemap_alternate_links):
+                if any(x.search(loc) for x in self._follow):
+                    yield Request(loc, callback=self._parse_sitemap)
+        elif s.type == "urlset":
+            for loc in iterloc(it, self.sitemap_alternate_links):
+                for r, c in self._cbs:
+                    if r.search(loc):
+                        loc = loc.replace("store-locations", "store-location")
+                        yield Request(loc, callback=self.parse)
+                        break
+
+    def parse(self, response):
+        item = Feature()
+        item["ref"] = response.url
+        overview_tab = response.xpath('//div[@id="Overview-tab"]')
+        columns = overview_tab.xpath('.//div[@class="mbot"]')
+        for idx, column in enumerate(columns):
+            if idx == 0:
+                phone_path = column.xpath('.//div[not(@class="clear")]')[0]
+                item["phone"] = phone_path.xpath(".//p/text()").extract_first()
+            elif idx == 1:
+                address_coord_path = column.xpath('.//div[not(@class="clear")]')[1]
+                item["addr_full"] = address_coord_path.xpath(".//p/text()").extract_first()
+                anchors = address_coord_path.xpath(".//a/@href").extract()
+                for anchor in anchors:
+                    if "google.com/maps" in anchor:
+                        item["lat"], item["lon"] = anchor.split("destination=")[1].split(",")
 
         yield item
+
+
+def iterloc(it, alt=False):
+    for d in it:
+        yield d["loc"]
+
+        # Also consider alternate URLs (xhtml:link rel="alternate")
+        if alt and "alternate" in d:
+            yield from d["alternate"]


### PR DESCRIPTION
The amount decreased by about two thirds compared to previous runs and I can see how this is somewhat of a hack way to fix it. But open to other ideas. Maybe crawl [this](https://www.dominos.co.in/restaurants-near-me) instead.

Summary of the changes is changing the sitemap urls from store-locations to store-location. 

<details><summary>New Stats</summary>

```python
{"atp/brand/Domino's": 588,
 'atp/brand_wikidata/Q839466': 588,
 'atp/category/amenity/fast_food': 588,
 'atp/field/city/missing': 588,
 'atp/field/country/from_spider_name': 588,
 'atp/field/email/missing': 588,
 'atp/field/image/missing': 588,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 588,
 'atp/field/operator/missing': 588,
 'atp/field/operator_wikidata/missing': 588,
 'atp/field/phone/invalid': 35,
 'atp/field/postcode/missing': 588,
 'atp/field/state/missing': 588,
 'atp/field/street_address/missing': 588,
 'atp/field/twitter/missing': 588,
 'atp/field/website/missing': 588,
 'atp/nsi/cc_match': 588,
 'downloader/exception_count': 5,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 5,
 'downloader/request_bytes': 717376,
 'downloader/request_count': 1719,
 'downloader/request_method_count/GET': 1719,
 'downloader/response_bytes': 144874071,
 'downloader/response_count': 1719,
 'downloader/response_status_count/200': 590,
 'downloader/response_status_count/404': 1129,
 'elapsed_time_seconds': 2096.839293,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 11, 13, 30, 5, 166330, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 110694944,
 'httpcompression/response_count': 590,
 'httperror/response_ignored_count': 1129,
 'httperror/response_ignored_status_count/404': 1129,
 'item_scraped_count': 588,
 'log_count/DEBUG': 2323,
 'log_count/INFO': 1172,
 'memusage/max': 305037312,
 'memusage/startup': 172072960,
 'request_depth_max': 1,
 'response_received_count': 1719,
 'robotstxt/forbidden': 5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1723,
 'scheduler/dequeued/memory': 1723,
 'scheduler/enqueued': 1723,
 'scheduler/enqueued/memory': 1723,
 'start_time': datetime.datetime(2024, 7, 11, 12, 55, 8, 327037, tzinfo=datetime.timezone.utc)}
```
</details>