### PR TITLE
[hifi_corp] Add spider

### DIFF
--- a/locations/spiders/hifi_corp.py
+++ b/locations/spiders/hifi_corp.py
@@ -1,0 +1,35 @@
+import chompjs
+
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class HifiCorpSpider(JSONBlobSpider):
+    name = "hifi_corp"
+    item_attributes = {"brand": "HiFiCorp", "brand_wikidata": "Q130331336"}
+    start_urls = ["https://www.hificorp.co.za/storelocator"]
+
+    def extract_json(self, response):
+        data_raw = response.xpath(
+            '//script[@type="text/x-magento-init"][contains(text(), "storelocator-store-list")]/text()'
+        ).get()
+        return chompjs.parse_js_object(data_raw)["#storelocator-store-list"]["Magento_Ui/js/core/app"]["components"][
+            "storelocatorList"
+        ]["storeData"]
+
+    def post_process_item(self, item, response, location):
+        if location["virtual_store"] == "1" or location["store_closed"] == "1":
+            return
+        item["branch"] = item.pop("name").replace("- HiFiCorp", "").strip()
+        item["website"] = f"https://www.hificorp.co.za/storelocator/store/index/id/{item['ref']}"
+        item["country"] = location["country_id"]
+        item["opening_hours"] = OpeningHours()
+        try:
+            for day in chompjs.parse_js_object(location["opening_hours"]).values():
+                try:
+                    item["opening_hours"].add_range(day["weekday"], day["open_time"], day["close_time"])
+                except ValueError:
+                    pass
+        except AttributeError:
+            pass
+        yield item


### PR DESCRIPTION
```
 'atp/brand/HiFiCorp': 54,
 'atp/brand_wikidata/Q130331336': 54,
 'atp/category/shop/electronics': 54,
 'atp/field/email/missing': 54,
 'atp/field/image/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/phone/invalid': 3,
 'atp/field/postcode/missing': 6,
 'atp/field/state/missing': 3,
 'atp/field/street_address/missing': 54,
 'atp/field/twitter/missing': 54,
 'atp/item_scraped_host_count/www.hificorp.co.za': 54,
 'atp/nsi/perfect_match': 54,
```