### PR TITLE
[Formula One Autocentres GB] Add spider

### DIFF
--- a/locations/spiders/formula_one_autocentres_gb.py
+++ b/locations/spiders/formula_one_autocentres_gb.py
@@ -1,0 +1,41 @@
+import html
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import apply_yes_no
+from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class FormulaOneAutocentresGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "formula_one_autocentres_gb"
+    item_attributes = {"brand": "Formula One Autocentres", "brand_wikidata": "Q79239635"}
+    sitemap_urls = ["https://www.f1autocentres.co.uk/sitemap.xml"]
+    sitemap_rules = [("/branch/", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["website"] = item["ref"] = response.url
+        item["image"] = None
+
+        item["branch"] = html.unescape(item.pop("name").removeprefix("Formula One Autocentres "))
+
+        item["opening_hours"] = OpeningHours()
+        for rule in response.xpath('//table[@class="opening-times-table"]/tbody/tr'):
+            day, start_time, end_time = rule.xpath("./td/text()").getall()
+            item["opening_hours"].add_range(day, start_time, end_time, "%I:%M%p")
+
+        services = response.xpath('//div[@class="services"]//div[@class="columns"]/text()').getall()
+
+        apply_yes_no("service:vehicle:air_conditioning", item, "Air Conditioning" in services)
+        apply_yes_no("service:vehicle:batteries", item, "Batteries" in services)
+        apply_yes_no("service:vehicle:brakes", item, "Brakes" in services)
+        apply_yes_no("service:vehicle:tyres", item, "Car Tyres" in services)
+        # apply_yes_no("", item, "Clutches" in services)
+        # apply_yes_no("", item, "Exhausts" in services)
+        apply_yes_no("service:vehicle:mot", item, "MOT" in services)
+        apply_yes_no("service:vehicle:tyres_repair", item, "Puncture Repair" in services)
+        # apply_yes_no("", item, "Servicing" in services)
+        # apply_yes_no("", item, "Suspension & Shock Absorbers" in services)
+        # apply_yes_no("", item, "Wheel Alignment" in services)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Formula One Autocentres': 154,
 'atp/brand_wikidata/Q79239635': 154,
 'atp/category/shop/car_repair': 154,
 'atp/cdn/cloudflare/response_count': 156,
 'atp/cdn/cloudflare/response_status_count/200': 156,
 'atp/field/email/missing': 154,
 'atp/field/image/missing': 154,
 'atp/field/operator/missing': 154,
 'atp/field/operator_wikidata/missing': 154,
 'atp/field/state/missing': 142,
 'atp/item_scraped_host_count/www.f1autocentres.co.uk': 154,
 'atp/nsi/perfect_match': 154,
 'downloader/request_bytes': 172471,
 'downloader/request_count': 156,
 'downloader/request_method_count/GET': 156,
 'downloader/response_bytes': 2262895,
 'downloader/response_count': 156,
 'downloader/response_status_count/200': 156,
 'elapsed_time_seconds': 1.629022,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 11, 14, 40, 31, 105302, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 156,
 'httpcompression/response_bytes': 9289023,
 'httpcompression/response_count': 156,
 'item_scraped_count': 154,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 254238720,
 'memusage/startup': 254238720,
 'request_depth_max': 1,
 'response_received_count': 156,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 155,
 'scheduler/dequeued/memory': 155,
 'scheduler/enqueued': 155,
 'scheduler/enqueued/memory': 155,
 'start_time': datetime.datetime(2024, 9, 11, 14, 40, 29, 476280, tzinfo=datetime.timezone.utc)}
```