### PR TITLE
[BrandyMelville] New spider (85 locations)

### DIFF
--- a/locations/spiders/brandy_melville.py
+++ b/locations/spiders/brandy_melville.py
@@ -1,0 +1,49 @@
+import json
+
+from geonamescache import GeonamesCache
+from scrapy import Spider
+
+from locations.google_url import url_to_coords
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class BrandyMelvilleSpider(Spider):
+    name = "brandy_melville"
+    item_attributes = {"brand": "Brandy Melville", "brand_wikidata": "Q25387414"}
+    start_urls = ["https://locations.brandymelville.com/"]
+
+    def parse(self, response):
+        script = response.xpath("//script[contains(text(), 'locations =')]/text()").get()
+        script = script[script.find("locations =") :].removeprefix("locations =").strip()
+        script = script[: script.find("};") + 1]
+
+        geonames = GeonamesCache()
+        countries = geonames.get_countries_by_names()
+        states = geonames.get_us_states_by_names()
+
+        for region, subregions in json.loads(script)["data"].items():
+            for subregion, locations in subregions.items():
+                for location in locations:
+                    item = Feature()
+
+                    item["city"] = location[0]
+                    if item["city"] in location[1]:
+                        item["addr_full"] = location[1]
+                    else:
+                        item["street_address"] = location[1]
+                    item["phone"] = item["ref"] = location[2]
+                    item["lat"], item["lon"] = url_to_coords(location[3])
+
+                    oh = OpeningHours()
+                    oh.add_ranges_from_string(location[4])
+                    item["opening_hours"] = oh
+
+                    if region in countries:
+                        item["country"] = countries[region]["iso"]
+                    elif subregion in countries:
+                        item["country"] = countries[subregion]["iso"]
+                    if subregion in states:
+                        item["state"] = states[subregion]["code"]
+
+                    yield item


### PR DESCRIPTION
I'm not sure if this one is worth it, since so few results have valid coordinates.

Also, sorry for the PR spam! I forget to push sometimes…

```py
{'atp/brand/Brandy Melville': 85,
 'atp/brand_wikidata/Q25387414': 85,
 'atp/category/shop/clothes': 85,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/email/missing': 85,
 'atp/field/image/missing': 85,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 74,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 74,
 'atp/field/operator/missing': 85,
 'atp/field/operator_wikidata/missing': 85,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 85,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 41,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 85,
 'atp/field/website/missing': 85,
 'atp/nsi/perfect_match': 85,
 'downloader/request_bytes': 628,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 34533,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.708248,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 27, 5, 45, 49, 114474, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 4,
 'item_dropped_reasons_count/DropItem': 4,
 'item_scraped_count': 85,
 'log_count/DEBUG': 102,
 'log_count/INFO': 9,
 'memusage/max': 164007936,
 'memusage/startup': 164007936,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 27, 5, 45, 46, 406226, tzinfo=datetime.timezone.utc)}
```