### PR TITLE
penske: drop image field

### DIFF
--- a/locations/spiders/penske.py
+++ b/locations/spiders/penske.py
@@ -13,10 +13,9 @@ class PenskeSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.pensketruckrental.com/sitemap.xml"]
     sitemap_rules = [(r"/locations/us/[-\w]+/[-\w]+/[0-9]+/$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
+    drop_attributes = {"email", "image"}
 
     def post_process_item(self, item, response, ld_data):
         item["ref"] = re.findall("[0-9]+", response.url)[0]
-        item.pop("email", None)
         item["branch"] = html.unescape(item.pop("name"))
-
         yield item


### PR DESCRIPTION
The image field is a generic image of a store, and not an individual image for each store.