### PR TITLE
[dorevitch_pathology_au] Fix Spider by new url (462 items)

### DIFF
--- a/locations/spiders/dorevitch_pathology_au.py
+++ b/locations/spiders/dorevitch_pathology_au.py
@@ -14,8 +14,7 @@ class DorevitchPathologyAUSpider(Spider):
         "brand_wikidata": "Q126165490",
         "extras": Categories.SAMPLE_COLLECTION.value,
     }
-    allowed_domains = ["www.healius.com.au"]
-    start_urls = ["https://www.healius.com.au/structr/rest/Location/fetchLocationFromFindUsAPI"]
+    start_urls = ["https://locations.healius.com.au/structr/rest/Location/fetchLocationFromFindUsAPI"]
     company_code = "dorevitch"
     custom_settings = {"ROBOTSTXT_OBEY": False}  # robots.txt doesn't exist, ignore to avoid warnings.
 


### PR DESCRIPTION
I was looking at the website and looks like there are many other brands (which we have spiders for) under Healius name.  Such as Abbott, Laverty, QML, TML, and Western_diagnostic_pathology. What is the standard for these. Should we merge all these together under just a HealiusPathologyAU spider? 