### PR TITLE
[Hyundai US] Fix spider

### DIFF
--- a/locations/spiders/hyundai_ca.py
+++ b/locations/spiders/hyundai_ca.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_EN, OpeningHours
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.hyundai_kr import HYUNDAI_SHARED_ATTRIBUTES
@@ -25,24 +25,24 @@ class HyundaiCASpider(JSONBlobSpider):
         if feature.get("Hours"):
             if "Sales" in feature["Hours"].keys():
                 item["ref"] = feature.get("DealerCode") + "_Sales"
-                sales = item.copy()
+                sales = item.deepcopy()
                 apply_category(Categories.SHOP_CAR, sales)
                 sales["opening_hours"] = self.parse_opening_hours(feature, "Sales")
                 yield sales
             if "Service" in feature["Hours"].keys():
                 item["ref"] = feature.get("DealerCode") + "_Service"
-                service = item.copy()
+                service = item.deepcopy()
                 apply_category(Categories.SHOP_CAR_REPAIR, service)
                 service["opening_hours"] = self.parse_opening_hours(feature, "Service")
                 yield service
             if "Parts" in feature["Hours"].keys():
                 item["ref"] = feature.get("DealerCode") + "_Parts"
-                parts = item.copy()
+                parts = item.deepcopy()
                 apply_category(Categories.SHOP_CAR_PARTS, parts)
                 parts["opening_hours"] = self.parse_opening_hours(feature, "Parts")
                 yield parts
 
-    def parse_opening_hours(self, feature: dict, hours_type: str) -> OpeningHours():
+    def parse_opening_hours(self, feature: dict, hours_type: str) -> OpeningHours:
         oh = OpeningHours()
         if not feature.get("Hours"):
             return oh
@@ -55,7 +55,7 @@ class HyundaiCASpider(JSONBlobSpider):
                 or day_hours["End"] == "--"
                 or day_hours["End"] == "By Appt. Only"
             ):
-                oh.set_closed(DAYS_EN[day_hours["Weekday"]])
+                oh.set_closed(day_hours["Weekday"])
             else:
-                oh.add_range(DAYS_EN[day_hours["Weekday"]], day_hours["Start"], day_hours["End"], "%I:%M %p")
+                oh.add_range(day_hours["Weekday"], day_hours["Start"], day_hours["End"], "%I:%M %p")
         return oh


### PR DESCRIPTION
```python
{'atp/brand/Hyundai': 2535,
 'atp/brand_wikidata/Q55931': 2535,
 'atp/category/shop/car': 845,
 'atp/category/shop/car_parts': 845,
 'atp/category/shop/car_repair': 845,
 'atp/field/branch/missing': 2535,
 'atp/field/country/from_spider_name': 2535,
 'atp/field/email/invalid': 72,
 'atp/field/email/missing': 948,
 'atp/field/image/missing': 2535,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 2535,
 'atp/field/operator_wikidata/missing': 2535,
 'atp/field/phone/invalid': 3,
 'atp/field/state/from_reverse_geocoding': 1506,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 2535,
 'atp/field/website/invalid': 9,
 'atp/field/website/missing': 3,
 'atp/item_scraped_host_count/www.hyundaiusa.com': 25563,
 'atp/nsi/cc_match': 1690,
 'atp/nsi/match_failed': 845,
 'downloader/exception_count': 3,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 3,
 'downloader/request_bytes': 161602,
 'downloader/request_count': 342,
 'downloader/request_method_count/GET': 342,
 'downloader/response_bytes': 4177445,
 'downloader/response_count': 339,
 'downloader/response_status_count/200': 339,
 'elapsed_time_seconds': 427.322193,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 27, 11, 13, 59, 588778, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 339,
 'httpcache/miss': 342,
 'httpcache/store': 339,
 'httpcompression/response_bytes': 33394016,
 'httpcompression/response_count': 334,
 'item_dropped_count': 23028,
 'item_dropped_reasons_count/DropItem': 23028,
 'item_scraped_count': 2535,
 'log_count/INFO': 17,
 'log_count/WARNING': 1,
 'memusage/max': 510902272,
 'memusage/startup': 255201280,
 'response_received_count': 339,
 'retry/count': 3,
 'retry/reason_count/twisted.internet.error.TimeoutError': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 341,
 'scheduler/dequeued/memory': 341,
 'scheduler/enqueued': 341,
 'scheduler/enqueued/memory': 341,
 'start_time': datetime.datetime(2024, 9, 27, 11, 6, 52, 266585, tzinfo=datetime.timezone.utc)}
```