### PR TITLE
fix name in duffys

### DIFF
--- a/locations/spiders/duffys.py
+++ b/locations/spiders/duffys.py
@@ -7,7 +7,7 @@ from locations.items import Feature
 
 class DuffysSpider(scrapy.Spider):
     name = "duffys"
-    item_attributes = {"brand": "Duffys", "extras": {"amenity": "restaurant", "cuisine": "american"}}
+    item_attributes = {"brand": "Duffy's", "extras": {"amenity": "restaurant", "cuisine": "american"}}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):


### PR DESCRIPTION
spotted by comparing to OSM, verified by looking at https://www.duffysmvp.com/

note: OSM often has longer name version. Not sure is it some import, actually used name (dubious, even in logo suffix is in small letters) or some systematic mistake