### PR TITLE
[Mcdonalds IT] Flag proxy and collect opening hours

### DIFF
--- a/locations/spiders/mcdonalds_it.py
+++ b/locations/spiders/mcdonalds_it.py
@@ -1,17 +1,50 @@
-import scrapy
+from typing import Any
+from urllib.parse import urljoin
 
+import scrapy
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.spiders.mcdonalds import McdonaldsSpider
+from locations.hours import OpeningHours
 
 
 class McdonaldsITSpider(scrapy.Spider):
     name = "mcdonalds_it"
-    item_attributes = McdonaldsSpider.item_attributes
+    item_attributes = {"brand": "McDonald's", "brand_wikidata": "Q38076"}
     start_urls = ["https://www.mcdonalds.it/static/json/store_locator.json"]
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["sites"]:
             store["street_address"] = store.pop("address")
             item = DictParser.parse(store)
-            item["website"] = "https://www.mcdonalds.it/ristorante/" + store["uri"]
+            item["branch"] = item.pop("name")
+            item["website"] = urljoin("https://www.mcdonalds.it/ristorante/", store["uri"])
+
+            for opening_hours in store["opening_hours"]:
+                if opening_hours["name"] == "mccafe":
+                    mccafe = item.deepcopy()
+                    item["ref"] = "{}-mccafe".format(item["ref"])
+                    mccafe["brand"] = "McCafé"
+                    mccafe["brand_wikidata"] = "Q3114287"
+                    apply_category(Categories.CAFE, mccafe)
+                    mccafe["opening_hours"] = self.parse_opening_hours(opening_hours)
+                    yield mccafe
+                elif opening_hours["name"] == "mcdrive":
+                    item["extras"]["opening_hours:drive_through"] = self.parse_opening_hours(opening_hours)
+                elif opening_hours["name"] == "restaurant":
+                    item["opening_hours"] = self.parse_opening_hours(opening_hours)
+
+            apply_category(Categories.FAST_FOOD, item)
+
             yield item
+
+    def parse_opening_hours(self, rules: dict) -> str:
+        if rules["all24h"] is True:
+            return "24/7"
+
+        oh = OpeningHours()
+        for rule in rules["days"]:
+            oh.add_range(rule["name"], *rule["times"].split(","))
+
+        return oh.as_opening_hours()


### PR DESCRIPTION
Fixes #11016

```python
{'atp/brand/McCafé': 619,
 "atp/brand/McDonald's": 726,
 'atp/brand_wikidata/Q3114287': 619,
 'atp/brand_wikidata/Q38076': 726,
 'atp/category/amenity/cafe': 619,
 'atp/category/amenity/fast_food': 726,
 'atp/field/country/from_spider_name': 1345,
 'atp/field/email/missing': 1345,
 'atp/field/image/missing': 1345,
 'atp/field/operator/missing': 1345,
 'atp/field/operator_wikidata/missing': 1345,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 1345,
 'atp/field/twitter/missing': 1345,
 'atp/item_scraped_host_count/www.mcdonalds.it': 1345,
 'atp/nsi/cc_match': 726,
 'atp/nsi/perfect_match': 619,
 'downloader/request_bytes': 634,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 109273,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.240988,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 11, 10, 43, 9, 652095, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 1245075,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1345,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 253419520,
 'memusage/startup': 253419520,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 11, 10, 43, 8, 411107, tzinfo=datetime.timezone.utc)}
```