### PR TITLE
Virgin Active AU, GB, IT, SG, TH spiders

### DIFF
--- a/locations/spiders/virgin_active_au.py
+++ b/locations/spiders/virgin_active_au.py
@@ -1,0 +1,6 @@
+from locations.spiders.virgin_active_sg import VirginActiveSGSpider
+
+
+class VirginActiveAUSpider(VirginActiveSGSpider):
+    name = "virgin_active_au"
+    start_urls = ["https://www.virginactive.com.au/locations"]

--- a/locations/spiders/virgin_active_bw_na_za.py
+++ b/locations/spiders/virgin_active_bw_na_za.py
@@ -1,14 +1,15 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.categories import Categories
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
+
+VIRGIN_ACTIVE_SHARED_ATTRIBUTES = {"brand": "Virgin Active", "brand_wikidata": "Q4013942"}
 
 
 class VirginActiveBWNAZASpider(Spider):
     name = "virgin_active_bw_na_za"
-    item_attributes = {"brand": "Virgin Active", "brand_wikidata": "Q4013942", "extras": Categories.GYM.value}
+    item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
     start_urls = ["https://cms.virginactive.co.za/wp-json/api/map_club_list"]
 
     def start_requests(self):

--- a/locations/spiders/virgin_active_gb.py
+++ b/locations/spiders/virgin_active_gb.py
@@ -1,0 +1,24 @@
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+
+
+class VirginActiveGB(JSONBlobSpider):
+    name = "virgin_active_gb"
+    item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+    start_urls = ["https://www.virginactive.co.uk/api/club/getclubdetails"]
+    locations_key = ["data", "clubs"]
+
+    def post_process_item(self, item, response, location):
+        item["ref"] = location["clubId"]
+        item["website"] = location["clubHomeUrl"]
+        item["branch"] = item.pop("name")
+        item["addr_full"] = location["compositeAddress"]
+
+        item["opening_hours"] = OpeningHours()
+        for day, times in location["openingHours"].items():
+            if times.upper() == "CLOSED":
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_range(day, times.split("-")[0], times.split("-")[1])
+        yield item

--- a/locations/spiders/virgin_active_gb.py
+++ b/locations/spiders/virgin_active_gb.py
@@ -3,7 +3,7 @@ from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
 
 
-class VirginActiveGB(JSONBlobSpider):
+class VirginActiveGBSpider(JSONBlobSpider):
     name = "virgin_active_gb"
     item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
     start_urls = ["https://www.virginactive.co.uk/api/club/getclubdetails"]

--- a/locations/spiders/virgin_active_it.py
+++ b/locations/spiders/virgin_active_it.py
@@ -8,7 +8,7 @@ from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIB
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class VirginActiveIT(CrawlSpider, StructuredDataSpider):
+class VirginActiveITSpider(CrawlSpider, StructuredDataSpider):
     name = "virgin_active_it"
     item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
     allowed_domains = ["www.virginactive.it"]

--- a/locations/spiders/virgin_active_it.py
+++ b/locations/spiders/virgin_active_it.py
@@ -1,0 +1,30 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories
+from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+from locations.hours import DAYS_IT
+
+
+class VirginActiveIT(CrawlSpider, StructuredDataSpider):
+    name = "virgin_active_it"
+    item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+    allowed_domains = ["www.virginactive.it"]
+    start_urls = ["https://www.virginactive.it/club"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"/club/[-\w]+/[-\w]+$"),
+            follow=True,
+        ),
+    ]
+    # days = DAYS_IT
+    time_format = "%H.%M"
+    wanted_types = ["ExerciseGym"]
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def post_process_item(self, item, response, ld_data):
+        item["branch"] = item.pop("name")
+        item["image"] = item["image"].split("?")[0]
+        yield item

--- a/locations/spiders/virgin_active_sg.py
+++ b/locations/spiders/virgin_active_sg.py
@@ -1,23 +1,29 @@
 from chompjs import parse_js_object
 from scrapy.http import JsonRequest
 
-from locations.hours import OpeningHours
+from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
 
 
+# Also used by virgin_active_au
 class VirginActiveSGSpider(JSONBlobSpider):
     name = "virgin_active_sg"
     item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
     start_urls = ["https://www.virginactive.com.sg/locations"]
 
