### PR TITLE
dominos_pizza_gb: drop image field

### DIFF
--- a/locations/spiders/dominos_pizza_gb.py
+++ b/locations/spiders/dominos_pizza_gb.py
@@ -18,5 +18,6 @@ class DominosPizzaGBSpider(SitemapSpider, StructuredDataSpider):
             "parse_sd",
         )
     ]
+    drop_attributes = ["image"]
     user_agent = BROWSER_DEFAULT
     requires_proxy = True


### PR DESCRIPTION
The image field is not of individual stores but rather logos and other brand imagery.