### PR TITLE
Apply `amenity=fuel` category for petrol_bg

### DIFF
--- a/locations/spiders/petrol_bg.py
+++ b/locations/spiders/petrol_bg.py
@@ -35,5 +35,5 @@ class PetrolBGSpider(AgileStoreLocatorSpider):
         apply_yes_no("self_service", item, "28" in categories)
         apply_yes_no(Fuel.ADBLUE, item, "29" in categories)
         apply_category(Categories.FUEL_STATION, item)
-        
+
         yield item

--- a/locations/spiders/petrol_bg.py
+++ b/locations/spiders/petrol_bg.py
@@ -34,5 +34,6 @@ class PetrolBGSpider(AgileStoreLocatorSpider):
         apply_yes_no("cafe", item, "27" in categories)
         apply_yes_no("self_service", item, "28" in categories)
         apply_yes_no(Fuel.ADBLUE, item, "29" in categories)
-
+        apply_category(Categories.FUEL_STATION, item)
+        
         yield item


### PR DESCRIPTION
All items are missing `amenity=fuel` in the latest run. This was not the case in the preview in #6033.