### PR TITLE
netto_salling: drop image field

### DIFF
--- a/locations/spiders/netto_salling.py
+++ b/locations/spiders/netto_salling.py
@@ -20,6 +20,7 @@ class NettoSallingSpider(SitemapSpider, StructuredDataSpider):
         ("/butikker/", "parse_sd"),
         ("/sklepy/", "parse_sd"),
     ]
+    drop_attributes = {"image"}
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["name"] = html.unescape(ld_data["name"])


### PR DESCRIPTION
The image field is a generic image of a store, and not an individual image for each store.