### PR TITLE
[burger_king_th] Add Spider (109 locations)

### DIFF
--- a/locations/spiders/burger_king_th.py
+++ b/locations/spiders/burger_king_th.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
+
+
+class BurgerKingTH(Spider):
+    name = "burger_king_th"
+    item_attributes = BURGER_KING_SHARED_ATTRIBUTES
+    start_urls = [
+        "https://apibgk2.buzzebees.com/place?center=13.7451765,100.5081332&distance=1500000&require_campaign=0&agencyId=7331"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["extras"]["name:en"] = location["name_en"]
+            item["extras"]["addr:full:en"] = location["address_en"]
+            item["state"] = None
+
+            services = [service["name"] for service in location["services"]]
+            apply_yes_no(Extras.DELIVERY, item, "Delivery" in services)
+            apply_yes_no(Extras.WIFI, item, "Wifi" in services)
+            apply_yes_no(Extras.INDOOR_SEATING, item, "Dine In" in services)
+            apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive Thru" in services)
+
+            yield item

--- a/locations/spiders/burger_king_th.py
+++ b/locations/spiders/burger_king_th.py
@@ -8,7 +8,7 @@ from locations.dict_parser import DictParser
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
 
-class BurgerKingTH(Spider):
+class BurgerKingTHSpider(Spider):
     name = "burger_king_th"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
     start_urls = [


### PR DESCRIPTION
```
{'atp/brand/Burger King': 109,
 'atp/brand_wikidata/Q177054': 109,
 'atp/category/amenity/fast_food': 109,
 'atp/field/city/missing': 109,
 'atp/field/country/from_spider_name': 109,
 'atp/field/email/missing': 109,
 'atp/field/image/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/postcode/missing': 109,
 'atp/field/state/missing': 109,
 'atp/field/street_address/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/field/website/missing': 109,
 'atp/nsi/cc_match': 109,
 'downloader/request_bytes': 1011,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 28.883708,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 19, 20, 33, 41, 282334, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 151924,
 'httpcompression/response_count': 1,
 'item_scraped_count': 109,
 'log_count/DEBUG': 129,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 19, 20, 33, 12, 398626, tzinfo=datetime.timezone.utc)}
```