### PR TITLE
Standard Bank Spider (ZA, MW, ZW)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -470,6 +470,7 @@ class Extras(Enum):
     ICE_CREAM = "ice_cream"
     INDOOR_SEATING = "indoor_seating"
     KOSHER = "diet:kosher"
+    MONEYGRAM = "money_transfer=moneygram"
     MOTOR_VEHICLES = "motor_vehicle"
     OIL_CHANGE = "service:vehicle:oil_change"
     OUTDOOR_SEATING = "outdoor_seating"

--- a/locations/spiders/guild_mortgage_us.py
+++ b/locations/spiders/guild_mortgage_us.py
@@ -1,0 +1,7 @@
+from locations.storefinders.rio_seo import RioSeoSpider
+
+
+class GuildMortgageUSSpider(RioSeoSpider):
+    name = "guild_mortgage_us"
+    item_attributes = {"brand": "Guild Mortgage Company", "brand_wikidata": "Q122074693"}
+    end_point = "https://maps-r1.guildmortgage.com"

--- a/locations/spiders/standard_bank_mw.py
+++ b/locations/spiders/standard_bank_mw.py
@@ -1,0 +1,13 @@
+from locations.spiders.standard_bank_za import StandardBankZASpider
+
+MW_REGIONS = ["Central", "Northern", "Southern"]
+
+
+class StandardBankMWSpider(StandardBankZASpider):
+    name = "standard_bank_mw"
+    item_attributes = {"brand": "Standard Bank", "brand_wikidata": "Q1576610"}
+    allowed_domains = ["digitalbanking.standardbank.co.za"]
+    start_urls = [
+        f"https://digitalbanking.standardbank.co.za:8083/sbg-mobile/rest/Communications/geolocator/search?searchTerm={region}&language=en&country=Malawi"
+        for region in MW_REGIONS
+    ]

--- a/locations/spiders/standard_bank_mw.py
+++ b/locations/spiders/standard_bank_mw.py
@@ -3,7 +3,7 @@ from locations.spiders.standard_bank_za import StandardBankZASpider
 MW_REGIONS = ["Central", "Northern", "Southern"]
 
 
-class StandardBankmWSpider(StandardBankZASpider):
+class StandardBankMWSpider(StandardBankZASpider):
     name = "standard_bank_mw"
     item_attributes = {"brand": "Standard Bank", "brand_wikidata": "Q1576610"}
     allowed_domains = ["digitalbanking.standardbank.co.za"]

