### PR TITLE
shell - remove names

### DIFF
--- a/locations/spiders/shell.py
+++ b/locations/spiders/shell.py
@@ -35,6 +35,7 @@ class ShellSpider(GeoMeSpider):
             yield select_shop_item
 
         apply_category(Categories.FUEL_STATION, item)
+        item.pop("name", None)
 
         # As we do not know the name of shop/restaurant attached, we apply to main item
         if "shop" in amenities:


### PR DESCRIPTION
I see that many are just copied city/state name

for example:

```
{
    'amenity': 'fuel',
    'fuel:engineoil': 'yes',
    '@source_uri': 'https://shellgsllocator.geoapp.me/api/v2/locations/nearest_to?lat=7.66634&lng=-5.02748&limit=50',
    '@spider': 'shell',
    'addr:street_address': 'Béoumi Route Seguela',
    'addr:city': 'BEOUMI',
    'addr:state': 'BEOUMI',
    'addr:postcode': '15 BP 378',
    'addr:country': 'CI',
    'phone': '+225 01 53 60 0145',
    'brand': 'Shell',
    'brand:wikidata': 'Q110716465',
    'atp_listing_name': 'BEOUMI',
    'name': 'Shell',
    'atp_ref': 'CI_28100166'
}
```