### PR TITLE
[toyota_br] Add spider (294 locations)

### DIFF
--- a/locations/pipelines/phone_clean_up.py
+++ b/locations/pipelines/phone_clean_up.py
@@ -26,7 +26,9 @@ class PhoneCleanUpPipeline:
 
     @staticmethod
     def is_phone_key(tag):
-        return tag in ("phone", "fax", "contact:sms") or tag.endswith(":phone") or tag.endswith(":fax")
+        return (
+            tag in ("phone", "fax", "contact:sms", "contact:whatsapp") or tag.endswith(":phone") or tag.endswith(":fax")
+        )
 
     def normalize_numbers(self, phone, country, spider):
         numbers = [self.normalize(p, country, spider) for p in re.split(r"[;/]\s", str(phone))]

--- a/locations/spiders/toyota_br.py
+++ b/locations/spiders/toyota_br.py
@@ -1,6 +1,6 @@
 from chompjs import parse_js_object
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import OpeningHours
 from locations.items import SocialMedia, set_social_media
 from locations.json_blob_spider import JSONBlobSpider
@@ -27,7 +27,12 @@ class ToyotaBRSpider(JSONBlobSpider):
         location["website"] = location.pop("site")
 
     def post_process_item(self, item, response, location):
+        services = [service["title"] for service in location["services"]]
+        for service in services:
+            self.crawler.stats.inc_value(f"atp/{self.name}/services/{service}")
+        # There don't seem to be many interesting categories to apply
         apply_category(Categories.SHOP_CAR, item)
+        apply_yes_no(Extras.TYRE_SERVICES, item, "Menu de pneus" in services)
 
         emails = [location.get("contactEmail"), location.get("salesEmail")]
         item["email"] = "; ".join([e for e in emails if e is not None])

--- a/locations/spiders/toyota_br.py
+++ b/locations/spiders/toyota_br.py
@@ -1,0 +1,52 @@
+from chompjs import parse_js_object
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import SocialMedia, set_social_media
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.toyota_au import TOYOTA_SHARED_ATTRIBUTES
+
+SOCIAL_MEDIA_MAP = {
+    "instagram": SocialMedia.INSTAGRAM,
+    "facebook": SocialMedia.FACEBOOK,
+    "x": SocialMedia.TWITTER,
+}
+
+
+class ToyotaBRSpider(JSONBlobSpider):
+    name = "toyota_br"
+    item_attributes = TOYOTA_SHARED_ATTRIBUTES
+    start_urls = ["https://www.toyota.com.br/contato/localize-uma-concessionaria"]
+
+    def extract_json(self, response):
+        data_raw = response.xpath('.//script[@id="__NEXT_DATA__"]/text()').get()
+        return parse_js_object(data_raw.split('"dealers":')[1])
+
+    def pre_process_data(self, location):
+        location["address"]["house_number"] = location["address"].pop("number", None)
+        location["website"] = location.pop("site")
+
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.SHOP_CAR, item)
+
+        emails = [location.get("contactEmail"), location.get("salesEmail")]
+        item["email"] = "; ".join([e for e in emails if e is not None])
+
+        set_social_media(item, SocialMedia.WHATSAPP, location.get("whatsapp"))
+        if (
+            location["dealerProducts"][0].get("attributes") is not None
+            and location["dealerProducts"][0]["attributes"].get("socialMedia") is not None
+        ):
+            social_medias = location["dealerProducts"][0]["attributes"]["socialMedia"]
+            for social_media in social_medias:
+                if service := SOCIAL_MEDIA_MAP.get(social_media["name"]):
+                    set_social_media(item, service, social_media["value"].strip())
+                else:
+                    self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_social_meda/{social_media['name']}")
+
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(f"Mo-Fr {location.get('showRoomWeekDaysHour')}")
+        item["opening_hours"].add_ranges_from_string(f"Sa {location.get('hfShowRoomSaturdayHour')}")
+        item["opening_hours"].add_ranges_from_string(f"Su {location.get('hfShowRoomSundayHour')}")
+
+        yield item

--- a/tests/test_pipeline_phone_cleanup.py
+++ b/tests/test_pipeline_phone_cleanup.py
@@ -31,7 +31,7 @@ def test_handle():
     pipeline.process_item(item, spider)
     assert item.get("phone") == "+32 2 633 17 59"
 
-    for key in ["fax", "operator:phone", "operator:fax"]:
+    for key in ["fax", "operator:phone", "operator:fax", "contact:whatsapp"]:
         assert pipeline.is_phone_key(key)
         item, pipeline, spider = get_objects(None, "TR")
         item["extras"] = {key: "+904441442"}


### PR DESCRIPTION
Waiting on merge of #10186 for shared attributes.

```
'atp/brand/Toyota': 294,
 'atp/brand_wikidata/Q53268': 294,
 'atp/category/shop/car': 294,
 'atp/field/branch/missing': 294,
 'atp/field/country/from_spider_name': 294,
 'atp/field/email/invalid': 184,
 'atp/field/email/missing': 185,
 'atp/field/image/missing': 294,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 294,
 'atp/field/operator_wikidata/missing': 294,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 5,
 'atp/field/street_address/missing': 294,
 'atp/field/twitter/missing': 294,
 'atp/field/website/invalid': 257,
 'atp/field/website/missing': 2,
 'atp/item_scraped_host_count/www.toyota.com.br': 294,
 'atp/nsi/cc_match': 294,
```