### PR TITLE
[gautrain_za] Add spider

### DIFF
--- a/locations/spiders/gautrain_za.py
+++ b/locations/spiders/gautrain_za.py
@@ -1,0 +1,17 @@
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class GautrainZASpider(JSONBlobSpider):
+    name = "gautrain_za"
+    item_attributes = {
+        "operator": "Gautrain",
+        "operator_wikidata": "Q1476881",
+    }
+    start_urls = ["https://www.gautrain.co.za/commuter/stations"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}  # redirects to login page
+
+    def post_process_item(self, item, response, location):
+        if "Rail" in location["modes"]:
+            apply_category(Categories.TRAIN_STATION, item)
+            yield item


### PR DESCRIPTION
```
 'atp/category/railway/station': 10,
 'atp/field/branch/missing': 10,
 'atp/field/brand/missing': 10,
 'atp/field/brand_wikidata/missing': 10,
 'atp/field/city/missing': 10,
 'atp/field/country/from_spider_name': 10,
 'atp/field/email/missing': 10,
 'atp/field/image/missing': 10,
 'atp/field/opening_hours/missing': 10,
 'atp/field/phone/missing': 10,
 'atp/field/postcode/missing': 10,
 'atp/field/state/missing': 10,
 'atp/field/street_address/missing': 10,
 'atp/field/twitter/missing': 10,
 'atp/field/website/missing': 10,
 'atp/item_scraped_host_count/www.gautrain.co.za': 10,
 'atp/nsi/operator_missing': 10,
 'atp/operator/Gautrain': 10,
 'atp/operator_wikidata/Q1476881': 10,
```