### PR TITLE
Fix sitemap_rules regex in EE spider

### DIFF
--- a/locations/spiders/ee_gb.py
+++ b/locations/spiders/ee_gb.py
@@ -11,7 +11,7 @@ class EeGBSpider(SitemapSpider):
     name = "ee_gb"
     item_attributes = {"brand": "EE", "brand_wikidata": "Q5322942"}
     sitemap_urls = ["https://ee.co.uk/sitemap-pages.xml"]
-    sitemap_rules = [(r"/stores/[^/]+/[^/]+/[^/]+/[^/]+", "parse")]
+    sitemap_rules = [(r"/stores/[^/]+(:?/[^/]+){0,2}/[^/]+", "parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()


### PR DESCRIPTION
Some EE store URLs only have two or three geographic levels rather than the currently assumed four, e.g. https://ee.co.uk/stores/england/one_braham and https://ee.co.uk/stores/england/suffolk/bury_st_edmunds and https://ee.co.uk/stores/england/isle_of_wight/isle_of_wight_newport