### PR TITLE
[LinkedDataParser] Fix openingHoursSpecification parsing with empty rule

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -128,7 +128,7 @@ class LinkedDataParser:
             logger.warning(f"Unable to parse opening hours - check time_format? Error was: {str(e)}")
         except Exception as e:
             logger.warning(f"Unhandled error, unable to parse opening hours. Error was: {type(e)} {str(e)}")
-            logger.debug(traceback.print_exc())
+            logger.debug(traceback.format_exc())
 
         if image := LinkedDataParser.get_case_insensitive(ld, "image"):
             if isinstance(image, list):

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -183,13 +183,14 @@ class LinkedDataParser:
     #  "opens":  "09:00:00"
     # }
     # See https://schema.org/OpeningHoursSpecification for further examples.
+    @staticmethod
     def _parse_opening_hours_specification(oh: OpeningHours, rule: dict, time_format: str):
         if (
             not type(LinkedDataParser.get_case_insensitive(rule, "dayOfWeek")) in [list, str]
             or not type(LinkedDataParser.get_case_insensitive(rule, "opens")) == str
             or not type(LinkedDataParser.get_case_insensitive(rule, "closes")) == str
         ):
-            return
+            return oh
 
         days = LinkedDataParser.get_case_insensitive(rule, "dayOfWeek")
         if not isinstance(days, list):
@@ -207,6 +208,7 @@ class LinkedDataParser:
     # Parse an individual https://schema.org/openingHours property value such as
     # "Mo,Tu,We,Th 09:00-12:00"
     # "Mo-Fr 10:00-19:00"
+    @staticmethod
     def _parse_opening_hours(oh: OpeningHours, rule: str, time_format: str):
         days, time_ranges = rule.split(" ", 1)
 

--- a/locations/spiders/meny_dk.py
+++ b/locations/spiders/meny_dk.py
@@ -3,7 +3,7 @@ from typing import Iterable
 
 from scrapy.http import JsonRequest, Response
 
-from locations.hours import OpeningHours, DAYS_3_LETTERS_FROM_SUNDAY
+from locations.hours import DAYS_3_LETTERS_FROM_SUNDAY, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.meny_no import MenyNOSpider
@@ -18,11 +18,9 @@ class MenyDKSpider(JSONBlobSpider):
 
     def start_requests(self) -> Iterable[JsonRequest]:
         data = {
-            "params": {
-                "wt": "json"
-            },
+            "params": {"wt": "json"},
             "filter": [],
-            "query": "ss_search_api_datasource:\"entity:node\" AND bs_status:true AND ss_type:\"store\"",
+            "query": 'ss_search_api_datasource:"entity:node" AND bs_status:true AND ss_type:"store"',
             "limit": 1000,
         }
         yield JsonRequest(url=self.start_urls[0], data=data, method="POST")
@@ -40,5 +38,10 @@ class MenyDKSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["opening_hours"] = OpeningHours()
         for day_hours in loads(feature["sm_solr_opening_hours"][0]):
-            item["opening_hours"].add_range(DAYS_3_LETTERS_FROM_SUNDAY[day_hours["day"]], str(day_hours["starthours"]).zfill(4), str(day_hours["endhours"]).zfill(4), "%H%M")
+            item["opening_hours"].add_range(
+                DAYS_3_LETTERS_FROM_SUNDAY[day_hours["day"]],
+                str(day_hours["starthours"]).zfill(4),
+                str(day_hours["endhours"]).zfill(4),
+                "%H%M",
+            )
         yield item

--- a/tests/test_ld_parser.py
+++ b/tests/test_ld_parser.py
@@ -294,6 +294,35 @@ def test_ld_parse_opening_hours():
     )
 
 
+def test_ld_parse_oh_empty_rule():
+    assert (
+        LinkedDataParser.parse_opening_hours(
+            {
+                "@context": "https://schema.org",
+                "@type": "Store",
+                "name": "Middle of Nowhere Foods",
+                "openingHoursSpecification": [
+                    {},
+                    {
+                        "@type": "OpeningHoursSpecification",
+                        "closes": "16:30:00",
+                        "dayOfWeek": "https://schema.org/Wednesday",
+                        "opens": "08:30:00",
+                    },
+                    {
+                        "@type": "OpeningHoursSpecification",
+                        "closes": "16:30:00",
+                        "dayOfWeek": "https://schema.org/Thursday",
+                        "opens": "08:30:00",
+                    },
+                ],
+            },
+            "%H:%M:%S",
+        ).as_opening_hours()
+        == "We-Th 08:30-16:30"
+    )
+
+
 def test_ld_parse_opening_hours_string():
     assert (
         LinkedDataParser.parse_opening_hours(


### PR DESCRIPTION
#10366 introduced a situation where `_parse_opening_hours_specification` can null itself 

https://github.com/alltheplaces/alltheplaces/blob/015713a839f21d2f6cad9a871fae2de22ed64af6/locations/linked_data_parser.py#L241-L244

Combined with https://github.com/alltheplaces/alltheplaces/blob/015713a839f21d2f6cad9a871fae2de22ed64af6/locations/linked_data_parser.py#L130-L131 makes it quite a noisy error.