### PR TITLE
[seven_eleven_th] add spider (6k locations)

### DIFF
--- a/locations/spiders/seven_eleven_th.py
+++ b/locations/spiders/seven_eleven_th.py
@@ -10,7 +10,7 @@ from locations.geo import city_locations
 from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
 
 
-class SevenElevenThSpider(scrapy.Spider):
+class SevenElevenTHSpider(scrapy.Spider):
     """
     Store locator: https://www.7eleven.co.th/find-store
     """

--- a/locations/spiders/seven_eleven_th.py
+++ b/locations/spiders/seven_eleven_th.py
@@ -35,4 +35,6 @@ class SevenElevenThSpider(scrapy.Spider):
             item = DictParser.parse(poi)
             item["name"] = None
             item["branch"] = poi.get("name")
+            item['extras']['addr:district'] = poi.get("district")
+            item['extras']['addr:subdistrict'] = poi.get("subdistrict")
             yield item

--- a/locations/spiders/seven_eleven_th.py
+++ b/locations/spiders/seven_eleven_th.py
@@ -1,0 +1,38 @@
+from typing import Iterable
+
+import scrapy
+from scrapy import Request
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+
+
+class SevenElevenThSpider(scrapy.Spider):
+    name = "seven_eleven_th"
+    start_urls = ["https://7eleven-api-prod.jenosize.tech/v1/Store/GetStoreByCurrentLocation"]
+    requires_proxy = "TH"
+    custom_settings = {
+        # The website may block the spider
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 1,
+        "DOWNLOAD_DELAY": 2,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    def start_requests(self) -> Iterable[Request]:
+        for city in city_locations("TH"):
+            payload = {
+                "latitude": city.get("latitude"),
+                "longitude": city.get("longitude"),
+                "products": [],
+                "distance": 10000000,
+                "limit": 10000000,
+            }
+            yield JsonRequest("https://7eleven-api-prod.jenosize.tech/v1/Store/GetStoreByCurrentLocation", data=payload)
+
+    def parse(self, response):
+        for poi in response.json().get("data", []):
+            item = DictParser.parse(poi)
+            item["name"] = None
+            item["branch"] = poi.get("name")
+            yield item


### PR DESCRIPTION
The website should have 14k locations, but the spider is getting only 6k at the moment. 
I'll comeback at some point to try to collect more locations.

```json
{
 "atp/brand/7-Eleven": 6208,
 "atp/brand_wikidata/Q259340": 6208,
 "atp/category/shop/convenience": 6208,
 "atp/field/city/missing": 6208,
 "atp/field/country/from_spider_name": 6208,
 "atp/field/email/missing": 6208,
 "atp/field/image/missing": 6208,
 "atp/field/opening_hours/missing": 6208,
 "atp/field/operator/missing": 6208,
 "atp/field/operator_wikidata/missing": 6208,
 "atp/field/phone/invalid": 2408,
 "atp/field/phone/missing": 2,
 "atp/field/postcode/missing": 2,
 "atp/field/state/missing": 4,
 "atp/field/street_address/missing": 6208,
 "atp/field/twitter/missing": 6208,
 "atp/field/website/missing": 6208,
 "atp/nsi/cc_match": 6208,
 "downloader/request_bytes": 102836,
 "downloader/request_count": 222,
 "downloader/request_method_count/POST": 222,
 "downloader/response_bytes": 9073272,
 "downloader/response_count": 222,
 "downloader/response_status_count/200": 222,
 "elapsed_time_seconds": 3.307083,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-07-29T12:31:52.050502+00:00",
 "httpcache/hit": 222,
 "item_dropped_count": 989,
 "item_dropped_reasons_count/DropItem": 989,
 "item_scraped_count": 6208,
 "log_count/INFO": 10,
 "memusage/max": 219611136,
 "memusage/startup": 219611136,
 "response_received_count": 222,
 "scheduler/dequeued": 222,
 "scheduler/dequeued/memory": 222,
 "scheduler/enqueued": 222,
 "scheduler/enqueued/memory": 222,
 "start_time": "2024-07-29T12:31:48.743419+00:00"
}
```