### PR TITLE
[power_fashion_ls_sz_za] Add spider (316 locations)

### DIFF
--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -56,6 +56,7 @@ COUNTRYCODE_COMPONENTS = {
     "KR",
     "KW",
     "KZ",
+    "LS",
     "LT",
     "LU",
     "LV",

--- a/locations/spiders/power_fashion_ls_sz_za.py
+++ b/locations/spiders/power_fashion_ls_sz_za.py
@@ -8,3 +8,4 @@ class PowerFashionLSSZZASpider(StorepointSpider):
 
     def parse_item(self, item, location):
         item["branch"] = item.pop("name")
+        yield item

--- a/locations/spiders/power_fashion_ls_sz_za.py
+++ b/locations/spiders/power_fashion_ls_sz_za.py
@@ -1,4 +1,5 @@
 from locations.storefinders.storepoint import StorepointSpider
+from locations.hours import OpeningHours
 
 
 class PowerFashionLSSZZASpider(StorepointSpider):
@@ -8,4 +9,6 @@ class PowerFashionLSSZZASpider(StorepointSpider):
 
     def parse_item(self, item, location):
         item["branch"] = item.pop("name")
+        for day_hours in location["description"].split("\n"):
+            item["opening_hours"].add_ranges_from_string(day_hours)
         yield item

--- a/locations/spiders/power_fashion_ls_sz_za.py
+++ b/locations/spiders/power_fashion_ls_sz_za.py
@@ -1,0 +1,10 @@
+from locations.storefinders.storepoint import StorepointSpider
+
+
+class PowerFashionLSSZZASpider(StorepointSpider):
+    name = "power_fashion_ls_sz_za"
+    key = "162e1380619248"
+    item_attributes = {"brand": "Power", "brand_wikidata": "Q118185713"}
+
+    def parse_item(self, item, location):
+        item["branch"] = item.pop("name")

--- a/locations/spiders/power_fashion_ls_sz_za.py
+++ b/locations/spiders/power_fashion_ls_sz_za.py
@@ -1,5 +1,4 @@
 from locations.storefinders.storepoint import StorepointSpider
-from locations.hours import OpeningHours
 
 
 class PowerFashionLSSZZASpider(StorepointSpider):

--- a/locations/spiders/power_fashion_za.py
+++ b/locations/spiders/power_fashion_za.py
@@ -1,7 +1,0 @@
-from locations.storefinders.storepoint import StorepointSpider
-
-
-class PowerFashionZASpider(StorepointSpider):
-    name = "power_fashion_za"
-    key = "162e1380619248"
-    item_attributes = {"brand": "Power", "brand_wikidata": "Q118185713"}

--- a/locations/spiders/power_fashion_za.py
+++ b/locations/spiders/power_fashion_za.py
@@ -1,0 +1,7 @@
+from locations.storefinders.storepoint import StorepointSpider
+
+
+class PowerFashionZASpider(StorepointSpider):
+    name = "power_fashion_za"
+    key = "162e1380619248"
+    item_attributes = {"brand": "Power", "brand_wikidata": "Q118185713"}


### PR DESCRIPTION
Appears to have some not very accurate reverse geocoding for a number of locations

```
 'atp/brand/Power': 316,
 'atp/brand_wikidata/Q118185713': 316,
 'atp/category/shop/clothes': 316,
 'atp/field/city/missing': 316,
 'atp/field/country/from_reverse_geocoding': 316,
 'atp/field/email/missing': 316,
 'atp/field/image/missing': 316,
 'atp/field/opening_hours/missing': 315,
 'atp/field/operator/missing': 316,
 'atp/field/operator_wikidata/missing': 316,
 'atp/field/phone/invalid': 11,
 'atp/field/phone/missing': 38,
 'atp/field/postcode/missing': 316,
 'atp/field/state/missing': 3,
 'atp/field/street_address/missing': 316,
 'atp/field/twitter/missing': 316,
 'atp/field/website/missing': 316,
 'atp/item_scraped_host_count/api.storepoint.co': 316,
 'atp/nsi/perfect_match': 316,
 'downloader/request_bytes': 340,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 20157,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
```