### PR TITLE
[scouts_za] Add spider (257 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -32,6 +32,8 @@ class Categories(Enum):
     ENFORCEMENT_MAXIMUM_SPEED = {"enforcement": "maxspeed"}
     ENFORCEMENT_TRAFFIC_SIGNALS = {"enforcement": "traffic_signals"}
 
+    CLUB_SCOUT = {"club": "scout"}
+
     CRAFT_CARPENTER = {"craft": "carpenter"}
     CRAFT_CATERER = {"craft": "caterer"}
     CRAFT_CLOCKMAKER = {"craft": "clockmaker"}

--- a/locations/spiders/scouts_za.py
+++ b/locations/spiders/scouts_za.py
@@ -1,0 +1,37 @@
+from chompjs import parse_js_object
+from scrapy import Selector
+from scrapy.http import Request
+from scrapy.linkextractors import LinkExtractor
+
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class ScoutsZASpider(JSONBlobSpider):
+    name = "scouts_za"
+    item_attributes = {
+        "brand": "Scouts South Africa",
+        "brand_wikidata": "Q7565791",
+    }
+    start_urls = ["https://www.scouts.org.za/scouts-near-you/"]
+    allowed_domains = ["scouts.org.za"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield Request(url=url, callback=self.parse_province)
+
+    def parse_province(self, response):
+        for link in LinkExtractor(allow=r"\/scouts-near-you\/$").extract_links(response):
+            yield Request(url=link.url, callback=self.parse)
+
+    def extract_json(self, response):
+        data_raw = response.xpath('.//script[@id="gmw-map-js-extra"]/text()').get()
+        return parse_js_object(data_raw.split('"locations":')[1])
+
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.CLUB_SCOUT, item)
+        selector = Selector(text=location["info_window_content"])
+        item["name"] = selector.xpath('.//div[contains(@class, "title")]/a/text()').get()
+        item["website"] = selector.xpath('.//div[contains(@class, "title")]/a/@href').get()
+        item["addr_full"] = selector.xpath('.//div[contains(@class, "address")]/text()').get()
+        yield item


### PR DESCRIPTION
```
'atp/brand/Scouts South Africa': 257,
 'atp/brand_wikidata/Q7565791': 257,
 'atp/category/club/scout': 257,
 'atp/field/branch/missing': 257,
 'atp/field/city/missing': 257,
 'atp/field/country/from_spider_name': 257,
 'atp/field/email/missing': 257,
 'atp/field/image/missing': 257,
 'atp/field/opening_hours/missing': 257,
 'atp/field/operator/missing': 257,
 'atp/field/operator_wikidata/missing': 257,
 'atp/field/phone/missing': 257,
 'atp/field/postcode/missing': 257,
 'atp/field/state/missing': 257,
 'atp/field/street_address/missing': 257,
 'atp/field/twitter/missing': 257,
 'atp/item_scraped_host_count/easterncapenorth.scouts.org.za': 16,
 'atp/item_scraped_host_count/easterncapesouth.scouts.org.za': 13,
 'atp/item_scraped_host_count/freestate.scouts.org.za': 21,
 'atp/item_scraped_host_count/gauteng.scouts.org.za': 84,
 'atp/item_scraped_host_count/kzn.scouts.org.za': 25,
 'atp/item_scraped_host_count/limpopo.scouts.org.za': 25,
 'atp/item_scraped_host_count/mpumalanga.scouts.org.za': 25,
 'atp/item_scraped_host_count/northerncape.scouts.org.za': 25,
 'atp/item_scraped_host_count/northwest.scouts.org.za': 5,
 'atp/item_scraped_host_count/westerncape.scouts.org.za': 25,
 'atp/nsi/cc_match': 257,
 'downloader/request_bytes': 7512,
 'downloader/request_count': 22,
 'downloader/request_method_count/GET': 22,
 'downloader/response_bytes': 298259,
 'downloader/response_count': 22,
 'downloader/response_status_count/200': 22,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 11.906156,
```