### PR TITLE
[WarbyParker] New spider (272 locations)

### DIFF
--- a/locations/spiders/warby_parker.py
+++ b/locations/spiders/warby_parker.py
@@ -1,0 +1,8 @@
+from locations.storefinders.yext_answers import YextAnswersSpider
+
+
+class WarbyParkerSpider(YextAnswersSpider):
+    name = "warby_parker"
+    experience_key = "warby-parker-search"
+    api_key = "5547ae84dd10f10663a8a5d13f71fd9a"
+    item_attributes = {"brand": "Warby Parker", "brand_wikidata": "Q7968882"}


### PR DESCRIPTION
```py
{'atp/brand/Warby Parker': 272,
 'atp/brand_wikidata/Q7968882': 272,
 'atp/category/shop/optician': 272,
 'atp/cdn/cloudflare/response_count': 7,
 'atp/cdn/cloudflare/response_status_count/200': 6,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 272,
 'atp/field/image/missing': 272,
 'atp/field/opening_hours/missing': 14,
 'atp/field/operator/missing': 272,
 'atp/field/operator_wikidata/missing': 272,
 'atp/field/twitter/missing': 272,
 'atp/nsi/perfect_match': 272,
 'downloader/request_bytes': 6099,
 'downloader/request_count': 7,
 'downloader/request_method_count/GET': 7,
 'downloader/response_bytes': 400109,
 'downloader/response_count': 7,
 'downloader/response_status_count/200': 6,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 8.41435,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 18, 1, 17, 44, 920289, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6458160,
 'httpcompression/response_count': 6,
 'item_scraped_count': 272,
 'log_count/DEBUG': 290,
 'log_count/INFO': 10,
 'memusage/max': 229167104,
 'memusage/startup': 229167104,
 'request_depth_max': 5,
 'response_received_count': 7,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 6,
 'scheduler/dequeued/memory': 6,
 'scheduler/enqueued': 6,
 'scheduler/enqueued/memory': 6,
 'start_time': datetime.datetime(2024, 7, 18, 1, 17, 36, 505939, tzinfo=datetime.timezone.utc)}
```