### PR TITLE
Allow checking missing from NSI by location code

### DIFF
--- a/docs/WIKIDATA.md
+++ b/docs/WIKIDATA.md
@@ -73,6 +73,13 @@ Missing by wikidata: 619
        -> https://www.wikidata.org/wiki/Special:EntityData/Q7797310.json
 ```
 
+You can also search by a location code such as "za" or "us-ct.geojson":
+```
+$ pipenv run scrapy nsi --detect-missing za
+Missing by wikidata: 66
+...
+```
+
 Check carefully if this is simply a scraper missing a wikidata entry, or if it is truely missing a scraper.
 
 ### Automatic POI categorisation

--- a/locations/commands/nsi.py
+++ b/locations/commands/nsi.py
@@ -70,20 +70,33 @@ class NameSuggestionIndexCommand(ScrapyCommand):
                 print("       -> " + str(item))
 
     def detect_missing(self, args):
+        # Exit early if the argument is in the wrong format
+        # Allow 3 letter country code in case of providing "001"
+        if not ("/" in args[0] or len(args[0]) in [2, 3]):
+            print(f"Unknown search option: {args[0]}. Provide a category from NSI or a 2-letter country code")
+            return
 
         codes = DuplicateWikidataCommand.wikidata_spiders(self.crawler_process)
+
+        missing = []
 
         # Fetch the category from NSI's github, and try to match to wikidata.
         # TODO: This assumes you are going for only one category, by wikidata ID.
         #       Is it worth having this just check all of the wikidata entries and printing out what is missing globally?
-        response = self.nsi._request_file(f"data/{args[0]}.json")
-        print(f"Fetched {len(response['items'])} {response['properties']['path']} from NSI")
+        if "/" in args[0]:
+            response = self.nsi._request_file(f"data/{args[0]}.json")
+            print(f"Fetched {len(response['items'])} {response['properties']['path']} from NSI")
 
-        missing = []
-        for item in response["items"]:
-            if "brand:wikidata" in item["tags"]:
-                if not item["tags"]["brand:wikidata"] in codes.keys():
-                    missing.append(item)
+            for item in response["items"]:
+                if "brand:wikidata" in item["tags"]:
+                    if not item["tags"]["brand:wikidata"] in codes.keys():
+                        missing.append(item)
+        elif len(args[0]) in [2, 3]:
+            for item in self.nsi.iter_country(args[0]):
+                if "brand:wikidata" in item["tags"]:
+                    if not item["tags"]["brand:wikidata"] in codes.keys():
+                        missing.append(item)
+
         print(f"Missing by wikidata: {len(missing)}")
         for brand in missing:
             wikidata = self.nsi.lookup_wikidata(brand["tags"]["brand:wikidata"])

--- a/locations/commands/nsi.py
+++ b/locations/commands/nsi.py
@@ -70,12 +70,6 @@ class NameSuggestionIndexCommand(ScrapyCommand):
                 print("       -> " + str(item))
 
     def detect_missing(self, args):
-        # Exit early if the argument is in the wrong format
-        # Allow 3 letter country code in case of providing "001"
-        if not ("/" in args[0] or len(args[0]) in [2, 3]):
-            print(f"Unknown search option: {args[0]}. Provide a category from NSI or a 2-letter country code")
-            return
-
         codes = DuplicateWikidataCommand.wikidata_spiders(self.crawler_process)
 
         missing = []
@@ -91,7 +85,8 @@ class NameSuggestionIndexCommand(ScrapyCommand):
                 if "brand:wikidata" in item["tags"]:
                     if not item["tags"]["brand:wikidata"] in codes.keys():
                         missing.append(item)
-        elif len(args[0]) in [2, 3]:
+        # Assume we are searching by location, either country code or some state geojson string
+        else:
             for item in self.nsi.iter_country(args[0]):
                 if "brand:wikidata" in item["tags"]:
                     if not item["tags"]["brand:wikidata"] in codes.keys():

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -96,18 +96,18 @@ class NSI(metaclass=Singleton):
                 if s in NSI.normalise(label):
                     yield k, v
 
-    def iter_country(self, country_code=None):
+    def iter_country(self, location_code=None):
         """
         Lookup by country code match in the NSI.
-        :param country_code: country code or NSI location to search for
+        :param location_code: country code or NSI location to search for
         :return: iterator of matching NSI wikidata.json entries
         """
         self._ensure_loaded()
         for v in self.nsi_json.values():
             for item in v["items"]:
-                if not country_code:
+                if not location_code:
                     yield item
-                elif country_code.lower() in item["locationSet"].get("include"):
+                elif location_code.lower() in item["locationSet"].get("include"):
                     yield item
 
     def iter_nsi(self, wikidata_code=None):

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -96,6 +96,20 @@ class NSI(metaclass=Singleton):
                 if s in NSI.normalise(label):
                     yield k, v
 
+    def iter_country(self, country_code=None):
+        """
+        Lookup by country code match in the NSI.
+        :param country_code: 2-letter country code to search for
+        :return: iterator of matching NSI wikidata.json entries
+        """
+        self._ensure_loaded()
+        for v in self.nsi_json.values():
+            for item in v["items"]:
+                if not country_code:
+                    yield item
+                elif country_code.lower() in item["locationSet"].get("include"):
+                    yield item
+
     def iter_nsi(self, wikidata_code=None):
         """
         Iterate NSI for all items in nsi.json with a matching wikidata code

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -99,7 +99,7 @@ class NSI(metaclass=Singleton):
     def iter_country(self, country_code=None):
         """
         Lookup by country code match in the NSI.
-        :param country_code: 2-letter country code to search for
+        :param country_code: country code or NSI location to search for
         :return: iterator of matching NSI wikidata.json entries
         """
         self._ensure_loaded()


### PR DESCRIPTION
Checking NSI by category is one thing, and the discussion posts on missing brands by @CloCkWeRX are interesting, but I don't know much about e.g. Japanese supermarkets so found myself searching the posts for "co.za" to find a brand I might know something about, or using https://nsi.guide and searching by country code.

I thought it would be easier to combine the two and so added this.

However, maybe it would be best if searching by location and by category were different commands?

You can search by country code or whatever can be in `["locationSet"]["include"]`, e.g. "us-ct.geojson".

e.g.
```
$ pipenv run scrapy nsi --detect-missing za
Missing by wikidata: 66
### Brand name

Astron Energy

fuel stations in South Africa

### Wikidata ID

Q120752181
https://www.wikidata.org/wiki/Q120752181
https://www.wikidata.org/wiki/Special:EntityData/Q120752181.json

### Store finder url(s)

Primary website: https://www.astronenergy.co.za/
Official Url(s): https://www.astronenergy.co.za/

----
...
```

or
```
$ pipenv run scrapy nsi --detect-missing 001
Missing by wikidata: 733
```