### PR TITLE
[total_energies] use services mapping, map more fuels

### DIFF
--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -10,7 +10,7 @@ from locations.categories import (
     apply_category,
     apply_yes_no,
 )
-from locations.items import get_lat_lon, set_lat_lon
+from locations.items import Feature, get_lat_lon, set_lat_lon
 from locations.storefinders.woosmap import WoosmapSpider
 
 
@@ -54,6 +54,55 @@ class TotalEnergiesSpider(WoosmapSpider):
         #      1 "fin"
         #      1 "em"
     }
+    SERVICES_MAPPING = {
+        # Fuels
+        "excellium_93": Fuel.OCTANE_93,
+        "excellium95": Fuel.OCTANE_95,
+        "excellium98": Fuel.OCTANE_98,
+        "excelliumdiesel": Fuel.DIESEL,
+        "sp95e10": Fuel.E10,
+        "sp95performance": Fuel.OCTANE_95,
+        "superethanole85": Fuel.E85,
+        "adblue": Fuel.ADBLUE,
+        "lpg": Fuel.LPG,
+        "kerosene": Fuel.KEROSENE,
+        "avgas100llautomate": Fuel.AV100LL,
+        "avgas100ll": Fuel.AV100LL,
+        "jeta1": Fuel.AVJetA1,
+        "engineoil": Fuel.ENGINE_OIL,
+        "wasserstoff": Fuel.LH2,
+        "sp95": Fuel.OCTANE_95,
+        "sp98": Fuel.OCTANE_98,
+        "dieseldetruck": Fuel.HGV_DIESEL,
+        # TODO: Other fuels: gasoil super superethanole85 excellium95e10 gasoline92_eg regulargasoline
+        # happyfuel sp95_lb supereffimax dieseleffimax dieselb10 adbluecar
+        # Payment methods
+        "amex": PaymentMethods.AMERICAN_EXPRESS,
+        "mastercard": PaymentMethods.MASTER_CARD,
+        "visa": PaymentMethods.VISA,
+        "maestro": PaymentMethods.MAESTRO,
+        "vpay": PaymentMethods.V_PAY,
+        "girocard": PaymentMethods.GIROCARD,
+        "appay": PaymentMethods.APPLE_PAY,
+        "googlepay": PaymentMethods.GOOGLE_PAY,
+        "cash": PaymentMethods.CASH,
+        "credit_card": PaymentMethods.CREDIT_CARDS,
+        "grcartefr": "payment:gr_total_card",
+        "totalcard": FuelCards.TOTAL_CARD,
+        "ffc": "payment:fleet_fuel_card",
+        "eurotrafic": "payment:eurotrafic",
+        "carteclubtotal": "payment:club_total_card",
+        # TODO: other cards: proficard bonjour mpayment westfalencard prepaidcard travelcard ecocash nimbacard ecash sonayacard
+        # Extras
+        "atm": Extras.ATM,
+        "carwash": Extras.CAR_WASH,
+        "restroom": Extras.TOILETS,
+        "freewifi": Extras.WIFI,
+        "accessibility": Extras.WHEELCHAIR,
+        "truckfriendly": Access.HGV,
+        "oilchange": Extras.OIL_CHANGE,
+        "carglass": "service:vehicle:glass",
+    }
 
     def parse_item(self, item, feature, **kwargs):
         if feature["properties"]["user_properties"]["status"] != "2":
@@ -71,46 +120,7 @@ class TotalEnergiesSpider(WoosmapSpider):
 
         item["website"] = f'https://store.totalenergies.fr/en_EN/{item["ref"]}'
 
-        apply_yes_no(Extras.ATM, item, "atm" in feature["properties"]["tags"])
-        apply_yes_no(Extras.CAR_WASH, item, "carwash" in feature["properties"]["tags"])
-        apply_yes_no(Extras.TOILETS, item, "restroom" in feature["properties"]["tags"])
-        apply_yes_no(Extras.WIFI, item, "freewifi" in feature["properties"]["tags"])
-        apply_yes_no(Extras.WHEELCHAIR, item, "accessibility" in feature["properties"]["tags"])
-        apply_yes_no(Access.HGV, item, "truckfriendly" in feature["properties"]["tags"])
-        apply_yes_no(Extras.OIL_CHANGE, item, "oilchange" in feature["properties"]["tags"])
-        apply_yes_no("service:vehicle:glass", item, "carglass" in feature["properties"]["tags"])
-
-        apply_yes_no(Fuel.ENGINE_OIL, item, "engineoil" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.AV100LL, item, "avgas100llautomate" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.AV100LL, item, "avgas100ll" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.AVJetA1, item, "jeta1" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.OCTANE_95, item, "excellium95" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.OCTANE_98, item, "excellium98" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.DIESEL, item, "excelliumdiesel" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.E10, item, "sp95e10" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.ADBLUE, item, "adblue" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.LPG, item, "lpg" in feature["properties"]["tags"])
-        apply_yes_no(Fuel.KEROSENE, item, "kerosene" in feature["properties"]["tags"])
-        # TODO: Other fuels?:
-        # gasoil sp95 sp98 super superethanole85 excellium95e10 gasoline92_eg regulargasoline superethanole85
-        # sp95performance happyfuel sp95_lb supereffimax dieseleffimax dieselb10 adbluecar excellium_93
-
-        apply_yes_no(PaymentMethods.AMERICAN_EXPRESS, item, "amex" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.MASTER_CARD, item, "mastercard" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.VISA, item, "visa" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.MAESTRO, item, "maestro" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.V_PAY, item, "vpay" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.GIROCARD, item, "girocard" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.APPLE_PAY, item, "appay" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.GOOGLE_PAY, item, "googlepay" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.CASH, item, "cash" in feature["properties"]["tags"])
-        apply_yes_no(PaymentMethods.CREDIT_CARDS, item, "credit_card" in feature["properties"]["tags"])
-        apply_yes_no("payment:gr_total_card", item, "grcartefr" in feature["properties"]["tags"])
-        apply_yes_no(FuelCards.TOTAL_CARD, item, "totalcard" in feature["properties"]["tags"])
-        apply_yes_no("payment:fleet_fuel_card", item, "ffc" in feature["properties"]["tags"])
-        apply_yes_no("payment:eurotrafic", item, "eurotrafic" in feature["properties"]["tags"])
-        apply_yes_no("payment:club_total_card", item, "carteclubtotal" in feature["properties"]["tags"])
-        # TODO: other cards: proficard bonjour mpayment westfalencard prepaidcard travelcard ecocash nimbacard ecash sonayacard
+        self.apply_services(item, feature)
 
         if "shop" in feature["properties"]["tags"]:
             apply_category(Categories.SHOP_CONVENIENCE, item)
