### PR TITLE
[fastrak_za] Add spider

### DIFF
--- a/locations/spiders/fastrak_za.py
+++ b/locations/spiders/fastrak_za.py
@@ -1,0 +1,25 @@
+import scrapy
+
+from locations.google_url import url_to_coords
+from locations.items import Feature
+
+
+class FastrakZASpider(scrapy.Spider):
+    name = "fastrak_za"
+    start_urls = ["https://www.fastrak.co.za/pages/fastrak-stores"]
+    item_attributes = {
+        "brand": "Fastrak",
+        "brand_wikidata": "Q120799603",
+    }
+    no_refs = True
+
+    def parse(self, response):
+        for location in response.xpath('.//tr[@data-mce-fragment="1"]')[1:]:
+            item = Feature()
+            item["state"] = location.xpath(".//td[1]/text()").get()
+            item["branch"] = location.xpath(".//td[2]/text()").get().replace("Fastrak: ", "")
+            item["phone"] = location.xpath(".//td[3]/text()").get()
+            item["email"] = location.xpath(".//td[4]/a/@href").get()
+            item["lat"], item["lon"] = url_to_coords(location.xpath(".//td[5]/a/@href").get())
+
+            yield item


### PR DESCRIPTION
Locations have a Google Maps link, but mostly without coordinates

```
 'atp/brand/Fastrak': 73,
 'atp/brand_wikidata/Q120799603': 73,
 'atp/category/shop/hifi': 73,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/city/missing': 73,
 'atp/field/country/from_spider_name': 73,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 73,
 'atp/field/lat/missing': 72,
 'atp/field/lon/missing': 72,
 'atp/field/opening_hours/missing': 73,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 73,
 'atp/field/state/missing': 2,
 'atp/field/street_address/missing': 73,
 'atp/field/twitter/missing': 73,
 'atp/field/website/missing': 73,
 'atp/item_scraped_host_count/www.fastrak.co.za': 73,
 'atp/nsi/perfect_match': 73,
```