### PR TITLE
[invitro_ru] add spider (1.5k locations)

### DIFF
--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -8,17 +8,18 @@ class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
     name = "invitro_ru"
     item_attributes = {
         "brand": "Инвитро",
-        "brand_wikidata": "Q4200546",
+        "brand_wikidata": "Q4200546"
     }
     sitemap_urls = ["https://www.invitro.ru/sitemap/offices.xml"]
     sitemap_rules = [
-        (r"/offices/.*/clinic.php\?ID=.*", "parse_sd"),
+        (r"/offices/.*/clinic.php\?ID=.*", "parse_sd")
     ]
     wanted_types = ["MedicalBusiness"]
     json_parser = "chompjs"
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = None
         coords = response.xpath('//div[@id="mapOfficeDetail"]/@data-coord').get()
         if coords:
             item["lat"], item["lon"] = coords.strip().split(",")

--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -6,14 +6,9 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
     name = "invitro_ru"
-    item_attributes = {
-        "brand": "Инвитро",
-        "brand_wikidata": "Q4200546"
-    }
+    item_attributes = {"brand": "Инвитро", "brand_wikidata": "Q4200546"}
     sitemap_urls = ["https://www.invitro.ru/sitemap/offices.xml"]
-    sitemap_rules = [
-        (r"/offices/.*/clinic.php\?ID=.*", "parse_sd")
-    ]
+    sitemap_rules = [(r"/offices/.*/clinic.php\?ID=.*", "parse_sd")]
     wanted_types = ["MedicalBusiness"]
     json_parser = "chompjs"
     custom_settings = {"ROBOTSTXT_OBEY": False}

--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -1,0 +1,26 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
+    name = "invitro_ru"
+    item_attributes = {
+        "brand": "Инвитро",
+        "brand_wikidata": "Q4200546",
+    }
+    sitemap_urls = ["https://www.invitro.ru/sitemap/offices.xml"]
+    sitemap_rules = [
+        (r"/offices/.*/clinic.php\?ID=.*", "parse_sd"),
+    ]
+    wanted_types = ["MedicalBusiness"]
+    json_parser = "chompjs"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        coords = response.xpath('//div[@id="mapOfficeDetail"]/@data-coord').get()
+        if coords:
+            item["lat"], item["lon"] = coords.strip().split(",")
+        apply_category(Categories.MEDICAL_LABORATORY, item)
+        yield item


### PR DESCRIPTION
```json
{
  "atp/brand/Инвитро": 1495,
  "atp/brand_wikidata/Q4200546": 1495,
  "atp/category/healthcare/laboratory": 1495,
  "atp/field/branch/missing": 1495,
  "atp/field/opening_hours/missing": 19,
  "atp/field/operator/missing": 1495,
  "atp/field/operator_wikidata/missing": 1495,
  "atp/field/postcode/missing": 1495,
  "atp/field/state/missing": 1495,
  "atp/field/twitter/missing": 1495,
  "atp/item_scraped_host_count/www.invitro.ru": 1495,
  "atp/nsi/perfect_match": 1495,
  "downloader/request_bytes": 1339569,
  "downloader/request_count": 1604,
  "downloader/request_method_count/GET": 1604,
  "downloader/response_bytes": 565990169,
  "downloader/response_count": 1604,
  "downloader/response_status_count/200": 1502,
  "downloader/response_status_count/301": 23,
  "downloader/response_status_count/302": 8,
  "downloader/response_status_count/404": 71,
  "dupefilter/filtered": 28,
  "elapsed_time_seconds": 1892.310169,
  "feedexport/success_count/FileFeedStorage": 1,
  "finish_reason": "finished",
  "finish_time": "2024-10-06T13:04:35.581247+00:00",
  "httpcache/firsthand": 1548,
  "httpcache/hit": 56,
  "httpcache/miss": 1548,
  "httpcache/store": 1548,
  "httpcompression/response_bytes": 3298005165,
  "httpcompression/response_count": 1572,
  "httperror/response_ignored_count": 71,
  "httperror/response_ignored_status_count/404": 71,
  "item_scraped_count": 1495,
  "log_count/INFO": 112,
  "memusage/max": 1036320768,
  "memusage/startup": 228917248,
  "request_depth_max": 1,
  "response_received_count": 1573,
  "scheduler/dequeued": 1604,
  "scheduler/dequeued/memory": 1604,
  "scheduler/enqueued": 1604,
  "scheduler/enqueued/memory": 1604,
  "start_time": "2024-10-06T12:33:03.271078+00:00"
}
```