### PR TITLE
'Newcastle-under-Lyme - Milehouse Lane Petrol Station' is not an actual name

### DIFF
--- a/locations/spiders/morrisons_gb.py
+++ b/locations/spiders/morrisons_gb.py
@@ -78,5 +78,5 @@ class MorrisonsGBSpider(Spider):
 
             if not item.get("brand"):
                 continue
-
+            item["branch"] = item.pop("name", None)
             yield item


### PR DESCRIPTION
(again, dropping them completely may be better as it is not exactly a branch but per #8782 it seems that keeping them is required)

warning: I never visited UK, I am not familiar with this chain but this guess seems safe