### PR TITLE
[mccoys] Fix Spider (87 locations)

### DIFF
--- a/locations/spiders/mccoys.py
+++ b/locations/spiders/mccoys.py
@@ -1,6 +1,8 @@
-import scrapy
-from locations.structured_data_spider import StructuredDataSpider
 from urllib.parse import urljoin
+
+import scrapy
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class McCoysSpider(StructuredDataSpider):
@@ -12,10 +14,8 @@ class McCoysSpider(StructuredDataSpider):
     def parse(self, response):
         locations = response.xpath('//*[@class="btn btn-block btn-outline-secondary"]//@href').getall()
         for location in locations:
-            url = urljoin('https://www.mccoys.com', location)
+            url = urljoin("https://www.mccoys.com", location)
             yield scrapy.Request(url=url, callback=self.parse_sd)
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["openingHoursSpecification"] = ld_data.pop("OpeningHoursSpecification", None)
-
-

--- a/locations/spiders/mccoys.py
+++ b/locations/spiders/mccoys.py
@@ -1,17 +1,21 @@
-from scrapy.spiders import SitemapSpider
-
+import scrapy
 from locations.structured_data_spider import StructuredDataSpider
+from urllib.parse import urljoin
 
 
-class McCoysSpider(SitemapSpider, StructuredDataSpider):
+class McCoysSpider(StructuredDataSpider):
     name = "mccoys"
     item_attributes = {"brand": "McCoy's Building Supply", "brand_wikidata": "Q27877295"}
-    allowed_domains = ["www.mccoys.com"]
-    sitemap_urls = ["https://www.mccoys.com/sitemap.xml"]
-    sitemap_rules = [(r"/stores/[-\w]+", "parse_sd")]
-    wanted_types = ["Store"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    time_format = "%I:%M %p"
+    start_urls = ["https://www.mccoys.com/stores"]
+    time_format = "%I%p"
+
+    def parse(self, response):
+        locations = response.xpath('//*[@class="btn btn-block btn-outline-secondary"]//@href').getall()
+        for location in locations:
+            url = urljoin('https://www.mccoys.com', location)
+            yield scrapy.Request(url=url, callback=self.parse_sd)
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["openingHoursSpecification"] = ld_data.pop("OpeningHoursSpecification", None)
+
+


### PR DESCRIPTION

```python
{"atp/brand/McCoy's Building Supply": 87,
 'atp/brand_wikidata/Q27877295': 87,
 'atp/category/shop/doityourself': 87,
 'atp/cdn/cloudflare/response_count': 89,
 'atp/cdn/cloudflare/response_status_count/200': 89,
 'atp/field/email/missing': 87,
 'atp/field/operator/missing': 87,
 'atp/field/operator_wikidata/missing': 87,
 'atp/nsi/perfect_match': 87,
 'downloader/request_bytes': 39848,
 'downloader/response_bytes': 702695,
 'downloader/response_count': 89,
 'elapsed_time_seconds': 109.294493,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 15, 19, 56, 0, 903943, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3735074,
 'httpcompression/response_count': 89,
 'item_scraped_count': 87,
 'log_count/DEBUG': 192,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 89,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 88,
 'scheduler/dequeued/memory': 88,
 'scheduler/enqueued': 88,
 'scheduler/enqueued/memory': 88,
 'start_time': datetime.datetime(2024, 7, 15, 19, 54, 11, 609450, tzinfo=datetime.timezone.utc)}

```
