### PR TITLE
[mica_hardware] Add spider

### DIFF
--- a/locations/spiders/mica_hardware.py
+++ b/locations/spiders/mica_hardware.py
@@ -14,6 +14,7 @@ class MicaHardwareSpider(Spider):
         "brand": "Mica Hardware",
         "brand_wikidata": "Q116771560",
     }
+    skip_auto_cc_domain = True
 
     def parse(self, response):
         for location in response.xpath('.//ul[@id="js-map-elements"]/li'):

--- a/locations/spiders/mica_hardware.py
+++ b/locations/spiders/mica_hardware.py
@@ -1,0 +1,44 @@
+import re
+
+from scrapy import Spider
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class MicaHardwareSpider(Spider):
+    name = "mica_hardware"
+    start_urls = ["https://www.mica.co.za/store-locator/"]
+    item_attributes = {
+        "brand": "Mica Hardware",
+        "brand_wikidata": "Q116771560",
+    }
+
+    def parse(self, response):
+        for location in response.xpath('.//ul[@id="js-map-elements"]/li'):
+            item = Feature()
+            item["ref"] = location.xpath("@data-marker-id").get()
+
+            if lat := location.xpath("@data-marker-lat").get():
+                item["lat"] = lat
+            else:
+                item["lat"] = response.xpath(f'//div[@data-marker="{item["ref"]}"]/@data-markerlat').get()
+            if lon := location.xpath("@data-marker-lon").get():
+                item["lon"] = lon
+            else:
+                item["lon"] = response.xpath(f'//div[@data-marker="{item["ref"]}"]/@data-markerlon').get()
+
+            item["name"] = location.xpath("@data-marker-title").get()  # This is used as fascia, not just branch
+            item["website"] = location.xpath(".//h2/a/@href").get()
+            item["phone"] = "; ".join(location.xpath('.//a[contains(@href, "tel:")]/@href').getall())
+            item["addr_full"] = clean_address(
+                location.xpath('.//span[@class="store-item store-address"]/text()').getall()
+            )
+
+            item["opening_hours"] = OpeningHours()
+            for day in location.xpath('.//span[@class="store-item store-hours"]/p/text()').getall():
+                day = re.sub(r"(\d)H(\d)", r"\1:\2", day)
+                item["opening_hours"].add_ranges_from_string(day)
+
+            yield item


### PR DESCRIPTION
```
 'atp/brand/Mica Hardware': 133,
 'atp/brand_wikidata/Q116771560': 133,
 'atp/category/shop/hardware': 133,
 'atp/field/branch/missing': 133,
 'atp/field/city/missing': 133,
 'atp/field/country/from_reverse_geocoding': 132,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 133,
 'atp/field/image/missing': 133,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 133,
 'atp/field/operator_wikidata/missing': 133,
 'atp/field/phone/invalid': 5,
 'atp/field/postcode/missing': 133,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 133,
 'atp/field/twitter/missing': 133,
 'atp/item_scraped_host_count/www.mica.co.za': 133,
 'atp/nsi/perfect_match': 133,
```