### PR TITLE
food_lion_us: drop image field

### DIFF
--- a/locations/spiders/food_lion_us.py
+++ b/locations/spiders/food_lion_us.py
@@ -9,3 +9,4 @@ class FoodLionUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://stores.foodlion.com/sitemap.xml"]
     sitemap_rules = [(r"https://stores.foodlion.com/\w{2}/[-\w]+/[-\w]+", "parse_sd")]
     requires_proxy = True
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is a generic image of a store, and not an individual image for each store.