### PR TITLE
[gbfs] Added some main brands that had most counts by name.

### DIFF
--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -1,6 +1,7 @@
 from scrapy.http import JsonRequest
 from scrapy.spiders import CSVFeedSpider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 # General Bikeshare Feed Specification
@@ -10,6 +11,313 @@ from locations.dict_parser import DictParser
 # spider stats at https://github.com/MobilityData/gbfs which offers a centralised catalog of networks or "systems".
 # It then processes each system and collects the docks or "stations" from it. Not every system has stations as some
 # are dockless.
+
+BRAND_MAPPING = {
+    "Bay Wheels": {
+        "names": ["Bay Wheels"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q16971391",
+    },
+    "BiciMAD": {
+        "names": ["bicimad", "BiciMAD (unofficial)"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q17402113",
+    },
+    "Bicing": {
+        "names": ["Bicing"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q1833385",
+    },
+    "Bike Share Toronto": {
+        "names": ["Bike Share Toronto"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q17018523",
+    },
+    "Bird": {
+        "names": [
+            "Bird Bordeaux",
+            "Bird Cascais",
+            "Bird Chalonsenchampagne",
+            "Bird Draguignan",
+            "Bird Larochesuryon",
+            "Bird Laval",
+            "Bird Millau",
+            "Bird Montlucon",
+            "Bird Sarreguemines",
+            "Bird Vichy",
+        ],
+        "category": {"amenity": "kick-scooter_rental"},
+        "secondary_category": {"amenity": "bicycle_rental"},
+        "wikidata": "",
+    },
+    "Biki": {
+        "names": ["BIXI Montr\u00e9al"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q386",
+    },
+    "Bolt": {
+        "names": ["Bolt Technology O\u00dc"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {"amenity": "kick-scooter_rental"},
+        "wikidata": "Q20529164",
+    },
+    "Call a Bike": {
+        "names": ["Call a Bike"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q1060525",
+    },
+    "Capital Bikeshare": {
+        "names": ["Capital Bike Share"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q1034635",
+    },
+    "Citi Bike": {
+        "names": ["Citi Bike"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q2974438",
+    },
+    "Docomo Bike Share": {
+        "names": ["docomo bike share service"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q55533296",
+    },
+    "Donkey Republic": {
+        "names": [
+            "Donkey Republic Aalborg",
+            "Donkey Republic Aarhus",
+            "Donkey Republic Amsterdam",
+            "Donkey Republic Antwerp",
+            "Donkey Republic Ballerup",
+            "Donkey Republic Bamberg",
+            "Donkey Republic Budapest",
+            "Donkey Republic Cheltenham Spa",
+            "Donkey Republic Cirencester",
+            "Donkey Republic Copenhagen",
+            "Donkey Republic Den Haag",
+            "Donkey Republic Dordrecht",
+            "Donkey Republic Frederikshavn",
+            "Donkey Republic Geneva",
+            "Donkey Republic Ghent",
+            "Donkey Republic Glostrup",
+            "Donkey Republic Gorinchem",
+            "Donkey Republic Hiller\u00f8d",
+            "Donkey Republic Iisalmi",
+            "Donkey Republic Imatra",
+            "Donkey Republic Kiel",
+            "Donkey Republic Kingham",
+            "Donkey Republic Klampenborg",
+            "Donkey Republic Kotka",
+            "Donkey Republic Kouvola",
+            "Donkey Republic Kreuzlingen",
+            "Donkey Republic Lappeenranta",
+            "Donkey Republic Le Locle",
+            "Donkey Republic Liechtenstein",
+            "Donkey Republic Malm\u00f6",
+            "Donkey Republic M\u00e4nts\u00e4l\u00e4",
+            "Donkey Republic Mikkeli",
+            "Donkey Republic Moreton In Marsh",
+            "Donkey Republic Munich",
+            "Donkey Republic Neuch\u00e2tel",
+            "Donkey Republic Odense",
+            "Donkey Republic Oxford",
+            "Donkey Republic Porvoo",
+            "Donkey Republic Raasepori",
+            "Donkey Republic Regensburg",
+            "Donkey Republic Reykjavik",
+            "Donkey Republic Riihim\u00e4ki",
+            "Donkey Republic Rotterdam",
+            "Donkey Republic Rotterdam/Den Haag",
+            "Donkey Republic Store Heddinge",
+            "Donkey Republic The Cotswold Water Park",
+            "Donkey Republic Thun",
+            "Donkey Republic Turku",
+            "Donkey Republic Utrecht",
+            "Donkey Republic Valenciennes",
+            "Donkey Republic Worthing",
+            "Donkey Republic Yverdon-les-Bains",
+        ],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q63753939",
+    },
+    "Dott": {
+        "names": ["Dott Stockholm"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {"amenity": "kick-scooter_rental"},
+        "wikidata": "Q107463014",
+    },
+    "Ecobici": {
+        "names": ["Ecobici"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q5817067",
+    },
+    "HELLO CYCLING": {
+        "names": ["HELLO CYCLING"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q91231927",
+    },
+    "Lyft": {
+        "names": ["Lyft Scooters Chicago", "Lyft Scooters Denver"],
+        "category": {"amenity": "kick-scooter_rental"},
+        "secondary_category": {},
+        "wikidata": "Q17077936",
+    },
+    "Metrorower": {
+        "names": ["METROROWER"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q123507620",
+    },
+    "Mevo": {
+        "names": ["MEVO"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q60860236",
+    },
+    "Neuron Mobility": {
+        "names": ["Neuron Mobility"],
+        "category": {"amenity": "kick-scooter_rental"},
+        "secondary_category": {"amenity": "bicycle_rental"},
+        "wikidata": "",
+    },
+    "Nextbike": {
+        "names": [
+            "nextbike Bene\u0161ov",
+            "nextbike Bergamo",
+            "nextbike Berlin",
+            "nextbike Berounsko",
+            "nextbike BIH",
+            "nextbike Brno",
+            "nextbike Bulgaria",
+            "nextbike Burgenland Austria",
+            "nextbike \u010cesk\u00e1 T\u0159ebov\u00e1",
+            "nextbike Croatia",
+            "nextbike Cyprus",
+            "nextbike D\u00fcsseldorf",
+            "nextbike Dv\u016fr Kr\u00e1lov\u00e9",
+            "nextbike Frankfurt",
+            "nextbike Fr\u00fddek-M\u00edstek",
+            "nextbike Gie\u00dfen",
+            "nextbike G\u00fctersloh",
+            "nextbike Hav\u00ed\u0159ov",
+            "nextbike Hodon\u00edn",
+            "nextbike Ho\u0159ice",
+            "nextbike Hradec Kr\u00e1lov\u00e9",
+            "nextbike Jablonec",
+            "nextbike Ji\u010d\u00edn",
+            "nextbike Jihlava",
+            "nextbike Kassel",
+            "nextbike Kiev",
+            "nextbike Kladno",
+            "nextbike Klagenfurt Austria",
+            "nextbike Kl\u00e1\u0161terec nad Oh\u0159\u00ed",
+            "nextbike Konya",
+            "nextbike Kop\u0159ivnice",
+            "nextbike Leipzig",
+            "nextbike Le\u00f3n",
+            "nextbike Liberec",
+            "nextbike Lippstadt",
+            "nextbike LV",
+            "nextbike Marburg",
+            "nextbike Mladoboleslavsko",
+            "nextbike Moravsk\u00e1 T\u0159ebov\u00e1",
+            "nextbike Most",
+            "nextbike Nieder\u00f6sterreich Austria",
+            "nextbike Norderstedt",
+            "nextbike OlbramoviceVotice",
+            "nextbike Olomouc",
+            "nextbike Opava",
+            "nextbike Ostrava",
+            "nextbike Pelh\u0159imov",
+            "nextbike P\u00edsek",
+            "nextbike Praha",
+            "nextbike P\u0159erov",
+            "nextbike Romania",
+            "nextbike R\u00fcsselsheim am Main",
+            "nextbike Rychnovsko",
+            "nextbike Stirling",
+            "nextbike Switzerland",
+            "nextbike T\u0159eb\u00ed\u010d",
+            "nextbike Trutnov",
+            "nextbike Uhersk\u00e9 Hradi\u0161t\u011b",
+            "nextbike Vinnitsa (Ukraine)",
+            "nextbike Vrchlab\u00ed",
+            "nextbike Wiesbaden",
+            "nextbike Zl\u00edn",
+        ],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q2351279",
+    },
+    "Pony": {
+        "names": [
+            "Pony Angers",
+            "Pony Basque Country",
+            "Pony Beauvais",
+            "Pony Beziers",
+            "Pony Bordeaux",
+            "Pony Bourges",
+            "Pony Brussels",
+            "Pony Charleroi",
+            "Pony Evry",
+            "Pony Herouville",
+            "Pony La Roche-sur-Yon",
+            "Pony Li\u00e8ge",
+            "Pony Limoges",
+            "Pony Lorient",
+            "Pony Nice",
+            "Pony Olivet",
+            "Pony Paris",
+            "Pony Perpignan",
+            "Pony Poitiers",
+        ],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {"amenity": "kick-scooter_rental"},
+        "wikidata": "",
+    },
+    "PubliBike": {
+        "names": ["PubliBike"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q3555363",
+    },
+    "Shared Mobility": {"names": ["sharedmobility.ch"], "category": {}, "secondary_category": {}, "wikidata": ""},
+    "TIER": {
+        "names": ["TIER Basel", "TIER Bern", "TIER Paris", "TIER Stgallen", "TIER Winterthur", "TIER Zurich"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {"amenity": "kick-scooter_rental"},
+        "wikidata": "Q63386916",
+    },
+    "V\u00e9lib' Metropole": {
+        "names": ["V\u00e9lib' Metropole"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q1120762",
+    },
+    "Velospot": {
+        "names": ["Velospot"],
+        "category": {"amenity": "bicycle_rental"},
+        "secondary_category": {},
+        "wikidata": "Q56314221",
+    },
+    "Voi": {
+        "names": ["Voi Marseille", "Voi Switzerland"],
+        "category": {"amenity": "kick-scooter_rental"},
+        "secondary_category": {},
+        "wikidata": "Q61650427",
+    },
+}
 
 
 class GbfsSpider(CSVFeedSpider):
@@ -56,7 +364,21 @@ class GbfsSpider(CSVFeedSpider):
             # TODO: we could do with the vehicles types, then add OSM tags
             # eg amenity=bicycle_rental, amenity=kick-scooter_rental, amenity=motorcycle_rental, amenity=car_rental
             # but until then, we can do a white lie and call it public transit
-            item["extras"]["public_transport"] = "stop_position"
+            # item["extras"]["public_transport"] = "stop_position"
+
+            brand_mapped = False
+            for brand in BRAND_MAPPING:
+                if kwargs["Name"] in BRAND_MAPPING[brand]["names"]:
+                    apply_category(BRAND_MAPPING[brand]["category"], item)
+                    item["brand"] = brand
+                    item["brand_wikidata"] = BRAND_MAPPING[brand]["wikidata"]
+                    brand_mapped = True
+                    break
+            if not brand_mapped:
+                if "bike" in kwargs["Name"].lower() or "cycle" in kwargs["Name"].lower():
+                    apply_category(Categories.BICYCLE_RENTAL, item)
+                else:
+                    apply_category({"public_transport": "stop_position"}, item)
 
             if station.get("is_virtual_station"):
                 item["extras"]["physically_present"] = "no"


### PR DESCRIPTION
I added vehicle types for the largest brands. I went by count using the stats. I went through and found QCodes when they existed for the ones with counts above 500. Then went through a second time and filled in ones that were same brand as ones found in first run through. For example Pony had several names `Pony <city>` Only one or two were above 500 then the rest were small, but they all were easy to change. If the name/brand is not mapped, then I check if bike or cycle is in the name. If so, I give it a bicycle rental category. If not, I add use the `public_transport=stop_position`

The category counts follow with full stats from my local run below
 'atp/category/amenity/bicycle_rental': 142397,
 'atp/category/amenity/kick-scooter_rental': 9134,
 'atp/category/missing': 7395,
 'atp/category/public_transport/stop_position': 16365,

<details><summary>Full Stats</summary>

```python
{'atp/brand/2EM Car Sharing': 1755,
 'atp/brand/AAR Bike': 120,
 'atp/brand/AB mit Lara': 11,
 'atp/brand/ARVAL': 1,
 'atp/brand/AW-bike': 17,
 'atp/brand/Accès Vélo': 14,
 'atp/brand/Ambici': 203,
 'atp/brand/Arizona': 119,
 'atp/brand/Arriva Nitra Slovakia': 12,
 'atp/brand/Austin B-cycle': 78,
 'atp/brand/Aventura BCycle': 5,
 'atp/brand/BARshare Barnim All': 22,
 'atp/brand/BARshare Barnim Cars': 22,
 'atp/brand/BBK Klimabizi': 4,
 'atp/brand/BIKER Białystok Poland': 64,
 'atp/brand/BIKETOWN': 241,
 'atp/brand/BL bike': 5,
 'atp/brand/Bay Wheels': 548,
 'atp/brand/BelfastBikes': 58,
 'atp/brand/Bergen Bysykkel': 105,
 'atp/brand/Bergen City Bike': 105,
 'atp/brand/Bergisches e-Bike': 55,
 'atp/brand/Beryl - BCP': 468,
 'atp/brand/Beryl - Brighton': 106,
 'atp/brand/Beryl - Cornwall': 103,
 'atp/brand/Beryl - Greater Manchester': 279,
 'atp/brand/Beryl - Hackney Cargo Bike': 4,
 'atp/brand/Beryl - Hereford': 74,
 'atp/brand/Beryl - Hertsmere': 27,
 'atp/brand/Beryl - Isle of Wight': 88,
 'atp/brand/Beryl - Leeds': 82,
 'atp/brand/Beryl - Norwich': 165,
 'atp/brand/Beryl - Plymouth': 133,
 'atp/brand/Beryl - Portsmouth': 104,
 'atp/brand/Beryl - Southampton': 105,
 'atp/brand/Beryl - Watford': 89,
 'atp/brand/Beryl - West Midlands': 408,
 'atp/brand/Beryl - Westminster Cargo Bike': 4,
 'atp/brand/Beryl - Wool': 7,
 'atp/brand/BiciMAD': 1216,
 'atp/brand/BiciMislata Mislata': 21,
 'atp/brand/BiciPalma': 84,
 'atp/brand/Bicicoruña': 53,
 'atp/brand/Bicing': 513,
 'atp/brand/Bike Chattanooga': 43,
 'atp/brand/Bike Itaú - Pernambuco': 90,
 'atp/brand/Bike Itaú - Poa': 90,
 'atp/brand/Bike Itaú - Rio': 406,
 'atp/brand/Bike Itaú - Riviera': 7,
 'atp/brand/Bike Itaú - Salvador': 59,
 'atp/brand/Bike Itaú - Sampa': 239,
 'atp/brand/Bike Itaú - Santiago': 228,
 'atp/brand/Bike Nordelta': 21,
 'atp/brand/Bike Share Toronto': 843,
 'atp/brand/BikeKIA': 32,
 'atp/brand/BikeLNK': 21,
 'atp/brand/Bikeshare Kona': 23,
 'atp/brand/Biki': 1004,
 'atp/brand/Bilbaobizi (Bilbao)': 46,
 'atp/brand/Bird': 3879,
 'atp/brand/Bizkaibizi Spain': 79,
 'atp/brand/Blue Bikes': 495,
 'atp/brand/Blue-bike': 190,
 'atp/brand/Boaz Bikes': 1,
 'atp/brand/Bogotá': 277,
 'atp/brand/Bolt': 2268,
 'atp/brand/Bolt Karlsruhe': 30,
 'atp/brand/Bolt Stuttgart': 22,
 'atp/brand/Bolt Zurich': 3,
 'atp/brand/Bonn nextbike': 76,
 'atp/brand/Boulder BCycle': 55,
 'atp/brand/Broward B-cycle': 20,
 'atp/brand/Bublr Bikes': 117,
 'atp/brand/Buzau VeloCity': 49,
 'atp/brand/C-Vélo': 55,
 'atp/brand/Call a Bike': 1242,
 'atp/brand/Capital Bikeshare': 774,
 'atp/brand/Careem BIKE': 275,
 'atp/brand/Castletroy Bikes (Ireland)': 38,
 'atp/brand/Charlotte B-cycle': 30,
 'atp/brand/Chełmski Rower': 17,
 'atp/brand/Ciechanowski Rower Miejski Poland': 9,
 'atp/brand/Cincy Red Bike': 72,
 'atp/brand/Citi Bike': 2213,
 'atp/brand/Clemson BikeShare': 11,
 'atp/brand/Co-bikes': 2,
 'atp/brand/CoGo': 92,
 'atp/brand/Cykl': 13,
 'atp/brand/Częstochowski Rower Miejski Poland': 26,
 'atp/brand/DCS Bike': 5,
 'atp/brand/Dbizi': 69,
 'atp/brand/Deer': 344,
 'atp/brand/Demoland': 4,
 'atp/brand/Des Moines B-cycle': 30,
 'atp/brand/Docomo Bike Share': 5377,
 'atp/brand/Donkey Republic': 7685,
 'atp/brand/Dott': 59484,
 'atp/brand/Drobeta Velopark': 2,
 'atp/brand/EDEKA Grünheide': 15,
 'atp/brand/Ecobici': 1046,
 'atp/brand/Eifel e-Bike': 55,
 'atp/brand/EinfachMobil': 60,
 'atp/brand/El Paso B-cycle': 19,
 'atp/brand/Explore Bike Share': 35,
 'atp/brand/Fa.Mo.Se': 25,
 'atp/brand/Flamingo Dunedin': 34,
 'atp/brand/Flamingo Palerston North': 53,
 'atp/brand/Flamingo Porirua': 16,
 'atp/brand/Flamingo Waimakariri': 6,
 'atp/brand/Flamingo Wellington': 34,
 'atp/brand/Fort Worth Bike Sharing': 62,
 'atp/brand/Frelo Freiburg': 122,
 'atp/brand/GREENbike': 57,
 'atp/brand/GRM Grodzisk Poland': 17,
 'atp/brand/GoAbout': 70,
 'atp/brand/Graben - ready4green': 2,
 'atp/brand/Grad Drniš (Croatia)': 6,
 'atp/brand/Grad Ivanić-Grad (Croatia)': 5,
 'atp/brand/Grad Karlovac (Croatia)': 12,
 'atp/brand/Grad Križevci (Croatia)': 11,
 'atp/brand/Grad Metković (Croatia)': 5,
 'atp/brand/Grad Pula (Croatia)': 10,
 'atp/brand/Grad Sisak (Croatia)': 5,
 'atp/brand/Grad Slavonski Brod (Croatia)': 10,
 'atp/brand/Grad Split (Croatia)': 96,
 'atp/brand/Grad Velika Gorica (Croatia)': 4,
 'atp/brand/Grad Vukovar (Croatia)': 2,
 'atp/brand/Grad Zadar (Croatia)': 8,
 'atp/brand/Grad Zaprešić (Croatia)': 7,
 'atp/brand/Grad Šibenik (Croatia)': 12,
 'atp/brand/Greenbike Aruba': 8,
 'atp/brand/Greenville B-cycle': 13,
 'atp/brand/HELLO CYCLING': 9010,
 'atp/brand/HOPR Atlanta': 113,
 'atp/brand/HOPR Bishop Ranch': 61,
 'atp/brand/Heartland B-cycle': 84,
 'atp/brand/Heraeus Hanau': 5,
 'atp/brand/Hertz Bildeling': 25,
 'atp/brand/Hvar': 2,
 'atp/brand/Hyre': 480,
 'atp/brand/Indego': 253,
 'atp/brand/Indy - Pacers Bikeshare': 48,
 'atp/brand/Jackson County': 1,
 'atp/brand/JasKółka': 30,
 'atp/brand/Jastrebarsko (Croatia)': 1,
 'atp/brand/KARBIS Turkey': 4,
 'atp/brand/KVB Rad Germany': 177,
 'atp/brand/KVV.nextbike': 99,
 'atp/brand/Kolumbus Bysykkel': 213,
 'atp/brand/Koniński Rower Miejski Poland': 12,
 'atp/brand/Koszaliński Rower Miejski Poland': 20,
 'atp/brand/Koło Marek Poland': 7,
 'atp/brand/Kołobrzeski Rower Miejski Poland': 12,
 'atp/brand/LE vélo STAR': 57,
 'atp/brand/LIEmobil Liechtenstein': 35,
 'atp/brand/LOVELO Libre-service': 112,
 'atp/brand/Landkreis Nordsachsen - Deutschland': 7,
 'atp/brand/LastenVelo Freiburg': 36,
 'atp/brand/Leipzig Sandkasten': 5,
 'atp/brand/Libélo': 52,
 'atp/brand/Lime Antwerp': 1,
 'atp/brand/Lime Arlington': 1,
 'atp/brand/Lime Brussels': 1,
 'atp/brand/Lime Calgary': 1,
 'atp/brand/Lime Chicago': 1,
 'atp/brand/Lime Cleveland': 1,
 'atp/brand/Lime Colorado Springs': 1,
 'atp/brand/Lime Detroit': 1,
 'atp/brand/Lime Edmonton': 1,
 'atp/brand/Lime Frankfurt': 1,
 'atp/brand/Lime Grand Rapids': 1,
 'atp/brand/Lime Hamburg': 1,
 'atp/brand/Lime Kelowna': 1,
 'atp/brand/Lime Louisville': 1,
 'atp/brand/Lime Marseille': 1,
 'atp/brand/Lime New York': 1,
 'atp/brand/Lime Oakland': 1,
 'atp/brand/Lime Oberhausen': 1,
 'atp/brand/Lime Opfikon': 1,
 'atp/brand/Lime Ottawa': 1,
 'atp/brand/Lime Paris': 1,
 'atp/brand/Lime Portland': 1,
 'atp/brand/Lime Reutlingen': 1,
 'atp/brand/Lime San Francisco': 1,
 'atp/brand/Lime San Jose': 1,
 'atp/brand/Lime Seattle': 1,
 'atp/brand/Lime Solingen': 1,
 'atp/brand/Lime Tel Aviv': 1,
 'atp/brand/Lime Washington DC': 1,
 'atp/brand/Lime Zug': 1,
 'atp/brand/Lovesharing': 12,
 'atp/brand/Lyft': 1896,
 'atp/brand/MOBIbike': 394,
 'atp/brand/MOL Bubi': 209,
 'atp/brand/MV-Rad': 45,
 'atp/brand/Madison B-cycle': 95,
 'atp/brand/Mein konrad': 37,
 'atp/brand/Metro Bike Share': 224,
 'atp/brand/Metrorower': 925,
 'atp/brand/Mevo': 736,
 'atp/brand/MiBiciTuBici': 90,
 'atp/brand/Mibici Guadalajara': 360,
 'atp/brand/Milan Bikemi': 324,
 'atp/brand/Mobi Bike Share': 258,
 'atp/brand/Mogo Detroit': 82,
 'atp/brand/MonaBike': 51,
 'atp/brand/Movemix Bike': 104,
 'atp/brand/NEW MöBus nextbike': 46,
 'atp/brand/NS OV Fiets': 283,
 'atp/brand/Nashville BCycle': 35,
 'atp/brand/Navan Bikes (Ireland)': 46,
 'atp/brand/Neuron Mobility': 1851,
 'atp/brand/Neuron Oshawa': 80,
 'atp/brand/Nextbike': 9779,
 'atp/brand/Nibelungen-Bike': 39,
 'atp/brand/Nomago Bikes - GO2GO': 21,
 'atp/brand/Nomago Bikes - GO2GO Gorizia': 3,
 'atp/brand/Nomago Bikes - KOLESCE': 79,
 'atp/brand/Nomago Bikes - LJUBLJANA': 41,
 'atp/brand/Nomago Bikes - SLOVENIA': 4,
 'atp/brand/Nomago Bikes - ZANAPREJ': 7,
 'atp/brand/OK Bike Poland': 14,
 'atp/brand/OLi-Bike': 29,
 'atp/brand/OVO Bikes Glasgow': 112,
 'atp/brand/Ontibici': 24,
 'atp/brand/Općina Brinje (Croatia)': 2,
 'atp/brand/Općina Pitomača (Croatia)': 3,
 'atp/brand/Oslo Bysykkel': 263,
 'atp/brand/Otto': 21,
 'atp/brand/Otwocki Rower Miejski Poland': 10,
 'atp/brand/Piaseczyński Rower Miejski Poland': 7,
 'atp/brand/PickeBike Aubonne': 14,
 'atp/brand/PickeBike Basel': 67,
 'atp/brand/PickeBike Fribourg': 53,
 'atp/brand/Piotrkowski Rower Miejski Poland': 5,
 'atp/brand/Pobiedziski Rower Gminny Poland': 3,
 'atp/brand/Pogoh': 60,
 'atp/brand/Pony': 12951,
 'atp/brand/Potsdam Rad': 122,
 'atp/brand/Pruszkowski Rower Miejski Poland': 15,
 'atp/brand/PubliBike': 661,
 'atp/brand/RSVG-Bike': 169,
 'atp/brand/RTC Bike Share': 29,
 'atp/brand/RVK': 54,
 'atp/brand/Rad Sharing Fleet': 3,
 'atp/brand/Redding Bikeshare': 22,
 'atp/brand/RegioRadStuttgart': 232,
 'atp/brand/Rower Miejski Szamotuły Poland (RMS) Poland': 7,
 'atp/brand/Rower Miejski w Ostrowie Wielkopolskim Poland': 12,
 'atp/brand/Rower Powiatowy Sokołów Podlaski': 6,
 'atp/brand/Rowerowe Łódzkie Poland (RL)': 136,
 'atp/brand/Ryde Trondheim': 193,
 'atp/brand/Ryde_Oslo': 720,
 'atp/brand/SAP Walldorf': 10,
 'atp/brand/SBU Wolf Ride Bike Share': 14,
 'atp/brand/San Antonio B-cycle': 15,
 'atp/brand/Santa Barbara BCycle': 86,
 'atp/brand/Santa Cruz BCycle': 104,
 'atp/brand/Santander Cycles - Brunel': 9,
 'atp/brand/Santander Cycles - Milton Keynes': 48,
 'atp/brand/Santander Cycles - Swansea': 5,
 'atp/brand/Saturn': 2,
 'atp/brand/Senica bajk': 24,
 'atp/brand/Share Birrer': 21,
 'atp/brand/Shared Mobility': 7395,
 'atp/brand/Sibiu BikeCity': 57,
 'atp/brand/Sitycleta (Las Palmas)': 71,
 'atp/brand/Slatina Velo City': 5,
 'atp/brand/Sobi Hamilton': 190,
 'atp/brand/StadtRad Greifswald': 20,
 'atp/brand/Stadtmobil Karlsruhe': 492,
 'atp/brand/Stadtmobil Stuttgart': 323,
 'atp/brand/Stadtmobil Südbaden': 289,
 'atp/brand/Stadtrad Innsbruck Austria': 51,
 'atp/brand/Stadtwerk Tauberfranken': 10,
 'atp/brand/Styr & Ställ (Sweden, Göteborg)': 137,
 'atp/brand/System Roweru Gminnego Poland': 4,
 'atp/brand/System Rowerów Miejskich w Pszczynie Poland': 9,
 'atp/brand/TIER': 13914,
 'atp/brand/TUeBICI': 26,
 'atp/brand/Tarnowski Rower Miejski Poland': 18,
 'atp/brand/Topoloveni Bike': 3,
 'atp/brand/Trondheim Bysykkel': 67,
 'atp/brand/Truckee BCycle': 20,
 'atp/brand/Tugo': 41,
 'atp/brand/Tychowski Rower Miejski Poland': 2,
 'atp/brand/UBC': 108,
 'atp/brand/UsedomRad Germany': 99,
 'atp/brand/VAG_Rad': 102,
 'atp/brand/VETURILO Poland': 332,
 'atp/brand/VRNnextbike': 418,
 'atp/brand/VVT REGIORAD Tirol': 26,
 'atp/brand/Valentine Bike Share': 1,
 'atp/brand/Valladolid': 98,
 'atp/brand/Velespeed': 43,
 'atp/brand/Velo Antwerpen': 307,
 'atp/brand/Velo Sântana': 8,
 'atp/brand/Velocity Aachen': 142,
 'atp/brand/Velospot': 863,
 'atp/brand/Verona Bike': 39,
 'atp/brand/Voi': 1508,
 'atp/brand/Vélhop - Strasbourg': 32,
 "atp/brand/Vélib' Metropole": 1497,
 'atp/brand/Vélivert': 56,
 'atp/brand/WE-cycle': 89,
 'atp/brand/WESTcargo powered by nextbike': 10,
 'atp/brand/WK-Bike (Bremen)': 88,
 'atp/brand/WRM nextbike Poland': 238,
 'atp/brand/WienMobil Rad': 229,
 'atp/brand/WinsenRad': 21,
 'atp/brand/Wolsztyński Rower Miejski': 3,
 'atp/brand/Zenica': 15,
 'atp/brand/biciArteixo': 8,
 'atp/brand/carvelo eCargo-Bike Sharing': 331,
 'atp/brand/city bike Linz': 45,
 'atp/brand/eMobi (Croatia)': 26,
 'atp/brand/edrive carsharing': 69,
 'atp/brand/fLotte Brandenburg': 46,
 'atp/brand/ibizi': 5,
 'atp/brand/kotobike': 149,
 'atp/brand/meinRad': 180,
 'atp/brand/meinSiggi': 64,
 'atp/brand/metropolradruhr Germany': 498,
 'atp/brand/mobic': 145,
 'atp/brand/my-e-car': 7,
 'atp/brand/sprintRAD': 52,
 'atp/brand/swu2go Carsharing': 47,
 'atp/brand/westBike': 20,
 'atp/brand/wupsiRad Leverkusen': 100,
 'atp/brand/àVélo': 115,
 'atp/brand/ŁoKeR - Łomża': 15,
 'atp/brand/Łódzki Rower Publiczny': 121,
 'atp/brand/Żyrardowski Rower Miejski Poland': 7,
 'atp/brand_wikidata/Q1034635': 774,
 'atp/brand_wikidata/Q1060525': 1242,
 'atp/brand_wikidata/Q107463014': 59484,
 'atp/brand_wikidata/Q1120762': 1497,
 'atp/brand_wikidata/Q123507620': 925,
 'atp/brand_wikidata/Q16971391': 548,
 'atp/brand_wikidata/Q17018523': 843,
 'atp/brand_wikidata/Q17077936': 1896,
 'atp/brand_wikidata/Q17402113': 1216,
 'atp/brand_wikidata/Q1833385': 513,
 'atp/brand_wikidata/Q20529164': 2268,
 'atp/brand_wikidata/Q2351279': 9779,
 'atp/brand_wikidata/Q2974438': 2213,
 'atp/brand_wikidata/Q3555363': 661,
 'atp/brand_wikidata/Q386': 871,
 'atp/brand_wikidata/Q55533296': 5377,
 'atp/brand_wikidata/Q56314221': 863,
 'atp/brand_wikidata/Q5817067': 1046,
 'atp/brand_wikidata/Q60860236': 736,
 'atp/brand_wikidata/Q61650427': 1508,
 'atp/brand_wikidata/Q63386916': 13914,
 'atp/brand_wikidata/Q63753939': 7685,
 'atp/brand_wikidata/Q91231927': 9010,
 'atp/category/amenity/bicycle_rental': 142397,
 'atp/category/amenity/kick-scooter_rental': 9134,
 'atp/category/missing': 7395,
 'atp/category/public_transport/stop_position': 16365,
 'atp/cdn/cloudflare/response_count': 76,
 'atp/cdn/cloudflare/response_status_count/200': 74,
 'atp/cdn/cloudflare/response_status_count/404': 2,
 'atp/field/branch/missing': 175291,
 'atp/field/brand_wikidata/missing': 50422,
 'atp/field/city/missing': 175201,
 'atp/field/email/missing': 175291,
 'atp/field/image/missing': 175291,
 'atp/field/lat/missing': 9,
 'atp/field/lon/missing': 9,
 'atp/field/name/missing': 6,
 'atp/field/name/wrong_type': 17298,
 'atp/field/opening_hours/missing': 175291,
 'atp/field/operator/missing': 152491,
 'atp/field/operator_wikidata/missing': 154609,
 'atp/field/phone/missing': 166260,
 'atp/field/postcode/missing': 168403,
 'atp/field/state/from_reverse_geocoding': 12750,
 'atp/field/state/missing': 162543,
 'atp/field/street_address/missing': 146366,
 'atp/field/twitter/missing': 175291,
 'atp/field/website/invalid': 568,
 'atp/item_scraped_host_count/abmitlara.de': 11,
 'atp/item_scraped_host_count/acoruna.publicbikesystem.net': 53,
 'atp/item_scraped_host_count/api-public.odpt.org': 14387,
 'atp/item_scraped_host_count/api.delijn.be': 190,
 'atp/item_scraped_host_count/api.entur.io': 2087,
 'atp/item_scraped_host_count/api.mobidata-bw.de': 6726,
 'atp/item_scraped_host_count/api.publibike.ch': 661,
 'atp/item_scraped_host_count/api.saint-etienne-metropole.fr': 56,
 'atp/item_scraped_host_count/api.voiapp.io': 1200,
 'atp/item_scraped_host_count/app.kotobike.jp': 149,
 'atp/item_scraped_host_count/app.linkalock.com': 120,
 'atp/item_scraped_host_count/aruba.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/aspen.publicbikesystem.net': 89,
 'atp/item_scraped_host_count/auto-birrer.ch': 21,
 'atp/item_scraped_host_count/barcelona.publicbikesystem.net': 513,
 'atp/item_scraped_host_count/beryl-gbfs-production.web.app': 2246,
 'atp/item_scraped_host_count/bogota.publicbikesystem.net': 277,
 'atp/item_scraped_host_count/buenosaires.publicbikesystem.net': 369,
 'atp/item_scraped_host_count/chattanooga.publicbikesystem.net': 43,
 'atp/item_scraped_host_count/clermontferrand.publicbikesystem.net': 55,
 'atp/item_scraped_host_count/data-sharing.tier-services.io': 13713,
 'atp/item_scraped_host_count/data.lime.bike': 30,
 'atp/item_scraped_host_count/data.rideflamingo.com': 143,
 'atp/item_scraped_host_count/detroit.publicbikesystem.net': 82,
 'atp/item_scraped_host_count/dubai.publicbikesystem.net': 275,
 'atp/item_scraped_host_count/eu.ftp.opendatasoft.com': 57,
 'atp/item_scraped_host_count/gbfs.api.ridedott.com': 59484,
 'atp/item_scraped_host_count/gbfs.bcycle.com': 1642,
 'atp/item_scraped_host_count/gbfs.bici.madrid': 608,
 'atp/item_scraped_host_count/gbfs.getapony.com': 12951,
 'atp/item_scraped_host_count/gbfs.goabout.com': 70,
 'atp/item_scraped_host_count/gbfs.hopr.city': 404,
 'atp/item_scraped_host_count/gbfs.lyft.com': 6259,
 'atp/item_scraped_host_count/gbfs.mex.lyftbikes.com': 677,
 'atp/item_scraped_host_count/gbfs.nextbike.net': 17643,
 'atp/item_scraped_host_count/gbfs.openov.nl': 283,
 'atp/item_scraped_host_count/gbfs.smartbike.com': 307,
 'atp/item_scraped_host_count/gbfs.urbansharing.com': 1316,
 'atp/item_scraped_host_count/gbfs.velobixi.com': 871,
 'atp/item_scraped_host_count/gbsf.movatic.co': 1,
 'atp/item_scraped_host_count/guadalajara.publicbikesystem.net': 360,
 'atp/item_scraped_host_count/hamilton.socialbicycles.com': 190,
 'atp/item_scraped_host_count/honolulu.publicbikesystem.net': 133,
 'atp/item_scraped_host_count/ixsi.swu.de': 47,
 'atp/item_scraped_host_count/kona.publicbikesystem.net': 23,
 'atp/item_scraped_host_count/madrid.publicbikesystem.net': 608,
 'atp/item_scraped_host_count/mds.bird.co': 3879,
 'atp/item_scraped_host_count/mds.bolt.eu': 2268,
 'atp/item_scraped_host_count/mds.neuron-mobility.com': 1931,
 'atp/item_scraped_host_count/monaco.publicbikesystem.net': 51,
 'atp/item_scraped_host_count/nicosia.publicbikesystem.net': 43,
 'atp/item_scraped_host_count/nitro.openvelo.org': 142,
 'atp/item_scraped_host_count/nordelta.publicbikesystem.net': 21,
 'atp/item_scraped_host_count/opendata.bbnavi.de': 90,
 'atp/item_scraped_host_count/pittsburgh.publicbikesystem.net': 60,
 'atp/item_scraped_host_count/portoalegre.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/quebec.publicbikesystem.net': 115,
 'atp/item_scraped_host_count/recife.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/riodejaneiro.publicbikesystem.net': 406,
 'atp/item_scraped_host_count/riviera.publicbikesystem.net': 7,
 'atp/item_scraped_host_count/saguenay.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/salvador.publicbikesystem.net': 59,
 'atp/item_scraped_host_count/sansebastian.publicbikesystem.net': 69,
 'atp/item_scraped_host_count/santana.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/santiago.publicbikesystem.net': 228,
 'atp/item_scraped_host_count/saopaulo.publicbikesystem.net': 239,
 'atp/item_scraped_host_count/sibiu.publicbikesystem.net': 57,
 'atp/item_scraped_host_count/stables.donkey.bike': 7685,
 'atp/item_scraped_host_count/stonybrook.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/toronto.publicbikesystem.net': 843,
 'atp/item_scraped_host_count/tucson.publicbikesystem.net': 41,
 'atp/item_scraped_host_count/valence.publicbikesystem.net': 52,
 'atp/item_scraped_host_count/valladolid.publicbikesystem.net': 98,
 'atp/item_scraped_host_count/vancouver-gbfs.smoove.pro': 258,
 'atp/item_scraped_host_count/velib-metropole-opendata.smovengo.cloud': 1497,
 'atp/item_scraped_host_count/www.cykl.nl': 13,
 'atp/item_scraped_host_count/www.mibicitubici.gob.ar': 90,
 'atp/item_scraped_host_count/www.sharedmobility.ch': 7395,
 'atp/nsi/brand_missing': 78045,
 'atp/nsi/cc_match': 1374,
 'atp/nsi/match_failed': 24024,
 'atp/nsi/perfect_match': 21426,
 'atp/operator/5M2-BKT': 1046,
 'atp/operator/CityBike Global': 736,
 'atp/operator/Deutsche Bahn Connect': 1242,
 'atp/operator/Donkey Republic': 336,
 'atp/operator/EMT Madrid': 1216,
 'atp/operator/Lyft': 3535,
 'atp/operator/Nextbike GZM': 925,
 'atp/operator/OpenStreet': 9010,
 'atp/operator/Pedalem Barcelona': 513,
 'atp/operator/PubliBike': 1524,
 'atp/operator/Smovengo': 1497,
 'atp/operator/Toronto Parking Authority': 843,
 'atp/operator/nextbike': 41,
 'atp/operator/nextbike Cy Ltd': 266,
 'atp/operator/ТОВ Некстбайк Україна': 70,
 'atp/operator_wikidata/Q1094755': 1216,
 'atp/operator_wikidata/Q1152100': 1242,
 'atp/operator_wikidata/Q123614695': 513,
 'atp/operator_wikidata/Q127573015': 925,
 'atp/operator_wikidata/Q17077936': 3535,
 'atp/operator_wikidata/Q2351279': 41,
 'atp/operator_wikidata/Q3555363': 1524,
 'atp/operator_wikidata/Q43593262': 9010,
 'atp/operator_wikidata/Q47008427': 1497,
 'atp/operator_wikidata/Q63753939': 336,
 'atp/operator_wikidata/Q7826466': 843,
 'downloader/exception_count': 18,
 'downloader/exception_type_count/twisted.internet.error.DNSLookupError': 15,
 'downloader/exception_type_count/twisted.web._newclient.ResponseNeverReceived': 3,
 'downloader/request_bytes': 773265,
 'downloader/request_count': 1662,
 'downloader/request_method_count/GET': 1662,
 'downloader/response_bytes': 32812709,
 'downloader/response_count': 1644,
 'downloader/response_status_count/200': 1573,
 'downloader/response_status_count/301': 12,
 'downloader/response_status_count/302': 2,
 'downloader/response_status_count/307': 1,
 'downloader/response_status_count/400': 4,
 'downloader/response_status_count/401': 5,
 'downloader/response_status_count/403': 1,
 'downloader/response_status_count/404': 34,
 'downloader/response_status_count/502': 12,
 'dupefilter/filtered': 990,
 'elapsed_time_seconds': 1644.956258,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 9, 18, 36, 52, 20821, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 49409974,
 'httpcompression/response_count': 1139,
 'httperror/response_ignored_count': 48,
 'httperror/response_ignored_status_count/400': 4,
 'httperror/response_ignored_status_count/401': 5,
 'httperror/response_ignored_status_count/403': 1,
 'httperror/response_ignored_status_count/404': 34,
 'httperror/response_ignored_status_count/502': 4,
 'item_scraped_count': 175291,
 'log_count/ERROR': 17314,
 'log_count/INFO': 84,
 'memusage/max': 572682240,
 'memusage/startup': 174936064,
 'request_depth_max': 2,
 'response_received_count': 1621,
 'retry/count': 20,
 'retry/max_reached': 10,
 'retry/reason_count/502 Bad Gateway': 8,
 'retry/reason_count/twisted.internet.error.DNSLookupError': 10,
 'retry/reason_count/twisted.web._newclient.ResponseNeverReceived': 2,
 'scheduler/dequeued': 1662,
 'scheduler/dequeued/memory': 1662,
 'scheduler/enqueued': 1662,
 'scheduler/enqueued/memory': 1662,
 'start_time': datetime.datetime(2024, 9, 9, 18, 9, 27, 64563, tzinfo=datetime.timezone.utc)}
```
</details>