### PR TITLE
Add GoReviewSpider storefinder and HungryLionZASpider and refactor existing spiders

### DIFF
--- a/locations/spiders/hungry_lion_ao.py
+++ b/locations/spiders/hungry_lion_ao.py
@@ -1,0 +1,8 @@
+from locations.spiders.hungry_lion_za import HUNGRY_LION_SHARED_ATTRIBUTES
+from locations.storefinders.go_review import GoReviewSpider
+
+
+class HungryLionAOSpider(GoReviewSpider):
+    name = "hungry_lion_ao"
+    item_attributes = HUNGRY_LION_SHARED_ATTRIBUTES
+    start_urls = ["https://hlainfo.goreview.co.za/store-locator"]

--- a/locations/spiders/hungry_lion_bw.py
+++ b/locations/spiders/hungry_lion_bw.py
@@ -1,0 +1,8 @@
+from locations.spiders.hungry_lion_za import HUNGRY_LION_SHARED_ATTRIBUTES
+from locations.storefinders.go_review import GoReviewSpider
+
+
+class HungryLionBWSpider(GoReviewSpider):
+    name = "hungry_lion_bw"
+    item_attributes = HUNGRY_LION_SHARED_ATTRIBUTES
+    start_urls = ["https://hlbinfo.goreview.co.za/store-locator"]

--- a/locations/spiders/hungry_lion_na.py
+++ b/locations/spiders/hungry_lion_na.py
@@ -1,0 +1,8 @@
+from locations.spiders.hungry_lion_za import HUNGRY_LION_SHARED_ATTRIBUTES
+from locations.storefinders.go_review import GoReviewSpider
+
+
+class HungryLionNASpider(GoReviewSpider):
+    name = "hungry_lion_na"
+    item_attributes = HUNGRY_LION_SHARED_ATTRIBUTES
+    start_urls = ["https://hlninfo.goreview.co.za/store-locator"]

--- a/locations/spiders/hungry_lion_za.py
+++ b/locations/spiders/hungry_lion_za.py
@@ -1,0 +1,7 @@
+from locations.storefinders.go_review import GoReviewSpider
+
+
+class HungryLionZASpider(GoReviewSpider):
+    name = "hungry_lion_za"
+    item_attributes = {"brand": "Hungry Lion", "brand_wikidata": "Q115636930"}
+    start_urls = ["https://hlinfo.goreview.co.za/store-locator"]

--- a/locations/spiders/hungry_lion_za.py
+++ b/locations/spiders/hungry_lion_za.py
@@ -1,7 +1,9 @@
 from locations.storefinders.go_review import GoReviewSpider
 
+HUNGRY_LION_SHARED_ATTRIBUTES = {"brand": "Hungry Lion", "brand_wikidata": "Q115636930"}
+
 
 class HungryLionZASpider(GoReviewSpider):
     name = "hungry_lion_za"
-    item_attributes = {"brand": "Hungry Lion", "brand_wikidata": "Q115636930"}
+    item_attributes = HUNGRY_LION_SHARED_ATTRIBUTES
     start_urls = ["https://hlinfo.goreview.co.za/store-locator"]

--- a/locations/spiders/hungry_lion_zm.py
+++ b/locations/spiders/hungry_lion_zm.py
@@ -1,0 +1,8 @@
+from locations.spiders.hungry_lion_za import HUNGRY_LION_SHARED_ATTRIBUTES
+from locations.storefinders.go_review import GoReviewSpider
+
+
+class HungryLionZMSpider(GoReviewSpider):
+    name = "hungry_lion_zm"
+    item_attributes = HUNGRY_LION_SHARED_ATTRIBUTES
+    start_urls = ["https://hlzinfo.goreview.co.za/store-locator"]

--- a/locations/spiders/pie_city_za.py
+++ b/locations/spiders/pie_city_za.py
@@ -1,17 +1,7 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import Rule
-
-from locations.spiders.tiger_wheel_and_tyre_za import TigerWheelAndTyreZASpider
+from locations.storefinders.go_review import GoReviewSpider
 
 
-class PieCityZASpider(TigerWheelAndTyreZASpider):
+class PieCityZASpider(GoReviewSpider):
     name = "pie_city_za"
     item_attributes = {"brand": "Pie City", "brand_wikidata": "Q116619195"}
     start_urls = ["https://pcsl.goreview.co.za/store-locator"]
-    rules = [
-        Rule(
-            LinkExtractor(allow=r"^https:\/\/piecity\d+\.goreview\.co\.za\/store-information\?store-locator=pcsl$"),
-            callback="parse",
-        )
-    ]
-    url_prefix = "piecity"

--- a/locations/spiders/tiger_wheel_and_tyre_za.py
+++ b/locations/spiders/tiger_wheel_and_tyre_za.py
@@ -1,63 +1,7 @@
-import re
-
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.storefinders.go_review import GoReviewSpider
 
 
-class TigerWheelAndTyreZASpider(CrawlSpider):
+class TigerWheelAndTyreZASpider(GoReviewSpider):
     name = "tiger_wheel_and_tyre_za"
     item_attributes = {"brand": "Tiger Wheel & Tyre", "brand_wikidata": "Q120762656"}
     start_urls = ["https://twtinfo.goreview.co.za/store-locator"]
