### PR TITLE
[porsche] Added Spider for USA & CAN (930 items)

### DIFF
--- a/locations/spiders/porsche.py
+++ b/locations/spiders/porsche.py
@@ -6,8 +6,8 @@ from locations.geo import city_locations
 from locations.hours import DAYS, OpeningHours
 
 
-class PorscheNorthAmericaSpider(scrapy.Spider):
-    name = "porsche_north_america"
+class PorscheSpider(scrapy.Spider):
+    name = "porsche"
     item_attributes = {"brand": "Porsche", "brand_wikidata": "Q40993"}
     countries = [
         "AE",

--- a/locations/spiders/porsche.py
+++ b/locations/spiders/porsche.py
@@ -131,8 +131,6 @@ class PorscheSpider(scrapy.Spider):
 
             apply_category(Categories.SHOP_CAR, item)
 
-            self.crawler.stats.inc_value(f"zzzz/country/{country}")
-
             yield item
 
     def parse_hours(self, hours, item):

--- a/locations/spiders/porsche_north_america.py
+++ b/locations/spiders/porsche_north_america.py
@@ -9,7 +9,7 @@ from locations.hours import OpeningHours
 class PorscheNorthAmericaSpider(scrapy.Spider):
     name = "porsche_north_america"
     item_attributes = {"brand": "Porsche", "brand_wikidata": "Q40993"}
-    countries = ["ca"]
+    countries = ["us", "ca"]
 
     def start_requests(self):
         for country in self.countries:

--- a/locations/spiders/porsche_north_america.py
+++ b/locations/spiders/porsche_north_america.py
@@ -1,0 +1,41 @@
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import OpeningHours
+
+
+class PorscheNorthAmericaSpider(scrapy.Spider):
+    name = "porsche_north_america"
+    item_attributes = {"brand": "Porsche", "brand_wikidata": "Q40993"}
+    countries = ["ca"]
+
+    def start_requests(self):
+        for country in self.countries:
+            for city in city_locations(country, 50000):
+                url = f"https://configurator.porsche.com/api/dealer-search/{country.upper()}/dealers?coordinates={city['latitude']}%2C{city['longitude']}"
+                yield scrapy.Request(url, callback=self.parse, cb_kwargs={"country": country})
+
+    def parse(self, response, country):
+        for dealer in response.json():
+            shop_info = dealer.get("dealer", {})
+            item = DictParser.parse(shop_info)
+            item["country"] = country
+            item["branch"] = item.pop("name")
+            item["phone"] = shop_info.get("contactDetails", {}).get("phoneNumber")
+            item["email"] = shop_info.get("contactDetails", {}).get("emailAddress")
+            item["website"] = shop_info.get("contactDetails", {}).get("homepage")
+            self.parse_hours(shop_info.get("contactDetails", {}).get("contactOpeningHours"), item)
+
+            apply_category(Categories.SHOP_CAR, item)
+
+            yield item
+
+    def parse_hours(self, hours, item):
+        if hours:
+            oh = OpeningHours()
+            for day in hours:
+                oh.add_range(day["day"], day["open"], day["close"])
+
+            item["opening_hours"] = oh

--- a/locations/spiders/porsche_north_america.py
+++ b/locations/spiders/porsche_north_america.py
@@ -23,6 +23,7 @@ class PorscheNorthAmericaSpider(scrapy.Spider):
             item = DictParser.parse(shop_info)
             item["country"] = country
             item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("street")
             item["phone"] = shop_info.get("contactDetails", {}).get("phoneNumber")
             item["email"] = shop_info.get("contactDetails", {}).get("emailAddress")
             item["website"] = shop_info.get("contactDetails", {}).get("homepage")

--- a/locations/spiders/porsche_north_america.py
+++ b/locations/spiders/porsche_north_america.py
@@ -3,18 +3,118 @@ import scrapy
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
-from locations.hours import OpeningHours
+from locations.hours import DAYS, OpeningHours
 
 
 class PorscheNorthAmericaSpider(scrapy.Spider):
     name = "porsche_north_america"
     item_attributes = {"brand": "Porsche", "brand_wikidata": "Q40993"}
-    countries = ["us", "ca"]
+    countries = [
+        "AE",
+        "AM",
+        "AR",
+        "AT",
+        "AU",
+        "AZ",
+        "BA",
+        "BE",
+        "BG",
+        "BH",
+        "BN",
+        "BO",
+        "BR",
+        "CA",
+        "CH",
+        "CL",
+        "CN",
+        "CO",
+        "CR",
+        "CW",
+        "CY",
+        "CZ",
+        "DE",
+        "DK",
+        "DO",
+        "EC",
+        "EE",
+        "EG",
+        "ES",
+        "FI",
+        "FR",
+        "GB",
+        "GE",
+        "GP",
+        "GR",
+        "GT",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IN",
+        "IS",
+        "IT",
+        "JM",
+        "JO",
+        "JP",
+        "KR",
+        "KW",
+        "KZ",
+        "LB",
+        "LK",
+        "LT",
+        "LU",
+        "LV",
+        "MA",
+        "MD",
+        "MK",
+        "MN",
+        "MO",
+        "MQ",
+        "MU",
+        "MX",
+        "MY",
+        "NC",
+        "NL",
+        "NO",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PH",
+        "PL",
+        "PR",
+        "PT",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "SA",
+        "SE",
+        "SG",
+        "SI",
+        "SK",
+        "SV",
+        "TH",
+        "TN",
+        "TR",
+        "TT",
+        "TW",
+        "UA",
+        "US",
+        "VN",
+        "ZA",
+    ]
 
     def start_requests(self):
         for country in self.countries:
             for city in city_locations(country, 50000):
-                url = f"https://configurator.porsche.com/api/dealer-search/{country.upper()}/dealers?coordinates={city['latitude']}%2C{city['longitude']}"
+                url = f"https://configurator.porsche.com/api/dealer-search/{country}/dealers?coordinates={city['latitude']}%2C{city['longitude']}"
                 yield scrapy.Request(url, callback=self.parse, cb_kwargs={"country": country})
 
     def parse(self, response, country):
@@ -31,12 +131,15 @@ class PorscheNorthAmericaSpider(scrapy.Spider):
 
             apply_category(Categories.SHOP_CAR, item)
 
+            self.crawler.stats.inc_value(f"zzzz/country/{country}")
+
             yield item
 
     def parse_hours(self, hours, item):
         if hours:
             oh = OpeningHours()
             for day in hours:
-                oh.add_range(day["day"], day["open"], day["close"])
+                if day["day"] in DAYS:
+                    oh.add_range(day["day"], day["open"], day["close"])
 
             item["opening_hours"] = oh


### PR DESCRIPTION
<details><summary>Canada Stats</summary>

```python
{'atp/brand/Porsche': 23,
 'atp/brand_wikidata/Q40993': 23,
 'atp/category/shop/car': 23,
 'atp/field/image/missing': 23,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 23,
 'atp/field/operator_wikidata/missing': 23,
 'atp/field/phone/missing': 1,
 'atp/field/state/from_reverse_geocoding': 23,
 'atp/field/street_address/missing': 23,
 'atp/field/twitter/missing': 23,
 'atp/item_scraped_host_count/configurator.porsche.com': 278,
 'atp/nsi/cc_match': 23,
 'downloader/request_bytes': 37642,
 'downloader/request_count': 103,
 'downloader/request_method_count/GET': 103,
 'downloader/response_bytes': 385419,
 'downloader/response_count': 103,
 'downloader/response_status_count/200': 103,
 'elapsed_time_seconds': 124.036028,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 28, 17, 30, 2, 849482, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 255,
 'item_dropped_reasons_count/DropItem': 255,
 'item_scraped_count': 23,
 'log_count/DEBUG': 392,
 'log_count/INFO': 11,
 'memusage/max': 484491264,
 'memusage/startup': 173887488,
 'response_received_count': 103,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 102,
 'scheduler/dequeued/memory': 102,
 'scheduler/enqueued': 102,
 'scheduler/enqueued/memory': 102,
 'start_time': datetime.datetime(2024, 8, 28, 17, 27, 58, 813454, tzinfo=datetime.timezone.utc)}
```
</details>


<details><summary>USA Stats</summary>

```python
{'atp/brand/Porsche': 199,
 'atp/brand_wikidata/Q40993': 199,
 'atp/category/shop/car': 199,
 'atp/field/image/missing': 199,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 199,
 'atp/field/operator_wikidata/missing': 199,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/street_address/missing': 199,
 'atp/field/twitter/missing': 199,
 'atp/field/website/invalid': 2,
 'atp/field/website/missing': 3,
 'atp/item_scraped_host_count/configurator.porsche.com': 3494,
 'atp/nsi/cc_match': 199,
 'downloader/request_bytes': 351790,
 'downloader/request_count': 961,
 'downloader/request_method_count/GET': 961,
 'downloader/response_bytes': 4873812,
 'downloader/response_count': 961,
 'downloader/response_status_count/200': 961,
 'elapsed_time_seconds': 1172.520006,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 28, 17, 24, 2, 319797, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 3295,
 'item_dropped_reasons_count/DropItem': 3295,
 'item_scraped_count': 199,
 'log_count/INFO': 28,
 'memusage/max': 337494016,
 'memusage/startup': 174092288,
 'response_received_count': 961,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 960,
 'scheduler/dequeued/memory': 960,
 'scheduler/enqueued': 960,
 'scheduler/enqueued/memory': 960,
 'start_time': datetime.datetime(2024, 8, 28, 17, 4, 29, 799791, tzinfo=datetime.timezone.utc)}
```
</details>