### PR TITLE
[Carpetright GB] Use new website

### DIFF
--- a/locations/spiders/carpetright_gb.py
+++ b/locations/spiders/carpetright_gb.py
@@ -1,7 +1,19 @@
-from locations.storefinders.yext import YextSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CarpetrightGBSpider(YextSpider):
+class CarpetrightGBSpider(CrawlSpider, StructuredDataSpider):
     name = "carpetright_gb"
     item_attributes = {"brand": "Carpetright", "brand_wikidata": "Q5045782"}
-    api_key = "a3853af22833fc3224b846180ad0bcc0"
+    start_urls = ["https://www.carpet-right.co.uk/stores/search"]
+    rules = [Rule(LinkExtractor(r"https://www.carpet-right.co.uk/stores/(.+-carpetright)$"), "parse")]
+    wanted_types = ["HomeGoodsStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["image"] = None
+        item["branch"] = item.pop("name").removesuffix(" Carpetright")
+        item["website"] = response.url
+
+        yield item


### PR DESCRIPTION
Fixes #10108

```python
{'atp/brand/Carpetright': 54,
 'atp/brand_wikidata/Q5045782': 54,
 'atp/category/shop/carpet': 54,
 'atp/cdn/cloudflare/response_count': 56,
 'atp/cdn/cloudflare/response_status_count/200': 56,
 'atp/field/city/missing': 14,
 'atp/field/country/from_spider_name': 54,
 'atp/field/email/missing': 54,
 'atp/field/image/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/state/missing': 54,
 'atp/field/twitter/missing': 54,
 'atp/item_scraped_host_count/www.carpet-right.co.uk': 54,
 'atp/nsi/perfect_match': 54,
 'downloader/request_bytes': 203750,
 'downloader/request_count': 56,
 'downloader/request_method_count/GET': 56,
 'downloader/response_bytes': 861114,
 'downloader/response_count': 56,
 'downloader/response_status_count/200': 56,
 'elapsed_time_seconds': 0.871025,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 4, 12, 45, 19, 6347, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 56,
 'httpcompression/response_bytes': 3876252,
 'httpcompression/response_count': 56,
 'item_scraped_count': 54,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 260833280,
 'memusage/startup': 260833280,
 'request_depth_max': 1,
 'response_received_count': 56,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 55,
 'scheduler/dequeued/memory': 55,
 'scheduler/enqueued': 55,
 'scheduler/enqueued/memory': 55,
 'start_time': datetime.datetime(2024, 9, 4, 12, 45, 18, 135322, tzinfo=datetime.timezone.utc)}
```