### PR TITLE
[PressedUS] New spider (106 locations)

### DIFF
--- a/locations/spiders/pressed_us.py
+++ b/locations/spiders/pressed_us.py
@@ -36,23 +36,20 @@ class PressedUSSpider(Spider):
     item_attributes = {"brand": "Pressed", "brand_wikidata": "Q123005477"}
 
     def start_requests(self):
-        return [
-            JsonRequest(
-                url="https://graphql.pressedjuicery.com/",
-                data={
-                    "query": QUERY,
-                    "variables": {
-                        "input": {
-                            "bounds": {
-                                "northeast": {"latitude": "90", "longitude": "180"},
-                                "southwest": {"latitude": "-90", "longitude": "-180"},
-                            }
+        yield JsonRequest(
+            url="https://graphql.pressedjuicery.com/",
+            data={
+                "query": QUERY,
+                "variables": {
+                    "input": {
+                        "bounds": {
+                            "northeast": {"latitude": "90", "longitude": "180"},
+                            "southwest": {"latitude": "-90", "longitude": "-180"},
                         }
-                    },
+                    }
                 },
-                callback=self.parse,
-            )
-        ]
+            },
+        )
 
     def parse(self, response):
         for location in response.json()["data"]["searchStores"]:

--- a/locations/spiders/pressed_us.py
+++ b/locations/spiders/pressed_us.py
@@ -57,16 +57,20 @@ class PressedUSSpider(Spider):
     def parse(self, response):
         for location in response.json()["data"]["searchStores"]:
             item = DictParser.parse(location)
+
             item["lat"] = location["geometry"]["coordinates"]["latitude"]
             item["lon"] = location["geometry"]["coordinates"]["longitude"]
+            item["branch"] = item.pop("name")
             item["website"] = (
                 f"https://pressed.com/pages/juice-bar-locations/US/{location['region']}/{quote(location['locality'])}/{quote(location['streetAddress'])}?storeId={location['id']}"
             )
-            item["branch"] = item.pop("name")
+
             hours = OpeningHours()
             for line in location["storeHours"]:
                 hours.add_ranges_from_string(line)
             item["opening_hours"] = hours
+
             apply_yes_no(Extras.TAKEAWAY, item, location["isPickupAvailable"], False)
             apply_yes_no(Extras.DELIVERY, item, location["isDeliveryAvailable"], False)
+
             yield item

--- a/locations/spiders/pressed_us.py
+++ b/locations/spiders/pressed_us.py
@@ -1,0 +1,72 @@
+from urllib.parse import quote
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+QUERY = """
+query($input: StoreSearchInput!) {
+    searchStores(input: $input) {
+        id
+        name
+        streetAddress
+        locality
+        region postal
+        phone
+        storeHours
+        isPickupAvailable
+        isDeliveryAvailable
+        geometry {
+            coordinates {
+                latitude
+                longitude
+            }
+            type
+        }
+    }
+}
+"""
+
+
+class PressedUSSpider(Spider):
+    name = "pressed_us"
+    item_attributes = {"brand": "Pressed", "brand_wikidata": "Q123005477"}
+
+    def start_requests(self):
+        return [
+            JsonRequest(
+                url="https://graphql.pressedjuicery.com/",
+                data={
+                    "query": QUERY,
+                    "variables": {
+                        "input": {
+                            "bounds": {
+                                "northeast": {"latitude": "90", "longitude": "180"},
+                                "southwest": {"latitude": "-90", "longitude": "-180"},
+                            }
+                        }
+                    },
+                },
+                callback=self.parse,
+            )
+        ]
+
+    def parse(self, response):
+        for location in response.json()["data"]["searchStores"]:
+            item = DictParser.parse(location)
+            item["lat"] = location["geometry"]["coordinates"]["latitude"]
+            item["lon"] = location["geometry"]["coordinates"]["longitude"]
+            item["website"] = (
+                f"https://pressed.com/pages/juice-bar-locations/US/{location['region']}/{quote(location['locality'])}/{quote(location['streetAddress'])}?storeId={location['id']}"
+            )
+            item["branch"] = item.pop("name")
+            hours = OpeningHours()
+            for line in location["storeHours"]:
+                hours.add_ranges_from_string(line)
+            item["opening_hours"] = hours
+            apply_yes_no(Extras.TAKEAWAY, item, location["isPickupAvailable"], False)
+            apply_yes_no(Extras.DELIVERY, item, location["isDeliveryAvailable"], False)
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Pressed': 106,
 'atp/brand_wikidata/Q123005477': 106,
 'atp/category/amenity/fast_food': 106,
 'atp/field/country/from_spider_name': 106,
 'atp/field/email/missing': 106,
 'atp/field/image/missing': 106,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 106,
 'atp/field/operator_wikidata/missing': 106,
 'atp/field/twitter/missing': 106,
 'atp/nsi/perfect_match': 106,
 'downloader/request_bytes': 1300,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 11685,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.764303,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 18, 1, 23, 23, 638311, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 40434,
 'httpcompression/response_count': 2,
 'item_scraped_count': 106,
 'log_count/DEBUG': 119,
 'log_count/INFO': 10,
 'memusage/max': 229466112,
 'memusage/startup': 229466112,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 18, 1, 23, 21, 874008, tzinfo=datetime.timezone.utc)}
```