### PR TITLE
[jet_at] Fix Spider (155 locations)

### DIFF
--- a/locations/spiders/jet_at.py
+++ b/locations/spiders/jet_at.py
@@ -1,73 +1,30 @@
 import re
+from typing import Any
 
-import scrapy
-from scrapy.linkextractors import LinkExtractor
+from scrapy.http import Response
+from scrapy import Spider
 
 from locations.categories import Categories, apply_category
-from locations.geo import city_locations
-from locations.google_url import extract_google_position
-from locations.hours import DAYS_DE, OpeningHours, day_range, sanitise_day
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from chompjs import parse_js_object
 
 
-class JetATSpider(scrapy.Spider):
+class JetATSpider(Spider):
     name = "jet_at"
     item_attributes = {"brand": "Jet", "brand_wikidata": "Q568940"}
+    start_urls = ["https://www.jet-austria.at/tankstellen-suche?"]
 
-    def start_requests(self):
-        url = "https://www.jet-tankstellen.at/de/tankstellen/suchergebnisse.php"
-        postcodes = [2130, 2540, 3910, 4400, 4780, 4820, 7000, 7400, 8472, 8600, 8753, 9900]
-        for postcode in postcodes:
-            yield scrapy.FormRequest(
-                url=url,
-                method="post",
-                formdata={"suche": str(postcode)},
-            )
-        MIN_POPULATION = 45000
-        for city in city_locations("AT", min_population=MIN_POPULATION):
-            yield scrapy.FormRequest(
-                url=url,
-                method="post",
-                formdata={"suche": city["name"]},
-                cb_kwargs=dict(city=city["name"]),
-            )
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = response.xpath('//script[contains(text(), "const globals")]').get()
+        locations = parse_js_object(re.search(r'stationsData:(.*?)};', raw_data, re.DOTALL).group(1))
+        for location in locations:
+            item = DictParser.parse(location)
+            item["ref"] = location["publicId"]
+            item["branch"] = location["operatorName"]
+            item["street_address"] = item.pop("street")
+            item["website"] = location["webUrl"]
 
-    def parse(self, response, **kwargs):
-        links = LinkExtractor(
-            allow=(
-                r"/de/tankstellen/suchergebnisse\.php\?plz=\d+$",
-                r"/de/tankstellen/details\.php\?TSNr=.*&plzsearch=\d+$",
-            )
-        ).extract_links(response)
-        for link in links:
-            if "suchergebnisse.php?plz=" in link.url and link.url is not response.url:
-                yield response.follow(link.url, callback=self.parse, cb_kwargs=kwargs)
-            elif "details.php?TSNr=" in link.url:
-                yield response.follow(link.url, callback=self.parse_stations, cb_kwargs=kwargs)
+            apply_category(Categories.FUEL_STATION, item)
+            yield item
 
-    def parse_stations(self, response, **kwargs):
-        item = Feature()
-        address_element = response.xpath('//*[@class="detail_top_inhalt1"]//p/text()').getall()
-        item["street_address"] = address_element[0]
-        item["postcode"] = re.search(r"\d{4}", address_element[1]).group(0)
-        item["addr_full"] = ", ".join(address_element[:2]).strip()
-        item["phone"] = response.xpath('//*[@title="anrufen"]/text()').get()
-        item["city"] = kwargs.get("city")
-        item["website"] = response.url
-        match = re.search(r"TSNr=(.*)&plzsearch=", response.url)
-        item["ref"] = match.group(1) if match else item["website"]
-        extract_google_position(item, response)
 
-        timing = response.xpath('//*[@class="detail_top_inhalt2"]').get()
-        item["opening_hours"] = OpeningHours()
-        for start_day, end_day, open_time, close_time in re.findall(
-            r">\s*(\w+)\s*-\s*(\w+)[:<>\w\s/]*(\d\d:\d\d)\s*-\s*(\d\d:\d\d)", timing
-        ):
-            for day in day_range(sanitise_day(start_day, DAYS_DE), sanitise_day(end_day, DAYS_DE)):
-                item["opening_hours"].add_range(day, open_time, close_time)
-        for day, open_time, close_time in re.findall(r">\s*(\w+)[:<>\w\s/]*(\d\d:\d\d)\s*-\s*(\d\d:\d\d)", timing):
-            if day := sanitise_day(day, DAYS_DE):
-                item["opening_hours"].add_range(day, open_time, close_time)
-        apply_category(Categories.FUEL_STATION, item)
-
-        yield item

--- a/locations/spiders/jet_at.py
+++ b/locations/spiders/jet_at.py
@@ -1,12 +1,12 @@
 import re
 from typing import Any
 
-from scrapy.http import Response
+from chompjs import parse_js_object
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from chompjs import parse_js_object
 
 
 class JetATSpider(Spider):
@@ -16,7 +16,7 @@ class JetATSpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         raw_data = response.xpath('//script[contains(text(), "const globals")]').get()
-        locations = parse_js_object(re.search(r'stationsData:(.*?)};', raw_data, re.DOTALL).group(1))
+        locations = parse_js_object(re.search(r"stationsData:(.*?)};", raw_data, re.DOTALL).group(1))
         for location in locations:
             item = DictParser.parse(location)
             item["ref"] = location["publicId"]
@@ -26,5 +26,3 @@ class JetATSpider(Spider):
 
             apply_category(Categories.FUEL_STATION, item)
             yield item
-
-


### PR DESCRIPTION
```
{'atp/brand/Jet': 155,
 'atp/brand_wikidata/Q568940': 155,
 'atp/category/amenity/fuel': 155,
 'atp/field/branch/missing': 1,
 'atp/field/country/from_spider_name': 155,
 'atp/field/email/missing': 155,
 'atp/field/image/missing': 155,
 'atp/field/opening_hours/missing': 155,
 'atp/field/operator/missing': 155,
 'atp/field/operator_wikidata/missing': 155,
 'atp/field/phone/missing': 8,
 'atp/field/state/missing': 155,
 'atp/field/twitter/missing': 155,
 'atp/item_scraped_host_count/www.jet-austria.at': 155,
 'atp/nsi/cc_match': 155,
 'downloader/request_bytes': 625,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28557,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.037926,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 9, 16, 35, 37, 544346, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 600052,
 'httpcompression/response_count': 2,
 'item_scraped_count': 155,
 'log_count/DEBUG': 168,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 9, 16, 35, 34, 506420, tzinfo=datetime.timezone.utc)}
```