### PR TITLE
[vida_e_caffe] Rename, fix and parse more features

### DIFF
--- a/locations/spiders/vida_e_caffe.py
+++ b/locations/spiders/vida_e_caffe.py
@@ -1,12 +1,12 @@
 import chompjs
 
 from locations.categories import Extras, PaymentMethods, apply_yes_no
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, sanitise_day
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class VidaCaffeSpider(JSONBlobSpider):
-    name = "vida_caffe"
+class VidaECaffeSpider(JSONBlobSpider):
+    name = "vida_e_caffe"
     item_attributes = {
         "brand": "Vida e Caffè",
         "brand_wikidata": "Q7927650",
@@ -21,15 +21,34 @@ class VidaCaffeSpider(JSONBlobSpider):
     def post_process_item(self, item, response, location):
         # {'id': 353, 'title': '@Home Sandton City', 'location': {'address': 'Sandton City, 163 5th St, Sandhurst, Sandton, GP, South Africa', 'lat': '-26.1082596', 'lng': '28.0531383'}, 'images': False, 'email': 'athomesandton@Caffe.co.za', 'facebook': None, 'times': False, 'shop_number': 'Shop U307', 'contact_number': '', 'store_type': ['corporate'], 'store_features': []}
 
-        if location["store_type"] == "vending":
+        if location["store_type"] == ["vending"]:
             # Beverage only? Vending machine only? Unclear
             return
 
-        item["housenumber"] = location["shop_number"]
-        if "Times" in location and location["Times"]:
+        item["branch"] = item.pop("name")
+
+        if isinstance(location["location"], dict):
+            item["housenumber"] = location["location"].get("street_number")
+            item["street"] = location["location"].get("street_name")
+            item["city"] = location["location"].get("city")
+            item["postcode"] = location["location"].get("post_code")
+            item["state"] = location["location"].get("state")
+            item["country"] = location["location"].get("country_short")
+            item["addr_full"] = location["location"].get("address")
+        if item["housenumber"] is None:
+            item["housenumber"] = location["shop_number"]
+
+        if "times" in location and location["times"]:
             item["opening_hours"] = OpeningHours()
-            for time in location["Times"]:
-                item["opening_hours"].add_ranges_from_string(time["label"] + " " + time["times"])
+            for time in location["times"]:
+                if time["times"] == "Open 24 hours":
+                    item["opening_hours"].add_ranges_from_string(time["label"] + " 00:00-23:59")
+                elif "closed" in time["times"].lower():
+                    day = sanitise_day(time["label"])
+                    if day:
+                        item["opening_hours"].set_closed(day)
+                else:
+                    item["opening_hours"].add_ranges_from_string(time["label"] + " " + time["times"])
 
         # Features
         # 'store_features': ['free-wifi', 'halaal', 'mobile-payment', 'redeem-vitality-rewards'


### PR DESCRIPTION
Parse address details where available, fix skipping of vending only locations, fix hours.

```
 'atp/brand/Vida e Caffè': 382,
 'atp/brand_wikidata/Q7927650': 382,
 'atp/category/amenity/cafe': 382,
 'atp/field/city/missing': 304,
 'atp/field/country/from_reverse_geocoding': 286,
 'atp/field/country/missing': 17,
 'atp/field/email/missing': 304,
 'atp/field/image/missing': 382,
 'atp/field/lat/missing': 17,
 'atp/field/lon/missing': 17,
 'atp/field/opening_hours/missing': 158,
 'atp/field/operator/missing': 382,
 'atp/field/operator_wikidata/missing': 382,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 119,
 'atp/field/postcode/missing': 322,
 'atp/field/state/missing': 17,
 'atp/field/street_address/missing': 382,
 'atp/field/twitter/missing': 382,
 'atp/field/website/missing': 382,
 'atp/item_scraped_host_count/vidaecaffe.com': 382,
 'atp/nsi/perfect_match': 382,
```