### PR TITLE
rainbow_shops: drop image field where not of specific store

### DIFF
--- a/locations/spiders/rainbow_shops.py
+++ b/locations/spiders/rainbow_shops.py
@@ -21,4 +21,9 @@ class RainbowShopsSpider(SitemapSpider, StructuredDataSpider):
         item["lat"] = response.xpath("//@data-lat").get()
         item["lon"] = response.xpath("//@data-lng").get()
 
+        if item.get("image") and "wkvygexq0az9oz125oof.jpg" in item["image"]:
+            # Ignore logo placeholder images where a specific image of a store
+            # does not exist.
+            item.pop("image")
+
         yield item


### PR DESCRIPTION
Some stores for this brand do not have an individual/specific store image and instead have a generic brand logo as the image.