### PR TITLE
[Jasons_deli] Fix spider (244 locations)

### DIFF
--- a/locations/spiders/jasons_deli.py
+++ b/locations/spiders/jasons_deli.py
@@ -1,15 +1,10 @@
-import pprint
-import re
 from typing import Any
+
+import scrapy
 from requests_cache import Response
 from scrapy.http import JsonRequest
 
-import scrapy
-
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, DAYS
-from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class JasonsDeliSpider(scrapy.Spider):
@@ -20,15 +15,11 @@ class JasonsDeliSpider(scrapy.Spider):
     def start_requests(self):
         yield JsonRequest(
             url="https://jdapi.jasonsdeli.com/api/v1/stores",
-            headers={"x-api-key": "683d4f90-1e20-11ef-9b2d-bf7a8563af57",
-                     "x-application-name": "jd-website-2024" },
+            headers={"x-api-key": "683d4f90-1e20-11ef-9b2d-bf7a8563af57", "x-application-name": "jd-website-2024"},
         )
-
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
             if location["isActive"]:
                 item = DictParser.parse(location)
                 yield item
-
-

--- a/locations/spiders/jasons_deli.py
+++ b/locations/spiders/jasons_deli.py
@@ -1,8 +1,13 @@
+import pprint
 import re
+from typing import Any
+from requests_cache import Response
+from scrapy.http import JsonRequest
 
 import scrapy
 
-from locations.hours import OpeningHours
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, DAYS
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -11,51 +16,19 @@ class JasonsDeliSpider(scrapy.Spider):
     name = "jasons_deli"
     item_attributes = {"brand": "Jason's Deli", "brand_wikidata": "Q16997641"}
     allowed_domains = ["jasonsdeli.com"]
-    start_urls = ("https://www.jasonsdeli.com/restaurants",)
 
-    def parse_hours(self, elements):
-        opening_hours = OpeningHours()
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://jdapi.jasonsdeli.com/api/v1/stores",
+            headers={"x-api-key": "683d4f90-1e20-11ef-9b2d-bf7a8563af57",
+                     "x-application-name": "jd-website-2024" },
+        )
 
-        for item in elements:
-            if m := re.search(
-                r"([a-z]+):.([0-9:\sAPM]+)\s-\s([0-9:\sAPM]+)",
-                item,
-                flags=re.IGNORECASE,
-            ):
-                opening_hours.add_range(m.group(1), m.group(2), m.group(3), time_format="%I:%M %p")
-        return opening_hours.as_opening_hours()
 
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+)", response.url).group(1)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            if location["isActive"]:
+                item = DictParser.parse(location)
+                yield item
 
-        properties = {
-            "addr_full": merge_address_lines(response.xpath('//div[@class="address"]/text()').getall()),
-            "city": response.xpath('//div[@class="address"]/text()').extract()[-1].split(",")[0],
-            "state": response.xpath('//div[@class="address"]/text()').extract()[-1].split(", ")[1].split(" ")[-2],
-            "postcode": response.xpath('//div[@class="address"]/text()').extract()[-1].split(", ")[1].split(" ")[-1],
-            "ref": ref,
-            "website": response.url,
-            "phone": response.xpath('//a[@class="cnphone"]/text()').extract_first(),
-        }
 
-        hours = self.parse_hours(response.xpath('//div[@class="loc-hours"]/p/text()').extract())
-
-        try:
-            bus_name = response.xpath('//div[@class="loc-title"]/text()').extract()[0].split(": ")[1]
-        except IndexError:
-            bus_name = response.xpath('//div[@class="loc-title"]/text()').extract_first()
-        properties["name"] = bus_name
-
-        if hours:
-            properties["opening_hours"] = hours
-
-        if m := re.search(r'"center":\{"lat":"(-?\d+\.\d+)","lon":"(-?\d+\.\d+)"', response.text):
-            properties["lat"], properties["lon"] = m.groups()
-
-        yield Feature(**properties)
-
-    def parse(self, response):
-        urls = response.xpath('//span[@class="field-content"]/a/@href').extract()
-
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url), callback=self.parse_store)


### PR DESCRIPTION
Opening Hours were not added as they were inconsistent from the website and google.
````
{"atp/brand/Jason's Deli": 244,
 'atp/brand_wikidata/Q16997641': 244,
 'atp/category/amenity/restaurant': 244,
 'atp/field/branch/missing': 244,
 'atp/field/country/from_reverse_geocoding': 244,
 'atp/field/email/missing': 244,
 'atp/field/image/missing': 244,
 'atp/field/opening_hours/missing': 244,
 'atp/field/operator/missing': 244,
 'atp/field/operator_wikidata/missing': 244,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 4,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 244,
 'atp/field/website/missing': 244,
 'atp/item_scraped_host_count/jdapi.jasonsdeli.com': 244,
 'atp/nsi/perfect_match': 244,
 'downloader/request_bytes': 1027,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 409806,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 4.855537,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 29, 19, 20, 47, 225113, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2070,
 'httpcompression/response_count': 1,
 'item_scraped_count': 244,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 29, 19, 20, 42, 369576, tzinfo=datetime.timezone.utc)}
```