### PR TITLE
levis: drop image field where not of specific store

### DIFF
--- a/locations/spiders/levis.py
+++ b/locations/spiders/levis.py
@@ -24,4 +24,8 @@ class LevisSpider(RioSeoSpider):
         else:
             item["name"] = item["brand"]
 
+        if item.get("image") and "levis-banner.png" in item["image"]:
+            # Generic brand image used instead of image of individual store.
+            item.pop("image")
+
         yield item


### PR DESCRIPTION
Some stores for this brand do not have an individual/specific store image and instead have a generic brand logo as the image.