### PR TITLE
[zebros_za] Add spider (14 locations)

### DIFF
--- a/locations/spiders/zebros_za.py
+++ b/locations/spiders/zebros_za.py
@@ -1,0 +1,20 @@
+from scrapy import Spider
+
+from locations.items import Feature
+
+
+class ZebrosZASpider(Spider):
+    name = "zebros_za"
+    item_attributes = {"brand": "Zebro's", "brand_wikidata": "Q116619443"}
+    start_urls = ["https://www.zebros.co.za/store-locator/"]
+    no_refs = True
+
+    def parse(self, response):
+        for location in response.xpath('.//div[@class="vc_tta-container"]/.//tbody/tr'):
+            item = Feature()
+            if location.xpath(".//td/text()") == []:
+                continue
+            item["branch"] = location.xpath(".//td/text()")[0].get()
+            item["addr_full"] = location.xpath(".//td/text()")[1].get()
+            item["phone"] = location.xpath('.//td/a[contains(@href, "tel:")]/@href').get()
+            yield item


### PR DESCRIPTION
No coordinates available, but there are decent addresses

```
 "atp/brand/Zebro's": 14,
 'atp/brand_wikidata/Q116619443': 14,
 'atp/category/amenity/fast_food': 14,
 'atp/field/city/missing': 14,
 'atp/field/country/from_spider_name': 14,
 'atp/field/email/missing': 14,
 'atp/field/image/missing': 14,
 'atp/field/lat/missing': 14,
 'atp/field/lon/missing': 14,
 'atp/field/opening_hours/missing': 14,
 'atp/field/operator/missing': 14,
 'atp/field/operator_wikidata/missing': 14,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 14,
 'atp/field/state/missing': 14,
 'atp/field/street_address/missing': 14,
 'atp/field/twitter/missing': 14,
 'atp/field/website/missing': 14,
 'atp/item_scraped_host_count/www.zebros.co.za': 14,
 'atp/nsi/perfect_match': 14,
```