### PR TITLE
the_cooperative_group: drop image field

### DIFF
--- a/locations/spiders/the_cooperative_group.py
+++ b/locations/spiders/the_cooperative_group.py
@@ -19,6 +19,7 @@ class TheCooperativeGroupSpider(SitemapSpider, StructuredDataSpider):
         ("/funeralcare/funeral-directors/", "parse_sd"),
     ]
     wanted_types = ["ConvenienceStore", "LocalBusiness"]
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if ld_data["@type"] == "ConvenienceStore":


### PR DESCRIPTION
The image field contains a single invalid image file for all locations.