### PR TITLE
Add BluffMeatSupplyZASpider

### DIFF
--- a/locations/spiders/bluff_meat_supply_za.py
+++ b/locations/spiders/bluff_meat_supply_za.py
@@ -1,0 +1,26 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class BluffMeatSupplyZASpider(WPStoreLocatorSpider):
+    name = "bluff_meat_supply_za"
+    item_attributes = {
+        "brand": "Bluff Meat Supply",
+        "brand_wikidata": "Q116981518",
+    }
+    allowed_domains = ["bluffmeatsupply.co.za"]
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature["hours"] = feature.pop("address2").removeprefix("Operating Hours:")
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").replace("BMS", "").strip()
+        item["addr_full"] = item.pop("street_address")
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(feature["hours"])
+        yield item


### PR DESCRIPTION
```
 'atp/brand/Bluff Meat Supply': 25,
 'atp/brand_wikidata/Q116981518': 25,
 'atp/category/shop/butcher': 25,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 25,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 24,
 'atp/field/state/missing': 25,
 'atp/field/street_address/missing': 25,
 'atp/field/twitter/missing': 25,
 'atp/field/website/missing': 25,
 'atp/item_scraped_host_count/bluffmeatsupply.co.za': 25,
 'atp/nsi/perfect_match': 25,
```