### PR TITLE
[paczkomat_inpost_pl] cleanup POI

### DIFF
--- a/locations/spiders/paczkomat_inpost_pl.py
+++ b/locations/spiders/paczkomat_inpost_pl.py
@@ -26,9 +26,9 @@ class PaczkomatInpostPLSpider(Spider):
             item["extras"]["description"] = poi["d"]
             item["city"] = poi["c"]
             if "/" not in poi["e"]:
-                item["street"] = poi["e"].removesuffix(poi["b"]).strip()
+                item["street"] = poi["e"].removesuffix(poi["b"]).removeprefix("ul.").strip()
             item["postcode"] = poi["o"]
-            if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru"]:
+            if poi["b"].lower() not in ["b/n", "bn", "b.n", "b.n.", "bn.", "brak numeru", "n/n"]:
                 item["housenumber"] = poi["b"]
             item["lat"] = poi["l"]["a"]
             item["lon"] = poi["l"]["o"]


### PR DESCRIPTION
1. Some POI have `streetname` starting with `ul.` (ulica - street) those should be removed
2. Remove `addr:housenumber=n/n` (no number?)