### PR TITLE
[Our Airports] Fix ele

### DIFF
--- a/locations/spiders/our_airports.py
+++ b/locations/spiders/our_airports.py
@@ -26,7 +26,7 @@ class OurAirportsSpider(CSVFeedSpider):
         item["name"] = row["name"]
         item["lat"] = row["latitude_deg"]
         item["lon"] = row["longitude_deg"]
-        item["extras"]["ele"] = row["elevation_ft"]
+        item["extras"]["ele:ft"] = row["elevation_ft"]
         item["country"] = row["iso_country"]
         item["extras"]["iata"] = row["iata_code"]
         item["website"] = row["home_link"]


### PR DESCRIPTION
`ele` is unusually defined as meters only, no option for us adding units like other OSM fields. However we weren't adding units anyway, so we were lying.