### PR TITLE
fifth_third_bank: drop image field

### DIFF
--- a/locations/spiders/fifth_third_bank.py
+++ b/locations/spiders/fifth_third_bank.py
@@ -14,6 +14,7 @@ class FifthThirdBankSpider(scrapy.spiders.SitemapSpider):
     sitemap_urls = [
         "https://locations.53.com/robots.txt",
     ]
+    drop_attributes = {"image"}
 
     def parse(self, response):
         MicrodataParser.convert_to_json_ld(response.selector)


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.