### PR TITLE
New spider: Caliber Collision (2477 locations)

### DIFF
--- a/locations/spiders/caliber_collision_us.py
+++ b/locations/spiders/caliber_collision_us.py
@@ -1,0 +1,64 @@
+import re
+from datetime import datetime
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.items import SocialMedia, set_social_media
+
+millisecond_date = re.compile(r"/Date\((\d+)\)/")
+mdy_date = re.compile(r"(?P<month>\d+)/(?P<day>\d+)/(?P<year>\d+)")
+iso_date = re.compile(r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)T(?P<hour>\d+):(?P<minute>\d+):(?P<second>\d+)")
+
+
+class CaliberCollisionUSSpider(Spider):
+    name = "caliber_collision_us"
+    item_attributes = {"brand": "Caliber Collision", "brand_wikidata": "Q109329782"}
+
+    def start_requests(self):
+        data = {"size": 100000, "query": {"bool": {"must": {"query_string": {"query": "+contentType:Center"}}}}}
+        yield JsonRequest("https://www.caliber.com/api/es/search", data=data)
+
+    def parse(self, response):
+        for location in response.json()["contentlets"]:
+            item = DictParser.parse(location)
+            item["branch"] = location["title"]
+            item["extras"]["fax"] = location.get("faxNumber")
+            item["postcode"] = str(location["zip"])
+            item["state"] = location.get("state")
+            set_social_media(item, SocialMedia.YELP, location.get("yelpUrl"))
+
+            if "metaTitle" in location and "|" in location["metaTitle"]:
+                item["name"] = location["metaTitle"].split("|")[1].strip()
+            else:
+                del item["name"]
+
+            oh = OpeningHours()
+            for day in DAYS_FULL:
+                oh.add_range(
+                    day,
+                    location.get(f"{day.lower()}HoursClose"),
+                    location.get(f"{day.lower()}HoursOpen"),
+                    time_format="%Y-%m-%d %H:%M:%S.0",
+                )
+            item["opening_hours"] = oh
+
+            if date_str := location.get("openDate"):
+                if match := millisecond_date.match(date_str):
+                    start_date = datetime.fromtimestamp(int(match.group(1)) / 1000)
+                elif (match := mdy_date.match(date_str)) or (match := iso_date.match(date_str)):
+                    start_date = datetime(**{k: int(v) for k, v in match.groupdict().items()})
+                else:
+                    self.logger.info(f"Unknown date format {date_str!r}")
+                    start_date = None
+                if start_date is not None:
+                    item["extras"]["start_date"] = start_date.strftime("%Y-%m-%d")
+
+            if path := location.get("urlMap"):
+                item["website"] = response.urljoin(path)
+            else:
+                del item["website"]
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Caliber Collision': 2477,
 'atp/brand_wikidata/Q109329782': 2477,
 'atp/category/shop/car_repair': 2477,
 'atp/field/city/missing': 76,
 'atp/field/country/from_spider_name': 2477,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 498,
 'atp/field/image/missing': 2477,
 'atp/field/lat/missing': 118,
 'atp/field/lon/missing': 118,
 'atp/field/opening_hours/missing': 91,
 'atp/field/operator/missing': 2477,
 'atp/field/operator_wikidata/missing': 2477,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 177,
 'atp/field/postcode/missing': 203,
 'atp/field/state/missing': 76,
 'atp/field/street_address/missing': 76,
 'atp/field/twitter/missing': 2477,
 'atp/field/website/invalid': 76,
 'atp/item_scraped_host_count/www.caliber.com': 2477,
 'atp/nsi/perfect_match': 2477,
 'downloader/request_bytes': 728,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 2216717,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 11.092566,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 29, 23, 52, 46, 333941, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14933350,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2477,
 'log_count/DEBUG': 2490,
 'log_count/INFO': 10,
 'memusage/max': 231747584,
 'memusage/startup': 231747584,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 29, 23, 52, 35, 241375, tzinfo=datetime.timezone.utc)}
```