### PR TITLE
PostalAnnex (328 locations)

### DIFF
--- a/locations/spiders/postalannex_us.py
+++ b/locations/spiders/postalannex_us.py
@@ -1,0 +1,34 @@
+import json
+
+from scrapy import Selector, Spider
+
+from locations.categories import Categories
+from locations.linked_data_parser import LinkedDataParser
+from locations.microdata_parser import MicrodataParser
+
+
+class PostalannexUSSpider(Spider):
+    name = "postalannex_us"
+    item_attributes = {"brand": "PostalAnnex", "brand_wikidata": "Q61960357", "extras": Categories.POST_OFFICE.value}
+    start_urls = ["https://www.postalannex.com/location-results"]
+
+    def parse(self, response):
+        script = response.xpath("//script[starts-with(text(), 'jQuery.extend')]/text()").get()
+        for marker in json.loads(script[script.find("{") : script.rfind("}") + 1])["gmap"]["auto1map"]["markers"]:
+            selector = Selector(text=marker["text"])
+            MicrodataParser.convert_to_json_ld(selector)
+            item = LinkedDataParser.parse_ld(
+                {
+                    "geo": {
+                        "@type": "GeoCoordinates",
+                        "latitude": marker["latitude"],
+                        "longitude": marker["longitude"],
+                    },
+                    "url": response.urljoin(selector.css(".views-field-field-store-name a::attr(href)").get()),
+                    "address": list(LinkedDataParser.iter_linked_data(selector)),
+                    "telephone": selector.css(".views-field-field-phone .field-content::text").get(),
+                }
+            )
+            item["branch"] = selector.css(".views-field-field-store-name a::text").get()
+            item["ref"] = item["website"].split("/")[-1]
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/PostalAnnex': 328,
 'atp/brand_wikidata/Q61960357': 328,
 'atp/category/amenity/post_office': 328,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 328,
 'atp/field/image/missing': 328,
 'atp/field/name/missing': 328,
 'atp/field/opening_hours/missing': 328,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 328,
 'atp/item_scraped_host_count/www.postalannex.com': 328,
 'atp/nsi/cc_match': 328,
 'atp/operator/PostalAnnex': 328,
 'atp/operator_wikidata/Q61960357': 328,
 'downloader/request_bytes': 626,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 82353,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.945139,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 7, 22, 12, 5, 89265, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1137215,
 'httpcompression/response_count': 2,
 'item_scraped_count': 328,
 'log_count/DEBUG': 349,
 'log_count/INFO': 9,
 'memusage/max': 166670336,
 'memusage/startup': 166670336,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 7, 22, 11, 58, 144126, tzinfo=datetime.timezone.utc)}
```