### PR TITLE
Add EngenQuickshopSpider and refine EngenSpider

### DIFF
--- a/locations/spiders/engen.py
+++ b/locations/spiders/engen.py
@@ -1,6 +1,6 @@
 import scrapy
 
-from locations.categories import Categories
+from locations.categories import Categories, Fuel, apply_yes_no
 from locations.dict_parser import DictParser
 
 
@@ -19,4 +19,5 @@ class EngenSpider(scrapy.Spider):
             if postcode and postcode != "0":
                 i["postcode"] = postcode
             item = DictParser.parse(i)
+            apply_yes_no(Fuel.ADBLUE, item, "AdBlue" in i["rental_units"])
             yield item

--- a/locations/spiders/engen_quickshop.py
+++ b/locations/spiders/engen_quickshop.py
@@ -1,20 +1,23 @@
-import scrapy
+from scrapy import Spider
 
 from locations.categories import Categories
 from locations.dict_parser import DictParser
 
 
-class EngenSpider(scrapy.Spider):
-    name = "engen"
-    item_attributes = {"brand": "Engen", "brand_wikidata": "Q3054251", "extras": Categories.FUEL_STATION.value}
-    allowed_domains = ["engen.co.za"]
+class EngenQuickshopSpider(Spider):
+    name = "engen_quickshop"
+    item_attributes = {
+        "brand": "Quickshop",
+        "brand_wikidata": "Q122764368",
+        "extras": Categories.SHOP_CONVENIENCE.value,
+    }
     start_urls = ["https://engen-admin.engen.co.za/api/service-stations/all"]
 
     def parse(self, response):
         data = response.json()
         for i in data["response"]["data"]["stations"]:
-            i["branch"] = i.pop("company_name").replace(self.item_attributes["brand"], "").strip()
-            i["phone"] = i.pop("mobile")
+            if "Quickshop" not in i.get("rental_units", ""):
+                continue
             postcode = i.pop("street_postal_code")
             if postcode and postcode != "0":
                 i["postcode"] = postcode


### PR DESCRIPTION
Quickshop is Engen's own brand convenience store, so this is basically first party information for the locations

Engen: Move name to branch and also collect AdBlue availability