### PR TITLE
Update Pick n Pay spider brands, wikidata and province fixes

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -43,6 +43,8 @@ class Categories(Enum):
 
     DARK_STORE_GROCERY = {"dark_store": "grocery"}
 
+    INDUSTRIAL_WAREHOUSE = {"industrial": "warehouse"}
+
     LEISURE_PLAYGROUND = {"leisure": "playground"}
     LEISURE_RESORT = {"leisure": "resort"}
 

--- a/locations/spiders/pick_n_pay.py
+++ b/locations/spiders/pick_n_pay.py
@@ -11,7 +11,10 @@ class PickNPaySpider(scrapy.Spider):
 
     def parse(self, response, **kwargs):
         for store in response.json():
-            if store["storeType"] in ("", "ONLINE", "NO_FORMAT", "WHOLESALE") or "(incomplete)" in store["storeName"].lower():
+            if (
+                store["storeType"] in ("", "ONLINE", "NO_FORMAT", "WHOLESALE")
+                or "(incomplete)" in store["storeName"].lower()
+            ):
                 # "" appears to be a data error and the single current result is a data error
                 # "WHOLESALE" appear to be colocated with HYPER locations, so is probably not a distinct store
                 continue
@@ -26,7 +29,7 @@ class PickNPaySpider(scrapy.Spider):
                 # dayId of 8 is only present on some 24/7 stores so we ignore it
                 if day["dayId"] < 8:
                     item["opening_hours"].add_range(DAYS[day["dayId"] - 1], day["openTime"], day["closeTime"])
-            
+
             if store["storeType"] in ("LOCAL", "MINI", "FAMILY", "SUPER", "MARKET"):
                 # "LOCAL", "MINI" appear to be branded as normal PnP supermarkets
                 # "FAMILY", "SUPER" are standard PnP supermarkets
@@ -93,7 +96,7 @@ class PickNPaySpider(scrapy.Spider):
                         "extras": Categories.SHOP_DOITYOURSELF.value,
                     }
                 )
-            elif store["storeType"] == "DC": # Distribution Centre
+            elif store["storeType"] == "DC":  # Distribution Centre
                 item.update(
                     {
                         "extras": Categories.INDUSTRIAL_WAREHOUSE.value,
@@ -119,5 +122,5 @@ class PickNPaySpider(scrapy.Spider):
                 )
             # Unhandled:
             # "DAILY" was two stores, but both marked as incomplete in the data
-            
+
             yield item

--- a/locations/spiders/pick_n_pay.py
+++ b/locations/spiders/pick_n_pay.py
@@ -13,7 +13,7 @@ class PickNPaySpider(scrapy.Spider):
         for store in response.json():
             if (
                 store["storeType"] in ("", "ONLINE", "NO_FORMAT", "WHOLESALE")
-                or "(incomplete)" in store["storeName"].lower()
+                or "(incomplete)" in (store["storeName"] or "").lower()
             ):
                 # "" appears to be a data error and the single current result is a data error
                 # "WHOLESALE" appear to be colocated with HYPER locations, so is probably not a distinct store

--- a/locations/spiders/pick_n_pay.py
+++ b/locations/spiders/pick_n_pay.py
@@ -7,16 +7,17 @@ from locations.hours import DAYS, OpeningHours
 
 class PickNPaySpider(scrapy.Spider):
     name = "pick_n_pay"
-    item_attributes = {"brand": "Pick n Pay", "brand_wikidata": "Q7190735", "extras": Categories.SHOP_SUPERMARKET.value}
     start_urls = ["https://api.pnp.co.za/stores/v2"]
 
     def parse(self, response, **kwargs):
         for store in response.json():
-            if store["storeType"] in ("ONLINE", "NO_FORMAT") or "(incomplete)" in store["storeName"].lower():
+            if store["storeType"] in ("", "ONLINE", "NO_FORMAT", "WHOLESALE") or "(incomplete)" in store["storeName"].lower():
+                # "" appears to be a data error and the single current result is a data error
+                # "WHOLESALE" appear to be colocated with HYPER locations, so is probably not a distinct store
                 continue
             address = store["storeAddress"]
+            address["province"] = (address.get("province") or {}).get("name")
             store.update(address)
-            store["province"] = (address.get("province") or {}).get("name")
             item = DictParser.parse(store)
 
             item["opening_hours"] = OpeningHours()
@@ -25,15 +26,26 @@ class PickNPaySpider(scrapy.Spider):
                 # dayId of 8 is only present on some 24/7 stores so we ignore it
                 if day["dayId"] < 8:
                     item["opening_hours"].add_range(DAYS[day["dayId"] - 1], day["openTime"], day["closeTime"])
-
-            if store["storeType"] == "HYPER":
+            
+            if store["storeType"] in ("LOCAL", "MINI", "FAMILY", "SUPER", "MARKET"):
+                # "LOCAL", "MINI" appear to be branded as normal PnP supermarkets
+                # "FAMILY", "SUPER" are standard PnP supermarkets
+                # "MARKET" probably should be shown as PnP supermarket. Township location stores and numbers have dropped significantly in recent years
+                item.update(
+                    {
+                        "brand": "Pick n Pay",
+                        "brand_wikidata": "Q7190735",
+                        "extras": Categories.SHOP_SUPERMARKET.value,
+                    }
+                )
+            elif store["storeType"] == "HYPER":
                 item.update(
                     {
                         "brand": "Pick n Pay Hyper",
-                        "brand_wikidata": TODO,
+                        "brand_wikidata": "Q128791977",
                     }
                 )
-            if store["storeType"] == "CLOTHING":
+            elif store["storeType"] == "CLOTHING":
                 item.update(
                     {
                         "brand": "Pick n Pay Clothing",
@@ -49,7 +61,7 @@ class PickNPaySpider(scrapy.Spider):
                         "extras": Categories.SHOP_ALCOHOL.value,
                     }
                 )
-            elif store["storeType"] == in ("EXPRESS", "BPFORECOURT"):
+            elif store["storeType"] in ("EXPRESS", "BPFORECOURT"):
                 item.update(
                     {
                         "brand": "Pick n Pay Express",
@@ -97,12 +109,15 @@ class PickNPaySpider(scrapy.Spider):
                         "brand_wikidata": "Q7190735",
                     }
                 )
+            else:
+                item.update(
+                    {
+                        "brand": "Pick n Pay",
+                        "brand_wikidata": "Q7190735",
+                        "extras": Categories.SHOP_SUPERMARKET.value,
+                    }
+                )
             # Unhandled:
-            # "" appears to be a data error and the single current result is a data error
             # "DAILY" was two stores, but both marked as incomplete in the data
-            " "LOCAL", "MINI" appear to be branded as normal PnP supermarkets
-            # "FAMILY", "SUPER" are standard PnP supermarkets
-            # "MARKET" probably should be shown as PnP supermarket. Township location stores and numbers have dropped significantly recently
-            # "WHOLESALE" appear to be colocated with HYPER locations
             
             yield item


### PR DESCRIPTION
Follow up to #7221, link to #6052 

All brand types should now correctly be dealt with and all have appropriate wikidata, having checked lots of Pick n Pay documentation as well as local knowledge.

Province field had been returning dict of code and name for many locations before.

Ping @michaelgrahamevans and maybe @Firefishy as you had interest in the previous PR.