### PR TITLE
[YardHouse] New spider (88 locations)

### DIFF
--- a/locations/spiders/yard_house.py
+++ b/locations/spiders/yard_house.py
@@ -1,0 +1,58 @@
+import re
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+def slugify(s):
+    return re.sub(r"[^\w]+", "-", s, count=0).lower()
+
+
+class YardHouseSpider(Spider):
+    name = "yard_house"
+    item_attributes = {"brand": "Yard House", "brand_wikidata": "Q21189156"}
+
+    def start_requests(self):
+        yield JsonRequest("https://www.yardhouse.com/api/restaurants", headers={"x-source-channel": "WEB"})
+
+    def parse(self, response):
+        for location in response.json()["restaurants"]:
+            item = DictParser.parse(location["contactDetail"]["address"])
+            item["ref"] = location["restaurantNumber"]
+            item["branch"] = location["restaurantName"]
+            item["phone"] = location["contactDetail"]["phoneDetail"][0]["phoneNumber"]
+            item["street_address"] = merge_address_lines(
+                [location["contactDetail"]["address"]["street1"], location["contactDetail"]["address"].get("street2")]
+            )
+            item["country"] = location["contactDetail"]["address"]["country"]
+            item["extras"]["start_date"] = location["restaurantOpenDate"]
+            # Opening hours are only today's
+
+            apply_yes_no(
+                Extras.TAKEAWAY,
+                item,
+                location["features"].get("isRestaurantTogoEnabled")
+                or location["features"].get("onlineTogoEnabled")
+                or location["features"].get("curbSideTogoEnabled"),
+            )
+            apply_yes_no(
+                Extras.OUTDOOR_SEATING,
+                item,
+                any(amenity["title"] == "Patio seating available" for amenity in location["amenities"]),
+            )
+            apply_yes_no(Extras.WIFI, item, any(amenity["title"] == "Free WiFi" for amenity in location["amenities"]))
+
+            item["website"] = (
+                f"https://www.yardhouse.com/locations/{slugify(item['state'])}/{slugify(item['city'])}/{slugify(item['branch'])}/{item['ref']}"
+            )
+
+            # Note: Not reliable (especially when there's more than one location in the city)
+            item["image"] = (
+                f"https://media.yardhouse.com/en_us/images/marketing/{slugify(item['city'])}-{slugify(item['state'])}-yard-house-599x430.jpg.jpg"
+            )
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Yard House': 88,
 'atp/brand_wikidata/Q21189156': 88,
 'atp/category/amenity/restaurant': 88,
 'atp/field/email/missing': 88,
 'atp/field/opening_hours/missing': 88,
 'atp/field/operator/missing': 88,
 'atp/field/operator_wikidata/missing': 88,
 'atp/field/twitter/missing': 88,
 'atp/nsi/perfect_match': 88,
 'downloader/request_bytes': 659,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 26655,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.323425,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 7, 31, 2, 59, 22, 307244, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 248132,
 'httpcompression/response_count': 1,
 'item_scraped_count': 88,
 'log_count/DEBUG': 101,
 'log_count/INFO': 9,
 'memusage/max': 163524608,
 'memusage/startup': 163524608,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 7, 31, 2, 59, 19, 983819, tzinfo=datetime.timezone.utc)}
```