### PR TITLE
bestone_gb: drop image field

### DIFF
--- a/locations/spiders/bestone_gb.py
+++ b/locations/spiders/bestone_gb.py
@@ -7,10 +7,10 @@ class BestoneGBSpider(scrapy.spiders.SitemapSpider):
     name = "bestone_gb"
     item_attributes = {"brand": "Best-one", "brand_wikidata": "Q4896532"}
     sitemap_urls = ["https://stores.best-one.co.uk/sitemap.xml"]
+    drop_attributes = {"name", "image"}
 
     def parse(self, response):
         for store_type in ["ConvenienceStore", "WholesaleStore"]:
             if item := LinkedDataParser.parse(response, store_type):
-                item.pop("name", None)
                 yield item
                 return


### PR DESCRIPTION
The image field is always the same brand logo, not an individual image of each branch.