-    def extract_json(self, response):
+    def parse(self, response):
         json_data = parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
-        return json_data["props"]["pageProps"]["clubGroups"][0]["clubs"]
+        club_groups = json_data["props"]["pageProps"]["clubGroups"]
+        for group in club_groups:
+            features = group["clubs"]
+            yield from self.parse_feature_array(response, features) or []
 
     def post_process_item(self, item, response, location):
         yield JsonRequest(
-            url="https://www.virginactive.com.sg/" + location["path"], meta={"item": item}, callback=self.parse_location
+            url=self.start_urls[0].replace("/locations", "") + location["path"],
+            meta={"item": item},
+            callback=self.parse_location,
         )
 
     def parse_location(self, response):
@@ -27,5 +33,8 @@ class VirginActiveSGSpider(JSONBlobSpider):
         item["email"] = location["email"]
         item["opening_hours"] = OpeningHours()
         for day in location["openingHours"]:
-            item["opening_hours"].add_ranges_from_string(day["label"] + " " + day["value"])
+            if day["value"].lower() == "closed" and day["label"] in DAYS_3_LETTERS:
+                item["opening_hours"].set_closed(day["label"])
+            else:
+                item["opening_hours"].add_ranges_from_string(day["label"] + " " + day["value"])
         yield item

--- a/locations/spiders/virgin_active_sg.py
+++ b/locations/spiders/virgin_active_sg.py
@@ -21,7 +21,7 @@ class VirginActiveSGSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
         yield JsonRequest(
-            url=self.start_urls[0].replace("/locations", "") + location["path"],
+            url=response.url.replace("/locations", "") + location["path"],
             meta={"item": item},
             callback=self.parse_location,
         )
@@ -31,6 +31,7 @@ class VirginActiveSGSpider(JSONBlobSpider):
         location = parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"]
         item["website"] = response.url
         item["email"] = location["email"]
+        item["branch"] = item.pop("name")
         item["opening_hours"] = OpeningHours()
         for day in location["openingHours"]:
             if day["value"].lower() == "closed" and day["label"] in DAYS_3_LETTERS:

--- a/locations/spiders/virgin_active_sg.py
+++ b/locations/spiders/virgin_active_sg.py
@@ -1,0 +1,31 @@
+from chompjs import parse_js_object
+from scrapy.http import JsonRequest
+
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+
+
+class VirginActiveSGSpider(JSONBlobSpider):
+    name = "virgin_active_sg"
+    item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
+    start_urls = ["https://www.virginactive.com.sg/locations"]
+
+    def extract_json(self, response):
+        json_data = parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
+        return json_data["props"]["pageProps"]["clubGroups"][0]["clubs"]
+
+    def post_process_item(self, item, response, location):
+        yield JsonRequest(
+            url="https://www.virginactive.com.sg/" + location["path"], meta={"item": item}, callback=self.parse_location
+        )
+
+    def parse_location(self, response):
+        item = response.meta["item"]
+        location = parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"]
+        item["website"] = response.url
+        item["email"] = location["email"]
+        item["opening_hours"] = OpeningHours()
+        for day in location["openingHours"]:
+            item["opening_hours"].add_ranges_from_string(day["label"] + " " + day["value"])
+        yield item

