### PR TITLE
[TravismathewUS] New spider (54 locations)

### DIFF
--- a/locations/spiders/travismathew_us.py
+++ b/locations/spiders/travismathew_us.py
@@ -1,0 +1,45 @@
+from urllib.parse import parse_qs, urlparse, urlunparse
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class TravismathewUSSpider(SitemapSpider):
+    name = "travismathew_us"
+    item_attributes = {"brand": "TravisMathew", "name": "TravisMathew", "extras": Categories.SHOP_CLOTHES.value}
+    sitemap_urls = ["https://www.travismathew.com/sitemap.xml"]
+    sitemap_rules = [(r"/stores?/T[0-9]+\?lat=[0-9.-]+&long=[0-9.-]+$", "parse_item")]
+    sitemap_follow = ["Store"]
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            entry["loc"] = entry["loc"].replace("/store/", "/stores/")
+            yield entry
+
+    def parse_item(self, response):
+        item = Feature()
+
+        url = urlparse(response.url)
+        query = parse_qs(url.query)
+
+        item["website"] = urlunparse(url._replace(query=None))
+        item["lat"] = query["lat"][0]
+        item["lon"] = query["long"][0]
+        item["ref"] = url.path.split("/")[2]
+
+        details = response.css(".s-details-box")
+        item["branch"] = details.xpath("h4/text()").get()
+        item["addr_full"] = "".join(details.xpath("h6/text()").getall())
+        item["phone"] = details.css(".phonetxt ~ span::text").get().replace("TBD", "")
+
+        oh = OpeningHours()
+        for line in details.css(".dayHouralign"):
+            oh.add_ranges_from_string("".join(line.css("*::text").getall()))
+        item["opening_hours"] = oh
+
+        item["image"] = response.urljoin(response.xpath("//@data-src").get())
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/TravisMathew': 54,
 'atp/category/shop/clothes': 54,
 'atp/field/brand_wikidata/missing': 54,
 'atp/field/city/missing': 54,
 'atp/field/country/from_spider_name': 54,
 'atp/field/email/missing': 54,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 54,
 'atp/field/state/from_reverse_geocoding': 54,
 'atp/field/street_address/missing': 54,
 'atp/field/twitter/missing': 54,
 'downloader/request_bytes': 144152,
 'downloader/request_count': 111,
 'downloader/request_method_count/GET': 111,
 'downloader/response_bytes': 5174817,
 'downloader/response_count': 111,
 'downloader/response_status_count/200': 57,
 'downloader/response_status_count/301': 54,
 'elapsed_time_seconds': 134.775009,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 27, 5, 7, 32, 683084, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25710290,
 'httpcompression/response_count': 57,
 'item_scraped_count': 54,
 'log_count/DEBUG': 167,
 'log_count/INFO': 11,
 'memusage/max': 352788480,
 'memusage/startup': 163954688,
 'request_depth_max': 2,
 'response_received_count': 57,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 110,
 'scheduler/dequeued/memory': 110,
 'scheduler/enqueued': 110,
 'scheduler/enqueued/memory': 110,
 'start_time': datetime.datetime(2024, 7, 27, 5, 5, 17, 908075, tzinfo=datetime.timezone.utc)}
```