### PR TITLE
[gov_dfe_gias_gb] Add spider for GB educational establishments (29885 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -17,6 +17,9 @@ class Categories(Enum):
     CAR_RENTAL = {"amenity": "car_rental"}
     CAR_WASH = {"amenity": "car_wash"}
     PARKING = {"amenity": "parking"}
+    SCHOOL = {"amenity": "school"}
+    UNIVERSITY = {"amenity": "university"}
+    COLLEGE = {"amenity": "college"}
 
     BUS_STOP = {"highway": "bus_stop", "public_transport": "platform"}
     BUS_STATION = {"amenity": "bus_station", "public_transport": "station"}

--- a/locations/spiders/gov_dfe_gias_gb.py
+++ b/locations/spiders/gov_dfe_gias_gb.py
@@ -1,0 +1,185 @@
+from datetime import datetime
+
+import pyproj
+from scrapy.spiders import CSVFeedSpider
+
+from locations.categories import Categories, apply_category, get_category_tags
+from locations.items import Feature, set_closed
+from locations.pipelines.address_clean_up import clean_address
+
+
+class GovDfeGiasGBSpider(CSVFeedSpider):
+    download_timeout = 400
+    name = "gov_dfe_gias_gb"
+    today = datetime.today()
+    start_urls = [
+        f"https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata{today.year}{today.month:02d}{today.day:02d}.csv"
+    ]
+    dataset_attributes = {
+        "license": "Open Government Licence v3.0",
+        "license:website": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        "license:wikidata": "Q99891702",
+        "attribution": "required",
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0.",
+    }
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    skip_auto_cc_spider_name = True
+    # British OSGB36 -> lat/lon (https://epsg.io/4326)
+    coord_transformer = pyproj.Transformer.from_crs(27700, 4326)
+
+    def adapt_response(self, response):
+        fixed_response = response.replace(body=response.text.encode("ISO8859-1", "ignore").decode("utf-8", "ignore"))
+        return fixed_response
+
+    def parse_row(self, response, row):
+        item = Feature()
+        if (
+            row["EstablishmentStatus (name)"] in ["Closed", "Open, but proposed to close"]
+            and row["ReasonEstablishmentClosed (name)"] == "Closure"
+        ):
+            if row["CloseDate"] in ["", "01-01-1900"]:
+                set_closed(item)
+            else:
+                set_closed(item, datetime.strptime(row["CloseDate"], "%d-%m-%Y"))
+        elif (
+            row["EstablishmentStatus (name)"] == "Proposed to open"
+            and row["ReasonEstablishmentOpened (name)"] == "New Provision"
+            and row["OpenDate"] != ""
+        ):
+            item["extras"]["start_date"] = datetime.strptime(row["OpenDate"], "%d-%m-%Y")
+        elif row["EstablishmentStatus (name)"] != "Open":
+            return
+
+        self.set_category(item, row)
+        if get_category_tags(item) is None:
+            return
+
+        if row.get("Easting") not in ["0", ""] and row.get("Northing") not in ["0", ""]:
+            item["lat"], item["lon"] = self.coord_transformer.transform(row.get("Easting"), row.get("Northing"))
+
+        item["ref"] = row["URN"]
+        item["extras"]["ref:edubase"] = row["URN"]
+        item["name"] = row["EstablishmentName"]
+        item["extras"]["min_age"] = row.get("StatutoryLowAge")
+        if row.get("StatutoryHighAge") == "99":
+            item["extras"]["max_age"] = "none"
+        else:
+            item["extras"]["max_age"] = row.get("StatutoryHighAge")
+        item["extras"]["capacity"] = row.get("SchoolCapacity")
+        item["street_address"] = row.get("Street")
+        item["city"] = row.get("Town")
+        item["postcode"] = row.get("Postcode")
+        item["addr_full"] = clean_address(
+            [
+                row.get("Street"),
+                row.get("Locality"),
+                row.get("Address3"),
+                row.get("Town"),
+                row.get("County (name)"),
+                row.get("Postcode"),
+            ]
+        )
+        item["website"] = row.get("SchoolWebsite")
+        item["phone"] = row.get("TelephoneNum")
+        item["extras"]["ref:GB:uprn"] = row.get("UPRN")
+
+        self.set_operator(item, row)
+        self.set_religion(item, row)
+
+        return item
+
+    def set_category(self, item, row):
+        if row.get("EstablishmentTypeGroup (name)") in [
+            "Academies",
+            "Free Schools",
+            "Independent schools",
+            "Local authority maintained schools",
+            "Special schools",
+            "Welsh schools",
+        ]:
+            establishment_type = row.get("TypeOfEstablishment (name)")
+            if establishment_type == "Local authority nursery school":
+                apply_category(Categories.KINDERGARTEN, item)
+            elif establishment_type in ["16-19", "16 to 19", "City technology college"]:
+                apply_category(Categories.COLLEGE, item)
+            else:
+                apply_category(Categories.SCHOOL, item)
+        elif row.get("EstablishmentTypeGroup (name)") == "Colleges":
+            apply_category(Categories.COLLEGE, item)
+        elif row.get("EstablishmentTypeGroup (name)") == "Universities":
+            apply_category(Categories.UNIVERSITY, item)
+        elif row.get("EstablishmentTypeGroup (name)") == "Other types":
+            if row.get("TypeOfEstablishment (name)") in ["British schools overseas", "Offshore schools"]:
+                apply_category(Categories.SCHOOL, item)
+            else:
+                self.crawler.stats.inc_value(
+                    f"atp/{self.name}/unhandled_other_type/{row.get('TypeOfEstablishment (name)')}"
+                )
+                return
+        elif row.get("EstablishmentTypeGroup (name)") == "Online provider":
+            return
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_type/{row.get('EstablishmentTypeGroup (name)')}")
+            return
+
+    def set_operator(self, item, row):
+        if row.get("TypeOfEstablishment (name)") in [
+            "Community school",
+            "Community special school",
+            "Pupil referral unit",
+            "Local authority nursery school",
+            "Welsh establishment",
+        ]:
+            item["operator"] = row["LA (name)"]
+            item["extras"]["operator:type"] = "government"
+        elif row.get("Trusts (name)") != "":
+            item["operator"] = row["Trusts (name)"]
+            item["extras"]["operator:type"] = "private"
+        elif row.get("SchoolSponsors (name)") != "":
+            item["operator"] = row["Trusts (name)"]
+            item["extras"]["operator:type"] = "private"
+        elif row.get("Federations (code)") != "":
+            item["operator"] = row["Trusts (name)"]
+            item["extras"]["operator:type"] = "private"
+
+    def set_religion(self, item, row):
+        row_religion = row.get("ReligiousCharacter (name)")
+        no_religion = ["Does not apply", "None"]
+        if row_religion == "" or any([religion in row_religion for religion in no_religion]):
+            return
+
+        christian = [
+            "Anglican",
+            "Baptist",
+            "Catholic",
+            "Christian",
+            "Church of England",
+            "Congregational Church",
+            "Free Church",
+            "Greek Orthodox",
+            "Inter- / non- denominational",
+            "Methodist",
+            "Moravian",
+            "Protestant",
+            "Quaker",
+            "Seventh Day Adventist",
+            "United Reformed Church",
+        ]
+        muslim = ["Islam", "Muslim", "Sunni Deobandi"]
+
+        if "Buddhist" in row_religion:
+            item["extras"]["religion"] = "buddhist"
+        elif any([religion in row_religion for religion in christian]):
+            item["extras"]["religion"] = "christian"
+        elif "Hindu" in row_religion:
+            item["extras"]["religion"] = "hindu"
+        elif "Jewish" in row_religion:
+            item["extras"]["religion"] = "jewish"
+        elif "Multi-faith" in row_religion:
+            item["extras"]["religion"] = "multifaith"
+        elif any([religion in row_religion for religion in muslim]):
+            item["extras"]["religion"] = "muslim"
+        elif "Sikh" in row_religion:
+            item["extras"]["religion"] = "sikh"
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_religion/{row.get('ReligiousCharacter (name)')}")


### PR DESCRIPTION
Maybe there could be a better spider name? DfE = Department for Education, GIAS = Get Information About Schools, but writing them in full seems too long

```
 'atp/category/amenity/college': 281,
 'atp/category/amenity/kindergarten': 412,
 'atp/category/amenity/school': 29062,
 'atp/category/amenity/university': 130,
 'atp/closed_poi': 3032,
 'atp/field/branch/missing': 29885,
 'atp/field/brand/missing': 29885,
 'atp/field/brand_wikidata/missing': 29885,
 'atp/field/city/missing': 787,
 'atp/field/country/from_reverse_geocoding': 21663,
 'atp/field/country/from_website_url': 7481,
 'atp/field/country/missing': 741,
 'atp/field/email/missing': 29885,
 'atp/field/image/missing': 29885,
 'atp/field/lat/missing': 839,
 'atp/field/lon/missing': 839,
 'atp/field/opening_hours/missing': 29885,
 'atp/field/operator/missing': 9189,
 'atp/field/operator_wikidata/missing': 29885,
 'atp/field/phone/invalid': 512,
 'atp/field/phone/missing': 3316,
 'atp/field/postcode/missing': 344,
 'atp/field/state/missing': 8222,
 'atp/field/street_address/missing': 120,
 'atp/field/twitter/missing': 29885,
 'atp/field/website/invalid': 14574,
 'atp/field/website/missing': 5687,
 'atp/gov_dfe_gias_gb/unhandled_other_type/Institution funded by other government department': 1,
 'atp/gov_dfe_gias_gb/unhandled_other_type/Miscellaneous': 142,
 'atp/gov_dfe_gias_gb/unhandled_other_type/Secure units': 40,
 "atp/gov_dfe_gias_gb/unhandled_other_type/Service children's education": 63,
 'atp/gov_dfe_gias_gb/unhandled_other_type/Special post 16 institution': 150,
 'atp/item_scraped_host_count/ea-edubase-api-prod.azurewebsites.net': 29885,
 'atp/operator/' (omitted for brevity)
 'downloader/request_bytes': 369,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 64784038,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
```