### PR TITLE
Wetzel's Pretzels (391 locations)

### DIFF
--- a/locations/spiders/wetzels_pretzels_ca_us.py
+++ b/locations/spiders/wetzels_pretzels_ca_us.py
@@ -1,0 +1,7 @@
+from locations.storefinders.storemapper import StoremapperSpider
+
+
+class WetzelsPretzelsCAUSSpider(StoremapperSpider):
+    name = "wetzels_pretzels_ca_us"
+    item_attributes = {"brand": "Wetzel's Pretzels", "brand_wikidata": "Q7990205"}
+    company_id = "13346"


### PR DESCRIPTION
```py
{"atp/brand/Wetzel's Pretzels": 391,
 'atp/brand_wikidata/Q7990205': 391,
 'atp/category/amenity/fast_food': 391,
 'atp/field/branch/missing': 391,
 'atp/field/city/missing': 391,
 'atp/field/country/from_reverse_geocoding': 391,
 'atp/field/email/missing': 390,
 'atp/field/image/missing': 391,
 'atp/field/opening_hours/missing': 391,
 'atp/field/operator/missing': 391,
 'atp/field/operator_wikidata/missing': 391,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 26,
 'atp/field/postcode/missing': 391,
 'atp/field/street_address/missing': 391,
 'atp/field/twitter/missing': 391,
 'atp/field/website/missing': 391,
 'atp/item_scraped_host_count/storemapper-herokuapp-com.global.ssl.fastly.net': 391,
 'atp/nsi/perfect_match': 391,
 'downloader/request_bytes': 368,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 34813,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.211845,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 10, 19, 47, 16, 326695, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 374844,
 'httpcompression/response_count': 1,
 'item_scraped_count': 391,
 'log_count/DEBUG': 403,
 'log_count/INFO': 9,
 'memusage/max': 170889216,
 'memusage/startup': 170889216,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 10, 19, 47, 15, 114850, tzinfo=datetime.timezone.utc)}
```