### PR TITLE
New spider: Bambu (66 locations)

### DIFF
--- a/locations/spiders/bambu.py
+++ b/locations/spiders/bambu.py
@@ -1,0 +1,86 @@
+import json
+from base64 import b64encode
+from gzip import compress
+
+from scrapy import Request, Spider
+
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature, SocialMedia, set_social_media
+
+
+class BambuSpider(Spider):
+    name = "bambu"
+    item_attributes = {"brand": "Bambu", "brand_wikidata": "Q83437245"}
+
+    # Start by acquiring a session cookie
+    start_urls = ["https://www.drinkbambu.com/_api/v1/access-tokens"]
+
+    def parse(self, response):
+        # Now that we have a session cookie, send the actual request
+        # TODO: This API seems to have a pagination mechanism (the response includes a cursor) but
+        # I don't know how to use it. Requesting 999 results works ok for now.
+        params = {
+            "urlParams": {"gridAppId": "26451472-ec1e-4598-a994-03f8b5503c63"},
+            "body": {
+                "routerPrefix": "/properties",
+                "config": {
+                    "patterns": {
+                        "/": {
+                            "pageRole": "2ce8cb33-8752-4449-94d9-2d91ce00e549",
+                            "title": "Properties",
+                            "config": {
+                                "collection": "Properties",
+                                "pageSize": 999,
+                            },
+                        }
+                    }
+                },
+                "pageRoles": {"2ce8cb33-8752-4449-94d9-2d91ce00e549": {"id": "q4yo6", "title": "Stores (All)"}},
+                "requestInfo": {"formFactor": "desktop"},
+                "routerSuffix": "/",
+                "fullUrl": "https://www.drinkbambu.com/properties/",
+            },
+        }
+        query = b64encode(compress(json.dumps(params, separators=(",", ":")).encode())).decode()
+        req = Request(
+            f"https://www.drinkbambu.com/_api/dynamic-pages-router/v1/pages?{query}",
+            callback=self.parse_pages,
+        )
+        req.cookies["svSession"] = response.json()["svSession"]
+        yield req
+
+    def parse_pages(self, response):
+        result = response.json()["result"]
+        if response.json().get("exception", False):
+            raise RuntimeError(result["name"] + result["message"])
+        for location in result["data"]["items"]:
+            item = Feature()
+            item["city"] = location["mapLocation"]["city"]
+            item["lat"] = location["mapLocation"]["location"]["latitude"]
+            item["lon"] = location["mapLocation"]["location"]["longitude"]
+            item["housenumber"] = location["mapLocation"]["streetAddress"]["number"]
+            item["street"] = location["mapLocation"]["streetAddress"]["name"]
+            item["extras"]["addr:unit"] = location["mapLocation"]["streetAddress"]["apt"]
+            item["country"] = location["mapLocation"]["country"]
+            item["postcode"] = location["mapLocation"].get("postalCode")
+            item["state"] = location["mapLocation"].get("subdivision")
+            item["email"] = location["agentEmail"]
+            item["ref"] = location["_id"]
+            item["phone"] = location["storePhone"]
+            set_social_media(item, SocialMedia.FACEBOOK, location.get("facebook"))
+            set_social_media(item, SocialMedia.YELP, location.get("yelp"))
+            item["addr_full"] = location["address"]
+            item["branch"] = location["title"].removeprefix("Bambu ")
+
+            if location.get("instagram") != "https://www.instagram.com/bambudessertdrinks/":
+                set_social_media(item, SocialMedia.INSTAGRAM, location.get("instagram"))
+
+            item["website"] = response.urljoin(location["link-location-pages-title"])
+
+            oh = OpeningHours()
+            for i, day in enumerate(DAYS):
+                hours = location.get("storeHours" + ("1" * i), "")
+                oh.add_ranges_from_string(f"{day} {hours}")
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Bambu': 66,
 'atp/brand_wikidata/Q83437245': 66,
 'atp/category/amenity/cafe': 66,
 'atp/field/email/invalid': 23,
 'atp/field/email/missing': 23,
 'atp/field/image/missing': 66,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 66,
 'atp/field/operator_wikidata/missing': 66,
 'atp/field/phone/invalid': 3,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 2,
 'atp/field/street_address/missing': 66,
 'atp/field/twitter/missing': 66,
 'atp/item_scraped_host_count/www.drinkbambu.com': 66,
 'atp/nsi/perfect_match': 66,
 'downloader/request_bytes': 2076,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 52569,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.285078,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 29, 18, 22, 58, 111195, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 348714,
 'httpcompression/response_count': 3,
 'item_scraped_count': 66,
 'log_count/DEBUG': 80,
 'log_count/INFO': 10,
 'memusage/max': 232169472,
 'memusage/startup': 232169472,
 'request_depth_max': 1,
 'response_received_count': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 8, 29, 18, 22, 54, 826117, tzinfo=datetime.timezone.utc)}
```