### PR TITLE
[Matalan GB] Collect all locations

### DIFF
--- a/locations/spiders/matalan_gb.py
+++ b/locations/spiders/matalan_gb.py
@@ -3,6 +3,7 @@ import json
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -12,13 +13,21 @@ class MatalanGBSpider(CrawlSpider, StructuredDataSpider):
     allowed_domains = ["www.matalan.co.uk"]
     start_urls = ["https://www.matalan.co.uk/stores/uk"]
     rules = [
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[-\w]+$")),
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[-\w]+/[-\w]+$")),
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/store/[-\/\w]+$"), "parse_sd"),
+        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[^/]+$")),
+        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[^/]+/[^/]+$"), "parse_sd", follow=True),
+        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/store/[^/]+/[^/]+$"), "parse_sd"),
     ]
     time_format = "%H:%M:%S"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["phone"] = None
+        item["website"] = response.url
+
+        if item["name"].startswith("CLOSED "):
+            set_closed(item)
+
+        item["branch"] = item.pop("name").split(" - ", 1)[1]
+
         storedata = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
         store = json.loads(storedata)["props"]["pageProps"]["store"]
         item["lat"] = store["latitude"]


### PR DESCRIPTION
We need the call back on the directory url because when they are redirects (eg `https://www.matalan.co.uk/stores/uk/east-of-england/luton` -> `https://www.matalan.co.uk/store/luton/luton`) it goes to the CrawlSpider callback, not `parse_sd`. 

```python
{'atp/brand/Matalan': 232,
 'atp/brand_wikidata/Q12061509': 232,
 'atp/category/shop/clothes': 232,
 'atp/closed_poi': 10,
 'atp/field/email/missing': 232,
 'atp/field/image/missing': 232,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 232,
 'atp/field/operator_wikidata/missing': 232,
 'atp/field/phone/missing': 232,
 'atp/item_scraped_host_count/www.matalan.co.uk': 232,
 'atp/nsi/perfect_match': 232,
 'downloader/request_bytes': 353792,
 'downloader/request_count': 453,
 'downloader/request_method_count/GET': 453,
 'downloader/response_bytes': 95571970,
 'downloader/response_count': 453,
 'downloader/response_status_count/200': 394,
 'downloader/response_status_count/301': 56,
 'downloader/response_status_count/500': 3,
 'dupefilter/filtered': 332,
 'elapsed_time_seconds': 14.148029,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 4, 10, 16, 12, 199928, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 453,
 'httpcompression/response_bytes': 412201068,
 'httpcompression/response_count': 394,
 'item_scraped_count': 232,
 'log_count/ERROR': 1,
 'log_count/INFO': 10,
 'log_count/WARNING': 2,
 'memusage/max': 255070208,
 'memusage/startup': 255070208,
 'request_depth_max': 3,
 'response_received_count': 395,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/500 Internal Server Error': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 452,
 'scheduler/dequeued/memory': 452,
 'scheduler/enqueued': 452,
 'scheduler/enqueued/memory': 452,
 'start_time': datetime.datetime(2024, 10, 4, 10, 15, 58, 51899, tzinfo=datetime.timezone.utc)}
```