### PR TITLE
bhf_gb: drop image field

### DIFF
--- a/locations/spiders/bhf_gb.py
+++ b/locations/spiders/bhf_gb.py
@@ -15,6 +15,7 @@ class BhfGBSpider(SitemapSpider, StructuredDataSpider):
         ("/find-bhf-near-you/.+-furniture-electrical-store", "parse_sd"),
     ]
     wanted_types = ["ClothingStore", "HomeGoodsStore"]
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         self.crawler.stats.inc_value("z/{}".format(ld_data["@type"]))


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.