### PR TITLE
[Kate spade CA US] Fix spider

### DIFF
--- a/locations/spiders/kate_spade_ca_us.py
+++ b/locations/spiders/kate_spade_ca_us.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.spiders.kate_spade import KateSpadeSpider
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -9,3 +11,7 @@ class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = KateSpadeSpider.item_attributes
     sitemap_urls = ["https://www.katespade.com/robots.txt"]
     sitemap_rules = [(r"/stores/\w\w/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Kate Spade ")
+        yield item

--- a/locations/spiders/kate_spade_ca_us.py
+++ b/locations/spiders/kate_spade_ca_us.py
@@ -9,4 +9,3 @@ class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = KateSpadeSpider.item_attributes
     sitemap_urls = ["https://www.katespade.com/robots.txt"]
     sitemap_rules = [(r"/stores/\w\w/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
-    wanted_types = ["OutletStore"]


### PR DESCRIPTION
`wanted_type`  used by spider earlier, is longer available, removed the same to fix the spider.

```
{'atp/brand/Kate Spade New York': 60,
 'atp/brand_wikidata/Q6375797': 60,
 'atp/category/shop/clothes': 60,
 'atp/cdn/cloudflare/response_count': 68,
 'atp/cdn/cloudflare/response_status_count/200': 68,
 'atp/field/operator/missing': 60,
 'atp/field/operator_wikidata/missing': 60,
 'atp/item_scraped_host_count/www.katespade.com': 60,
 'atp/nsi/perfect_match': 60,
 'downloader/request_bytes': 122519,
 'downloader/request_count': 68,
 'downloader/request_method_count/GET': 68,
 'downloader/response_bytes': 2051353,
 'downloader/response_count': 68,
 'downloader/response_status_count/200': 68,
 'elapsed_time_seconds': 1.875047,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 14, 11, 32, 31, 452994, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 68,
 'httpcompression/response_bytes': 12669554,
 'httpcompression/response_count': 68,
 'item_scraped_count': 60,
 'log_count/DEBUG': 140,
 'log_count/INFO': 10,
 'request_depth_max': 2,
 'response_received_count': 68,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 67,
 'scheduler/dequeued/memory': 67,
 'scheduler/enqueued': 67,
 'scheduler/enqueued/memory': 67,
 'start_time': datetime.datetime(2024, 10, 14, 11, 32, 29, 577947, tzinfo=datetime.timezone.utc)}
```