### PR TITLE
Add Raley's and sub-brands (118 locations)

### DIFF
--- a/locations/spiders/raleys_us.py
+++ b/locations/spiders/raleys_us.py
@@ -1,0 +1,45 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+BRAND_WIKIDATA = {
+    "Bel Air": "Q112922067",
+    "Nob Hill Foods": "Q121816894",
+    "Raley's": "Q7286970",
+    "Raley's ONE Market": "Q7286970",
+}
+
+
+class RaleysUSSpider(Spider):
+    name = "raleys_us"
+    item_attributes = {"extras": Categories.SHOP_SUPERMARKET.value}
+    custom_settings = {"DOWNLOAD_TIMEOUT": 55}
+
+    def start_requests(self):
+        yield JsonRequest(
+            "https://www.raleys.com/api/store", data={"rows": 250, "searchParameter": {"shippingMethod": "pickup"}}
+        )
+
+    def parse(self, response):
+        result = response.json()
+
+        if result["limit"] < result["total"]:
+            raise RuntimeError(f"Got {result['total']} results, need to increase limit")
+
+        for location in response.json()["data"]:
+            item = DictParser.parse(location)
+            item["ref"] = location["number"]
+            item["website"] = f"https://www.raleys.com/store/{location['number']}"
+            item["brand"] = item["name"] = location["brand"]["name"]
+            item["brand_wikidata"] = BRAND_WIKIDATA[location["brand"]["name"]]
+            item["street_address"] = item.pop("street")
+
+            oh = OpeningHours()
+            # TODO: Is it safe to assume that all stores are open 7 days?
+            oh.add_ranges_from_string(f"Mo-Su {location['storeHours'].removeprefix('Between ')}")
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Bel Air': 21,
 'atp/brand/Nob Hill Foods': 18,
 "atp/brand/Raley's": 75,
 "atp/brand/Raley's ONE Market": 4,
 'atp/brand_wikidata/Q112922067': 21,
 'atp/brand_wikidata/Q121816894': 18,
 'atp/brand_wikidata/Q7286970': 79,
 'atp/category/shop/supermarket': 118,
 'atp/field/branch/missing': 118,
 'atp/field/country/from_spider_name': 118,
 'atp/field/email/missing': 7,
 'atp/field/image/missing': 118,
 'atp/field/operator/missing': 118,
 'atp/field/operator_wikidata/missing': 118,
 'atp/field/twitter/missing': 118,
 'atp/item_scraped_host_count/www.raleys.com': 118,
 'atp/nsi/brand_missing': 18,
 'atp/nsi/perfect_match': 100,
 'downloader/request_bytes': 905,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 32656,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 26.67015,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 7, 17, 30, 54, 797806, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 766100,
 'httpcompression/response_count': 2,
 'item_scraped_count': 118,
 'log_count/DEBUG': 132,
 'log_count/INFO': 10,
 'memusage/max': 244477952,
 'memusage/startup': 244477952,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 7, 17, 30, 28, 127656, tzinfo=datetime.timezone.utc)}
```