### PR TITLE
[Boconcept] New spider (295 items)

### DIFF
--- a/locations/spiders/boconcept.py
+++ b/locations/spiders/boconcept.py
@@ -1,0 +1,62 @@
+from scrapy import Spider
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class BoconceptSpider(Spider):
+    name = "boconcept"
+    item_attributes = {"brand": "BoConcept", "brand_wikidata": "Q11338915"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.boconcept.com/api/store/search/?locale=en-us&mb=-90%2C-180%2C90%2C180"]
+
+    def parse(self, response):
+        for location in response.json():
+            if location["storeType"] != "Brand store":
+                continue
+
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("street")
+
+            # The chain was founded in 1952, use this fact to filter out invalid dates
+            opening = location["operationalStatus"]["storeFirstDayOpen"].split("T")[0]
+            if int(opening[:4]) >= 1952:
+                item["extras"]["start_date"] = opening
+            closing = location["operationalStatus"]["storeClosingDay"].split("T")[0]
+            if int(closing[:4]) >= 1952:
+                item["extras"]["end_date"] = closing
+
+            amenities = {amenity["id"] for amenity in location["amenities"]}
+            apply_yes_no(Extras.DELIVERY, item, "deliveryassembly" in amenities)
+            apply_yes_no(
+                Extras.WHEELCHAIR,
+                item,
+                not amenities.isdisjoint({"wheelchairelevator", "wheelchairenterance", "wheelchairparking"}),
+            )
+            apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, "wheelchairrestroom" in amenities)
+
+            oh = OpeningHours()
+            for day in location["normalWeekOpeningHours"].values():
+                if day["closed"]:
+                    oh.set_closed(day["dayOfWeek"])
+                else:
+                    for row in day["openingHoursList"]:
+                        oh.add_range(day["dayOfWeek"], row["open"], row["close"])
+            item["opening_hours"] = oh
+
+            contact_info = location["contactInformation"]
+            item["email"] = contact_info["email"]
+            if contact_info["phone"]:
+                if contact_info["phone"].startswith("+"):
+                    item["phone"] = contact_info["phone"]
+                else:
+                    item["phone"] = f"{contact_info['phoneCountryCode']} {contact_info['phone']}"
+
+            if location["images"]:
+                item["image"] = location["images"][0]["imageUrl"]
+            if location["storePageUrl"]:
+                item["website"] = response.urljoin(location["storePageUrl"])
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/BoConcept': 295,
 'atp/brand_wikidata/Q11338915': 295,
 'atp/category/shop/furniture': 295,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/closed_poi': 3,
 'atp/field/city/missing': 33,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 251,
 'atp/field/operator/missing': 295,
 'atp/field/operator_wikidata/missing': 295,
 'atp/field/phone/invalid': 21,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 51,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 219,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 295,
 'atp/field/website/missing': 180,
 'atp/nsi/perfect_match': 295,
 'downloader/request_bytes': 353,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 115807,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.751911,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 31, 0, 42, 5, 896394, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1177683,
 'httpcompression/response_count': 1,
 'item_scraped_count': 295,
 'log_count/DEBUG': 307,
 'log_count/INFO': 9,
 'memusage/max': 163102720,
 'memusage/startup': 163102720,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 31, 0, 42, 1, 144483, tzinfo=datetime.timezone.utc)}
```