### PR TITLE
[Second Cup CA] Fix coords

### DIFF
--- a/locations/spiders/second_cup_ca.py
+++ b/locations/spiders/second_cup_ca.py
@@ -6,17 +6,19 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class SecondCupCASpider(SitemapSpider, StructuredDataSpider):
     name = "second_cup_ca"
-    item_attributes = {
-        "brand": "Second Cup",
-        "brand_wikidata": "Q862180",
-    }
+    item_attributes = {"brand": "Second Cup", "brand_wikidata": "Q862180"}
     sitemap_urls = ["https://secondcup.com/sitemap_index.xml"]
-    sitemap_rules = [
-        (r"^https://secondcup\.com/location/.*/$", "parse_sd"),
-    ]
+    sitemap_follow = ["locations"]
+    sitemap_rules = [(r"^https://secondcup\.com/location/.*/$", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "openingHours" in ld_data:
             item["opening_hours"].add_ranges_from_string(ld_data["openingHours"], days=DAYS_FR)
 
-        return super().post_process_item(item, response, ld_data, **kwargs)
+        item["name"] = None
+        item["branch"] = response.xpath("//h1/text()").get()
+
+        if float(item["lon"]) > 0:
+            item["lon"] = item["lon"] * -1
+
+        yield item


### PR DESCRIPTION
Fixes #11063

```python
{'atp/brand/Second Cup': 169,
 'atp/brand_wikidata/Q862180': 169,
 'atp/category/amenity/cafe': 169,
 'atp/field/email/missing': 169,
 'atp/field/image/missing': 169,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 88,
 'atp/field/operator/missing': 169,
 'atp/field/operator_wikidata/missing': 169,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 2,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/geometry/null_island': 2,
 'atp/item_scraped_host_count/secondcup.com': 169,
 'atp/nsi/perfect_match': 169,
 'downloader/request_bytes': 70444,
 'downloader/request_count': 187,
 'downloader/request_method_count/GET': 187,
 'downloader/response_bytes': 5318619,
 'downloader/response_count': 187,
 'downloader/response_status_count/200': 185,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 2.700872,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 14, 13, 46, 46, 347532, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 187,
 'httpcompression/response_bytes': 36946741,
 'httpcompression/response_count': 187,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/404': 2,
 'item_scraped_count': 169,
 'log_count/INFO': 12,
 'log_count/WARNING': 85,
 'memusage/max': 245567488,
 'memusage/startup': 245567488,
 'request_depth_max': 2,
 'response_received_count': 187,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 186,
 'scheduler/dequeued/memory': 186,
 'scheduler/enqueued': 186,
 'scheduler/enqueued/memory': 186,
 'start_time': datetime.datetime(2024, 10, 14, 13, 46, 43, 646660, tzinfo=datetime.timezone.utc)}
```