### PR TITLE
[Papa John's] Fix spider

### DIFF
--- a/locations/spiders/papa_johns.py
+++ b/locations/spiders/papa_johns.py
@@ -8,13 +8,10 @@ class PapaJohnsSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Papa John's", "brand_wikidata": "Q2759586"}
     allowed_domains = ["papajohns.com"]
     sitemap_urls = ["https://locations.papajohns.com/sitemap.xml"]
-    sitemap_rules = [(r"com/(?:united\-states|canada)/\w{2}/([-\w]+)/[^/]+/[^/]+$", "parse_sd")]
+    sitemap_rules = [(r"com/(?:united\-states|canada)/\w{2}/[-\w]+/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["FastFoodRestaurant"]
     search_for_twitter = False
     search_for_facebook = False
-
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        ld_data["@id"] = None
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if item.get("name").startswith("Coming Soon - "):

--- a/locations/spiders/papa_johns.py
+++ b/locations/spiders/papa_johns.py
@@ -14,6 +14,7 @@ class PapaJohnsSpider(SitemapSpider, StructuredDataSpider):
     search_for_facebook = False
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["ref"] = item["ref"].strip("/.")
         if item.get("name").startswith("Coming Soon - "):
             item["opening_hours"] = "off"
         item["name"] = item["image"] = None

--- a/locations/spiders/papa_johns.py
+++ b/locations/spiders/papa_johns.py
@@ -8,22 +8,19 @@ class PapaJohnsSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Papa John's", "brand_wikidata": "Q2759586"}
     allowed_domains = ["papajohns.com"]
     sitemap_urls = ["https://locations.papajohns.com/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/locations\.papajohns\.com\/(?:united\-states|canada)\/\w{2}\/[-\w]+\/[-\w]+\/.+$",
-            "parse_sd",
-        )
-    ]
+    sitemap_rules = [(r"com/(?:united\-states|canada)/\w{2}/([-\w]+)/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["FastFoodRestaurant"]
-    drop_attributes = {"image"}
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data["@id"] = None
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        if name := item.get("name", "").lower():
-            if name.startswith("coming soon - "):
-                return
-            else:
-                item["branch"] = item.pop("name").removeprefix("Papa Johns Pizza ")
+        if item.get("name").startswith("Coming Soon - "):
+            item["opening_hours"] = "off"
+        item["name"] = item["image"] = None
 
-        item["website"] = response.urljoin(item["website"])
+        item["website"] = response.url
 
         yield item


### PR DESCRIPTION
Dropped duplicates and dropped address as "branch", 
```python
{"atp/brand/Papa John's": 3366,
 'atp/brand_wikidata/Q2759586': 3366,
 'atp/category/amenity/fast_food': 3366,
 'atp/cdn/cloudflare/response_count': 3370,
 'atp/cdn/cloudflare/response_status_count/200': 3370,
 'atp/field/branch/missing': 3366,
 'atp/field/email/missing': 3366,
 'atp/field/image/missing': 3366,
 'atp/field/opening_hours/invalid': 7,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 3366,
 'atp/field/operator_wikidata/missing': 3366,
 'atp/field/phone/missing': 13,
 'atp/field/twitter/missing': 3366,
 'atp/item_scraped_host_count/locations.papajohns.com': 3366,
 'atp/nsi/cc_match': 3366,
 'downloader/request_bytes': 1887582,
 'downloader/request_count': 3372,
 'downloader/request_method_count/GET': 3372,
 'downloader/response_bytes': 83509891,
 'downloader/response_count': 3372,
 'downloader/response_status_count/200': 3370,
 'downloader/response_status_count/301': 2,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 22.224543,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 16, 13, 8, 46, 814342, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 3372,
 'httpcompression/response_bytes': 382958249,
 'httpcompression/response_count': 3370,
 'item_scraped_count': 3366,
 'log_count/INFO': 10,
 'log_count/WARNING': 8,
 'memusage/max': 253878272,
 'memusage/startup': 253878272,
 'request_depth_max': 2,
 'response_received_count': 3370,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3371,
 'scheduler/dequeued/memory': 3371,
 'scheduler/enqueued': 3371,
 'scheduler/enqueued/memory': 3371,
 'start_time': datetime.datetime(2024, 10, 16, 13, 8, 24, 589799, tzinfo=datetime.timezone.utc)}
```