### PR TITLE
[YextSearch] Don't always apply payments

### DIFF
--- a/locations/storefinders/yext_search.py
+++ b/locations/storefinders/yext_search.py
@@ -65,13 +65,13 @@ class YextSearchSpider(Spider):
                 item["extras"]["ref:google"] = location["profile"].get("googlePlaceId")
 
             if payment_methods := location["profile"].get("paymentOptions"):
-                apply_yes_no(PaymentMethods.CASH, item, "Cash" in payment_methods, False)
-                apply_yes_no(PaymentMethods.CHEQUE, item, "Check" in payment_methods, False)
-                apply_yes_no(PaymentMethods.MASTER_CARD, item, "MasterCard" in payment_methods, False)
-                apply_yes_no(PaymentMethods.VISA, item, "Visa" in payment_methods, False)
-                apply_yes_no(PaymentMethods.AMERICAN_EXPRESS, item, "American Express" in payment_methods, False)
-                apply_yes_no(PaymentMethods.DISCOVER_CARD, item, "Discover" in payment_methods, False)
-                apply_yes_no(PaymentMethods.CONTACTLESS, item, "Contactless Payment" in payment_methods, False)
+                apply_yes_no(PaymentMethods.CASH, item, "Cash" in payment_methods)
+                apply_yes_no(PaymentMethods.CHEQUE, item, "Check" in payment_methods)
+                apply_yes_no(PaymentMethods.MASTER_CARD, item, "MasterCard" in payment_methods)
+                apply_yes_no(PaymentMethods.VISA, item, "Visa" in payment_methods)
+                apply_yes_no(PaymentMethods.AMERICAN_EXPRESS, item, "American Express" in payment_methods)
+                apply_yes_no(PaymentMethods.DISCOVER_CARD, item, "Discover" in payment_methods)
+                apply_yes_no(PaymentMethods.CONTACTLESS, item, "Contactless Payment" in payment_methods)
 
             item["opening_hours"] = self.parse_opening_hours(location)
 


### PR DESCRIPTION
I don't think the absence of a payment method can be taken to mean that it is definitely not accepted. Also, I think these do not all apply globally.