### PR TITLE
note Mo-Su closed

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -67,6 +67,7 @@ When we can, the format for opening hours follows [OpenStreetMap's `opening_hour
 * In some cases only some days of week can be parsed. The unparseable days are omitted from the opening hours while not actually be closed. It is impossible to distinguish between a parsing error and the store being closed, as described in [this issue](https://github.com/alltheplaces/alltheplaces/issues/6943).
 * Opening hours provided by a source and recorded in All the Places may be special for the week due to presence of public holidays within the week at the time of parsing. As a result, the day may be omitted from opening hours output. Also for this reason, some days may have unusually short or unusually long opening hours. Data captured from previous All the Places builds can be checked to find the most common (regular) opening hours for a location.
 * Opening hours format does not match OSM syntax exactly [when time ranges extend across midnight](https://github.com/alltheplaces/alltheplaces/discussions/4959).
+* You should skip entries with `Mo-Su closed` if you want to process only open POIs. These POIs may be not marked otherwise as not existing.
 
 ## Categories
 

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -68,7 +68,7 @@ When we can, the format for opening hours follows [OpenStreetMap's `opening_hour
 * Opening hours provided by a source and recorded in All the Places may be special for the week due to presence of public holidays within the week at the time of parsing. As a result, the day may be omitted from opening hours output. Also for this reason, some days may have unusually short or unusually long opening hours. Data captured from previous All the Places builds can be checked to find the most common (regular) opening hours for a location.
 * Opening hours format does not match OSM syntax exactly [when time ranges extend across midnight](https://github.com/alltheplaces/alltheplaces/discussions/4959).
 * `Mo-Su closed` typically indicates POI closed temporarily for reasons of maintenance and refurbishment. POIs that are permanently closed but listed by source data are returned with the `end_date` field (see `end_date` specification for details).
-  
+
 ## Categories
 
 Along with the above properties we aim to output [OpenStreetMap categories](https://wiki.openstreetmap.org/wiki/Map_features) as properties on the GeoJSON Feature.

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -67,7 +67,7 @@ When we can, the format for opening hours follows [OpenStreetMap's `opening_hour
 * In some cases only some days of week can be parsed. The unparseable days are omitted from the opening hours while not actually be closed. It is impossible to distinguish between a parsing error and the store being closed, as described in [this issue](https://github.com/alltheplaces/alltheplaces/issues/6943).
 * Opening hours provided by a source and recorded in All the Places may be special for the week due to presence of public holidays within the week at the time of parsing. As a result, the day may be omitted from opening hours output. Also for this reason, some days may have unusually short or unusually long opening hours. Data captured from previous All the Places builds can be checked to find the most common (regular) opening hours for a location.
 * Opening hours format does not match OSM syntax exactly [when time ranges extend across midnight](https://github.com/alltheplaces/alltheplaces/discussions/4959).
-* You should skip entries with `Mo-Su closed` if you want to process only open POIs. These POIs may be not marked otherwise as not existing.
+* `Mo-Su closed` typically indicates POI closed temporarily for reasons of maintenance and refurbishment. POIs that are permanently closed should be omitted by spiders.
 
 ## Categories
 

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -51,7 +51,7 @@ Each GeoJSON feature will have a `properties` object with as many of the followi
 | `located_in`          | The name of the feature that this feature is located in.
 | `located_in:wikidata` | The [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) [item ID](https://www.wikidata.org/wiki/Help:Items) for the brand or chain of the feature that this feature is located in. This is a machine-readable identifier counterpart for the human-readable `located_in` above.
 | `nsi_id`              | The [Name Suggestion Index](https://nsi.guide/) (NSI) ID for the feature. NSI IDs aren't stable, so you may require [old NSI data](https://github.com/osmlab/name-suggestion-index/tree/main/dist) if you are working with old ATP data.
-| `end_date`            | `end_date=yes` is applied when given location is closed at unknown date and can be assumed to not operate right now, `end_date` may also have values in year-month-day format, including future dates for planned closures.
+| `end_date`            | `end_date=yes` is applied when given location is closed at unknown date and can be assumed to not operate right now, `end_date` may also have values in year-month-day format, including future dates for planned closures. If the POI has been deleted entirely in the source data, ATP will stop returning the former POI.
 
 ### Extras
 
@@ -67,8 +67,8 @@ When we can, the format for opening hours follows [OpenStreetMap's `opening_hour
 * In some cases only some days of week can be parsed. The unparseable days are omitted from the opening hours while not actually be closed. It is impossible to distinguish between a parsing error and the store being closed, as described in [this issue](https://github.com/alltheplaces/alltheplaces/issues/6943).
 * Opening hours provided by a source and recorded in All the Places may be special for the week due to presence of public holidays within the week at the time of parsing. As a result, the day may be omitted from opening hours output. Also for this reason, some days may have unusually short or unusually long opening hours. Data captured from previous All the Places builds can be checked to find the most common (regular) opening hours for a location.
 * Opening hours format does not match OSM syntax exactly [when time ranges extend across midnight](https://github.com/alltheplaces/alltheplaces/discussions/4959).
-* `Mo-Su closed` typically indicates POI closed temporarily for reasons of maintenance and refurbishment. POIs that are permanently closed should be omitted by spiders.
-
+* `Mo-Su closed` typically indicates POI closed temporarily for reasons of maintenance and refurbishment. POIs that are permanently closed but listed by source data are returned with the `end_date` field (see `end_date` specification for details).
+  
 ## Categories
 
 Along with the above properties we aim to output [OpenStreetMap categories](https://wiki.openstreetmap.org/wiki/Map_features) as properties on the GeoJSON Feature.


### PR DESCRIPTION
This `opening_hours=Mo-Su closed` can easily confuse people, especially as ATP is not using lifecycle prefixes in such cases (it is still `amenity=fast_food` etc) so warning at least in docs would be nice