### PR TITLE
salon_centric_us: drop image field

### DIFF
--- a/locations/spiders/salon_centric_us.py
+++ b/locations/spiders/salon_centric_us.py
@@ -14,6 +14,7 @@ class SalonCentricUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://stores.saloncentric.com/sitemap.xml"]
     sitemap_rules = [(r"com/\w\w/[^/]+/(\d+)$", "parse")]
     wanted_types = ["HealthAndBeautyBusiness"]
+    drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "Coming Soon" in item["name"]:


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.