### PR TITLE
Correct store regex in bensons_for_beds_gb.py

### DIFF
--- a/locations/spiders/bensons_for_beds_gb.py
+++ b/locations/spiders/bensons_for_beds_gb.py
@@ -7,7 +7,7 @@ class BensonsForBedsGBSpider(SitemapSpider, StructuredDataSpider):
     name = "bensons_for_beds_gb"
     item_attributes = {"brand": "Bensons for Beds", "brand_wikidata": "Q4890299"}
     sitemap_urls = ["https://stores.bensonsforbeds.co.uk/robots.txt"]
-    sitemap_rules = [(r"uk/[^/]+/[^/]+$", "parse")]
+    sitemap_rules = [(r"uk/[^/]+/[^/]+(?:/[1-9][^/]+)?$", "parse")]
     wanted_types = ["FurnitureStore"]
     search_for_email = False
     search_for_facebook = False


### PR DESCRIPTION
There are a couple of Bensons stores whose URL slugs contain a forward slash:
* https://stores.bensonsforbeds.co.uk/murton/unit-28/29-dalton-park
* https://stores.bensonsforbeds.co.uk/bristol/unit-10/11-imperial-retail-park

These two stores are currently missed by the spider, as it allows only two directory levels in the URL. We can't simply allow another level since the sitemap also lists sub-pages under each store, such as  https://stores.bensonsforbeds.co.uk/luton/unit-4-hatters-way-retail-park/mattresses , which we don't want to process.

I think this PR will do the job though, allowing a slash in the store slug provided that it's followed by a number.