### PR TITLE
[scouts_gb] Add spider (9824 locations)

### DIFF
--- a/locations/spiders/scouts_gb.py
+++ b/locations/spiders/scouts_gb.py
@@ -1,0 +1,28 @@
+from scrapy.http import JsonRequest
+
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class ScoutsGBSpider(JSONBlobSpider):
+    name = "scouts_gb"
+    item_attributes = {
+        "brand": "The Scout Association",
+        "brand_wikidata": "Q849740",
+    }
+    start_urls = ["https://groupfinder.azurewebsites.net/GroupFinder?page=1&pageSize=500&location=london"]
+    locations_key = "Data"
+
+    def parse(self, response):
+        features = self.extract_json(response)
+        yield from self.parse_feature_array(response, features)
+        if not response.json()["PagingData"]["LastPage"]:
+            yield JsonRequest(
+                url="https://groupfinder.azurewebsites.net" + response.json()["PagingData"]["nextPage"],
+                callback=self.parse,
+            )
+
+    def post_process_item(self, item, response, location):
+        if item.get("postcode") is not None and item["postcode"].lower() == "null":
+            item.pop("postcode")
+        item["website"] = f"https://www.scouts.org.uk/groups/{location['id']}?slug={location['slug']}"
+        yield item

--- a/locations/spiders/scouts_gg_gb_im_je.py
+++ b/locations/spiders/scouts_gg_gb_im_je.py
@@ -3,8 +3,8 @@ from scrapy.http import JsonRequest
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class ScoutsGBSpider(JSONBlobSpider):
-    name = "scouts_gb"
+class ScoutsGGGBIMJESpider(JSONBlobSpider):
+    name = "scouts_gg_gb_im_je"
     item_attributes = {
         "brand": "The Scout Association",
         "brand_wikidata": "Q849740",


### PR DESCRIPTION
```
 'atp/brand/The Scout Association': 9824,
 'atp/brand_wikidata/Q849740': 9824,
 'atp/category/club/scout': 9824,
 'atp/field/branch/missing': 9824,
 'atp/field/city/missing': 9824,
 'atp/field/country/from_spider_name': 9824,
 'atp/field/email/missing': 9824,
 'atp/field/image/missing': 9824,
 'atp/field/opening_hours/missing': 9824,
 'atp/field/operator/missing': 9824,
 'atp/field/operator_wikidata/missing': 9824,
 'atp/field/phone/missing': 9824,
 'atp/field/postcode/missing': 4068,
 'atp/field/state/missing': 9824,
 'atp/field/street_address/missing': 9824,
 'atp/field/twitter/missing': 9824,
 'atp/item_scraped_host_count/groupfinder.azurewebsites.net': 9824,
 'atp/nsi/perfect_match': 9824,
 'downloader/request_bytes': 13548,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 21,
 'downloader/response_bytes': 963957,
 'downloader/response_count': 21,
 'downloader/response_status_count/200': 20,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 236.98349,
```