### PR TITLE
this is not a branch code

### DIFF
--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -40,7 +40,7 @@ class DinoPLSpider(Spider):
             if location["properties"]["status"] != "MARKET OTWARTY":  # "MARKET OPEN"
                 continue
             item = DictParser.parse(location["properties"])
-            item["branch"] = item.pop("name", None)
+            item.pop("name", None)
             item["geometry"] = location["geometry"]
             item["opening_hours"] = OpeningHours()
             if week_hours := location["properties"].get("weekHours"):


### PR DESCRIPTION
resubmission of #8782 code removal

this is merely some web listing name

"Lubiąż 1" from https://www.alltheplaces.xyz/map/#19.53/51.2662366/16.467911 does not appear in shop or even on receipt

Likely the same should be done with

- https://github.com/alltheplaces/alltheplaces/pull/8839/files
- https://github.com/alltheplaces/alltheplaces/pull/8836/files
- https://github.com/alltheplaces/alltheplaces/pull/8835/files
- https://github.com/alltheplaces/alltheplaces/pull/8834/files

Created as in https://github.com/alltheplaces/alltheplaces/pull/8837 the web listing code was removed, instead of shunted into `branch` so maybe the same can succeed here?

(can gave photo of receipt from this shop if anyone wants - "Lubiąż 1" is really not listed there, company name, company address and shop address is there, not such code - maybe it can be put into `web_listing_name` or similar?)