### PR TITLE
Vodacom CD, MZ and TZ spiders

### DIFF
--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -24,6 +24,7 @@ COUNTRYCODE_COMPONENTS = {
     "BW",
     "BY",
     "CA",
+    "CD",
     "CH",
     "CL",
     "CN",

--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -116,6 +116,7 @@ COUNTRYCODE_COMPONENTS = {
     "TR",
     "TT",
     "TW",
+    "TZ",
     "UA",
     "US",
     "UY",

--- a/locations/spiders/vodacom_cd.py
+++ b/locations/spiders/vodacom_cd.py
@@ -1,12 +1,15 @@
 from scrapy.http import JsonRequest
 
 from locations.json_blob_spider import JSONBlobSpider
-from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
 
 
 class VodacomCDSpider(JSONBlobSpider):
     name = "vodacom_cd"
-    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    item_attributes = item_attributes = {
+        "brand": "Vodacom Congo",
+        "brand_wikidata": "Q130477507",
+        "extras": Categories.SHOP_MOBILE_PHONE.value,
+    }
     locations_key = ["response", "stores"]
 
     def start_requests(self):

--- a/locations/spiders/vodacom_cd.py
+++ b/locations/spiders/vodacom_cd.py
@@ -1,0 +1,22 @@
+from scrapy.http import JsonRequest
+
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
+
+
+class VodacomCDSpider(JSONBlobSpider):
+    name = "vodacom_cd"
+    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    locations_key = ["response", "stores"]
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://www.vodacom.cd/integration/drcportal/store_locator/portal",
+            data={"method": "findNearestStore", "longitude": 0, "latitude": 0, "source": "portal"},
+        )
+
+    def post_process_item(self, item, response, location):
+        item["ref"] = location["_id"]
+        item["branch"] = location.get("nameStructure")
+        item["street_address"] = item.pop("addr_full")
+        yield item

--- a/locations/spiders/vodacom_cd.py
+++ b/locations/spiders/vodacom_cd.py
@@ -1,5 +1,6 @@
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.json_blob_spider import JSONBlobSpider
 
 

--- a/locations/spiders/vodacom_mz.py
+++ b/locations/spiders/vodacom_mz.py
@@ -1,0 +1,51 @@
+from scrapy import Request
+from scrapy.http import JsonRequest
+
+from locations.hours import DAYS_3_LETTERS, DAYS_WEEKDAY, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
+
+
+class VodacomMZSpider(JSONBlobSpider):
+    name = "vodacom_mz"
+    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    start_urls = ["https://www.vm.co.mz/lojas"]
+    locations_key = "data"
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield Request(url=url, callback=self.parse_provinces)
+
+    def parse_provinces(self, response):
+        for province in response.xpath('.//select[@data-testid="select-province"]/option'):
+            province_id = province.xpath("@value").get()
+            province_name = province.xpath("text()").get()
+            yield JsonRequest(
+                url=f"https://website-api.vm.co.mz/api/shops?populate[0]=working_days&populate[1]=sat&populate[2]=sun&filters[province]={province_id}",
+                callback=self.parse,
+                meta={"province": province_name},
+            )
+
+    def pre_process_data(self, feature: dict):
+        for key, value in feature["attributes"].items():
+            feature[key] = value
+
+    def post_process_item(self, item, response, location):
+        item["state"] = response.meta["province"]
+        item["branch"] = item.pop("name")
+        item["street_address"] = item.pop("addr_full")
+
+        item["opening_hours"] = OpeningHours()
+        for day in location["working_days"]:
+            if day["is_open"]:
+                item["opening_hours"].add_ranges_from_string(
+                    f'{day["working_days"]} {day["open"].replace(":00.000", "")}-{day["close"].replace(":00.000", "")}'
+                )
+            elif day["working_days"] in DAYS_3_LETTERS:
+                item["opening_hours"].set_closed(day["working_days"])
+            elif day["working_days"] == "Weekdays":
+                for weekday in DAYS_WEEKDAY:
+                    item["opening_hours"].set_closed(weekday)
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/closed/failed")
+        yield item

--- a/locations/spiders/vodacom_mz.py
+++ b/locations/spiders/vodacom_mz.py
@@ -3,12 +3,15 @@ from scrapy.http import JsonRequest
 
 from locations.hours import DAYS_3_LETTERS, DAYS_WEEKDAY, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
-from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
 
 
 class VodacomMZSpider(JSONBlobSpider):
     name = "vodacom_mz"
-    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    item_attributes = item_attributes = {
+        "brand": "Vodacom Moçambique",
+        "brand_wikidata": "Q130477552",
+        "extras": Categories.SHOP_MOBILE_PHONE.value,
+    }
     start_urls = ["https://www.vm.co.mz/lojas"]
     locations_key = "data"
 

--- a/locations/spiders/vodacom_mz.py
+++ b/locations/spiders/vodacom_mz.py
@@ -1,6 +1,7 @@
 from scrapy import Request
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.hours import DAYS_3_LETTERS, DAYS_WEEKDAY, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 

--- a/locations/spiders/vodacom_tz.py
+++ b/locations/spiders/vodacom_tz.py
@@ -1,0 +1,34 @@
+from scrapy.http import JsonRequest
+
+from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
+
+
+class VodacomTZSpider(JSONBlobSpider):
+    name = "vodacom_tz"
+    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    start_urls = ["https://myvodacom.vodacom.co.tz/app/myvodacom/web/vodacom/shop/get-region"]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield JsonRequest(url=url, callback=self.parse_regions)
+
+    def parse_regions(self, response):
+        for region in response.json():
+            yield JsonRequest(
+                url=f"https://myvodacom.vodacom.co.tz/app/myvodacom/web/vodacom/shop/get-district/{region['regionId']}",
+                callback=self.parse_districts,
+            )
+
+    def parse_districts(self, response):
+        for district in response.json():
+            yield JsonRequest(
+                url=f"https://myvodacom.vodacom.co.tz/app/myvodacom/web/vodacom/shop/get-store/{district['districtId']}",
+                callback=self.parse,
+            )
+
+    def post_process_item(self, item, response, location):
+        item["branch"] = item.pop("name").replace("Vodashop ", "")
+        item["addr_full"] = location.get("location")
+        item["phone"] = location["contacts"]
+        yield item

--- a/locations/spiders/vodacom_tz.py
+++ b/locations/spiders/vodacom_tz.py
@@ -1,12 +1,15 @@
 from scrapy.http import JsonRequest
 
 from locations.json_blob_spider import JSONBlobSpider
-from locations.spiders.vodacom_za import VODACOM_SHARED_ATTRIBUTES
 
 
 class VodacomTZSpider(JSONBlobSpider):
     name = "vodacom_tz"
-    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    item_attributes = item_attributes = {
+        "brand": "Vodacom Tanzania",
+        "brand_wikidata": "Q7939274",
+        "extras": Categories.SHOP_MOBILE_PHONE.value,
+    }
     start_urls = ["https://myvodacom.vodacom.co.tz/app/myvodacom/web/vodacom/shop/get-region"]
 
     def start_requests(self):

--- a/locations/spiders/vodacom_tz.py
+++ b/locations/spiders/vodacom_tz.py
@@ -1,5 +1,6 @@
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.json_blob_spider import JSONBlobSpider
 
 

--- a/locations/spiders/vodacom_za.py
+++ b/locations/spiders/vodacom_za.py
@@ -1,14 +1,12 @@
 from locations.categories import Categories
 from locations.storefinders.location_bank import LocationBankSpider
 
-VODACOM_SHARED_ATTRIBUTES = {
-    "brand": "Vodacom",
-    "brand_wikidata": "Q1856518",
-    "extras": Categories.SHOP_MOBILE_PHONE.value,
-}
-
 
 class VodacomZASpider(LocationBankSpider):
     name = "vodacom_za"
     client_id = "19ced8ad-ae12-440c-abb5-423a1d49a002"
-    item_attributes = VODACOM_SHARED_ATTRIBUTES
+    item_attributes = {
+        "brand": "Vodacom",
+        "brand_wikidata": "Q1856518",
+        "extras": Categories.SHOP_MOBILE_PHONE.value,
+    }

--- a/locations/spiders/vodacom_za.py
+++ b/locations/spiders/vodacom_za.py
@@ -1,8 +1,14 @@
 from locations.categories import Categories
 from locations.storefinders.location_bank import LocationBankSpider
 
+VODACOM_SHARED_ATTRIBUTES = {
+    "brand": "Vodacom",
+    "brand_wikidata": "Q1856518",
+    "extras": Categories.SHOP_MOBILE_PHONE.value,
+}
+
 
 class VodacomZASpider(LocationBankSpider):
     name = "vodacom_za"
     client_id = "19ced8ad-ae12-440c-abb5-423a1d49a002"
-    item_attributes = {"brand": "Vodacom", "brand_wikidata": "Q1856518", "extras": Categories.SHOP_MOBILE_PHONE.value}
+    item_attributes = VODACOM_SHARED_ATTRIBUTES


### PR DESCRIPTION
CD:

```
 'atp/brand/Vodacom': 73,
 'atp/brand_wikidata/Q1856518': 73,
 'atp/category/shop/mobile_phone': 73,
 'atp/field/country/from_spider_name': 73,
 'atp/field/email/missing': 73,
 'atp/field/image/missing': 73,
 'atp/field/opening_hours/missing': 73,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/phone/missing': 73,
 'atp/field/postcode/missing': 73,
 'atp/field/twitter/missing': 73,
 'atp/field/website/missing': 73,
 'atp/item_scraped_host_count/www.vodacom.cd': 73,
 'atp/nsi/cc_match': 73,
```

MZ:

```
 'atp/brand/Vodacom': 169,
 'atp/brand_wikidata/Q1856518': 169,
 'atp/category/shop/mobile_phone': 169,
 'atp/field/city/missing': 169,
 'atp/field/country/from_spider_name': 169,
 'atp/field/email/missing': 169,
 'atp/field/image/missing': 169,
 'atp/field/operator/missing': 169,
 'atp/field/operator_wikidata/missing': 169,
 'atp/field/phone/missing': 169,
 'atp/field/postcode/missing': 169,
 'atp/field/twitter/missing': 169,
 'atp/field/website/missing': 169,
 'atp/item_scraped_host_count/website-api.vm.co.mz': 169,
 'atp/nsi/cc_match': 169,
```

TZ:

```
 'atp/brand/Vodacom': 159,
 'atp/brand_wikidata/Q1856518': 159,
 'atp/category/shop/mobile_phone': 159,
 'atp/field/city/missing': 159,
 'atp/field/country/from_spider_name': 159,
 'atp/field/email/missing': 159,
 'atp/field/image/missing': 159,
 'atp/field/lat/invalid': 5,
 'atp/field/lat/missing': 5,
 'atp/field/lon/missing': 5,
 'atp/field/opening_hours/missing': 159,
 'atp/field/operator/missing': 159,
 'atp/field/operator_wikidata/missing': 159,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 112,
 'atp/field/postcode/missing': 159,
 'atp/field/street_address/missing': 159,
 'atp/field/twitter/missing': 159,
 'atp/field/website/missing': 159,
 'atp/item_scraped_host_count/myvodacom.vodacom.co.tz': 159,
 'atp/nsi/cc_match': 159,
```