### PR TITLE
Add IcebolethuZASpider (132 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -272,6 +272,7 @@ class Categories(Enum):
     VETERINARY = {"amenity": "veterinary"}
     WATER_RESCUE = {"emergency": "water_rescue"}
     ANIMAL_BOARDING = {"amenity": "animal_boarding"}
+    MORTUARY = {"amenity": "mortuary"}
 
     DATA_CENTRE = {"telecom": "data_center"}
 

--- a/locations/spiders/icebolethu_za.py
+++ b/locations/spiders/icebolethu_za.py
@@ -16,6 +16,7 @@ class IcebolethuZASpider(Spider):
     custom_settings = {
         "ITEM_PIPELINES": ITEM_PIPELINES | {"locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": None}
     }
+    no_refs = True
 
     def parse(self, response):
         for id in ICEBOLETHU_CATEGORIES:
@@ -33,8 +34,6 @@ class IcebolethuZASpider(Spider):
                 except:
                     pass
                 properties["street_address"] = " ".join(address_lines).lstrip("Address:").strip()
-
-                properties["ref"] = properties["name"]
 
                 # Some short maps.app.goo.gl links which can't be extracted from
                 try:

--- a/locations/spiders/icebolethu_za.py
+++ b/locations/spiders/icebolethu_za.py
@@ -1,0 +1,49 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import url_to_coords
+from locations.items import Feature
+from locations.settings import ITEM_PIPELINES
+
+ICEBOLETHU_CATEGORIES = {"branches": Categories.SHOP_FUNERAL_DIRECTORS, "mortuaryinformation": Categories.MORTUARY}
+
+
+class IcebolethuZASpider(Spider):
+    name = "icebolethu_za"
+    item_attributes = {"brand": "Icebolethu Funerals", "brand_wikidata": "Q122594408"}
+    allowed_domains = ["www.icebolethugroup.co.za"]
+    start_urls = ["https://www.icebolethugroup.co.za/contact/"]
+    custom_settings = {
+        "ITEM_PIPELINES": ITEM_PIPELINES | {"locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": None}
+    }
+
+    def parse(self, response):
+        for id in ICEBOLETHU_CATEGORIES:
+            for location in response.xpath(f'//*[@id="{id}"]//*[@class="question"]'):
+                properties = {
+                    "name": location.xpath('.//*[@class="title wpb_toggle"]/text()').get(),
+                    "phone": location.xpath('.//*[@class="wpb_toggle_content answer"]/p/text()').get(),
+                }
+
+                info = location.xpath('string(.//*[@class="wpb_toggle_content answer"])').get().split("\n")
+
+                # Free text, so typos mean this phrase may not be present
+                try:
+                    address_lines = info[1 : info.index("Open location in Google maps.")]
+                except:
+                    pass
+                properties["street_address"] = " ".join(address_lines).lstrip("Address:").strip()
+
+                properties["ref"] = properties["name"]
+
+                # Some short maps.app.goo.gl links which can't be extracted from
+                try:
+                    properties["lat"], properties["lon"] = url_to_coords(
+                        location.xpath('.//a[contains(@href, "google.com/maps")]/@href').get()
+                    )
+                except:
+                    pass
+
+                apply_category(ICEBOLETHU_CATEGORIES[id], properties)
+
+                yield Feature(**properties)


### PR DESCRIPTION
There's nothing I can see to use for `ref`, but I don't seem to be able to leave it out. Using the name seems wrong, so what is a better option?

Website was messier than it first appeared, so some items/properties get dropped.

```
'atp/brand/Icebolethu Funerals': 132,
 'atp/brand_wikidata/Q122594408': 132,
 'atp/category/amenity/mortuary': 29,
 'atp/category/shop/funeral_directors': 103,
 'atp/field/city/missing': 132,
 'atp/field/country/from_spider_name': 132,
 'atp/field/email/missing': 132,
 'atp/field/image/missing': 132,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 132,
 'atp/field/operator/missing': 132,
 'atp/field/operator_wikidata/missing': 132,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 29,
 'atp/field/postcode/missing': 132,
 'atp/field/state/missing': 132,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 132,
 'atp/field/website/missing': 132,
 'atp/item_scraped_host_count/www.icebolethugroup.co.za': 133,
```