### PR TITLE
[Charley's Philly Steaks] Fix spider (Fixes #10482)

### DIFF
--- a/locations/spiders/charleys_philly_steaks.py
+++ b/locations/spiders/charleys_philly_steaks.py
@@ -1,46 +1,23 @@
-import re
+import html
 
-import scrapy
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CharleysPhillySteaksSpider(scrapy.Spider):
+class CharleysPhillySteaksSpider(SitemapSpider, StructuredDataSpider):
     name = "charleys_philly_steaks"
-    allowed_domains = ["charleys.com"]
     item_attributes = {"brand": "Charley's Philly Steaks", "brand_wikidata": "Q1066777"}
+    sitemap_urls = ["https://www.charleys.com/robots.txt"]
+    sitemap_follow = ["locations"]
+    sitemap_rules = [(r"/locations/([^/]+)/$", "parse")]
+    wanted_types = ["Restaurant"]
+    requires_proxy = True
 
-    def start_requests(self):
-        url = "https://www.charleys.com/wp-admin/admin-ajax.php"
-        payload = "action=get_nearby_locations&lat=40.7127753&lng=-74.0059728&distance=5000"
-        headers = {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
-
-        yield scrapy.Request(url=url, headers=headers, method="POST", body=payload, callback=self.parse_list)
-
-    def parse_list(self, response):
-        for data in response.json().get("data"):
-            yield scrapy.Request(
-                url=data.get("permalink"),
-                callback=self.parse_store,
-                cb_kwargs={"data": data},
-            )
-
-    def parse_store(self, response, data):
-        oh = OpeningHours()
-        if days := response.xpath('//div[@id="business-0"]//tr'):
-            for day in days:
-                if day.xpath("./td/text()").get().strip() == "Closed":
-                    continue
-                oh.add_range(
-                    day=day.xpath("./th/text()").get().strip(),
-                    open_time=re.split(" - |-", day.xpath("./td/text()").get().strip())[0],
-                    close_time=re.split(" - |-", day.xpath("./td/text()").get().strip())[1],
-                    time_format="%I:%M%p",
-                )
-
-        item = DictParser.parse(data)
-        item["website"] = response.url
-        item["opening_hours"] = oh.as_opening_hours()
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = html.unescape(item.pop("name"))
+        item["website"] = response.url.split("?", 1)[0]
 
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Charley's Philly Steaks": 872,
 'atp/brand_wikidata/Q1066777': 872,
 'atp/category/amenity/fast_food': 872,
 'atp/field/city/missing': 5,
 'atp/field/country/from_reverse_geocoding': 872,
 'atp/field/email/missing': 872,
 'atp/field/image/missing': 872,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 124,
 'atp/field/operator/missing': 872,
 'atp/field/operator_wikidata/missing': 872,
 'atp/field/phone/invalid': 18,
 'atp/field/phone/missing': 27,
 'atp/field/postcode/missing': 37,
 'atp/field/street_address/missing': 5,
 'atp/item_scraped_host_count/www.charleys.com': 872,
 'atp/nsi/perfect_match': 872,
 'downloader/request_bytes': 389692,
 'downloader/request_count': 896,
 'downloader/request_method_count/GET': 896,
 'downloader/response_bytes': 23704182,
 'downloader/response_count': 896,
 'downloader/response_status_count/200': 877,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 17,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 7.724448,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 23, 14, 9, 45, 780415, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 896,
 'httpcompression/response_bytes': 80959572,
 'httpcompression/response_count': 875,
 'item_scraped_count': 872,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 253554688,
 'memusage/startup': 253554688,
 'request_depth_max': 3,
 'response_received_count': 877,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 895,
 'scheduler/dequeued/memory': 895,
 'scheduler/enqueued': 895,
 'scheduler/enqueued/memory': 895,
 'start_time': datetime.datetime(2024, 9, 23, 14, 9, 38, 55967, tzinfo=datetime.timezone.utc)}
```