### PR TITLE
[Bank OZK US] Add spider

### DIFF
--- a/locations/spiders/ozk_bank_us.py
+++ b/locations/spiders/ozk_bank_us.py
@@ -1,0 +1,54 @@
+import json
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class OzkBankUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "ozk_bank_us"
+    item_attributes = {"brand": "Bank OZK", "brand_wikidata": "Q20708654"}
+    start_urls = ["https://www.ozk.com/locations/locations-list/"]
+    rules = [
+        Rule(LinkExtractor(r"/locations-list/\w\w$")),
+        Rule(LinkExtractor(r"/locations-list/\w\w/[^/]+$")),
+        Rule(LinkExtractor(r"/locations/\w\w/[^/]+/[^/]+/?$"), "parse"),
+    ]
+    wanted_types = ["BankOrCreditUnion"]
+    time_format = "%H:%M:%S"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item["phone"] == "+17702928000":
+            return  # Duplicate ld json on every page
+
+        apply_category(Categories.BANK, item)
+        yield item
+
+        if data := response.xpath('//div[@class="store-hours drive hours-box"]//astro-island/@props').get():
+            atm = Feature()
+            atm["opening_hours"] = self.parse_opening_hours(json.loads(data))
+            atm["ref"] = "{}-ATM".format(item["ref"])
+            atm["lat"] = item["lat"]
+            atm["lon"] = item["lon"]
+
+            apply_category(Categories.ATM, atm)
+            apply_yes_no(Extras.DRIVE_THROUGH, atm, True)
+
+            yield atm
+
+    def parse_opening_hours(self, data: dict) -> OpeningHours:
+        oh = OpeningHours()
+        for day, rules in data["hours"][1].items():
+            if rules[1]["status"][1] == "Closed":
+                oh.set_closed(day)
+            else:
+                for times in rules[1]["blocks"][1]:
+                    end_time = times[1]["to"][1]
+                    if end_time == "2400":
+                        end_time = "2359"
+                    oh.add_range(day, times[1]["from"][1], end_time, "%H%M")
+        return oh

--- a/locations/spiders/ozk_bank_us.py
+++ b/locations/spiders/ozk_bank_us.py
@@ -25,9 +25,6 @@ class OzkBankUSSpider(CrawlSpider, StructuredDataSpider):
         if item["phone"] == "+17702928000":
             return  # Duplicate ld json on every page
 
-        apply_category(Categories.BANK, item)
-        yield item
-
         if data := response.xpath('//div[@class="store-hours drive hours-box"]//astro-island/@props').get():
             atm = Feature()
             atm["opening_hours"] = self.parse_opening_hours(json.loads(data))
@@ -39,6 +36,9 @@ class OzkBankUSSpider(CrawlSpider, StructuredDataSpider):
             apply_yes_no(Extras.DRIVE_THROUGH, atm, True)
 
             yield atm
+
+        apply_category(Categories.BANK, item)
+        yield item
 
     def parse_opening_hours(self, data: dict) -> OpeningHours:
         oh = OpeningHours()


### PR DESCRIPTION
```python
{'atp/brand/Bank OZK': 464,
 'atp/brand_wikidata/Q20708654': 464,
 'atp/category/amenity/atm': 230,
 'atp/category/amenity/bank': 234,
 'atp/cdn/cloudflare/response_count': 414,
 'atp/cdn/cloudflare/response_status_count/200': 413,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/branch/missing': 464,
 'atp/field/city/missing': 230,
 'atp/field/country/from_spider_name': 230,
 'atp/field/email/missing': 464,
 'atp/field/image/missing': 464,
 'atp/field/name/missing': 230,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 464,
 'atp/field/operator_wikidata/missing': 464,
 'atp/field/phone/missing': 230,
 'atp/field/postcode/missing': 230,
 'atp/field/state/from_reverse_geocoding': 230,
 'atp/field/street_address/missing': 230,
 'atp/field/twitter/missing': 230,
 'atp/field/website/missing': 230,
 'atp/item_scraped_host_count/www.ozk.com': 464,
 'atp/nsi/brand_missing': 464,
 'downloader/request_bytes': 187954,
 'downloader/request_count': 477,
 'downloader/request_method_count/GET': 477,
 'downloader/response_bytes': 33690313,
 'downloader/response_count': 477,
 'downloader/response_status_count/200': 413,
 'downloader/response_status_count/308': 63,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 163,
 'elapsed_time_seconds': 6.271152,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 11, 11, 29, 42, 322004, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 477,
 'httpcompression/response_bytes': 172298566,
 'httpcompression/response_count': 414,
 'item_scraped_count': 464,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 258560000,
 'memusage/startup': 258560000,
 'request_depth_max': 3,
 'response_received_count': 414,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 476,
 'scheduler/dequeued/memory': 476,
 'scheduler/enqueued': 476,
 'scheduler/enqueued/memory': 476,
 'start_time': datetime.datetime(2024, 9, 11, 11, 29, 36, 50852, tzinfo=datetime.timezone.utc)}
```