### PR TITLE
[Kirklands] Fix spider

### DIFF
--- a/locations/spiders/kirklands.py
+++ b/locations/spiders/kirklands.py
@@ -16,6 +16,7 @@ class KirklandsSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.kirklands.com/custserv/locate_store.cmd"]
     rules = [Rule(LinkExtractor(allow="/store.jsp?"), callback="parse_sd")]
     requires_proxy = True
+    time_format = "%I %p"
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if isinstance(item.get("city"), list):  # e.g. ['Suite A-1', 'Huntsville']

--- a/locations/spiders/kirklands.py
+++ b/locations/spiders/kirklands.py
@@ -14,6 +14,7 @@ class KirklandsSpider(Spider):
     }
     start_urls = ["https://www.kirklands.com/js/dyn/store_locator_all_stores.js"]
     ROBOTSTXT_OBEY = False
+    requires_proxy = True
 
     def parse(self, response):
         location_objects = re.split(r"allStores\[\d+\] = ", response.text)[1:]

--- a/locations/spiders/kirklands.py
+++ b/locations/spiders/kirklands.py
@@ -1,38 +1,15 @@
-import re
-import urllib.parse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from scrapy import Spider
-
-from locations.dict_parser import DictParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class KirklandsSpider(Spider):
+class KirklandsSpider(CrawlSpider, StructuredDataSpider):
     name = "kirklands"
     item_attributes = {
         "brand": "Kirkland's",
         "brand_wikidata": "Q6415714",
     }
-    start_urls = ["https://www.kirklands.com/js/dyn/store_locator_all_stores.js"]
-    ROBOTSTXT_OBEY = False
+    start_urls = ["https://www.kirklands.com/custserv/locate_store.cmd"]
+    rules = [Rule(LinkExtractor(allow="/store.jsp?"), callback="parse_sd")]
     requires_proxy = True
-
-    def parse(self, response):
-        location_objects = re.split(r"allStores\[\d+\] = ", response.text)[1:]
-        location_list = []
-        for location_obj in location_objects:
-            loc_info = {}
-            matches = re.findall(r"store\.(.*?) = (.*?);", location_obj)
-            for key, value in matches:
-                loc_info[key.strip()] = value.strip().strip("'").replace('"', "")
-            location_list.append(loc_info)
-
-        for location in location_list:
-            if location:
-                item = DictParser.parse(location)
-                item["branch"] = item.pop("name")
-                item["street_address"] = " ".join([location["ADDRESS_LINE_1"], location["ADDRESS_LINE_2"]])
-                item["website"] = "https://www.kirklands.com/custserv/store.jsp?storeName=" + urllib.parse.quote(
-                    location["STORE_NAME"]
-                )
-
-                yield item

--- a/locations/spiders/kirklands.py
+++ b/locations/spiders/kirklands.py
@@ -19,6 +19,7 @@ class KirklandsSpider(CrawlSpider, StructuredDataSpider):
     time_format = "%I %p"
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name")
         if isinstance(item.get("city"), list):  # e.g. ['Suite A-1', 'Huntsville']
             item["street_address"] = merge_address_lines([item["street_address"], item["city"][0]])
             item["city"] = item["city"][-1]


### PR DESCRIPTION
Works fine from `IN`,  `requires_proxy` made `True`. Spider code refactored to use `Structured Data`, which gives `opening_hours` as well.

```
{"atp/brand/Kirkland's": 325,
 'atp/brand_wikidata/Q6415714': 325,
 'atp/category/shop/interior_decoration': 325,
 'atp/field/country/from_reverse_geocoding': 325,
 'atp/field/email/missing': 325,
 'atp/field/image/missing': 325,
 'atp/field/operator/missing': 325,
 'atp/field/operator_wikidata/missing': 325,
 'atp/field/phone/missing': 1,
 'atp/item_scraped_host_count/www.kirklands.com': 325,
 'atp/nsi/perfect_match': 325,
 'downloader/request_bytes': 169272,
 'downloader/request_count': 327,
 'downloader/request_method_count/GET': 327,
 'downloader/response_bytes': 13606383,
 'downloader/response_count': 327,
 'downloader/response_status_count/200': 326,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 8.281249,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 15, 11, 55, 33, 704640, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 327,
 'httpcompression/response_bytes': 83890931,
 'httpcompression/response_count': 327,
 'item_scraped_count': 325,
 'log_count/DEBUG': 960,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 327,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 326,
 'scheduler/dequeued/memory': 326,
 'scheduler/enqueued': 326,
 'scheduler/enqueued/memory': 326,
 'start_time': datetime.datetime(2024, 10, 15, 11, 55, 25, 423391, tzinfo=datetime.timezone.utc)}
```