### PR TITLE
Pep spider (Southern Africa) (2508 locations)

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -24,6 +24,9 @@ class DictParser:
         "item-id",
         "ItemID",
         "itemID",
+        "branch-id",
+        "BranchID",
+        "branchID",
     ]
 
     name_keys = [

--- a/locations/spiders/pep.py
+++ b/locations/spiders/pep.py
@@ -1,0 +1,62 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class PepSpider(Spider):
+    name = "pep"
+    allowed_domains = ["pepstores.com"]
+    start_urls = ["https://www.pepstores.com/graphql?operationName=nearbyStores"]
+
+    def start_requests(self):
+        graphql_query = """query nearbyStores($brandId: String, $latitude: Float, $longitude: Float, $radius: Int) {
+          nearbyStores(
+            brandId: $brandId
+            latitude: $latitude
+            longitude: $longitude
+            radius: $radius
+          ) {
+              address
+              branch_id
+              business_hours
+              description
+              distance
+              latitude
+              longitude
+              store_brand
+              telephone_number
+              __typename
+            }
+        }"""
+        data = {
+            "operationName": "nearbyStores",
+            "variables": {"brandId": "pep", "latitude": -22, "longitude": 24, "radius": 2000},
+            "query": graphql_query,
+        }
+        for url in self.start_urls:
+            yield JsonRequest(url=url, method="POST", data=data)
+
+    def parse(self, response):
+        for location in response.json()["data"]["nearbyStores"]:
+            item = DictParser.parse(location)
+
+            item["name"] = location.get("description")
+
+            if location.get("description").startswith("PEP Cell"):
+                item["brand"] = "Pep Cell"
+                item["brand_wikidata"] = "Q128802743"
+            elif location.get("description").startswith("PEP Home"):
+                item["brand"] = "Pep Home"
+                item["brand_wikidata"] = "Q128802022"
+            else:
+                item["brand"] = "Pep"
+                item["brand_wikidata"] = "Q7166182"
+
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(
+                location["business_hours"].replace("\\n", " ").replace("H", ":")
+            )
+
+            yield item

--- a/locations/spiders/pep.py
+++ b/locations/spiders/pep.py
@@ -56,7 +56,11 @@ class PepSpider(Spider):
 
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(
-                location["business_hours"].replace("\\n", " ").replace("H", ":")
+                # 00H00-00H00 was interpreted as being open all day, but has the opposite meaning
+                location["business_hours"]
+                .replace("00H00-00H00", "closed")
+                .replace("\\n", " ")
+                .replace("H", ":")
             )
 
             yield item


### PR DESCRIPTION
This appears to cover South Africa, Lesotho, eSwatini, Namibia and Botswana.

I only very recently updated NSI with separate wikidata for Pep Cell and Pep Home, so they are not yet being matched.

```
'atp/brand/Pep': 1646,
 'atp/brand/Pep Cell': 551,
 'atp/brand/Pep Home': 311,
 'atp/brand_wikidata/Q128802022': 311,
 'atp/brand_wikidata/Q128802743': 551,
 'atp/brand_wikidata/Q7166182': 1646,
 'atp/category/missing': 2256,
 'atp/category/shop/clothes': 252,
 'atp/field/city/missing': 2508,
 'atp/field/country/from_reverse_geocoding': 2508,
 'atp/field/email/missing': 2508,
 'atp/field/image/missing': 2508,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 2508,
 'atp/field/operator_wikidata/missing': 2508,
 'atp/field/phone/invalid': 166,
 'atp/field/postcode/missing': 2508,
 'atp/field/state/missing': 14,
 'atp/field/street_address/missing': 2508,
 'atp/field/twitter/missing': 2508,
 'atp/field/website/missing': 2508,
 'atp/item_scraped_host_count/www.pepstores.com': 2508,
 'atp/nsi/brand_missing': 862,
 'atp/nsi/cc_match': 252,
 'atp/nsi/match_failed': 1394,
```