### PR TITLE
MTN ZA and MTN Deals ZA spiders

### DIFF
--- a/locations/spiders/mtn_deals_za.py
+++ b/locations/spiders/mtn_deals_za.py
@@ -1,0 +1,14 @@
+from locations.categories import Categories
+from locations.storefinders.super_store_finder import SuperStoreFinderSpider
+
+
+class MtnDealsZASpider(SuperStoreFinderSpider):
+    name = "mtn_deals_za"
+    item_attributes = {
+        "brand_wikidata": "Q1813361",
+        "brand": "MTN",
+        "extras": Categories.SHOP_MOBILE_PHONE.value,
+    }
+    allowed_domains = [
+        "mtndeals.co.za",
+    ]

--- a/locations/spiders/mtn_za.py
+++ b/locations/spiders/mtn_za.py
@@ -1,0 +1,29 @@
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import clean_address
+
+
+class MtnZASpider(JSONBlobSpider):
+    name = "mtn_za"
+    item_attributes = {
+        "brand_wikidata": "Q1813361",
+        "brand": "MTN",
+    }
+    start_urls = [
+        "https://www.mtn.co.za/api/cms/v1/store-location/1725724280978268358/coverage-map-store-app?storeCount=10000&latitude=-29&longitude=24"
+    ]
+
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.SHOP_MOBILE_PHONE, item)
+        item["branch"] = item.pop("name").replace("MTN Store - ", "").replace("MTN Lite - ", "")
+        item["street_address"] = clean_address([location["addressExtra"], location["streetAndNumber"]])
+        item["website"] = "https://www.mtn.co.za/home/coverage/store/" + location["slug"]
+
+        item["opening_hours"] = OpeningHours()
+        for day_hours in location["openingHours"]:
+            if day_hours["closed"]:
+                item["opening_hours"].set_closed(DAYS[day_hours["dayOfWeek"] - 1])
+            item["opening_hours"].add_range(DAYS[day_hours["dayOfWeek"] - 1], day_hours["from1"], day_hours["to1"])
+
+        yield item

--- a/locations/spiders/mtn_za.py
+++ b/locations/spiders/mtn_za.py
@@ -13,6 +13,7 @@ class MtnZASpider(JSONBlobSpider):
     start_urls = [
         "https://www.mtn.co.za/api/cms/v1/store-location/1725724280978268358/coverage-map-store-app?storeCount=10000&latitude=-29&longitude=24"
     ]
+    download_timeout = 60
 
     def post_process_item(self, item, response, location):
         apply_category(Categories.SHOP_MOBILE_PHONE, item)


### PR DESCRIPTION
MTN deals is an authorised reseller of MTN, but stores appear to be branded as MTN, so I'm not doing a different Wikidata for them.

mtn_za:
```
 'atp/brand/MTN': 376,
 'atp/brand_wikidata/Q1813361': 376,
 'atp/category/shop/mobile_phone': 376,
 'atp/field/country/from_spider_name': 376,
 'atp/field/email/invalid': 3,
 'atp/field/image/missing': 376,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 376,
 'atp/field/operator_wikidata/missing': 376,
 'atp/field/postcode/missing': 376,
 'atp/field/state/missing': 376,
 'atp/field/twitter/missing': 376,
 'atp/item_scraped_host_count/www.mtn.co.za': 376,
 'atp/nsi/cc_match': 376,
```

mtn_deals_za:
```
 'atp/brand/MTN': 75,
 'atp/brand_wikidata/Q1813361': 75,
 'atp/category/shop/mobile_phone': 75,
 'atp/field/branch/missing': 75,
 'atp/field/city/missing': 75,
 'atp/field/country/from_spider_name': 75,
 'atp/field/email/missing': 7,
 'atp/field/image/missing': 75,
 'atp/field/opening_hours/missing': 75,
 'atp/field/operator/missing': 75,
 'atp/field/operator_wikidata/missing': 75,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 75,
 'atp/field/state/missing': 75,
 'atp/field/street_address/missing': 75,
 'atp/field/twitter/missing': 75,
 'atp/field/website/missing': 75,
 'atp/item_scraped_host_count/mtndeals.co.za': 75,
 'atp/nsi/cc_match': 75,
 ```