### PR TITLE
[Pandora] Refactor spider using RioSeoSpider to cover more countries, missing in the sitemap (6472 locations)

### DIFF
--- a/locations/spiders/pandora.py
+++ b/locations/spiders/pandora.py
@@ -18,7 +18,7 @@ class PandoraSpider(RioSeoSpider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # Fix error because of some html tags
         response.json()["maplist"] = (
-            response.json()["maplist"].replace('<\\\/sup\\"', '</sup>\\"').replace("<sup>", "").replace("</sup>", "")
+            response.json()["maplist"].replace('<\\/sup\\"', '</sup>\\"').replace("<sup>", "").replace("</sup>", "")
         )
         yield from RioSeoSpider.parse(self, response=response)
 

--- a/locations/spiders/pandora.py
+++ b/locations/spiders/pandora.py
@@ -1,51 +1,31 @@
-import re
+from typing import Any, Iterable
 
-import scrapy
+from scrapy.http import Response
 
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
+from locations.storefinders.rio_seo import RioSeoSpider
 
 
-class PandoraSpider(scrapy.spiders.SitemapSpider):
+class PandoraSpider(RioSeoSpider):
     name = "pandora"
-    item_attributes = {
-        "brand": "Pandora",
-        "brand_wikidata": "Q2241604",
-    }
-    download_delay = 0.2
-    allowed_domains = ["pandora.net"]
-    sitemap_urls = ["https://stores.pandora.net/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/stores\.pandora\.net\/[^(?{2,})]+-([\w\d]+)\.html$", "parse_store")]
+    item_attributes = {"brand": "Pandora", "brand_wikidata": "Q2241604"}
+    # Not all search text give the same POIs count from this API https://maps.pandora.net/api/getAutocompleteData
+    # The search text used below gives the max POIs count.
+    start_urls = [
+        "https://maps.pandora.net/api/getAsyncLocations?template=domain&level=domain&search=Makkah, SA&radius=10000&limit=10000",
+    ]
 
-    def parse_store(self, response):
-        yield self.parse_item(response, self.sitemap_rules[0][0])
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Fix error because of some html tags
+        response.json()["maplist"] = (
+            response.json()["maplist"].replace('<\\\/sup\\"', '</sup>\\"').replace("<sup>", "").replace("</sup>", "")
+        )
+        yield from RioSeoSpider.parse(self, response=response)
 
-    @staticmethod
-    def parse_item(response, ref_regex) -> Feature:
-        ld_item = LinkedDataParser.find_linked_data(response, "JewelryStore")
-
-        if not ld_item:
-            return
-
-        if not ld_item.get("telephone"):
-            ld_item["telephone"] = ld_item["address"].get("telephone")
-
-        if ld_item.get("openingHours") and isinstance(ld_item["openingHours"], str):
-            ld_item["openingHours"] = re.findall(r"\w{2} \d{2}:\d{2} - \d{2}:\d{2}", ld_item["openingHours"])
-
-        if not ld_item.get("branchCode") and not ld_item.get("@id"):
-            ld_item["branchCode"] = re.match(ref_regex, response.url).group(1)
-
-        item = LinkedDataParser.parse_ld(ld_item)
-        if item:
-            item["website"] = response.url
-
-            if item["state"] == "JE":
-                item["state"] = "JE-JerseyIsSpecial"
-            # In many countries "state" is set to "country-region", unpick and discard region
-            splits = item["state"].split("-")
-            if len(splits) == 2 and len(splits[0]) == 2:
-                item["state"] = None
-                item["country"] = splits[0]
-
-            return item
+    def post_process_feature(self, feature: Feature, location: dict) -> Iterable[Feature]:
+        feature["phone"] = location.get("location_phone") or location.get("local_phone")
+        feature["postcode"] = location.get("location_post_code") or location.get("post_code")
+        feature["website"] = "https://stores.pandora.net/"
+        if location.get("Store Type_CS") == "Authorized Retailers":
+            feature["extras"]["secondary"] = "yes"
+        yield feature


### PR DESCRIPTION
```
{'atp/brand/Pandora': 6472,
 'atp/brand_wikidata/Q2241604': 6472,
 'atp/category/shop/jewelry': 6472,
 'atp/field/country/from_reverse_geocoding': 2959,
 'atp/field/email/missing': 6472,
 'atp/field/image/missing': 6472,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 1874,
 'atp/field/operator/missing': 6472,
 'atp/field/operator_wikidata/missing': 6472,
 'atp/field/phone/invalid': 156,
 'atp/field/phone/missing': 564,
 'atp/field/postcode/missing': 397,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 3514,
 'atp/field/twitter/missing': 6472,
 'atp/item_scraped_host_count/maps.pandora.net': 6472,
 'atp/nsi/perfect_match': 6472,
 'downloader/request_bytes': 714,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 6484255,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 30.68747,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 1, 17, 43, 16, 610314, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 84797248,
 'httpcompression/response_count': 2,
 'item_scraped_count': 6472,
 'log_count/DEBUG': 6485,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 1, 17, 42, 45, 922844, tzinfo=datetime.timezone.utc)}
```