### PR TITLE
Use pyarrow to concatenate parquet files instead of geopandas

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,ijson,json5,lxml,openpyxl,pandas,parsel,phonenumbers,phpserialize,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,shapely,unidecode,w3lib,xmltodict
+known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,ijson,json5,lxml,openpyxl,parsel,phonenumbers,phpserialize,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,shapely,unidecode,w3lib,xmltodict

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -132,20 +132,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0d16832f23e6bd3ae94e35ea8e625529850bfad9baccd426de96ad8f445d8e03",
-                "sha256:b590ce80c65149194def43ebf0ea1cf0533945502507837389a8d22e3ecbcf05"
+                "sha256:2f3e88b10b8fcc5f6100a9d74cd28230edc9d4fa226d99dd40a3ab38ac213673",
+                "sha256:b8433d481d50b68a0162c0379c0dd4aabfc3d1ad901800beb5b87815997511c1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.143"
+            "version": "==1.34.144"
         },
         "botocore": {
             "hashes": [
-                "sha256:059f032ec05733a836e04e869c5a15534420102f93116f3bc9a5b759b0651caf",
-                "sha256:094aea179e8aaa1bc957ad49cc27d93b189dd3a1f3075d8b0ca7c445a2a88430"
+                "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8",
+                "sha256:a2cf26e1bf10d5917a2285e50257bc44e94a1d16574f282f3274f7a5d8d1f08b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.143"
+            "version": "==1.34.144"
         },
         "brotli": {
             "hashes": [
@@ -1607,12 +1607,12 @@
         },
         "scrapy-playwright": {
             "hashes": [
-                "sha256:7df0440fd46423122b2adb7cc67ec449d62cb5d7ee304bba7a20a8e326fa05d0",
-                "sha256:7ffb3db8dbd2b240de7f8a4f7b6f8806a0997c5d2d150abe940951a9afcd2135"
+                "sha256:4765963f06b727dbfa19d239cd103ba28ecfd90c9b4dda951dc18c7786c41faf",
+                "sha256:d7e10afa5b0dec58af44fc71508b4985937fe0f7df361f93fbbc513f99b19287"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.0.38"
+            "version": "==0.0.39"
         },
         "scrapy-zyte-api": {
             "hashes": [
@@ -1640,51 +1640,46 @@
         },
         "shapely": {
             "hashes": [
-                "sha256:011b77153906030b795791f2fdfa2d68f1a8d7e40bce78b029782ade3afe4f2f",
-                "sha256:03152442d311a5e85ac73b39680dd64a9892fa42bb08fd83b3bab4fe6999bfa0",
-                "sha256:05ffd6491e9e8958b742b0e2e7c346635033d0a5f1a0ea083547fcc854e5d5cf",
-                "sha256:0776c92d584f72f1e584d2e43cfc5542c2f3dd19d53f70df0900fda643f4bae6",
-                "sha256:263bcf0c24d7a57c80991e64ab57cba7a3906e31d2e21b455f493d4aab534aaa",
-                "sha256:2fbdc1140a7d08faa748256438291394967aa54b40009f54e8d9825e75ef6113",
-                "sha256:30982f79f21bb0ff7d7d4a4e531e3fcaa39b778584c2ce81a147f95be1cd58c9",
-                "sha256:31c19a668b5a1eadab82ff070b5a260478ac6ddad3a5b62295095174a8d26398",
-                "sha256:3f9103abd1678cb1b5f7e8e1af565a652e036844166c91ec031eeb25c5ca8af0",
-                "sha256:41388321a73ba1a84edd90d86ecc8bfed55e6a1e51882eafb019f45895ec0f65",
-                "sha256:4310b5494271e18580d61022c0857eb85d30510d88606fa3b8314790df7f367d",
-                "sha256:464157509ce4efa5ff285c646a38b49f8c5ef8d4b340f722685b09bb033c5ccf",
-                "sha256:485246fcdb93336105c29a5cfbff8a226949db37b7473c89caa26c9bae52a242",
-                "sha256:489c19152ec1f0e5c5e525356bcbf7e532f311bff630c9b6bc2db6f04da6a8b9",
-                "sha256:4f2ab0faf8188b9f99e6a273b24b97662194160cc8ca17cf9d1fb6f18d7fb93f",
-                "sha256:55a38dcd1cee2f298d8c2ebc60fc7d39f3b4535684a1e9e2f39a80ae88b0cea7",
-                "sha256:58b0ecc505bbe49a99551eea3f2e8a9b3b24b3edd2a4de1ac0dc17bc75c9ec07",
-                "sha256:5af4cd0d8cf2912bd95f33586600cac9c4b7c5053a036422b97cfe4728d2eb53",
-                "sha256:5bbd974193e2cc274312da16b189b38f5f128410f3377721cadb76b1e8ca5328",
-                "sha256:5c4849916f71dc44e19ed370421518c0d86cf73b26e8656192fcfcda08218fbd",
-                "sha256:5dc736127fac70009b8d309a0eeb74f3e08979e530cf7017f2f507ef62e6cfb8",
-                "sha256:63f3a80daf4f867bd80f5c97fbe03314348ac1b3b70fb1c0ad255a69e3749879",
-                "sha256:674d7baf0015a6037d5758496d550fc1946f34bfc89c1bf247cabdc415d7747e",
-                "sha256:6cd4ccecc5ea5abd06deeaab52fcdba372f649728050c6143cc405ee0c166679",
-                "sha256:790a168a808bd00ee42786b8ba883307c0e3684ebb292e0e20009588c426da47",
-                "sha256:7d56ce3e2a6a556b59a288771cf9d091470116867e578bebced8bfc4147fbfd7",
-                "sha256:841f93a0e31e4c64d62ea570d81c35de0f6cea224568b2430d832967536308e6",
-                "sha256:8de4578e838a9409b5b134a18ee820730e507b2d21700c14b71a2b0757396acc",
-                "sha256:92a41d936f7d6743f343be265ace93b7c57f5b231e21b9605716f5a47c2879e7",
-                "sha256:9831816a5d34d5170aa9ed32a64982c3d6f4332e7ecfe62dc97767e163cb0b17",
-                "sha256:994c244e004bc3cfbea96257b883c90a86e8cbd76e069718eb4c6b222a56f78b",
-                "sha256:9dab4c98acfb5fb85f5a20548b5c0abe9b163ad3525ee28822ffecb5c40e724c",
-                "sha256:b79bbd648664aa6f44ef018474ff958b6b296fed5c2d42db60078de3cffbc8aa",
-                "sha256:c3e700abf4a37b7b8b90532fa6ed5c38a9bfc777098bc9fbae5ec8e618ac8f30",
-                "sha256:c52ed79f683f721b69a10fb9e3d940a468203f5054927215586c5d49a072de8d",
-                "sha256:c75c98380b1ede1cae9a252c6dc247e6279403fae38c77060a5e6186c95073ac",
-                "sha256:d2b4431f522b277c79c34b65da128029a9955e4481462cbf7ebec23aab61fc58",
-                "sha256:ddf4a9bfaac643e62702ed662afc36f6abed2a88a21270e891038f9a19bc08fc",
-                "sha256:de0205cb21ad5ddaef607cda9a3191eadd1e7a62a756ea3a356369675230ac35",
-                "sha256:ec555c9d0db12d7fd777ba3f8b75044c73e576c720a851667432fabb7057da6c",
-                "sha256:fb5cdcbbe3080181498931b52a91a21a781a35dcb859da741c0345c6402bf00c"
+                "sha256:03bd7b5fa5deb44795cc0a503999d10ae9d8a22df54ae8d4a4cd2e8a93466195",
+                "sha256:06efe39beafde3a18a21dde169d32f315c57da962826a6d7d22630025200c5e6",
+                "sha256:0f8e71bb9a46814019f6644c4e2560a09d44b80100e46e371578f35eaaa9da1c",
+                "sha256:1b65365cfbf657604e50d15161ffcc68de5cdb22a601bbf7823540ab4918a98d",
+                "sha256:1e5cb5ee72f1bc7ace737c9ecd30dc174a5295fae412972d3879bac2e82c8fae",
+                "sha256:21f64e647a025b61b19585d2247137b3a38a35314ea68c66aaf507a1c03ef6fe",
+                "sha256:2e119444bc27ca33e786772b81760f2028d930ac55dafe9bc50ef538b794a8e1",
+                "sha256:2ff9521991ed9e201c2e923da014e766c1aa04771bc93e6fe97c27dcf0d40ace",
+                "sha256:30e8737983c9d954cd17feb49eb169f02f1da49e24e5171122cf2c2b62d65c95",
+                "sha256:35110e80070d664781ec7955c7de557456b25727a0257b354830abb759bf8311",
+                "sha256:3ac7dc1350700c139c956b03d9c3df49a5b34aaf91d024d1510a09717ea39199",
+                "sha256:401cb794c5067598f50518e5a997e270cd7642c4992645479b915c503866abed",
+                "sha256:4461509afdb15051e73ab178fae79974387f39c47ab635a7330d7fee02c68a3f",
+                "sha256:45211276900c4790d6bfc6105cbf1030742da67594ea4161a9ce6812a6721e68",
+                "sha256:49b299b91557b04acb75e9732645428470825061f871a2edc36b9417d66c1fc5",
+                "sha256:4c83a36f12ec8dee2066946d98d4d841ab6512a6ed7eb742e026a64854019b5f",
+                "sha256:5bbfb048a74cf273db9091ff3155d373020852805a37dfc846ab71dde4be93ec",
+                "sha256:6c6b78c0007a34ce7144f98b7418800e0a6a5d9a762f2244b00ea560525290c9",
+                "sha256:7545a39c55cad1562be302d74c74586f79e07b592df8ada56b79a209731c0219",
+                "sha256:798090b426142df2c5258779c1d8d5734ec6942f778dab6c6c30cfe7f3bf64ff",
+                "sha256:7e8cf5c252fac1ea51b3162be2ec3faddedc82c256a1160fc0e8ddbec81b06d2",
+                "sha256:7fed9dbfbcfec2682d9a047b9699db8dcc890dfca857ecba872c42185fc9e64e",
+                "sha256:8203a8b2d44dcb366becbc8c3d553670320e4acf0616c39e218c9561dd738d92",
+                "sha256:89d34787c44f77a7d37d55ae821f3a784fa33592b9d217a45053a93ade899375",
+                "sha256:89e640c2cd37378480caf2eeda9a51be64201f01f786d127e78eaeff091ec897",
+                "sha256:8af6f7260f809c0862741ad08b1b89cb60c130ae30efab62320bbf4ee9cc71fa",
+                "sha256:93be600cbe2fbaa86c8eb70656369f2f7104cd231f0d6585c7d0aa555d6878b8",
+                "sha256:9a4492a2b2ccbeaebf181e7310d2dfff4fdd505aef59d6cb0f217607cb042fb3",
+                "sha256:b5870633f8e684bf6d1ae4df527ddcb6f3895f7b12bced5c13266ac04f47d231",
+                "sha256:b714a840402cde66fd7b663bb08cacb7211fa4412ea2a209688f671e0d0631fd",
+                "sha256:bff2366bc786bfa6cb353d6b47d0443c570c32776612e527ee47b6df63fcfe32",
+                "sha256:d5251c28a29012e92de01d2e84f11637eb1d48184ee8f22e2df6c8c578d26760",
+                "sha256:e91ee179af539100eb520281ba5394919067c6b51824e6ab132ad4b3b3e76dd0",
+                "sha256:f5456dd522800306ba3faef77c5ba847ec30a0bd73ab087a25e0acdd4db2514f",
+                "sha256:ff7731fea5face9ec08a861ed351734a79475631b7540ceb0b66fb9732a5f529",
+                "sha256:ff9e520af0c5a578e174bca3c18713cd47a6c6a15b6cf1f50ac17dc8bb8db6a2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.4"
+            "version": "==2.0.5"
         },
         "six": {
             "hashes": [
@@ -1960,7 +1955,7 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.9.4"
         },
-        "zope-interface": {
+        "zope.interface": {
             "hashes": [
                 "sha256:00b5c3e9744dcdc9e84c24ed6646d5cf0cf66551347b310b3ffd70f056535854",
                 "sha256:0e4fa5d34d7973e6b0efa46fe4405090f3b406f64b6290facbb19dcbf642ad6b",
@@ -2013,11 +2008,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94",
-                "sha256:e8a0083b4bb28fcffb6207a3bfc9e5d0a68be951dd7e336d5dcf639c682388c0"
+                "sha256:3eae9ea67c11c858cdd2c91337d2e816bd019ac897ca07d7b346ac10105fceb3",
+                "sha256:7099b5a60985529d8d46858befa103b82d0d05a5a5e8b816b5303ed96075e1d9"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.2.2"
+            "version": "==3.2.3"
         },
         "autoflake8": {
             "hashes": [
@@ -2030,12 +2025,12 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:6693c533e13d02e8d9ae901c4ec8124b730f0550ec73845309a97daad22f8721",
-                "sha256:c70d7e580b8e6c045a2de0ee3de5824cd89c5c66031997e619c4bc14f02f9d3a"
+                "sha256:b3047b2b8ab6d4a8b5bb04e28e4531be8e72fc87e5fb8f2588196eca9dd11dd0",
+                "sha256:e542f2ae56dc8ac0bb1774f835031e818af2e3a0e3fd133363d5932621e8e66c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.33.25"
+            "version": "==1.33.26"
         },
         "black": {
             "hashes": [
@@ -2068,20 +2063,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0d16832f23e6bd3ae94e35ea8e625529850bfad9baccd426de96ad8f445d8e03",
-                "sha256:b590ce80c65149194def43ebf0ea1cf0533945502507837389a8d22e3ecbcf05"
+                "sha256:2f3e88b10b8fcc5f6100a9d74cd28230edc9d4fa226d99dd40a3ab38ac213673",
+                "sha256:b8433d481d50b68a0162c0379c0dd4aabfc3d1ad901800beb5b87815997511c1"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.143"
+            "version": "==1.34.144"
         },
         "botocore": {
             "hashes": [
-                "sha256:059f032ec05733a836e04e869c5a15534420102f93116f3bc9a5b759b0651caf",
-                "sha256:094aea179e8aaa1bc957ad49cc27d93b189dd3a1f3075d8b0ca7c445a2a88430"
+                "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8",
+                "sha256:a2cf26e1bf10d5917a2285e50257bc44e94a1d16574f282f3274f7a5d8d1f08b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.143"
+            "version": "==1.34.144"
         },
         "cfgv": {
             "hashes": [

--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -1,9 +1,30 @@
 import argparse
 import glob
-import os.path
+import json
 
-import geopandas
-import pandas
+import pyarrow.parquet
+
+
+def align_schema(row_group: pyarrow.Table, schema: pyarrow.Schema) -> pyarrow.Table:
+    """
+    Align the schema of a table to match the unified schema.
+
+    Args:
+        row_group: The table to align.
+        schema: The unified schema to align to.
+
+    Returns:
+        A new table with a schema matching the unified schema.
+    """
+    aligned_columns = []
+    for field in schema:
+        if field.name in row_group.schema.names:
+            aligned_columns.append(row_group.column(field.name))
+        else:
+            # Create a column of nulls if the field is missing in the table
+            aligned_columns.append(pyarrow.array([None] * row_group.num_rows, type=field.type).cast(field.type))
+
+    return pyarrow.Table.from_arrays(aligned_columns, schema=schema)
 
 
 def main():
@@ -15,22 +36,61 @@ def main():
 
     args = parser.parse_args()
 
-    files = []
+    parquet_filenames = []
     for pattern in args.files:
-        for file in glob.glob(pattern):
-            if os.path.getsize(file) > 0:
-                files.append(file)
+        parquet_filenames.extend(glob.glob(pattern))
 
-    dataframes = []
-    for f in files:
-        if f is None:
-            continue
+    if not parquet_filenames:
+        print("No input files found.")
+        exit(1)
 
-        dataframes.append(geopandas.read_parquet(f))
+    if args.output is None:
+        print("No output file specified.")
+        exit(1)
 
-    joined_df = geopandas.GeoDataFrame(pandas.concat(dataframes, ignore_index=True), crs=dataframes[0].crs)
+    # Unify the schema of all Parquet files and gather the geoparquet metadata
+    geo_metadata = {}
+    schemas = []
+    for parquet_filename in parquet_filenames:
+        parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
+        schemas.append(parquet_file.schema_arrow)
 
-    joined_df.to_parquet(args.output)
+        if geo_metadata_str := parquet_file.metadata.metadata.get(b"geo"):
+            this_geo_metadata = json.loads(geo_metadata_str)
+
+            if not geo_metadata:
+                geo_metadata = this_geo_metadata
+
+            # Expand the bounding box to include all the bounding boxes
+            if bounding_box := this_geo_metadata.get("columns", {}).get("geometry", {}).get("bbox"):
+                geo_metadata["columns"]["geometry"]["bbox"] = [
+                    min(geo_metadata["columns"]["geometry"]["bbox"][0], bounding_box[0]),
+                    min(geo_metadata["columns"]["geometry"]["bbox"][1], bounding_box[1]),
+                    max(geo_metadata["columns"]["geometry"]["bbox"][2], bounding_box[2]),
+                    max(geo_metadata["columns"]["geometry"]["bbox"][3], bounding_box[3]),
+                ]
+
+            # Union the geometry types
+            if geometry_types := this_geo_metadata.get("columns", {}).get("geometry", {}).get("geometry_types"):
+                for geometry_type in geometry_types:
+                    if geometry_type not in geo_metadata["columns"]["geometry"]["geometry_types"]:
+                        geo_metadata["columns"]["geometry"]["geometry_types"].append(geometry_type)
+
+    unified_schema = pyarrow.unify_schemas(schemas, promote_options="permissive")
+
+    unified_metadata = unified_schema.metadata
+    unified_metadata[b"geo"] = json.dumps(geo_metadata)
+    unified_schema = unified_schema.with_metadata(unified_metadata)
+
+    # Concatenate the Parquet files, extending the bounding box in the geoparquet metadata if necessary
+    with pyarrow.parquet.ParquetWriter(args.output, unified_schema) as writer:
+        for parquet_filename in parquet_filenames:
+            parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
+
+            for i in range(parquet_file.num_row_groups):
+                row_group = parquet_file.read_row_group(i)
+                aligned_row_group = align_schema(row_group, unified_schema)
+                writer.write(aligned_row_group)
 
 
 if __name__ == "__main__":

--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -41,11 +41,9 @@ def main():
         parquet_filenames.extend(glob.glob(pattern))
 
     if not parquet_filenames:
-        print("No input files found.")
         exit(1)
 
     if args.output is None:
-        print("No output file specified.")
         exit(1)
 
     # Unify the schema of all Parquet files and gather the geoparquet metadata


### PR DESCRIPTION
Prompted by the discussion in https://github.com/alltheplaces/alltheplaces/pull/8798#issuecomment-2226903728, I rewrote the concatenation script that the weekly script uses to generate a single parquet for the output of all the spiders to use pyarrow directly instead of going through geopandas. Running this locally on a recent run, I see a maximum memory usage of ~5GB.

I spent a bunch of time trying to rewrite the Parquet item exporter to use pyarrow directly, but I gave up after dealing with the translation between "list of dictionaries/rows" to "list of columns" that is required. And it helps to have geopandas there for producing a valid geoparquet, too.