### PR TITLE
[KumAndGo] Fix spider

### DIFF
--- a/locations/spiders/kum_and_go.py
+++ b/locations/spiders/kum_and_go.py
@@ -8,17 +8,25 @@ from locations.structured_data_spider import StructuredDataSpider
 
 FUEL_TYPES_MAPPING = {
     "CNG": Fuel.CNG,
+    "DEF": Fuel.ADBLUE,
     "Diesel": Fuel.DIESEL,
     "Dyed Diesel": Fuel.UNTAXED_DIESEL,
     "E85": Fuel.E85,
     "E15": Fuel.E15,
+    "Ethanol Free 87": Fuel.ETHANOL_FREE,
+    "Ethanol Free 88": Fuel.ETHANOL_FREE,
+    "Ethanol Free 91": Fuel.ETHANOL_FREE,
     "Kerosene": Fuel.KEROSENE,
     "Midgrade - Ethanol Free": Fuel.ETHANOL_FREE,
-    "Midgrade": Fuel.OCTANE_87,
+    "Mid": Fuel.OCTANE_89,
+    "Midgrade": Fuel.OCTANE_89,
+    "Mid-High": Fuel.OCTANE_90,
     "Premium - Ethanol Free": Fuel.ETHANOL_FREE,
     "Premium Plus (93 octane)": Fuel.OCTANE_93,
     "Premium": Fuel.OCTANE_91,
+    "Regular": Fuel.OCTANE_87,
     "Super Unleaded/Regular": Fuel.OCTANE_87,
+    "Truck Diesel": Fuel.HGV_DIESEL,
     "Xtreme Diesel": Fuel.DIESEL,
 }
 

--- a/locations/spiders/kum_and_go_us.py
+++ b/locations/spiders/kum_and_go_us.py
@@ -35,8 +35,8 @@ SERVICES_MAPPING = {
 }
 
 
-class KumAndGoSpider(SitemapSpider, StructuredDataSpider):
-    name = "kum_and_go"
+class KumAndGoUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "kum_and_go_us"
     item_attributes = {"brand": "Kum & Go", "brand_wikidata": "Q6443340"}
     sitemap_urls = ["https://locations.kumandgo.com/robots.txt"]
     sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+$", "parse")]


### PR DESCRIPTION
```
{'atp/brand/Kum & Go': 304,
 'atp/brand_wikidata/Q6443340': 304,
 'atp/category/amenity/fuel': 303,
 'atp/category/shop/convenience': 1,
 'atp/cdn/cloudflare/response_count': 368,
 'atp/cdn/cloudflare/response_status_count/200': 368,
 'atp/field/branch/missing': 304,
 'atp/field/email/missing': 304,
 'atp/field/opening_hours/missing': 13,
 'atp/field/operator/missing': 304,
 'atp/field/operator_wikidata/missing': 304,
 'atp/item_scraped_host_count/locations.kumandgo.com': 304,
 'atp/nsi/cc_match': 304,
 'downloader/request_bytes': 139736,
 'downloader/request_count': 368,
 'downloader/request_method_count/GET': 368,
 'downloader/response_bytes': 4375471,
 'downloader/response_count': 368,
 'downloader/response_status_count/200': 368,
 'dupefilter/filtered': 51,
 'elapsed_time_seconds': 6.657869,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 17, 4, 7, 41, 832836, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 368,
 'httpcompression/response_bytes': 26614945,
 'httpcompression/response_count': 368,
 'item_scraped_count': 304,
 'kum_and_go/unknown_service/RV Lanes': 1,
 'log_count/DEBUG': 685,
 'log_count/INFO': 9,
 'request_depth_max': 3,
 'response_received_count': 368,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 367,
 'scheduler/dequeued/memory': 367,
 'scheduler/enqueued': 367,
 'scheduler/enqueued/memory': 367,
 'start_time': datetime.datetime(2024, 10, 17, 4, 7, 35, 174967, tzinfo=datetime.timezone.utc)}
```