### PR TITLE
Capitec Bank spider

### DIFF
--- a/locations/spiders/capitec_bank_za.py
+++ b/locations/spiders/capitec_bank_za.py
@@ -1,0 +1,57 @@
+from scrapy import Request, Spider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
+from locations.hours import DAYS_WEEKDAY, OpeningHours
+
+DAYS_TERMS = {
+    "OpeningHours": DAYS_WEEKDAY,
+    "SaturdayHours": "Sa",
+    "SundayHours": "Su",
+}
+
+
+class CapitecBankZASpider(Spider):
+    name = "capitec_bank_za"
+    item_attributes = {"brand": "Capitec Bank", "brand_wikidata": "Q5035822"}
+    allowed_domains = ["capitecbank.co.za"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    no_refs = True
+
+    def start_requests(self):
+        # Maximum returned is 100, even with larger "Take"
+        # Even with 48km radius, not all locations are returned, and it is making ove 260 requests
+        for lat, lon in country_iseadgg_centroids("ZA", 48):
+            yield Request(
+                url="https://www.capitecbank.co.za/api/Branch",
+                body=f"Latitude={lat}&Longitude={lon}&Take=100",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                method="POST",
+            )
+
+    def parse(self, response):
+        for location in response.json()["Branches"]:
+            if location["IsClosed"]:
+                continue
+            item = DictParser.parse(location)
+            if location["IsAtm"]:
+                item["ref"] = location["Id"]
+                apply_category(Categories.ATM, item)
+                apply_yes_no(Extras.CASH_IN, item, location["CashAccepting"], False)
+            else:
+                item["ref"] = None
+                apply_category(Categories.BANK, item)
+
+            item["branch"] = item.pop("name")
+
+            oh = OpeningHours()
+            for day in DAYS_TERMS:
+                if location[day] is not None:
+                    if location[day].startswith("Closed"):
+                        oh.set_closed(DAYS_TERMS[day])
+                    else:
+                        oh.add_ranges_from_string(location[day])
+            item["opening_hours"] = oh.as_opening_hours()
+
+            yield item


### PR DESCRIPTION
Fixes #828 but I'm not sure about this because:
* The robots.txt disallows /api/
* The API only returns a maximum of 100 objects, so we need to do lots of requests to get everything.
* We can't limit to e.g. just branches because there's no way I can see to do separate searches for branches and ATMS, filtering is done client-side after the results are returned

I tried different radii for searching points and got the following:

- 315km radius, 13 requests, 987 objects (199 branches)
- 158km radius, 36 requests, 1975 objects (359 branches)
- 94km radius, 78 requests, 2884 objects (520 branches)
- 79km radius, 98 requests, 3123 objects (567 branches)
- 48 km radius, 262 requests, 3483 objects (635 branches)
- 24km radius, 964 requests, not attempted

Even comparing 48km and 79km radii I can see that there are locations in the 79km search not returned in the 48km search.

The website claims 7000 ATMS, but I don't think we will get that many. I think ATMs at branches are not included in these results and there could be 2 or 3 per branch.