### PR TITLE
[rite_aid_us][walgreens.py] Only output Pharmacy Category POIs

### DIFF
--- a/locations/spiders/rite_aid_us.py
+++ b/locations/spiders/rite_aid_us.py
@@ -24,13 +24,17 @@ class RiteAidUSSpider(SitemapSpider, StructuredDataSpider):
 
         for department in ld_data.get("department", []):
             if department.get("@type") == "Pharmacy":
-                pharmacy = item.deepcopy()
-                pharmacy["ref"] = "{}-pharmacy".format(item["ref"])
-                pharmacy["phone"] = department["telephone"]
-                pharmacy["opening_hours"] = LinkedDataParser.parse_opening_hours(department)
-                apply_category(Categories.PHARMACY, pharmacy)
-                yield pharmacy
+                item["extras"]["opening_hours:pharmacy"] = LinkedDataParser.parse_opening_hours(
+                    department
+                ).as_opening_hours()
                 break
 
-        apply_category(Categories.SHOP_CHEMIST, item)
+        # If there is no retail opening_hours, use the pharmacy hours
+        # If there is a default retail opening_hours, add that to extras
+        if not item.get("opening_hours") and item["extras"].get("opening_hours:pharmacy"):
+            item["opening_hours"] = item["extras"]["opening_hours:pharmacy"]
+        else:
+            item["extras"]["opening_hours:retail"] = item["opening_hours"].as_opening_hours()
+
+        apply_category(Categories.PHARMACY, item)
         yield item

--- a/locations/spiders/walgreens.py
+++ b/locations/spiders/walgreens.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -18,12 +19,31 @@ class WalgreensSpider(SitemapSpider, StructuredDataSpider):
             if len(rule["dayOfWeek"]) > 2:
                 rule["dayOfWeek"] = rule["dayOfWeek"][:2]
 
+        for department in ld_data.get("department", []):
+            for rule in department.get("OpeningHoursSpecification", []):
+                if len(rule["dayOfWeek"]) > 2:
+                    rule["dayOfWeek"] = rule["dayOfWeek"][:2]
+
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "/locator/walgreens-" in response.url:
             item.update(self.WALGREENS)
         elif item["name"] == "Duane Reade":
             item.update(self.DUANE_READE)
         # TODO: a few more brands here
+
+        for department in ld_data.get("department", []):
+            if department.get("@type") == "Pharmacy":
+                item["extras"]["opening_hours:pharmacy"] = LinkedDataParser.parse_opening_hours(
+                    department
+                ).as_opening_hours()
+                break
+
+        # If there is no retail opening_hours, use the pharmacy hours
+        # If there is a default retail opening_hours, add that to extras
+        if not item.get("opening_hours") and item["extras"].get("opening_hours:pharmacy"):
+            item["opening_hours"] = item["extras"]["opening_hours:pharmacy"]
+        else:
+            item["extras"]["opening_hours:retail"] = item["opening_hours"].as_opening_hours()
 
         apply_category(Categories.PHARMACY, item)
         yield item


### PR DESCRIPTION
Changed the `rite_aid_us` spider to only output Pharmacy Category POIs as well as addind `opening_hours:pharmacy` to extras for `rite_aid_us` and `walgreens`. I made this PR so that the big 3 pharmacy brands in US are similar in what they produce. As `cvs_us` spider only outputs Pharmacy POIs and not `shop=chemist` I think `rite_aid_us` should as well. I get why `rite_aid_us` were outputting both. One for retail and one for pharmacy, but I think it is unnecessary as most Americans including myself think of them as Pharmacy. Especially as you can get almost everything in the retail section at Walmart or Target for cheaper prices.

<details><summary>Rite Aid Stats</summary>

```json
{
 "atp/brand/Rite Aid": 1383,
 "atp/brand_wikidata/Q3433273": 1383,
 "atp/category/amenity/pharmacy": 1383,
 "atp/category/multiple": 1383,
 "atp/cdn/cloudflare/response_count": 1383,
 "atp/cdn/cloudflare/response_status_count/200": 1383,
 "atp/field/branch/missing": 1383,
 "atp/field/email/missing": 1383,
 "atp/field/image/missing": 1383,
 "atp/field/operator/missing": 1383,
 "atp/field/operator_wikidata/missing": 1383,
 "atp/field/twitter/missing": 1383,
 "atp/item_scraped_host_count/www.riteaid.com": 1383,
 "atp/nsi/cc_match": 1383,
 "downloader/request_bytes": 558576,
 "downloader/request_count": 1387,
 "downloader/request_method_count/GET": 1387,
 "downloader/response_bytes": 61900697,
 "downloader/response_count": 1387,
 "downloader/response_status_count/200": 1387,
 "elapsed_time_seconds": 1699.241894,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2024-09-20T13:46:08.689046+00:00",
 "httpcompression/response_bytes": 563629525,
 "httpcompression/response_count": 1387,
 "item_scraped_count": 1383,
 "log_count/INFO": 38,
 "memusage/max": 573095936,
 "memusage/startup": 249094144,
 "request_depth_max": 3,
 "response_received_count": 1387,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 1386,
 "scheduler/dequeued/memory": 1386,
 "scheduler/enqueued": 1386,
 "scheduler/enqueued/memory": 1386,
 "start_time": "2024-09-20T13:17:49.447152+00:00"
}
```
</details>

<details><summary>Walgreen Partial Stats</summary>

```json
{
 "atp/brand/Duane Reade": 35,
 "atp/brand/Walgreens": 2330,
 "atp/brand_wikidata/Q1591889": 2330,
 "atp/brand_wikidata/Q5310380": 35,
 "atp/category/amenity/pharmacy": 2432,
 "atp/category/multiple": 2432,
 "atp/field/branch/missing": 2432,
 "atp/field/brand/missing": 67,
 "atp/field/brand_wikidata/missing": 67,
 "atp/field/email/missing": 2432,
 "atp/field/image/dropped": 2432,
 "atp/field/image/missing": 2432,
 "atp/field/name/missing": 17,
 "atp/field/operator/missing": 2432,
 "atp/field/operator_wikidata/missing": 2432,
 "atp/field/phone/invalid": 1,
 "atp/field/twitter/missing": 2432,
 "atp/item_scraped_host_count/www.walgreens.com": 2432,
 "atp/nsi/cc_match": 2330,
 "atp/nsi/perfect_match": 35,
 "downloader/request_bytes": 4123870,
 "downloader/request_count": 2435,
 "downloader/request_method_count/GET": 2435,
 "downloader/response_bytes": 290869590,
 "downloader/response_count": 2435,
 "downloader/response_status_count/200": 2434,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 5965.62424,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "shutdown",
 "finish_time": "2024-09-20T15:01:50.631716+00:00",
 "httpcompression/response_bytes": 1963766174,
 "httpcompression/response_count": 2435,
 "httperror/response_ignored_count": 1,
 "httperror/response_ignored_status_count/404": 1,
 "item_scraped_count": 2432,
 "log_count/INFO": 111,
 "memusage/max": 654442496,
 "memusage/startup": 248885248,
 "request_depth_max": 1,
 "response_received_count": 2435,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2434,
 "scheduler/dequeued/memory": 2434,
 "scheduler/enqueued": 8559,
 "scheduler/enqueued/memory": 8559,
 "start_time": "2024-09-20T13:22:25.007476+00:00"
}
```
</details>
