### PR TITLE
[MyEyeDr] Fix Spider

### DIFF
--- a/locations/spiders/my_eye_dr.py
+++ b/locations/spiders/my_eye_dr.py
@@ -1,50 +1,11 @@
-import re
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class MyEyeDrSpider(scrapy.Spider):
+class MyEyeDrSpider(SitemapSpider, StructuredDataSpider):
     name = "my_eye_dr"
     item_attributes = {"brand": "MyEyeDr.", "brand_wikidata": "Q117864710"}
-    allowed_domains = ["myeyedr.com"]
-    start_urls = [
-        "https://locations.myeyedr.com/index.html",
+    sitemap_urls = [
+        "https://locations.myeyedr.com/sitemap1.xml",
     ]
-    download_delay = 0.3
-
-    def parse(self, response):
-        urls = response.xpath('//a[@class="Directory-listLink"]/@href').extract()
-        is_store_list = response.xpath('//a[@class="Teaser-titleLink"]/@href').extract()
-
-        if not urls and is_store_list:
-            urls = is_store_list
-        for url in urls:
-            if url.count("/") >= 2:
-                yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
-            else:
-                yield scrapy.Request(response.urljoin(url))
-
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-
-        properties = {
-            "ref": ref,
-            "name": "".join(response.xpath('//h1[@class="Hero-title"]//text()').extract()),
-            "street_address": response.xpath(
-                'normalize-space(//span[@class="c-address-street-1"]//text())'
-            ).extract_first(),
-            "city": response.xpath('normalize-space(//span[@class="c-address-city"]//text())').extract_first(),
-            "state": response.xpath('normalize-space(//abbr[@class="c-address-state"]//text())').extract_first(),
-            "postcode": response.xpath(
-                'normalize-space(//span[@class="c-address-postal-code"]//text())'
-            ).extract_first(),
-            "country": response.xpath('normalize-space(//abbr[@itemprop="addressCountry"]//text())').extract_first(),
-            "phone": response.xpath('normalize-space(//div[@itemprop="telephone"]//text())').extract_first(),
-            "website": response.url,
-            "lat": response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first(),
-            "lon": response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first(),
-        }
-
-        yield Feature(**properties)


### PR DESCRIPTION
`Fixes : code refactored to use sitemap spider`

{'atp/brand/MyEyeDr.': 856,
 'atp/brand_wikidata/Q117864710': 856,
 'atp/category/shop/optician': 856,
 'atp/cdn/cloudflare/response_count': 1511,
 'atp/cdn/cloudflare/response_status_count/200': 1510,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/branch/missing': 856,
 'atp/field/email/missing': 856,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 856,
 'atp/field/operator_wikidata/missing': 856,
 'atp/field/twitter/missing': 856,
 'atp/item_scraped_host_count/locations.myeyedr.com': 856,
 'atp/nsi/perfect_match': 856,
 'downloader/request_bytes': 822982,
 'downloader/request_count': 1511,
 'downloader/request_method_count/GET': 1511,
 'downloader/response_bytes': 31968915,
 'downloader/response_count': 1511,
 'downloader/response_status_count/200': 1510,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1860.60389,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 10, 10, 44, 13, 747086, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 115346448,
 'httpcompression/response_count': 1511,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 856,
 'log_count/DEBUG': 2378,
 'log_count/INFO': 41,
 'request_depth_max': 1,
 'response_received_count': 1511,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1510,
 'scheduler/dequeued/memory': 1510,
 'scheduler/enqueued': 1510,
 'scheduler/enqueued/memory': 1510,
 'start_time': datetime.datetime(2024, 10, 10, 10, 13, 13, 143196, tzinfo=datetime.timezone.utc)}