### PR TITLE
american_eagle_outfitters: drop image field

### DIFF
--- a/locations/spiders/american_eagle_outfitters.py
+++ b/locations/spiders/american_eagle_outfitters.py
@@ -9,6 +9,7 @@ class AmericanEagleOutfittersSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://stores.aeostores.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["brand"] = response.xpath('//*[@class="LocationName-brand"]/text()').get()


### PR DESCRIPTION
The image field is either always the same brand logo, or is an invalid link to the store's individual website.