### PR TITLE
Add WinMart and WinMart+ (VN) (2422 stores)

### DIFF
--- a/locations/json_blob_spider.py
+++ b/locations/json_blob_spider.py
@@ -50,7 +50,7 @@ class JSONBlobSpider(Spider):
     data array. This can either be specified as a single string if a single
     dictionary contains the location data array, or as an ordered list of
     strings if a nested set of dictionaries exists.
-    
+
     Example 1:
     locations_key = "data"
 

--- a/locations/json_blob_spider.py
+++ b/locations/json_blob_spider.py
@@ -28,8 +28,8 @@ class JSONBlobSpider(Spider):
        `pre_process_data` and/or `post_process_item` functions to adjust
        feature attributes before and/or after `DictParser` has been used to
        automatically extract the feature.
-    3. If the JSON response is more complex, for example, three dictionaries
-       nested within each other followed by an array of features, overload
+    3. If the JSON response is more complex, for example, a nested tree of
+       dictionaries and arrays followed by an array of features, overload
        the `parse` function to obtain the required dictionary or array of
        features which can then be passed to `parse_feature_dict` or
        `parse_feature_array` functions.
@@ -44,8 +44,20 @@ class JSONBlobSpider(Spider):
     received.
     """
 
-    # If set then use as a key into the JSON response to return the location data array.
-    locations_key: str = None
+    """
+    locations_key:
+    If set then use as a key into the JSON response to return the location
+    data array. This can either be specified as a single string if a single
+    dictionary contains the location data array, or as an ordered list of
+    strings if a nested set of dictionaries exists.
+    
+    Example 1:
+    locations_key = "data"
+
+    Example 2:
+    locations_key = ["data", "locationData", "stores"]
+    """
+    locations_key: str | list[str] = None
 
     def extract_json(self, response: Response) -> dict | list:
         """
@@ -67,7 +79,11 @@ class JSONBlobSpider(Spider):
         """
         json_data = response.json()
         if self.locations_key:
-            return json_data[self.locations_key]
+            if isinstance(self.locations_key, str):
+                json_data = json_data[self.locations_key]
+            elif isinstance(self.locations_key, list):
+                for key in self.locations_key:
+                    json_data = json_data[key]
         return json_data
 
     def parse(self, response: Response) -> Iterable[Feature]:

--- a/locations/spiders/winmart_vn.py
+++ b/locations/spiders/winmart_vn.py
@@ -1,0 +1,41 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import apply_category, Categories
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class WinmartVNSpider(JSONBlobSpider):
+    name = "winmart_vn"
+    allowed_domains = ["api-crownx.winmart.vn"]
+    start_urls = ["https://api-crownx.winmart.vn/mt/api/web/v1/store-by-province?pageSize=1000"]
+    locations_key = "data"
+
+    def parse(self, response: Response) -> Iterable[Feature]:
+        features = self.extract_json(response)
+        for district in features:
+            for ward in district["wardStores"]:
+                yield from self.parse_feature_array(response, ward["stores"])
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature["chainId"] == "VMT":
+            item["brand"] = "WinMart"
+            item["brand_wikidata"] = "Q60245505"
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+        elif feature["chainId"] == "VMP":
+            item["brand"] = "WinMart+"
+            item["brand_wikidata"] = "Q113236478"
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+        else:
+            raise ValueError("Unknown brand detected: {}".format(feature["chainId"]))
+
+        item["branch"] = item.pop("name", "").removeprefix("WM ").removeprefix("WM+ ").removeprefix("{} ".format(feature.get("provinceCode", "")))
+        item["addr_full"] = feature.get("officeAddress")
+        item["state"] = feature.get("provinceCode")
+        item["city"] = feature.get("wardName").removeprefix("P. ").removeprefix("TT. ").removeprefix("X. ")
+        item["phone"] = feature.get("contactMobile")
+
+        yield item
+

--- a/locations/spiders/winmart_vn.py
+++ b/locations/spiders/winmart_vn.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -31,11 +31,15 @@ class WinmartVNSpider(JSONBlobSpider):
         else:
             raise ValueError("Unknown brand detected: {}".format(feature["chainId"]))
 
-        item["branch"] = item.pop("name", "").removeprefix("WM ").removeprefix("WM+ ").removeprefix("{} ".format(feature.get("provinceCode", "")))
+        item["branch"] = (
+            item.pop("name", "")
+            .removeprefix("WM ")
+            .removeprefix("WM+ ")
+            .removeprefix("{} ".format(feature.get("provinceCode", "")))
+        )
         item["addr_full"] = feature.get("officeAddress")
         item["state"] = feature.get("provinceCode")
         item["city"] = feature.get("wardName").removeprefix("P. ").removeprefix("TT. ").removeprefix("X. ")
         item["phone"] = feature.get("contactMobile")
 
         yield item
-


### PR DESCRIPTION
Source data is a bit patchy--for example, some locations do not have coordinates provided.

There are other alternative APIs available, all requiring different forms of search and with different fields of data returned. The selected API of this spider is the only one found to return all stores in a single query, and seems to contain most data fields that are of interest.

Fixes #9103