### PR TITLE
[FogoDeChao] New spider (91 locations)

### DIFF
--- a/locations/spiders/fogo_de_chao.py
+++ b/locations/spiders/fogo_de_chao.py
@@ -1,0 +1,28 @@
+import json
+
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class FogoDeChaoSpider(Spider):
+    name = "fogo_de_chao"
+    item_attributes = {"brand": "Fogo de Chão", "brand_wikidata": "Q5464133"}
+    start_urls = ["https://fogodechao.com/locations/"]
+    skip_auto_cc_spider_name = True  # Brazil, not Germany...
+
+    def parse(self, response):
+        script = response.xpath("//script[starts-with(text(), 'locationsData =')]/text()").get()
+        locations_data = json.loads(script[script.find("{") : script.rfind("}") + 1])
+
+        for ref, location in locations_data.items():
+            if location["coming_soon_url"]:
+                continue
+            item = DictParser.parse(location)
+            item["ref"] = ref
+            item["addr_full"] = merge_address_lines([location["address1"], location["address2"]])
+            item["branch"] = item.pop("name")
+            item["state"] = location["state"]
+            item["website"] = response.urljoin(location["url"])
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Fogo de Chão': 91,
 'atp/brand_wikidata/Q5464133': 91,
 'atp/category/amenity/restaurant': 91,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/city/missing': 91,
 'atp/field/country/from_reverse_geocoding': 91,
 'atp/field/email/missing': 91,
 'atp/field/image/missing': 91,
 'atp/field/opening_hours/missing': 91,
 'atp/field/operator/missing': 91,
 'atp/field/operator_wikidata/missing': 91,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 91,
 'atp/field/twitter/missing': 91,
 'atp/nsi/perfect_match': 91,
 'downloader/request_bytes': 610,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 37708,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.416504,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 27, 5, 43, 33, 100008, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 231714,
 'httpcompression/response_count': 2,
 'item_scraped_count': 91,
 'log_count/DEBUG': 104,
 'log_count/INFO': 9,
 'memusage/max': 163897344,
 'memusage/startup': 163897344,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 27, 5, 43, 30, 683504, tzinfo=datetime.timezone.utc)}
```