### PR TITLE
[barko_loans_za] Add spider

### DIFF
--- a/locations/spiders/barko_loans_za.py
+++ b/locations/spiders/barko_loans_za.py
@@ -1,0 +1,53 @@
+from typing import Iterable
+
+from chompjs import parse_js_object
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+from locations.google_url import url_to_coords
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+PROVINCES = {
+    "MPUMALANGA": "Mpumalanga",
+    "GAUTENG": "Gauteng",
+    "LIMPOPO": "Limpopo",
+    "FREE_STATE": "Free State",
+    "WESTERN_CAPE": "Western Cape",
+    "NORTHWEST": "North West",
+    "KWAZULU_NATAL": "KwaZulu-Natal",
+    "NORTHERN_CAPE": "Northern Cape",
+}
+
+
+class BarkoLoansZASpider(JSONBlobSpider):
+    name = "barko_loans_za"
+    item_attributes = {
+        "brand": "Barko Loans",
+        "brand_wikidata": "Q118185897",
+    }
+    start_urls = ["https://www.barko.co.za/Barkomap.js.txt"]
+    no_refs = True
+
+    def extract_json(self, response):
+        return parse_js_object(response.text)
+
+    def parse_feature_dict(self, response: Response, feature_dict: dict) -> Iterable[Feature]:
+        for province, feature_list in feature_dict.items():
+            province_name = PROVINCES.get(province)
+            if province_name is None:
+                province_name = province
+                self.crawler.stats.inc_value(f"atp/{self.name}/unknown_province/{province}")
+            for feature in feature_list:
+                self.pre_process_data(feature)
+                item = DictParser.parse(feature)
+                item["state"] = province_name
+                yield from self.post_process_item(item, response, feature) or []
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        item["street_address"] = location["officeAddress"]
+        item["phone"] = location.get("officeNumber")
+        item["lat"], item["lon"] = url_to_coords(location.get("googleOfficeAddress"))
+
+        yield item


### PR DESCRIPTION
No coordinates available. The data includes Google Maps links, but they seem to be just auto-generated search links from the address

```
 'atp/brand/Barko Loans': 202,
 'atp/brand_wikidata/Q118185897': 202,
 'atp/category/shop/money_lender': 202,
 'atp/field/country/from_spider_name': 202,
 'atp/field/image/missing': 202,
 'atp/field/lat/missing': 202,
 'atp/field/lon/missing': 202,
 'atp/field/opening_hours/missing': 202,
 'atp/field/operator/missing': 202,
 'atp/field/operator_wikidata/missing': 202,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 202,
 'atp/field/twitter/missing': 202,
 'atp/field/website/missing': 202,
 'atp/item_scraped_host_count/www.barko.co.za': 202,
 'atp/nsi/perfect_match': 202,
```