### PR TITLE
[RoadRunnerSportsUS] New spider (48 locations)

### DIFF
--- a/locations/spiders/road_runner_sports_us.py
+++ b/locations/spiders/road_runner_sports_us.py
@@ -1,0 +1,14 @@
+from locations.storefinders.rio_seo import RioSeoSpider
+
+
+class RoadRunnerSportsUSSpider(RioSeoSpider):
+    name = "road_runner_sports_us"
+    item_attributes = {
+        "brand_wikidata": "Q113494713",
+        "brand": "Road Runner Sports",
+    }
+    domain = "stores.roadrunnersports.com"
+
+    def post_process_feature(self, feature, location):
+        feature["branch"] = feature.pop("name")
+        yield feature


### PR DESCRIPTION
```py
{'atp/brand/Road Runner Sports': 48,
 'atp/brand_wikidata/Q113494713': 48,
 'atp/category/shop/shoes': 48,
 'atp/field/country/from_spider_name': 48,
 'atp/field/email/missing': 48,
 'atp/field/image/missing': 48,
 'atp/field/operator/missing': 48,
 'atp/field/operator_wikidata/missing': 48,
 'atp/field/twitter/missing': 48,
 'atp/item_scraped_host_count/maps.stores.roadrunnersports.com': 48,
 'atp/nsi/perfect_match': 48,
 'downloader/request_bytes': 1181,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 12852,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.170044,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 16, 0, 8, 26, 310041, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 163367,
 'httpcompression/response_count': 3,
 'item_scraped_count': 48,
 'log_count/DEBUG': 62,
 'log_count/INFO': 10,
 'memusage/max': 231223296,
 'memusage/startup': 231223296,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 8, 16, 0, 8, 23, 139997, tzinfo=datetime.timezone.utc)}
```