### PR TITLE
[KrefelBE] Fix spider

### DIFF
--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -20,7 +20,7 @@ class KrefelBESpider(Spider):
         for location in locations:
             location["ref"] = location.pop("name")
             location["website"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
-            location["phone"] = ";".join(
+            location["phone"] = "; ".join(
                 filter(None, [location["address"].get("phone"), location["address"].get("phone2")])
             ).replace("/", "")
             location["address"]["house_number"] = location["address"].pop("line2", "")

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -1,3 +1,4 @@
+import xmltodict
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
@@ -11,7 +12,12 @@ class KrefelBESpider(Spider):
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response, **kwargs):
-        for location in response.json()["stores"]:
+        # API response's content-type is not consistent.
+        if response.headers["Content-Type"] == "application/json":
+            locations = response.json()["stores"]
+        else:
+            locations = xmltodict.parse(response.text)["storeFinderSearchPage"]["stores"]
+        for location in locations:
             location["ref"] = location.pop("name")
             location["website"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
             location["phone"] = ";".join(

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -28,4 +28,5 @@ class KrefelBESpider(Spider):
 
             item = DictParser.parse(location)
             item["extras"]["website:fr"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
+            item["branch"] = item.pop("name")
             yield item

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -7,17 +7,19 @@ from locations.user_agents import BROWSER_DEFAULT
 class KrefelBESpider(Spider):
     name = "krefel_be"
     item_attributes = {"brand": "Krëfel", "brand_wikidata": "Q3200093"}
-    start_urls = ["https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=fr"]
+    start_urls = ["https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=nl"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response, **kwargs):
         for location in response.json()["stores"]:
             location["ref"] = location.pop("name")
-            location["website"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
+            location["website"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
             location["phone"] = ";".join(
                 filter(None, [location["address"].get("phone"), location["address"].get("phone2")])
             ).replace("/", "")
             location["address"]["house_number"] = location["address"].pop("line2", "")
             location["address"]["street"] = location["address"].pop("line1")
 
-            yield DictParser.parse(location)
+            item = DictParser.parse(location)
+            item["extras"]["website:fr"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
+            yield item

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -18,7 +18,6 @@ class KrefelBESpider(Spider):
     def parse(self, response, **kwargs):
         for location in response.json()["stores"]:
             location["ref"] = location.pop("name")
-            location["website"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
             location["phone"] = "; ".join(
                 filter(None, [location["address"].get("phone"), location["address"].get("phone2")])
             ).replace("/", "")
@@ -26,6 +25,7 @@ class KrefelBESpider(Spider):
             location["address"]["street"] = location["address"].pop("line1")
 
             item = DictParser.parse(location)
+            item["website"] = item["extras"]["website:nl"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
             item["extras"]["website:fr"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
             item["branch"] = item.pop("name")
             yield item

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -1,7 +1,7 @@
-from typing import Iterable
+from typing import Any, Iterable
 
 from scrapy import Request, Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
@@ -11,11 +11,12 @@ class KrefelBESpider(Spider):
     name = "krefel_be"
     item_attributes = {"brand": "Krëfel", "brand_wikidata": "Q3200093"}
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def start_requests(self) -> Iterable[Request]:
         yield JsonRequest(url="https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=nl")
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["stores"]:
             location["ref"] = location.pop("name")
             location["phone"] = "; ".join(

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -1,12 +1,14 @@
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class KrefelBESpider(Spider):
     name = "krefel_be"
     item_attributes = {"brand": "Krëfel", "brand_wikidata": "Q3200093"}
     start_urls = ["https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=fr"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response, **kwargs):
         for location in response.json()["stores"]:

--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -19,7 +19,7 @@ class KrefelBESpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # API response's content-type is not consistent.
-        if response.headers["Content-Type"] == "application/json":
+        if response.headers["Content-Type"] == b"application/json":
             locations = response.json()["stores"]
         else:
             locations = xmltodict.parse(response.text)["storeFinderSearchPage"]["stores"]


### PR DESCRIPTION
```

{'atp/brand/Krëfel': 73,
 'atp/brand_wikidata/Q3200093': 73,
 'atp/category/shop/electronics': 73,
 'atp/field/country/from_spider_name': 73,
 'atp/field/email/missing': 73,
 'atp/field/image/missing': 73,
 'atp/field/opening_hours/missing': 73,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/state/missing': 73,
 'atp/field/street_address/missing': 73,
 'atp/field/twitter/missing': 73,
 'atp/item_scraped_host_count/api.krefel.be': 73,
 'atp/nsi/perfect_match': 73,
 'downloader/request_bytes': 1038,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 11317,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.750119,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 11, 10, 55, 31, 456104, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 223329,
 'httpcompression/response_count': 1,
 'item_scraped_count': 73,
 'log_count/DEBUG': 87,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 11, 10, 55, 29, 705985, tzinfo=datetime.timezone.utc)}
```