### PR TITLE
[jumbo_ch] Fix Spider

### DIFF
--- a/locations/spiders/jumbo_ch.py
+++ b/locations/spiders/jumbo_ch.py
@@ -16,7 +16,7 @@ class JumboCHSpider(SitemapSpider):
     }
     allowed_domains = ["www.jumbo.ch"]
     sitemap_urls = ["https://www.jumbo.ch/sitemap.xml"]
-    sitemap_follow = ["/medias/STORE-de-"]
+    sitemap_follow = ["/sitemap/STORE-de-"]
     sitemap_rules = [(r"_POS$", "parse_store")]
 
     def parse_store(self, response):


### PR DESCRIPTION
updated sitemap


```python
{'atp/brand/Jumbo': 123,
 'atp/brand_wikidata/Q1713190': 123,
 'atp/category/shop/doityourself': 123,
 'atp/field/email/missing': 123,
 'atp/field/operator/missing': 123,
 'atp/field/operator_wikidata/missing': 123,
 'atp/field/state/missing': 123,
 'atp/field/twitter/missing': 123,
 'atp/nsi/perfect_match': 123,
 'downloader/request_bytes': 234437,
 'downloader/request_count': 274,
 'downloader/request_method_count/GET': 274,
 'downloader/response_bytes': 9729808,
 'downloader/response_count': 274,
 'downloader/response_status_count/404': 7,
 'elapsed_time_seconds': 338.729687,
 'finish_time': datetime.datetime(2024, 7, 11, 15, 29, 6, 557790, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 41257644,
 'httpcompression/response_count': 132,
 'httperror/response_ignored_count': 7,
 'httperror/response_ignored_status_count/404': 7,
 'item_scraped_count': 123,
 'log_count/INFO': 21,
 'request_depth_max': 2,
 'response_received_count': 151,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 273,
 'scheduler/dequeued/memory': 273,
 'scheduler/enqueued': 273,
 'scheduler/enqueued/memory': 273,
 'start_time': datetime.datetime(2024, 7, 11, 15, 23, 27, 828103, tzinfo=datetime.timezone.utc)}

```
