### PR TITLE
[Core] Make TrackSourcesMiddleware safer

### DIFF
--- a/locations/middlewares/track_sources.py
+++ b/locations/middlewares/track_sources.py
@@ -13,6 +13,8 @@ class TrackSourcesMiddleware:
     def _process_item(self, response, item: Item, spider: Spider):
         if not isinstance(item, Item):
             return
+        if not isinstance(item.get("extras"), dict):
+            item["extras"] = {}
 
         if not item["extras"].get("@source_uri"):
             item["extras"]["@source_uri"] = response.url


### PR DESCRIPTION
As pointed out by https://github.com/alltheplaces/alltheplaces/pull/9075#discussion_r1703102202 this is now the first "pipeline", so any errors regarding a lack of `extras` would happen here. I don't think this is a real issue, a spider would have to go out of it's way to not have `extras`, but may as well be safer.