### PR TITLE
[walmart_us] align wikidata for fuel stations with NSI

### DIFF
--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -78,6 +78,9 @@ class WalmartUSSpider(SitemapSpider):
 
             apply_category(self.CATEGORIES[service["name"]], poi)
 
+            if service["name"] == "GAS_STATION":
+                poi["brand_wikidata"] = "Q62606411"
+
             yield poi
 
         item["extras"]["type"] = store.get("type")


### PR DESCRIPTION
NSI has different Q-code for fuel stations: https://nsi.guide/index.html?t=brands&k=amenity&v=fuel&tt=walmart