### PR TITLE
picard_fr: drop image field

### DIFF
--- a/locations/spiders/picard_fr.py
+++ b/locations/spiders/picard_fr.py
@@ -10,11 +10,10 @@ class PicardFRSpider(SitemapSpider):
     allowed_domains = ["magasins.picard.fr"]
     sitemap_urls = ["https://magasins.picard.fr/sitemap.xml"]
     sitemap_follow = [r"https:\/\/magasins\.picard\.fr\/locationsitemap\d+\.xml"]
+    drop_attributes = {"image"}
 
     def parse(self, response, **kwargs):
-
         feature = LinkedDataParser.parse(response, "LocalBusiness")
         feature["website"] = response.url
         feature["ref"] = response.url
-
         yield feature


### PR DESCRIPTION
The image field is a generic image of a store, and not an individual image for each store.