### PR TITLE
Philz Coffee (71 locations)

### DIFF
--- a/locations/spiders/philz_coffee_us.py
+++ b/locations/spiders/philz_coffee_us.py
@@ -1,0 +1,31 @@
+import json
+
+from locations.categories import Extras, apply_yes_no
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class PhilzCoffeeUSSpider(JSONBlobSpider):
+    name = "philz_coffee_us"
+    item_attributes = {"brand": "Philz Coffee", "brand_wikidata": "Q18156812"}
+    start_urls = ["https://philzcoffee.com/locations"]
+
+    def extract_json(self, response):
+        return json.loads(response.xpath("//@data-locations-locations-value").get())
+
+    def post_process_item(self, item, response, feature):
+        item["branch"] = item.pop("name")
+        item["state"] = feature["state"]
+        item["website"] = f"https://philzcoffee.com/locations/{item['ref']}"
+
+        if feature["header_image_one_url"]:
+            item["image"] = response.urljoin(feature["header_image_one_url"])
+
+        oh = OpeningHours()
+        for day in feature["hours"]:
+            oh.add_range(day["day"], day["opens"], day["closes"])
+        item["opening_hours"] = oh
+
+        apply_yes_no(Extras.DRIVE_THROUGH, item, feature["has_drive_thru"])
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Philz Coffee': 71,
 'atp/brand_wikidata/Q18156812': 71,
 'atp/category/amenity/cafe': 71,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_spider_name': 71,
 'atp/field/email/missing': 71,
 'atp/field/image/missing': 2,
 'atp/field/operator/missing': 71,
 'atp/field/operator_wikidata/missing': 71,
 'atp/field/postcode/missing': 71,
 'atp/field/street_address/missing': 71,
 'atp/field/twitter/missing': 71,
 'atp/item_scraped_host_count/philzcoffee.com': 71,
 'atp/nsi/perfect_match': 71,
 'downloader/request_bytes': 1080,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 32402,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.000545,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 7, 22, 14, 28, 744184, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 247135,
 'httpcompression/response_count': 2,
 'item_scraped_count': 71,
 'log_count/DEBUG': 84,
 'log_count/INFO': 9,
 'memusage/max': 166612992,
 'memusage/startup': 166612992,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 7, 22, 14, 26, 743639, tzinfo=datetime.timezone.utc)}
```