### PR TITLE
[BastideFR] Added Spider for Bastide (160 locations)

### DIFF
--- a/locations/spiders/bastide_fr.py
+++ b/locations/spiders/bastide_fr.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.linked_data_parser import LinkedDataParser
+
+
+class BastideFRSpider(SitemapSpider):
+    name = "bastide_fr"
+    item_attributes = {"brand": "Bastide le confort médical", "brand_wikidata": "Q2887693"}
+    allowed_domains = ["bastideleconfortmedical.com"]
+    sitemap_urls = ["https://www.bastideleconfortmedical.com/Assets/Rbs/Seo/100190/fr_FR/Rbs_Store_Store.1.xml"]
+
+    def parse(self, response, **kwargs):
+
+        feature = LinkedDataParser.parse(response, "Organization")
+        feature["website"] = response.url
+        feature["ref"] = response.url
+        feature["name"] = "Bastide"
+
+        yield feature


### PR DESCRIPTION
```python
{'atp/brand/Bastide le confort médical': 160,
 'atp/brand_wikidata/Q2887693': 160,
 'atp/category/shop/medical_supply': 160,
 'atp/field/image/dropped': 160,
 'atp/field/image/missing': 160,
 'atp/field/lat/missing': 160,
 'atp/field/lon/missing': 160,
 'atp/field/opening_hours/missing': 160,
 'atp/field/operator/missing': 160,
 'atp/field/operator_wikidata/missing': 160,
 'atp/field/twitter/missing': 160,
 'atp/nsi/perfect_match': 160,
 'downloader/request_bytes': 83028,
 'downloader/request_count': 162,
 'downloader/request_method_count/GET': 162,
 'downloader/response_bytes': 29554204,
 'downloader/response_count': 162,
 'downloader/response_status_count/200': 162,
 'elapsed_time_seconds': 199.024548,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 16, 21, 41, 58, 311759, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 168854745,
 'httpcompression/response_count': 162,
 'item_scraped_count': 160,
 'log_count/DEBUG': 333,
 'log_count/INFO': 12,
 'memusage/max': 399216640,
 'memusage/startup': 172285952,
 'request_depth_max': 1,
 'response_received_count': 162,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 161,
 'scheduler/dequeued/memory': 161,
 'scheduler/enqueued': 161,
 'scheduler/enqueued/memory': 161,
 'start_time': datetime.datetime(2024, 9, 16, 21, 38, 39, 287211, tzinfo=datetime.timezone.utc)}
```

Fixes #9083 