### PR TITLE
[StorageKing AU NZ] Add spider

### DIFF
--- a/locations/spiders/storage_king_au.py
+++ b/locations/spiders/storage_king_au.py
@@ -1,0 +1,40 @@
+from urllib.parse import urljoin
+
+from scrapy.http import Response
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class StorageKingAUSpider(JSONBlobSpider):
+    name = "storage_king_au"
+    item_attributes = {"brand": "Storage King", "brand_wikidata": "Q114353097"}
+    start_urls = ["https://www.storageking.com.au/apps/checkout/api/facility/all"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict):
+        if feature["is_active"] is False:
+            return
+        item["name"] = None
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = feature.get("short_name")
+        item["geometry"] = feature["Location"]
+        item["website"] = urljoin("https://www.storageking.com.au/collections/", feature["collection_handle"])
+
+        item["opening_hours"] = self.parse_oh(feature.get("trading_hours", {}).get("accessHours", {}))
+        item["extras"]["opening_hours:office"] = self.parse_oh(
+            feature.get("trading_hours", {}).get("officeHours", {})
+        ).as_opening_hours()
+
+        yield item
+
+    def parse_oh(self, rules: dict) -> OpeningHours:
+        oh = OpeningHours()
+        if rules:
+            for day, rule in rules.items():
+                if rule["closed"] is True:
+                    oh.set_closed(day)
+                else:
+                    oh.add_range(day, rule["from"], rule["to"])
+        return oh

--- a/locations/spiders/storage_king_au_nz.py
+++ b/locations/spiders/storage_king_au_nz.py
@@ -7,10 +7,13 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class StorageKingAUSpider(JSONBlobSpider):
-    name = "storage_king_au"
+class StorageKingAUNZSpider(JSONBlobSpider):
+    name = "storage_king_au_nz"
     item_attributes = {"brand": "Storage King", "brand_wikidata": "Q114353097"}
-    start_urls = ["https://www.storageking.com.au/apps/checkout/api/facility/all"]
+    start_urls = [
+        "https://www.storageking.com.au/apps/checkout/api/facility/all",
+        "https://www.storageking.co.nz/apps/checkout/api/facility/all",
+    ]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item: Feature, response: Response, feature: dict):
@@ -20,7 +23,14 @@ class StorageKingAUSpider(JSONBlobSpider):
         item["street_address"] = item.pop("addr_full")
         item["branch"] = feature.get("short_name")
         item["geometry"] = feature["Location"]
-        item["website"] = urljoin("https://www.storageking.com.au/collections/", feature["collection_handle"])
+        item["website"] = urljoin(
+            (
+                "https://www.storageking.com.au/collections/"
+                if ".com.au" in response.url
+                else "https://www.storageking.co.nz/collections/"
+            ),
+            feature["collection_handle"],
+        )
 
         item["opening_hours"] = self.parse_oh(feature.get("trading_hours", {}).get("accessHours", {}))
         item["extras"]["opening_hours:office"] = self.parse_oh(


### PR DESCRIPTION
Fixes #8506 Fixes #8507

```python
{'atp/brand/Storage King': 198,
 'atp/brand_wikidata/Q114353097': 198,
 'atp/category/shop/storage_rental': 198,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 64,
 'atp/field/email/missing': 6,
 'atp/field/image/missing': 198,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 198,
 'atp/field/operator_wikidata/missing': 198,
 'atp/field/twitter/missing': 198,
 'atp/item_scraped_host_count/www.storageking.co.nz': 24,
 'atp/item_scraped_host_count/www.storageking.com.au': 176,
 'atp/nsi/perfect_match': 198,
 'downloader/request_bytes': 665,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 141014,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.360792,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 26, 12, 45, 27, 887811, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1,
 'httpcache/hit': 1,
 'httpcache/miss': 1,
 'httpcache/store': 1,
 'httpcompression/response_bytes': 1962578,
 'httpcompression/response_count': 2,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 198,
 'log_count/DEBUG': 220,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 243933184,
 'memusage/startup': 243933184,
 'response_received_count': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 8, 26, 12, 45, 23, 527019, tzinfo=datetime.timezone.utc)}
```