### PR TITLE
Add spider for virginia blue ridge distrinct health inspection data

### DIFF
--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -35,7 +35,7 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
         for inspection in response.json():
             item = DictParser.parse(inspection)
 
-            item["ref"] = item["ref:myhealthdepartment.com"] = inspection["inspectionID"]
+            item["ref"] = item["ref:myhealthdepartment.com:inspectionID"] = inspection["inspectionID"]
             item["name"] = inspection["establishmentName"]
 
             item["extras"]["checked_date"] = inspection["inspectionDate"]

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -35,11 +35,10 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
         for inspection in response.json():
             item = DictParser.parse(inspection)
 
-            item["ref"] = inspection["inspectionID"]
+            item["ref"] = item["ref:myhealthdepartment.com"] = inspection["inspectionID"]
             item["name"] = inspection["establishmentName"]
 
-            # TODO: should this be check_date or is that controversial to use for a third-party check?
-            item["extras"]["inspectionDate"] = inspection["inspectionDate"]
+            item["extras"]["checked_date"] = inspection["inspectionDate"]
 
             # categorize the inspection to OSM standards
             if inspection["inspectionType"] == "Fast Food":

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -50,6 +50,6 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
             elif inspection["inspectionType"] == "Educational Facility Food Service":
                 item["extras"]["amenity"] = "school"
             else:
-                return
+                continue
 
             yield item

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -3,6 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 
+
 class VirginiaHealthInspectionBlueRidgeSpider(Spider):
     name = "virginia_health_inspection_blue_ridge"
     item_attributes = {}
@@ -31,13 +32,13 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
             )
 
     def parse_location_list(self, response):
-        for inspection in response.json():            
+        for inspection in response.json():
             item = DictParser.parse(inspection)
-            
+
             item["ref"] = inspection["inspectionID"]
             item["name"] = inspection["establishmentName"]
 
-            item["extras"] = {"inspectionDate": inspection["inspectionDate"]},
+            item["extras"] = ({"inspectionDate": inspection["inspectionDate"]},)
 
             # categorize the inspection to OSM standards
             if inspection["inspectionType"] == "Fast Food":
@@ -50,5 +51,5 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
                 item["extras"]["amenity"] = "school"
             else:
                 return
-            
+
             yield item

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -38,7 +38,8 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
             item["ref"] = inspection["inspectionID"]
             item["name"] = inspection["establishmentName"]
 
-            item["extras"] = ({"inspectionDate": inspection["inspectionDate"]},)
+            # TODO: should this be check_date or is that controversial to use for a third-party check?
+            item["extras"]["inspectionDate"] = inspection["inspectionDate"]
 
             # categorize the inspection to OSM standards
             if inspection["inspectionType"] == "Fast Food":

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -35,7 +35,8 @@ class VirginiaHealthInspectionBlueRidgeSpider(Spider):
         for inspection in response.json():
             item = DictParser.parse(inspection)
 
-            item["ref"] = item["ref:myhealthdepartment.com:inspectionID"] = inspection["inspectionID"]
+            item["ref"] = inspection["inspectionID"]
+            item["extras"]["ref:myhealthdepartment.com:inspectionID"] = inspection["inspectionID"]
             item["name"] = inspection["establishmentName"]
 
             item["extras"]["checked_date"] = inspection["inspectionDate"]

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -3,7 +3,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 
-class VirginiaHealthInspectionBlueRidge(Spider):
+class VirginiaHealthInspectionBlueRidgeSpider(Spider):
     name = "virginia_health_inspection_blue_ridge"
     item_attributes = {}
     start_urls = ["https://inspections.myhealthdepartment.com"]

--- a/locations/spiders/virginia_health_inspection_blue_ridge.py
+++ b/locations/spiders/virginia_health_inspection_blue_ridge.py
@@ -1,0 +1,54 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+
+class VirginiaHealthInspectionBlueRidge(Spider):
+    name = "virginia_health_inspection_blue_ridge"
+    item_attributes = {}
+    start_urls = ["https://inspections.myhealthdepartment.com"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(
+                url=url,
+                callback=self.parse_location_list,
+                data={
+                    "data": {
+                        "path": "va-blue-ridge",
+                        "programName": "",
+                        # TODO: make the date dynamic
+                        "filters": {"date": "2024-01-01 to 2024-09-27", "purpose": "", "city": "", "zip": ""},
+                        "start": 0,
+                        "count": 2000,
+                        "searchQueryOverride": None,
+                        "searchStr": "",
+                        "lat": 0,
+                        "lng": 0,
+                    },
+                    "task": "searchInspections",
+                },
+            )
+
+    def parse_location_list(self, response):
+        for inspection in response.json():            
+            item = DictParser.parse(inspection)
+            
+            item["ref"] = inspection["inspectionID"]
+            item["name"] = inspection["establishmentName"]
+
+            item["extras"] = {"inspectionDate": inspection["inspectionDate"]},
+
+            # categorize the inspection to OSM standards
+            if inspection["inspectionType"] == "Fast Food":
+                item["extras"]["amenity"] = "fast_food"
+            elif inspection["inspectionType"] == "Full Service Restaurant":
+                item["extras"]["amenity"] = "restaurant"
+            elif inspection["inspectionType"] == "Hospital Food Service":
+                item["extras"]["amenity"] = "hospital"
+            elif inspection["inspectionType"] == "Educational Facility Food Service":
+                item["extras"]["amenity"] = "school"
+            else:
+                return
+            
+            yield item


### PR DESCRIPTION
Mostly here for discussion since this may be out of scope to include in ATP.

There are 136 districts available on https://inspections.myhealthdepartment.com/ spanning several states, but for now I've hard-coded it to a single district in Virginia.

The main benefit to including this source is having access to recent data "on the ground" from a health inspector. A lot of the restaurants in OSM are quite old, and may or may not still exist.

I've been geocoding this data for the state of Virginia to find missing restaurants in OSM, corroborated with public sources like the restaurant's website.

Although it's not super useful to include by itself because the source is not geocoded, a geocoding step in the pipeline would make this quite valuable for auditing OSM data.
