### PR TITLE
[Netto DE] Fix spider

### DIFF
--- a/locations/spiders/netto_de.py
+++ b/locations/spiders/netto_de.py
@@ -1,122 +1,32 @@
-import scrapy
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
-from locations.hours import OpeningHours
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-
-DAY_MAPPING = {
-    "Mo.": "Mo",
-    "Di.": "Tu",
-    "Mi.": "We",
-    "Do.": "Th",
-    "Fr.": "Fr",
-    "Sa.": "Sa",
-    "So.": "Su",
-}
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class NettoDESpider(scrapy.Spider):
+class NettoDESpider(SitemapSpider, StructuredDataSpider):
     name = "netto_de"
-    NETTO_CITY = {"brand": "Netto City", "brand_wikidata": "Q879858", "extras": Categories.SHOP_SUPERMARKET.value}
-    NETTO_GETRANKE = {
-        "brand": "Netto Getränke-Discount",
-        "brand_wikidata": "Q879858",
-        "extras": Categories.SHOP_BEVERAGES.value,
-    }
-    NETTO_MARKEN = {
-        "brand": "Netto Marken-Discount",
-        "brand_wikidata": "Q879858",
-        "extras": Categories.SHOP_SUPERMARKET.value,
-    }
-    item_attributes = NETTO_MARKEN
     allowed_domains = ["netto-online.de"]
-    requires_proxy = True
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    sitemap_urls = ["https://www.netto-online.de/ueber-netto/sitemap/index"]
+    sitemap_rules = [(r"/filialen/[^/]+/[^/]+/(\d+)/$", "parse")]
+    wanted_types = ["GroceryStore"]
+    user_agent = BROWSER_DEFAULT
 
-    def start_requests(self):
-        yield scrapy.http.FormRequest(
-            url="https://www.netto-online.de/INTERSHOP/web/WFS/Plus-NettoDE-Site/de_DE/-/EUR/ViewNettoStoreFinder-GetStoreItems",
-            formdata={
-                "n": "56.0",
-                "e": "15.0",
-                "w": "5.0",
-                "s": "47.0",
-                "netto": "false",
-                "city": "false",
-                "service": "false",
-                "beverage": "false",
-                "nonfood": "false",
-            },
-        )
+    categories = {
+        "Netto City": Categories.SHOP_SUPERMARKET,
+        "Netto Getränke-Discount": Categories.SHOP_BEVERAGES,
+        "Netto Marken-Discount": Categories.SHOP_SUPERMARKET,
+    }
 
-    def parse_opening_hours(self, hours):
-        days_with_dot = list(DAY_MAPPING.keys())
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["brand"] = item["name"] = ld_data["name"].split(" - ", 1)[0]
+        if cat := self.categories.get(item["brand"]):
+            apply_category(cat, item)
+        else:
+            self.crawler.stats.inc_value("{}/unknown_type/{}".format(self.name, item["brand"]))
+            self.logger.error("Unknown type: {}".format(ld_data["name"]))
 
-        opening_hours = OpeningHours()
-        for block in hours.split("<br />"):
-            if not block:
-                continue
-            try:
-                days, hrs = block.split(":")
-                if hrs.strip().lower() == "geschlossen":
-                    continue
-                if "-" in days:
-                    start_day, end_day = days.split("-")
-                else:
-                    start_day, end_day = days, days
-                for day in days_with_dot[days_with_dot.index(start_day) : days_with_dot.index(end_day) + 1]:
-                    open_time, close_time = hrs.split("-")
-                    close_time = close_time.replace("Uhr", "").strip()
-                    open_time = open_time.strip()
-                    if open_time == "24.00":
-                        open_time = "23.59"
-                    if close_time == "24.00":
-                        close_time = "23.59"
-                    opening_hours.add_range(
-                        day=DAY_MAPPING[day],
-                        open_time=open_time,
-                        close_time=close_time,
-                        time_format="%H.%M",
-                    )
-            except:
-                pass
-        return opening_hours.as_opening_hours()
-
-    def parse(self, response):
-        stores = response.json()["store_items"]
-
-        for store in stores:
-            properties = {
-                "ref": store["store_id"],
-                "name": store["store_name"],
-                "brand": store["store_name"],
-                "street_address": store["street"],
-                "city": store["city"],
-                "state": store["state"],
-                "postcode": store["post_code"],
-                "lat": store["coord_latitude"],
-                "lon": store["coord_longitude"],
-                "website": "https://www.netto-online.de/filialen/{city}/{street}/{id}".format(
-                    city=self.urlify(store["city"].lower()),
-                    street=self.urlify(store["street"]),
-                    id=store["store_id"],
-                ),
-            }
-
-            if store["store_name"] == "Netto City":
-                properties.update(self.NETTO_CITY)
-            elif store["store_name"] == "Netto Getränke-Discount":
-                properties.update(self.NETTO_GETRANKE)
-            elif store["store_name"] == "Netto Marken-Discount":
-                properties.update(self.NETTO_MARKEN)
-            else:
-                properties["brand"] = store["store_name"]
-                self.crawler.stats.inc_value(f'atp/netto_de/unmapped_brand/{store["store_name"]}')
-
-            properties["opening_hours"] = self.parse_opening_hours(store["store_opening"])
-
-            yield Feature(**properties)
-
-    def urlify(self, param):
-        # They also do ß -> ss, but it's not vital
-        return param.lower().replace(" ", "-").replace(".", "").replace(",", "").replace("'", "")
+        yield item

