### PR TITLE
Paris Baguette in KR (3511 locations)

### DIFF
--- a/locations/spiders/paris_baguette_kr.py
+++ b/locations/spiders/paris_baguette_kr.py
@@ -1,0 +1,33 @@
+from scrapy import Request, Spider
+
+from locations.categories import Extras, apply_yes_no
+from locations.items import Feature
+
+
+class ParisBaguetteKRSpider(Spider):
+    name = "paris_baguette_kr"
+    item_attributes = {"brand": "파리바게뜨", "brand_wikidata": "Q62605260"}
+    start_urls = ["https://www.paris.co.kr/wp-admin/admin-ajax.php?action=pb_store_get_area"]
+
+    def parse(self, response):
+        for state in response.json().values():
+            if "id" in state:
+                yield Request(
+                    f"https://www.paris.co.kr/wp-admin/admin-ajax.php?action=pb_store_get_list&type=%23search&area1={state['id']}",
+                    callback=self.parse_stores,
+                    cb_kwargs={"state": state["name"]},
+                )
+
+    def parse_stores(self, response, state=None):
+        for location in response.xpath("//li"):
+            item = Feature()
+            item["state"] = state
+            item["ref"] = location.xpath("div/@data-id").get()
+            item["lat"] = location.xpath("div/@data-latitude").get()
+            item["lon"] = location.xpath("div/@data-longitude").get()
+            item["branch"] = location.xpath(".//h3[@class='store-name']/span/text()").get()
+            item["addr_full"] = location.xpath(".//p[@class='store-addr']/text()").get()
+            item["phone"] = location.xpath(".//a[@class='tel']/text()").get()
+            item["website"] = f"https://www.paris.co.kr/store-detail/?id={item['ref']}"
+            apply_yes_no(Extras.DELIVERY, item, bool(location.xpath(".//i[@class='delivery']")))
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/파리바게뜨': 3511,
 'atp/brand_wikidata/Q62605260': 3511,
 'atp/category/shop/bakery': 3511,
 'atp/field/city/missing': 3511,
 'atp/field/country/from_spider_name': 3511,
 'atp/field/email/missing': 3511,
 'atp/field/image/missing': 3511,
 'atp/field/lat/missing': 13,
 'atp/field/lon/missing': 13,
 'atp/field/opening_hours/missing': 3511,
 'atp/field/operator/missing': 3511,
 'atp/field/operator_wikidata/missing': 3511,
 'atp/field/phone/invalid': 13,
 'atp/field/phone/missing': 43,
 'atp/field/postcode/missing': 3511,
 'atp/field/street_address/missing': 3511,
 'atp/field/twitter/missing': 3511,
 'atp/item_scraped_host_count/www.paris.co.kr': 3554,
 'atp/nsi/cc_match': 3511,
 'downloader/request_bytes': 8334,
 'downloader/request_count': 19,
 'downloader/request_method_count/GET': 19,
 'downloader/response_bytes': 339356,
 'downloader/response_count': 19,
 'downloader/response_status_count/200': 19,
 'elapsed_time_seconds': 22.882425,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 5, 18, 20, 47, 990404, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4502645,
 'httpcompression/response_count': 19,
 'item_dropped_count': 43,
 'item_dropped_reasons_count/DropItem': 43,
 'item_scraped_count': 3511,
 'log_count/DEBUG': 3584,
 'log_count/INFO': 9,
 'memusage/max': 166240256,
 'memusage/startup': 166240256,
 'request_depth_max': 1,
 'response_received_count': 19,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 18,
 'scheduler/dequeued/memory': 18,
 'scheduler/enqueued': 18,
 'scheduler/enqueued/memory': 18,
 'start_time': datetime.datetime(2024, 9, 5, 18, 20, 25, 107979, tzinfo=datetime.timezone.utc)}
```