### PR TITLE
[toyota_ca] Add spider (247 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -501,6 +501,8 @@ class Extras(Enum):
     TOILETS_WHEELCHAIR = "toilets:wheelchair"
     TRUCK_WASH = "truck_wash"
     TYRE_SERVICES = "service:vehicle:tyres"
+    USED_CAR_PARTS = "service:vehicle:used_car_parts"
+    USED_CAR_SALES = "service:vehicle:used_car_sales"
     VACUUM_CLEANER = "vacuum_cleaner"
     WHEELCHAIR = "wheelchair"
     WIFI = "internet_access=wlan"

--- a/locations/json_blob_spider.py
+++ b/locations/json_blob_spider.py
@@ -89,6 +89,7 @@ class JSONBlobSpider(Spider):
                 feature["id"] = feature_id
             else:
                 feature["feature_id"] = feature_id
+            self.pre_process_data(feature)
             item = DictParser.parse(feature)
             yield from self.post_process_item(item, response, feature) or []
 

--- a/locations/spiders/toyota_ca.py
+++ b/locations/spiders/toyota_ca.py
@@ -19,15 +19,15 @@ class ToyotaCASpider(JSONBlobSpider):
         if "New Vehicle Sales" in departments:
             apply_category(Categories.SHOP_CAR, item)
             apply_yes_no(Extras.USED_CAR_SALES, item, "Pre-owned Vehicle Sales" in departments)
-            apply_yes_no(Extras.USED_CAR_PARTS, item, "Parts" in departments)
+            apply_yes_no(Extras.CAR_PARTS, item, "Parts" in departments)
             apply_yes_no(Extras.CAR_REPAIR, item, "Service" in departments)
         elif "Pre-owned Vehicle Sales" in departments:
             apply_category(Categories.SHOP_CAR, item)
-            apply_yes_no(Extras.USED_CAR_PARTS, item, "Parts" in departments)
+            apply_yes_no(Extras.CAR_PARTS, item, "Parts" in departments)
             apply_yes_no(Extras.CAR_REPAIR, item, "Service" in departments)
         elif "Service" in departments:
             apply_category(Categories.SHOP_CAR_REPAIR, item)
-            apply_yes_no(Extras.USED_CAR_PARTS, item, "Parts" in departments)
+            apply_yes_no(Extras.CAR_PARTS, item, "Parts" in departments)
         elif "Parts" in departments:
             apply_category(Categories.SHOP_CAR_PARTS, item)
 

--- a/locations/spiders/toyota_ca.py
+++ b/locations/spiders/toyota_ca.py
@@ -1,0 +1,39 @@
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.toyota_au import TOYOTA_SHARED_ATTRIBUTES
+
+
+class ToyotaCASpider(JSONBlobSpider):
+    name = "toyota_ca"
+    item_attributes = TOYOTA_SHARED_ATTRIBUTES
+    start_urls = ["https://www.toyota.ca/toyota/data/dealer/.json"]
+    locations_key = "dealers"
+
+    def pre_process_data(self, location):
+        location["name_dict"] = location.pop("name")
+        location["name"] = location["name_dict"].get("en")
+
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.SHOP_CAR, item)
+        if location["name_dict"].get("en") != location["name_dict"].get("fr"):
+            item["extras"]["name:en"] = location["name_dict"].get("en")
+            item["extras"]["name:fr"] = location["name_dict"].get("fr")
+        item["phone"] = "; ".join([phone["CompleteNumber"]["$"] for phone in location["phoneNumbers"]])
+
+        item["opening_hours"] = OpeningHours()
+        for department in location["departments"]:
+            if department["name"]["en"] == "New Vehicle Sales":
+                for hour in department["hours"]:
+                    if "toDay" in hour:
+                        item["opening_hours"].add_ranges_from_string(
+                            f"{hour['fromDay']['en']}-{hour['toDay']['en']} {hour['startTime']['en']}-{hour['endTime']['en']}"
+                        )
+                    else:
+                        item["opening_hours"].add_ranges_from_string(
+                            f"{hour['fromDay']['en']} {hour['startTime']['en']}-{hour['endTime']['en']}"
+                        )
+            elif "hours" in department:
+                self.crawler.stats.inc_value(f"atp/{self.name}/other_opening_hours_type/{department['name']['en']}")
+
+        yield item


### PR DESCRIPTION
Waiting on merge of https://github.com/alltheplaces/alltheplaces/pull/10226 for shared attributes

Also I found here that for a feature dict, the pre_process_data had not been applying in JSONBlobSpider, so I added that.

```
 'atp/brand/Toyota': 247,
 'atp/brand_wikidata/Q53268': 247,
 'atp/category/shop/car': 247,
 'atp/field/branch/missing': 247,
 'atp/field/country/from_spider_name': 247,
 'atp/field/email/missing': 247,
 'atp/field/image/missing': 247,
 'atp/field/operator/missing': 247,
 'atp/field/operator_wikidata/missing': 247,
 'atp/field/twitter/missing': 247,
 'atp/field/website/missing': 247,
 'atp/item_scraped_host_count/www.toyota.ca': 247,
 'atp/nsi/cc_match': 247,
```