### PR TITLE
OK Foods spider (ZA, SZ, NA) (576 locations)

### DIFF
--- a/locations/spiders/ok_foods.py
+++ b/locations/spiders/ok_foods.py
@@ -87,7 +87,9 @@ class OkFoodsSpider(Spider):
                         oh.add_range(day, location[day].split("-")[0].strip(), location[day].split("-")[1].strip())
                     else:
                         oh.set_closed(day)
-                item["opening_hours"] = oh.as_opening_hours()
+                # Fully undefined opening hours should not be treated as closed
+                if "".join([location[day].strip() for day in DAYS_FULL]) != "":
+                    item["opening_hours"] = oh.as_opening_hours()
             except Exception:
                 pass
 

--- a/locations/spiders/ok_foods.py
+++ b/locations/spiders/ok_foods.py
@@ -51,7 +51,7 @@ class OkFoodsSpider(Spider):
 
             location = {k: v for k, v in location.items() if v != "null"}
 
-            if location.get("phoneInternationalCode") != None:
+            if location.get("phoneInternationalCode") is not None:
                 location["phoneNumber"] = (
                     "+" + location["phoneInternationalCode"] + " " + location["phoneNumber"].lstrip("0")
                 )

--- a/locations/spiders/ok_foods.py
+++ b/locations/spiders/ok_foods.py
@@ -1,0 +1,93 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+
+OK_FOODS_BRANDS = {
+    # "FR SEVENELEVEN": {"brand": "", "brand_wikidata": ""}, # Not sure what this is. Only 1 store at time of writing
+    "MEGASAVE": {"brand": "Megasave", "brand_wikidata": "Q116520541", "extras": Categories.SHOP_WHOLESALE.value},
+    "OK EXPRESS": {"brand": "OK Express", "brand_wikidata": "Q116520407", "extras": Categories.SHOP_CONVENIENCE.value},
+    "OK FOODS": {"brand": "OK Foods", "brand_wikidata": "Q116520377", "extras": Categories.SHOP_SUPERMARKET.value},
+    "OK GROCER": {"brand": "OK Grocer", "brand_wikidata": "Q116520377", "extras": Categories.SHOP_SUPERMARKET.value},
+    "OK LIQUOR": {"brand": "OK Liquor", "brand_wikidata": "Q116520424", "extras": Categories.SHOP_ALCOHOL.value},
+    "OK MINIMARK": {
+        "brand": "OK Minimark",
+        "brand_wikidata": "Q116520457",
+        "extras": Categories.SHOP_CONVENIENCE.value,
+    },
+    "OK URBAN": {"brand": "OK Urban", "brand_wikidata": "Q116520377", "extras": Categories.SHOP_CONVENIENCE.value},
+    "OK VALUE": {"brand": "OK Value", "brand_wikidata": "Q116520377", "extras": Categories.SHOP_CONVENIENCE.value},
+    "PRESIDENT HYPER": {
+        "brand": "President Hyper",
+        "brand_wikidata": "Q116520377",
+        "extras": Categories.SHOP_SUPERMARKET.value,
+    },
+    "SENTRA": {"brand": "Sentra", "brand_wikidata": "Q116520377", "extras": Categories.SHOP_SUPERMARKET.value},
+}
+
+
+class OkFoodsSpider(Spider):
+    name = "ok_foods"
+    start_urls = [
+        "https://www.okfoods.co.za/content/okfoods/za/en_ZA/find-a-store/jcr:content/root/container/okfoodsstorelocator.stores.json?countryId=SouthAfrica",
+        "https://www.okfoods.co.za/content/okfoods/na/en_NA/find-a-store/jcr:content/root/container/okfoodsstorelocator.stores.json?countryId=Namibia",
+        "https://www.okfoods.co.za/content/okfoods/sz/en_SZ/find-a-store/jcr:content/root/container/okfoodsstorelocator.stores.json?countryId=Eswatini",
+    ]
+    base_website = {
+        "NAMIBIA": "https://www.okfoods.co.za/content/okfoods/na/en_NA/find-a-store.html",
+        "ESWATINI": "https://www.okfoods.co.za/content/okfoods/sz/en_SZ/find-a-store.html",
+        "SOUTH AFRICA": "https://www.okfoods.co.za/find-a-store.html",
+    }
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url, callback=self.parse)
+
+    def parse(self, response):
+        for location in response.replace(body=response.json()["results"]).json():
+            location["ref"] = location.pop("uid")
+
+            location = {k: v for k, v in location.items() if v != "null"}
+
+            if location.get("phoneInternationalCode") != None:
+                location["phoneNumber"] = (
+                    "+" + location["phoneInternationalCode"] + " " + location["phoneNumber"].lstrip("0")
+                )
+
+            location["street-address"] = ""
+            for i in ["1", "2", "3"]:
+                if ("physicalAdd" + i) in location:
+                    location["street-address"] += location.pop("physicalAdd" + i) + ", "
+            location["street-address"] = location["street-address"].rstrip(", ")
+
+            if "physicalProvince" in location:
+                location["province"] = location.pop("physicalProvince")
+
+            item = DictParser.parse(location)
+
+            item["branch"] = location["branch"].replace(location["brand"], "").strip()
+            item["website"] = (
+                self.base_website[location["country"]]
+                + "?stName="
+                + location["branch"].replace(" ", "%20")
+                + "&storeType="
+                + location["brand"].replace(" ", "%20")
+            )
+
+            if location["brand"] in OK_FOODS_BRANDS:
+                item.update(OK_FOODS_BRANDS[location["brand"]])
+
+            try:
+                oh = OpeningHours()
+                for day in DAYS_FULL:
+                    if location[day].strip() != "":
+                        oh.add_range(day, location[day].split("-")[0].strip(), location[day].split("-")[1].strip())
+                    else:
+                        oh.set_closed(day)
+                item["opening_hours"] = oh.as_opening_hours()
+            except Exception:
+                pass
+
+            yield item

--- a/locations/spiders/ok_foods.py
+++ b/locations/spiders/ok_foods.py
@@ -78,6 +78,7 @@ class OkFoodsSpider(Spider):
 
             if location["brand"] in OK_FOODS_BRANDS:
                 item.update(OK_FOODS_BRANDS[location["brand"]])
+                item["name"] = item["brand"]
 
             try:
                 oh = OpeningHours()


### PR DESCRIPTION
Some of the items are not getting a clean country code and are keeping the value from the source, e.g. "SOUTH AFRICA", but I can't tell why.

```
 'atp/brand/Megasave': 13,
 'atp/brand/OK Express': 102,
 'atp/brand/OK Foods': 135,
 'atp/brand/OK Grocer': 65,
 'atp/brand/OK Liquor': 117,
 'atp/brand/OK Minimark': 126,
 'atp/brand/OK Urban': 1,
 'atp/brand/OK Value': 1,
 'atp/brand/President Hyper': 3,
 'atp/brand/Sentra': 12,
 'atp/brand_wikidata/Q116520377': 217,
 'atp/brand_wikidata/Q116520407': 102,
 'atp/brand_wikidata/Q116520424': 117,
 'atp/brand_wikidata/Q116520457': 126,
 'atp/brand_wikidata/Q116520541': 13,
 'atp/category/missing': 1,
 'atp/category/shop/alcohol': 117,
 'atp/category/shop/convenience': 230,
 'atp/category/shop/supermarket': 215,
 'atp/category/shop/wholesale': 13,
```