### PR TITLE
use store_type not storeType for trade_point_gb

### DIFF
--- a/locations/spiders/trade_point_gb.py
+++ b/locations/spiders/trade_point_gb.py
@@ -32,7 +32,7 @@ class TradePointGBSpider(Spider):
             item["extras"] = {
                 "email": store["attributes"]["store"]["contactPoint"]["email"],
                 "fax": store["attributes"]["store"]["contactPoint"]["faxNumber"],
-                "storeType": store["attributes"]["store"]["storeType"],
+                "store_type": store["attributes"]["store"]["storeType"],
             }
 
             item["addr_full"] = ", ".join(


### PR DESCRIPTION
store_type is used also elsewhere, lets use the same key for the same type of info in various spiders