### PR TITLE
Autodetect storefrontgateway

### DIFF
--- a/locations/items.py
+++ b/locations/items.py
@@ -130,6 +130,6 @@ def set_closed(item: Feature, end_date: datetime = None):
     item["extras"]["end_date"] = end_date.strftime("%Y-%m-%d") if end_date else "yes"
 
 
-class GeneratedSpider(scrapy.Item):
+class GeneratedSpider(Feature):
     storefinder_url = scrapy.Field()
     spider = scrapy.Field()

--- a/locations/storefinder_detector.py
+++ b/locations/storefinder_detector.py
@@ -35,9 +35,9 @@ from locations.storefinders.rio_seo import RioSeoSpider
 from locations.storefinders.shopapps import ShopAppsSpider
 from locations.storefinders.stockinstore import StockInStoreSpider
 from locations.storefinders.stockist import StockistSpider
-from locations.storefinders.storefrontgateway import StorefrontgatewaySpider
 from locations.storefinders.store_locator_plus_cloud import StoreLocatorPlusCloudSpider
 from locations.storefinders.store_locator_plus_self import StoreLocatorPlusSelfSpider
+from locations.storefinders.storefrontgateway import StorefrontgatewaySpider
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
 from locations.storefinders.storemapper import StoremapperSpider
 from locations.storefinders.storepoint import StorepointSpider

--- a/locations/storefinder_detector.py
+++ b/locations/storefinder_detector.py
@@ -35,6 +35,7 @@ from locations.storefinders.rio_seo import RioSeoSpider
 from locations.storefinders.shopapps import ShopAppsSpider
 from locations.storefinders.stockinstore import StockInStoreSpider
 from locations.storefinders.stockist import StockistSpider
+from locations.storefinders.storefrontgateway import StorefrontgatewaySpider
 from locations.storefinders.store_locator_plus_cloud import StoreLocatorPlusCloudSpider
 from locations.storefinders.store_locator_plus_self import StoreLocatorPlusSelfSpider
 from locations.storefinders.storelocatorwidgets import StoreLocatorWidgetsSpider
@@ -213,6 +214,7 @@ class StorefinderDetectorSpider(Spider):
             ShopAppsSpider,
             StockInStoreSpider,
             StockistSpider,
+            StorefrontgatewaySpider,
             StoreLocatorPlusCloudSpider,
             StoreLocatorPlusSelfSpider,
             StoreLocatorWidgetsSpider,

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -18,7 +18,6 @@ class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):
     """
 
     start_urls = []
-    api_key: str = ""
     detection_rules = [
         DetectionRequestRule(url=r"^(?P<start_urls__list>https?:\/\/storefrontgateway(?:\.[\w\-]+)+\/api\/stores)\/?$")
         DetectionResponseRule(

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -21,7 +21,7 @@ class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):
     api_key: str = ""
     detection_rules = [
         DetectionRequestRule(url=r"^https?:\/\/storefrontgateway\.[w\.-]+/api/stores"),
-        DetectionResponseRule(js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API]"}),
+        DetectionResponseRule(js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API + 'stores']"}),
     ]
 
     def start_requests(self):

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -21,7 +21,9 @@ class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):
     api_key: str = ""
     detection_rules = [
         DetectionRequestRule(url=r"^https?:\/\/storefrontgateway\.[w\.-]+/api/stores"),
-        DetectionResponseRule(js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API + 'stores']"}),
+        DetectionResponseRule(
+            js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API + 'stores']"}
+        ),
     ]
 
     def start_requests(self):

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -20,7 +20,7 @@ class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):
     start_urls = []
     api_key: str = ""
     detection_rules = [
-        DetectionRequestRule(url=r"^https?:\/\/storefrontgateway\.[w\.-]+/api/stores"),
+        DetectionRequestRule(url=r"^(?P<start_urls__list>https?:\/\/storefrontgateway(?:\.[\w\-]+)+\/api\/stores)\/?$")
         DetectionResponseRule(
             js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API + 'stores']"}
         ),

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -7,9 +7,10 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.automatic_spider_generator import AutomaticSpiderGenerator, DetectionRequestRule, DetectionResponseRule
 
 
-class StorefrontgatewaySpider(Spider):
+class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):
     """
     A relatively unknown storefinder, associated with https://mi9retail.com/
 
@@ -17,6 +18,11 @@ class StorefrontgatewaySpider(Spider):
     """
 
     start_urls = []
+    api_key: str = ""
+    detection_rules = [
+        DetectionRequestRule(url=r"^https?:\/\/storefrontgateway\.[w\.-]+/api/stores"),
+        DetectionResponseRule(js_objects={"start_urls": r"[window.__PRELOADED_STATE__.settings.env.PUBLIC_API]"}),
+    ]
 
     def start_requests(self):
         for url in self.start_urls:

--- a/locations/storefinders/storefrontgateway.py
+++ b/locations/storefinders/storefrontgateway.py
@@ -3,11 +3,11 @@ from typing import Iterable
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
+from locations.automatic_spider_generator import AutomaticSpiderGenerator, DetectionRequestRule, DetectionResponseRule
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
-from locations.automatic_spider_generator import AutomaticSpiderGenerator, DetectionRequestRule, DetectionResponseRule
 
 
 class StorefrontgatewaySpider(Spider, AutomaticSpiderGenerator):


### PR DESCRIPTION
Part of #10063

```
ubuntu@codespaces-dc76c9:/workspaces/alltheplaces$ pipenv run scrapy sf https://www.saveonfoods.com/
from locations.storefinders.storefrontgateway import StorefrontgatewaySpider


class SaveOnFoodsCASpider(StorefrontgatewaySpider):
    name = "saveonfoods_ca"
    item_attributes = {
        "brand_wikidata": "Q7427974",
        "brand": "Save-On-Foods",
    }
    start_urls = [
        "https://storefrontgateway.saveonfoods.com/api/",
    ]
```

Fixes bug with GeneratedSpider and new extras pipeline.