### PR TITLE
StructuredDataSpiders - Kirklands - Drop usage of deprecated inspect_item 

### DIFF
--- a/locations/spiders/kirklands.py
+++ b/locations/spiders/kirklands.py
@@ -20,7 +20,7 @@ class KirklandsSpider(CrawlSpider, StructuredDataSpider):
         response.css('a[href=""][itemprop="telephone"]').remove()
         yield from self.parse_sd(response)
 
-    def inspect_item(self, item, response):
+    def post_process_item(self, item, response, ld_data, **kwargs):
         oh = OpeningHours()
         for row in response.css("#inStoreDiv .hours tr"):
             day, interval = row.css("td ::text").extract()


### PR DESCRIPTION
Last few weekly runs are 0 items; as their site is cactus:
![image](https://github.com/user-attachments/assets/05f652df-34be-4931-91bf-90586219f730)
I'm inclined to leave the spider in place; assuming they fix it. 