### PR TITLE
New spider: Coinstar kiosks (24910 locations)

### DIFF
--- a/locations/spiders/coinstar.py
+++ b/locations/spiders/coinstar.py
@@ -1,0 +1,37 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
+
+
+class CoinstarSpider(Spider):
+    name = "coinstar"
+    item_attributes = {"brand": "Coinstar", "brand_wikidata": "Q5141641"}
+    max_results = 1000
+
+    def start_requests(self):
+        for lat, lon in country_iseadgg_centroids(["ca", "de", "es", "fr", "gb", "ie", "it", "us"], 158):
+            yield JsonRequest(
+                "https://coinstar.com/api?type=kiosk_selector",
+                data={"radius": 100, "total_kiosks": self.max_results, "latitude": lat, "longitude": lon},
+            )
+
+    def parse(self, response):
+        j = response.json()
+        if j["status"] != "000":
+            self.logger.error(j.get("status_text"))
+            return
+
+        kiosks = j["data"]
+        if len(kiosks) >= self.max_results:
+            raise RuntimeError("Results truncated, need to use a larger max_results.")
+
+        for kiosk in kiosks:
+            item = DictParser.parse(kiosk)
+            item["ref"] = kiosk["machine_placement_id"]
+            item["located_in"] = kiosk["banner_name"]
+            item["street_address"] = kiosk["street_address_text"]
+            item["state"] = kiosk["state_province_code"]
+            item["website"] = f"https://coinstar.com/kiosk-info?KioskId={kiosk['machine_placement_id']}"
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Coinstar': 24910,
 'atp/brand_wikidata/Q5141641': 24910,
 'atp/category/amenity/payment_terminal': 24910,
 'atp/cdn/cloudflare/response_count': 505,
 'atp/cdn/cloudflare/response_status_count/200': 505,
 'atp/field/branch/missing': 24910,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 24910,
 'atp/field/image/missing': 24910,
 'atp/field/opening_hours/missing': 24910,
 'atp/field/operator/missing': 24910,
 'atp/field/operator_wikidata/missing': 24910,
 'atp/field/phone/missing': 24910,
 'atp/field/postcode/missing': 130,
 'atp/field/state/missing': 1280,
 'atp/field/twitter/missing': 24910,
 'atp/item_scraped_host_count/coinstar.com': 30944,
 'atp/nsi/perfect_match': 24910,
 'downloader/request_bytes': 211731,
 'downloader/request_count': 506,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 505,
 'downloader/response_bytes': 3633186,
 'downloader/response_count': 506,
 'downloader/response_status_count/200': 505,
 'downloader/response_status_count/502': 1,
 'elapsed_time_seconds': 616.208828,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 2, 19, 13, 44, 807545, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 173875535,
 'httpcompression/response_count': 505,
 'item_dropped_count': 6034,
 'item_dropped_reasons_count/DropItem': 6034,
 'item_scraped_count': 24910,
 'log_count/DEBUG': 31461,
 'log_count/INFO': 20,
 'memusage/max': 408215552,
 'memusage/startup': 241213440,
 'response_received_count': 505,
 'retry/count': 1,
 'retry/reason_count/502 Bad Gateway': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 505,
 'scheduler/dequeued/memory': 505,
 'scheduler/enqueued': 505,
 'scheduler/enqueued/memory': 505,
 'start_time': datetime.datetime(2024, 9, 2, 19, 3, 28, 598717, tzinfo=datetime.timezone.utc)}
```