### PR TITLE
bojangles: drop image field

### DIFF
--- a/locations/spiders/bojangles.py
+++ b/locations/spiders/bojangles.py
@@ -13,6 +13,7 @@ class BojanglesSpider(scrapy.spiders.SitemapSpider):
     sitemap_rules = [
         (r"^https://locations.bojangles.com/[^/]+/[^/]+/[^/]+.html$", "parse_store"),
     ]
+    drop_attributes = {"image"}
 
     def parse_store(self, response):
         MicrodataParser.convert_to_json_ld(response)


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.