### PR TITLE
[UrbanPlatesUS] New spider (19 locations)

### DIFF
--- a/locations/spiders/urban_plates.py
+++ b/locations/spiders/urban_plates.py
@@ -1,0 +1,51 @@
+from scrapy import FormRequest, Spider
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class UrbanPlatesSpider(Spider):
+    name = "urban_plates"
+    item_attributes = {
+        "brand": "Urban Plates",
+        "brand_wikidata": "Q96413021",
+        "name": "Urban Plates",
+        "extras": Categories.FAST_FOOD.value,
+        # They claim it's not fast food, but it appears that you order at the cashier, not with a waiter
+    }
+
+    def start_requests(self):
+        yield FormRequest(
+            "https://api.urbanplates.com/proxy.php", formdata={"route": "/stores?all_stores=true", "method": "GET"}
+        )
+
+    def parse(self, response):
+        for location in response.json()["response"]:
+            # skip customer service store
+            if location["store_id"] == "900":
+                continue
+
+            item = DictParser.parse(location)
+
+            item["website"] = f"https://urbanplates.com/store-details/?store_id={location['store_id']}"
+            item["image"] = f"https://urbanplates.com/assets/img/locations/{location['store_id']}.jpg"
+            item["branch"] = item.pop("name")
+
+            apply_yes_no(
+                Extras.DELIVERY,
+                item,
+                any(service["group_name"] == "delivery" and service["is_visible"] for service in location["services"]),
+            )
+            apply_yes_no(
+                Extras.TAKEAWAY,
+                item,
+                any(service["group_name"] == "pickup" and service["is_visible"] for service in location["services"]),
+            )
+
+            oh = OpeningHours()
+            for day in location["hours"]:
+                oh.add_range(DAYS[day["day_of_week"]], day["start_time"], day["end_time"])
+            item["opening_hours"] = oh
+
+            yield item

--- a/locations/spiders/urban_plates_us.py
+++ b/locations/spiders/urban_plates_us.py
@@ -21,7 +21,7 @@ class UrbanPlatesUSSpider(Spider):
 
     def parse(self, response):
         for location in response.json()["response"]:
-            # skip customer service store
+            # Copied from website code: skip customer service store
             if location["store_id"] == "900":
                 continue
 

--- a/locations/spiders/urban_plates_us.py
+++ b/locations/spiders/urban_plates_us.py
@@ -12,7 +12,6 @@ class UrbanPlatesUSSpider(Spider):
         "brand_wikidata": "Q96413021",
         "name": "Urban Plates",
         "extras": Categories.FAST_FOOD.value,
-        # They claim it's not fast food, but it appears that you order at the cashier, not with a waiter
     }
 
     def start_requests(self):

--- a/locations/spiders/urban_plates_us.py
+++ b/locations/spiders/urban_plates_us.py
@@ -5,8 +5,8 @@ from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
 
-class UrbanPlatesSpider(Spider):
-    name = "urban_plates"
+class UrbanPlatesUSSpider(Spider):
+    name = "urban_plates_us"
     item_attributes = {
         "brand": "Urban Plates",
         "brand_wikidata": "Q96413021",


### PR DESCRIPTION
```py
{'atp/brand/Urban Plates': 19,
 'atp/brand_wikidata/Q96413021': 19,
 'atp/category/amenity/fast_food': 19,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/nsi/brand_missing': 19,
 'downloader/request_bytes': 715,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 4601,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.792028,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 5, 17, 44, 36, 222196, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 112413,
 'httpcompression/response_count': 1,
 'item_scraped_count': 19,
 'log_count/DEBUG': 33,
 'log_count/INFO': 10,
 'memusage/max': 228478976,
 'memusage/startup': 228478976,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 5, 17, 44, 34, 430168, tzinfo=datetime.timezone.utc)}
```