### PR TITLE
Try to resolve parquet concatenation again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG BUILD_OPT_DEPS=" \
 # basic update & locale setting
 RUN apt-get update \
  && apt-get upgrade -yqq \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -yqq --no-install-recommends \
         ${BUILD_PYTHON_DEPS} \
         ${BUILD_OPT_DEPS} \
  && localedef -f UTF-8 -i en_US en_US.UTF-8 \

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -80,7 +80,6 @@ python ci/concatenate_parquet.py \
 retval=$?
 if [ ! $retval -eq 0 ]; then
     (>&2 echo "Couldn't convert to parquet")
-    exit 1
 fi
 
 # concatenate_parquet.py leaves behind the parquet files for each spider, and I don't

--- a/locations/spiders/albertsons.py
+++ b/locations/spiders/albertsons.py
@@ -34,7 +34,7 @@ class AlbertsonsSpider(SitemapSpider, StructuredDataSpider):
         },
         "vons": {"brand": "Vons", "brand_wikidata": "Q7941609"},
     }
-    item_attributes = {"nsi_id": -1}  # Most of these are too small to justify NSI entries
+    item_attributes = {"nsi_id": "-1"}  # Most of these are too small to justify NSI entries
     allowed_domains = [
         "local.albertsons.com",
         "local.fuel.albertsons.com",

--- a/locations/spiders/goodwill.py
+++ b/locations/spiders/goodwill.py
@@ -26,7 +26,7 @@ class GoodwillSpider(scrapy.Spider):
     item_attributes = {
         "brand": "Goodwill",
         "brand_wikidata": "Q5583655",
-        "nsi_id": -1,
+        "nsi_id": "-1",
         "extras": Categories.SHOP_CHARITY.value,
     }
     allowed_domains = ["www.goodwill.org"]

--- a/locations/spiders/lidl_bg.py
+++ b/locations/spiders/lidl_bg.py
@@ -16,6 +16,7 @@ class LidlBGSpider(VirtualEarthSpider):
 
     def parse_item(self, item, feature, **kwargs):
         item["name"] = feature["ShownStoreName"]
+        item["nsi_id"] = "-1"
 
         item["opening_hours"] = OpeningHours()
         for day, start_time, end_time in re.findall(
@@ -26,5 +27,4 @@ class LidlBGSpider(VirtualEarthSpider):
                 item["opening_hours"].add_range(day, start_time, end_time)
 
         apply_category(Categories.SHOP_SUPERMARKET, item)
-        item["nsi_id"] = -1
         yield item

--- a/locations/spiders/via313.py
+++ b/locations/spiders/via313.py
@@ -9,7 +9,7 @@ class Via313Spider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Via 313",
         "brand_wikidata": "Q115699944",
-        "nsi_id": -1,
+        "nsi_id": "-1",
         "extras": {**Categories.RESTAURANT.value, "cuisine": "pizza"},
     }
     sitemap_urls = ["https://locations.via313.com/robots.txt"]


### PR DESCRIPTION
Follows #8798
For #8932 

The latest weekly build failed with an error like:

```
Traceback (most recent call last):
File "/home/ubuntu/ci/concatenate_parquet.py", line 106, in <module>
  main()
File "/home/ubuntu/ci/concatenate_parquet.py", line 88, in main
  unified_schema = pyarrow.unify_schemas(schemas, promote_options="permissive")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "pyarrow/types.pxi", line 3444, in pyarrow.lib.unify_schemas
File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
  pyarrow.lib.ArrowTypeError: Unable to merge: Field nsi_id has incompatible types: string vs int64
```

Basically: the `nsi_id` field is usually a `string` but sometimes its an `int64`, and the schema unifier doesn't know what to do when it encounters that mismatch.

To resolve, I'm trying to find all the spots where we output integers to avoid nsi_id matches and change them to strings.

I am also allowing the Parquet build to fail without killing the whole weekly run.