### PR TITLE
[JbHiFiAU] Rename spider, filter non-stores, move name to branch

### DIFF
--- a/locations/spiders/jb_hi_fi_au.py
+++ b/locations/spiders/jb_hi_fi_au.py
@@ -1,10 +1,12 @@
+import re
+
 from locations.hours import DAYS_3_LETTERS_FROM_SUNDAY, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
 from locations.storefinders.algolia import AlgoliaSpider
 
 
-class JbhifiSpider(AlgoliaSpider):
-    name = "jbhifi"
+class JbHiFiAUSpider(AlgoliaSpider):
+    name = "jb_hi_fi_au"
     item_attributes = {"brand": "JB Hi-Fi", "brand_wikidata": "Q3310113"}
     api_key = "a0c0108d737ad5ab54a0e2da900bf040"
     app_id = "VTVKM5URPX"
@@ -21,8 +23,16 @@ class JbhifiSpider(AlgoliaSpider):
         return opening_hours.as_opening_hours()
 
     def parse_item(self, item, location):
+        if location.get("displayOnWeb") != "p":
+            return
+
+        if location["locationType"] == 2:
+            item["brand"] = item["name"] = "JB Hi-Fi Home"
+        else:
+            del item["name"]
+
         item["ref"] = location["shopId"]
-        item["name"] = location["storeName"]
+        item["branch"] = location["storeName"]
         item["street_address"] = clean_address(
             [
                 location["storeAddress"]["Line1"],
@@ -30,13 +40,11 @@ class JbhifiSpider(AlgoliaSpider):
                 location["storeAddress"].get("Line3"),
             ]
         )
-        item["city"] = location["storeAddress"]["Suburb"]
-        item["state"] = location["storeAddress"].get("State")
-        item["postcode"] = location["storeAddress"]["Postcode"]
-        item["country"] = "AU"
         item["lat"] = location["_geoloc"]["lat"]
         item["lon"] = location["_geoloc"]["lng"]
-        item["phone"] = location["phone"]
         item["opening_hours"] = self.process_trading_hours(location["normalTradingHours"])
+
+        slug = re.sub(r"\W+", "-", location["storeName"]).lower()
+        item["website"] = f"https://www.jbhifi.com.au/pages/{slug}"
 
         yield item

--- a/locations/spiders/jb_hifi_au.py
+++ b/locations/spiders/jb_hifi_au.py
@@ -5,8 +5,8 @@ from locations.pipelines.address_clean_up import clean_address
 from locations.storefinders.algolia import AlgoliaSpider
 
 
-class JbHiFiAUSpider(AlgoliaSpider):
-    name = "jb_hi_fi_au"
+class JbHifiAUSpider(AlgoliaSpider):
+    name = "jb_hifi_au"
     item_attributes = {"brand": "JB Hi-Fi", "brand_wikidata": "Q3310113"}
     api_key = "a0c0108d737ad5ab54a0e2da900bf040"
     app_id = "VTVKM5URPX"


### PR DESCRIPTION
```py
{'atp/brand/JB Hi-Fi': 148,
 'atp/brand/JB Hi-Fi Home': 63,
 'atp/brand_wikidata/Q3310113': 211,
 'atp/category/shop/electronics': 211,
 'atp/field/country/from_website_url': 15,
 'atp/field/email/missing': 211,
 'atp/field/image/missing': 211,
 'atp/field/operator/missing': 211,
 'atp/field/operator_wikidata/missing': 211,
 'atp/field/twitter/missing': 211,
 'atp/nsi/perfect_match': 211,
 'downloader/request_bytes': 1133,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 61570,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.30783,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 3, 4, 2, 10, 403187, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 770658,
 'httpcompression/response_count': 1,
 'item_scraped_count': 211,
 'log_count/DEBUG': 226,
 'log_count/INFO': 9,
 'memusage/max': 163303424,
 'memusage/startup': 163303424,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 3, 4, 2, 6, 95357, tzinfo=datetime.timezone.utc)}
```