### PR TITLE
Skip over empty parquet files during concat

### DIFF
--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -1,7 +1,9 @@
 import argparse
 import glob
 import json
+import sys
 
+import pyarrow.lib
 import pyarrow.parquet
 
 
@@ -78,6 +80,10 @@ def main():
                 for geometry_type in geometry_types:
                     if geometry_type not in geo_metadata["columns"]["geometry"]["geometry_types"]:
                         geo_metadata["columns"]["geometry"]["geometry_types"].append(geometry_type)
+
+    if not schemas:
+        sys.stderr.write("No valid Parquet files found.\n")
+        exit(1)
 
     unified_schema = pyarrow.unify_schemas(schemas, promote_options="permissive")
 

--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -91,7 +91,7 @@ def main():
     unified_metadata[b"geo"] = json.dumps(geo_metadata)
     unified_schema = unified_schema.with_metadata(unified_metadata)
 
-    # Concatenate the Parquet files, extending the bounding box in the geoparquet metadata if necessary
+    # Concatenate the Parquet files
     with pyarrow.parquet.ParquetWriter(args.output, unified_schema) as writer:
         for parquet_filename in parquet_filenames:
             parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)

--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -50,7 +50,12 @@ def main():
     geo_metadata = {}
     schemas = []
     for parquet_filename in parquet_filenames:
-        parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
+        try:
+            parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
+        except pyarrow.lib.ArrowInvalid as e:
+            print(f"Skipping {parquet_filename} because: {e}")
+            continue
+
         schemas.append(parquet_file.schema_arrow)
 
         if geo_metadata_str := parquet_file.metadata.metadata.get(b"geo"):

--- a/ci/concatenate_parquet.py
+++ b/ci/concatenate_parquet.py
@@ -55,7 +55,7 @@ def main():
         try:
             parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
         except pyarrow.lib.ArrowInvalid as e:
-            print(f"Skipping {parquet_filename} because: {e}")
+            sys.stderr.write(f"Skipping {parquet_filename} because: {e}\n")
             continue
 
         schemas.append(parquet_file.schema_arrow)


### PR DESCRIPTION
Follows #8827 

We were getting the following error during builds:

```
Traceback (most recent call last):
  File ""/home/ubuntu/ci/concatenate_parquet.py", line 95, in <module>
    main()
  File ""/home/ubuntu/ci/concatenate_parquet.py", line 53, in main
    parquet_file = pyarrow.parquet.ParquetFile(parquet_filename)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/ubuntu/.pyenv/versions/3.11.9/lib/python3.11/site-packages/pyarrow/parquet/core.py", line 317, in __init__
    self.reader.open(
  File "pyarrow/_parquet.pyx", line 1480, in pyarrow._parquet.ParquetReader.open
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Parquet file size is 0 bytes
```

This attempts to catch that error and skip the file instead of crashing the whole thing.