### PR TITLE
cato_us: drop image field

### DIFF
--- a/locations/spiders/cato_us.py
+++ b/locations/spiders/cato_us.py
@@ -9,6 +9,7 @@ class CatoUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://stores.catofashions.com/robots.txt"]
     sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+$", "parse")]
     wanted_types = ["ClothingStore"]
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Cato Fashions ")


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each location.