### PR TITLE
[Cb2, Crateandbarrel] New spider for spinoff brand (23 locations), and tweak Crateandbarrel tagging

### DIFF
--- a/locations/spiders/cb2.py
+++ b/locations/spiders/cb2.py
@@ -1,0 +1,19 @@
+from locations.categories import Categories
+from locations.spiders.crateandbarrel import CrateandbarrelSpider
+
+
+class Cb2Spider(CrateandbarrelSpider):
+    name = "cb2"
+    allowed_domains = ["www.cb2.com"]
+    item_attributes = {
+        "brand": "CB2",
+        "name": "CB2",
+        "brand_wikidata": "Q113164236",
+        "extras": Categories.SHOP_FURNITURE.value,
+    }
+    start_urls = ["https://www.cb2.com/stores/list-state/retail-stores"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        for item in super().post_process_item(item, response, ld_data, **kwargs):
+            item["branch"] = item["branch"].removeprefix("CB2 ")
+            yield item

--- a/locations/spiders/crateandbarrel.py
+++ b/locations/spiders/crateandbarrel.py
@@ -20,7 +20,9 @@ class CrateandbarrelSpider(CrawlSpider, StructuredDataSpider):
             callback="parse_sd",
         ),
     ]
+    search_for_facebook = False
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["ref"] = item["website"] = response.url
+        item["branch"] = item.pop("name")
         yield item

--- a/locations/spiders/crateandbarrel.py
+++ b/locations/spiders/crateandbarrel.py
@@ -8,7 +8,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class CrateandbarrelSpider(CrawlSpider, StructuredDataSpider):
     name = "crateandbarrel"
     allowed_domains = ["www.crateandbarrel.com"]
-    item_attributes = {"brand": "crateandbarrel", "brand_wikidata": "Q5182604"}
+    item_attributes = {"brand": "Crate & Barrel", "brand_wikidata": "Q5182604"}
     start_urls = ["https://www.crateandbarrel.com/stores/list-state/retail-stores"]
     user_agent = BROWSER_DEFAULT
     rules = [


### PR DESCRIPTION
```py
{'atp/brand/CB2': 23,
 'atp/brand_wikidata/Q113164236': 23,
 'atp/category/shop/furniture': 23,
 'atp/field/email/missing': 23,
 'atp/field/operator/missing': 23,
 'atp/field/operator_wikidata/missing': 23,
 'atp/field/twitter/missing': 23,
 'atp/nsi/brand_missing': 23,
 'downloader/request_bytes': 24218,
 'downloader/request_count': 41,
 'downloader/request_method_count/GET': 41,
 'downloader/response_bytes': 4325930,
 'downloader/response_count': 41,
 'downloader/response_status_count/200': 41,
 'dupefilter/filtered': 30,
 'elapsed_time_seconds': 49.773888,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 3, 3, 58, 59, 624257, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 23534817,
 'httpcompression/response_count': 41,
 'item_scraped_count': 23,
 'log_count/DEBUG': 76,
 'log_count/INFO': 9,
 'memusage/max': 162070528,
 'memusage/startup': 162070528,
 'request_depth_max': 2,
 'response_received_count': 41,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 40,
 'scheduler/dequeued/memory': 40,
 'scheduler/enqueued': 40,
 'scheduler/enqueued/memory': 40,
 'start_time': datetime.datetime(2024, 8, 3, 3, 58, 9, 850369, tzinfo=datetime.timezone.utc)}
```