### PR TITLE
[ben_and_jerrys] Add spider

### DIFF
--- a/locations/spiders/ben_and_jerrys.py
+++ b/locations/spiders/ben_and_jerrys.py
@@ -1,0 +1,36 @@
+from chompjs import parse_js_object
+
+from locations.categories import Extras, apply_yes_no
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.storefinders.where2getit import Where2GetItSpider
+
+
+class BenAndJerrysSpider(Where2GetItSpider):
+    download_timeout = 60
+    name = "ben_and_jerrys"
+    item_attributes = {"brand": "Ben & Jerry's", "brand_wikidata": "Q816412"}
+    api_key = "3D71930E-EC80-11E6-A0AE-8347407E493E"
+    api_filter = {"icon": {"in": "default,SHOP"}}
+
+    def parse_item(self, item, location):
+        try:
+            shop_info = parse_js_object(location["jsonshopinfo"])
+            try:
+                shop = shop_info[0]["ShopInfoContent"][0]["StoreDetails"]
+                if url := shop.get("WebsiteURL"):
+                    item["website"] = url
+            except (TypeError, IndexError):
+                pass
+        except ValueError:
+            pass
+        item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
+        apply_yes_no(Extras.DELIVERY, item, location["offersdelivery"] == "1")
+        item["opening_hours"] = OpeningHours()
+        for day in DAYS_FULL:
+            if location.get(day.lower()) in [None, ""]:
+                continue
+            if "closed" in location.get(day.lower()):
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_ranges_from_string(day + " " + location.get(day.lower()))
+        yield item

--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -52,7 +52,7 @@ from locations.pipelines.address_clean_up import clean_address
 # }
 #
 # As filters are complex to understand, it is best to search spiders
-# using "api_query" to see other examples of filters being used.
+# using "api_filter" to see other examples of filters being used.
 
 # Instead of Where2GetIt being provided as a service, it is also
 # possible for brands to self-host the software at a custom domain


### PR DESCRIPTION
#8893 appears to be abandoned, so I had a look.

```
 "atp/brand/Ben & Jerry's": 2492,
 'atp/brand_wikidata/Q816412': 2492,
 'atp/category/amenity/ice_cream': 2492,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 2492,
 'atp/field/image/missing': 2492,
 'atp/field/opening_hours/missing': 2273,
 'atp/field/operator/missing': 2492,
 'atp/field/operator_wikidata/missing': 2492,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 2231,
 'atp/field/postcode/missing': 7,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 2234,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2492,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 2278,
 'atp/item_scraped_host_count/hosted.where2getit.com': 2492,
 'atp/nsi/perfect_match': 2492,
```