### PR TITLE
Marie Callender's (23 locations)

### DIFF
--- a/locations/spiders/marie_callenders_us.py
+++ b/locations/spiders/marie_callenders_us.py
@@ -1,0 +1,12 @@
+from locations.storefinders.metalocator import MetaLocatorSpider
+
+
+class MarieCallendersUSSpider(MetaLocatorSpider):
+    name = "marie_callenders_us"
+    item_attributes = {"brand_wikidata": "Q6762784", "brand": "Marie Callender's"}
+    brand_id = "15171"
+
+    def parse_item(self, item, location):
+        item["branch"] = item.pop("name")
+        item["website"] = location["link"]
+        yield item


### PR DESCRIPTION
Ironically, I suspect this one (or maybe all metalocators) is using OSM for geocoding! :smile: 
```py
{"atp/brand/Marie Callender's": 23,
 'atp/brand_wikidata/Q6762784': 23,
 'atp/category/amenity/restaurant': 23,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 23,
 'atp/field/image/missing': 23,
 'atp/field/operator/missing': 23,
 'atp/field/operator_wikidata/missing': 23,
 'atp/field/twitter/missing': 23,
 'atp/item_scraped_host_count/code.metalocator.com': 23,
 'atp/nsi/perfect_match': 23,
 'downloader/request_bytes': 360,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 4129,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.987684,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 8, 4, 1, 8, 217381, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 33231,
 'httpcompression/response_count': 1,
 'item_scraped_count': 23,
 'log_count/DEBUG': 35,
 'log_count/INFO': 10,
 'memusage/max': 244633600,
 'memusage/startup': 244633600,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 8, 4, 1, 7, 229697, tzinfo=datetime.timezone.utc)}
```