### PR TITLE
Usave ZA spider (423 locations)

### DIFF
--- a/locations/spiders/medirite_za.py
+++ b/locations/spiders/medirite_za.py
@@ -11,6 +11,7 @@ class MediriteZASpider(Spider):
     item_attributes = {"brand_wikidata": "Q115696233"}
     custom_settings = {"DOWNLOAD_TIMEOUT": 30}
     start_urls = ["https://www.medirite.co.za/bin/stores.json?national=yes&brand=medirite&country=198"]
+    base_url = "https://www.medirite.co.za"
     brands = ["MediRite", "MediRite Plus"]
 
     def start_requests(self):
@@ -29,12 +30,12 @@ class MediriteZASpider(Spider):
             if "phoneInternationalCode" in location:
                 location["phoneNumber"] = "+" + location["phoneInternationalCode"] + " " + location["phoneNumber"]
 
-            if "physicalAdd3" in location and location["physicalAdd3"]:
-                location["physicalAdd2"] += ", " + location["physicalAdd3"]
-            if "physicalAdd2" in location and location["physicalAdd2"]:
-                location["physicalAdd1"] += ", " + location["physicalAdd2"]
-            if "physicalAdd1" in location:
-                location["street-address"] = location.pop("physicalAdd1")
+            location["street-address"] = ""
+            for i in ["1", "2", "3"]:
+                if ("physicalAdd" + i) in location:
+                    location["street-address"] += location.pop("physicalAdd" + i) + ", "
+            location["street-address"] = location["street-address"].rstrip(", ")
+
             if "physicalProvince" in location:
                 location["province"] = location.pop("physicalProvince")
 
@@ -44,7 +45,7 @@ class MediriteZASpider(Spider):
             item["brand"] = location["brand"]
 
             yield JsonRequest(
-                url=f'https://www.medirite.co.za/bin/stores.json?uid={item["ref"]}',
+                url=f'{self.base_url}/bin/stores.json?uid={item["ref"]}',
                 meta={"item": item},
                 callback=self.parse_store,
             )

--- a/locations/spiders/usave_za.py
+++ b/locations/spiders/usave_za.py
@@ -1,0 +1,14 @@
+from locations.categories import Categories
+from locations.spiders.medirite_za import MediriteZASpider
+
+
+class UsaveZASpider(MediriteZASpider):
+    name = "usave_za"
+    item_attributes = {
+        "brand": "Usave",
+        "brand_wikidata": "Q115696368",
+        "extras": Categories.SHOP_SUPERMARKET.value,
+    }
+    brands = ["Usave"]
+    start_urls = ["https://www.usave.co.za/bin/stores.json?national=yes&brand=shoprite&country=198"]
+    base_url = "https://www.usave.co.za"


### PR DESCRIPTION
```
 'atp/brand/Usave': 423,
 'atp/brand_wikidata/Q115696368': 423,
 'atp/category/shop/supermarket': 423,
 'atp/field/city/missing': 25,
 'atp/field/email/missing': 423,
 'atp/field/image/missing': 423,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 423,
 'atp/field/operator_wikidata/missing': 423,
 'atp/field/phone/invalid': 8,
 'atp/field/phone/missing': 11,
 'atp/field/postcode/missing': 6,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 423,
 'atp/field/website/missing': 423,
 'atp/item_scraped_host_count/www.usave.co.za': 423,
 'atp/nsi/cc_match': 423,
```