### PR TITLE
[moncler] Fix Spider (369 locations)

### DIFF
--- a/locations/spiders/moncler.py
+++ b/locations/spiders/moncler.py
@@ -1,7 +1,9 @@
+from typing import Any
+from requests_cache import Response
 import scrapy
 
-from locations.items import Feature
-
+from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
 
 class MonclerSpider(scrapy.Spider):
     name = "moncler"
@@ -9,20 +11,12 @@ class MonclerSpider(scrapy.Spider):
     allowed_domains = ["moncler.com"]
     start_urls = ["https://www.moncler.com/on/demandware.store/Sites-MonclerEU-Site/it_IT/StoresApi-FindAll"]
     requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    user_agent = BROWSER_DEFAULT
 
-    def parse(self, response):
-        data = response.json()
-        for i in data["stores"]:
-            properties = {
-                "ref": i["ID"],
-                "name": i["name"],
-                "street_address": i["address1"],
-                "city": i["city"],
-                "postcode": i.get("postalCode"),
-                "country": i["countryCode"]["value"],
-                "phone": i["phone"],
-                "lat": i["latitude"],
-                "lon": i["longitude"],
-            }
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["stores"]:
+            item = DictParser.parse(location)
+            item["state"] = location.get("stateCode")
+            yield item
 
-            yield Feature(**properties)


### PR DESCRIPTION
```
{'atp/brand/Moncler': 369,
 'atp/brand_wikidata/Q1548951': 369,
 'atp/category/shop/clothes': 369,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/branch/missing': 369,
 'atp/field/country/from_reverse_geocoding': 369,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 369,
 'atp/field/opening_hours/missing': 369,
 'atp/field/operator/missing': 369,
 'atp/field/operator_wikidata/missing': 369,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 19,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 369,
 'atp/field/website/missing': 369,
 'atp/item_scraped_host_count/www.moncler.com': 369,
 'atp/nsi/perfect_match': 369,
 'downloader/request_bytes': 314,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 46817,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.626134,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 7, 18, 7, 54, 299939, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 448247,
 'httpcompression/response_count': 1,
 'item_scraped_count': 369,
 'log_count/DEBUG': 381,
 'log_count/INFO': 9,
 'memusage/max': 182202368,
 'memusage/startup': 182202368,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 7, 18, 7, 52, 673805, tzinfo=datetime.timezone.utc)}
```