--- a/locations/spiders/standard_bank_za.py
+++ b/locations/spiders/standard_bank_za.py
@@ -1,0 +1,153 @@
+import scrapy
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.pipelines.address_clean_up import clean_address
+
+ZA_PROVINCES = [
+    "Eastern Cape",
+    "Free State",
+    "Gauteng",
+    "KwaZulu-Natal",
+    "Limpopo",
+    "Mpumalanga",
+    "North West",
+    "Northern Cape",
+    "Western Cape",
+]
+
+ATM_TYPES_CASH_IN = {
+    "AUTOCASH": False,
+    "AUTOBANK": True,
+    "AUTOPLUS": False,  # An option in the data, but no info about it on the website, does not appear to be used
+}
+
+CHAIN_LOCATIONS = {
+    "7 Eleven": {"located_in": "7-Eleven", "located_in_wikidata": "Q259340"},
+    "Boxer": {"located_in": "Boxer", "located_in_wikidata": "Q116586275"},
+    "Bp": {"located_in": "BP", "located_in_wikidata": "Q152057"},
+    "Caltex": {"located_in": "Caltex", "located_in_wikidata": "Q277470"},
+    "Cambridge": {"located_in": "Cambridge Food", "located_in_wikidata": "Q129263104"},
+    "Checkers": {"located_in": "Checkers", "located_in_wikidata": "Q5089126"},
+    "Engen": {"located_in": "Engen", "located_in_wikidata": "Q3054251"},
+    # 'Exel':         {"located_in": "", "located_in_wikidata": ""},
+    # 'Foodworld':    {"located_in": "", "located_in_wikidata": ""}, # Essentialy defunct/bought-out brand
+    # 'Friendly 7-11':{"located_in": "", "located_in_wikidata": ""},
+    "Game": {"located_in": "Game", "located_in_wikidata": "Q129263113"},
+    "Ok": {"located_in": "OK", "located_in_wikidata": "Q116520377"},
+    "Pick 'n Pay": {"located_in": "Pick n Pay", "located_in_wikidata": "Q7190735"},
+    "Puma Energy": {"located_in": "Puma", "located_in_wikidata": "Q7259769"},
+    "Sasol": {"located_in": "Sasol", "located_in_wikidata": "Q905998"},
+    # 'Score':        {"located_in": "", "located_in_wikidata": ""},
+    "Shell": {"located_in": "Shell", "located_in_wikidata": "Q110716465"},
+    "Shoprite": {"located_in": "Shoprite", "located_in_wikidata": "Q1857639"},
+    "Spar": {"located_in": "Spar", "located_in_wikidata": "Q610492"},
+    "Specsavers": {"located_in": "Specsavers", "located_in_wikidata": "Q2000610"},
+    "Total": {"located_in": "Total", "located_in_wikidata": "Q154037"},
+    "U - Save": {"located_in": "Usave", "located_in_wikidata": "Q115696368"},
+    "Woolworths": {"located_in": "Woolworths", "located_in_wikidata": "Q8033997"},
+    # 'Zenex':        {"located_in": "", "located_in_wikidata": ""},
+}
+
+
+class StandardBankZASpider(scrapy.Spider):
+    name = "standard_bank_za"
+    item_attributes = {"brand": "Standard Bank", "brand_wikidata": "Q1576610", "extras": Categories.BANK.value}
+    allowed_domains = ["digitalbanking.standardbank.co.za"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}  # HTTP 500 error for robots.txt
+    start_urls = [
+        f"https://digitalbanking.standardbank.co.za:8083/sbg-mobile/rest/Communications/geolocator/search?searchTerm={province}&language=en&country=South%20Africa"
+        for province in ZA_PROVINCES
+    ]
+
+    def parse(self, response):
+        data = response.json()
+        for location in data["centers"]:
+            item = DictParser.parse(location)
+            item["ref"] = location.pop("gresId")
+            item["lat"] = location["location"]["latitude"]
+            item["lon"] = location["location"]["longitude"]
+            item["state"] = location["location"]["nationalProv"]
+            item["city"] = location["location"]["town"]
+            item["postcode"] = location["location"]["postalCode"]
+            item["country"] = location["location"]["country"]
+            item["street"] = location["location"]["street"]
+            item["street_address"] = clean_address(
+                [location["location"]["shopNo"], location["location"]["shoppingCenter"], location["location"]["street"]]
+            )
+            item["branch"] = item.pop("name")
+
+            if location["locationType"] == "Branch":
+                apply_category(Categories.BANK, item)
+                yield from self.parse_branch(item, location)
+            elif location["locationType"] == "ATM":
+                apply_category(Categories.ATM, item)
+                yield from self.parse_atm(item, location)
+            else:
+                self.logger.warning("Unknown category: {}".format(location["locationType"]))
+                continue
+
+    def parse_branch(self, item, location):
+        services = [service["name"] for service in location["services"]]
+        # Possible services: 'Internet Kiosk', 'SBFC presence', 'Cashless Outlet', 'Forex', 'MoneyGram', 'Safe Custody',
+        #    'MIE presence', 'Home Affairs Presence', 'Liberty Presence'
+
+        apply_yes_no(Extras.MONEYGRAM, item, "MoneyGram" in services, True)
+
+        apply_yes_no(Extras.WHEELCHAIR, item, location["wheelChairAccess"] == "YES")  # Value can be "UNKNOWN"
+        apply_yes_no(
+            Extras.BACKUP_GENERATOR, item, location.get("shoppingCenterGeneratorStatus") == "YES"
+        )  # Value can be "UNKNOWN"
+
+        oh = OpeningHours()
+        for line in location["operatingHours"]:
+            try:
+                day_time = line["hours"].split(":")
+                # Slight hack so that the later splitting on dash works
+                day_time[1] = day_time[1].lower().replace("only", "").strip()
+                if day_time[1].strip().lower() == "closed":
+                    day_time[1] = "closed-closed"
+                if day_time[0].strip().title() in DAYS_3_LETTERS:
+                    oh.add_range(
+                        day_time[0], day_time[1].split("-")[0].strip(), day_time[1].split("-")[1].strip(), "%HH%M"
+                    )
+                elif "&" in day_time[0]:
+                    for day in day_time[0].split("&"):
+                        try:
+                            for times in day_time[1].split("&"):
+                                times = times.strip()
+                                oh.add_range(day, times.split("-")[0].strip(), times.split("-")[1].strip(), "%HH%M")
+                        except ValueError:
+                            pass
+                elif "-" in day_time[0]:
+                    try:
+                        for times in day_time[1].split("&"):
+                            times = times.strip()
+                            oh.add_days_range(
+                                oh.days_in_day_range(
+                                    [day_time[0].split("-")[0].strip(), day_time[0].split("-")[1].strip()]
+                                ),
+                                times.split("-")[0].strip(),
+                                times.split("-")[1].strip(),
+                                "%HH%M",
+                            )
+                    except ValueError:
+                        pass
+            except:
+                pass
+
+        item["opening_hours"] = oh.as_opening_hours()
+        yield item
+
+    def parse_atm(self, item, location):
+        # Despite being a list, it appears to always have either 0 or 1 elements
+        if len(location["atms"]) > 0:
+            apply_yes_no(Extras.CASH_IN, item, ATM_TYPES_CASH_IN[location["atms"][0]["atmType"]], False)
+            if location["atms"][0]["chain"] in CHAIN_LOCATIONS:
+                item.update(CHAIN_LOCATIONS[location["atms"][0]["chain"]])
+            else:
+                item["located_in"] = location["atms"][0]["chain"]
+            # location["atms"]["typeOfSite"] does not appear to be useful
+
+        yield item

