### PR TITLE
[Away] New spider (17 locations)

### DIFF
--- a/locations/spiders/away.py
+++ b/locations/spiders/away.py
@@ -1,0 +1,56 @@
+import html
+import json
+import re
+
+from parsel import Selector
+from scrapy.spiders import Spider
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+HTML_TAGS = re.compile("<[^<]+?>")
+
+
+def strip_tags(s):
+    return html.unescape(HTML_TAGS.sub("", s))
+
+
+class AwaySpider(Spider):
+    name = "away"
+    item_attributes = {
+        "brand": "Away",
+        "brand_wikidata": "Q48743138",
+        "extras": Categories.SHOP_BAG.value,
+        "name": "Away",
+    }
+    start_urls = ["https://www.awaytravel.com/stores"]
+
+    def parse(self, response):
+        data = json.loads(response.xpath('//*[@id="__NEXT_DATA__"]/text()').get())
+        for location in data["props"]["pageProps"]["fallback"]["store-location-section-us"]["stores"]:
+            item = DictParser.parse(location)
+
+            item["addr_full"] = strip_tags(item["addr_full"])
+            item["branch"] = location["homepageCity"]
+            item["website"] = response.urljoin(location["linkHref"])
+            item["image"] = location["metaImage"]["url"]
+            del item["name"]
+
+            oh = OpeningHours()
+            oh.add_ranges_from_string(strip_tags(location["hours"]))
+            item["opening_hours"] = oh
+
+            links = Selector(text=location["description"]).xpath("//a/@href").getall()
+
+            if not item["email"]:
+                for link in links:
+                    if link.startswith("mailto:"):
+                        item["email"] = link.removeprefix("mailto:")
+
+            if not item["phone"]:
+                for link in links:
+                    if link.startswith("tel:"):
+                        item["phone"] = link.removeprefix("tel:")
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Away': 17,
 'atp/brand_wikidata/Q48743138': 17,
 'atp/category/shop/bag': 17,
 'atp/field/city/missing': 17,
 'atp/field/country/from_reverse_geocoding': 17,
 'atp/field/email/missing': 1,
 'atp/field/operator/missing': 17,
 'atp/field/operator_wikidata/missing': 17,
 'atp/field/postcode/missing': 16,
 'atp/field/street_address/missing': 17,
 'atp/field/twitter/missing': 17,
 'atp/nsi/brand_missing': 17,
 'downloader/request_bytes': 691,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 39451,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.054558,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 25, 2, 39, 37, 924458, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 275916,
 'httpcompression/response_count': 1,
 'item_scraped_count': 17,
 'log_count/DEBUG': 30,
 'log_count/INFO': 9,
 'memusage/max': 163098624,
 'memusage/startup': 163098624,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 25, 2, 39, 35, 869900, tzinfo=datetime.timezone.utc)}
```