### PR TITLE
Rewrite Panera Bread spider to use API

### DIFF
--- a/locations/spiders/panera_bread_us.py
+++ b/locations/spiders/panera_bread_us.py
@@ -1,12 +1,42 @@
-from scrapy.spiders import SitemapSpider
+import re
 
-from locations.structured_data_spider import StructuredDataSpider
+from geonamescache import GeonamesCache
+from scrapy import Request, Spider
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
 
 
-class PaneraBreadUSSpider(SitemapSpider, StructuredDataSpider):
+def slugify(s):
+    return re.sub(r"\W+", "-", s).lower()
+
+
+class PaneraBreadUSSpider(Spider):
     name = "panera_bread_us"
     item_attributes = {"brand": "Panera Bread", "brand_wikidata": "Q7130852"}
-    allowed_domains = ["panerabread.com"]
-    sitemap_urls = ["https://locations.panerabread.com/robots.txt"]
-    sitemap_rules = [(r"/\w\w/[-\w]+/[-\w]+\.html$", "parse_sd")]
-    wanted_types = ["CafeOrCoffeeShop"]
+
+    def start_requests(self):
+        for state in GeonamesCache().get_us_states():
+            yield Request(
+                f"https://www-api.panerabread.com/www-api/public/cafe/location/{state.lower()}",
+                headers={"Referer": "https://www.panerabread.com/"},
+            )
+
+    def parse(self, response):
+        for city in response.json():
+            for cafe in city["cafes"]:
+                item = DictParser.parse(cafe)
+                item["branch"] = item.pop("name")
+                item["ref"] = cafe["cafeId"]
+                item["street_address"] = item.pop("street")
+                item["website"] = (
+                    f"https://www.panerabread.com/content/panerabread_com/en-us/cafe/locations/{slugify(cafe['state'])}/{slugify(cafe['city'])}/{slugify(cafe['streetName'])}"
+                )
+
+                features = cafe["searchFlags"]
+                apply_yes_no(Extras.INDOOR_SEATING, item, features["hasDineIn"])
+                apply_yes_no(Extras.DELIVERY, item, features["hasDelivery"])
+                apply_yes_no(Extras.TAKEAWAY, item, features["hasPickup"])
+                apply_yes_no(Extras.DRIVE_THROUGH, item, features["hasDriveThru"])
+
+                yield item


### PR DESCRIPTION
There is a sitemap but the location pages don't seem to have any structured data (or even any data! it's all through the API). Unfortunately this endpoint does not include opening hours. There are two other endpoints that do: one is a geographic search but has a max result cap of 15, which is too small; and one requires the store ID, so would need an extra request per store just to get the opening hours.