### PR TITLE
[mobilelink] Fix Spider (455 locations)

### DIFF
--- a/locations/spiders/mobilelink.py
+++ b/locations/spiders/mobilelink.py
@@ -1,14 +1,17 @@
-from scrapy import Request, Spider
 from typing import Any
+
+from scrapy import Request, Spider
 from scrapy.http import Response
+
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+
 
 class MobilelinkSpider(Spider):
     name = "mobilelink"
     item_attributes = {"brand": "Mobilelink"}
-    allowed_domains = ["mobilelinkusa.com"]   
-    
+    allowed_domains = ["mobilelinkusa.com"]
+
     def start_requests(self):
         yield Request(
             url="https://mobilelinkusa.com/GetStores",
@@ -24,13 +27,11 @@ class MobilelinkSpider(Spider):
             oh = OpeningHours()
             for day in DAYS:
                 if day == "Sa":
-                    oh.add_range(day, location["SatOpentime"], location["SatClosetime"], "%H:%M:%S") 
+                    oh.add_range(day, location["SatOpentime"], location["SatClosetime"], "%H:%M:%S")
                 elif day == "Su":
-                    oh.add_range(day, location["SunOpentime"], location["SunClosetime"], "%H:%M:%S") 
+                    oh.add_range(day, location["SunOpentime"], location["SunClosetime"], "%H:%M:%S")
                 else:
                     oh.add_range(day, location["Opentime"], location["Closetime"], "%H:%M:%S")
             item["opening_hours"] = oh
 
             yield item
-
-


### PR DESCRIPTION
```
{'atp/brand/Mobilelink': 455,
 'atp/category/missing': 455,
 'atp/field/brand_wikidata/missing': 455,
 'atp/field/city/missing': 455,
 'atp/field/country/from_reverse_geocoding': 455,
 'atp/field/email/missing': 455,
 'atp/field/image/missing': 455,
 'atp/field/name/missing': 455,
 'atp/field/operator/missing': 455,
 'atp/field/operator_wikidata/missing': 455,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 455,
 'atp/field/website/missing': 455,
 'downloader/request_bytes': 616,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 340734,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.572048,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 24, 18, 27, 14, 233755, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 455,
 'log_count/DEBUG': 465,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 24, 18, 27, 10, 661707, tzinfo=datetime.timezone.utc)}
```