### PR TITLE
[burger_king_no] Add spider

### DIFF
--- a/locations/spiders/burger_king_no.py
+++ b/locations/spiders/burger_king_no.py
@@ -16,6 +16,7 @@ class BurgerKingNOSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
         item["website"] = f"https://burgerking.no/restaurants/{location['slug']}"
+        item["branch"] = item.pop("name")
         apply_yes_no(Extras.DRIVE_THROUGH, item, location["hasDriveThru"], False)
         # apply_yes_no(Extras.WHEELCHAIR, item, location["hasWheelchairAccess"], False) # Always false, not sure it is accurate
         # apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["hasDisabledToilets"], False) # Always false, not sure it is accurate

--- a/locations/spiders/burger_king_no.py
+++ b/locations/spiders/burger_king_no.py
@@ -1,4 +1,7 @@
+from scrapy.http import JsonRequest
+
 from locations.categories import Extras, apply_yes_no
+from locations.hours import OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
@@ -18,11 +21,33 @@ class BurgerKingNOSpider(JSONBlobSpider):
         item["website"] = f"https://burgerking.no/restaurants/{location['slug']}"
         item["branch"] = item.pop("name")
         apply_yes_no(Extras.DRIVE_THROUGH, item, location["hasDriveThru"], False)
-        # apply_yes_no(Extras.WHEELCHAIR, item, location["hasWheelchairAccess"], False) # Always false, not sure it is accurate
-        # apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["hasDisabledToilets"], False) # Always false, not sure it is accurate
-        # apply_yes_no(Extras.BABY_CHANGING_TABLE, item, location["hasBabyChanging"], False) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.WHEELCHAIR, item, location["hasWheelchairAccess"], False) # Always false, so not sure it is accurate
+        # apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["hasDisabledToilets"], False) # Always false, so not sure it is accurate
+        # apply_yes_no(Extras.BABY_CHANGING_TABLE, item, location["hasBabyChanging"], False) # Always false, so not sure it is accurate
         # apply_yes_no(Extras.DELIVERY, item, location["isDeliveryAvailable"], False) # See below, which is what seems to be used by the website
         apply_yes_no(Extras.DELIVERY, item, location["isOrderingAvailable"], False)
-        # apply_yes_no(Extras.TOILETS, item, location["hasToilets"], False) # Always false, not sure it is accurate
-        # apply_yes_no(Extras.WIFI, item, location["hasWiFi"]) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.TOILETS, item, location["hasToilets"], False) # Always false, so not sure it is accurate
+        # apply_yes_no(Extras.WIFI, item, location["hasWiFi"]) # Always false, so not sure it is accurate
+
+        yield JsonRequest(
+            url=f"https://bk-no-ordering-api-fd-ebghbnd6ebadc7fz.z01.azurefd.net/api/v2/restaurants/{location['slug']}",
+            callback=self.parse_store,
+            meta={"item": item},
+        )
+
+    def parse_store(self, response):
+        item = response.meta["item"]
+        location = response.json()["data"]
+        item["phone"] = location.get("storeContactNumber")
+        item["email"] = location.get("storeEmailAddress")
+
+        item["opening_hours"] = OpeningHours()
+        for day in location["storeOpeningHours"]:
+            item["opening_hours"].add_range(
+                day["dayOfTheWeek"],
+                day["hoursOfBusiness"]["opensAt"].split("T")[1],
+                day["hoursOfBusiness"]["closesAt"].split("T")[1],
+                time_format="%H:%M:%S",
+            )
+
         yield item

--- a/locations/spiders/burger_king_no.py
+++ b/locations/spiders/burger_king_no.py
@@ -1,0 +1,27 @@
+from locations.categories import Extras, apply_yes_no
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
+
+
+class BurgerKingNOSpider(JSONBlobSpider):
+    name = "burger_king_no"
+    item_attributes = BURGER_KING_SHARED_ATTRIBUTES
+    start_urls = [
+        "https://bk-no-ordering-api-fd-ebghbnd6ebadc7fz.z01.azurefd.net/api/v2/restaurants?latitude=65&longitude=11&radius=99900000&top=500"
+    ]
+    locations_key = "data"
+
+    def pre_process_data(self, feature):
+        feature.update(feature["storeLocation"].pop("coordinates"))
+
+    def post_process_item(self, item, response, location):
+        item["website"] = f"https://burgerking.no/restaurants/{location['slug']}"
+        apply_yes_no(Extras.DRIVE_THROUGH, item, location["hasDriveThru"], False)
+        # apply_yes_no(Extras.WHEELCHAIR, item, location["hasWheelchairAccess"], False) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, location["hasDisabledToilets"], False) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.BABY_CHANGING_TABLE, item, location["hasBabyChanging"], False) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.DELIVERY, item, location["isDeliveryAvailable"], False) # See below, which is what seems to be used by the website
+        apply_yes_no(Extras.DELIVERY, item, location["isOrderingAvailable"], False)
+        # apply_yes_no(Extras.TOILETS, item, location["hasToilets"], False) # Always false, not sure it is accurate
+        # apply_yes_no(Extras.WIFI, item, location["hasWiFi"]) # Always false, not sure it is accurate
+        yield item


### PR DESCRIPTION
There really do seem to be exactly 100 locations, I've tried a coordinate search including other locations, but it just gets duplicates.

```
 'atp/brand/Burger King': 100,
 'atp/brand_wikidata/Q177054': 100,
 'atp/category/amenity/fast_food': 100,
 'atp/field/city/missing': 100,
 'atp/field/country/from_spider_name': 100,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 5,
 'atp/field/image/missing': 100,
 'atp/field/operator/missing': 100,
 'atp/field/operator_wikidata/missing': 100,
 'atp/field/phone/missing': 100,
 'atp/field/postcode/missing': 100,
 'atp/field/state/missing': 100,
 'atp/field/street_address/missing': 100,
 'atp/field/twitter/missing': 100,
 'atp/item_scraped_host_count/bk-no-ordering-api-fd-ebghbnd6ebadc7fz.z01.azurefd.net': 100,
 'atp/nsi/cc_match': 100,
```