### PR TITLE
Add spider for Hertz (4538 locations)

### DIFF
--- a/locations/spiders/hertz.py
+++ b/locations/spiders/hertz.py
@@ -1,0 +1,86 @@
+from scrapy import Request, Spider
+
+from locations.categories import Categories, FuelCards, PaymentMethods, apply_yes_no
+from locations.geo import point_locations
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+PAYMENT_MAP = {
+    "AMEX": PaymentMethods.AMERICAN_EXPRESS,
+    "AMX": PaymentMethods.AMERICAN_EXPRESS,
+    "AXP": PaymentMethods.AMERICAN_EXPRESS,
+    "CHINAUNIONPAY": PaymentMethods.UNIONPAY,
+    "CHQ": PaymentMethods.CHEQUE,
+    "CSH": PaymentMethods.CASH,
+    "CUP": PaymentMethods.UNIONPAY,
+    "DC": PaymentMethods.DISCOVER_CARD,
+    "DINERS": PaymentMethods.DINERS_CLUB,
+    "DISC": PaymentMethods.DISCOVER_CARD,
+    "DISCOVER": PaymentMethods.DISCOVER_CARD,
+    "DKV": FuelCards.DKV,
+    "JCB": PaymentMethods.JCB,
+    "MASTER": PaymentMethods.MASTER_CARD,
+    "MASTERDEBIT": PaymentMethods.MASTER_CARD_DEBIT,
+    "MC": PaymentMethods.MASTER_CARD,
+    "UTA": FuelCards.UTA,
+    "VISA": PaymentMethods.VISA,
+    "VISADEBIT": PaymentMethods.VISA_DEBIT,
+    # TODO: CRQ, DB, ECH, FCH, HCC, VCH
+}
+
+
+class HertzSpider(Spider):
+    name = "hertz"
+    item_attributes = {"extras": Categories.CAR_RENTAL.value}  # "brand" is applied in code
+
+    def start_requests(self):
+        for lat, lon in point_locations("earth_centroids_iseadgg_346km_radius.csv"):
+            yield Request(
+                f"https://ecom.mss.hertz.io/mdm-locations/internal-lookup/geo-search/hertz/?lat={lat}&long={lon}&radius=347"
+            )
+
+    def parse(self, response):
+        for location in response.json()["data"]:
+            item = Feature()
+
+            name = location["name"].removeprefix("Hertz Car Rental - ").removeprefix("Hertz Truck Rental - ")
+            if location.get("ownership_type") == "CORPORATE":
+                # Only apply brand tags to "Corporate" type locations
+                item["brand"] = "Hertz"
+                item["brand_wikidata"] = "Q1543874"
+                item["branch"] = name
+            else:
+                item["name"] = name
+
+            item["extras"]["fax"] = location["contact_info"]["fax"]
+            item["email"] = location["contact_info"]["email"]
+            item["website"] = location["website_urls"]["full_url"]
+            item["ref"] = location["oag"]
+
+            item["street_address"] = merge_address_lines(
+                [location["address"]["address1"], location["address"]["address2"]]
+            )
+            item["city"] = location["address"]["city"]
+            item["lat"] = location["address"]["latitude"]
+            item["country"] = location["address"]["country_short"]
+            item["postcode"] = location["address"]["postal_code"]
+            item["state"] = location["address"]["state_short"]
+            item["lon"] = location["address"]["longitude"]
+
+            if location["contact_info"]["phone"]:
+                item["phone"] = location["contact_info"]["phone"]["international_phone_number"]
+
+            oh = OpeningHours()
+            for day_idx, day_hours in location["curated_days"].items():
+                day = DAYS[int(day_idx) - 1]
+                for hours in day_hours:
+                    oh.add_range(day, hours["start_time"], hours["end_time"])
+            item["opening_hours"] = oh
+
+            if location.get("allowed_payment_methods"):
+                for payment in location["allowed_payment_methods"]:
+                    if payment_tag := PAYMENT_MAP.get(payment):
+                        apply_yes_no(payment_tag, item, True)
+
+            yield item


### PR DESCRIPTION
Fixes https://github.com/alltheplaces/alltheplaces/issues/3899

```py
{'atp/brand/Hertz': 2485,
 'atp/brand_wikidata/Q1543874': 2485,
 'atp/category/amenity/car_rental': 4538,
 'atp/field/branch/missing': 2053,
 'atp/field/brand/missing': 2053,
 'atp/field/brand_wikidata/missing': 2053,
 'atp/field/email/missing': 1693,
 'atp/field/image/missing': 4538,
 'atp/field/lat/missing': 9,
 'atp/field/lon/missing': 9,
 'atp/field/operator/missing': 4538,
 'atp/field/operator_wikidata/missing': 4538,
 'atp/field/phone/invalid': 62,
 'atp/field/phone/missing': 53,
 'atp/field/postcode/missing': 357,
 'atp/field/state/missing': 1886,
 'atp/field/twitter/missing': 4538,
 'atp/geometry/null_island': 8,
 'atp/item_scraped_host_count/ecom.mss.hertz.io': 5034,
 'atp/nsi/perfect_match': 2485,
 'downloader/request_bytes': 1014918,
 'downloader/request_count': 1443,
 'downloader/request_method_count/GET': 1443,
 'downloader/response_bytes': 2040036,
 'downloader/response_count': 1443,
 'downloader/response_status_count/200': 1443,
 'elapsed_time_seconds': 1756.334388,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 4, 22, 20, 55, 122576, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8360824,
 'httpcompression/response_count': 1443,
 'item_dropped_count': 496,
 'item_dropped_reasons_count/DropItem': 496,
 'item_scraped_count': 4538,
 'log_count/DEBUG': 6488,
 'log_count/INFO': 39,
 'memusage/max': 413564928,
 'memusage/startup': 232943616,
 'response_received_count': 1443,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1442,
 'scheduler/dequeued/memory': 1442,
 'scheduler/enqueued': 1442,
 'scheduler/enqueued/memory': 1442,
 'start_time': datetime.datetime(2024, 9, 4, 21, 51, 38, 788188, tzinfo=datetime.timezone.utc)}
```