### PR TITLE
debonairs_pizza_africa and debonairs_pizza_na spiders

### DIFF
--- a/locations/spiders/debonairs_pizza_africa.py
+++ b/locations/spiders/debonairs_pizza_africa.py
@@ -2,7 +2,7 @@ from locations.categories import Extras, apply_yes_no
 from locations.storefinders.yext_search import YextSearchSpider
 
 
-class DebonairsAfricaSpider(YextSearchSpider):
+class DebonairsPizzaAfricaSpider(YextSearchSpider):
     name = "debonairs_pizza_africa"
     item_attributes = {"brand": "Debonairs Pizza", "brand_wikidata": "Q65079407"}
     host = "https://location.debonairspizza.africa"

--- a/locations/spiders/debonairs_pizza_africa.py
+++ b/locations/spiders/debonairs_pizza_africa.py
@@ -1,0 +1,18 @@
+from locations.categories import Extras, apply_yes_no
+from locations.storefinders.yext_search import YextSearchSpider
+
+
+class DebonairsAfricaSpider(YextSearchSpider):
+    name = "debonairs_pizza_africa"
+    item_attributes = {"brand": "Debonairs Pizza", "brand_wikidata": "Q65079407"}
+    host = "https://location.debonairspizza.africa"
+
+    def parse_item(self, location, item):
+        item["branch"] = location["profile"].get("geomodifier")
+        item["extras"]["website:menu"] = location["profile"].get("menuUrl")
+        if "c_debonairsPizzaLocatorFilters" in location["profile"]:
+            apply_yes_no(Extras.HALAL, item, "Halaal" in location["profile"]["c_debonairsPizzaLocatorFilters"])
+            apply_yes_no(Extras.TAKEAWAY, item, "Takeaway" in location["profile"]["c_debonairsPizzaLocatorFilters"])
+            apply_yes_no(Extras.DELIVERY, item, "Delivery" in location["profile"]["c_debonairsPizzaLocatorFilters"])
+        item["website"] = location["profile"]["c_pagesURL"]
+        yield item

--- a/locations/spiders/debonairs_pizza_na.py
+++ b/locations/spiders/debonairs_pizza_na.py
@@ -1,0 +1,22 @@
+from scrapy import Selector
+from scrapy.spiders import Spider
+
+from locations.google_url import url_to_coords
+from locations.items import Feature
+
+
+class DebonairsPizzaNASpider(Spider):
+    name = "debonairs_pizza_na"
+    item_attributes = {"brand": "Debonairs Pizza", "brand_wikidata": "Q65079407"}
+    start_urls = ["https://namibia.debonairspizza.africa/contact/locate-us"]
+    no_refs = True
+
+    def parse(self, response):
+        for location in response.xpath('.//a[contains(@href, "google.com/maps")]').getall():
+            coords = url_to_coords(Selector(text=location).xpath(".//a/@href").get())
+            properties = {
+                "lat": coords[0],
+                "lon": coords[1],
+                "branch": Selector(text=location).xpath(".//a/text()").get(),
+            }
+            yield Feature(**properties)

--- a/locations/storefinders/yext_search.py
+++ b/locations/storefinders/yext_search.py
@@ -57,7 +57,7 @@ class YextSearchSpider(Spider):
 
             emails = location["profile"].get("emails")
             if emails:
-                item["email"] = emails[0]
+                item["email"] = "; ".join(emails)
 
             item["facebook"] = location["profile"].get("facebookPageUrl")
 


### PR DESCRIPTION
I don't know why they have a great YextSearch thing set up, but Namibia isn't included, so we get a lot less data for Namibia.

'Africa':
```
 'atp/brand/Debonairs Pizza': 72,
 'atp/brand_wikidata/Q65079407': 72,
 'atp/category/amenity/fast_food': 72,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 72,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 72,
 'atp/field/operator_wikidata/missing': 72,
 'atp/field/postcode/missing': 29,
 'atp/field/state/missing': 63,
 'atp/field/twitter/missing': 72,
 'atp/item_scraped_host_count/location.debonairspizza.africa': 72,
 'atp/nsi/perfect_match': 72,
 ```

 Namibia:
 ```
 'atp/brand/Debonairs Pizza': 11,
 'atp/brand_wikidata/Q65079407': 11,
 'atp/category/amenity/fast_food': 11,
 'atp/field/city/missing': 11,
 'atp/field/country/from_spider_name': 11,
 'atp/field/email/missing': 11,
 'atp/field/image/missing': 11,
 'atp/field/opening_hours/missing': 11,
 'atp/field/operator/missing': 11,
 'atp/field/operator_wikidata/missing': 11,
 'atp/field/phone/missing': 11,
 'atp/field/postcode/missing': 11,
 'atp/field/state/missing': 11,
 'atp/field/street_address/missing': 11,
 'atp/field/twitter/missing': 11,
 'atp/field/website/missing': 11,
 'atp/item_scraped_host_count/namibia.debonairspizza.africa': 11,
 'atp/nsi/perfect_match': 11,
```
