### PR TITLE
papa_murphys: drop image field

### DIFF
--- a/locations/spiders/papa_murphys.py
+++ b/locations/spiders/papa_murphys.py
@@ -15,6 +15,7 @@ class PapaMurphysSpider(SitemapSpider):
             "parse_store",
         ),
     ]
+    drop_attributes = {"image"}
 
     def parse_store(self, response):
         MicrodataParser.convert_to_json_ld(response)


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.