### PR TITLE
FNB (ZA) ATMs and branches

### DIFF
--- a/locations/spiders/fnb_atm_za.py
+++ b/locations/spiders/fnb_atm_za.py
@@ -1,0 +1,59 @@
+from scrapy import Request, Selector, Spider
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+ZA_PROVINCES = [
+    "Eastern Cape",
+    "Free State",
+    "Gauteng",
+    "KwaZulu-Natal",
+    "Limpopo",
+    "Mpumalanga",
+    "North West",
+    "Northern Cape",
+    "Western Cape",
+]
+
+
+class FnbAtmZASpider(Spider):
+    download_delay = 0.2
+    name = "fnb_atm_za"
+    item_attributes = {"brand": "FNB", "brand_wikidata": "Q3072956", "extras": Categories.ATM.value}
+
+    def start_requests(self):
+        for province in ZA_PROVINCES:
+            yield Request(
+                url="https://www.fnb.co.za/Controller?nav=locators.ATMLocatorSearch",
+                body="nav=locators.ATMLocatorSearch&atmName=" + province,
+                headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+                method="POST",
+            )
+
+    def parse(self, response):
+        onclicks = response.xpath('.//a[@class="link fontTurq searchResult       "]/@onclick').getall()
+        links = [onclick.split("(event,'")[1].split("');")[0] for onclick in onclicks]
+
+        for link in links:
+            yield Request(url="https://www.fnb.co.za" + link, callback=self.parse_item)
+
+    def parse_item(self, response):
+        details = response.xpath('.//p[@class="      "]').getall()
+        deposits = Selector(text=details[2]).xpath(".//strong/text()").get().strip()
+        # details[0] # address, in multiple <strong>s
+        # details[1] # ATM type, not clear what the different types mean though
+        # details[2] # Accepts deposits - Yes/No
+        properties = {
+            "branch": response.xpath(".//h2/text()").get().strip(),
+            "addr_full": clean_address(Selector(text=details[0]).xpath(".//strong/text()").getall()),
+            "lon": response.xpath('.//p[@class="  fontGrey   linePadding "]/text()').getall()[1].strip(),
+            "lat": response.xpath('.//p[@class="  fontGrey    "]/text()').getall()[1].strip(),
+            "ref": response.request.url.replace(
+                "https://www.fnb.co.za/Controller?nav=locators.ATMLocatorSearch&atmid=", ""
+            ).replace("&details=true", ""),
+        }
+
+        apply_yes_no(Extras.CASH_IN, properties, deposits == "Yes", False)
+
+        yield Feature(**properties)

