### PR TITLE
[LePainQuotidien] New spider (177 locations) (fixes #9158)

### DIFF
--- a/locations/spiders/le_pain_quotidien.py
+++ b/locations/spiders/le_pain_quotidien.py
@@ -41,6 +41,8 @@ DELIVERY_PARTNERS = {
 
 
 def time_dict_to_struct(t):
+    if t is None:
+        return None
     if t["hours"] >= 24:
         t["hours"] = 23
         t["minutes"] = 59
@@ -74,7 +76,9 @@ class LePainQuotidienSpider(Spider):
             oh = OpeningHours()
             for period in location["regularHours"]["periods"]:
                 oh.add_range(
-                    period["openDay"], time_dict_to_struct(period["openTime"]), time_dict_to_struct(period["closeTime"])
+                    period["openDay"],
+                    time_dict_to_struct(period.get("openTime")),
+                    time_dict_to_struct(period.get("closeTime")),
                 )
             item["opening_hours"] = oh
 

--- a/locations/spiders/le_pain_quotidien.py
+++ b/locations/spiders/le_pain_quotidien.py
@@ -1,0 +1,91 @@
+from time import struct_time
+from urllib.parse import quote
+
+from scrapy import Request, Spider
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+COUNTRY_TO_LANGUAGE = {
+    "AE": "en",
+    "AR": "es",
+    "BE": "fr",
+    "BR": "pt",
+    "CH": "en",
+    "CO": "es",
+    "ES": "es",
+    "FR": "fr",
+    "GB": "en",
+    "GR": "en",
+    "JP": "ja",
+    "LU": "en",
+    "MA": "en",
+    "MX": "es",
+    "NL": "nl",
+    "TR": "tr",
+    "UK": "en",
+    "US": "en",
+    "UY": "en",
+}
+
+DELIVERY_PARTNERS = {
+    "pedidosYa": "Pedidos Ya",
+    "clickAndConnect": None,
+    "uberEats": "Ubereats",
+    "deliveroo": "Deliveroo",
+    "justEat": "Just Eat",
+    "rappi": "Rappi",
+}
+
+
+def time_dict_to_struct(t):
+    if t["hours"] >= 24:
+        t["hours"] = 23
+        t["minutes"] = 59
+    return struct_time((1900, 1, 1, t["hours"], t.get("minutes", 0), 0, 0, 1, -1))
+
+
+class LePainQuotidienSpider(Spider):
+    name = "le_pain_quotidien"
+    item_attributes = {"brand": "Le Pain Quotidien", "brand_wikidata": "Q2046903"}
+
+    def start_requests(self):
+        yield Request(
+            "https://api.obenan.com/api/v1/listing/search",
+            headers={
+                "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2NhdGlvbkFwaURhdGEiOnsiaWQiOiIxNzUifSwiaWF0IjoxNjgzNzMwNzAyfQ.Oy4pCx-1kTiRVifVdXDS6B5ymu0wC4E4Ieq5HewoBfY"
+            },
+        )
+
+    def parse(self, response):
+        for location in response.json()["data"]["data"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["country"] = location["regionCode"]
+            item["geometry"] = location["latlng"]
+            item["street_address"] = merge_address_lines(location["addressLines"])
+            # Note: Doesn't work for Mexico (slug missing)
+            item["website"] = (
+                f"https://www.lepainquotidien.com/{location['regionCode'].lower()}/{COUNTRY_TO_LANGUAGE[location['regionCode']]}/locations/{quote(location['slug'])}/{quote(location['addressLines'][0].replace(' ', '-'))}"
+            )
+
+            oh = OpeningHours()
+            for period in location["regularHours"]["periods"]:
+                oh.add_range(
+                    period["openDay"], time_dict_to_struct(period["openTime"]), time_dict_to_struct(period["closeTime"])
+                )
+            item["opening_hours"] = oh
+
+            delivery_options = {partner for partner, url in location["deliveryOptions"].items() if url != ""}
+            if len(delivery_options) > 0:
+                apply_yes_no(Extras.DELIVERY, item, True)
+                for partner in delivery_options:
+                    if partner not in DELIVERY_PARTNERS:
+                        self.crawler.stats.inc_value(f"atp/le_pain_quotidien/unmapped_delivery/{partner}")
+                item["extras"]["delivery:partner"] = ";".join(
+                    filter(None, (DELIVERY_PARTNERS.get(partner) for partner in delivery_options))
+                )
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Le Pain Quotidien': 177,
 'atp/brand_wikidata/Q2046903': 177,
 'atp/category/amenity/cafe': 177,
 'atp/field/city/missing': 3,
 'atp/field/email/missing': 177,
 'atp/field/image/missing': 177,
 'atp/field/operator/missing': 177,
 'atp/field/operator_wikidata/missing': 177,
 'atp/field/phone/missing': 10,
 'atp/field/state/from_reverse_geocoding': 49,
 'atp/field/state/missing': 128,
 'atp/field/twitter/missing': 177,
 'atp/item_scraped_host_count/api.obenan.com': 177,
 'atp/nsi/perfect_match': 177,
 'downloader/request_bytes': 792,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 27128,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.664646,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 7, 19, 20, 41, 855414, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 286656,
 'httpcompression/response_count': 2,
 'item_scraped_count': 177,
 'log_count/DEBUG': 190,
 'log_count/INFO': 10,
 'memusage/max': 230191104,
 'memusage/startup': 230191104,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 7, 19, 20, 38, 190768, tzinfo=datetime.timezone.utc)}
```

Note that it looks to be using a storefinder, "Obenan," but no other spiders appear to use it yet.

The Authorization "Bearer" code is partly base64 for some JSON, but the token is hard-coded as b64 in the website code so I think it's fine to do the same.