### PR TITLE
[Marks & Spencer] Improve branding and store types

### DIFF
--- a/locations/spiders/marks_and_spencer.py
+++ b/locations/spiders/marks_and_spencer.py
@@ -2,14 +2,15 @@ import json
 
 import scrapy
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.spiders.central_england_cooperative import set_operator
 
 
 class MarksAndSpencerSpider(scrapy.Spider):
     name = "marks_and_spencer"
-    item_attributes = {"brand": "Marks and Spencer", "brand_wikidata": "Q714491"}
+    item_attributes = {"brand": "Marks & Spencer", "brand_wikidata": "Q714491"}
     start_urls = (
         "https://www.marksandspencer.com/webapp/wcs/stores/servlet/MSResStoreFinderConfigCmd?storeId=10151&langId=-24",
     )
@@ -22,9 +23,11 @@ class MarksAndSpencerSpider(scrapy.Spider):
     def parse_stores(self, response):
         stores = response.json()
         for store in stores["results"]:
+            if store.get("locationTypeName") in [None, "Applegreen", "LondonRetailPartner", "Event", "Compass UK"]:
+                continue
+
             properties = {
                 "ref": store["id"],
-                "name": store["name"],
                 "street_address": store["address"]["addressLine2"],
                 "city": store["address"]["city"],
                 "country": store["address"]["country"],
@@ -41,30 +44,69 @@ class MarksAndSpencerSpider(scrapy.Spider):
             }
 
             if store["storeType"] == "mands":
-                properties["operator"] = "Marks and Spencer"
-                properties["operator_wikidata"] = "Q714491"
+                set_operator(self.item_attributes, properties)
 
             name = store["name"].lower()
-            if name.endswith("foodhall"):
-                properties["brand"] = "M&S Foodhall"
+            if store["locationTypeName"] == "BP Store":
+                properties["located_in"] = "BP"
+                properties["located_in_wikidata"] = "Q152057"
+                properties["name"] = "M&S Simply Food"  # Or M&S Food
+                apply_category(Categories.SHOP_CONVENIENCE, properties)  # Or SHOP_SUPERMARKET
+            elif store["locationTypeName"] == "MOTO (Simply Food)":
+                properties["operator"] = "Moto"
+                properties["operator_wikidata"] = "Q6917970"
+                properties["name"] = "M&S Simply Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
+            elif store["locationTypeName"] in ["SSP Air (Simply)", "SSP Rail (Simply)", "SSP Hospitals"]:
+                properties["operator"] = "SSP"
+                properties["operator_wikidata"] = "Q7447660"
+                properties["name"] = "M&S Simply Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
+            elif store["locationTypeName"] == "Frn Prtn Simply Food":
+                properties["name"] = "M&S Simply Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
+            elif store["locationTypeName"] == "Outlet Store":
+                properties["name"] = "M&S Outlet"
+                apply_category(Categories.SHOP_DEPARTMENT_STORE, properties)
+            elif store["locationTypeName"] in ["Full Line", "Ireland - Full Line"]:
+                properties["name"] = "Marks & Spencer"
+                apply_category(Categories.SHOP_DEPARTMENT_STORE, properties)
+            elif store["locationTypeName"] == "HM Stanley":
+                properties["name"] = "M&S Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
+            elif name.endswith("foodhall"):
+                properties["name"] = "M&S Foodhall"
                 apply_category(Categories.SHOP_SUPERMARKET, properties)
             elif name.endswith("simply food"):
-                properties["brand"] = "M&S Simply Food"
+                properties["name"] = "M&S Simply Food"
                 apply_category(Categories.SHOP_CONVENIENCE, properties)
-            elif name.endswith("outlet"):
-                properties["brand"] = "M&S Outlet"
-                apply_category(Categories.SHOP_DEPARTMENT_STORE, properties)
             else:
-                apply_category(Categories.SHOP_DEPARTMENT_STORE, properties)
+                properties["name"] = "Marks & Spencer"
+                apply_category({"shop": "yes"}, properties)
+            properties["extras"]["as"] = ";".join([s["id"] for s in store["departments"]])
+
+            properties["extras"]["locationTypeCode"] = str(store["locationTypeCode"])
+            properties["extras"]["locationTypeName"] = store.get("locationTypeName")
+
+            services = [s["id"] for s in store["services"]]
+            apply_yes_no(Extras.ATM, properties, "SVC_CASHMC" in services)
+            apply_yes_no(Extras.WIFI, properties, "SVC_WIFI" in services)
+            for s in store["services"]:
+                self.crawler.stats.inc_value("z/services/{}/{}".format(s["id"], s["name"]))
+            for d in store["departments"]:
+                self.crawler.stats.inc_value("z/departments/{}/{}".format(d["id"], d["name"]))
 
             yield Feature(**properties)
 
     def get_opening_hours(self, store):
         o = OpeningHours()
         for day in store["coreOpeningHours"]:
+            if day["open"] == "00:00" and day["close"] == "00:00":
+                o.set_closed(day["day"])
+                continue
             o.add_range(
                 day["day"][:2],
                 day["open"].replace("24:00", "00:00"),
                 day["close"].replace("24:00", "23:59"),
             )
-        return o.as_opening_hours()
+        return o


### PR DESCRIPTION
Improve is the key word here. It's not perfect, I think that's partially because they are in the middle of own rebrands eg `M&S Simply Food` to `M&S Food`, which I don't fully understand, also I think the data isn't always right. eg [Foodhall](https://www.google.com/maps/place/M%26S+Simply+Food/@55.9281543,-3.2093829,3a,41.5y,247.22h,86.18t/data=!3m6!1e1!3m4!1sicIhDQ8XV30brrc-XrEu5w!2e0!7i16384!8i8192!4m12!1m5!3m4!2zNTXCsDU1JzQyLjQiTiAzwrAxMiczNS4zIlc!8m2!3d55.92844!4d-3.2098!3m5!1s0x4887c70bc1600b8f:0xcd095eaec99af19d!8m2!3d55.9280948!4d-3.209776!16s%2Fg%2F1tfgjd1n?coh=205409&entry=ttu) or [Simply Food](https://www.marksandspencer.com/stores/edinburgh-morningside-simply-food-6211).


This isn't perfect, simply improved.