### PR TITLE
[hertz] use different API, parse all POIs (6661 locations)

### DIFF
--- a/locations/spiders/hertz.py
+++ b/locations/spiders/hertz.py
@@ -61,15 +61,15 @@ class HertzSpider(Spider):
             poi = poi["data"]
             item = DictParser.parse(poi)
             item["ref"] = poi.get("oag")
-            item["country"] = poi.get("countryCode")
             item["branch"] = item.pop("name")
+            item["country"] = poi.get("countryCode")
+            item["street_address"] = poi.get("address2")
             item["extras"]["check_date"] = (
                 datetime.strptime(poi.get("lastUpdated"), "%a %b %d %H:%M:%S UTC %Y").strftime("%Y-%m-%d")
                 if poi.get("lastUpdated")
                 else None
             )
             item["extras"]["fax"] = poi.get("fax")
-
             item["website"] = (
                 (
                     "https://www.hertz.com/rentacar/location/"
@@ -81,8 +81,8 @@ class HertzSpider(Spider):
                 .lower()
                 .replace(" ", "")
             )
+            item["extras"]["type"] = poi.get("type")
 
-            item["street_address"] = poi.get("address2")
             oh = OpeningHours()
             for day, day_hours in poi.get("openHours", {}).items():
                 day = DAYS_EN.get(day.title())
@@ -92,7 +92,9 @@ class HertzSpider(Spider):
                 for hours in day_hours:
                     oh.add_range(day, hours["start"], hours["end"])
             item["opening_hours"] = oh
+
             apply_category(Categories.CAR_RENTAL, item)
             yield item
+
         if next_page := response["_links"].get("next", {}).get("href"):
             yield from self.get_locations_page(next_page)


### PR DESCRIPTION
rel: #3899 

A general improvement of the spider - using another API we get all locations in 9 requests (26 seconds). In exchange there is no payment types information. 
Authorization might be a bit brittle, if it's a problem we can try another API, as there are 3 of them with different data...

```json
{
 "atp/brand/Hertz": 6661,
 "atp/brand_wikidata/Q1543874": 6661,
 "atp/category/amenity/car_rental": 6661,
 "atp/field/city/missing": 14,
 "atp/field/email/invalid": 1,
 "atp/field/email/missing": 2753,
 "atp/field/image/missing": 6661,
 "atp/field/lat/invalid": 1,
 "atp/field/lat/missing": 14,
 "atp/field/lon/missing": 14,
 "atp/field/operator/missing": 6661,
 "atp/field/operator_wikidata/missing": 6661,
 "atp/field/phone/invalid": 366,
 "atp/field/postcode/missing": 426,
 "atp/field/state/from_reverse_geocoding": 30,
 "atp/field/state/missing": 3149,
 "atp/field/street_address/missing": 14,
 "atp/field/twitter/missing": 6661,
 "atp/geometry/null_island": 11,
 "atp/item_scraped_host_count/api.hertz.io": 6661,
 "atp/nsi/perfect_match": 6661,
 "downloader/request_bytes": 11384,
 "downloader/request_count": 9,
 "downloader/request_method_count/GET": 8,
 "downloader/request_method_count/POST": 1,
 "downloader/response_bytes": 1672125,
 "downloader/response_count": 9,
 "downloader/response_status_count/200": 8,
 "downloader/response_status_count/403": 1,
 "elapsed_time_seconds": 5.13268,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-09-11T09:25:28.644138+00:00",
 "httpcache/hit": 9,
 "httpcompression/response_bytes": 13046444,
 "httpcompression/response_count": 8,
 "item_scraped_count": 6661,
 "log_count/INFO": 10,
 "memusage/max": 224542720,
 "memusage/startup": 224542720,
 "request_depth_max": 7,
 "response_received_count": 9,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/403": 1,
 "scheduler/dequeued": 8,
 "scheduler/dequeued/memory": 8,
 "scheduler/enqueued": 8,
 "scheduler/enqueued/memory": 8,
 "start_time": "2024-09-11T09:25:23.511458+00:00"
}
```