### PR TITLE
Fix Mediamarkt DE Spider

### DIFF
--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -2,7 +2,6 @@ from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.structured_data_spider import StructuredDataSpider
 
 
 class MediamarktDESpider(scrapy.Spider):

--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -5,7 +5,7 @@ from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class MediamarktDESpider(StructuredDataSpider):
+class MediamarktDESpider(scrapy.Spider):
     name = "mediamarkt_de"
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
 

--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -1,22 +1,32 @@
-import json
+from scrapy.http import JsonRequest, Response
 
-from scrapy.http import Request
-
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class MediamarktDESpider(StructuredDataSpider):
     name = "mediamarkt_de"
     item_attributes = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
-    start_urls = ["https://www.mediamarkt.de/de/store/store-finder"]
 
-    def parse(self, response):
-        script = response.xpath('//script[contains(text(), "__PRELOADED_STATE__")]/text()').extract_first()
-        script = script[script.index("{") : script.rindex("}") + 1]
-        state = json.loads(script)["apolloState"]["ROOT_QUERY"]['localStorePage({"uid":"store-finder"})']["content"]
+    def start_requests(self):
+        url = "https://www.mediamarkt.de/api/v1/graphql?operationName=AllStores&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2260c474a136d174045108cc578a0c99621e9eea0b3ae26d2c30f2fdfee410abb5%22%7D%2C%22pwa%22%3A%7B%22captureChannel%22%3A%22DESKTOP%22%2C%22salesLine%22%3A%22Media%22%2C%22country%22%3A%22DE%22%2C%22language%22%3A%22de%22%2C%22globalLoyaltyProgram%22%3Atrue%2C%22isOneAccountProgramActive%22%3Atrue%2C%22isMdpActive%22%3Atrue%7D%7D"
+        headers = {
+            "x-operation": "AllStores",
+            "x-cacheable": "true",
+            "apollographql-client-version": "8.129.1",
+            "content-type": "application/json",
+        }
+        yield JsonRequest(url=url, headers=headers)
 
-        for item in state:
-            if item.get("__typename") == "GraphqlLocalStorePageContentAccordion":
-                for region in item["regions"]:
-                    for store in region["regionStores"]:
-                        yield Request(f"https://www.mediamarkt.de/de/store/{store['uid']}", callback=self.parse_sd)
+    def parse(self, response: Response, **kwargs):
+        for store in response.json()["data"]["stores"]:
+            item = DictParser.parse(store)
+            item["website"] = "https://www.mediamarkt.de/"
+            item["opening_hours"] = OpeningHours()
+            for day_time in store["openingTimes"]["regular"]:
+                day = day_time["type"]
+                open_time = day_time["start"]
+                close_time = day_time["end"]
+                item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+            yield item

--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -1,5 +1,5 @@
 from scrapy.http import JsonRequest, Response
-
+import scrapy
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 

--- a/locations/spiders/mediamarkt_de.py
+++ b/locations/spiders/mediamarkt_de.py
@@ -1,5 +1,6 @@
-from scrapy.http import JsonRequest, Response
 import scrapy
+from scrapy.http import JsonRequest, Response
+
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 


### PR DESCRIPTION
**Stats:**

{'atp/brand/MediaMarkt': 308,
 'atp/brand_wikidata/Q2381223': 308,
 'atp/category/shop/electronics': 308,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 308,
 'atp/field/image/missing': 308,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 308,
 'atp/field/operator_wikidata/missing': 308,
 'atp/field/phone/invalid': 300,
 'atp/field/state/missing': 30,
 'atp/field/street_address/missing': 308,
 'atp/field/twitter/missing': 308,
 'atp/item_scraped_host_count/www.mediamarkt.de': 308,
 'atp/nsi/cc_match': 308,
 'downloader/request_bytes': 1462,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 51185,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.22887,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 5, 7, 11, 49, 133583, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 690948,
 'httpcompression/response_count': 2,
 'item_scraped_count': 308,
 'log_count/DEBUG': 321,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 5, 7, 11, 44, 904713, tzinfo=datetime.timezone.utc)}
