### PR TITLE
[BUILD] fix REQUEST_FINGERPRINTER_IMPLEMENTATION warning messages

### DIFF
--- a/tests/test_bad_coords.py
+++ b/tests/test_bad_coords.py
@@ -1,5 +1,5 @@
 from scrapy import Spider
-from scrapy.crawler import Crawler
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature, get_lat_lon
 from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline
@@ -7,8 +7,7 @@ from locations.pipelines.check_item_properties import CheckItemPropertiesPipelin
 
 def get_objects(lat, lon):
     spider = Spider("test")
-    spider.crawler = Crawler(Spider)
-    spider.crawler._apply_settings()
+    spider.crawler = get_crawler()
     return (
         [
             Feature(lat=lat, lon=lon),

--- a/tests/test_pipeline_count_categories.py
+++ b/tests/test_pipeline_count_categories.py
@@ -1,9 +1,8 @@
-from scrapy.crawler import Crawler
+from scrapy.utils.test import get_crawler
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.count_categories import CountCategoriesPipeline
-from locations.spiders.greggs_gb import GreggsGBSpider
 
 
 def get_objects():
@@ -11,9 +10,7 @@ def get_objects():
         pass
 
     spider = Spider()
-    crawler = Crawler(GreggsGBSpider)
-    spider.crawler = crawler
-    crawler._apply_settings()
+    spider.crawler = get_crawler()
     return Feature(), CountCategoriesPipeline(), spider
 
 

--- a/tests/test_pipeline_country_code_cleanup.py
+++ b/tests/test_pipeline_country_code_cleanup.py
@@ -1,18 +1,13 @@
-from scrapy.crawler import Crawler
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
 from locations.pipelines.country_code_clean_up import CountryCodeCleanUpPipeline
-from locations.spiders.greggs_gb import GreggsGBSpider
 
 
 def get_objects(spider_name):
-    class Spider(object):
-        pass
-
-    spider = Spider()
-    spider.name = spider_name
-    spider.crawler = Crawler(GreggsGBSpider)
-    spider.crawler._apply_settings()
+    spider = Spider(name=spider_name)
+    spider.crawler = get_crawler()
     return Feature(), CountryCodeCleanUpPipeline(), spider
 
 

--- a/tests/test_pipeline_drop_attributes.py
+++ b/tests/test_pipeline_drop_attributes.py
@@ -1,15 +1,13 @@
 from scrapy import Spider
-from scrapy.crawler import Crawler
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
 from locations.pipelines.drop_attributes import DropAttributesPipeline
-from locations.spiders.greggs_gb import GreggsGBSpider
 
 
 def get_objects() -> (Spider, DropAttributesPipeline, Feature):
-    spider = GreggsGBSpider()
-    spider.crawler = Crawler(GreggsGBSpider)
-    spider.crawler._apply_settings()
+    spider = Spider(name="test")
+    spider.crawler = get_crawler()
     return spider, DropAttributesPipeline(), Feature()
 
 

--- a/tests/test_pipeline_nsi_categories.py
+++ b/tests/test_pipeline_nsi_categories.py
@@ -1,18 +1,14 @@
-from scrapy.crawler import Crawler
+from scrapy import Spider
+from scrapy.utils.test import get_crawler
 
 from locations.categories import Categories, apply_category, get_category_tags
 from locations.items import Feature
 from locations.pipelines.apply_nsi_categories import ApplyNSICategoriesPipeline
-from locations.spiders.greggs_gb import GreggsGBSpider
 
 
 def get_objects():
-    class Spider(object):
-        pass
-
-    spider = Spider()
-    spider.crawler = Crawler(GreggsGBSpider)
-    spider.crawler._apply_settings()
+    spider = Spider(name="test")
+    spider.crawler = get_crawler()
     return Feature(), ApplyNSICategoriesPipeline(), spider
 
 

--- a/tests/test_pipeline_phone_cleanup.py
+++ b/tests/test_pipeline_phone_cleanup.py
@@ -1,14 +1,13 @@
-from scrapy.crawler import Crawler
+from scrapy import Spider
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
 from locations.pipelines.phone_clean_up import PhoneCleanUpPipeline
-from locations.spiders.greggs_gb import GreggsGBSpider
 
 
 def get_objects(phone, country):
-    spider = GreggsGBSpider()
-    spider.crawler = Crawler(GreggsGBSpider)
-    spider.crawler._apply_settings()
+    spider = Spider(name="test")
+    spider.crawler = get_crawler()
     return (
         Feature(phone=phone, country=country),
         PhoneCleanUpPipeline(),

--- a/tests/test_pipeline_state_cleanup.py
+++ b/tests/test_pipeline_state_cleanup.py
@@ -1,4 +1,4 @@
-from scrapy.crawler import Crawler
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
 from locations.pipelines.state_clean_up import StateCodeCleanUpPipeline
@@ -7,8 +7,7 @@ from locations.spiders.greggs_gb import GreggsGBSpider
 
 def get_objects():
     spider = GreggsGBSpider()
-    spider.crawler = Crawler(GreggsGBSpider)
-    spider.crawler._apply_settings()
+    spider.crawler = get_crawler()
     return Feature(), StateCodeCleanUpPipeline(), spider
 
 


### PR DESCRIPTION
When running `pipenv run pytest` from the command line then WARNINGs of the form below appear:

```
ScrapyDeprecationWarning: '2.6' is a deprecated value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting
```
This is due to how the `Crawler` is being instantiated. Use the `scrapy` test util support for now.
