### PR TITLE
[SubwayQA] Add spider (31 locations)

### DIFF
--- a/locations/spiders/subway_qa.py
+++ b/locations/spiders/subway_qa.py
@@ -1,0 +1,5 @@
+from locations.spiders.subway_th import SubwayWorldwideSpider
+
+
+class SubwayQASpider(SubwayWorldwideSpider):
+    name = "subway_qa"


### PR DESCRIPTION
Added QA locations and fixed address for Subway Worldwide Spider.

Stats for `subway_qa`:

```
{'atp/brand/Subway': 31,
 'atp/brand_wikidata/Q244457': 31,
 'atp/category/amenity/fast_food': 31,
 'atp/field/email/missing': 31,
 'atp/field/image/missing': 31,
 'atp/field/opening_hours/missing': 31,
 'atp/field/operator/missing': 31,
 'atp/field/operator_wikidata/missing': 31,
 'atp/field/phone/missing': 31,
 'atp/field/postcode/missing': 7,
 'atp/field/state/missing': 31,
 'atp/field/twitter/missing': 31,
 'atp/field/website/missing': 31,
 'atp/item_scraped_host_count/locator-svc.subway.com': 155,
 'atp/nsi/cc_match': 31,
 'downloader/request_bytes': 7523,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 1094292,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 5,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 9.438569,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 13, 8, 49, 34, 596253, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 124,
 'item_dropped_reasons_count/DropItem': 124,
 'item_scraped_count': 31,
 'log_count/DEBUG': 179,
 'log_count/INFO': 9,
 'response_received_count': 6,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2024, 8, 13, 8, 49, 25, 157684, tzinfo=datetime.timezone.utc)}
```