### PR TITLE
moes_southwest_grill: drop image field

### DIFF
--- a/locations/spiders/moes_southwest_grill.py
+++ b/locations/spiders/moes_southwest_grill.py
@@ -14,6 +14,7 @@ class MoesSouthwestGrillSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"locations\.moes\.com/.*/.*/.*$", "parse_sd"),
     ]
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if name := item.get("name"):


### PR DESCRIPTION
The image field is a generic stock art image, and not an individual image for each store.