### PR TITLE
[paczkomat_inpost_pl] cleanup POI, fix generation of webiste

### DIFF
--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -25,7 +25,8 @@ class PaczkomatInpostPLSpider(Spider):
             item["ref"] = poi["n"]
             item["extras"]["description"] = poi["d"]
             item["city"] = poi["c"]
-            item["street"] = poi["e"]
+            if "/" not in item["street]: 
+                item["street"] = poi["e"].removesuffix(poi["b"]).strip()
             item["postcode"] = poi["o"]
             if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru"]:
                 item["housenumber"] = poi["b"]
@@ -41,7 +42,7 @@ class PaczkomatInpostPLSpider(Spider):
             # poi["g"]
             # poi["p"]  # payment
 
-            item["website"] = f"https://inpost.pl/{self.parse_slug(item)}"
+            item["website"] = f"https://inpost.pl/{self.parse_slug(item, poi["r"])}"
             if poi["h"] == "24/7":
                 item["opening_hours"] = "24/7"
             else:
@@ -49,12 +50,8 @@ class PaczkomatInpostPLSpider(Spider):
                 item["opening_hours"].add_ranges_from_string(poi["h"], days=DAYS_PL)
             yield item
 
-    def parse_slug(self, item):
-        slug_parts = ["paczkomat", item["city"], item["ref"], item["street"], "paczkomaty"]
-
-        if item_state := item.get("state"):
-            slug_parts.append(item_state)
-
+    def parse_slug(self, item, state):
+        slug_parts = ["paczkomat", item["city"], item["ref"], item["street"], "paczkomaty", state]
         slug = "-".join(map(lambda x: unidecode(x.lower().strip()), slug_parts))
         slug = re.sub(r"[·/_:; ]", "-", slug)
         slug = re.sub(r"[^a-z0-9 -]", "", slug)

--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -42,7 +42,7 @@ class PaczkomatInpostPLSpider(Spider):
             # poi["g"]
             # poi["p"]  # payment
 
-            item["website"] = f"https://inpost.pl/{self.parse_slug(item, poi["r"])}"
+            item["website"] = f'https://inpost.pl/{self.parse_slug(item, poi["e"], poi["r"])}'
             if poi["h"] == "24/7":
                 item["opening_hours"] = "24/7"
             else:
@@ -50,8 +50,8 @@ class PaczkomatInpostPLSpider(Spider):
                 item["opening_hours"].add_ranges_from_string(poi["h"], days=DAYS_PL)
             yield item
 
-    def parse_slug(self, item, state):
-        slug_parts = ["paczkomat", item["city"], item["ref"], item["street"], "paczkomaty", state]
+    def parse_slug(self, item, street, state):
+        slug_parts = ["paczkomat", item["city"], item["ref"], street, "paczkomaty", state]
         slug = "-".join(map(lambda x: unidecode(x.lower().strip()), slug_parts))
         slug = re.sub(r"[·/_:; ]", "-", slug)
         slug = re.sub(r"[^a-z0-9 -]", "", slug)

--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -25,7 +25,7 @@ class PaczkomatInpostPLSpider(Spider):
             item["ref"] = poi["n"]
             item["extras"]["description"] = poi["d"]
             item["city"] = poi["c"]
-            if "/" not in item["street]: 
+            if "/" not in item["street]:
                 item["street"] = poi["e"].removesuffix(poi["b"]).strip()
             item["postcode"] = poi["o"]
             if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru"]:

--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -25,7 +25,7 @@ class PaczkomatInpostPLSpider(Spider):
             item["ref"] = poi["n"]
             item["extras"]["description"] = poi["d"]
             item["city"] = poi["c"]
-            if "/" not in item["street"]:
+            if "/" not in poi["e"]:
                 item["street"] = poi["e"].removesuffix(poi["b"]).strip()
             item["postcode"] = poi["o"]
             if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru"]:

--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -25,7 +25,7 @@ class PaczkomatInpostPLSpider(Spider):
             item["ref"] = poi["n"]
             item["extras"]["description"] = poi["d"]
             item["city"] = poi["c"]
-            if "/" not in item["street]:
+            if "/" not in item["street"]:
                 item["street"] = poi["e"].removesuffix(poi["b"]).strip()
             item["postcode"] = poi["o"]
             if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru"]:


### PR DESCRIPTION
1. FIX of regression caused by #8881. State is needed to generate website, without it `https://inpost.pl/paczkomat-staniatki-sit01m-staniatki-paczkomaty` would generate instead of `https://inpost.pl/paczkomat-staniatki-sit01m-staniatki-paczkomaty-malopolskie` 
2. Some POI have streets like `Ułańska/Tysiąclecia` which is not valid in OSM and should be removed
3. Some POI have house number also at the end of street, these should be removed