### PR TITLE
[Hilti US] Add spider

### DIFF
--- a/locations/spiders/hilti_us.py
+++ b/locations/spiders/hilti_us.py
@@ -1,0 +1,37 @@
+import json
+from typing import Any
+from urllib.parse import urljoin
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class HiltiUSSpider(Spider):
+    name = "hilti_us"
+    item_attributes = {"brand": "Hilti", "brand_wikidata": "Q1361530"}
+    start_urls = ["https://www.hilti.com/stores"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in json.loads(response.xpath('//script[@id="hdms-website-state"]/text()').get())[
+            "apollo.state"
+        ].values():
+            if location.get("__typename") != "HiltiCenter":
+                continue
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("street")
+            item["name"] = None
+            item["branch"] = location["description"]
+            item["state"] = location["address"]["region"]["__ref"].split(":", 1)[1]
+            item["website"] = urljoin("https://www.hilti.com/stores/", location["slug"])
+
+            item["opening_hours"] = OpeningHours()
+            for rule in location["openingSchedule"]["days"]:
+                if rule["open"] is False:
+                    item["opening_hours"].set_closed(rule["day"])
+                else:
+                    for times in rule["workingHours"]:
+                        item["opening_hours"].add_range(rule["day"], times["start"], times["end"], "%H:%M:%S")
+            yield item


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/issues/9823
```python
{'atp/brand/Hilti': 74,
 'atp/brand_wikidata/Q1361530': 74,
 'atp/category/shop/hardware': 74,
 'atp/field/country/from_reverse_geocoding': 74,
 'atp/field/email/missing': 74,
 'atp/field/image/missing': 74,
 'atp/field/operator/missing': 74,
 'atp/field/operator_wikidata/missing': 74,
 'atp/field/phone/missing': 74,
 'atp/field/twitter/missing': 74,
 'atp/item_scraped_host_count/www.hilti.com': 74,
 'atp/nsi/perfect_match': 74,
 'downloader/request_bytes': 808,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 40419,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 0.713997,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 2, 11, 57, 27, 190250, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 317804,
 'httpcompression/response_count': 2,
 'item_scraped_count': 74,
 'log_count/INFO': 9,
 'memusage/max': 183484416,
 'memusage/startup': 183484416,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 2, 11, 57, 26, 476253, tzinfo=datetime.timezone.utc)}
```