### PR TITLE
A couple Parquet output fixes

### DIFF
--- a/locations/exporters/geoparquet.py
+++ b/locations/exporters/geoparquet.py
@@ -28,6 +28,10 @@ class GeoparquetExporter(BaseItemExporter):
         self.features.append(feature)
 
     def finish_exporting(self):
+        # Don't write an empty Parquet file
+        if not self.features:
+            return
+
         # Create a GeoDataFrame from the features
         gdf = geopandas.GeoDataFrame.from_features(self.features)
 

--- a/locations/exporters/geoparquet.py
+++ b/locations/exporters/geoparquet.py
@@ -17,7 +17,15 @@ class GeoparquetExporter(BaseItemExporter):
             # self.write_dataset_attributes_table(item)
             self.first_item = False
 
-        self.features.append(item_to_geojson_feature(item))
+        # Convert the item to a GeoJSON feature
+        feature = item_to_geojson_feature(item)
+
+        # Convert all attributes to strings so that the Parquet output is of consistent type.
+        # Without this, the "global" Parquet file would have mixed types in the same column.
+        for key, value in feature["properties"].items():
+            feature["properties"][key] = str(value)
+
+        self.features.append(feature)
 
     def finish_exporting(self):
         # Create a GeoDataFrame from the features


### PR DESCRIPTION
1. When capturing items for the `GeoparquetExporter`, convert the attributes to strings so that the parquet columns are stored as strings. Without this, the `concatenate_parquet.py` script was having a very hard time unifying the schema types.
2. When a spider fails or otherwise doesn't scrape items, the `GeoparquetExporter` throws an exception because GeoPandas doesn't want to write out an empty parquet file. Instead of throwing that exception, just skip the writing of the parquet file.