### PR TITLE
[lilly_rs] Fix Spider (236 locations)

### DIFF
--- a/locations/spiders/lilly_rs.py
+++ b/locations/spiders/lilly_rs.py
@@ -1,8 +1,9 @@
 import re
 from typing import Any
+
+import xmltodict
 from requests_cache import Response
 from scrapy import Spider
-import xmltodict
 
 from locations.dict_parser import DictParser
 from locations.hours import NAMED_DAY_RANGES_EN, OpeningHours
@@ -12,9 +13,7 @@ class LillyRSSpider(Spider):
     name = "lilly_rs"
     item_attributes = {"brand": "Lilly", "brand_wikidata": "Q111764460"}
     allowed_domains = ["www.lilly.rs"]
-    start_urls = [
-        "https://www.lilly.rs/rest/V1/locations?name="
-    ]
+    start_urls = ["https://www.lilly.rs/rest/V1/locations?name="]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in xmltodict.parse(response.text)["response"]["item"]:
@@ -25,20 +24,17 @@ class LillyRSSpider(Spider):
 
             oh = OpeningHours()
             hours_data = {
-                    "Weekdays": re.sub("Ne radi", "", location["monday_to_friday_wh"]),
-                    "Sa": re.sub("Ne radi", "", location["saturday_wh"]),
-                    "Su": re.sub("Ne radi", "", location["sunday_wh"]),
-                }
+                "Weekdays": re.sub("Ne radi", "", location["monday_to_friday_wh"]),
+                "Sa": re.sub("Ne radi", "", location["saturday_wh"]),
+                "Su": re.sub("Ne radi", "", location["sunday_wh"]),
+            }
             for day, hours in hours_data.items():
                 if hours:
                     hour = hours.split("-")
                     if len(hour) == 2:
                         oh.add_days_range(
                             NAMED_DAY_RANGES_EN[day] if day == "Weekdays" else [day], hour[0].strip(), hour[1].strip()
-                                )
+                        )
 
             item["opening_hours"] = oh
             yield item
-
-
-

--- a/locations/spiders/lilly_rs.py
+++ b/locations/spiders/lilly_rs.py
@@ -1,8 +1,11 @@
+import re
+from typing import Any
+from requests_cache import Response
 from scrapy import Spider
-from scrapy.http import JsonRequest
+import xmltodict
 
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_SR, OpeningHours
+from locations.hours import NAMED_DAY_RANGES_EN, OpeningHours
 
 
 class LillyRSSpider(Spider):
@@ -10,22 +13,31 @@ class LillyRSSpider(Spider):
     item_attributes = {"brand": "Lilly", "brand_wikidata": "Q111764460"}
     allowed_domains = ["www.lilly.rs"]
     start_urls = [
-        "https://www.lilly.rs/phpsqlsearch_genjson.php?lat=44.8019&lng=20.4671&radius=10000&limit=10000&keyword=none"
+        "https://www.lilly.rs/rest/V1/locations?name="
     ]
-    requires_proxy = "US"  # Cloudflare bot blocking is in use
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
-
-    def parse(self, response):
-        for location in response.json():
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in xmltodict.parse(response.text)["response"]["item"]:
             item = DictParser.parse(location)
-            item["name"] = location["naziv_prodavnice"]
-            item["street_address"] = location["adresa"]
-            item["city"] = location["naziv_grada"]
-            item["phone"] = location["telefon"]
-            item["opening_hours"] = OpeningHours()
-            hours_string = "Pon-Pet: " + location["pon_pet"] + " Sub: " + location["sub"] + " Ned: " + location["ned"]
-            item["opening_hours"].add_ranges_from_string(hours_string, DAYS_SR)
+            item["ref"] = location["entity_id"]
+            item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("addr_full")
+
+            oh = OpeningHours()
+            hours_data = {
+                    "Weekdays": re.sub("Ne radi", "", location["monday_to_friday_wh"]),
+                    "Sa": re.sub("Ne radi", "", location["saturday_wh"]),
+                    "Su": re.sub("Ne radi", "", location["sunday_wh"]),
+                }
+            for day, hours in hours_data.items():
+                if hours:
+                    open, close = hours.split("-")
+                    oh.add_days_range(
+                        NAMED_DAY_RANGES_EN[day] if day == "Weekdays" else [day], open, close
+                            )
+
+            item["opening_hours"] = oh
             yield item
+
+
+

--- a/locations/spiders/lilly_rs.py
+++ b/locations/spiders/lilly_rs.py
@@ -31,10 +31,11 @@ class LillyRSSpider(Spider):
                 }
             for day, hours in hours_data.items():
                 if hours:
-                    open, close = hours.split("-")
-                    oh.add_days_range(
-                        NAMED_DAY_RANGES_EN[day] if day == "Weekdays" else [day], open, close
-                            )
+                    hour = hours.split("-")
+                    if len(hour) == 2:
+                        oh.add_days_range(
+                            NAMED_DAY_RANGES_EN[day] if day == "Weekdays" else [day], hour[0].strip(), hour[1].strip()
+                                )
 
             item["opening_hours"] = oh
             yield item


### PR DESCRIPTION
```
{'atp/brand/Lilly': 236,
 'atp/brand_wikidata/Q111764460': 236,
 'atp/category/shop/chemist': 236,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 236,
 'atp/field/email/missing': 236,
 'atp/field/image/missing': 236,
 'atp/field/operator/missing': 236,
 'atp/field/operator_wikidata/missing': 236,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 236,
 'atp/field/state/missing': 236,
 'atp/field/twitter/missing': 236,
 'atp/field/website/missing': 236,
 'atp/item_scraped_host_count/www.lilly.rs': 236,
 'atp/nsi/cc_match': 236,
 'downloader/request_bytes': 786,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29860,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.740393,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 28, 20, 7, 5, 213392, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 182152,
 'httpcompression/response_count': 2,
 'item_scraped_count': 236,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 28, 20, 7, 2, 472999, tzinfo=datetime.timezone.utc)}
```