### PR TITLE
Storefinders - Locally - Rename pre_process method, slightly refactor post process method

### DIFF
--- a/locations/spiders/crocs_eu.py
+++ b/locations/spiders/crocs_eu.py
@@ -10,5 +10,6 @@ class CrocsEUSpider(LocallySpider):
     ]
     skip_auto_cc_spider_name = True
 
-    def post_process_item(self, item, location):
+    def post_process_item(self, item, response, location):
         item["street_address"] = item.pop("addr_full")
+        yield item

--- a/locations/spiders/crocs_eu.py
+++ b/locations/spiders/crocs_eu.py
@@ -10,5 +10,5 @@ class CrocsEUSpider(LocallySpider):
     ]
     skip_auto_cc_spider_name = True
 
-    def post_process_item(self, item, store):
+    def post_process_item(self, item, location):
         item["street_address"] = item.pop("addr_full")

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -27,6 +27,7 @@ class AheadworksSpider(Spider):
 
         for tab in locations:
             location = tab["tabs"][0]
+            self.pre_process_data(location)
 
             item = DictParser.parse(location)
             item["website"] = self.start_urls[0] + location["slug"]
@@ -35,4 +36,12 @@ class AheadworksSpider(Spider):
             for day, hours in json.loads(location["hoursofoperation"])["hoursofoperation"].items():
                 item["opening_hours"].add_range(day, hours[0], hours[1])
 
-            yield item
+            yield from self.post_process_item(item, response, location) or []
+
+
+    def pre_process_data(self, location, **kwargs):
+        """Override with any pre-processing on the item."""
+
+    def post_process_item(self, item, response, location):
+        """Override with any post-processing on the item."""
+        return item

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -40,7 +40,6 @@ class AheadworksSpider(Spider):
 
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
-        pass
 
     def post_process_item(self, item, response, location):
         """Override with any post-processing on the item."""

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -40,6 +40,7 @@ class AheadworksSpider(Spider):
 
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
+        pass
 
     def post_process_item(self, item, response, location):
         """Override with any post-processing on the item."""

--- a/locations/storefinders/aheadworks.py
+++ b/locations/storefinders/aheadworks.py
@@ -38,7 +38,6 @@ class AheadworksSpider(Spider):
 
             yield from self.post_process_item(item, response, location) or []
 
-
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
 

--- a/locations/storefinders/locally.py
+++ b/locations/storefinders/locally.py
@@ -33,7 +33,6 @@ class LocallySpider(scrapy.Spider):
 
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
-        pass
 
     def post_process_item(self, item, response, location):
         """Override with any post-processing on the item."""

--- a/locations/storefinders/locally.py
+++ b/locations/storefinders/locally.py
@@ -13,26 +13,28 @@ class LocallySpider(scrapy.Spider):
     # "https://crocs.locally.com/stores/conversion_data?has_data=true&company_id=1762&category=Store&inline=1&map_center_lat=46.661219&map_center_lng=2.587603&map_distance_diag=3000&sort_by=proximity&lang=en-gb",
 
     def parse(self, response):
-        for store in response.json()["markers"]:
+        for location in response.json()["markers"]:
             oh = OpeningHours()
-            self.pre_process_data(store)
-            item = DictParser.parse(store)
+            self.pre_process_data(location)
+            item = DictParser.parse(location)
             for day in DAYS_FULL:
                 open = f"{day[:3].lower()}_time_open"
                 close = f"{day[:3].lower()}_time_close"
-                if not store.get(open) or len(str(store.get(open))) < 3:
+                if not location.get(open) or len(str(location.get(open))) < 3:
                     continue
                 oh.add_range(
                     day=day,
-                    open_time=f"{str(store.get(open))[:-2]}:{str(store.get(open))[-2:]}",
-                    close_time=f"{str(store.get(close))[:-2]}:{str(store.get(close))[-2:]}",
+                    open_time=f"{str(location.get(open))[:-2]}:{str(location.get(open))[-2:]}",
+                    close_time=f"{str(location.get(close))[:-2]}:{str(location.get(close))[-2:]}",
                 )
             item["opening_hours"] = oh.as_opening_hours()
-            self.post_process_item(item, store)
-            yield item
+
+            yield from self.post_process_item(item, response, location) or []
+
 
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
 
-    def post_process_item(self, item, store):
+    def post_process_item(self, item, response, location):
+        """Override with any post-processing on the item."""
         yield item

--- a/locations/storefinders/locally.py
+++ b/locations/storefinders/locally.py
@@ -31,7 +31,6 @@ class LocallySpider(scrapy.Spider):
 
             yield from self.post_process_item(item, response, location) or []
 
-
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
 

--- a/locations/storefinders/locally.py
+++ b/locations/storefinders/locally.py
@@ -15,8 +15,8 @@ class LocallySpider(scrapy.Spider):
     def parse(self, response):
         for store in response.json()["markers"]:
             oh = OpeningHours()
+            self.pre_process_data(store)
             item = DictParser.parse(store)
-            self.pre_process_item(item, store)
             for day in DAYS_FULL:
                 open = f"{day[:3].lower()}_time_open"
                 close = f"{day[:3].lower()}_time_close"
@@ -31,8 +31,8 @@ class LocallySpider(scrapy.Spider):
             self.post_process_item(item, store)
             yield item
 
-    def pre_process_item(self, item, store):
-        yield item
+    def pre_process_data(self, location, **kwargs):
+        """Override with any pre-processing on the item."""
 
     def post_process_item(self, item, store):
         yield item

--- a/locations/storefinders/locally.py
+++ b/locations/storefinders/locally.py
@@ -33,6 +33,7 @@ class LocallySpider(scrapy.Spider):
 
     def pre_process_data(self, location, **kwargs):
         """Override with any pre-processing on the item."""
+        pass
 
     def post_process_item(self, item, response, location):
         """Override with any post-processing on the item."""


### PR DESCRIPTION
pre_process - None of the child spiders implement it; so safe to rename.
post_process - Only used by one spider