### PR TITLE
Added Pošta Slovenije spider (456 locations)

### DIFF
--- a/locations/spiders/posta_si.py
+++ b/locations/spiders/posta_si.py
@@ -1,0 +1,63 @@
+import scrapy
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.hours import DAYS_FULL, OpeningHours
+
+from locations.items import Feature
+
+
+class PostaSpider(scrapy.Spider):
+    name = "posta_si"
+    item_attributes = {"brand": "Pošta Slovenije", "brand_wikidata": "Q6522631"}
+    allowed_domains = ["www.posta.si"]
+
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    start_urls = [
+        "https://www.posta.si/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/SearchPostOffices/" + c + "/"
+        for c in "abcčdefghijklmnoprsštuvzž"
+    ]
+
+    ids_seen = set()
+
+    def parse(self, response):
+        for posta in response.json():
+            if posta["PostOfficeId"] in self.ids_seen:
+                continue
+            self.ids_seen.add(posta["PostOfficeId"])
+
+            feature = Feature(
+                ref=posta["PostOfficeId"],
+                name=posta.get("Title"),
+                lat=posta["Geo"]["Lat"],
+                lon=posta["Geo"]["Lng"],
+                street_address=posta["Address"],
+                country="SI",
+                phone=posta.get("FirstPhone"),
+                opening_hours=self.parse_open_hours(posta["WorkTimes"] or {}),
+            )
+
+            apply_category(Categories.POST_OFFICE, feature)
+
+            services = [service["ServiceId"] for service in posta["Services"]]
+
+            apply_yes_no("sells:lottery", feature, 8 in services)
+            apply_yes_no("services:copy", feature, 9 in services)
+
+            if 2 in services:
+                apply_category(Categories.BUREAU_DE_CHANGE, feature)
+
+            yield feature
+
+    def parse_open_hours(self, obj):
+        opening_hours = OpeningHours()
+
+        for day in DAYS_FULL:
+            times = obj.get(day + "WorkTime")
+            if not times:
+                continue
+            if times["From1"]:
+                opening_hours.add_range(day=day[:2], open_time=times["From1"], close_time=times["To1"])
+            if times["From2"]:
+                opening_hours.add_range(day=day[:2], open_time=times["From2"], close_time=times["To2"])
+
+        return opening_hours.as_opening_hours()

--- a/locations/spiders/posta_si.py
+++ b/locations/spiders/posta_si.py
@@ -1,7 +1,7 @@
 import scrapy
-from locations.categories import Categories, apply_category, apply_yes_no
-from locations.hours import DAYS_FULL, OpeningHours
 
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 
@@ -12,8 +12,9 @@ class PostaSpider(scrapy.Spider):
 
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
+    # There is no "show all" option, but we can search for every letter to get all of them
     start_urls = [
-        "https://www.posta.si/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/SearchPostOffices/" + c + "/"
+        "https://www.posta.si/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/PostalOffice/" + c
         for c in "abcčdefghijklmnoprsštuvzž"
     ]
 
@@ -21,43 +22,50 @@ class PostaSpider(scrapy.Spider):
 
     def parse(self, response):
         for posta in response.json():
-            if posta["PostOfficeId"] in self.ids_seen:
+
+            # Skip everything that isn't a post office (newsagents, petrol stations...)
+            # 0 = Pošta, 1 = BS petrol, 2 = PS Paketomat, 4 = BS MOL, 7 = TRAFIKA 3DVA
+            if posta["VrstaEnote"] != 0:
                 continue
-            self.ids_seen.add(posta["PostOfficeId"])
+
+            # Units with no physical location, only used for administrative purposes
+            if "Pin" not in posta:
+                continue
+
+            # Skip already-seen post offices
+            if posta["PostalId"] in self.ids_seen:
+                continue
+            self.ids_seen.add(posta["PostalId"])
 
             feature = Feature(
-                ref=posta["PostOfficeId"],
-                name=posta.get("Title"),
-                lat=posta["Geo"]["Lat"],
-                lon=posta["Geo"]["Lng"],
-                street_address=posta["Address"],
+                ref=posta["PostalId"],
+                name=posta["PostalClassNumAndTitle"],
+                lat=posta["Pin"]["GPSx"],
+                lon=posta["Pin"]["GPSy"],
+                street_address=posta["PostalAddress"],
                 country="SI",
                 phone=posta.get("FirstPhone"),
-                opening_hours=self.parse_open_hours(posta["WorkTimes"] or {}),
+                opening_hours=self.parse_open_hours(posta["FormatWorkingDays"]),
             )
 
             apply_category(Categories.POST_OFFICE, feature)
 
-            services = [service["ServiceId"] for service in posta["Services"]]
-
-            apply_yes_no("sells:lottery", feature, 8 in services)
-            apply_yes_no("services:copy", feature, 9 in services)
-
-            if 2 in services:
-                apply_category(Categories.BUREAU_DE_CHANGE, feature)
+            # Some post offices offer additional services. Descriptions are next to the IDs in the JSON reposne ("ServiceTitle")
+            service_ids = [service["PostalServiceId"] for service in posta["PostalOfficeServices"]]
+            apply_yes_no("sells:lottery", feature, 11 in service_ids)  # 11 = Igre na srečo Loterije Slovenije
+            apply_yes_no("services:copy", feature, 12 in service_ids)  # 12 = Fotokopiranje
 
             yield feature
 
-    def parse_open_hours(self, obj):
+    def parse_open_hours(self, lst):
         opening_hours = OpeningHours()
 
-        for day in DAYS_FULL:
-            times = obj.get(day + "WorkTime")
-            if not times:
-                continue
-            if times["From1"]:
-                opening_hours.add_range(day=day[:2], open_time=times["From1"], close_time=times["To1"])
-            if times["From2"]:
-                opening_hours.add_range(day=day[:2], open_time=times["From2"], close_time=times["To2"])
+        for times in lst:
+            day = DAYS[times["Day"] - 1]
+
+            if times["WorkingTimeFrom"]:
+                opening_hours.add_range(day=day, open_time=times["WorkingTimeFrom"], close_time=times["WorkingTimeTo"])
+            if times["OtherTimeFrom"]:
+                opening_hours.add_range(day=day, open_time=times["OtherTimeFrom"], close_time=times["OtherTimeTo"])
 
         return opening_hours.as_opening_hours()

--- a/locations/spiders/posta_si.py
+++ b/locations/spiders/posta_si.py
@@ -5,7 +5,7 @@ from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 
-class PostaSpider(scrapy.Spider):
+class PostaSISpider(scrapy.Spider):
     name = "posta_si"
     item_attributes = {"brand": "Pošta Slovenije", "brand_wikidata": "Q6522631"}
     allowed_domains = ["www.posta.si"]


### PR DESCRIPTION
Pošta Slovenije is the Slovenian national postal service operator. This spider is based on the API behind their location finder: https://en.posta.si/post-offices

I couldn't find an endpoint that returns all the data at once, but the minimum length for a search query is 1, so iterating through the alphabet gets you everything without too many requests (26).

The two locations that appear in Italy are also there on the website, so this is an issue at the source, not the spider. I've already informed them about it.