### PR TITLE
bealls_us: drop image where not of specific store

### DIFF
--- a/locations/spiders/bealls_us.py
+++ b/locations/spiders/bealls_us.py
@@ -5,3 +5,9 @@ class BeallsUSSpider(RioSeoSpider):
     name = "bealls_us"
     item_attributes = {"brand": "Bealls", "brand_wikidata": "Q4876153"}
     end_point = "https://maps.stores.bealls.com"
+
+    def post_process_feature(self, item, location):
+        if item.get("image") and "_bealls_store_front.jpg" in item["image"]:
+            # Generic brand image used instead of image of individual store.
+            item.pop("image")
+        yield item


### PR DESCRIPTION
Some stores for this brand do not have an individual/specific store image and instead have a generic store image instead.