### PR TITLE
[eathappy] Add spider (3343 locations)

### DIFF
--- a/locations/spiders/eathappy.py
+++ b/locations/spiders/eathappy.py
@@ -1,0 +1,84 @@
+import base64
+import json
+import re
+from typing import Iterable
+
+import scrapy
+from scrapy import Request
+from scrapy.spiders import Response
+
+from locations.categories import Categories
+from locations.hours import DAYS_DE, DAYS_IT, OpeningHours
+from locations.items import Feature
+
+
+class EathappySpider(scrapy.Spider):
+    name = "eathappy"
+    item_attributes = {"brand": "Eat Happy", "brand_wikidata": "Q125578025", "extras": Categories.FAST_FOOD.value}
+    countries = {
+        "AT": {
+            "url": "https://www.eathappy.at/standorte/",
+            "day_names": DAYS_DE,
+        },
+        "DE": {
+            "url": "https://www.eathappy.de/standorte/",
+            "day_names": DAYS_DE,
+        },
+        "IT": {
+            "url": "https://www.eathappy.it/dove-siamo/",
+            "day_names": DAYS_IT,
+        },
+    }
+    ajax_post_id = 1086
+
+    def start_requests(self) -> Iterable[Request]:
+        # Need to get the data from two URLs: The HTML page contains a JavaScript block with the IDs and coordinates
+        for country, country_definition in self.countries.items():
+            yield Request(url=country_definition["url"], callback=self.parse, cb_kwargs={"country": country})
+
+    def parse(self, response: Response, country: str = "DE", **kwargs) -> Iterable[Feature]:
+        re_extract = r"\s*var locations\s*=\s*(\[.*\]);\s*"
+        locations_javascript = response.xpath('//div[@id="map"]/following-sibling::script/text()').re(re_extract)
+        if locations_javascript:
+            locations_javascript = locations_javascript[0]
+        else:
+            locations_base64 = response.xpath('//div[@id="map"]/following-sibling::script/@src').get()
+            locations_javascript = str(base64.standard_b64decode(locations_base64.split(",")[-1]), "utf-8")
+            locations_javascript = re.sub(re_extract, r"\1", locations_javascript, re.MULTILINE)
+        locations_array = json.loads(locations_javascript)
+        shop_coordinates = {shop["id"]: shop for shop in locations_array}
+        # This is the second URL and contains the name, address and opening hours. The data is merged with the first URL
+        # via the ID
+        yield scrapy.FormRequest(
+            url=response.urljoin("/wp-admin/admin-ajax.php"),
+            formdata={"action": "ajax_load_map_locations", "post_id": str(self.ajax_post_id)},
+            meta={"shops": shop_coordinates},
+            callback=self.parse_shops,
+            cb_kwargs={"country": country},
+        )
+
+    def parse_shops(self, response: Response, country: str = "DE") -> Iterable[Feature]:
+        shop_coordinates = response.meta["shops"]
+        for location in response.xpath('/html/body/div[@class="map-sidebar-location"]'):
+            item = Feature()
+            shop_id = int(location.attrib["data-location-id"])
+            item["ref"] = shop_id
+            div = location.xpath('div[@class="desc"]')
+            item["name"] = div.xpath("h6/text()").get()
+            item["addr_full"] = div.xpath("h6/following-sibling::p/text()").get()
+            item["country"] = country
+            opening_hours = OpeningHours()
+            for row in div.xpath('div/div[@class="opening-hours-table"]/div[@class="opening-hours-row"]'):
+                label = row.xpath('div[@class="opening-hours-label"]/text()').get().replace(":", "")
+                day = self.countries[country]["day_names"][label.title()]
+                period = row.xpath('normalize-space(div[@class="opening-hours-value"]/text())').get()
+                if "-" in period:
+                    opening_time, closing_time = period.split("-")
+                    opening_hours.add_range(day, opening_time, closing_time, "%H:%M")
+            item["opening_hours"] = opening_hours
+            item["extras"] = {}
+            for tag in div.xpath('p[@class="tag"]/text()').getall():
+                item["extras"][tag] = True
+            item["lon"] = shop_coordinates[shop_id]["lng"]
+            item["lat"] = shop_coordinates[shop_id]["lat"]
+            yield item

--- a/locations/spiders/yuzu_de.py
+++ b/locations/spiders/yuzu_de.py
@@ -1,0 +1,16 @@
+from locations.categories import Categories
+from locations.hours import DAYS_DE
+from locations.spiders.eathappy import EathappySpider
+
+
+class YuzuDESpider(EathappySpider):
+    name = "yuzu_de"
+    item_attributes = {"brand": "Yuzu", "brand_wikidata": "Q130392622", "extras": Categories.FAST_FOOD.value}
+    base_domain = "https://www.yuzu-food.com"
+    countries = {
+        "DE": {
+            "url": "https://www.yuzu-food.com/standorte/",
+            "day_names": DAYS_DE,
+        },
+    }
+    ajax_post_id = 71123


### PR DESCRIPTION
[Eat Happy](https://www.eathappygroup.com/en/) is a sushi store-in-store chain in supermarkets in AT, DE and IT.

This also adds [Yuzu](https://www.yuzu-food.com/) which is a smaller sub-brand of the same group in DE.

```
2024-10-15 22:45:10 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Eat Happy': 3343,
 'atp/brand_wikidata/Q125578025': 3343,
 'atp/category/amenity/fast_food': 3343,
 'atp/field/branch/missing': 3343,
 'atp/field/city/missing': 3343,
 'atp/field/email/missing': 3343,
 'atp/field/image/missing': 3343,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 3343,
 'atp/field/operator_wikidata/missing': 3343,
 'atp/field/phone/missing': 3343,
 'atp/field/postcode/missing': 3343,
 'atp/field/state/missing': 3343,
 'atp/field/street_address/missing': 3343,
 'atp/field/twitter/missing': 3343,
 'atp/field/website/missing': 3343,
 'atp/item_scraped_host_count/www.eathappy.at': 1419,
 'atp/item_scraped_host_count/www.eathappy.de': 1892,
 'atp/item_scraped_host_count/www.eathappy.it': 54,
 'atp/nsi/perfect_match': 3343,

2024-10-15 22:44:31 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Yuzu': 102,
 'atp/brand_wikidata/Q130392622': 102,
 'atp/category/amenity/fast_food': 102,
 'atp/field/branch/missing': 102,
 'atp/field/city/missing': 102,
 'atp/field/email/missing': 102,
 'atp/field/image/missing': 102,
 'atp/field/operator/missing': 102,
 'atp/field/operator_wikidata/missing': 102,
 'atp/field/phone/missing': 102,
 'atp/field/postcode/missing': 102,
 'atp/field/state/missing': 102,
 'atp/field/street_address/missing': 102,
 'atp/field/twitter/missing': 102,
 'atp/field/website/missing': 102,
 'atp/item_scraped_host_count/www.yuzu-food.com': 102,
 'atp/nsi/brand_missing': 102,
```