### PR TITLE
[MendocinoFarms] New spider (72 locations)

### DIFF
--- a/locations/spiders/mendocino_farms.py
+++ b/locations/spiders/mendocino_farms.py
@@ -1,0 +1,22 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MendocinoFarmsSpider(CrawlSpider, StructuredDataSpider):
+    name = "mendocino_farms"
+    item_attributes = {"brand": "Mendocino Farms", "brand_wikidata": "Q110671982"}
+    start_urls = ["https://www.mendocinofarms.com/locations"]
+    allowed_domains = ["www.mendocinofarms.com"]
+    rules = [Rule(LinkExtractor(allow=(r"/locations/[\w-]+$",)), callback="parse_sd")]
+    search_for_twitter = False
+    search_for_facebook = False
+
+    # The site lists both LocalBusiness and Restaurant. Both of these are accepded by StructuredDataSpider by default, so only allowing one removes duplicates.
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item, response, ld_data):
+        item["branch"] = item.pop("name")
+        item["website"] = item["ref"]
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Mendocino Farms': 72,
 'atp/brand_wikidata/Q110671982': 72,
 'atp/category/amenity/fast_food': 72,
 'atp/cdn/cloudflare/response_count': 75,
 'atp/cdn/cloudflare/response_status_count/200': 75,
 'atp/field/email/missing': 72,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 72,
 'atp/field/operator_wikidata/missing': 72,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 72,
 'atp/nsi/perfect_match': 72,
 'downloader/request_bytes': 73113,
 'downloader/request_count': 75,
 'downloader/request_method_count/GET': 75,
 'downloader/response_bytes': 496695,
 'downloader/response_count': 75,
 'downloader/response_status_count/200': 75,
 'elapsed_time_seconds': 93.396789,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 31, 0, 48, 38, 144788, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1531680,
 'httpcompression/response_count': 75,
 'item_scraped_count': 72,
 'log_count/DEBUG': 158,
 'log_count/INFO': 10,
 'memusage/max': 308346880,
 'memusage/startup': 163344384,
 'request_depth_max': 1,
 'response_received_count': 75,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 74,
 'scheduler/dequeued/memory': 74,
 'scheduler/enqueued': 74,
 'scheduler/enqueued/memory': 74,
 'start_time': datetime.datetime(2024, 7, 31, 0, 47, 4, 747999, tzinfo=datetime.timezone.utc)}
```