### PR TITLE
[Smart Charge GB] Add spider

### DIFF
--- a/locations/spiders/smart_charge_gb.py
+++ b/locations/spiders/smart_charge_gb.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+SOCKET_MAP = {
+    "Chademo": "chademo",
+    "IEC_62196_T2_Combo": "type2_combo",
+}
+
+
+class SmartChargeGBSpider(Spider):
+    name = "smart_charge_gb"
+    item_attributes = {"brand": "Smart Charge", "brand_wikidata": "Q127686420"}
+    start_urls = ["https://smartcharge.co.uk/api/locations"]
+    no_refs = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            if location["status"] == "Announced":
+                continue
+
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full", None)
+
+            if max_power := location.get("maxPowerKw"):
+                item["extras"]["charging_station:output"] = "{} kW".format(max_power)
+
+            for socket in location["evseInformation"]:
+                if m := SOCKET_MAP.get(socket["type"]):
+                    item["extras"]["socket:{}".format(m)] = str(socket["totalEvses"])
+
+            apply_category(Categories.CHARGING_STATION, item)
+
+            yield item

--- a/locations/spiders/smart_charge_gb.py
+++ b/locations/spiders/smart_charge_gb.py
@@ -24,7 +24,7 @@ class SmartChargeGBSpider(Spider):
                 continue
 
             item = DictParser.parse(location)
-            item["street_address"] = item.pop("addr_full", None)
+            item.pop("addr_full", None)
 
             if max_power := location.get("maxPowerKw"):
                 item["extras"]["charging_station:output"] = "{} kW".format(max_power)


### PR DESCRIPTION
```python
{'atp/brand/Smart Charge': 52,
 'atp/brand_wikidata/Q127686420': 52,
 'atp/category/amenity/charging_station': 52,
 'atp/field/city/missing': 52,
 'atp/field/country/from_spider_name': 52,
 'atp/field/email/missing': 52,
 'atp/field/image/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/field/phone/missing': 52,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 52,
 'atp/field/twitter/missing': 52,
 'atp/field/website/missing': 52,
 'atp/nsi/brand_missing': 52,
 'downloader/request_bytes': 619,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 34593,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 0.376086,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 23, 11, 25, 17, 59905, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 2009,
 'httpcompression/response_count': 1,
 'item_scraped_count': 52,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 244744192,
 'memusage/startup': 244744192,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 23, 11, 25, 16, 683819, tzinfo=datetime.timezone.utc)}
```