--- a/locations/spiders/fnb_atm_za.py
+++ b/locations/spiders/fnb_atm_za.py
@@ -18,7 +18,7 @@ ZA_PROVINCES = [
 
 
 class FnbAtmZASpider(Spider):
-    download_delay = 0.2
+    # download_delay = 0.2
     name = "fnb_atm_za"
     item_attributes = {"brand": "FNB", "brand_wikidata": "Q3072956", "extras": Categories.ATM.value}
 
@@ -39,6 +39,8 @@ class FnbAtmZASpider(Spider):
             yield Request(url="https://www.fnb.co.za" + link, callback=self.parse_item)
 
     def parse_item(self, response):
+        # from scrapy.shell import inspect_response
+        # inspect_response(response, self)
         details = response.xpath('.//p[@class="      "]').getall()
         deposits = Selector(text=details[2]).xpath(".//strong/text()").get().strip()
         # details[0] # address, in multiple <strong>s

--- a/locations/spiders/fnb_banks_za.py
+++ b/locations/spiders/fnb_banks_za.py
@@ -1,0 +1,75 @@
+import string
+
+from scrapy import Request, Spider
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.items import Feature
+
+
+class FnbBanksZASpider(Spider):
+    # download_delay = 0.2
+    name = "fnb_banks_za"
+    item_attributes = {"brand": "FNB", "brand_wikidata": "Q3072956", "extras": Categories.BANK.value}
+
+    def start_requests(self):
+        # Search claims to accept search by province, in practice this returns barely any results
+        # Single letter searches return no results, so doing this instead
+        letter_pairs = [i + j for i in string.ascii_lowercase for j in string.ascii_lowercase]
+        for pair in letter_pairs:
+            yield Request(
+                url="https://www.fnb.co.za/Controller?nav=locators.BranchLocatorSearch",
+                body="nav=locators.BranchLocatorSearch&branchName=" + pair,
+                headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+                method="POST",
+            )
+
+    def parse(self, response):
+        onclicks = response.xpath('.//a[@class="link fontTurq searchResult       "]/@onclick').getall()
+        links = [onclick.split("(event,'")[1].split("');")[0] for onclick in onclicks]
+
+        for link in links:
+            yield Request(url="https://www.fnb.co.za" + link, callback=self.parse_item)
+
+    def parse_item(self, response):
+        # from scrapy.shell import inspect_response
+        # inspect_response(response, self)
+        properties = {
+            "branch": response.xpath(".//h2/text()").get().strip(),
+            "lon": response.xpath('.//p[@class="  fontGrey   linePadding "]/text()').getall()[1].strip(),
+            "lat": response.xpath('.//p[@class="  fontGrey    "]/text()').getall()[1].strip(),
+            "ref": response.request.url.replace(
+                "https://www.fnb.co.za/Controller?nav=locators.BranchLocatorSearch&costCentreCode=", ""
+            ).replace("&details=true", ""),
+            "addr_full": response.xpath('.//p[@class="      "]/strong/text()').get().strip(),
+            "email": response.xpath('.//p[@class="     linePadding "]/.//a[contains(@href, "@")]/@href').get(),
+            "phone": response.xpath('.//p[@class="     linePadding "]/strong/text()').get().strip(),
+        }
+
+        if properties["email"] == "info@fnb.co.za":
+            properties.pop("email")
+        if not (properties["phone"][0] == "(" or properties["phone"][0] == "0"):
+            properties.pop("phone")
+        # Generic telephone banking number
+        if properties["phone"].replace(" ", "").replace("(", "").replace(")", "") == "0875759404":
+            properties.pop("phone")
+
+        wifi = (
+            response.xpath('.//div[@class="readOut"]/label[contains(text(), "Wifi")]/.././/strong/text()').get().strip()
+        )
+        apply_yes_no(Extras.WIFI, properties, wifi == "Yes", False)
+
+        oh = OpeningHours()
+        for day in DAYS_FULL:
+            times = (
+                response.xpath('.//div[@class="readOut"]/label[contains(text(), "' + day + '")]/.././/strong/text()')
+                .get()
+                .strip()
+            )
+            if times.lower() == "closed":
+                oh.set_closed(day)
+            else:
+                oh.add_ranges_from_string(f"{day} {times}")
+        properties["opening_hours"] = oh.as_opening_hours()
+
+        yield Feature(**properties)


### PR DESCRIPTION
Fixes #823 and fixes #824

All of this feels very messy, not least having to do `response.xpath('.//p[@class="      "]')`, and the fact that it actually returns useful information.

Also, a total hack of search results for the branches, which is strange since the ATM search seems to work just fine by provinces. Fortunately, scrapy's deduplication of requests makes it not as bad as it might seem at first.

```
 'atp/brand/FNB': 4654,
 'atp/brand_wikidata/Q3072956': 4654,
 'atp/category/amenity/atm': 4654,
 'atp/field/city/missing': 4654,
 'atp/field/country/from_spider_name': 4654,
 'atp/field/email/missing': 4654,
 'atp/field/image/missing': 4654,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/name/missing': 4654,
 'atp/field/opening_hours/missing': 4654,
 'atp/field/phone/missing': 4654,
 'atp/field/postcode/missing': 4654,
 'atp/field/state/missing': 4654,
 'atp/field/street_address/missing': 4654,
 'atp/field/twitter/missing': 4654,
 'atp/field/website/missing': 4654,
 'atp/geometry/null_island': 3,
 'atp/item_scraped_host_count/www.fnb.co.za': 4654,
 'atp/nsi/cc_match': 4654,
 'atp/operator/FNB': 4654,
 'atp/operator_wikidata/Q3072956': 4654,
```

```
 'atp/brand/FNB': 621,
 'atp/brand_wikidata/Q3072956': 621,
 'atp/category/amenity/bank': 621,
 'atp/field/city/missing': 621,
 'atp/field/country/from_spider_name': 621,
 'atp/field/email/missing': 621,
 'atp/field/image/missing': 621,
 'atp/field/operator/missing': 621,
 'atp/field/operator_wikidata/missing': 621,
 'atp/field/phone/missing': 621,
 'atp/field/postcode/missing': 621,
 'atp/field/state/missing': 621,
 'atp/field/street_address/missing': 621,
 'atp/field/twitter/missing': 621,
 'atp/field/website/missing': 621,
 'atp/item_scraped_host_count/www.fnb.co.za': 621,
 'atp/nsi/cc_match': 621,
 ```