### PR TITLE
[Dream Doors GB] Add spider

### DIFF
--- a/locations/spiders/dream_doors_gb.py
+++ b/locations/spiders/dream_doors_gb.py
@@ -1,0 +1,45 @@
+import re
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class DreamDoorsGBSpider(CrawlSpider):
+    name = "dream_doors_gb"
+    item_attributes = {"brand": "Dream Doors", "brand_wikidata": "Q84702301"}
+    start_urls = ["https://www.dreamdoors.co.uk/kitchen-showrooms"]
+    rules = [Rule(LinkExtractor(allow=[r"https://www.dreamdoors.co.uk/kitchen-showrooms/[^/]+$"]), callback="parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["ref"] = item["website"] = response.url
+        item["addr_full"] = merge_address_lines(response.xpath('//div[@class="address"]/p/text()').getall())
+        item["phone"] = response.xpath('//a[@id="showroom-phone"]/text()').get()
+
+        item["opening_hours"] = OpeningHours()
+        for rule in response.xpath('//div[@class="opening_times"]/div[@class="day"]'):
+            day = rule.xpath("./p[1]/text()").get()
+            times = rule.xpath("./p[2]/text()").get().replace(".", ":")
+            if times == "Closed":
+                item["opening_hours"].set_closed(day)
+            else:
+                start_time, end_time = times.replace("-", "–").split("–")
+                if ":" not in start_time:
+                    start_time = start_time.replace("am", ":00am")
+                if ":" not in end_time:
+                    end_time = end_time.replace("pm", ":00pm")
+                item["opening_hours"].add_range(day, start_time.strip(), end_time.strip(), "%I:%M%p")
+
+        if m := re.search(
+            r'map_initialize\("map_canvas",\s*"(.+?)",\s*(-?\d+\.\d+),\s*(-?\d+\.\d+)\s*\);',
+            response.text,
+        ):
+            _, item["lat"], item["lon"] = m.groups()
+
+        yield item


### PR DESCRIPTION
Fixes #9836
```python
{'atp/brand/Dream Doors': 89,
 'atp/brand_wikidata/Q84702301': 89,
 'atp/category/shop/kitchen': 89,
 'atp/cdn/cloudflare/response_count': 91,
 'atp/cdn/cloudflare/response_status_count/200': 91,
 'atp/field/branch/missing': 89,
 'atp/field/city/missing': 89,
 'atp/field/country/from_spider_name': 89,
 'atp/field/email/missing': 89,
 'atp/field/image/missing': 89,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 89,
 'atp/field/operator_wikidata/missing': 89,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 89,
 'atp/field/street_address/missing': 89,
 'atp/field/twitter/missing': 89,
 'atp/item_scraped_host_count/www.dreamdoors.co.uk': 89,
 'atp/nsi/perfect_match': 89,
 'downloader/request_bytes': 65721,
 'downloader/request_count': 91,
 'downloader/request_method_count/GET': 91,
 'downloader/response_bytes': 3909944,
 'downloader/response_count': 91,
 'downloader/response_status_count/200': 91,
 'elapsed_time_seconds': 1.691831,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 18, 11, 18, 44, 4706, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 91,
 'httpcompression/response_bytes': 28957986,
 'httpcompression/response_count': 91,
 'item_scraped_count': 89,
 'log_count/DEBUG': 192,
 'log_count/INFO': 9,
 'memusage/max': 182255616,
 'memusage/startup': 182255616,
 'request_depth_max': 1,
 'response_received_count': 91,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 90,
 'scheduler/dequeued/memory': 90,
 'scheduler/enqueued': 90,
 'scheduler/enqueued/memory': 90,
 'start_time': datetime.datetime(2024, 9, 18, 11, 18, 42, 312875, tzinfo=datetime.timezone.utc)}
```