### PR TITLE
maurices: drop image field

### DIFF
--- a/locations/spiders/maurices.py
+++ b/locations/spiders/maurices.py
@@ -9,3 +9,4 @@ class MauricesSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://locations.maurices.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     download_delay = 0.2
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.