--- a/locations/spiders/virgin_active_th.py
+++ b/locations/spiders/virgin_active_th.py
@@ -1,0 +1,42 @@
+from chompjs import parse_js_object
+
+from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.items import get_merged_item
+from locations.spiders.virgin_active_sg import VirginActiveSGSpider
+
+
+class VirginActiveTHSpider(VirginActiveSGSpider):
+    name = "virgin_active_th"
+    start_urls = ["https://www.virginactive.co.th/locations", "https://www.virginactive.co.th/en/locations"]
+    stored_items = {}
+
+    def parse_location(self, response):
+        item = response.meta["item"]
+        location = parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"]
+        item["website"] = response.url
+        item["email"] = location["email"]
+        item["branch"] = item.pop("name")
+        item["opening_hours"] = OpeningHours()
+        for day in location["openingHours"]:
+            if day["value"].lower() == "closed" and day["label"] in DAYS_3_LETTERS:
+                item["opening_hours"].set_closed(day["label"])
+            else:
+                item["opening_hours"].add_ranges_from_string(day["label"] + " " + day["value"])
+
+        if item["ref"] in self.stored_items:
+            other_item = self.stored_items.pop(item["ref"])
+            if "/en/" in response.url:
+                # TH opening hours are not parsed, so copy them over
+                other_item["opening_hours"] = item["opening_hours"]
+                item["lat"] = other_item["lat"]
+                item["lon"] = other_item["lon"]  # Slightly different location for some items, for some reason
+                yield get_merged_item({"en": item, "th": other_item}, "th")
+            else:
+                # TH opening hours are not parsed, so copy them over
+                item["opening_hours"] = other_item["opening_hours"]
+                other_item["lat"] = item["lat"]
+                other_item["lon"] = item["lon"]  # Slightly different location for some items, for some reason
+                yield get_merged_item({"en": other_item, "th": item}, "th")
+
+        else:
+            self.stored_items[item["ref"]] = item


### PR DESCRIPTION
Fixes #9973, fixes #9974

For IT, which has structured data, I felt like I should have been able to specify `days = DAYS_IT` in the same way I can specify `time_format`. However, it felt like a bit too much of a refactor to do that now.

GB:

```
 'atp/brand/Virgin Active': 32,
 'atp/brand_wikidata/Q4013942': 32,
 'atp/category/leisure/fitness_centre': 32,
 'atp/field/city/missing': 32,
 'atp/field/country/from_spider_name': 32,
 'atp/field/email/missing': 32,
 'atp/field/image/missing': 32,
 'atp/field/operator/missing': 32,
 'atp/field/operator_wikidata/missing': 32,
 'atp/field/state/missing': 32,
 'atp/field/street_address/missing': 32,
 'atp/field/twitter/missing': 32,
 'atp/item_scraped_host_count/www.virginactive.co.uk': 32,
 'atp/nsi/perfect_match': 32,
```

SG:

```
 'atp/brand/Virgin Active': 5,
 'atp/brand_wikidata/Q4013942': 5,
 'atp/category/leisure/fitness_centre': 5,
 'atp/field/branch/missing': 5,
 'atp/field/city/missing': 5,
 'atp/field/country/from_spider_name': 5,
 'atp/field/image/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 5,
 'atp/field/street_address/missing': 5,
 'atp/field/twitter/missing': 5,
 'atp/item_scraped_host_count/www.virginactive.com.sg': 5,
 'atp/nsi/perfect_match': 5,
```

AU:

```
 'atp/brand/Virgin Active': 9,
 'atp/brand_wikidata/Q4013942': 9,
 'atp/category/leisure/fitness_centre': 9,
 'atp/field/branch/missing': 9,
 'atp/field/city/missing': 9,
 'atp/field/country/from_spider_name': 9,
 'atp/field/image/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/postcode/missing': 9,
 'atp/field/state/missing': 9,
 'atp/field/street_address/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/item_scraped_host_count/www.virginactive.com.au': 9,
 'atp/nsi/perfect_match': 9,
```

TH:

```
 'atp/brand/Virgin Active': 8,
 'atp/brand_wikidata/Q4013942': 8,
 'atp/category/leisure/fitness_centre': 8,
 'atp/field/city/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/image/missing': 8,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/postcode/missing': 8,
 'atp/field/state/missing': 8,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 8,
 'atp/item_scraped_host_count/www.virginactive.co.th': 8,
 'atp/nsi/perfect_match': 8,
```

IT:

```
 'atp/brand/Virgin Active': 39,
 'atp/brand_wikidata/Q4013942': 39,
 'atp/category/leisure/fitness_centre': 39,
 'atp/field/email/missing': 39,
 'atp/field/operator/missing': 39,
 'atp/field/operator_wikidata/missing': 39,
 'atp/field/phone/missing': 39,
 'atp/field/state/missing': 39,
 'atp/field/twitter/missing': 39,
 'atp/item_scraped_host_count/www.virginactive.it': 39,
 'atp/nsi/perfect_match': 39,
```