### PR TITLE
Deduplicate capitec_bank_za

### DIFF
--- a/locations/spiders/capitec_bank_za.py
+++ b/locations/spiders/capitec_bank_za.py
@@ -1,9 +1,9 @@
-from scrapy import Request, Spider
+from scrapy import Request
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.dict_parser import DictParser
 from locations.geo import country_iseadgg_centroids
 from locations.hours import DAYS_WEEKDAY, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
 
 DAYS_TERMS = {
     "OpeningHours": DAYS_WEEKDAY,
@@ -12,18 +12,17 @@ DAYS_TERMS = {
 }
 
 
-class CapitecBankZASpider(Spider):
+class CapitecBankZASpider(JSONBlobSpider):
     name = "capitec_bank_za"
     item_attributes = {"brand": "Capitec Bank", "brand_wikidata": "Q5035822"}
-    allowed_domains = ["capitecbank.co.za"]
+    locations_key = "Branches"
     custom_settings = {"ROBOTSTXT_OBEY": False}
-    no_refs = True
     requires_proxy = "ZA"
 
     def start_requests(self):
         # Maximum returned is 100, even with larger "Take"
-        # Even with 48km radius, not all locations are returned, and it is making ove 260 requests
-        for lat, lon in country_iseadgg_centroids("ZA", 48):
+        # Even with 48km radius, not all locations are returned, and it is making over 260 requests
+        for lat, lon in country_iseadgg_centroids("ZA", 24):
             yield Request(
                 url="https://www.capitecbank.co.za/api/Branch",
                 body=f"Latitude={lat}&Longitude={lon}&Take=100",
@@ -31,28 +30,25 @@ class CapitecBankZASpider(Spider):
                 method="POST",
             )
 
-    def parse(self, response):
-        for location in response.json()["Branches"]:
-            if location["IsClosed"]:
-                continue
-            item = DictParser.parse(location)
-            if location["IsAtm"]:
-                item["ref"] = location["Id"]
-                apply_category(Categories.ATM, item)
-                apply_yes_no(Extras.CASH_IN, item, location["CashAccepting"], False)
-            else:
-                item["ref"] = None
-                apply_category(Categories.BANK, item)
+    def post_process_item(self, item, response, location):
+        if location["IsClosed"]:
+            return
+        if location["IsAtm"]:
+            apply_category(Categories.ATM, item)
+            apply_yes_no(Extras.CASH_IN, item, location["CashAccepting"], False)
+        else:
+            item["ref"] = location["Name"].lower().replace(" ", "-")
+            apply_category(Categories.BANK, item)
 
-            item["branch"] = item.pop("name")
+        item["branch"] = item.pop("name")
 
-            oh = OpeningHours()
-            for day in DAYS_TERMS:
-                if location[day] is not None:
-                    if location[day].startswith("Closed"):
-                        oh.set_closed(DAYS_TERMS[day])
-                    else:
-                        oh.add_ranges_from_string(location[day])
-            item["opening_hours"] = oh.as_opening_hours()
+        oh = OpeningHours()
+        for day in DAYS_TERMS:
+            if location[day] is not None:
+                if location[day].startswith("Closed"):
+                    oh.set_closed(DAYS_TERMS[day])
+                else:
+                    oh.add_ranges_from_string(location[day])
+        item["opening_hours"] = oh.as_opening_hours()
 
-            yield item
+        yield item

--- a/locations/spiders/capitec_bank_za.py
+++ b/locations/spiders/capitec_bank_za.py
@@ -22,7 +22,7 @@ class CapitecBankZASpider(JSONBlobSpider):
     def start_requests(self):
         # Maximum returned is 100, even with larger "Take"
         # Even with 48km radius, not all locations are returned, and it is making over 260 requests
-        for lat, lon in country_iseadgg_centroids("ZA", 24):
+        for lat, lon in country_iseadgg_centroids("ZA", 48):
             yield Request(
                 url="https://www.capitecbank.co.za/api/Branch",
                 body=f"Latitude={lat}&Longitude={lon}&Take=100",


### PR DESCRIPTION
It was set to `no_refs` because atms have a ref, but branches don't. However this meant that duplicates were not being dropped. So I've used a dummy ref from the name for the branches, I hope that's a reasonable compromise.

Also switch to JsonBlobSpider while I'm there.

This is using the 48km radius for lat, long points but I also did a test with 24km radius.

48km:
```
 'atp/brand/Capitec Bank': 3611,
 'atp/brand_wikidata/Q5035822': 3611,
 'atp/category/amenity/atm': 2975,
 'atp/category/amenity/bank': 636,
 'atp/cdn/cloudflare/response_count': 262,
 ```

24km:
```
 'atp/brand/Capitec Bank': 4302,
 'atp/brand_wikidata/Q5035822': 4302,
 'atp/category/amenity/atm': 3524,
 'atp/category/amenity/bank': 778,
 'atp/cdn/cloudflare/response_count': 964,
```

So the 700 extra requests get about 700 extra items, which doesn't quite seem worth it.