### PR TITLE
jackson_hewitt: drop image field

### DIFF
--- a/locations/spiders/jackson_hewitt.py
+++ b/locations/spiders/jackson_hewitt.py
@@ -12,6 +12,7 @@ class JacksonHewittSpider(scrapy.spiders.SitemapSpider):
     sitemap_rules = [
         (r"/\d+$", "parse"),
     ]
+    drop_attributes = {"image"}
 
     def parse(self, response):
         MicrodataParser.convert_to_json_ld(response)


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.