### PR TITLE
subway: drop image field

### DIFF
--- a/locations/spiders/subway.py
+++ b/locations/spiders/subway.py
@@ -9,7 +9,7 @@ class SubwaySpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["restaurants.subway.com"]
     sitemap_urls = ["https://restaurants.subway.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
-    download_delay = 0
+    drop_attributes = {"image"}
 
     def pre_process_data(self, ld_data, **kwargs):
         if isinstance(ld_data["name"], list):


### PR DESCRIPTION
The image field is either always the same brand logo, or is an invalid link to the store's individual website.