### PR TITLE
[banca_sella_it] new spider (282 locations)

### DIFF
--- a/locations/spiders/banca_sella_it.py
+++ b/locations/spiders/banca_sella_it.py
@@ -1,0 +1,17 @@
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class BancaSellaITSpider(JSONBlobSpider):
+    name = "banca_sella_it"
+    item_attributes = {"brand": "Banca Sella", "brand_wikidata": "Q3633749"}
+    start_urls = ["https://www.sella.it/banca-online/store-locator/store-list.jsp"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    locations_key = "stores"
+    no_refs = True
+
+    def post_process_item(self, item, response, location):
+        item["city"] = location.get("citta")
+        item["postcode"] = location.get("cap")
+        apply_category(Categories.BANK, item)
+        yield item


### PR DESCRIPTION
Saw what @CloCkWeRX had done with the `JSONBlobSpider` and thought we could default `extract_json` to treating the body response as JSON which is a regular pattern and then having an optional single level key to get the location array which is also a common pattern leading into the `DictParser` dance.
