### PR TITLE
[Kaporal FR] Add spider

### DIFF
--- a/locations/spiders/kaporal_fr.py
+++ b/locations/spiders/kaporal_fr.py
@@ -5,6 +5,7 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class KaporalFRSpider(Spider):
@@ -21,6 +22,7 @@ class KaporalFRSpider(Spider):
             if obj["__typename"] != "KaporalShop":
                 continue
             item = DictParser.parse(obj)
+            item["street_address"] = merge_address_lines([obj["street1"], obj["street2"]])
             item["website"] = item["extras"]["website:fr"] = "https://www.kaporal.com/fr_fr{}".format(obj["url"])
             item["extras"]["website:en"] = "https://www.kaporal.com/en_fr{}".format(obj["url"])
 

--- a/locations/spiders/kaporal_fr.py
+++ b/locations/spiders/kaporal_fr.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+import chompjs
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+
+
+class KaporalFRSpider(Spider):
+    name = "kaporal_fr"
+    item_attributes = {"brand": "Kaporal", "brand_wikidata": "Q125660181"}
+    start_urls = ["https://www.kaporal.com/fr_fr/shops"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for key, obj in chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "__APOLLO_STATE__")]/text()').get()
+        ).items():
+            # if not key.startswith("KaporalShop"):
+            #    continue
+            if obj["__typename"] != "KaporalShop":
+                continue
+            item = DictParser.parse(obj)
+            item["website"] = item["extras"]["website:fr"] = "https://www.kaporal.com/fr_fr{}".format(obj["url"])
+            item["extras"]["website:en"] = "https://www.kaporal.com/en_fr{}".format(obj["url"])
+
+            item["branch"] = item.pop("name").removeprefix("KAPORAL STORE ")
+            if item["branch"].startswith("OUTLET "):
+                item["branch"] = item["branch"].removeprefix("OUTLET ")
+                item["extras"]["factory_outlet"] = "yes"
+
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/9938

```python
{'atp/brand/Kaporal': 55,
 'atp/brand_wikidata/Q125660181': 55,
 'atp/category/missing': 55,
 'atp/field/email/missing': 55,
 'atp/field/image/missing': 55,
 'atp/field/name/missing': 55,
 'atp/field/opening_hours/missing': 55,
 'atp/field/operator/missing': 55,
 'atp/field/operator_wikidata/missing': 55,
 'atp/field/state/missing': 55,
 'atp/field/twitter/missing': 55,
 'atp/item_scraped_host_count/www.kaporal.com': 55,
 'atp/nsi/brand_missing': 55,
 'downloader/request_bytes': 613,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 122132,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.994328,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 11, 15, 55, 6, 188261, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 2,
 'httpcache/miss': 2,
 'httpcache/store': 2,
 'httpcompression/response_bytes': 1268022,
 'httpcompression/response_count': 2,
 'item_scraped_count': 55,
 'log_count/DEBUG': 69,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 251461632,
 'memusage/startup': 251461632,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 9, 11, 15, 55, 3, 193933, tzinfo=datetime.timezone.utc)}
```