### PR TITLE
Documentation: multiple phone numbers and phone cleaning

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -41,7 +41,7 @@ Each GeoJSON feature will have a `properties` object with as many of the followi
 | `addr:postcode`       | The postcode part of the address.
 | `addr:country`        | The country part of the address.
 | **Contact**           | _Contact information for the venue_
-| `phone`               | The telephone number for the venue. Note that this is usually pulled from a website assuming local visitors, so it probably doesn't include the country code.
+| `phone`               | The telephone number(s) for the venue, separated by `;` if there is more than one number. These numbers are cleaned using the [phonenumbers library](https://pypi.org/project/phonenumbers/), however invalid numbers will still be returned as-is if they cannot be parsed.
 | `website`             | The website for the venue. We try to make this a URL specific to the venue and not a generic URL for the brand that is operating the venue.
 | `email`               | The email address for the venue. We try to make this an email specific to the venue and not a generic email for the brand that is operating the venue.
 | `contact:twitter`     | The twitter account for the venue. We try to make this specific to the venue and not generic for the brand that is operating the venue.

--- a/locations/pipelines/phone_clean_up.py
+++ b/locations/pipelines/phone_clean_up.py
@@ -29,7 +29,7 @@ class PhoneCleanUpPipeline:
         return tag in ("phone", "fax") or tag.endswith(":phone") or tag.endswith(":fax")
 
     def normalize_numbers(self, phone, country, spider):
-        numbers = [self.normalize(p, country, spider) for p in re.split(r"[;/]\s?", str(phone))]
+        numbers = [self.normalize(p, country, spider) for p in re.split(r"[;/]\s", str(phone))]
         return ";".join(filter(None, numbers))
 
     def normalize(self, phone, country, spider):

--- a/locations/pipelines/phone_clean_up.py
+++ b/locations/pipelines/phone_clean_up.py
@@ -29,7 +29,7 @@ class PhoneCleanUpPipeline:
         return tag in ("phone", "fax") or tag.endswith(":phone") or tag.endswith(":fax")
 
     def normalize_numbers(self, phone, country, spider):
-        numbers = [self.normalize(p, country, spider) for p in re.split(r"[;/]\s", str(phone))]
+        numbers = [self.normalize(p, country, spider) for p in re.split(r"[;/]\s?", str(phone))]
         return ";".join(filter(None, numbers))
 
     def normalize(self, phone, country, spider):


### PR DESCRIPTION
I spotted in #9531 that multiple phone numbers are being dealt with inconsistently. The split requires `; ` but the merge uses only `;` so I'm making the whitespace optional and updating the documentation for phone numbers to match what is happening.