### PR TITLE
[starbucks_hk_mo] Add spider

### DIFF
--- a/locations/json_blob_spider.py
+++ b/locations/json_blob_spider.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
 from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Request, Response
 
 from locations.dict_parser import DictParser
 from locations.items import Feature
@@ -58,6 +58,15 @@ class JSONBlobSpider(Spider):
     locations_key = ["data", "locationData", "stores"]
     """
     locations_key: str | list[str] = None
+    needs_json_request = False
+
+    def start_requests(self) -> Iterable[Request]:
+        if self.needs_json_request:
+            for url in self.start_urls:
+                yield JsonRequest(url)
+        else:
+            for url in self.start_urls:
+                yield Request(url)
 
     def extract_json(self, response: Response) -> dict | list:
         """

--- a/locations/spiders/starbucks_hk_mo.py
+++ b/locations/spiders/starbucks_hk_mo.py
@@ -3,7 +3,7 @@ from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class StarbucksHKMO(JSONBlobSpider):
+class StarbucksHKMOSpider(JSONBlobSpider):
     name = "starbucks_hk_mo"
     item_attributes = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
     start_urls = ["https://www.starbucks.com.hk/rest/V1/mxstarbucks-getSBStoreList"]

--- a/locations/spiders/starbucks_hk_mo.py
+++ b/locations/spiders/starbucks_hk_mo.py
@@ -1,0 +1,45 @@
+from locations.categories import Extras, apply_yes_no
+from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class StarbucksHKMO(JSONBlobSpider):
+    name = "starbucks_hk_mo"
+    item_attributes = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
+    start_urls = ["https://www.starbucks.com.hk/rest/V1/mxstarbucks-getSBStoreList"]
+    needs_json_request = True
+    locations_key = "data"
+
+    def post_process_item(self, item, response, location):
+        if location["locates_hk_or_mc"] == "Hong Kong":
+            item["country"] = "HK"
+        elif location["locates_hk_or_mc"] == "Macau":
+            item["country"] = "MO"
+
+        item["extras"]["branch:en"] = location["name_en"]
+        item["extras"]["branch:zh"] = location["name_cn"]
+        item["branch"] = item["extras"]["branch:zh"] + " " + item["extras"]["branch:en"]
+
+        item["extras"]["addr:full:en"] = location["address1_en"]
+        item["extras"]["addr:full:zh"] = location["address1_cn"]
+        item["addr_full"] = item["extras"]["addr:full:zh"] + " " + item["extras"]["addr:full:en"]
+
+        apply_yes_no(Extras.WIFI, item, location["is_free_wifi"] == "1")
+        apply_yes_no(Extras.TAKEAWAY, item, location["has_starbucks_take_away"] == "1")
+
+        item["opening_hours"] = OpeningHours()
+        if location["is24_hours"] == "1":
+            item["opening_hours"] = "Mo-Su 00:00-24:00"
+        else:
+            for day in DAYS_3_LETTERS:
+                day = day.lower()
+                if day == "thu":
+                    day = "thurs"
+                if location["enable_mon"] == "0":
+                    item["opening_hours"].set_closed(day)
+                if location[f"{day}_is24_hour"] == "1":
+                    item["opening_hours"].add_range(day, "00:00", "23:59")
+                else:
+                    item["opening_hours"].add_range(day, location[f"{day}_open_hour"], location[f"{day}_close_hour"])
+
+        yield item


### PR DESCRIPTION
Also adding an option in JsonBlobSpider to force a JsonRequest, as I have now come across that a few times

```
 'atp/brand/Starbucks': 180,
 'atp/brand_wikidata/Q37158': 180,
 'atp/category/amenity/cafe': 180,
 'atp/field/city/missing': 180,
 'atp/field/email/missing': 180,
 'atp/field/image/missing': 180,
 'atp/field/operator/missing': 180,
 'atp/field/operator_wikidata/missing': 180,
 'atp/field/postcode/missing': 180,
 'atp/field/state/missing': 180,
 'atp/field/street_address/missing': 180,
 'atp/field/twitter/missing': 180,
 'atp/field/website/missing': 180,
 'atp/item_scraped_host_count/www.starbucks.com.hk': 180,
 'atp/nsi/cc_match': 180,
 'downloader/request_bytes': 661,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 662534,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
```