### PR TITLE
[longhorn_steakhouse] Fix spider

### DIFF
--- a/locations/spiders/longhorn_steakhouse.py
+++ b/locations/spiders/longhorn_steakhouse.py
@@ -1,9 +1,10 @@
 from typing import Any
 
 from scrapy import Spider
-from scrapy.http import Response, JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
+
 
 class LonghornSteakhouseSpider(Spider):
     name = "longhorn_steakhouse"
@@ -20,11 +21,8 @@ class LonghornSteakhouseSpider(Spider):
             item["ref"] = location["restaurantNumber"]
             item["branch"] = location["restaurantName"]
             item["phone"] = location["phoneDetail"][0].get("phoneNumber")
-            item["street_address"] =  location["address"].get("street1")
+            item["street_address"] = location["address"].get("street1")
             item["lat"] = location["address"]["coordinates"]["latitude"]
             item["lon"] = location["address"]["coordinates"]["longitude"]
- 
+
             yield item
-
-
-   

--- a/locations/spiders/longhorn_steakhouse.py
+++ b/locations/spiders/longhorn_steakhouse.py
@@ -1,69 +1,30 @@
-import json
-import re
+from typing import Any
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Response, JsonRequest
 
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
-
-class LonghornSteakhouseSpider(scrapy.Spider):
+class LonghornSteakhouseSpider(Spider):
     name = "longhorn_steakhouse"
     item_attributes = {"brand": "LongHorn Steakhouse", "brand_wikidata": "Q3259007"}
-    allowed_domains = []
-    start_urls = [
-        "https://www.longhornsteakhouse.com/locations-sitemap.xml",
-    ]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,
-        "user-agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36 RuxitSynthetic/1.0 v2946028852165593646 t2919217341348717815",
-    }
-    download_delay = 0.3
 
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
+    def start_requests(self):
+        url = "https://m.longhornsteakhouse.com/api/restaurants?"
+        yield JsonRequest(url=url, headers={"X-Source-Channel": "WEB"})
 
-        for hour in hours:
-            day, open_close = hour.split(" ")
-            open_time, close_time = open_close.split("-")
-            opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M")
-        return opening_hours.as_opening_hours()
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["restaurants"]:
+            location.update(location.pop("contactDetail"))
+            item = DictParser.parse(location)
+            item["ref"] = location["restaurantNumber"]
+            item["branch"] = location["restaurantName"]
+            item["phone"] = location["phoneDetail"][0].get("phoneNumber")
+            item["street_address"] =  location["address"].get("street1")
+            item["lat"] = location["address"]["coordinates"]["latitude"]
+            item["lon"] = location["address"]["coordinates"]["longitude"]
+ 
+            yield item
 
-    def parse(self, response):
-        response.selector.remove_namespaces()
-        urls = response.xpath("//url/loc/text()").extract()
-        for url in urls:
-            yield scrapy.Request(url=url, callback=self.parse_store)
 
-    def parse_store(self, response):
-        store_data = response.xpath(
-            '//script[@type="application/ld+json" and contains(text(), "streetAddress")]/text()'
-        ).extract_first()
-        if store_data:
-            data = json.loads(store_data)
-            ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-
-            # Handle store pages that are missing the application/ld+json data
-            addr, city_state_zip, phone = response.xpath('//p[@id="info-link-webhead"]/text()').extract()
-            city, state, postcode = re.search(r"(.*?),\s([A-Z]{2})\s([\d-]+)$", city_state_zip).groups()
-
-            properties = {
-                "name": data.get("name") or response.xpath('//h1[@class="style_h1"]/text()').extract_first().strip(),
-                "ref": data["branchCode"] or ref,
-                "addr_full": data["address"]["streetAddress"].strip() or addr.strip(),
-                "city": data["address"]["addressLocality"] or city,
-                "state": data["address"]["addressRegion"] or state,
-                "postcode": data["address"]["postalCode"] or postcode,
-                "country": data["address"]["addressCountry"],
-                "phone": data.get("telephone") or phone.strip(),
-                "website": data.get("url") or response.url,
-                "lat": float(data["geo"]["latitude"]),
-                "lon": float(data["geo"]["longitude"]),
-            }
-
-            hours = data.get("openingHours")
-            if hours:
-                store_hours = self.parse_hours(hours)
-                properties["opening_hours"] = store_hours
-
-            yield Feature(**properties)
+   


### PR DESCRIPTION
Opening hours only provided for day of.  Not simple to parse, so left out.

```
{'atp/brand/LongHorn Steakhouse': 600,
 'atp/brand_wikidata/Q3259007': 600,
 'atp/category/amenity/restaurant': 600,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 587,
 'atp/field/email/missing': 600,
 'atp/field/image/missing': 600,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 600,
 'atp/field/operator/missing': 600,
 'atp/field/operator_wikidata/missing': 600,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 600,
 'atp/field/website/missing': 600,
 'atp/geometry/null_island': 2,
 'atp/item_scraped_host_count/m.longhornsteakhouse.com': 600,
 'atp/nsi/perfect_match': 600,
 'downloader/request_bytes': 673,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 102828,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.081743,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 5, 15, 37, 9, 805924, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1641755,
 'httpcompression/response_count': 1,
 'item_scraped_count': 600,
 'log_count/DEBUG': 613,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 5, 15, 37, 2, 724181, tzinfo=datetime.timezone.utc)}
```