--- a/locations/spiders/standard_bank_zw.py
+++ b/locations/spiders/standard_bank_zw.py
@@ -1,0 +1,24 @@
+from locations.spiders.standard_bank_za import StandardBankZASpider
+
+ZW_PROVINCES = [
+    "Bulawayo",
+    "Harare",
+    "Manicaland",
+    "Mashonaland Central",
+    "Mashonaland East",
+    "Mashonaland West",
+    "Masvingo",
+    "Matabeleland North",
+    "Matabeleland South",
+    "Midlands",
+]
+
+
+class StandardBankZWSpider(StandardBankZASpider):
+    name = "standard_bank_zw"
+    item_attributes = {"brand": "Standard Bank", "brand_wikidata": "Q1576610"}
+    allowed_domains = ["digitalbanking.standardbank.co.za"]
+    start_urls = [
+        f"https://digitalbanking.standardbank.co.za:8083/sbg-mobile/rest/Communications/geolocator/search?searchTerm={province}&language=en&country=Zimbabwe"
+        for province in ZW_PROVINCES
+    ]


### PR DESCRIPTION
Fixes #825

These are all the countries I can see that use this format and I can get to work with searches. More countries may be possible however. Although, there are also some badly located items which are meant to be in Uganda but show up in Egypt.

ZA:
```
 'atp/brand/Standard Bank': 2299,
 'atp/brand_wikidata/Q1576610': 2299,
 'atp/category/amenity/atm': 1830,
 'atp/category/amenity/bank': 469,
 'atp/field/city/missing': 3,
 'atp/field/email/missing': 2299,
 'atp/field/image/missing': 2299,
 'atp/field/name/missing': 1830,
 'atp/field/opening_hours/missing': 1830,
 'atp/field/operator/missing': 469,
 'atp/field/operator_wikidata/missing': 469,
 'atp/field/phone/missing': 2299,
 'atp/field/postcode/missing': 40,
 'atp/field/street_address/missing': 66,
 'atp/field/twitter/missing': 2299,
 'atp/field/website/missing': 2299,
 'atp/item_scraped_host_count/digitalbanking.standardbank.co.za:8083': 2346,
 'atp/nsi/cc_match': 2299,
 'atp/operator/Standard Bank': 1830,
 'atp/operator_wikidata/Q1576610': 1830,
```

 ZW:
```
 'atp/brand/Standard Bank': 20,
 'atp/brand_wikidata/Q1576610': 20,
 'atp/category/amenity/atm': 5,
 'atp/category/amenity/bank': 15,
 'atp/field/email/missing': 20,
 'atp/field/image/missing': 20,
 'atp/field/name/missing': 5,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 15,
 'atp/field/operator_wikidata/missing': 15,
 'atp/field/phone/missing': 20,
 'atp/field/postcode/missing': 20,
 'atp/field/twitter/missing': 20,
 'atp/field/website/missing': 20,
 'atp/item_scraped_host_count/digitalbanking.standardbank.co.za:8083': 20,
 'atp/nsi/cc_match': 20,
 'atp/operator/Standard Bank': 5,
 'atp/operator_wikidata/Q1576610': 5,
```

MW:
```
 'atp/brand/Standard Bank': 25,
 'atp/brand_wikidata/Q1576610': 25,
 'atp/category/amenity/bank': 25,
 'atp/field/city/missing': 25,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 25,
 'atp/field/opening_hours/invalid': 25,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/phone/missing': 25,
 'atp/field/postcode/missing': 25,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 25,
 'atp/field/website/missing': 25,
 'atp/item_scraped_host_count/digitalbanking.standardbank.co.za:8083': 25,
 'atp/nsi/cc_match': 25,
```