### PR TITLE
[Nuffield Health GB] Add spider (fixes #8927)

### DIFF
--- a/locations/spiders/nuffield_health_gb.py
+++ b/locations/spiders/nuffield_health_gb.py
@@ -1,0 +1,26 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NuffieldHealthGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "nuffield_health_gb"
+    item_attributes = {"brand_wikidata": "Q7068711"}
+    sitemap_urls = ["https://www.nuffieldhealth.com/robots.txt"]
+    sitemap_follow = ["gyms"]
+    sitemap_rules = [(r"/gyms/([^/]+)$", "parse")]
+    wanted_types = ["ExerciseGym"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if response.url == "https://www.nuffieldhealth.com/gyms/247":
+            return
+
+        if coords := response.xpath('//div[@class="location__map"]/@data-markers').get():
+            coords = json.loads(coords)[0]
+            item["lat"] = coords["lat"]
+            item["lon"] = coords["lon"]
+        item["phone"] = response.xpath('//span[@class="location__telephone"]/span[@itemprop="telephone"]/text()').get()
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Nuffield Health Fitness & Wellbeing': 113,
 'atp/brand_wikidata/Q7068711': 113,
 'atp/category/leisure/fitness_centre': 113,
 'atp/cdn/cloudflare/response_count': 132,
 'atp/cdn/cloudflare/response_status_count/200': 132,
 'atp/field/city/missing': 113,
 'atp/field/country/from_spider_name': 113,
 'atp/field/email/missing': 112,
 'atp/field/image/missing': 113,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 113,
 'atp/field/operator/missing': 113,
 'atp/field/operator_wikidata/missing': 113,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 113,
 'atp/field/street_address/missing': 113,
 'atp/field/twitter/missing': 113,
 'atp/nsi/perfect_match': 113,
 'downloader/request_bytes': 49575,
 'downloader/request_count': 132,
 'downloader/request_method_count/GET': 132,
 'downloader/response_bytes': 2700693,
 'downloader/response_count': 132,
 'downloader/response_status_count/200': 132,
 'elapsed_time_seconds': 1.693826,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 24, 15, 24, 46, 607859, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 132,
 'httpcompression/response_bytes': 13700650,
 'httpcompression/response_count': 132,
 'item_scraped_count': 113,
 'log_count/DEBUG': 257,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 244633600,
 'memusage/startup': 244633600,
 'request_depth_max': 3,
 'response_received_count': 132,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 131,
 'scheduler/dequeued/memory': 131,
 'scheduler/enqueued': 131,
 'scheduler/enqueued/memory': 131,
 'start_time': datetime.datetime(2024, 7, 24, 15, 24, 44, 914033, tzinfo=datetime.timezone.utc)}
```