### PR TITLE
[HSBC UK] Fix spider (Fixes #10258)

### DIFF
--- a/locations/spiders/hsbc_uk_gb.py
+++ b/locations/spiders/hsbc_uk_gb.py
@@ -1,22 +1,39 @@
+from typing import Iterable
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class HsbcUkGBSpider(SitemapSpider, StructuredDataSpider):
     name = "hsbc_uk_gb"
-    item_attributes = {"brand": "HSBC UK", "brand_wikidata": "Q64767453", "extras": Categories.BANK.value}
+    item_attributes = {"brand": "HSBC UK", "brand_wikidata": "Q64767453"}
     start_urls = ["https://www.hsbc.co.uk/branch-list/"]
     sitemap_urls = ["https://www.hsbc.co.uk/sitemaps-pages.xml"]
-    sitemap_rules = [(r"/branch-list/.+", "parse_sd")]
+    sitemap_rules = [(r"/branch-list/(.+)/$", "parse_sd")]
+
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            if not ld_obj.get("@type"):
+                yield ld_obj
 
     def post_process_item(self, item, response, ld_data):
-        item["name"] = item["name"].split(" - ", 2)[1]
         item.pop("image", None)
         item.pop("facebook", None)
         item.pop("twitter", None)
-        extra_features = [feature["itemOffered"]["name"] for feature in ld_data["hasOfferCatalog"]["itemListElement"]]
-        apply_yes_no(Extras.ATM, item, len(list(filter(lambda x: " ATM" in x.upper(), extra_features))) > 0, False)
-        apply_yes_no(Extras.WIFI, item, "Wi-Fi" in extra_features, False)
+
+        item["website"] = response.url
+
+        services = [
+            feature["itemOffered"]["name"] for feature in ld_data.get("hasOfferCatalog", {}).get("itemListElement", [])
+        ]
+        apply_yes_no(Extras.ATM, item, any("ATM" in s.upper().split() for s in services))
+        apply_yes_no(Extras.WIFI, item, "Wi-Fi" in services)
+        apply_yes_no(Extras.WHEELCHAIR, item, "Accessible Branch" in services)
+
+        apply_category(Categories.BANK, item)
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/HSBC UK': 395,
 'atp/brand_wikidata/Q64767453': 395,
 'atp/category/amenity/bank': 395,
 'atp/field/branch/missing': 395,
 'atp/field/email/missing': 395,
 'atp/field/image/missing': 395,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 395,
 'atp/field/operator_wikidata/missing': 395,
 'atp/field/phone/missing': 395,
 'atp/field/state/missing': 395,
 'atp/field/twitter/missing': 395,
 'atp/item_scraped_host_count/www.hsbc.co.uk': 395,
 'atp/nsi/cc_match': 395,
 'downloader/request_bytes': 169221,
 'downloader/request_count': 425,
 'downloader/request_method_count/GET': 425,
 'downloader/response_bytes': 14651576,
 'downloader/response_count': 425,
 'downloader/response_status_count/200': 397,
 'downloader/response_status_count/404': 28,
 'elapsed_time_seconds': 8.092848,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 16, 15, 0, 53, 33029, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 425,
 'httpcompression/response_bytes': 72427391,
 'httpcompression/response_count': 397,
 'httperror/response_ignored_count': 28,
 'httperror/response_ignored_status_count/404': 28,
 'item_scraped_count': 395,
 'log_count/INFO': 38,
 'log_count/WARNING': 1,
 'memusage/max': 256167936,
 'memusage/startup': 256167936,
 'request_depth_max': 1,
 'response_received_count': 425,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 424,
 'scheduler/dequeued/memory': 424,
 'scheduler/enqueued': 424,
 'scheduler/enqueued/memory': 424,
 'start_time': datetime.datetime(2024, 9, 16, 15, 0, 44, 940181, tzinfo=datetime.timezone.utc)}
```