### PR TITLE
lloyds_bank_gb: drop image field

### DIFF
--- a/locations/spiders/lloyds_bank_gb.py
+++ b/locations/spiders/lloyds_bank_gb.py
@@ -13,6 +13,7 @@ class LloydsBankGBSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://branches.lloydsbank.com/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/branches\.lloydsbank\.com\/[-\w]+\/[-\/'\w]+$", "parse_sd")]
+    drop_attributes = {"image"}
 
     def sitemap_filter(self, entries):
         for entry in entries:


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.