### PR TITLE
gnc: drop image field

### DIFF
--- a/locations/spiders/gnc.py
+++ b/locations/spiders/gnc.py
@@ -12,3 +12,4 @@ class GncSpider(SitemapSpider, StructuredDataSpider):
         (r"^https://stores.gnc.com/all-stores-[^/]+/[^/]+/[^/]+$", "parse_sd"),
     ]
     wanted_types = ["HobbyShop"]
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.