### PR TITLE
Fix sweetgreen_us domain

### DIFF
--- a/locations/spiders/sweetgreen_us.py
+++ b/locations/spiders/sweetgreen_us.py
@@ -9,7 +9,7 @@ from locations.hours import OpeningHours
 class SweetgreenUSSpider(Spider):
     name = "sweetgreen_us"
     item_attributes = {"brand": "Sweetgreen", "brand_wikidata": "Q18636413"}
-    allowed_domains = ["www.sweetgreen.com"]
+    allowed_domains = ["sweetgreen.com"]
     start_urls = ["https://order.sweetgreen.com/graphql"]
 
     def start_requests(self):


### PR DESCRIPTION
Arguably this could also crawl https://www.sweetgreen.com/locations ; but individual pages don't have coordinates.

The request to hit ratio of this is pretty low; I'm up to 194 pages/0 hits.