### PR TITLE
Big O Tires (473 locations) (fix #9001)

### DIFF
--- a/locations/spiders/big_o_tires_ca.py
+++ b/locations/spiders/big_o_tires_ca.py
@@ -1,0 +1,30 @@
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class BigOTiresCASpider(Spider):
+    name = "big_o_tires_ca"
+    item_attributes = {"brand": "Big O Tires", "brand_wikidata": "Q4906085"}
+    start_urls = ["https://wl.tireconnect.ca/api//v2/location/list?key=f5658cf9372416d9e285adb59383b55b"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response):
+        for location in response.json()["data"]["locations"]:
+            item = DictParser.parse(location)
+            if item["name"].startswith("Big O Tire"):
+                item["branch"] = item.pop("name").removeprefix("Big O Tire").removeprefix("s").strip()
+            item["street_address"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
+            item["state"] = location["province_code"]
+
+            oh = OpeningHours()
+            for day, hours in location["working_hours"].items():
+                open_hours = (hours["open"] or []) + (hours["break"] or [])
+                open_hours.sort()
+                for open_time, close_time in zip(open_hours[0::2], open_hours[1::2]):
+                    oh.add_range(day, open_time, close_time)
+            item["opening_hours"] = oh
+
+            yield item

--- a/locations/spiders/big_o_tires_us.py
+++ b/locations/spiders/big_o_tires_us.py
@@ -1,5 +1,3 @@
-import logging
-
 from scrapy import Spider
 from scrapy.downloadermiddlewares.retry import get_retry_request
 from scrapy.http import JsonRequest
@@ -7,8 +5,6 @@ from scrapy.http import JsonRequest
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.searchable_points import open_searchable_points
-
-logger = logging.getLogger(__name__)
 
 
 class BigOTiresUSSpider(Spider):
@@ -40,7 +36,7 @@ class BigOTiresUSSpider(Spider):
             # Unfortunately, this can also mean "too many stores"
             return
         elif status["code"] != "000":
-            logger.error(f"Got code {status['code']} for request {params}: {status['description']}")
+            self.logger.error(f"Got code {status['code']} for request {params}: {status['description']}")
             return
 
         if "storesType" not in response.json() or "stores" not in response.json()["storesType"]:

--- a/locations/spiders/big_o_tires_us.py
+++ b/locations/spiders/big_o_tires_us.py
@@ -1,0 +1,62 @@
+import logging
+
+from scrapy import Spider
+from scrapy.downloadermiddlewares.retry import get_retry_request
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.searchable_points import open_searchable_points
+
+logger = logging.getLogger(__name__)
+
+
+class BigOTiresUSSpider(Spider):
+    name = "big_o_tires_us"
+    item_attributes = {"brand": "Big O Tires", "brand_wikidata": "Q4906085"}
+
+    def start_requests(self):
+        with open_searchable_points("us_centroids_100mile_radius.csv") as points:
+            next(points)
+            for point in points:
+                _, lat, lon = tuple(map(float, point.strip().split(",")))
+                params = {"latitude": lat, "longitude": lon, "distanceInMiles": 100}
+                yield JsonRequest(
+                    "https://www.bigotires.com/restApi/dp/v1/store/storesByLatitudeAndLongitude",
+                    data=params,
+                    headers={"X-Requested-By": "123"},
+                    cb_kwargs={"params": params},
+                )
+
+    def parse(self, response, params):
+        if "status" not in response.json():
+            return get_retry_request(response.request, spider=self, reason="missing status")
+
+        status = response.json()["status"]
+        if status["code"] == "002":
+            return get_retry_request(response.request, spider=self, reason="status 002")
+        elif status["code"] == "013":
+            # No stores found
+            # Unfortunately, this can also mean "too many stores"
+            return
+        elif status["code"] != "000":
+            logger.error(f"Got code {status['code']} for request {params}: {status['description']}")
+            return
+
+        if "storesType" not in response.json() or "stores" not in response.json()["storesType"]:
+            return get_retry_request(response.request, spider=self, reason="missing stores")
+
+        for location in response.json()["storesType"]["stores"]:
+            item = DictParser.parse(location)
+            item["phone"] = location["phoneNumbers"][0]
+            item["lat"] = location["mapCenter"]["latitude"]
+            item["lon"] = location["mapCenter"]["longitude"]
+            item["website"] = response.urljoin(location["storeDetailsUrl"])
+            item["email"] = location["owner"]["email"]
+
+            oh = OpeningHours()
+            for day in location["workingHours"]:
+                oh.add_range(day["day"], day["openingHour"], day["closingHour"], "%I:%M %p")
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Big O Tires': 464,
 'atp/brand_wikidata/Q4906085': 464,
 'atp/category/shop/tyres': 464,
 'atp/field/country/from_spider_name': 464,
 'atp/field/image/missing': 464,
 'atp/field/operator/missing': 464,
 'atp/field/operator_wikidata/missing': 464,
 'atp/field/twitter/missing': 464,
 'atp/item_scraped_host_count/www.bigotires.com': 898,
 'atp/nsi/perfect_match': 464,
 'downloader/request_bytes': 390840,
 'downloader/request_count': 477,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 476,
 'downloader/response_bytes': 1082690,
 'downloader/response_count': 477,
 'downloader/response_status_count/200': 477,
 'elapsed_time_seconds': 577.376104,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 8, 20, 50, 12, 382390, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1499803,
 'httpcompression/response_count': 106,
 'item_dropped_count': 434,
 'item_dropped_reasons_count/DropItem': 434,
 'item_scraped_count': 464,
 'log_count/DEBUG': 1387,
 'log_count/INFO': 19,
 'memusage/max': 375152640,
 'memusage/startup': 231628800,
 'response_received_count': 477,
 'retry/count': 1,
 'retry/reason_count/status 002': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 476,
 'scheduler/dequeued/memory': 476,
 'scheduler/enqueued': 476,
 'scheduler/enqueued/memory': 476,
 'start_time': datetime.datetime(2024, 8, 8, 20, 40, 35, 6286, tzinfo=datetime.timezone.utc)}
```
```py
{'atp/brand/Big O Tires': 9,
 'atp/brand_wikidata/Q4906085': 9,
 'atp/category/shop/tyres': 9,
 'atp/field/image/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/website/missing': 9,
 'atp/item_scraped_host_count/wl.tireconnect.ca': 9,
 'atp/nsi/perfect_match': 9,
 'downloader/request_bytes': 356,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 10616,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.953652,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 8, 21, 26, 18, 702955, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9,
 'log_count/DEBUG': 21,
 'log_count/INFO': 10,
 'memusage/max': 230977536,
 'memusage/startup': 230977536,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 8, 21, 26, 17, 749303, tzinfo=datetime.timezone.utc)}
```
I noticed that the Canada site actually has a second, larger list of locations as well as a store finder map. The map has some locations not on the location list. The location list has website links but no coordinates.