-    rules = [
-        Rule(
-            LinkExtractor(allow=r"^https:\/\/twt\d+\.goreview\.co\.za\/store-information\?store-locator=twtinfo$"),
-            callback="parse",
-        )
-    ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    url_prefix = "twt"
-
-    def parse(self, response):
-        properties = {
-            "ref": response.url.lstrip("https://" + self.url_prefix).split(".")[0],
-            "branch": response.xpath('//div[@class="left-align-header"]/h2/text()')
-            .get()
-            .replace(self.item_attributes["brand"], "")
-            .strip(),
-            "addr_full": re.sub(
-                r"\s+",
-                " ",
-                ", ".join(
-                    filter(
-                        None,
-                        map(
-                            str.strip,
-                            response.xpath(
-                                '//div[contains(@class, "content-wrapper")]/div[2]/div[1]//p/text()'
-                            ).getall(),
-                        ),
-                    )
-                ),
-            ),
-            "phone": response.xpath(
-                '//div[contains(@class, "content-wrapper")]/div[2]/div[3]//a[contains(@href, "tel:")]/@href'
-            )
-            .get()
-            .replace("tel:", ""),
-            "facebook": response.xpath(
-                '//div[contains(@class, "content-wrapper")]/div[2]/div[5]//a[contains(@href, "facebook.com")]/@href'
-            ).get(),
-            "website": response.url,
-        }
-        if maps_links_js := response.xpath('//script[contains(text(), "#apple_maps_directions")]/text()').get():
-            if "&sll=" in maps_links_js:
-                properties["lat"], properties["lon"] = maps_links_js.split("&sll=", 1)[1].split("&", 1)[0].split(",", 2)
-        hours_string = " ".join(
-            response.xpath('//div[contains(@class, "content-wrapper")]/div[2]/div[4]/p//text()').getall()
-        )
-        properties["opening_hours"] = OpeningHours()
-        properties["opening_hours"].add_ranges_from_string(hours_string)
-        yield Feature(**properties)

--- a/locations/storefinders/go_review.py
+++ b/locations/storefinders/go_review.py
@@ -47,9 +47,7 @@ class GoReviewSpider(CrawlSpider):
             ),
             "phone": response.xpath(
                 '//div[contains(@class, "content-wrapper")]/div[2]/div[3]//a[contains(@href, "tel:")]/@href'
-            )
-            .get()
-            .replace("tel:", ""),
+            ).get(),
             "facebook": response.xpath(
                 '//div[contains(@class, "content-wrapper")]/div[2]/div[5]//a[contains(@href, "facebook.com")]/@href'
             ).get(),

--- a/locations/storefinders/go_review.py
+++ b/locations/storefinders/go_review.py
@@ -1,0 +1,71 @@
+import re
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class GoReviewSpider(CrawlSpider):
+    """
+    To use this spider, specify one or more start_urls,
+    normally something like "https://hlinfo.goreview.co.za/store-locator/store-information"
+
+    Also known as socialplaces.io or Social Places
+    """
+
+    custom_settings = {"ROBOTSTXT_OBEY": False}  # robots.txt disallows everything
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"^https:\/\/.*?\d+\.goreview\.co\.za\/store-information\?store-locator=.*$"),
+            callback="parse",
+        )
+    ]
+
+    def parse(self, response):
+        properties = {
+            "ref": re.sub(r"\.goreview\.co\.za.*", "", re.sub(r"https:\/\/", "", response.url)),
+            "branch": response.xpath('//div[@class="left-align-header"]/h2/text()')
+            .get()
+            .replace(self.item_attributes["brand"], "")
+            .strip(),
+            "addr_full": re.sub(
+                r"\s+",
+                " ",
+                ", ".join(
+                    filter(
+                        None,
+                        map(
+                            str.strip,
+                            response.xpath(
+                                '//div[contains(@class, "content-wrapper")]/div[2]/div[1]//p/text()'
+                            ).getall(),
+                        ),
+                    )
+                ),
+            ),
+            "phone": response.xpath(
+                '//div[contains(@class, "content-wrapper")]/div[2]/div[3]//a[contains(@href, "tel:")]/@href'
+            )
+            .get()
+            .replace("tel:", ""),
+            "facebook": response.xpath(
+                '//div[contains(@class, "content-wrapper")]/div[2]/div[5]//a[contains(@href, "facebook.com")]/@href'
+            ).get(),
+            "website": response.url,
+        }
+        if maps_links_js := response.xpath('//script[contains(text(), "#apple_maps_directions")]/text()').get():
+            if "&sll=" in maps_links_js:
+                properties["lat"], properties["lon"] = maps_links_js.split("&sll=", 1)[1].split("&", 1)[0].split(",", 2)
+        hours_string = " ".join(
+            response.xpath('//div[contains(@class, "content-wrapper")]/div[2]/div[4]/p//text()').getall()
+        )
+        properties["opening_hours"] = OpeningHours()
+        properties["opening_hours"].add_ranges_from_string(hours_string)
+        item = Feature(**properties)
+        yield from self.post_process_item(item, response) or []
+
+    def post_process_item(self, item, response):
+        """Override with any post-processing on the item."""
+        yield item


### PR DESCRIPTION
Such store finder pages have something like `https://hlinfo.goreview.co.za/store-locator/store-information` embedded in a the page and an icon on that page says "Powered by Social Places".

Fixes #9778 