### PR TITLE
[Tesla] Fix spider

### DIFF
--- a/locations/spiders/tesla.py
+++ b/locations/spiders/tesla.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import scrapy
@@ -37,7 +38,8 @@ class TeslaSpider(scrapy.Spider):
             )
 
     def parse_location(self, response):
-        location_data = response.json()
+        # Many responses have false error message appended to the json data, clean them to get a proper json
+        location_data = json.loads(response.text.removesuffix("Error: 400"))
         if isinstance(location_data, list):
             return
         feature = DictParser.parse(location_data)

--- a/locations/spiders/tesla.py
+++ b/locations/spiders/tesla.py
@@ -1,6 +1,6 @@
-import json
 import re
 
+import chompjs
 import scrapy
 
 from locations.categories import Categories, apply_category
@@ -39,7 +39,7 @@ class TeslaSpider(scrapy.Spider):
 
     def parse_location(self, response):
         # Many responses have false error message appended to the json data, clean them to get a proper json
-        location_data = json.loads(response.text.removesuffix("Error: 400"))
+        location_data = chompjs.parse_js_object(response.text)
         if isinstance(location_data, list):
             return
         feature = DictParser.parse(location_data)

--- a/locations/spiders/tesla.py
+++ b/locations/spiders/tesla.py
@@ -4,12 +4,16 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.user_agents import FIREFOX_LATEST
 
 
 class TeslaSpider(scrapy.Spider):
     name = "tesla"
     item_attributes = {"brand": "Tesla", "brand_wikidata": "Q478214"}
     requires_proxy = True
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+    }
 
     def start_requests(self):
         yield scrapy.Request(


### PR DESCRIPTION
User agent added to get the response with desired data. Without this response is not reachable. Also tried `playwright`, but didn't work. 
Many POIs have [response](https://www.tesla.com/cua-api/tesla-location?translate=en_US&usetrt=true&id=cnsc10155)  with garbage text (error message) `Error: 400` appended, cleaned to fix the JSON decode error which was resulting in loss of POIs count. 

Note: `downloader/response_status_count/500': 1401` : It looks these are not random but are specific responses with 500 error [page](https://www.tesla.com/cua-api/tesla-location?translate=en_US&usetrt=true&id=cnsc9070).
```
{'atp/brand/Tesla': 1139,
 'atp/brand/Tesla Supercharger': 6163,
 'atp/brand_wikidata/Q17089620': 6163,
 'atp/brand_wikidata/Q478214': 1139,
 'atp/category/amenity/charging_station': 6163,
 'atp/category/missing': 259,
 'atp/category/multiple': 52,
 'atp/category/shop/car': 318,
 'atp/category/shop/car;car_repair': 442,
 'atp/category/shop/car_repair': 120,
 'atp/field/branch/missing': 7302,
 'atp/field/city/missing': 1101,
 'atp/field/email/missing': 6909,
 'atp/field/email/wrong_type': 786,
 'atp/field/image/missing': 7302,
 'atp/field/opening_hours/missing': 7302,
 'atp/field/operator/missing': 1324,
 'atp/field/operator_wikidata/missing': 1324,
 'atp/field/phone/missing': 7302,
 'atp/field/postcode/missing': 1569,
 'atp/field/state/missing': 1239,
 'atp/field/street_address/missing': 63,
 'atp/field/twitter/missing': 7302,
 'atp/field/website/missing': 7302,
 'atp/item_scraped_host_count/www.tesla.com': 7315,
 'atp/nsi/cc_match': 6416,
 'atp/nsi/match_failed': 886,
 'atp/operator/Tesla, Inc.': 5978,
 'atp/operator_wikidata/Q478214': 5978,
 'downloader/request_bytes': 14235397,
 'downloader/request_count': 8873,
 'downloader/request_method_count/GET': 8873,
 'downloader/response_bytes': 37670241,
 'downloader/response_count': 8873,
 'downloader/response_status_count/200': 7472,
 'downloader/response_status_count/500': 1401,
 'elapsed_time_seconds': 10899.021214,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 6, 15, 18, 31, 804700, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 16098914,
 'httpcompression/response_count': 7317,
 'httperror/response_ignored_count': 467,
 'httperror/response_ignored_status_count/500': 467,
 'item_dropped_count': 13,
 'item_dropped_reasons_count/DropItem': 13,
 'item_scraped_count': 7302,
 'log_count/DEBUG': 16199,
 'log_count/ERROR': 860,
 'log_count/INFO': 658,
 'request_depth_max': 1,
 'response_received_count': 7939,
 'retry/count': 934,
 'retry/max_reached': 467,
 'retry/reason_count/500 Internal Server Error': 934,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 8872,
 'scheduler/dequeued/memory': 8872,
 'scheduler/enqueued': 8872,
 'scheduler/enqueued/memory': 8872,
 'start_time': datetime.datetime(2024, 9, 6, 12, 16, 52, 783486, tzinfo=datetime.timezone.utc)}

```