### PR TITLE
[open_graph_parser] play a little bit less fast and loose with the namespace

### DIFF
--- a/locations/open_graph_parser.py
+++ b/locations/open_graph_parser.py
@@ -1,16 +1,20 @@
 from locations.dict_parser import DictParser
 from locations.items import Feature
 
+KNOWN_PREFIXES = ["og:", "place:location:", "business:contact_data:"]
+
 
 class OpenGraphParser:
     def extract_properties(self, response):
         keys = response.xpath("/html/head/meta/@property").getall()
         src = {}
         for key in keys:
-            if key.startswith("og:") or key.startswith("place:location:") or key.startswith("business:contact_data:"):
-                content = response.xpath('//meta[@property="{}"]/@content'.format(key)).get()
-                if content:
-                    src[key.split(":")[-1]] = content
+            for known_prefix in KNOWN_PREFIXES:
+                if key.startswith(known_prefix):
+                    if content := response.xpath('//meta[@property="{}"]/@content'.format(key)).get():
+                        src[key.split(known_prefix)[-1]] = content
+                        # No need to look at other KNOWN_PREFIXES
+                        break
         return src
 
     def as_item(self, properties, response):


### PR DESCRIPTION
I noticed that my [local Franco Manca](https://www.francomanca.co.uk/restaurants/edinburgh-stockbridge/) was no longer in the output! Traced to new property keys appearing on the page and the code to build dict for `DictParser` taking away too much of the context.
