### PR TITLE
ups_store: drop image field

### DIFF
--- a/locations/spiders/ups_store.py
+++ b/locations/spiders/ups_store.py
@@ -9,3 +9,4 @@ class UpsStoreSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["locations.theupsstore.com"]
     sitemap_urls = ["https://locations.theupsstore.com/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/locations.theupsstore.com\/[a-z]{2}\/[a-z]+\/\d+-[a-z-]+$", "parse_sd")]
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.