### PR TITLE
vans: drop image field

### DIFF
--- a/locations/spiders/vans.py
+++ b/locations/spiders/vans.py
@@ -9,3 +9,4 @@ class VansSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["vans.com"]
     sitemap_urls = ["https://www.vans.com/sitemaps/store-locations.xml"]
     sitemap_rules = [(r"/stores/.+/.+/\w+\d+$", "parse_sd")]
+    drop_attributes = {"image"}


### PR DESCRIPTION
The image field is populated with a banner/advertising image.