### PR TITLE
societe_generale: drop image field where not of specific store

### DIFF
--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -17,4 +17,9 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
 
         apply_category(Categories.BANK, item)
 
+        if item.get("image") and "agence-sg.jpg" in item["image"]:
+            # Ignore generic image of a store that is used as a placeholder
+            # when a location-specific image is not available.
+            item.pop("image")
+
         yield item


### PR DESCRIPTION
Some stores for this brand do not have an individual/specific store image and instead have a generic store image instead.