### PR TITLE
[lidl spiders] fixes after virtualearth spider refactoring

### DIFF
--- a/locations/spiders/lidl_ch.py
+++ b/locations/spiders/lidl_ch.py
@@ -7,5 +7,5 @@ class LidlCHSpider(LidlATSpider):
 
     dataset_id = "7d24986af4ad4548bb34f034b067d207"
     dataset_name = "Filialdaten-CH/Filialdaten-CH"
-    key = "AijRQid01hkLFxKFV7vcRwCWv1oPyY5w6XIWJ-LdxHXxwfH7UUG46Z7dMknbj_rL"
+    api_key = "AijRQid01hkLFxKFV7vcRwCWv1oPyY5w6XIWJ-LdxHXxwfH7UUG46Z7dMknbj_rL"
     days = DAYS_IT

--- a/locations/spiders/lidl_cy.py
+++ b/locations/spiders/lidl_cy.py
@@ -7,5 +7,5 @@ class LidlCYSpider(LidlATSpider):
 
     dataset_id = "cb33ea3051cb48c29ed0bf1022885485"
     dataset_name = "Filialdaten-CY/Filialdaten-CY"
-    key = "AmX2Tc6F7G8vXa586XIzoFwbnhI3ViP6BvDenldmtaxLB1uELgvbADtwRxdwEZTS"
+    api_key = "AmX2Tc6F7G8vXa586XIzoFwbnhI3ViP6BvDenldmtaxLB1uELgvbADtwRxdwEZTS"
     days = DAYS_ES

--- a/locations/spiders/lidl_cz.py
+++ b/locations/spiders/lidl_cz.py
@@ -7,5 +7,5 @@ class LidlCZSpider(LidlATSpider):
 
     dataset_id = "f6c4e6f3d86d464088f7a6db1598538e"
     dataset_name = "Filialdaten-CZ/Filialdaten-CZ"
-    key = "AiNNY2F5r0vNd6fJFLwr-rT5fPEDBzibjcQ0KMyUalKrIqaoM8HUlNAMEFFkBEv-"
+    api_key = "AiNNY2F5r0vNd6fJFLwr-rT5fPEDBzibjcQ0KMyUalKrIqaoM8HUlNAMEFFkBEv-"
     days = DAYS_CZ

--- a/locations/spiders/lidl_dk.py
+++ b/locations/spiders/lidl_dk.py
@@ -7,5 +7,5 @@ class LidlDKSpider(LidlATSpider):
 
     dataset_id = "9ca2963cb5f44aa3b4c241fed29895f8"
     dataset_name = "Filialdaten-DK/Filialdaten-DK"
-    key = "AsaaAZuUgeIzOb829GUz0a2yjzX0Xw1-OTmjH_27CS5ilYr5v9ylNxg4rQSRhh8Z"
+    api_key = "AsaaAZuUgeIzOb829GUz0a2yjzX0Xw1-OTmjH_27CS5ilYr5v9ylNxg4rQSRhh8Z"
     days = DAYS_DK

--- a/locations/spiders/lidl_ee.py
+++ b/locations/spiders/lidl_ee.py
@@ -7,5 +7,5 @@ class LidlEESpider(LidlATSpider):
 
     dataset_id = "f3201025df8a4f0084ab28a941fc61a2"
     dataset_name = "Filialdaten-EE/Filialdaten-ee"
-    key = "AoKxuS8Tx5-VZMhvnRZgacG6XJaANkWzi2fZ49KrJCh72EkdH8qpNfodnH-S-pKq"
+    api_key = "AoKxuS8Tx5-VZMhvnRZgacG6XJaANkWzi2fZ49KrJCh72EkdH8qpNfodnH-S-pKq"
     days = DAYS_ES

--- a/locations/spiders/lidl_es.py
+++ b/locations/spiders/lidl_es.py
@@ -7,5 +7,5 @@ class LidlESSpider(LidlATSpider):
 
     dataset_id = "b5843d604cd14b9099f57cb23a363702"
     dataset_name = "Filialdaten-ES/Filialdaten-ES"
-    key = "AjhJAzQQN7zhpMcZcJinxel86P600c6JcsHsyNjlqpO7MhjrPO-lcpDGHF9jNZOw"
+    api_key = "AjhJAzQQN7zhpMcZcJinxel86P600c6JcsHsyNjlqpO7MhjrPO-lcpDGHF9jNZOw"
     days = DAYS_ES

