### PR TITLE
[mkrf_ru] add parks (502 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -47,6 +47,7 @@ class Categories(Enum):
 
     LEISURE_PLAYGROUND = {"leisure": "playground"}
     LEISURE_RESORT = {"leisure": "resort"}
+    LEISURE_PARK = {"leisure": "park"}
 
     SHOP_AGRARIAN = {"shop": "agrarian"}
     SHOP_ALCOHOL = {"shop": "alcohol"}

--- a/locations/spiders/mkrf_ru.py
+++ b/locations/spiders/mkrf_ru.py
@@ -67,7 +67,7 @@ MUSEUM_TYPES = {
 class MkrfRUSpider(Spider):
     name = "mkrf_ru"
     allowed_domains = ["opendata.mkrf.ru"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 100}
     dataset_attributes = {
         "attribution": "required",
         "attribution:name": "Министерство культуры Российской Федерации",

--- a/locations/spiders/mkrf_ru.py
+++ b/locations/spiders/mkrf_ru.py
@@ -10,6 +10,7 @@ CATEGORY_MAPPING = {
     "muzei-i-galerei": Categories.MUSEUM,
     "biblioteki": Categories.LIBRARY,
     "dvorcy-kultury-i-kluby": Categories.COMMUNITY_CENTRE,
+    "parki": Categories.LEISURE_PARK,
 }
 
 MUSEUM_TYPES = {
@@ -69,6 +70,7 @@ class MkrfRUSpider(Spider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     dataset_attributes = {
         "attribution": "required",
+        "attribution:name": "Министерство культуры Российской Федерации",
         "attribution:name:en": "Ministry of Culture of the Russian Federation",
         "attribution:name:ru": "Министерство культуры Российской Федерации",
         "attribution:website": "https://opendata.mkrf.ru/",
@@ -76,7 +78,7 @@ class MkrfRUSpider(Spider):
         "use:commercial": "permit",
     }
     # TODO: add more datasets from https://opendata.mkrf.ru/item/api
-    datasets = ["museums", "cinema", "libraries", "culture_palaces_clubs"]
+    datasets = ["museums", "cinema", "libraries", "culture_palaces_clubs", "parks"]
 
     api_key = "be088ddb94bfd718a196c7ac7f67d32303ba69681948ec0a21744cdd4f78bd16"
 
@@ -108,6 +110,7 @@ class MkrfRUSpider(Spider):
         if poi_attributes:
             item = DictParser.parse(poi_attributes)
             item["ref"] = str(poi_attributes.get("id", "")) + "-" + dataset
+            self.crawler.stats.inc_value(f"atp/{self.name}/dataset/{dataset}")
             item["street"] = None
 
             # 'locale' is inconsistent, sometimes it's is city, sometimes it's region - skip it
@@ -145,7 +148,7 @@ class MkrfRUSpider(Spider):
                     oh.add_range(DAYS[int(k)], v.get("from"), v.get("to"), "%H:%M:%S")
                 item["opening_hours"] = oh.as_opening_hours()
             except:
-                self.crawler.stats.inc_value("atp/mkrf/failed_to_parse_hours")
+                self.crawler.stats.inc_value(f"atp/{self.name}/hours/failed")
 
     def parse_museum_types(self, item, poi_attributes):
         if poi_attributes.get("category", {}).get("sysName") == "muzei-i-galerei":
@@ -154,4 +157,4 @@ class MkrfRUSpider(Spider):
                     if value := MUSEUM_TYPES.get(type):
                         apply_category({"museum": value}, item)
                     else:
-                        self.crawler.stats.inc_value(f"atp/mkrf/museum_types/failed/{type}")
+                        self.crawler.stats.inc_value(f"atp/{self.name}/museum_types/failed/{type}")


### PR DESCRIPTION
There are few locations that require correction, but in general this is very good dataset.
<img width="804" alt="image" src="https://github.com/user-attachments/assets/af5f9a6a-cebb-4d29-9d15-67a06a8bd488">


Stats for parks only:

```json
{
 "atp/category/leisure/park": 502,
 "atp/field/branch/missing": 502,
 "atp/field/brand/missing": 502,
 "atp/field/brand_wikidata/missing": 502,
 "atp/field/city/missing": 502,
 "atp/field/country/from_spider_name": 502,
 "atp/field/email/missing": 150,
 "atp/field/opening_hours/missing": 18,
 "atp/field/operator/missing": 502,
 "atp/field/operator_wikidata/missing": 502,
 "atp/field/phone/invalid": 4,
 "atp/field/phone/missing": 130,
 "atp/field/postcode/missing": 502,
 "atp/field/state/missing": 502,
 "atp/field/street_address/missing": 78,
 "atp/field/twitter/missing": 502,
 "atp/field/website/invalid": 26,
 "atp/field/website/missing": 140,
 "atp/item_scraped_host_count/opendata.mkrf.ru": 502,
 "atp/mkrf/failed_to_parse_hours": 1,
 "atp/mkrf_ru/dataset/parks": 502,
 "downloader/request_bytes": 983,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 637303,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 10.899257,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-08-26T08:06:21.309255+00:00",
 "httpcompression/response_bytes": 3208365,
 "httpcompression/response_count": 2,
 "item_scraped_count": 502,
 "log_count/INFO": 11,
 "memusage/max": 216203264,
 "memusage/startup": 216203264,
 "request_depth_max": 1,
 "response_received_count": 2,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2024-08-26T08:06:10.409998+00:00"
}
```
