### PR TITLE
[starbucks_cn] Add spider (7432 locations)

### DIFF
--- a/locations/spiders/starbucks_cn.py
+++ b/locations/spiders/starbucks_cn.py
@@ -1,0 +1,79 @@
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, Extras, apply_yes_no
+from locations.geo import country_iseadgg_centroids
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import clean_address
+
+FEATURE_MAPPING = {
+    # "BE"  # Barista-Crafted Reserve Beverages
+    "DL": Extras.DELIVERY,
+    # "MIC"  # Starbucks Ice Cream Plus
+    # "MOP"  # Mobile order and pickup
+    # "NCB"  # Nitro Cold Brew
+    # "OG"  # Origami
+    # "PO"  # Pour Over
+    # "RC"  # Reserve
+    # "SBB",  # Unknown, not listed in the filters
+}
+
+
+class StarbucksCNSpider(JSONBlobSpider):
+    download_timeout = 30
+    name = "starbucks_cn"
+    item_attributes = {"brand": "星巴克", "brand_wikidata": "Q37158", "extras": Categories.COFFEE_SHOP.value}
+    custom_settings = {
+        "CONCURRENT_REQUESTS": 1,  # Ensure that EN processing happens before ZH items are fetched,
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 1,
+    }
+    locations_key = "data"
+    en_items = {}
+
+    def start_requests(self):
+        for lat, lon in country_iseadgg_centroids(["CN"], 79):
+            yield JsonRequest(
+                url=f"https://www.starbucks.com.cn/api/stores/nearby?lat={lat}&lon={lon}&limit=1000&locale=EN&features=&radius=100000",
+                meta={"locale": "EN"},
+            )
+            yield JsonRequest(
+                url=f"https://www.starbucks.com.cn/api/stores/nearby?lat={lat}&lon={lon}&limit=1000&locale=ZH&features=&radius=100000",
+                meta={"locale": "ZH"},
+            )
+
+    def post_process_item(self, item, response, location):
+        item["branch"] = item.pop("name")
+        item["street_address"] = location["address"]["streetAddressLine1"]
+        item["addr_full"] = clean_address(
+            [
+                location["address"].get("streetAddressLine1"),
+                location["address"].get("streetAddressLine2"),
+                location["address"].get("streetAddressLine3"),
+                location["address"].get("city"),
+                location["address"].get("postalCode"),
+            ]
+        )
+        for feature in location["features"]:
+            if match := FEATURE_MAPPING.get(feature):
+                apply_yes_no(match, item, True)
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_feature/{feature}")
+        if response.meta["locale"] == "EN":
+            self.en_items[item["ref"]] = item
+        else:
+            for key, value in self.en_items[item["ref"]].items():
+                if value is None or value == "":
+                    continue
+                if value == item.get(key):
+                    continue
+                if key == "extras":
+                    continue
+                if key in ["city", "postcode", "street_address"]:
+                    item["extras"]["addr:" + key + ":en"] = value
+                    item["extras"]["addr:" + key + ":zh"] = item.get(key)
+                elif key == "addr_full":
+                    item["extras"]["addr:full:en"] = value
+                    item["extras"]["addr:full:zh"] = item.get(key)
+                else:
+                    item["extras"][key + ":en"] = value
+                    item["extras"][key + ":zh"] = item.get(key)
+            yield item


### PR DESCRIPTION
```
 'atp/brand/星巴克': 7432,
 'atp/brand_wikidata/Q37158': 7432,
 'atp/category/amenity/cafe': 7432,
 'atp/field/country/from_spider_name': 7432,
 'atp/field/email/missing': 7432,
 'atp/field/image/missing': 7432,
 'atp/field/opening_hours/missing': 7432,
 'atp/field/operator/missing': 7432,
 'atp/field/operator_wikidata/missing': 7432,
 'atp/field/phone/missing': 7432,
 'atp/field/state/missing': 7432,
 'atp/field/twitter/missing': 7432,
 'atp/field/website/missing': 7432,
 'atp/item_scraped_host_count/www.starbucks.com.cn': 13152,
 'atp/nsi/cc_match': 7432,
 'atp/starbucks_cn/unhandled_feature/BE': 742,
 'atp/starbucks_cn/unhandled_feature/MIC': 10972,
 'atp/starbucks_cn/unhandled_feature/MOP': 18474,
 'atp/starbucks_cn/unhandled_feature/NCB': 1960,
 'atp/starbucks_cn/unhandled_feature/OG': 26304,
 'atp/starbucks_cn/unhandled_feature/PO': 7036,
 'atp/starbucks_cn/unhandled_feature/RC': 1916,
 'atp/starbucks_cn/unhandled_feature/SBB': 1616,
 'downloader/request_bytes': 517991,
 'downloader/request_count': 1269,
 'downloader/request_method_count/GET': 1269,
 'downloader/response_bytes': 12939273,
 'downloader/response_count': 1269,
 'downloader/response_status_count/200': 1268,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2317.89123,
```