### PR TITLE
petco: drop image field

### DIFF
--- a/locations/spiders/petco.py
+++ b/locations/spiders/petco.py
@@ -9,3 +9,4 @@ class PetcoSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://stores.petco.com/sitemap.xml"]
     sitemap_rules = [(r"pet-supplies-(.+).html$", "parse_sd")]
     download_delay = 0.5
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is either always the same brand logo, or is an invalid link to the store's individual website.