--- a/locations/spiders/lidl_fi.py
+++ b/locations/spiders/lidl_fi.py
@@ -7,5 +7,5 @@ class LidlFISpider(LidlATSpider):
 
     dataset_id = "d5239b243d6b4672810cbd11f82750f5"
     dataset_name = "Filialdaten-FI/Filialdaten-FI"
-    key = "AhRg1sJKLrhfytyanzu32Io1e7le8W-AZs5Xo88SgdwF33tPSxjVn9h72EpJ7gqD"
+    api_key = "AhRg1sJKLrhfytyanzu32Io1e7le8W-AZs5Xo88SgdwF33tPSxjVn9h72EpJ7gqD"
     days = DAYS_FI

--- a/locations/spiders/lidl_fr.py
+++ b/locations/spiders/lidl_fr.py
@@ -7,5 +7,5 @@ class LidlFRSpider(LidlBESpider):
 
     dataset_id = "717c7792c09a4aa4a53bb789c6bb94ee"
     dataset_name = "Filialdaten-FR/Filialdaten-FR"
-    key = "AgC167Ojch2BCIEvqkvyrhl-yLiZLv6nCK_p0K1wyilYx4lcOnTjm6ud60JnqQAa"
+    api_key = "AgC167Ojch2BCIEvqkvyrhl-yLiZLv6nCK_p0K1wyilYx4lcOnTjm6ud60JnqQAa"
     days = DAYS_FR

--- a/locations/spiders/lidl_gr.py
+++ b/locations/spiders/lidl_gr.py
@@ -7,5 +7,5 @@ class LidlGRSpider(LidlATSpider):
 
     dataset_id = "c1070f3f97ad43c7845ab237eef704c0"
     dataset_name = "Filialdaten-GR/Filialdaten-GR"
-    key = "AjbddE6Qo-RdEfEZ74HKQxTGiCSM4dEoDL5uGGCiw7nOWaQiaKWSzPoGpezAfY_x"
+    api_key = "AjbddE6Qo-RdEfEZ74HKQxTGiCSM4dEoDL5uGGCiw7nOWaQiaKWSzPoGpezAfY_x"
     days = DAYS_GR

--- a/locations/spiders/lidl_hu.py
+++ b/locations/spiders/lidl_hu.py
@@ -7,5 +7,5 @@ class LidlHUSpider(LidlATSpider):
 
     dataset_id = "4c781cd459b444558df3d574f082358d"
     dataset_name = "Filialdaten-HU/Filialdaten-HU"
-    key = "Ao1GqKj4R8CqJrqpewEs49enx3QSzeWBPtSei353drKi3WWHOzPad_qzp3Fn7qs0"
+    api_key = "Ao1GqKj4R8CqJrqpewEs49enx3QSzeWBPtSei353drKi3WWHOzPad_qzp3Fn7qs0"
     days = DAYS_HU

--- a/locations/spiders/lidl_it.py
+++ b/locations/spiders/lidl_it.py
@@ -7,5 +7,5 @@ class LidlITSpider(LidlATSpider):
 
     dataset_id = "a360ccf2bf8c442da306b6eb56c638d7"
     dataset_name = "Filialdaten-IT/Filialdaten-IT"
-    key = "AotMQpa96W8m5_F4ayN9WYBaEQLlxtI3ma8VpOWubmVHTOdZmmKoXjZ8IGLnratj"
+    api_key = "AotMQpa96W8m5_F4ayN9WYBaEQLlxtI3ma8VpOWubmVHTOdZmmKoXjZ8IGLnratj"
     days = DAYS_IT

--- a/locations/spiders/lidl_lt.py
+++ b/locations/spiders/lidl_lt.py
@@ -7,5 +7,5 @@ class LidlLTSpider(LidlATSpider):
 
     dataset_id = "8a2167d4bd8a47d9930fc73f5837f0bf"
     dataset_name = "Filialdaten-LT/Filialdaten-LT"
-    key = "AkEdcFBe-gxNmSmCIpOKE_KuLBZv-NHRKY_ndbJKiVvc0ramz4hZKta-rZRpuNZS"
+    api_key = "AkEdcFBe-gxNmSmCIpOKE_KuLBZv-NHRKY_ndbJKiVvc0ramz4hZKta-rZRpuNZS"
     days = DAYS_ES

