### PR TITLE
[Cuisinella FR] Fix coords

### DIFF
--- a/locations/spiders/cuisinella_fr.py
+++ b/locations/spiders/cuisinella_fr.py
@@ -1,5 +1,9 @@
+import html
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -7,6 +11,22 @@ class CuisinellaFRSpider(SitemapSpider, StructuredDataSpider):
     name = "cuisinella_fr"
     item_attributes = {"brand": "Cuisinella", "brand_wikidata": "Q3007012"}
     sitemap_urls = ["https://www.ma.cuisinella/robots.txt"]
-    sitemap_rules = [
-        (r"/fr-fr/magasins/[\w-]+/[\w-]+", "parse"),
-    ]
+    sitemap_rules = [(r"/fr-fr/magasins/[\w-]+/[\w-]+", "parse")]
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        # Currently 100% malformed eg
+        # {
+        #     "@type": "GeoCoordinates",
+        #     "latitude": "16.242304, -61.562389?.Latitude",
+        #     "longitude": "16.242304, -61.562389?.Longitude",
+        # }
+
+        if (ld_data.get("geo") or {}).get("latitude").endswith("?.Latitude"):
+            ld_data["geo"]["latitude"], ld_data["geo"]["longitude"] = (
+                ld_data["geo"]["latitude"].split("?", 1)[0].split(", ", 1)
+            )
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["image"] = None
+        item["branch"] = html.unescape(item.pop("name"))
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Cuisinella': 324,
 'atp/brand_wikidata/Q3007012': 324,
 'atp/category/shop/kitchen': 324,
 'atp/field/email/missing': 324,
 'atp/field/image/invalid': 324,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 324,
 'atp/field/operator_wikidata/missing': 324,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 318,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 324,
 'atp/item_scraped_host_count/www.ma.cuisinella': 324,
 'atp/nsi/perfect_match': 324,
 'downloader/request_bytes': 237103,
 'downloader/request_count': 337,
 'downloader/request_method_count/GET': 337,
 'downloader/response_bytes': 10829140,
 'downloader/response_count': 337,
 'downloader/response_status_count/200': 330,
 'downloader/response_status_count/301': 6,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 4,
 'elapsed_time_seconds': 98.675625,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 9, 30, 15, 35, 41, 572684, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 81,
 'httpcache/hit': 256,
 'httpcache/miss': 81,
 'httpcache/store': 81,
 'httpcompression/response_bytes': 39269349,
 'httpcompression/response_count': 330,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 324,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 440832000,
 'memusage/startup': 255160320,
 'request_depth_max': 2,
 'response_received_count': 331,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 336,
 'scheduler/dequeued/memory': 336,
 'scheduler/enqueued': 336,
 'scheduler/enqueued/memory': 336,
 'start_time': datetime.datetime(2024, 9, 30, 15, 34, 2, 897059, tzinfo=datetime.timezone.utc)}
```