### PR TITLE
ameriprise_us: drop image field

### DIFF
--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -10,6 +10,7 @@ class AmeripriseUSSpider(SitemapSpider):
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
     sitemap_urls = ["https://www.ameripriseadvisors.com/robots.txt"]
     sitemap_rules = [(r"/contact/$", "parse")]
+    drop_attributes = {"image"}
 
     def parse(self, response):
         properties = LinkedDataParser.parse(response, "ContactPage")


### PR DESCRIPTION
The image field is always either a brand logo or a photo of the financial advisor (or group of advisors) at a given office, rather than an image of an actual physical location/office.