--- a/locations/spiders/lidl_lv.py
+++ b/locations/spiders/lidl_lv.py
@@ -7,5 +7,5 @@ class LidlLVSpider(LidlATSpider):
 
     dataset_id = "b2565f2cd7f64c759e2b5707b969e8dd"
     dataset_name = "Filialdaten-LV/Filialdaten-lv"
-    key = "Ao9qjkbz2fsxw0EyySLTNvzuynLua7XKixA0yBEEGLeNmvrfkkb3XbfIs4fAyV-Z"
+    api_key = "Ao9qjkbz2fsxw0EyySLTNvzuynLua7XKixA0yBEEGLeNmvrfkkb3XbfIs4fAyV-Z"
     days = DAYS_ES

--- a/locations/spiders/lidl_nl.py
+++ b/locations/spiders/lidl_nl.py
@@ -7,5 +7,5 @@ class LidlNLSpider(LidlATSpider):
 
     dataset_id = "067b84e1e31f4f71974d1bfb6c412382"
     dataset_name = "Filialdaten-NL/Filialdaten-NL"
-    key = "Ajsi91aW1OJ9ikqcOGadJ74W0D94pBKQ9Gha57tI6vXTTZZi1lwUuTXD2xDA-i7B"
+    api_key = "Ajsi91aW1OJ9ikqcOGadJ74W0D94pBKQ9Gha57tI6vXTTZZi1lwUuTXD2xDA-i7B"
     days = DAYS_NL

--- a/locations/spiders/lidl_pl.py
+++ b/locations/spiders/lidl_pl.py
@@ -7,5 +7,5 @@ class LidlPLSpider(LidlATSpider):
 
     dataset_id = "f4c8c3e0d96748348fe904413a798be3"
     dataset_name = "Filialdaten-PL/Filialdaten-PL"
-    key = "AnZ7UrM33kcHeNxFJsJ6McC4-iAx6Mv55FfsAzmlImV6eJ1n6OX4zfhe2rsut6CD"
+    api_key = "AnZ7UrM33kcHeNxFJsJ6McC4-iAx6Mv55FfsAzmlImV6eJ1n6OX4zfhe2rsut6CD"
     days = DAYS_PL

--- a/locations/spiders/lidl_pt.py
+++ b/locations/spiders/lidl_pt.py
@@ -7,5 +7,5 @@ class LidlPTSpider(LidlATSpider):
 
     dataset_id = "e470ca5678c5440aad7eecf431ff461a"
     dataset_name = "Filialdaten-PT/Filialdaten-PT"
-    key = "Ahu0_AMpxF4eh7QlrRMfkhtrPnAKxYItqztODUDyRvuE4TzajeGVOxJSIZ6PUoR_"
+    api_key = "Ahu0_AMpxF4eh7QlrRMfkhtrPnAKxYItqztODUDyRvuE4TzajeGVOxJSIZ6PUoR_"
     days = DAYS_PT

--- a/locations/spiders/lidl_se.py
+++ b/locations/spiders/lidl_se.py
@@ -7,5 +7,5 @@ class LidlSESpider(LidlBESpider):
 
     dataset_id = "b340d487953044ba8e2b20406ce3fcc6"
     dataset_name = "Filialdaten-SE/Filialdaten-SE"
-    key = "AiHIKQCACRaaOyOJQjGEGl5uxp7KOTXwae435wJqW3jBo_HLpRWmOVrhOI-eI-Rj"
+    api_key = "AiHIKQCACRaaOyOJQjGEGl5uxp7KOTXwae435wJqW3jBo_HLpRWmOVrhOI-eI-Rj"
     days = DAYS_FR

--- a/locations/spiders/lidl_sk.py
+++ b/locations/spiders/lidl_sk.py
@@ -7,5 +7,5 @@ class LidlSKSpider(LidlATSpider):
 
     dataset_id = "018f9e1466694a03b6190cb8ccc19272"
     dataset_name = "Filialdaten-SK/Filialdaten-SK"
-    key = "AqN50YiXhDtZtWqXZcb7nWvF-4Xc9rg9IXd6YWepqk4WnlmbvD-NV3KHA3A0dOtw"
+    api_key = "AqN50YiXhDtZtWqXZcb7nWvF-4Xc9rg9IXd6YWepqk4WnlmbvD-NV3KHA3A0dOtw"
     days = DAYS_SK


### PR DESCRIPTION
rel: https://github.com/alltheplaces/alltheplaces/pull/9507

LidlATSpider and LidlBESpider were refactored, but their descendant classes were not.