### PR TITLE
New spider: Mountain America Credit Union (105 locations)

### DIFF
--- a/locations/spiders/mountain_america_credit_union_us.py
+++ b/locations/spiders/mountain_america_credit_union_us.py
@@ -1,0 +1,44 @@
+import json
+from collections import defaultdict
+
+from scrapy import Spider
+
+from locations.categories import Categories
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class MountainAmericaCreditUnionUSSpider(Spider):
+    name = "mountain_america_credit_union_us"
+    item_attributes = {
+        "brand": "Mountain America Credit Union",
+        "brand_wikidata": "Q6924862",
+        "extras": Categories.BANK.value,
+    }
+    start_urls = ["https://www.macu.com/page-data/branch-locations/page-data.json"]
+
+    def parse(self, response):
+        for location in response.json()["result"]["pageContext"]["frontmatter"]["tableEntries"]["branches"].values():
+            item = Feature()
+            item["ref"] = location["branch_id"]
+            item["state"], _ = location["name"].split(" - ")
+            item["branch"] = location["headline"]
+            item["street_address"] = location["address_line_1"]
+            item["addr_full"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
+            item["phone"] = location["phone"]
+            item["lat"] = location["latitude"]
+            item["lon"] = location["longitude"]
+            item["website"] = response.urljoin(location["details_url"])
+
+            open_close_times = json.loads(location["open_close_times"])
+            opening_hours = defaultdict(OpeningHours)
+            for day, open_types in open_close_times.items():
+                for open_type, open_close in open_types.items():
+                    opening_hours[open_type].add_range(
+                        day, open_close["open"], open_close["closed"], time_format="%H:%M:%S"
+                    )
+            item["opening_hours"] = opening_hours["lobby"]
+            item["extras"]["opening_hours:drive_through"] = opening_hours["driveUp"].as_opening_hours()
+
+            yield item

--- a/locations/spiders/mountain_america_credit_union_us.py
+++ b/locations/spiders/mountain_america_credit_union_us.py
@@ -1,15 +1,13 @@
 import json
 from collections import defaultdict
 
-from scrapy import Spider
-
 from locations.categories import Categories
 from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class MountainAmericaCreditUnionUSSpider(Spider):
+class MountainAmericaCreditUnionUSSpider(JSONBlobSpider):
     name = "mountain_america_credit_union_us"
     item_attributes = {
         "brand": "Mountain America Credit Union",
@@ -17,28 +15,29 @@ class MountainAmericaCreditUnionUSSpider(Spider):
         "extras": Categories.BANK.value,
     }
     start_urls = ["https://www.macu.com/page-data/branch-locations/page-data.json"]
+    locations_key = ["result", "pageContext", "frontmatter", "tableEntries", "branches"]
 
-    def parse(self, response):
-        for location in response.json()["result"]["pageContext"]["frontmatter"]["tableEntries"]["branches"].values():
-            item = Feature()
-            item["ref"] = location["branch_id"]
-            item["state"], _ = location["name"].split(" - ")
-            item["branch"] = location["headline"]
-            item["street_address"] = location["address_line_1"]
-            item["addr_full"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
-            item["phone"] = location["phone"]
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-            item["website"] = response.urljoin(location["details_url"])
+    def post_process_item(self, item, response, location):
+        if location["id"] == "member_service_team":
+            return
 
-            open_close_times = json.loads(location["open_close_times"])
-            opening_hours = defaultdict(OpeningHours)
-            for day, open_types in open_close_times.items():
-                for open_type, open_close in open_types.items():
-                    opening_hours[open_type].add_range(
-                        day, open_close["open"], open_close["closed"], time_format="%H:%M:%S"
-                    )
-            item["opening_hours"] = opening_hours["lobby"]
-            item["extras"]["opening_hours:drive_through"] = opening_hours["driveUp"].as_opening_hours()
+        del item["name"]
+        item["ref"] = location["branch_id"]
+        item["state"], _ = location["name"].split(" - ")
+        item["branch"] = location["headline"]
+        item["street_address"] = location["address_line_1"]
+        item["addr_full"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
+        item["phone"] = location["phone"]
+        item["website"] = response.urljoin(location["details_url"])
 
-            yield item
+        open_close_times = json.loads(location["open_close_times"])
+        opening_hours = defaultdict(OpeningHours)
+        for day, open_types in open_close_times.items():
+            for open_type, open_close in open_types.items():
+                opening_hours[open_type].add_range(
+                    day, open_close["open"], open_close["closed"], time_format="%H:%M:%S"
+                )
+        item["opening_hours"] = opening_hours["lobby"]
+        item["extras"]["opening_hours:drive_through"] = opening_hours["driveUp"].as_opening_hours()
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Mountain America Credit Union': 106,
 'atp/brand_wikidata/Q6924862': 106,
 'atp/category/amenity/bank': 106,
 'atp/field/branch/missing': 1,
 'atp/field/city/missing': 106,
 'atp/field/country/from_spider_name': 106,
 'atp/field/email/missing': 106,
 'atp/field/image/missing': 106,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/operator/missing': 106,
 'atp/field/operator_wikidata/missing': 106,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 106,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 106,
 'atp/item_scraped_host_count/www.macu.com': 106,
 'atp/nsi/cc_match': 106,
 'downloader/request_bytes': 874,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17373,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.452485,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 7, 20, 11, 5, 244454, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 314223,
 'httpcompression/response_count': 2,
 'item_scraped_count': 106,
 'log_count/DEBUG': 119,
 'log_count/INFO': 10,
 'memusage/max': 249376768,
 'memusage/startup': 249376768,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 7, 20, 11, 3, 791969, tzinfo=datetime.timezone.utc)}
```