### PR TITLE
[simply_asia_za] Fix spider and parse addr_full in LocationBankSpider

### DIFF
--- a/locations/spiders/simply_asia_za.py
+++ b/locations/spiders/simply_asia_za.py
@@ -1,11 +1,11 @@
-from locations.storefinders.go_review_api import GoReviewApiSpider
+from locations.storefinders.location_bank import LocationBankSpider
 
 
-class SimplyAsiaZASpider(GoReviewApiSpider):
+class SimplyAsiaZASpider(LocationBankSpider):
     name = "simply_asia_za"
-    domain = "localpages.simplyasia.co.za"
+    client_id = "9e487353-4db4-4096-bebf-79ebd729f60f"
     item_attributes = {"brand": "Simply Asia", "brand_wikidata": "Q130358521"}
 
     def post_process_item(self, item, response, location):
-        item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
+        item["website"] = "https://stores.simplyasia.co.za/details/" + location["storeLocatorDetailsShortURL"]
         yield item


### PR DESCRIPTION
Broken in the most recent run, they appear to have changed storefinder.

```
 'atp/brand/Simply Asia': 54,
 'atp/brand_wikidata/Q130358521': 54,
 'atp/category/amenity/restaurant': 54,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/email/missing': 54,
 'atp/field/image/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/twitter/missing': 54,
 'atp/item_scraped_host_count/api.locationbank.net': 54,
 'atp/nsi/perfect_match': 54,
```