### PR TITLE
[PeoplesBankUS] New spider (151 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -199,6 +199,7 @@ class Categories(Enum):
     OFFICE_ESTATE_AGENT = {"office": "estate_agent"}
     OFFICE_FINANCIAL = {"office": "financial"}
     OFFICE_FINANCIAL_ADVISOR = {"office": "financial_advisor"}
+    OFFICE_INSURANCE = {"office": "insurance"}
     OFFICE_IT = {"office": "it"}
 
     TOURISM_APARTMENT = {"tourism": "apartment"}

--- a/locations/spiders/peoples_bank_us.py
+++ b/locations/spiders/peoples_bank_us.py
@@ -1,0 +1,40 @@
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.storefinders.rio_seo import RioSeoSpider
+
+
+class PeoplesBankUSSpider(RioSeoSpider):
+    name = "peoples_bank_us"
+    item_attributes = {"brand": "Peoples Bank", "brand_wikidata": "Q65716607"}
+    end_point = "https://maps.locations.peoplesbancorp.com"
+
+    def post_process_feature(self, feature, location):
+        feature["branch"] = feature.pop("name")
+
+        location_type = location["Location Type_CS"]
+        if location_type == "Branch & ATM":
+            apply_category(Categories.BANK, feature)
+            apply_yes_no(Extras.ATM, feature, True)
+            feature["name"] = self.item_attributes["brand"]
+        elif location_type == "Branch":
+            apply_category(Categories.BANK, feature)
+            feature["name"] = self.item_attributes["brand"]
+        elif location_type == "24 hour ATM":
+            apply_category(Categories.ATM, feature)
+            feature["operator"] = self.item_attributes["brand"]
+            feature["operator_wikidata"] = self.item_attributes["brand_wikidata"]
+        elif location_type == "Insurance Location":
+            apply_category(Categories.OFFICE_INSURANCE, feature)
+            feature["name"] = self.item_attributes["brand"]
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unmapped_type/{location_type}")
+            apply_category(Categories.BANK, feature)
+            feature["name"] = self.item_attributes["brand"]
+
+        oh = self.parse_hours(location["hours_sets:drive_thru_hours"])
+        if oh is not None:
+            feature["extras"]["opening_hours:drive_through"] = oh.as_opening_hours()
+        oh = self.parse_hours(location["hours_sets:atm_hours"])
+        if oh is not None:
+            feature["extras"]["opening_hours:atm"] = oh.as_opening_hours()
+
+        yield feature

--- a/locations/storefinders/rio_seo.py
+++ b/locations/storefinders/rio_seo.py
@@ -81,9 +81,12 @@ class RioSeoSpider(Spider):
         opening_hours = OpeningHours()
 
         for weekday, intervals in days.items():
-            for interval in intervals:
-                if not isinstance(interval, dict):
-                    continue
-                opening_hours.add_range(weekday, interval["open"], interval["close"])
+            if intervals == "open24":
+                opening_hours.add_range(weekday, "00:00", "23:59")
+            else:
+                for interval in intervals:
+                    if not isinstance(interval, dict):
+                        continue
+                    opening_hours.add_range(weekday, interval["open"], interval["close"])
 
         return opening_hours


### PR DESCRIPTION
```py
{'atp/brand/Peoples Bank': 151,
 'atp/brand_wikidata/Q65716607': 151,
 'atp/category/amenity/atm': 16,
 'atp/category/amenity/bank': 132,
 'atp/category/office/insurance': 3,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/field/country/from_spider_name': 151,
 'atp/field/email/missing': 151,
 'atp/field/image/missing': 151,
 'atp/field/name/missing': 16,
 'atp/field/operator/missing': 135,
 'atp/field/operator_wikidata/missing': 135,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 151,
 'atp/item_scraped_host_count/maps.locations.peoplesbancorp.com': 151,
 'atp/nsi/match_failed': 151,
 'atp/operator/Peoples Bank': 16,
 'atp/operator_wikidata/Q65716607': 16,
 'atp/peoples_bank_us/unmapped_type/': 1,
 'downloader/request_bytes': 1166,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 46522,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.418991,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 18, 3, 36, 33, 553225, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1096777,
 'httpcompression/response_count': 3,
 'item_scraped_count': 151,
 'log_count/DEBUG': 165,
 'log_count/INFO': 10,
 'memusage/max': 231059456,
 'memusage/startup': 231059456,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 8, 18, 3, 36, 30, 134234, tzinfo=datetime.timezone.utc)}
```