### PR TITLE
Add spider for L&L Hawaiian Barbecue (249 locations)

### DIFF
--- a/locations/spiders/l_and_l_hawaiian_barbecue_us.py
+++ b/locations/spiders/l_and_l_hawaiian_barbecue_us.py
@@ -1,0 +1,38 @@
+from scrapy import Spider
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+
+
+class LAndLHawaiianBarbecueUSSpider(Spider):
+    name = "l_and_l_hawaiian_barbecue_us"
+    item_attributes = {
+        "brand": "L&L Hawaiian Barbecue",
+        "brand_wikidata": "Q6455441",
+        "extras": Categories.FAST_FOOD.value | {"cuisine": "hawaiian", Extras.TAKEAWAY.value: "yes"},
+    }
+    start_urls = ["https://www.hawaiianbarbecue.com/page-data/sq/d/1339288897.json"]
+
+    def parse(self, response):
+        for location in response.json()["data"]["allPrismicLocation"]["nodes"]:
+            item = DictParser.parse(
+                {
+                    k: list(v.values())[0] if isinstance(v, dict) and len(v) == 1 else v
+                    for k, v in location["data"].items()
+                }
+            )
+            item["ref"] = location["uid"]
+            item["website"] = response.urljoin(location["url"])
+            item["branch"] = item.pop("name")
+            item["name"] = item["brand"] = location["data"]["type"]
+            item["extras"]["website:menu"] = (location["data"]["menu"] or {}).get("url")
+            apply_yes_no(Extras.DELIVERY, item, location["data"]["provides_delivery"])
+
+            oh = OpeningHours()
+            for day in DAYS_FULL:
+                hours = location["data"][f"{day.lower()}_hours"]["text"]
+                oh.add_ranges_from_string(f"{day} {hours}")
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/L&L Hawaiian Barbecue': 246,
 'atp/brand/Mixplate': 3,
 'atp/brand_wikidata/Q6455441': 249,
 'atp/category/amenity/fast_food': 249,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 247,
 'atp/field/email/missing': 249,
 'atp/field/image/missing': 249,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 25,
 'atp/field/operator/missing': 249,
 'atp/field/operator_wikidata/missing': 249,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 25,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 249,
 'atp/item_scraped_host_count/www.hawaiianbarbecue.com': 249,
 'atp/nsi/match_failed': 249,
 'downloader/request_bytes': 650,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 86531,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.29976,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 8, 31, 23, 29, 45, 233842, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 529492,
 'httpcompression/response_count': 2,
 'item_scraped_count': 249,
 'log_count/DEBUG': 265,
 'log_count/INFO': 10,
 'memusage/max': 232120320,
 'memusage/startup': 232120320,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 8, 31, 23, 29, 42, 934082, tzinfo=datetime.timezone.utc)}
```