### PR TITLE
[Kia] Add more countries,  apply some fixes and add category (1853 locations)

### DIFF
--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -45,8 +45,13 @@ class KiaSpider(scrapy.Spider):
             )
             email = store.get("dealerEmail")
             item["email"] = email.strip().strip(".").replace("@@", "@") if email else None
-            if store.get("websiteUrl") not in ["None", ""]:
-                item["website"] = store.get("websiteUrl")
+            if store.get("websiteUrl") not in ["None", "", "No Website", None]:
+                website = store.get("websiteUrl").strip().replace("null", "")
+                if website.startswith("www"):
+                    website = "https://" + website
+                elif website.startswith("kia"):
+                    website = "https://www." + website
+                item["website"] = website
             else:
                 item["website"] = "https://www.kia.com/"
             item["ref"] = store.get("dealerSeq")

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -52,7 +52,7 @@ class KiaSpider(scrapy.Spider):
                 elif website.startswith("kia"):
                     website = "https://www." + website
                 item["website"] = website
-            else:
+            if not item.get("website"):
                 item["website"] = "https://www.kia.com/"
             item["ref"] = store.get("dealerSeq")
             item["country"] = store.get("dealerCountry")

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -7,24 +7,27 @@ class KiaSpider(scrapy.Spider):
     name = "kia"
     item_attributes = {"brand": "Kia", "brand_wikidata": "Q35349"}
     start_urls = [
-        "https://www.kia.com/api/bin/dealer?locale=at-de&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=fr-fr&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=de-de&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=es-es&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=nl-nl&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=be-nl&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=cz-cz&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=dk-da&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=fi-fi&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=gr-el&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=hu-hu&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=ie-en&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=it-it&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=lu-fr&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=no-nn&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=se-sv&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=pl-pl&program=dealerLocatorSearch",
-        "https://www.kia.com/api/bin/dealer?locale=sk-sk&program=dealerLocatorSearch",
+        f"https://www.kia.com/api/bin/dealer?locale={locale}&program=dealerLocatorSearch"
+        for locale in [
+            "at-de",
+            "fr-fr",
+            "de-de",
+            "es-es",
+            "nl-nl",
+            "be-nl",
+            "cz-cz",
+            "dk-da",
+            "fi-fi",
+            "gr-el",
+            "hu-hu",
+            "ie-en",
+            "it-it",
+            "lu-fr",
+            "no-nn",
+            "se-sv",
+            "pl-pl",
+            "sk-sk",
+        ]
     ]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -12,6 +12,19 @@ class KiaSpider(scrapy.Spider):
         "https://www.kia.com/api/bin/dealer?locale=de-de&program=dealerLocatorSearch",
         "https://www.kia.com/api/bin/dealer?locale=es-es&program=dealerLocatorSearch",
         "https://www.kia.com/api/bin/dealer?locale=nl-nl&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=be-nl&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=cz-cz&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=dk-da&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=fi-fi&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=gr-el&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=hu-hu&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=ie-en&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=it-it&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=lu-fr&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=no-nn&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=se-sv&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=pl-pl&program=dealerLocatorSearch",
+        "https://www.kia.com/api/bin/dealer?locale=sk-sk&program=dealerLocatorSearch",
     ]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -1,5 +1,6 @@
 import scrapy
 
+from locations.categories import Categories, apply_category, apply_yes_no
 from locations.items import Feature
 
 
@@ -56,4 +57,10 @@ class KiaSpider(scrapy.Spider):
                 item["website"] = "https://www.kia.com/"
             item["ref"] = store.get("dealerSeq")
             item["country"] = store.get("dealerCountry")
+            dealer_type = store.get("dealerDealertype", "").lower()
+            if "sales" in dealer_type:
+                apply_category(Categories.SHOP_CAR, item)
+            else:
+                apply_category(Categories.SHOP_CAR_REPAIR, item)
+            apply_yes_no("service:vehicle:car_repair", item, "service" in dealer_type)
             yield item

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -39,7 +39,10 @@ class KiaSpider(scrapy.Spider):
             item["city"] = store.get("dealerResidence")
             item["lat"] = store.get("dealerLatitude")
             item["lon"] = store.get("dealerLongitude")
-            item["phone"] = store.get("dealerPhone")
+            phone = store.get("dealerPhone")
+            item["phone"] = (
+                phone.replace(";", "").replace(".", "").replace("/", "").replace(",", ";") if phone else None
+            )
             item["email"] = store.get("dealerEmail")
             if store.get("websiteUrl") not in ["None", ""]:
                 item["website"] = store.get("websiteUrl")

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -46,4 +46,5 @@ class KiaSpider(scrapy.Spider):
             else:
                 item["website"] = "https://www.kia.com/"
             item["ref"] = store.get("dealerSeq")
+            item["country"] = store.get("dealerCountry")
             yield item

--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -43,7 +43,8 @@ class KiaSpider(scrapy.Spider):
             item["phone"] = (
                 phone.replace(";", "").replace(".", "").replace("/", "").replace(",", ";") if phone else None
             )
-            item["email"] = store.get("dealerEmail")
+            email = store.get("dealerEmail")
+            item["email"] = email.strip().strip(".").replace("@@", "@") if email else None
             if store.get("websiteUrl") not in ["None", ""]:
                 item["website"] = store.get("websiteUrl")
             else:


### PR DESCRIPTION
```
{'atp/brand/Kia': 1853,
 'atp/brand_wikidata/Q35349': 1853,
 'atp/category/shop/car': 1548,
 'atp/category/shop/car_repair': 305,
 'atp/field/country/from_reverse_geocoding': 31,
 'atp/field/country/from_website_url': 20,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 323,
 'atp/field/image/missing': 1853,
 'atp/field/opening_hours/missing': 1853,
 'atp/field/operator/missing': 1853,
 'atp/field/operator_wikidata/missing': 1853,
 'atp/field/phone/invalid': 35,
 'atp/field/phone/missing': 31,
 'atp/field/state/missing': 1822,
 'atp/field/twitter/missing': 1853,
 'atp/nsi/cc_match': 1853,
 'downloader/request_bytes': 6789,
 'downloader/request_count': 19,
 'downloader/request_method_count/GET': 19,
 'downloader/response_bytes': 412757,
 'downloader/response_count': 19,
 'downloader/response_status_count/200': 19,
 'elapsed_time_seconds': 23.880477,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 30, 21, 53, 37, 55387, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6652483,
 'httpcompression/response_count': 17,
 'item_scraped_count': 1853,
 'log_count/DEBUG': 1883,
 'log_count/INFO': 9,
 'response_received_count': 19,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 18,
 'scheduler/dequeued/memory': 18,
 'scheduler/enqueued': 18,
 'scheduler/enqueued/memory': 18,
 'start_time': datetime.datetime(2024, 7, 30, 21, 53, 13, 174910, tzinfo=datetime.timezone.utc)}
```