### PR TITLE
Support passing in DAYS_XY when parsing structured data

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -59,7 +59,7 @@ class LinkedDataParser:
                 return ld_obj
 
     @staticmethod
-    def parse_ld(ld, time_format: str = "%H:%M") -> Feature:  # noqa: C901
+    def parse_ld(ld, time_format: str = "%H:%M", days: {} = DAYS_EN) -> Feature:  # noqa: C901
         item = Feature()
 
         if (
@@ -122,7 +122,7 @@ class LinkedDataParser:
         item["website"] = LinkedDataParser.get_case_insensitive(ld, "url")
 
         try:
-            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld, time_format=time_format)
+            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld, time_format=time_format, days=days)
         except ValueError as e:
             # Explicitly handle a ValueError, which is likely time_format related
             logger.warning(f"Unable to parse opening hours - check time_format? Error was: {str(e)}")

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -187,7 +187,7 @@ class LinkedDataParser:
     # This defaults to DAYS_EN, which is the standard (see https://schema.org/DayOfWeek)
     # As some publishers publish localised days, we allow this to be overridden.
     @staticmethod
-    def _parse_opening_hours_specification(oh: OpeningHours, rule: dict, time_format: str, days: DAYS_EN):
+    def _parse_opening_hours_specification(oh: OpeningHours, rule: dict, time_format: str, days: {} = DAYS_EN):
         if (
             not type(LinkedDataParser.get_case_insensitive(rule, "dayOfWeek")) in [list, str]
             or not type(LinkedDataParser.get_case_insensitive(rule, "opens")) == str
@@ -200,8 +200,10 @@ class LinkedDataParser:
             parsed_days = [parsed_days]
 
         for day in parsed_days:
+            # Handle plain text days, or URI references to a DayOfWeek enumeration, ie https://schema.org/Friday
+            parsed_day = day.strip().replace("http://schema.org/", "").replace("https://schema.org/", "")
             oh.add_range(
-                day=days[day.strip()],
+                day=days[parsed_day],
                 open_time=LinkedDataParser.get_case_insensitive(rule, "opens").strip(),
                 close_time=LinkedDataParser.get_case_insensitive(rule, "closes").strip(),
                 time_format=time_format,
@@ -212,7 +214,7 @@ class LinkedDataParser:
     # "Mo,Tu,We,Th 09:00-12:00"
     # "Mo-Fr 10:00-19:00"
     @staticmethod
-    def _parse_opening_hours(oh: OpeningHours, rule: str, time_format: str, permitted_days: DAYS_EN):
+    def _parse_opening_hours(oh: OpeningHours, rule: str, time_format: str, permitted_days: {} = DAYS_EN):
         days, time_ranges = rule.split(" ", 1)
 
         for time_range in time_ranges.split(","):
@@ -239,7 +241,7 @@ class LinkedDataParser:
         return oh
 
     @staticmethod
-    def parse_opening_hours(linked_data, time_format: str = "%H:%M", days: DAYS_EN) -> OpeningHours:
+    def parse_opening_hours(linked_data, time_format: str = "%H:%M", days: {} = DAYS_EN) -> OpeningHours:
         oh = OpeningHours()
         if spec := LinkedDataParser.get_case_insensitive(linked_data, "openingHoursSpecification"):
             if isinstance(spec, list):

--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -6,7 +6,7 @@ import traceback
 import chompjs
 import json5
 
-from locations.hours import OpeningHours, day_range, sanitise_day, DAYS_EN
+from locations.hours import DAYS_EN, OpeningHours, day_range, sanitise_day
 from locations.items import Feature, add_social_media
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fix https://github.com/alltheplaces/alltheplaces/issues/10897

I agree that this not the standard, but from a spider developer point of view there's value in just being able to say _StructuredDataSpider, please parse this using this constant, not your default assumption, because the publisher got it wrong_.

The other alternative is to nag the data producer to conform to the specification... but even the schema.org validator doesn't do that:

https://validator.schema.org/#url=https%3A%2F%2Fwww.virginactive.it%2Fclub%2Fcatania%2Fcatania
![image](https://github.com/user-attachments/assets/0d4b1b53-da6a-418f-9f7f-f7f1170c6a3f)
