### PR TITLE
[LagkagehusetDK] Fix spider

### DIFF
--- a/locations/spiders/lagkagehuset_dk.py
+++ b/locations/spiders/lagkagehuset_dk.py
@@ -21,4 +21,5 @@ class LagkagehusetDKSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("addr_full")
         item["branch"] = item.pop("name")
+        item["email"] = feature.get("mail")
         yield item

--- a/locations/spiders/lagkagehuset_dk.py
+++ b/locations/spiders/lagkagehuset_dk.py
@@ -1,7 +1,7 @@
+import json
 import re
 from typing import Iterable
 
-import chompjs
 from scrapy.http import Response
 
 from locations.hours import DAYS_3_LETTERS, OpeningHours
@@ -15,9 +15,7 @@ class LagkagehusetDKSpider(JSONBlobSpider):
     start_urls = ["https://lagkagehuset.dk/select-shop"]
 
     def extract_json(self, response: Response) -> list:
-        return chompjs.parse_js_object(
-            re.search(r"\\\"shops\\\":(\[.+?\])}", response.text).group(1), unicode_escape=True
-        )
+        return json.loads(re.search(r"\"shops\":(\[.+?\])}", response.text.replace('\\"', '"')).group(1))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("addr_full")

--- a/locations/spiders/lagkagehuset_dk.py
+++ b/locations/spiders/lagkagehuset_dk.py
@@ -1,23 +1,24 @@
-import scrapy
+import re
+from typing import Iterable
 
-from locations.google_url import url_to_coords
+import chompjs
+from scrapy.http import Response
+
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class LagkagehusetDKSpider(scrapy.Spider):
+class LagkagehusetDKSpider(JSONBlobSpider):
     name = "lagkagehuset_dk"
     item_attributes = {"brand": "Lagkagehuset", "brand_wikidata": "Q12323572"}
-    start_urls = ["https://lagkagehuset.dk/butikker"]
-    no_refs = True
+    start_urls = ["https://lagkagehuset.dk/select-shop"]
 
-    def parse(self, response, **kwargs):
-        for store in response.xpath("//*[@region]"):
-            item = Feature()
-            item["name"] = store.xpath('.//*[@class="store-headline"]/text()').get()
-            item["addr_full"] = merge_address_lines(store.xpath('.//*[@class="store-content"]/p[1]/text()').getall())
-            if map_url := store.xpath(".//a[contains(@href, 'google')]/@href").get():
-                item["lat"], item["lon"] = url_to_coords(map_url.replace("google.dk", "google.com"))
-            item["email"] = store.xpath('.//a[contains(@href, "mailto")]/text()').get()
-            item["phone"] = store.xpath('.//a[contains(@href, "tel")]/text()').get()
-            yield item
+    def extract_json(self, response: Response) -> list:
+        return chompjs.parse_js_object(
+            re.search(r"\\\"shops\\\":(\[.+?\])}", response.text).group(1), unicode_escape=True
+        )
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = item.pop("name")
+        yield item

--- a/locations/spiders/lagkagehuset_dk.py
+++ b/locations/spiders/lagkagehuset_dk.py
@@ -23,6 +23,7 @@ class LagkagehusetDKSpider(JSONBlobSpider):
         item["street_address"] = item.pop("addr_full")
         item["branch"] = item.pop("name")
         item["email"] = feature.get("mail")
+        item["website"] = f'https://lagkagehuset.dk/butik/{item["branch"]}'.replace(" ", "_")
         if all(feature.get("openingHours", {}).get(day.lower()) == "0:00-0:00" for day in DAYS_3_LETTERS):
             set_closed(item)
         else:

--- a/locations/spiders/lagkagehuset_dk.py
+++ b/locations/spiders/lagkagehuset_dk.py
@@ -4,7 +4,8 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response
 
-from locations.items import Feature
+from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.items import Feature, set_closed
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -22,4 +23,10 @@ class LagkagehusetDKSpider(JSONBlobSpider):
         item["street_address"] = item.pop("addr_full")
         item["branch"] = item.pop("name")
         item["email"] = feature.get("mail")
+        if all(feature.get("openingHours", {}).get(day.lower()) == "0:00-0:00" for day in DAYS_3_LETTERS):
+            set_closed(item)
+        else:
+            item["opening_hours"] = OpeningHours()
+            for day, hours in feature.get("openingHours").items():
+                item["opening_hours"].add_range(day, *hours.split("-"))
         yield item


### PR DESCRIPTION
[Sitemap](https://lagkagehuset.dk/sitemap.xml) approach doesn't look efficient one, hence ignored.
Some of the POIs identified as `closed`, verified with google maps info.

```
{'atp/brand/Lagkagehuset': 110,
 'atp/brand_wikidata/Q12323572': 110,
 'atp/category/shop/bakery': 110,
 'atp/closed_poi': 4,
 'atp/field/image/missing': 110,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 110,
 'atp/field/operator_wikidata/missing': 110,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 110,
 'atp/field/twitter/missing': 110,
 'atp/item_scraped_host_count/lagkagehuset.dk': 110,
 'atp/nsi/cc_match': 110,
 'downloader/request_bytes': 613,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 30877,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.953244,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 10, 3, 55, 17, 412053, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 270651,
 'httpcompression/response_count': 1,
 'item_scraped_count': 110,
 'log_count/DEBUG': 123,
 'log_count/INFO': 10,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 10, 3, 55, 14, 458809, tzinfo=datetime.timezone.utc)}
```