### PR TITLE
New spider: Suitsupply (107 locations)

### DIFF
--- a/locations/spiders/suitsupply.py
+++ b/locations/spiders/suitsupply.py
@@ -1,0 +1,98 @@
+import json
+
+from scrapy.selector import Selector
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_3_LETTERS_FROM_SUNDAY, OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+COUNTRY_DEFAULT_LANGUAGE = {
+    "AE": "en-ae",
+    "AU": "en-au",
+    "BE": "en-be",
+    "CA": "en-ca",
+    "CH": "en-ch",
+    "CN": "zh-cn",
+    "DE": "de-de",
+    "DK": "en-dk",
+    "EE": "en-ee",
+    "ES": "es-es",
+    "FI": "en-fi",
+    "FR": "fr-fr",
+    "GB": "en-gb",
+    "IT": "it-it",
+    "LT": "en-lt",
+    "LV": "en-lv",
+    "NL": "en-nl",
+    "SE": "sv-se",
+    "US": "en-us",
+}
+SEARCH_COUNTRIES = {
+    "AE",
+    "AU",
+    "BE",
+    "CA",
+    "CH",
+    "CN",
+    "CO",
+    "DE",
+    "DK",
+    "EE",
+    "ES",
+    "FI",
+    "FR",
+    "GB",
+    "IT",
+    "KR",
+    "LT",
+    "LV",
+    "NL",
+    "PA",
+    "SE",
+    "US",
+}
+
+
+class SuitsupplySpider(Spider):
+    name = "suitsupply"
+    item_attributes = {"brand": "Suitsupply", "brand_wikidata": "Q17149142"}
+    start_urls = [
+        f"https://suitsupply.com/on/demandware.store/Sites-USA-Site/en_US/Stores-FindStores?country={country}"
+        for country in SEARCH_COUNTRIES
+    ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response, **kwargs):
+        # This part doesn't have all the stores shown on the website, but it does have a lot more useful information.
+        for location in response.json()["stores"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
+            item["website"] = (
+                f"https://suitsupply.com/{COUNTRY_DEFAULT_LANGUAGE.get(item['country'], 'en-us')}/stores/{item['ref'].removeprefix('stores-')}"
+            )
+
+            oh = OpeningHours()
+            for data in location["storeHoursData"]:
+                if data["open"] != "--:--":
+                    oh.add_range(DAYS_3_LETTERS_FROM_SUNDAY[int(data["day"])], data["open"], data["close"])
+            item["opening_hours"] = oh
+
+            yield item
+
+        # This is the part that's actually shown on the website. Dupe filter will figure out which ones we already parsed.
+        for location in json.loads(response.json()["locations"]):
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+
+            sel = Selector(text=location["infoWindowHtml"])
+            item["ref"] = sel.xpath("//@data-store-id").get()
+            item["addr_full"] = merge_address_lines(
+                sel.xpath(
+                    "//span[starts-with(@class, 'store__info-line ') and not(contains(@class, 'store__hours'))]/text()"
+                ).getall()
+            )
+            item["website"] = response.urljoin(sel.xpath("//@href").get())
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Suitsupply': 107,
 'atp/brand_wikidata/Q17149142': 107,
 'atp/category/shop/clothes': 107,
 'atp/cdn/cloudflare/response_count': 22,
 'atp/cdn/cloudflare/response_status_count/200': 22,
 'atp/field/city/missing': 24,
 'atp/field/country/from_reverse_geocoding': 24,
 'atp/field/email/missing': 25,
 'atp/field/image/missing': 107,
 'atp/field/opening_hours/missing': 26,
 'atp/field/operator/missing': 107,
 'atp/field/operator_wikidata/missing': 107,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 25,
 'atp/field/postcode/missing': 24,
 'atp/field/state/missing': 50,
 'atp/field/street_address/missing': 24,
 'atp/field/twitter/missing': 107,
 'atp/item_scraped_host_count/suitsupply.com': 190,
 'atp/nsi/perfect_match': 107,
 'downloader/request_bytes': 21902,
 'downloader/request_count': 22,
 'downloader/request_method_count/GET': 22,
 'downloader/response_bytes': 220276,
 'downloader/response_count': 22,
 'downloader/response_status_count/200': 22,
 'elapsed_time_seconds': 26.936163,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 7, 22, 52, 9, 94517, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3014003,
 'httpcompression/response_count': 22,
 'item_dropped_count': 83,
 'item_dropped_reasons_count/DropItem': 83,
 'item_scraped_count': 107,
 'log_count/DEBUG': 223,
 'log_count/INFO': 10,
 'memusage/max': 249286656,
 'memusage/startup': 249286656,
 'response_received_count': 22,
 'scheduler/dequeued': 22,
 'scheduler/dequeued/memory': 22,
 'scheduler/enqueued': 22,
 'scheduler/enqueued/memory': 22,
 'start_time': datetime.datetime(2024, 10, 7, 22, 51, 42, 158354, tzinfo=datetime.timezone.utc)}
```