### PR TITLE
[AviaEU] Add spider covering Avia, Avia Xpress and other brands for NL and  other EU countries (1512 locations)

### DIFF
--- a/locations/spiders/avia_eu.py
+++ b/locations/spiders/avia_eu.py
@@ -1,0 +1,74 @@
+from typing import Any, Iterable
+
+from scrapy import FormRequest, Request, Selector, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
+
+
+class AviaEUSpider(Spider):
+    name = "avia_eu"
+    BRANDS_MAPPING = {
+        "Avia Xpress": {"brand": "Avia XPress", "brand_wikidata": "Q124611203"},
+        "Avia": AVIA_SHARED_ATTRIBUTES,
+        "Esso Express": {"brand": "Esso Express", "brand_wikidata": "Q2350336"},
+        "Esso": {"brand": "Esso", "brand_wikidata": "Q867662"},
+        "Tamoil Express": {"brand": "Tamoil express", "brand_wikidata": "Q124658477"},
+        "Tamoil": {"brand": "Tamoil", "brand_wikidata": "Q706793"},
+        "Tankeasy": {"brand": "TankEasy", "brand_wikidata": "Q124608381"},
+        "Truckeasy": {"brand": "TruckEasy", "brand_wikidata": "Q124608382"},
+        "T-Energy Express": {"brand": "T-Energy express", "brand_wikidata": "Q127687413"},
+        "T-Energy": {"brand": "T-Energy", "brand_wikidata": "Q127687159"},
+        "Tank S": {"brand": "Tank S", "brand_wikidata": "Q122904613"},
+        "Firezone": {"brand": "Firezone", "brand_wikidata": "Q14628080"},
+        "Dcb Energy": {"brand": "DCB Energy", "brand_wikidata": "Q124608379"},
+        "Kuster": {"brand": "Kuster Olie", "brand_wikidata": "Q129832689"},
+        "Ids": {"brand": "IDS", "brand_wikidata": "Q125462248"},
+        "Tankpoint": {"brand": "Tank Point"},
+        "Rolande": {"brand": "Rolande"},
+        "Swing": {"brand": "Swing"},
+    }
+    # Already covered by other spiders:
+    IGNORED_BRANDS = [
+        "Tango",
+        "Total Express",  # TotalEnergies
+        "Texaco",
+        "BSP",  # Related to Texaco?
+    ]
+    skip_auto_cc_domain = True
+
+    def make_request(self, page: int) -> FormRequest:
+        return FormRequest(
+            url="https://avia.nl/wp-admin/admin-ajax.php",
+            formdata={"action": "load_map", "current_page": str(page)},
+            meta=dict(page=page),
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(1)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in Selector(text=response.json()["buf_info"]).xpath('//*[contains(@class, "location-info")]'):
+            item = Feature()
+            item["ref"] = location.xpath("./@data-locationid").get()
+            station = location.xpath('.//a[@class="station-title"]')
+            item["name"] = station.xpath("./text()").get()
+            item["website"] = station.xpath("./@href").get()
+            item["addr_full"] = clean_address(location.xpath('.//*[@class="st-address-text"]//text()').getall())
+            extract_google_position(item, location)
+            station_title = item["name"].title()
+            if any(brand_key.title() in station_title for brand_key in self.IGNORED_BRANDS):
+                continue  # Ignore locations as duplicates data from other spiders
+            for brand in self.BRANDS_MAPPING:
+                if brand in station_title:
+                    item.update(self.BRANDS_MAPPING[brand])
+                    break
+            apply_category(Categories.FUEL_STATION, item)
+            yield item
+
+        if response.meta["page"] < response.json()["number_of_pages"]:
+            yield self.make_request(response.meta["page"] + 1)


### PR DESCRIPTION
[Sitemap](https://avia.nl/sitemap_index.xml) contains [Avia stations urls](https://avia.nl/ww-avia-station-sitemap.xml), but POI [pages](https://avia.nl/tankstations/avia-xpress-callantsoog) don't have coordinates, hence ignored Sitemap.

`'atp/field/brand/missing': 144` : This is mainly because of few locations `brand` identification doesn't look feasible, as `item["name"]` fails to indicated info regarding `brand` . Few might belong to `Avia` or others.

```
{'atp/brand/Avia': 417,
 'atp/brand/Avia XPress': 239,
 'atp/brand/DCB Energy': 6,
 'atp/brand/Esso': 192,
 'atp/brand/Esso Express': 113,
 'atp/brand/Firezone': 31,
 'atp/brand/IDS': 91,
 'atp/brand/Kuster Olie': 27,
 'atp/brand/Rolande': 18,
 'atp/brand/Swing': 7,
 'atp/brand/T-Energy': 3,
 'atp/brand/T-Energy express': 1,
 'atp/brand/Tamoil': 35,
 'atp/brand/Tamoil express': 146,
 'atp/brand/Tank Point': 7,
 'atp/brand/Tank S': 16,
 'atp/brand/TankEasy': 1,
 'atp/brand/TruckEasy': 18,
 'atp/brand_wikidata/Q122904613': 16,
 'atp/brand_wikidata/Q124608379': 6,
 'atp/brand_wikidata/Q124608381': 1,
 'atp/brand_wikidata/Q124608382': 18,
 'atp/brand_wikidata/Q124611203': 239,
 'atp/brand_wikidata/Q124658477': 146,
 'atp/brand_wikidata/Q125462248': 91,
 'atp/brand_wikidata/Q127687159': 3,
 'atp/brand_wikidata/Q127687413': 1,
 'atp/brand_wikidata/Q129832689': 27,
 'atp/brand_wikidata/Q14628080': 31,
 'atp/brand_wikidata/Q2350336': 113,
 'atp/brand_wikidata/Q300147': 417,
 'atp/brand_wikidata/Q706793': 35,
 'atp/brand_wikidata/Q867662': 192,
 'atp/category/amenity/fuel': 1512,
 'atp/cdn/cloudflare/response_count': 177,
 'atp/cdn/cloudflare/response_status_count/200': 177,
 'atp/field/branch/missing': 1512,
 'atp/field/brand/missing': 144,
 'atp/field/brand_wikidata/missing': 176,
 'atp/field/city/missing': 1512,
 'atp/field/country/from_reverse_geocoding': 1512,
 'atp/field/email/missing': 1512,
 'atp/field/image/missing': 1512,
 'atp/field/opening_hours/missing': 1512,
 'atp/field/operator/missing': 1512,
 'atp/field/operator_wikidata/missing': 1512,
 'atp/field/phone/missing': 1512,
 'atp/field/postcode/missing': 1512,
 'atp/field/street_address/missing': 1512,
 'atp/field/twitter/missing': 1512,
 'atp/item_scraped_host_count/avia.nl': 1512,
 'atp/nsi/brand_missing': 293,
 'atp/nsi/cc_match': 982,
 'atp/nsi/match_failed': 61,
 'downloader/request_bytes': 78108,
 'downloader/request_count': 177,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 176,
 'downloader/response_bytes': 9618088,
 'downloader/response_count': 177,
 'downloader/response_status_count/200': 177,
 'elapsed_time_seconds': 23.085971,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 13, 12, 56, 54, 24274, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 177,
 'httpcompression/response_bytes': 79594614,
 'httpcompression/response_count': 177,
 'item_scraped_count': 1512,
 'log_count/DEBUG': 1701,
 'log_count/INFO': 9,
 'request_depth_max': 175,
 'response_received_count': 177,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 176,
 'scheduler/dequeued/memory': 176,
 'scheduler/enqueued': 176,
 'scheduler/enqueued/memory': 176,
 'start_time': datetime.datetime(2024, 9, 13, 12, 56, 30, 938303, tzinfo=datetime.timezone.utc)}
```