### PR TITLE
[Barrys] New spider (93 locations)

### DIFF
--- a/locations/spiders/barrys.py
+++ b/locations/spiders/barrys.py
@@ -1,0 +1,14 @@
+from locations.storefinders.storemapper import StoremapperSpider
+
+
+class BarrysSpider(StoremapperSpider):
+    name = "barrys"
+    item_attributes = {
+        "brand_wikidata": "Q96373178",
+        "brand": "Barry's",
+    }
+    key = "5809"
+
+    def parse_item(self, item, location):
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
Template generated by autospidergen/sf.

```py
{"atp/brand/Barry's": 93,
 'atp/brand_wikidata/Q96373178': 93,
 'atp/category/leisure/fitness_centre': 93,
 'atp/field/city/missing': 93,
 'atp/field/country/from_reverse_geocoding': 93,
 'atp/field/email/missing': 7,
 'atp/field/image/missing': 93,
 'atp/field/opening_hours/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/phone/missing': 30,
 'atp/field/postcode/missing': 87,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/field/website/missing': 9,
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 367,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 10813,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.871808,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 19, 1, 1, 18, 724313, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 85151,
 'httpcompression/response_count': 1,
 'item_scraped_count': 93,
 'log_count/DEBUG': 105,
 'log_count/INFO': 10,
 'memusage/max': 229347328,
 'memusage/startup': 229347328,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 19, 1, 1, 17, 852505, tzinfo=datetime.timezone.utc)}
```