### PR TITLE
[starbucks_reserve] Add spider

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -266,6 +266,7 @@ class DictParser:
                     "geo-point",
                     "geocoded-coordinate",
                     "coordinates",
+                    "coords",
                     "geo-position",
                     "position",
                     "positions",

--- a/locations/spiders/starbucks_reserve.py
+++ b/locations/spiders/starbucks_reserve.py
@@ -1,0 +1,23 @@
+from chompjs import parse_js_object
+
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import clean_address
+
+
+class StarbucksReserveSpider(JSONBlobSpider):
+    name = "starbucks_reserve"
+    item_attributes = {
+        "brand": "Starbucks Reserve",
+        "brand_wikidata": "Q71150001",
+    }
+    start_urls = ["https://storage.googleapis.com/maps-solutions-x2wb8n4oyb/locator-plus/pvuv/locator-plus-config.js"]
+    no_refs = True
+
+    def extract_json(self, response):
+        js_blob = "[" + response.text.split('"locations": [', 1)[1].split("],", 1)[0] + "]"
+        return parse_js_object(js_blob)
+
+    def post_process_item(self, item, response, location):
+        item["addr_full"] = clean_address([location["address1"], location["address2"]])
+        item["extras"]["ref:google"] = location.get("placeId")
+        yield item


### PR DESCRIPTION
Waiting on https://github.com/osmlab/name-suggestion-index/commit/3f6575cfd152a742b60f3668ec04b8d0b1311ad8 for categories

There are now a few spiders like this, `https://storage.googleapis.com/maps-solutions-.../locator-plus/.../locator-plus-config.js`. Might be worth a storefinder

```
 'atp/brand/Starbucks Reserve': 9,
 'atp/brand_wikidata/Q71150001': 9,
 'atp/category/missing': 9,
 'atp/field/branch/missing': 9,
 'atp/field/city/missing': 9,
 'atp/field/country/from_reverse_geocoding': 9,
 'atp/field/email/missing': 9,
 'atp/field/image/missing': 9,
 'atp/field/opening_hours/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/phone/missing': 9,
 'atp/field/postcode/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/website/missing': 9,
 'atp/item_scraped_host_count/storage.googleapis.com': 9,
 'atp/nsi/brand_missing': 9,
```