--- a/locations/spiders/netto_de.py
+++ b/locations/spiders/netto_de.py
@@ -13,7 +13,7 @@ class NettoDESpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.netto-online.de/ueber-netto/sitemap/index"]
     sitemap_rules = [(r"/filialen/[^/]+/[^/]+/(\d+)/$", "parse")]
     wanted_types = ["GroceryStore"]
-    user_agent = BROWSER_DEFAULT
+    requires_proxy = "GB"
 
     categories = {
         "Netto City": Categories.SHOP_SUPERMARKET,

--- a/locations/spiders/netto_de.py
+++ b/locations/spiders/netto_de.py
@@ -4,6 +4,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import FIREFOX_LATEST
 
 
 class NettoDESpider(SitemapSpider, StructuredDataSpider):
@@ -12,7 +13,8 @@ class NettoDESpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.netto-online.de/ueber-netto/sitemap/index"]
     sitemap_rules = [(r"/filialen/[^/]+/[^/]+/(\d+)/$", "parse")]
     wanted_types = ["GroceryStore"]
-    requires_proxy = "GB"
+    user_agent = FIREFOX_LATEST
+    custom_settings = {"DOWNLOAD_HANDLERS": {"https": "scrapy.core.downloader.handlers.http2.H2DownloadHandler"}}
 
     categories = {
         "Netto City": Categories.SHOP_SUPERMARKET,

--- a/locations/spiders/netto_de.py
+++ b/locations/spiders/netto_de.py
@@ -4,7 +4,6 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class NettoDESpider(SitemapSpider, StructuredDataSpider):


### PR DESCRIPTION
```python
{'atp/brand/Netto City': 184,
 'atp/brand/Netto Getränke-Discount': 81,
 'atp/brand/Netto Marken-Discount': 4144,
 'atp/category/shop/beverages': 81,
 'atp/category/shop/supermarket': 4328,
 'atp/field/branch/missing': 4409,
 'atp/field/brand_wikidata/missing': 4409,
 'atp/field/email/missing': 4409,
 'atp/field/image/missing': 4409,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 4409,
 'atp/field/operator_wikidata/missing': 4409,
 'atp/field/phone/missing': 4409,
 'atp/field/twitter/missing': 4409,
 'atp/item_scraped_host_count/www.netto-online.de': 4409,
 'downloader/request_bytes': 14652711,
 'downloader/request_count': 4411,
 'downloader/request_method_count/GET': 4411,
 'downloader/response_bytes': 170621368,
 'downloader/response_count': 4411,
 'downloader/response_status_count/200': 4411,
 'elapsed_time_seconds': 74.935535,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 8, 16, 3, 23, 8058, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 4411,
 'httpcompression/response_bytes': 1676260956,
 'httpcompression/response_count': 4411,
 'item_scraped_count': 4409,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'memusage/max': 653705216,
 'memusage/startup': 250994688,
 'request_depth_max': 1,
 'response_received_count': 4411,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4410,
 'scheduler/dequeued/memory': 4410,
 'scheduler/enqueued': 4410,
 'scheduler/enqueued/memory': 4410,
 'start_time': datetime.datetime(2024, 10, 8, 16, 2, 8, 72523, tzinfo=datetime.timezone.utc)}
```