### PR TITLE
big_lots: drop image field

### DIFF
--- a/locations/spiders/big_lots.py
+++ b/locations/spiders/big_lots.py
@@ -14,6 +14,7 @@ class BigLotsSpider(scrapy.spiders.SitemapSpider):
     sitemap_rules = [
         (r"https://local\.biglots\.com/[^/]+/[^/]+/[^/]+$", "parse"),
     ]
+    drop_attributes = {"image"}
 
     def parse(self, response):
         MicrodataParser.convert_to_json_ld(response)


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.