### PR TITLE
[playa_bowls_us] Fix address parsing

### DIFF
--- a/locations/spiders/playa_bowls_us.py
+++ b/locations/spiders/playa_bowls_us.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from scrapy import Spider
 from scrapy.http import Response
 
@@ -7,19 +9,16 @@ from locations.hours import OpeningHours
 
 class PlayaBowlsUSSpider(Spider):
     name = "playa_bowls_us"
-    item_attributes = {
-        "brand_wikidata": "Q114618507",
-        "brand": "Playa Bowls",
-    }
-    allowed_domains = [
-        "www.playabowls.com",
-    ]
+    item_attributes = {"brand": "Playa Bowls", "brand_wikidata": "Q114618507"}
+    allowed_domains = ["www.playabowls.com"]
     start_urls = ["https://services.playabowls.com/api/locations"]
 
-    def parse(self, response: Response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
             location["street_address"] = location.pop("address")
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["website"] = location["link"]
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(location["timing"].replace("Open Everyday ", "Mo-Su"))
             yield item

--- a/locations/spiders/playa_bowls_us.py
+++ b/locations/spiders/playa_bowls_us.py
@@ -18,6 +18,7 @@ class PlayaBowlsUSSpider(Spider):
 
     def parse(self, response: Response):
         for location in response.json():
+            location["street_address"] = location.pop("address")
             item = DictParser.parse(location)
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(location["timing"].replace("Open Everyday ", "Mo-Su"))


### PR DESCRIPTION
This fixes the `playa_bowls_us` scraper. Previously, it only included the "street address" part of the address in `addr:full`.

Fixes #11116 