### PR TITLE
jamba_juice: drop image field

### DIFF
--- a/locations/spiders/jamba_juice.py
+++ b/locations/spiders/jamba_juice.py
@@ -10,3 +10,4 @@ class JambaJuiceSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://locations.jamba.com/sitemap.xml"]
     sitemap_rules = [(r"/[-\w]+/[-\w]+/[-\w]+", "parse_sd")]
     wanted_types = ["Restaurant"]
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is a generic stock art image, and not an individual image for each store.