### PR TITLE
extend duplicate_wikidata command, multi spider directory support

### DIFF
--- a/locations/commands/duplicate_wikidata.py
+++ b/locations/commands/duplicate_wikidata.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -15,42 +16,65 @@ class DuplicateWikidataCommand(ScrapyCommand):
     Look for the same wikidata code appearing in multiple spider files. In many cases
     this provides the nudge for the attribute value to be shared between spiders
     where the duplication is very simple i.e. the same brand in multiple countries
-    (e.g. vodafone_de and vodafone_it).
+    (e.g. vodafone_de and vodafone_it). In other cases it can show that duplicate
+    spiders have crept into the code base!
     """
 
     requires_project = True
     default_settings = {"LOG_ENABLED": True}
 
     def short_desc(self):
-        return "Look for wikidata code duplication across spiders"
+        return "Report instances of the same wikidata code in multiple spider files"
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
+        parser.add_argument(
+            "--outfile",
+            dest="outfile",
+            metavar="OUTFILE",
+            help="write output to file in JSON format",
+        )
+        parser.add_argument(
+            "--cross-directory",
+            dest="cross_directory",
+            action="store_true",
+            help="only report duplicate wikidata codes if from multiple spider directories",
+        )
 
     @staticmethod
-    def spider_properties(name):
-        spider = find_spider_class(name)
-        filename = sys.modules[spider.__module__].__file__
-        filename = filename.replace(".pyc", ".py")
-        filename = os.path.relpath(filename)
-        wikidata_codes = set()
-        with open(filename) as f:
-            for line in f.readlines():
-                codes = re.findall("[\"|'](Q[0-9]*)[\"|']", line)
-                for code in codes:
-                    wikidata_codes.add(code)
-        return {"name": name, "filename": filename, "wikidata_codes": wikidata_codes}
+    def wikidata_spiders(crawler_process):
+        codes = {}
+        for spider_name in crawler_process.spider_loader.list():
+            spider = find_spider_class(spider_name)
+            file_name = sys.modules[spider.__module__].__file__
+            simple_name = file_name.split("/locations/")[-1]
+            with open(file_name) as f:
+                for code in re.findall("[\"|'](Q[0-9]*)[\"|']", f.read()):
+                    files = codes.get(code, set())
+                    files.add(simple_name)
+                    codes[code] = files
+        return codes
 
     def run(self, args, opts):
-        codes = dict()
-        for spider_name in self.crawler_process.spider_loader.list():
-            props = self.spider_properties(spider_name)
-            for code in props["wikidata_codes"]:
-                code_spiders = codes.get(code, set())
-                code_spiders.add(props["filename"])
-                codes[code] = code_spiders
+        duplicates = {}
+        codes = self.wikidata_spiders(self.crawler_process)
+        for code, files in codes.items():
+            if len(files) == 1:
+                # wikidata codes that come from one spider only are not interesting to report
+                continue
+            if opts.cross_directory:
+                unique_dirs = set()
+                for file in files:
+                    unique_dirs.add(os.path.dirname(file))
+                if len(unique_dirs) == 1:
+                    # duplicates all exist in the same spider directory, ignore given command line option
+                    continue
+            duplicates[code] = list(files)
 
-        # Now look for wikidata codes appearing in multiple spiders.
-        for code, code_spiders in codes.items():
-            if len(code_spiders) > 1:
-                logger.info("%s -> %s", code, code_spiders)
+        # The results either go to terminal or a JSON file
+        if opts.outfile:
+            with open(opts.outfile, "w") as f:
+                json.dump(duplicates, f)
+        else:
+            for code, files in duplicates.items():
+                print(code + " -> " + str(files))

--- a/locations/commands/nsi.py
+++ b/locations/commands/nsi.py
@@ -70,13 +70,8 @@ class NameSuggestionIndexCommand(ScrapyCommand):
                 print("       -> " + str(item))
 
     def detect_missing(self, args):
-        codes = {}
-        for spider_name in self.crawler_process.spider_loader.list():
-            props = DuplicateWikidataCommand.spider_properties(spider_name)
-            for code in props["wikidata_codes"]:
-                code_spiders = codes.get(code, set())
-                code_spiders.add(props["filename"])
-                codes[code] = code_spiders
+
+        codes = DuplicateWikidataCommand.wikidata_spiders(self.crawler_process)
 
         # Fetch the category from NSI's github, and try to match to wikidata.
         # TODO: This assumes you are going for only one category, by wikidata ID.


### PR DESCRIPTION
Some light changes:

- support writing an output report in JSON format as an option
- have an option to report on wikidata duplicates across spider directories
