### PR TITLE
[Korian FR] Fix Spider

### DIFF
--- a/locations/spiders/korian_fr.py
+++ b/locations/spiders/korian_fr.py
@@ -1,58 +1,16 @@
-import scrapy
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class KorianFRSpider(scrapy.Spider):
+class KorianFRSpider(CrawlSpider, StructuredDataSpider):
     name = "korian_fr"
     item_attributes = {"brand": "Korian", "brand_wikidata": "Q3198944"}
-    allowed_domains = ["api-www.korian.fr"]
-
-    def start_requests(self):
-        types = [
-            "maison-retraite",
-            "clinique-ssr",
-            "residence-seniors",
-            "hospitalisation-a-domicile",
-        ]
-
-        regions = [
-            "bretagne",
-            "occitanie",
-            "ile-de-france",
-            "normandie",
-            "auvergne-rhone-alpes",
-            "nouvelle-aquitaine",
-            "hauts-de-france",
-            "provence-alpes-cote-dazur",
-            "centre-val-de-loire",
-            "pays-de-la-loire",
-            "bourgogne-franche-comte",
-            "grand-est",
-        ]
-
-        for type in types:
-            for region in regions:
-                url = "https://api-www.korian.fr/api-front/FR/{type}/{region}".format(type=type, region=region)
-                yield scrapy.Request(url=url, callback=self.parse)
-
-    def parse(self, response):
-        result = response.json()
-
-        stores = result["data"]["content"][0]["results"]
-
-        for store in stores:
-            properties = {
-                "ref": store["id"],
-                "name": store["name"],
-                "street_address": store["address"],
-                "city": store["city"],
-                "state": store["region"],
-                "postcode": store["zipcode"],
-                "country": "FR",
-                "lat": store["latitude"],
-                "lon": store["longitude"],
-                "website": "https://www.korian.fr/" + store["redirecturl"],
-            }
-
-            yield Feature(**properties)
+    start_urls = ["https://www.korian.fr/maisons-retraite"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"https://www.korian.fr/maisons-retraite/[-\w]+/[-\w]+/[-\w]+/[-\w]+$"),
+            callback="parse_sd",
+        )
+    ]


### PR DESCRIPTION
```
{'atp/brand/Korian': 267,
 'atp/brand_wikidata/Q3198944': 267,
 'atp/category/amenity/social_facility': 267,
 'atp/field/branch/missing': 267,
 'atp/field/email/missing': 5,
 'atp/field/opening_hours/missing': 267,
 'atp/field/state/missing': 267,
 'atp/field/twitter/missing': 5,
 'atp/item_scraped_host_count/www.korian.fr': 267,
 'atp/nsi/perfect_match': 267,
 'atp/operator/Korian': 267,
 'atp/operator_wikidata/Q3198944': 267,
 'downloader/request_bytes': 116617,
 'downloader/request_count': 269,
 'downloader/request_method_count/GET': 269,
 'downloader/response_bytes': 17293871,
 'downloader/response_count': 269,
 'downloader/response_status_count/200': 269,
 'elapsed_time_seconds': 6.854602,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 15, 15, 14, 45, 382946, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 269,
 'httpcompression/response_bytes': 104711487,
 'httpcompression/response_count': 268,
 'item_scraped_count': 267,
 'log_count/DEBUG': 548,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 269,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 268,
 'scheduler/dequeued/memory': 268,
 'scheduler/enqueued': 268,
 'scheduler/enqueued/memory': 268,
 'start_time': datetime.datetime(2024, 10, 15, 15, 14, 38, 528344, tzinfo=datetime.timezone.utc)}
```