### PR TITLE
Add CUM Books ZA Spider (35 locations)

### DIFF
--- a/locations/spiders/cum_books_za.py
+++ b/locations/spiders/cum_books_za.py
@@ -1,0 +1,32 @@
+from chompjs import parse_js_object
+from scrapy import Spider
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class CumBooksZASpider(Spider):
+    name = "cum_books_za"
+    item_attributes = {
+        "brand_wikidata": "Q128930625",
+        "brand": "CUM Books",
+    }
+    allowed_domains = ["storage.googleapis.com"]
+    start_urls = ["https://storage.googleapis.com/maps-solutions-5awgpybsml/locator-plus/k456/locator-plus-config.js"]
+    no_refs = True
+
+    def parse(self, response):
+        js_blob = "[" + response.text.split('"locations": [', 1)[1].split("],", 1)[0] + "]"
+        locations = parse_js_object(js_blob)
+
+        for location in locations:
+            properties = {
+                "branch": location["title"].replace("CUM Books - ", ""),
+                "lat": location["coords"]["lat"],
+                "lon": location["coords"]["lng"],
+                "street_address": location["address1"],
+                "addr_full": clean_address([location["address1"], location["address2"]]),
+                "extras": {"ref:google": location.get("placeId")},
+            }
+
+            yield Feature(**properties)


### PR DESCRIPTION
```
 'atp/brand/CUM Books': 35,
 'atp/brand_wikidata/Q128930625': 35,
 'atp/category/shop/books': 35,
 'atp/field/city/missing': 35,
 'atp/field/country/from_spider_name': 35,
 'atp/field/email/missing': 35,
 'atp/field/image/missing': 35,
 'atp/field/opening_hours/missing': 35,
 'atp/field/operator/missing': 35,
 'atp/field/operator_wikidata/missing': 35,
 'atp/field/phone/missing': 35,
 'atp/field/postcode/missing': 35,
 'atp/field/state/missing': 35,
 'atp/field/twitter/missing': 35,
 'atp/field/website/missing': 35,
 'atp/item_scraped_host_count/storage.googleapis.com': 35,
 'atp/nsi/perfect_match': 35,
```