### PR TITLE
massage_envy: drop image field

### DIFF
--- a/locations/spiders/massage_envy.py
+++ b/locations/spiders/massage_envy.py
@@ -12,3 +12,4 @@ class MassageEnvySpider(SitemapSpider, StructuredDataSpider):
         (r"^https://locations.massageenvy.com/[^/]+/[^/]+/[^/]+.html$", "parse_sd"),
     ]
     wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.