### PR TITLE
New spider: Payomatic (117 locations)

### DIFF
--- a/locations/spiders/payomatic_us.py
+++ b/locations/spiders/payomatic_us.py
@@ -1,0 +1,42 @@
+import json
+
+from scrapy import Spider
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class PayomaticUSSpider(Spider):
+    name = "payomatic_us"
+    start_urls = ["https://www.payomatic.com/store-locator/"]
+    item_attributes = {
+        "brand": "Payomatic",
+        "brand_wikidata": "Q48742899",
+        "extras": Categories.SHOP_MONEY_LENDER.value,
+    }
+
+    def parse(self, response):
+        searchstr = "var stores_data = "
+        script = response.xpath(f"//script[contains(text(), '{searchstr}')]/text()").get()
+        start = script.find(searchstr) + len(searchstr)
+        end = script.find(";\r\n", start)
+        geojson = json.loads(script[start:end])
+        for feature in geojson["features"]:
+            item = DictParser.parse(feature["properties"])
+            item["geometry"] = feature["geometry"]
+            item["street_address"] = item.pop("addr_full")
+            if item["phone"] in ("516-496-1970", "(516) 496-1970"):
+                del item["phone"]
+
+            oh = OpeningHours()
+            for day, hours in feature["properties"]["store_hours"].items():
+                if hours == "Closed":
+                    oh.set_closed(day)
+                elif hours == "24 Hours":
+                    oh.add_range(day, "00:00", "23:59")
+                else:
+                    oh.add_ranges_from_string(f"{day} {hours}")
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Payomatic': 117,
 'atp/brand_wikidata/Q48742899': 117,
 'atp/category/shop/money_lender': 117,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 117,
 'atp/field/country/from_spider_name': 117,
 'atp/field/email/missing': 117,
 'atp/field/image/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/phone/missing': 110,
 'atp/field/twitter/missing': 117,
 'atp/item_scraped_host_count/www.payomatic.com': 117,
 'atp/nsi/brand_missing': 117,
 'downloader/request_bytes': 620,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 25672,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.672135,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 8, 19, 22, 23, 689054, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 519456,
 'httpcompression/response_count': 2,
 'item_scraped_count': 117,
 'log_count/DEBUG': 130,
 'log_count/INFO': 10,
 'memusage/max': 249303040,
 'memusage/startup': 249303040,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 8, 19, 22, 21, 16919, tzinfo=datetime.timezone.utc)}
```