@@ -119,7 +129,7 @@ class TotalEnergiesSpider(WoosmapSpider):
             item.update(brand)
         else:
             self.crawler.stats.inc_value(
-                f'atp/total_energies/unknown_brand/{feature["properties"]["user_properties"]["brand"]}'
+                f'atp/{self.name}/unknown_brand/{feature["properties"]["user_properties"]["brand"]}'
             )
 
         # Some locations have flipped coordinates - all gas stations of certain brands (Agip) and
@@ -134,3 +144,13 @@ class TotalEnergiesSpider(WoosmapSpider):
             set_lat_lon(item, lon, lat)
 
         yield item
+
+    def apply_services(self, item: Feature, poi: dict) -> None:
+        tags = poi.get("properties", {}).get("tags", [])
+        if not tags:
+            return
+        for tag in tags:
+            if match := self.SERVICES_MAPPING.get(tag):
+                apply_yes_no(match, item, True)
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/unknown_tag/{tag}")


### PR DESCRIPTION
The intent was just to map a bit more fuels, but I ended up changing from multiple `apply_yes_no` to looping over SERVICES_MAPPING dict.

<details><summary> Stats </summary>

```json
{
 "atp/brand/AS 24": 494,
 "atp/brand/Agip": 417,
 "atp/brand/Aral": 2314,
 "atp/brand/Avia": 699,
 "atp/brand/BP": 2349,
 "atp/brand/Cepsa": 3067,
 "atp/brand/Dyneff": 113,
 "atp/brand/Elan": 323,
 "atp/brand/Esso": 533,
 "atp/brand/Filoil": 103,
 "atp/brand/Gulf": 107,
 "atp/brand/MOL": 746,
 "atp/brand/OMV": 15,
 "atp/brand/Shell": 202,
 "atp/brand/Slovnaft": 188,
 "atp/brand/Total Access": 775,
 "atp/brand/TotalEnergies": 11696,
 "atp/brand/TotalEnergies Express": 170,
 "atp/brand/TotalErg": 1791,
 "atp/brand/Westfalen": 258,
 "atp/brand_wikidata/Q110716465": 202,
 "atp/brand_wikidata/Q1411209": 258,
 "atp/brand_wikidata/Q152057": 2349,
 "atp/brand_wikidata/Q154037": 12641,
 "atp/brand_wikidata/Q1587563": 188,
 "atp/brand_wikidata/Q16630266": 113,
 "atp/brand_wikidata/Q168238": 15,
 "atp/brand_wikidata/Q2819394": 494,
 "atp/brand_wikidata/Q300147": 699,
 "atp/brand_wikidata/Q377915": 417,
 "atp/brand_wikidata/Q3995933": 1791,
 "atp/brand_wikidata/Q549181": 746,
 "atp/brand_wikidata/Q5617505": 107,
 "atp/brand_wikidata/Q565734": 2314,
 "atp/brand_wikidata/Q57980752": 323,
 "atp/brand_wikidata/Q608819": 3067,
 "atp/brand_wikidata/Q867662": 533,
 "atp/category/amenity/charging_station": 68,
 "atp/category/amenity/fuel": 28139,
 "atp/category/multiple": 3149,
 "atp/cdn/cloudflare/response_count": 254,
 "atp/cdn/cloudflare/response_status_count/200": 253,
 "atp/cdn/cloudflare/response_status_count/404": 1,
 "atp/field/branch/missing": 28207,
 "atp/field/brand/missing": 1847,
 "atp/field/brand_wikidata/missing": 1950,
 "atp/field/city/missing": 54,
 "atp/field/email/invalid": 11,
 "atp/field/email/missing": 27090,
 "atp/field/image/missing": 28207,
 "atp/field/lat/missing": 12,
 "atp/field/lon/missing": 12,
 "atp/field/opening_hours/missing": 20507,
 "atp/field/operator/missing": 28207,
 "atp/field/operator_wikidata/missing": 28207,
 "atp/field/phone/invalid": 154,
 "atp/field/phone/missing": 17012,
 "atp/field/postcode/missing": 4928,
 "atp/field/state/missing": 28207,
 "atp/field/street_address/missing": 1022,
 "atp/field/twitter/missing": 28207,
 "atp/geometry/null_island": 12,
 "atp/item_scraped_host_count/api.woosmap.com": 28207,
 "atp/nsi/brand_missing": 1791,
 "atp/nsi/cc_match": 14499,
 "atp/nsi/match_failed": 9967,
 "atp/total_energies/unknown_brand/deal": 1,
 "atp/total_energies/unknown_brand/em": 1,
 "atp/total_energies/unknown_brand/eos": 159,
 "atp/total_energies/unknown_brand/freie": 133,
 "atp/total_energies/unknown_brand/g&v": 1,
 "atp/total_energies/unknown_brand/haa": 20,
 "atp/total_energies/unknown_brand/sup": 25,
 "atp/total_energies/unknown_brand/totalagri": 1,
 "atp/total_energies/unknown_brand/totfa": 33,
 "atp/total_energies/unknown_brand/unb": 1451,
 "atp/total_energies/unknown_brand/wei": 21,
 "atp/total_energies/unknown_brand/white": 1,
 "atp/total_energies/unknown_tag/08n": 7,
 "atp/total_energies/unknown_tag/08q": 9,
 "atp/total_energies/unknown_tag/0d2": 1,
 "atp/total_energies/unknown_tag/0ny": 1,
 "atp/total_energies/unknown_tag/0o0": 1,
 "atp/total_energies/unknown_tag/0sh": 1,
 "atp/total_energies/unknown_tag/0w0": 1,
 "atp/total_energies/unknown_tag/100pour100": 1492,
 "atp/total_energies/unknown_tag/108": 1,
 "atp/total_energies/unknown_tag/12x": 1,
 "atp/total_energies/unknown_tag/13t": 6,
 "atp/total_energies/unknown_tag/1wx": 1,
 "atp/total_energies/unknown_tag/2424openinghours": 1075,
 "atp/total_energies/unknown_tag/2424shop": 275,
 "atp/total_energies/unknown_tag/25o": 1,
 "atp/total_energies/unknown_tag/2t": 15,
 "atp/total_energies/unknown_tag/3t6": 1,
 "atp/total_energies/unknown_tag/466": 1,
 "atp/total_energies/unknown_tag/467": 71,
 "atp/total_energies/unknown_tag/47w": 1,
 "atp/total_energies/unknown_tag/4hs": 1,
 "atp/total_energies/unknown_tag/4ik": 1,
 "atp/total_energies/unknown_tag/4jj": 1,
 "atp/total_energies/unknown_tag/4t": 75,
 "atp/total_energies/unknown_tag/50kw": 15,
 "atp/total_energies/unknown_tag/6au": 1,
 "atp/total_energies/unknown_tag/6e4": 1,
 "atp/total_energies/unknown_tag/714": 59,
 "atp/total_energies/unknown_tag/715": 39,
 "atp/total_energies/unknown_tag/716": 1,
 "atp/total_energies/unknown_tag/745": 18,
 "atp/total_energies/unknown_tag/746": 11,
 "atp/total_energies/unknown_tag/7bj": 1,
 "atp/total_energies/unknown_tag/8lb": 1,
 "atp/total_energies/unknown_tag/8ln": 1,
 "atp/total_energies/unknown_tag/969": 1,
 "atp/total_energies/unknown_tag/976": 9,
 "atp/total_energies/unknown_tag/977": 52,
 "atp/total_energies/unknown_tag/9we": 23,
 "atp/total_energies/unknown_tag/absaatm": 14,
 "atp/total_energies/unknown_tag/abyssiniacard": 1,
 "atp/total_energies/unknown_tag/adbleupl": 306,
 "atp/total_energies/unknown_tag/adbluebottles": 469,
 "atp/total_energies/unknown_tag/adbluecar": 118,
 "atp/total_energies/unknown_tag/adbluevl": 161,
 "atp/total_energies/unknown_tag/adbluevrac": 16,
 "atp/total_energies/unknown_tag/adhesion_station": 1294,
 "atp/total_energies/unknown_tag/africapass": 90,
 "atp/total_energies/unknown_tag/agglo": 263,
 "atp/total_energies/unknown_tag/ago": 5,
 "atp/total_energies/unknown_tag/airconditioner": 2,
 "atp/total_energies/unknown_tag/airtel": 442,
 "atp/total_energies/unknown_tag/alignment": 3,
 "atp/total_energies/unknown_tag/amazon": 12,
 "atp/total_energies/unknown_tag/amazon_locker": 126,
 "atp/total_energies/unknown_tag/aral_de": 7062,
 "atp/total_energies/unknown_tag/as24carte": 109,
 "atp/total_energies/unknown_tag/aspirateur": 43,
 "atp/total_energies/unknown_tag/aspirateur_mrn": 867,
 "atp/total_energies/unknown_tag/assistance_club_10j": 871,
 "atp/total_energies/unknown_tag/assistance_club_30j": 1004,
 "atp/total_energies/unknown_tag/atmsolutions": 31,
 "atp/total_energies/unknown_tag/autoart": 1,
 "atp/total_energies/unknown_tag/autofast": 4,
 "atp/total_energies/unknown_tag/autoroutiere": 225,
 "atp/total_energies/unknown_tag/avia": 883,
 "atp/total_energies/unknown_tag/awi": 1,
 "atp/total_energies/unknown_tag/babycorner": 99,
 "atp/total_energies/unknown_tag/balancing": 1,
 "atp/total_energies/unknown_tag/banc": 3148,
 "atp/total_energies/unknown_tag/bank": 5,
 "atp/total_energies/unknown_tag/bankafrica": 12,
 "atp/total_energies/unknown_tag/bcmc": 527,
 "atp/total_energies/unknown_tag/bdgrill": 11,
 "atp/total_energies/unknown_tag/be_borne_electrique": 68,
 "atp/total_energies/unknown_tag/be_bouteilles_de_gaz2": 173,
 "atp/total_energies/unknown_tag/be_car_wash_roll-over": 47,
 "atp/total_energies/unknown_tag/be_centre_de_pneus": 39,
 "atp/total_energies/unknown_tag/be_coffee_corner2": 408,
 "atp/total_energies/unknown_tag/be_coffee_corner3": 271,
 "atp/total_energies/unknown_tag/be_mrn_cstore2": 274,
 "atp/total_energies/unknown_tag/be_mrn_cstore3": 67,
 "atp/total_energies/unknown_tag/be_mrn_jetwash": 68,
 "atp/total_energies/unknown_tag/be_mrn_pellets": 260,
 "atp/total_energies/unknown_tag/be_mrn_truckbasic": 121,
 "atp/total_energies/unknown_tag/be_presse": 155,
 "atp/total_energies/unknown_tag/be_restau_lunch_partenaire": 81,
 "atp/total_energies/unknown_tag/be_salle_de_reunion": 3,
 "atp/total_energies/unknown_tag/be_sanwichespreemballes": 198,
 "atp/total_energies/unknown_tag/be_viennoiseries": 289,
 "atp/total_energies/unknown_tag/be_wifi_gratuit": 39,
 "atp/total_energies/unknown_tag/benzin": 17,
 "atp/total_energies/unknown_tag/bonjour": 2221,
 "atp/total_energies/unknown_tag/bonjour-lb": 237,
 "atp/total_energies/unknown_tag/bonjour_tn": 323,
 "atp/total_energies/unknown_tag/bonjourmarket": 4,
 "atp/total_energies/unknown_tag/boo": 41,
 "atp/total_energies/unknown_tag/bornedc150kw": 2,
 "atp/total_energies/unknown_tag/bornedc300kw": 2,
 "atp/total_energies/unknown_tag/bornerecharge": 141,
 "atp/total_energies/unknown_tag/bosch": 15,
 "atp/total_energies/unknown_tag/bottlesadblue": 1397,
 "atp/total_energies/unknown_tag/boulangerie": 304,
 "atp/total_energies/unknown_tag/bouteillesgaz": 1948,
 "atp/total_energies/unknown_tag/boxgourmande": 47,
 "atp/total_energies/unknown_tag/bq4": 1,
 "atp/total_energies/unknown_tag/brake": 2,
 "atp/total_energies/unknown_tag/bridgestone": 5,
 "atp/total_energies/unknown_tag/briochedoree": 23,
 "atp/total_energies/unknown_tag/brosseparebrisepl": 403,
 "atp/total_energies/unknown_tag/burgerking": 6,
 "atp/total_energies/unknown_tag/businesspro": 85,
 "atp/total_energies/unknown_tag/butane13kg": 34,
 "atp/total_energies/unknown_tag/bxt": 1,
 "atp/total_energies/unknown_tag/by3": 1,
 "atp/total_energies/unknown_tag/cafe_tn": 180,
 "atp/total_energies/unknown_tag/cafebonjour": 1563,
 "atp/total_energies/unknown_tag/cafecomptoirarome": 658,
 "atp/total_energies/unknown_tag/cagnotte_total_direct_energie": 1090,
 "atp/total_energies/unknown_tag/canalsat": 1,
 "atp/total_energies/unknown_tag/capitecatm": 1,
 "atp/total_energies/unknown_tag/carcare": 1627,
 "atp/total_energies/unknown_tag/cargaragetype": 5,
 "atp/total_energies/unknown_tag/cargo": 1,
 "atp/total_energies/unknown_tag/carltons": 4,
 "atp/total_energies/unknown_tag/carmax": 1,
 "atp/total_energies/unknown_tag/carrefourexpress": 14,
 "atp/total_energies/unknown_tag/carte_club_acceptee": 1906,
 "atp/total_energies/unknown_tag/cartefleettotalenergies": 1993,
 "atp/total_energies/unknown_tag/cartegrise": 12,
 "atp/total_energies/unknown_tag/cartelavage": 537,
 "atp/total_energies/unknown_tag/carwash_generic": 263,
 "atp/total_energies/unknown_tag/carwashjetwash": 227,
 "atp/total_energies/unknown_tag/cashdispenser": 410,
 "atp/total_energies/unknown_tag/cashunited": 45,
 "atp/total_energies/unknown_tag/casinocafeteria": 6,
 "atp/total_energies/unknown_tag/cb": 229,
 "atp/total_energies/unknown_tag/centrepneus": 60,
 "atp/total_energies/unknown_tag/chargeav": 1,
 "atp/total_energies/unknown_tag/chemist": 8,
 "atp/total_energies/unknown_tag/cilantro": 1,
 "atp/total_energies/unknown_tag/citydia": 37,
 "atp/total_energies/unknown_tag/claim": 37,
 "atp/total_energies/unknown_tag/clickcollect": 96,
 "atp/total_energies/unknown_tag/club_total_bus": 67,
 "atp/total_energies/unknown_tag/club_total_truck": 790,
 "atp/total_energies/unknown_tag/cng_gm": 133,
 "atp/total_energies/unknown_tag/coca_cola": 493,
 "atp/total_energies/unknown_tag/codengo": 5,
 "atp/total_energies/unknown_tag/coeurdeble": 6,
 "atp/total_energies/unknown_tag/coffecornerilly": 1,
 "atp/total_energies/unknown_tag/coffeecorner": 1125,
 "atp/total_energies/unknown_tag/conta": 447,
 "atp/total_energies/unknown_tag/coopbank": 5,
 "atp/total_energies/unknown_tag/costa": 44,
 "atp/total_energies/unknown_tag/crediter_depenser_jauge": 1175,
 "atp/total_energies/unknown_tag/crh": 9,
 "atp/total_energies/unknown_tag/crocade": 74,
 "atp/total_energies/unknown_tag/cup": 1,
 "atp/total_energies/unknown_tag/darty": 27,
 "atp/total_energies/unknown_tag/dc_berkel": 21,
 "atp/total_energies/unknown_tag/de-truckparking": 251,
 "atp/total_energies/unknown_tag/de_carwash": 778,
 "atp/total_energies/unknown_tag/de_waschmasch": 22,
 "atp/total_energies/unknown_tag/debonairspizza": 4,
 "atp/total_energies/unknown_tag/defibrillateur": 72,
 "atp/total_energies/unknown_tag/delarteexpress": 2,
 "atp/total_energies/unknown_tag/dfg": 18,
 "atp/total_energies/unknown_tag/dfi": 1,
 "atp/total_energies/unknown_tag/dgd": 1,
 "atp/total_energies/unknown_tag/dhl": 1,
 "atp/total_energies/unknown_tag/diesel_lb": 235,
 "atp/total_energies/unknown_tag/diesel_mw": 510,
 "atp/total_energies/unknown_tag/dieselb10": 112,
 "atp/total_energies/unknown_tag/dieseleffimax": 83,
 "atp/total_energies/unknown_tag/dieselevolution": 1,
 "atp/total_energies/unknown_tag/dieselexcelan": 223,
 "atp/total_energies/unknown_tag/dinersclub": 495,
 "atp/total_energies/unknown_tag/directcard": 1168,
 "atp/total_energies/unknown_tag/dkv": 2221,
 "atp/total_energies/unknown_tag/dm6": 1,
 "atp/total_energies/unknown_tag/docbiker": 5,
 "atp/total_energies/unknown_tag/douchepl": 6,
 "atp/total_energies/unknown_tag/driverlicense": 98,
 "atp/total_energies/unknown_tag/driversclub": 4,
 "atp/total_energies/unknown_tag/dtdobie": 1,
 "atp/total_energies/unknown_tag/easycoachb": 160,
 "atp/total_energies/unknown_tag/eaucrystal": 19,
 "atp/total_energies/unknown_tag/ecash": 86,
 "atp/total_energies/unknown_tag/ecocash": 81,
 "atp/total_energies/unknown_tag/efuel": 8,
 "atp/total_energies/unknown_tag/ego": 1,
 "atp/total_energies/unknown_tag/electricity": 14,
 "atp/total_energies/unknown_tag/electricrecharge": 37,
 "atp/total_energies/unknown_tag/eni": 861,
 "atp/total_energies/unknown_tag/equitybank": 2,
 "atp/total_energies/unknown_tag/erdgascng": 490,
 "atp/total_energies/unknown_tag/ero": 1,
 "atp/total_energies/unknown_tag/espacejeux": 1,
 "atp/total_energies/unknown_tag/etas": 2,
 "atp/total_energies/unknown_tag/etisalat": 3,
 "atp/total_energies/unknown_tag/europcar": 3,
 "atp/total_energies/unknown_tag/excellium95e10": 658,
 "atp/total_energies/unknown_tag/excellium97": 42,
 "atp/total_energies/unknown_tag/excellium_93": 23,
 "atp/total_energies/unknown_tag/excellium_gasoil_tn": 540,
 "atp/total_energies/unknown_tag/excellium_lb": 68,
 "atp/total_energies/unknown_tag/excellium_sans_plomb_tn": 56,
 "atp/total_energies/unknown_tag/excelliumdieselpremium": 221,
 "atp/total_energies/unknown_tag/excelliumma": 3,
 "atp/total_energies/unknown_tag/excelliumtruck": 26,
 "atp/total_energies/unknown_tag/f99": 1,
 "atp/total_energies/unknown_tag/fastcharge": 45,
 "atp/total_energies/unknown_tag/fdhbankatm": 4,
 "atp/total_energies/unknown_tag/fdj": 17,
 "atp/total_energies/unknown_tag/fishaways": 13,
 "atp/total_energies/unknown_tag/flex_card": 5,
 "atp/total_energies/unknown_tag/flooz": 27,
 "atp/total_energies/unknown_tag/fm2": 1,
 "atp/total_energies/unknown_tag/fm9": 1,
 "atp/total_energies/unknown_tag/fnbatm": 28,
 "atp/total_energies/unknown_tag/fod": 36,
 "atp/total_energies/unknown_tag/foodservices": 153,
 "atp/total_energies/unknown_tag/freeway": 89,
 "atp/total_energies/unknown_tag/fuel2024": 2,
 "atp/total_energies/unknown_tag/fuelacs": 157,
 "atp/total_energies/unknown_tag/fuelautomat": 2956,
 "atp/total_energies/unknown_tag/fuelcards": 15,
 "atp/total_energies/unknown_tag/fullev": 38,
 "atp/total_energies/unknown_tag/g4scourier": 2,
 "atp/total_energies/unknown_tag/garage": 114,
 "atp/total_energies/unknown_tag/gas_bottle_ao": 192,
 "atp/total_energies/unknown_tag/gasoil": 8364,
 "atp/total_energies/unknown_tag/gasoil_tn": 450,
 "atp/total_energies/unknown_tag/gasole_sans_souffre_tn": 157,
 "atp/total_energies/unknown_tag/gasoleo": 37,
 "atp/total_energies/unknown_tag/gasolina": 163,
 "atp/total_energies/unknown_tag/gasoline92_eg": 219,
 "atp/total_energies/unknown_tag/gaz12": 179,
 "atp/total_energies/unknown_tag/gaz32": 86,
 "atp/total_energies/unknown_tag/gaz35": 62,
 "atp/total_energies/unknown_tag/gaz6": 730,
 "atp/total_energies/unknown_tag/gazoleeffimax": 8,
 "atp/total_energies/unknown_tag/generator": 478,
 "atp/total_energies/unknown_tag/gjtl": 410,
 "atp/total_energies/unknown_tag/gnr": 395,
 "atp/total_energies/unknown_tag/gnv": 1,
 "atp/total_energies/unknown_tag/gonflage": 3504,
 "atp/total_energies/unknown_tag/gonflage_tn": 944,
 "atp/total_energies/unknown_tag/gonflagepl": 340,
 "atp/total_energies/unknown_tag/goodlife": 2,
 "atp/total_energies/unknown_tag/gractyseurotrafic": 3577,
 "atp/total_energies/unknown_tag/granderecre": 50,
 "atp/total_energies/unknown_tag/greggs": 1,
 "atp/total_energies/unknown_tag/grnetherlands": 3578,
 "atp/total_energies/unknown_tag/gutscheinkarte": 702,
 "atp/total_energies/unknown_tag/happyfuel": 546,
 "atp/total_energies/unknown_tag/heavydutyoils": 1,
 "atp/total_energies/unknown_tag/hertz": 9,
 "atp/total_energies/unknown_tag/hot_dog": 15,
 "atp/total_energies/unknown_tag/hotsnacks": 196,
 "atp/total_energies/unknown_tag/hpc": 49,
 "atp/total_energies/unknown_tag/hvo100": 3,
 "atp/total_energies/unknown_tag/hvo100-nsap": 3,
 "atp/total_energies/unknown_tag/i7x": 6,
 "atp/total_energies/unknown_tag/ip": 12,
 "atp/total_energies/unknown_tag/javahouse": 2,
 "atp/total_energies/unknown_tag/jk7": 1,
 "atp/total_energies/unknown_tag/jubileo": 3160,
 "atp/total_energies/unknown_tag/justbip2": 727,
 "atp/total_energies/unknown_tag/kcb": 1,
 "atp/total_energies/unknown_tag/kfc": 7,
 "atp/total_energies/unknown_tag/kingsway": 3,
 "atp/total_energies/unknown_tag/kiosquepain": 2,
 "atp/total_energies/unknown_tag/kir": 12,
 "atp/total_energies/unknown_tag/kukito": 1,
 "atp/total_energies/unknown_tag/kvy": 6,
 "atp/total_energies/unknown_tag/lacroissanterie": 79,
 "atp/total_energies/unknown_tag/lacuregourmande": 35,
 "atp/total_energies/unknown_tag/lampes_sunshine": 23,
 "atp/total_energies/unknown_tag/lampesolaire": 857,
 "atp/total_energies/unknown_tag/laposte": 1,
 "atp/total_energies/unknown_tag/lavage2roues": 39,
 "atp/total_energies/unknown_tag/lavage_haute_pression_mrn": 455,
 "atp/total_energies/unknown_tag/lavage_mrn": 1099,
 "atp/total_energies/unknown_tag/lavage_rouleau_mrn": 1243,
 "atp/total_energies/unknown_tag/lavage_tn": 249,
 "atp/total_energies/unknown_tag/lavagehp": 246,
 "atp/total_energies/unknown_tag/lavagelotus": 792,
 "atp/total_energies/unknown_tag/lavageosmos": 58,
 "atp/total_energies/unknown_tag/lavomatic": 3,
 "atp/total_energies/unknown_tag/le_plein_gagnant": 1004,
 "atp/total_energies/unknown_tag/lj0": 1,
 "atp/total_energies/unknown_tag/lj2": 1,
 "atp/total_energies/unknown_tag/lkx": 1,
 "atp/total_energies/unknown_tag/lky": 1,
 "atp/total_energies/unknown_tag/lkz": 1,
 "atp/total_energies/unknown_tag/llu": 1,
 "atp/total_energies/unknown_tag/lng": 8,
 "atp/total_energies/unknown_tag/lng_gm": 1,
 "atp/total_energies/unknown_tag/logp": 1163,
 "atp/total_energies/unknown_tag/loto": 205,
 "atp/total_energies/unknown_tag/lubricant_generic": 3267,
 "atp/total_energies/unknown_tag/lubricants": 2135,
 "atp/total_energies/unknown_tag/lunchgrill": 25,
 "atp/total_energies/unknown_tag/maintenance": 1,
 "atp/total_energies/unknown_tag/maintenancebays": 1745,
 "atp/total_energies/unknown_tag/marine": 2,
 "atp/total_energies/unknown_tag/mav": 2,
 "atp/total_energies/unknown_tag/mcdonalds": 7,
 "atp/total_energies/unknown_tag/mechanic": 2,
 "atp/total_energies/unknown_tag/mezzodipasta": 4,
 "atp/total_energies/unknown_tag/milkylane": 2,
 "atp/total_energies/unknown_tag/moderncoast": 160,
 "atp/total_energies/unknown_tag/mol": 8766,
 "atp/total_energies/unknown_tag/monster": 542,
 "atp/total_energies/unknown_tag/moq": 1,
 "atp/total_energies/unknown_tag/morrisons": 4,
 "atp/total_energies/unknown_tag/mow": 1,
 "atp/total_energies/unknown_tag/mox": 1,
 "atp/total_energies/unknown_tag/mpayment": 724,
 "atp/total_energies/unknown_tag/mpesa": 228,
 "atp/total_energies/unknown_tag/mtc": 337,
 "atp/total_energies/unknown_tag/mtn": 179,
 "atp/total_energies/unknown_tag/muggbean": 62,
 "atp/total_energies/unknown_tag/multicaixa_card": 23,
 "atp/total_energies/unknown_tag/murdesreg": 97,
 "atp/total_energies/unknown_tag/myorder": 10,
 "atp/total_energies/unknown_tag/nationalbankatm": 4,
 "atp/total_energies/unknown_tag/nationalfleet": 607,
 "atp/total_energies/unknown_tag/nct": 1,
 "atp/total_energies/unknown_tag/nedbank": 7,
 "atp/total_energies/unknown_tag/newdriversclub": 369,
 "atp/total_energies/unknown_tag/nih": 1,
 "atp/total_energies/unknown_tag/nimbacard": 95,
 "atp/total_energies/unknown_tag/nip": 6,
 "atp/total_energies/unknown_tag/o2t": 38,
 "atp/total_energies/unknown_tag/o5a": 21,
 "atp/total_energies/unknown_tag/oelub": 2,
 "atp/total_energies/unknown_tag/offre_stations_total_direct_energie": 1335,
 "atp/total_energies/unknown_tag/oilfilter": 274,
 "atp/total_energies/unknown_tag/ome": 647,
 "atp/total_energies/unknown_tag/operation_cafe": 26,
 "atp/total_energies/unknown_tag/optaneevolution95e10": 1,
 "atp/total_energies/unknown_tag/optaneevolution98": 1,
 "atp/total_energies/unknown_tag/orange": 209,
 "atp/total_energies/unknown_tag/orangemoney": 470,
 "atp/total_energies/unknown_tag/ozc": 1,
 "atp/total_energies/unknown_tag/ozd": 1,
 "atp/total_energies/unknown_tag/paiementmarchand": 5,
 "atp/total_energies/unknown_tag/painchaud": 1,
 "atp/total_energies/unknown_tag/panneaux_photovoltaiques": 129,
 "atp/total_energies/unknown_tag/parking": 53,
 "atp/total_energies/unknown_tag/parkingtruck": 362,
 "atp/total_energies/unknown_tag/parrafin": 3,
 "atp/total_energies/unknown_tag/partnertruckst": 2109,
 "atp/total_energies/unknown_tag/pastry": 45,
 "atp/total_energies/unknown_tag/pause_gourmande": 73,
 "atp/total_energies/unknown_tag/pelletbags": 1,
 "atp/total_energies/unknown_tag/pellets": 25,
 "atp/total_energies/unknown_tag/petrole": 1225,
 "atp/total_energies/unknown_tag/petrolepompe": 313,
 "atp/total_energies/unknown_tag/phenix": 103,
 "atp/total_energies/unknown_tag/pikachu": 1172,
 "atp/total_energies/unknown_tag/pirelli": 4,
 "atp/total_energies/unknown_tag/pizzahut": 2,
 "atp/total_energies/unknown_tag/podcast": 112,
 "atp/total_energies/unknown_tag/pointposte": 176,
 "atp/total_energies/unknown_tag/pokmon": 1416,
 "atp/total_energies/unknown_tag/pompepl": 720,
 "atp/total_energies/unknown_tag/prayingroom": 13,
 "atp/total_energies/unknown_tag/premium95": 4,
 "atp/total_energies/unknown_tag/premiumfuelaral": 182,
 "atp/total_energies/unknown_tag/premiumlkwparkplatz": 2,
 "atp/total_energies/unknown_tag/prepaid": 553,
 "atp/total_energies/unknown_tag/prepaidcard": 1131,
 "atp/total_energies/unknown_tag/proficard": 3301,
 "atp/total_energies/unknown_tag/promoclubfr": 52,
 "atp/total_energies/unknown_tag/proximitefr": 31,
 "atp/total_energies/unknown_tag/pxy": 1,
 "atp/total_energies/unknown_tag/qbp": 1,
 "atp/total_energies/unknown_tag/qfb": 34,
 "atp/total_energies/unknown_tag/rechargegratuite": 3,
 "atp/total_energies/unknown_tag/regulargasoline": 330,
 "atp/total_energies/unknown_tag/restaurant": 81,
 "atp/total_energies/unknown_tag/restaurant_be": 10,
 "atp/total_energies/unknown_tag/restaurantfr": 111,
 "atp/total_energies/unknown_tag/restauration": 99,
 "atp/total_energies/unknown_tag/restroom_tn": 347,
 "atp/total_energies/unknown_tag/retail_ru": 8,
 "atp/total_energies/unknown_tag/rolloverhigpressure": 30,
 "atp/total_energies/unknown_tag/routex": 10,
 "atp/total_energies/unknown_tag/routex_fr": 231,
 "atp/total_energies/unknown_tag/s02": 1,
 "atp/total_energies/unknown_tag/saaloyalty": 228,
 "atp/total_energies/unknown_tag/samba": 39,
 "atp/total_energies/unknown_tag/sandwicherie": 338,
 "atp/total_energies/unknown_tag/sandwichvillage": 25,
 "atp/total_energies/unknown_tag/sans_plomb_tn": 159,
 "atp/total_energies/unknown_tag/sbm": 1,
 "atp/total_energies/unknown_tag/sdt": 1,
 "atp/total_energies/unknown_tag/service_sur_piste": 78,
 "atp/total_energies/unknown_tag/services_generic": 83,
 "atp/total_energies/unknown_tag/sheetrepair": 2,
 "atp/total_energies/unknown_tag/shellacceptance": 4,
 "atp/total_energies/unknown_tag/shop": 3149,
 "atp/total_energies/unknown_tag/shop2024": 40,
 "atp/total_energies/unknown_tag/shop_generic": 40,
 "atp/total_energies/unknown_tag/shop_lb": 90,
 "atp/total_energies/unknown_tag/shopbycasino": 39,
 "atp/total_energies/unknown_tag/shoppingfr": 18,
 "atp/total_energies/unknown_tag/showers": 71,
 "atp/total_energies/unknown_tag/snpservdisney": 211,
 "atp/total_energies/unknown_tag/sola": 298,
 "atp/total_energies/unknown_tag/sonayacard": 70,
 "atp/total_energies/unknown_tag/sp95_lb": 226,
 "atp/total_energies/unknown_tag/sp95performance": 130,
 "atp/total_energies/unknown_tag/sparuk": 27,
 "atp/total_energies/unknown_tag/specialfluids": 1,
 "atp/total_energies/unknown_tag/specialtruckers": 7,
 "atp/total_energies/unknown_tag/speedy": 42,
 "atp/total_energies/unknown_tag/spg": 6,
 "atp/total_energies/unknown_tag/spur": 1,
 "atp/total_energies/unknown_tag/standardbank": 26,
 "atp/total_energies/unknown_tag/standardchartered": 3,
 "atp/total_energies/unknown_tag/starbucks": 35,
 "atp/total_energies/unknown_tag/stationery": 2,
 "atp/total_energies/unknown_tag/stationtruck": 72,
 "atp/total_energies/unknown_tag/steers": 76,
 "atp/total_energies/unknown_tag/stopandwin": 824,
 "atp/total_energies/unknown_tag/stratto": 1,
 "atp/total_energies/unknown_tag/subway": 4,
 "atp/total_energies/unknown_tag/super": 569,
 "atp/total_energies/unknown_tag/supereffimax": 83,
 "atp/total_energies/unknown_tag/superethanole85": 930,
 "atp/total_energies/unknown_tag/superette": 710,
 "atp/total_energies/unknown_tag/supermarket": 1,
 "atp/total_energies/unknown_tag/svcborne": 59,
 "atp/total_energies/unknown_tag/svcplace": 54,
 "atp/total_energies/unknown_tag/svcpompe": 97,
 "atp/total_energies/unknown_tag/tabacpresse": 1,
 "atp/total_energies/unknown_tag/takdrive": 2,
 "atp/total_energies/unknown_tag/tbs": 12,
 "atp/total_energies/unknown_tag/telecash": 15,
 "atp/total_energies/unknown_tag/tgtg": 139,
 "atp/total_energies/unknown_tag/tkashagent": 162,
 "atp/total_energies/unknown_tag/toiletenonsap": 674,
 "atp/total_energies/unknown_tag/toilets": 545,
 "atp/total_energies/unknown_tag/tollcollect": 44,
 "atp/total_energies/unknown_tag/tomcard": 658,
 "atp/total_energies/unknown_tag/topservicecard": 16,
 "atp/total_energies/unknown_tag/total_quartz_auto": 97,
 "atp/total_energies/unknown_tag/total_wash_tn": 169,
 "atp/total_energies/unknown_tag/totalclubde": 623,
 "atp/total_energies/unknown_tag/totaldealercard": 5,
 "atp/total_energies/unknown_tag/totalfioulpremier": 843,
 "atp/total_energies/unknown_tag/totalgazbouteilles": 116,
 "atp/total_energies/unknown_tag/totalrestaurant": 2,
 "atp/total_energies/unknown_tag/totalsupere5": 13,
 "atp/total_energies/unknown_tag/totaltruckfr": 491,
 "atp/total_energies/unknown_tag/totalwash": 655,
 "atp/total_energies/unknown_tag/touch_point": 933,
 "atp/total_energies/unknown_tag/tourfrance2": 5,
 "atp/total_energies/unknown_tag/tourfrance3": 5,
 "atp/total_energies/unknown_tag/tqas": 848,
 "atp/total_energies/unknown_tag/trademktfrance": 1,
 "atp/total_energies/unknown_tag/transmission": 1,
 "atp/total_energies/unknown_tag/travelcard": 303,
 "atp/total_energies/unknown_tag/truck_parking_be": 1,
 "atp/total_energies/unknown_tag/truckparking": 904,
 "atp/total_energies/unknown_tag/truckparkingpayant": 222,
 "atp/total_energies/unknown_tag/truckstation": 128,
 "atp/total_energies/unknown_tag/truckstore": 394,
 "atp/total_energies/unknown_tag/tyrecenter_generic": 447,
 "atp/total_energies/unknown_tag/uta": 2889,
 "atp/total_energies/unknown_tag/veloelectrique": 1,
 "atp/total_energies/unknown_tag/vidange_tn": 325,
 "atp/total_energies/unknown_tag/wakaberry": 2,
 "atp/total_energies/unknown_tag/wallet": 29,
 "atp/total_energies/unknown_tag/wash_ao": 47,
 "atp/total_energies/unknown_tag/washcard_de": 808,
 "atp/total_energies/unknown_tag/westfalencard": 1163,
 "atp/total_energies/unknown_tag/xpress": 4,
 "downloader/request_bytes": 102157,
 "downloader/request_count": 254,
 "downloader/request_method_count/GET": 254,
 "downloader/response_bytes": 6089984,
 "downloader/response_count": 254,
 "downloader/response_status_count/200": 253,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 310.265295,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-08-26T17:42:12.639808+00:00",
 "httpcache/firsthand": 254,
 "httpcache/miss": 254,
 "httpcache/store": 254,
 "httpcompression/response_bytes": 99528149,
 "httpcompression/response_count": 253,
 "item_scraped_count": 28207,
 "log_count/INFO": 15,
 "memusage/max": 821673984,
 "memusage/startup": 218431488,
 "request_depth_max": 252,
 "response_received_count": 254,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 253,
 "scheduler/dequeued/memory": 253,
 "scheduler/enqueued": 253,
 "scheduler/enqueued/memory": 253,
 "start_time": "2024-08-26T17:37:02.374513+00:00"
}
```
</details>