### PR TITLE
[mistercarwash] fix spider (500 locations)

### DIFF
--- a/locations/spiders/mistercarwash.py
+++ b/locations/spiders/mistercarwash.py
@@ -4,21 +4,23 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
-
-
 class MisterCarWashSpider(scrapy.Spider):
     name = "mistercarwash"
     item_attributes = {"brand": "Mister Car Wash", "brand_wikidata": "Q114185788"}
     allowed_domains = ["mistercarwash.com/"]
-    start_urls = ["https://mistercarwash.com/api/v1/locations/getbydistance?cLat=36.778261&cLng=-119.4179324&radius=10&cityName=California&stateName=&allServices=true"]
+    start_urls = [
+        "https://mistercarwash.com/api/v1/locations/getbydistance?cLat=36.778261&cLng=-119.4179324&radius=10&cityName=California&stateName=&allServices=true"
+    ]
 
     def parse(self, response):
         for location in response.json()["data"]["body"]["locationServicePriceDetailsModel"]:
             item = DictParser.parse(location)
             item["street_address"] = item.pop("addr_full")
             item["phone"] = location["contacts"][0]["phoneNumber"]
-            
-            hours_string = " ".join(f"{i['dayOfWeek']}: {i['localStartTime']}-{i['localEndTime']}" for i in location["hours"])
+
+            hours_string = " ".join(
+                f"{i['dayOfWeek']}: {i['localStartTime']}-{i['localEndTime']}" for i in location["hours"]
+            )
             oh = OpeningHours()
             oh.add_ranges_from_string(hours_string)
             item["opening_hours"] = oh


### PR DESCRIPTION
Exactly 500 locations seemed suspicious.  I checked their website and other articles and confirmed there is likely 500 locations.    


```python
{'atp/brand/Mister Car Wash': 500,
 'atp/brand_wikidata/Q114185788': 500,
 'atp/category/amenity/car_wash': 500,
 'atp/field/country/from_reverse_geocoding': 500,
 'atp/field/email/missing': 500,
 'atp/field/image/missing': 500,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 500,
 'atp/field/operator_wikidata/missing': 500,
 'atp/field/phone/invalid': 5,
 'atp/field/twitter/missing': 500,
 'atp/field/website/missing': 500,
 'atp/nsi/perfect_match': 500,
 'downloader/exception_count': 1,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 10.320732,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 17, 13, 58, 9, 717980, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 500,
 'log_count/DEBUG': 513,
 'log_count/INFO': 9,
 'offsite/domains': 1,
 'offsite/filtered': 1,
 'response_received_count': 1,
 'robotstxt/request_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 17, 13, 57, 59, 397248, tzinfo=datetime.timezone.utc)}
```