### PR TITLE
[Refactor] Use deepcopy over copy

### DIFF
--- a/locations/spiders/hyundai_gb.py
+++ b/locations/spiders/hyundai_gb.py
@@ -35,20 +35,20 @@ class HyundaiGBSpider(JSONBlobSpider):
             if service["serviceId"] == "sales" or service["serviceId"] == "predaj":
                 # Features where new (and sometimes used) vehicles can be purchased.
                 # "Predaj" is "Sales" in Slovak.
-                sales_feature = item.copy()
+                sales_feature = item.deepcopy()
                 sales_feature["ref"] = sales_feature["ref"] + "_Sales"
                 apply_category(Categories.SHOP_CAR, sales_feature)
                 yield sales_feature
             elif service["serviceId"] == "service" or service["serviceId"] == "servis":
                 # Features where vehicles can be serviced and repaired.
                 # "Servis" is "Service" in Slovak.
-                service_feature = item.copy()
+                service_feature = item.deepcopy()
                 service_feature["ref"] = service_feature["ref"] + "_Service"
                 apply_category(Categories.SHOP_CAR_REPAIR, service_feature)
                 yield service_feature
             elif service["serviceId"] == "parts":
                 # Features where vehicle parts can be purchased.
-                parts_feature = item.copy()
+                parts_feature = item.deepcopy()
                 parts_feature["ref"] = service_feature["ref"] + "_Parts"
                 apply_category(Categories.SHOP_CAR_PARTS, parts_feature)
                 yield parts_feature

--- a/locations/spiders/hyundai_ie.py
+++ b/locations/spiders/hyundai_ie.py
@@ -21,14 +21,14 @@ class HyundaiIESpider(JSONBlobSpider):
         item["name"] = feature["DealerName"]
         item["website"] = "https://www.hyundai.ie/dealer/?dealer=" + feature["Slug"]
 
-        sales = item.copy()
+        sales = item.deepcopy()
         apply_category(Categories.SHOP_CAR, sales)
         sales["ref"] = feature["Slug"] + "_Sales"
         sales["opening_hours"] = OpeningHours()
         sales["opening_hours"].add_ranges_from_string(re.sub(r"\s+", " ", feature["OpeningHours"]))
         yield sales
 
-        service = item.copy()
+        service = item.deepcopy()
         apply_category(Categories.SHOP_CAR_REPAIR, service)
         service["ref"] = feature["Slug"] + "_Service"
         service["opening_hours"] = OpeningHours()

--- a/locations/spiders/hyundai_nz.py
+++ b/locations/spiders/hyundai_nz.py
@@ -23,6 +23,12 @@ class HyundaiNZSpider(JSONBlobSpider):
         item["branch"] = item.pop("name", None)
         item.pop("email", None)  # E-mail of primary contact person only. Ignore.
 
+        if website := item.get("website"):
+            if website == "/":
+                item["website"] = None
+            elif not website.startswith("http"):
+                item["website"] = "https://{}".format(website)
+
         if isinstance(feature.get("Type"), list) and len(feature["Type"]) > 0:
             if feature["Type"][0] == "Passenger sales and service":
                 service_feature = item.deepcopy()

--- a/locations/spiders/hyundai_nz.py
+++ b/locations/spiders/hyundai_nz.py
@@ -25,7 +25,7 @@ class HyundaiNZSpider(JSONBlobSpider):
 
         if isinstance(feature.get("Type"), list) and len(feature["Type"]) > 0:
             if feature["Type"][0] == "Passenger sales and service":
-                service_feature = item.copy()
+                service_feature = item.deepcopy()
                 apply_category(Categories.SHOP_CAR, item)
                 item["ref"] = item["ref"] + "_Sales"
                 apply_category(Categories.SHOP_CAR_REPAIR, service_feature)
@@ -37,7 +37,7 @@ class HyundaiNZSpider(JSONBlobSpider):
                 item["ref"] = item["ref"] + "_Service"
                 yield item
             elif feature["Type"][0] == "Truck sales and service":
-                service_feature = item.copy()
+                service_feature = item.deepcopy()
                 apply_category(Categories.SHOP_TRUCK, item)
                 item["ref"] = item["ref"] + "_Sales"
                 apply_category(Categories.SHOP_TRUCK_REPAIR, service_feature)

--- a/locations/spiders/hyundai_us.py
+++ b/locations/spiders/hyundai_us.py
@@ -49,7 +49,7 @@ class HyundaiUSSpider(JSONBlobSpider):
             service["ref"] = feature["dealerCd"] + "_Service"
             service["opening_hours"] = self.parse_opening_hours(feature, "operations")
             yield service
-            parts = item.copy()
+            parts = item.deepcopy()
             apply_category(Categories.SHOP_CAR_PARTS, parts)
             parts["ref"] = feature["dealerCd"] + "_Parts"
             parts["opening_hours"] = self.parse_opening_hours(feature, "operations")

--- a/locations/spiders/intermarche.py
+++ b/locations/spiders/intermarche.py
@@ -84,7 +84,7 @@ class IntermarcheSpider(scrapy.Spider):
                 continue  # Something to do with post offices
 
             if any(s["code"] == "ess" for s in place["ecommerce"]["services"]):
-                fuel = item.copy()
+                fuel = item.deepcopy()
                 fuel["ref"] += "_fuel"
                 fuel.update(self.INTERMARCHE)
 
@@ -93,7 +93,7 @@ class IntermarcheSpider(scrapy.Spider):
                 yield fuel
 
             if any(s["code"] == "lav" for s in place["ecommerce"]["services"]):
-                car_wash = item.copy()
+                car_wash = item.deepcopy()
                 car_wash["ref"] += "_carwash"
                 car_wash.update(self.INTERMARCHE)
 

--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -70,7 +70,7 @@ class WalmartUSSpider(SitemapSpider):
             if service["name"] not in ["PHARMACY", "GAS_STATION"]:
                 self.crawler.stats.inc_value("atp/walmart/ignored/{}".format(service["name"]))
                 continue
-            poi = item.copy()
+            poi = item.deepcopy()
             poi["ref"] += service["name"]
             poi["name"] = service["displayName"]
             poi["phone"] = service["phone"]


### PR DESCRIPTION
`.copy()` doesn't work as expected for nested dicts (`extras`). (cc @davidhicks)

```
>>> a = {"a":"abc"}
>>> b = a.copy()
>>> a["1"] = 123
>>> print(b)
{'a': 'abc'}
>>> print(a)
{'a': 'abc', '1': 123}
```

With shallow dicts/strings, it works as expected, you get a copy.

```
>>> a = {"a": "abc", "extras": {"shop": "yes"}}
>>> b = a.copy()
>>> a["extras"]["shop"] = "no"
>>> print(a)
{'a': 'abc', 'extras': {'shop': 'no'}}
>>> print(b)
{'a': 'abc', 'extras': {'shop': 'no'}}
```

But with dicts you get pointers so changing one, changes both.