### PR TITLE
[wingstop_mx] add spider (114 locations)

### DIFF
--- a/locations/spiders/wingstop_mx.py
+++ b/locations/spiders/wingstop_mx.py
@@ -1,0 +1,19 @@
+import json
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+
+
+class WingstopMXSpider(Spider):
+    name = "wingstop_mx"
+    item_attributes = {"brand": "Wingstop", "brand_wikidata": "Q8025339"}
+    start_urls = ["https://wingstopmexico.com/wp-admin/admin-ajax.php?action=asl_load_stores"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in json.loads(response.text):
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("street")
+            yield item


### PR DESCRIPTION
@iandees - would you prefer to change the name of wingstop spider to wingstop_us?  or just leave as is?

```
{'atp/brand/Wingstop': 114,
 'atp/brand_wikidata/Q8025339': 114,
 'atp/category/amenity/fast_food': 114,
 'atp/field/email/missing': 65,
 'atp/field/image/missing': 114,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 114,
 'atp/field/operator/missing': 114,
 'atp/field/operator_wikidata/missing': 114,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 8,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 114,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 113,
 'atp/item_scraped_host_count/wingstopmexico.com': 114,
 'atp/nsi/perfect_match': 114,
 'downloader/request_bytes': 700,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14429,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.565678,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 15, 17, 21, 39, 278012, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 85651,
 'httpcompression/response_count': 2,
 'item_scraped_count': 114,
 'log_count/DEBUG': 133,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 15, 17, 21, 32, 712334, tzinfo=datetime.timezone.utc)}
```