### PR TITLE
Add taco_palenque spider

### DIFF
--- a/locations/spiders/taco_palenque.py
+++ b/locations/spiders/taco_palenque.py
@@ -1,0 +1,43 @@
+import re
+from html import unescape
+
+from geonamescache import GeonamesCache
+from scrapy import Selector
+
+from locations.items import Feature
+from locations.storefinders.super_store_finder import SuperStoreFinderSpider
+
+
+class TacoPalenqueSpider(SuperStoreFinderSpider):
+    name = "taco_palenque"
+    item_attributes = {
+        "brand_wikidata": "Q7673965",
+        "brand": "Taco Palenque",
+    }
+    allowed_domains = [
+        "www.tacopalenque.com",
+    ]
+
+    def get_us_state_code_from_address(self, address: str) -> bool:
+        states = GeonamesCache.us_states
+        # state is either at the end or right before the ZIP
+        split_address = re.split(r"[\s,]+", address.upper())[-2:]
+        for key in states:
+            state_code = states[key]["code"]
+            state_name = states[key]["name"]
+            if state_code in split_address or state_name.upper() in split_address:
+                return state_code
+        return None
+
+    def parse_item(self, item: Feature, location: Selector):
+        item["branch"] = unescape(item.pop("name"))
+
+        # this makes the assumption that the chain only exists in US and Mexico
+        state_code = self.get_us_state_code_from_address(item["addr_full"])
+        if state_code is not None:
+            item["state"] = state_code
+            item["country"] = "US"
+        else:
+            item["country"] = "MX"
+
+        yield item

--- a/locations/spiders/taco_palenque.py
+++ b/locations/spiders/taco_palenque.py
@@ -4,6 +4,7 @@ from html import unescape
 from geonamescache import GeonamesCache
 from scrapy import Selector
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.super_store_finder import SuperStoreFinderSpider
 
@@ -39,5 +40,7 @@ class TacoPalenqueSpider(SuperStoreFinderSpider):
             item["country"] = "US"
         else:
             item["country"] = "MX"
+
+        apply_category(Categories.FAST_FOOD, item)
 
         yield item

--- a/locations/spiders/taco_palenque.py
+++ b/locations/spiders/taco_palenque.py
@@ -11,13 +11,8 @@ from locations.storefinders.super_store_finder import SuperStoreFinderSpider
 
 class TacoPalenqueSpider(SuperStoreFinderSpider):
     name = "taco_palenque"
-    item_attributes = {
-        "brand_wikidata": "Q7673965",
-        "brand": "Taco Palenque",
-    }
-    allowed_domains = [
-        "www.tacopalenque.com",
-    ]
+    item_attributes = {"brand": "Taco Palenque", "brand_wikidata": "Q7673965"}
+    allowed_domains = ["www.tacopalenque.com"]
 
     def get_us_state_code_from_address(self, address: str) -> bool:
         states = GeonamesCache.us_states
@@ -31,7 +26,7 @@ class TacoPalenqueSpider(SuperStoreFinderSpider):
         return None
 
     def parse_item(self, item: Feature, location: Selector):
-        item["branch"] = unescape(item.pop("name"))
+        item["branch"] = unescape(item.pop("name").removeprefix("Taco Palenque - "))
 
         # this makes the assumption that the chain only exists in US and Mexico
         state_code = self.get_us_state_code_from_address(item["addr_full"])


### PR DESCRIPTION
Adds a spider for [Taco Palenque](https://tacopalenque.com/) a fast food chain in the US and Mexico.

The addresses from the store locator are very messy, so I had to try to extract the state from the string to help the geocoder disambiguate restaurants that are very close to the US-Mexico border. This could be avoided by only matching within the country boundaries, but I'm not sure if this is possible.

Additionally, I have manually applied the fast food category, since NSI has not released since I added it (https://github.com/osmlab/name-suggestion-index/pull/10041)

This is my first spider, so please let me know if I am reinventing the wheel with the state matching!