### PR TITLE
burlington_us: drop image field

### DIFF
--- a/locations/spiders/burlington_us.py
+++ b/locations/spiders/burlington_us.py
@@ -11,3 +11,4 @@ class BurlingtonUSSpider(SitemapSpider, StructuredDataSpider):
         "brand": "Burlington",
         "brand_wikidata": "Q4999220",
     }
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is a generic image of a store, and not an individual image for each store.