### PR TITLE
american_eagle_outfitters: fix spider

### DIFF
--- a/locations/spiders/american_eagle_outfitters.py
+++ b/locations/spiders/american_eagle_outfitters.py
@@ -5,11 +5,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class AmericanEagleOutfittersSpider(SitemapSpider, StructuredDataSpider):
     name = "american_eagle_outfitters"
-    item_attributes = {
-        "brand": "American Eagle Outfitters",
-        "brand_wikidata": "Q2842931",
-    }
-    allowed_domains = ["ae.com"]
+    item_attributes = {"brand": "American Eagle Outfitters", "brand_wikidata": "Q2842931"}
     sitemap_urls = ["https://stores.aeostores.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     custom_settings = {"ROBOTSTXT_OBEY": False}


### PR DESCRIPTION
Changes to scrapy mean that the sitemap URL is ignored as not in the `allowed_domains`. There will be more like this. As not a `CrawlSpider` lets make life simpler.
