### PR TITLE
[LaserawayUS] New spider (172 locations)

### DIFF
--- a/locations/spiders/laseraway_us.py
+++ b/locations/spiders/laseraway_us.py
@@ -1,0 +1,37 @@
+from html import unescape
+from urllib.parse import urljoin
+
+from parsel import Selector
+
+from locations.hours import DAYS_EN, OpeningHours
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class LaserawayUSSpider(WPStoreLocatorSpider):
+    name = "laseraway_us"
+    item_attributes = {
+        "brand_wikidata": "Q119982751",
+        "brand": "LaserAway",
+    }
+    allowed_domains = [
+        "www.laseraway.com",
+    ]
+    days = DAYS_EN
+    time_format = "%I:%M %p"
+
+    def parse_item(self, item, location):
+        del item["addr_full"]
+        item["branch"] = unescape(item.pop("name").removeprefix("LaserAway ")).removeprefix("– ")
+        item["website"] = urljoin("https://www.laseraway.com", location["url"])
+        yield item
+
+    def parse_opening_hours(self, location, days):
+        if not location.get("hours"):
+            return
+        selector = Selector(text=location["hours"])
+        if text := selector.xpath("//p/text()").get():
+            oh = OpeningHours()
+            oh.add_ranges_from_string(text, days=days)
+            return oh
+        else:
+            return super().parse_opening_hours(location, days)


### PR DESCRIPTION
Template generated by autospidergen/sf.

```py
{'atp/brand/LaserAway': 172,
 'atp/brand_wikidata/Q119982751': 172,
 'atp/category/shop/beauty': 172,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 47,
 'atp/field/image/missing': 172,
 'atp/field/operator/missing': 172,
 'atp/field/operator_wikidata/missing': 172,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/twitter/missing': 172,
 'atp/nsi/perfect_match': 172,
 'downloader/request_bytes': 675,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14067,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.395632,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 19, 0, 47, 57, 287922, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 146166,
 'httpcompression/response_count': 2,
 'item_scraped_count': 172,
 'log_count/DEBUG': 185,
 'log_count/INFO': 10,
 'memusage/max': 229089280,
 'memusage/startup': 229089280,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 19, 0, 47, 54, 892290, tzinfo=datetime.timezone.utc)}
```