### PR TITLE
[SantanderUS] New spider (1902 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -198,6 +198,7 @@ class Categories(Enum):
     OFFICE_ENGINEER = {"office": "engineer"}
     OFFICE_ESTATE_AGENT = {"office": "estate_agent"}
     OFFICE_FINANCIAL = {"office": "financial"}
+    OFFICE_FINANCIAL_ADVISOR = {"office": "financial_advisor"}
     OFFICE_IT = {"office": "it"}
 
     TOURISM_APARTMENT = {"tourism": "apartment"}

--- a/locations/spiders/santander_us.py
+++ b/locations/spiders/santander_us.py
@@ -1,0 +1,23 @@
+from locations.categories import Categories, apply_category
+from locations.storefinders.rio_seo import RioSeoSpider
+
+LOCATION_CATEGORIES = {
+    "ATM": Categories.ATM,
+    "Branch": Categories.BANK,
+    "Financial Center": Categories.OFFICE_FINANCIAL_ADVISOR,
+}
+
+
+class SantanderUSSpider(RioSeoSpider):
+    name = "santander_us"
+    item_attributes = {"brand": "Santander", "brand_wikidata": "Q5835668"}
+    domain = "locations.santanderbank.com"
+
+    def post_process_feature(self, feature, location):
+        location_type = location["Location Type_CS"]
+        category = LOCATION_CATEGORIES.get(location_type)
+        if category:
+            apply_category(category, feature)
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unknown_category/{location_type}")
+        yield feature


### PR DESCRIPTION
```py
{'atp/brand/Santander': 1902,
 'atp/brand_wikidata/Q5835668': 1902,
 'atp/category/amenity/atm': 1497,
 'atp/category/amenity/bank': 401,
 'atp/category/office/financial_advisor': 4,
 'atp/field/email/missing': 1902,
 'atp/field/image/missing': 1902,
 'atp/field/opening_hours/missing': 336,
 'atp/field/operator/missing': 405,
 'atp/field/operator_wikidata/missing': 405,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 1902,
 'atp/item_scraped_host_count/maps.locations.santanderbank.com': 1902,
 'atp/nsi/cc_match': 1898,
 'atp/nsi/match_failed': 4,
 'atp/operator/Santander': 1497,
 'atp/operator_wikidata/Q5835668': 1497,
 'downloader/request_bytes': 1182,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 466358,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 6.542771,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 15, 21, 5, 2, 940791, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10583218,
 'httpcompression/response_count': 3,
 'item_scraped_count': 1902,
 'log_count/DEBUG': 1916,
 'log_count/INFO': 10,
 'memusage/max': 231600128,
 'memusage/startup': 231600128,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 8, 15, 21, 4, 56, 398020, tzinfo=datetime.timezone.utc)}
```