### PR TITLE
[zenith_bank_branch_gh] and [zenith_bank_atm_gh] Add spiders

### DIFF
--- a/locations/spiders/zenith_bank_atm_gh.py
+++ b/locations/spiders/zenith_bank_atm_gh.py
@@ -1,0 +1,21 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.zenith_bank_branch_gh import ZENITH_BANK_SHARED_ATTRIBUTES
+
+
+class ZenithBankAtmGH(Spider):
+    name = "zenith_bank_atm_gh"
+    start_urls = ["https://www.zenithbank.com.gh/tools-resources/atm-locator/"]
+    item_attributes = ZENITH_BANK_SHARED_ATTRIBUTES
+    no_refs = True
+
+    def parse(self, response):
+        for location in response.xpath('.//div[@class="vc_column-inner"]/.//li/a'):
+            item = Feature()
+            item["lat"] = location.xpath("@data-lat").get()
+            item["lon"] = location.xpath("@data-lng").get()
+            item["branch"] = location.xpath("text()").get()
+            apply_category(Categories.ATM, item)
+            yield item

--- a/locations/spiders/zenith_bank_atm_gh.py
+++ b/locations/spiders/zenith_bank_atm_gh.py
@@ -5,7 +5,7 @@ from locations.items import Feature
 from locations.spiders.zenith_bank_branch_gh import ZENITH_BANK_SHARED_ATTRIBUTES
 
 
-class ZenithBankAtmGH(Spider):
+class ZenithBankAtmGHSpider(Spider):
     name = "zenith_bank_atm_gh"
     start_urls = ["https://www.zenithbank.com.gh/tools-resources/atm-locator/"]
     item_attributes = ZENITH_BANK_SHARED_ATTRIBUTES

--- a/locations/spiders/zenith_bank_branch_gh.py
+++ b/locations/spiders/zenith_bank_branch_gh.py
@@ -1,0 +1,23 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
+from locations.items import Feature
+
+ZENITH_BANK_SHARED_ATTRIBUTES = {"brand": "Zenith Bank", "brand_wikidata": "Q5978240"}
+
+
+class ZenithBankBranchGH(Spider):
+    name = "zenith_bank_branch_gh"
+    start_urls = ["https://www.zenithbank.com.gh/about-us/branches/"]
+    item_attributes = ZENITH_BANK_SHARED_ATTRIBUTES
+    no_refs = True
+
+    def parse(self, response):
+        for location in response.xpath('.//div[@class="bordered-container"]'):
+            item = Feature()
+            item["branch"] = location.xpath(".//h2/span/text()").get()
+            extract_google_position(item, location)
+            apply_category(Categories.BANK, item)
+            yield item
+            # TODO phone numbers, address and opening hours, but HTML is not easy to parse

--- a/locations/spiders/zenith_bank_branch_gh.py
+++ b/locations/spiders/zenith_bank_branch_gh.py
@@ -7,7 +7,7 @@ from locations.items import Feature
 ZENITH_BANK_SHARED_ATTRIBUTES = {"brand": "Zenith Bank", "brand_wikidata": "Q5978240"}
 
 
-class ZenithBankBranchGH(Spider):
+class ZenithBankBranchGHSpider(Spider):
     name = "zenith_bank_branch_gh"
     start_urls = ["https://www.zenithbank.com.gh/about-us/branches/"]
     item_attributes = ZENITH_BANK_SHARED_ATTRIBUTES


### PR DESCRIPTION
```
 'atp/brand/Zenith Bank': 43,
 'atp/brand_wikidata/Q5978240': 43,
 'atp/category/amenity/bank': 43,
 'atp/field/city/missing': 43,
 'atp/field/country/from_spider_name': 43,
 'atp/field/email/missing': 43,
 'atp/field/image/missing': 43,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 43,
 'atp/field/operator/missing': 43,
 'atp/field/operator_wikidata/missing': 43,
 'atp/field/phone/missing': 43,
 'atp/field/postcode/missing': 43,
 'atp/field/state/missing': 43,
 'atp/field/street_address/missing': 43,
 'atp/field/twitter/missing': 43,
 'atp/field/website/missing': 43,
 'atp/item_scraped_host_count/www.zenithbank.com.gh': 43,
 'atp/nsi/cc_match': 43,
```

```
 'atp/brand/Zenith Bank': 71,
 'atp/brand_wikidata/Q5978240': 71,
 'atp/category/amenity/atm': 71,
 'atp/field/city/missing': 71,
 'atp/field/country/from_spider_name': 71,
 'atp/field/email/missing': 71,
 'atp/field/image/missing': 71,
 'atp/field/name/missing': 71,
 'atp/field/opening_hours/missing': 71,
 'atp/field/phone/missing': 71,
 'atp/field/postcode/missing': 71,
 'atp/field/state/missing': 71,
 'atp/field/street_address/missing': 71,
 'atp/field/twitter/missing': 71,
 'atp/field/website/missing': 71,
 'atp/item_scraped_host_count/www.zenithbank.com.gh': 71,
 'atp/nsi/cc_match': 71,
 'atp/operator/Zenith Bank': 71,
 'atp/operator_wikidata/Q5978240': 71,
```