### PR TITLE
[LaSalsa] Fix spider

### DIFF
--- a/locations/spiders/la_salsa.py
+++ b/locations/spiders/la_salsa.py
@@ -1,23 +1,13 @@
-import scrapy
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LaSalsaSpider(scrapy.Spider):
+class LaSalsaSpider(CrawlSpider, StructuredDataSpider):
     name = "la_salsa"
     item_attributes = {"brand": "La Salsa", "brand_wikidata": "Q48835190"}
-    allowed_domains = ["www.lasalsa.com"]
-    start_urls = ("http://lasalsa.com/wp-content/themes/lasalsa-main/locations-search.php?lat=0&lng=0&radius=99999999",)
-
-    def parse(self, response):
-        for match in response.xpath("//markers/marker"):
-            yield Feature(
-                ref=match.xpath(".//@name").extract_first(),
-                lat=float(match.xpath(".//@latitude").extract_first()),
-                lon=float(match.xpath(".//@longitude").extract_first()),
-                addr_full=match.xpath(".//@address").extract_first(),
-                city=match.xpath(".//@city").extract_first(),
-                state=match.xpath(".//@state").extract_first(),
-                postcode=match.xpath(".//@zip").extract_first(),
-                phone=match.xpath(".//@phone").extract_first(),
-            )
+    start_urls = ["https://www.lasalsa.com/locator/index.php?brand=26&pagesize=1000&q=us"]
+    rules = [
+        Rule(LinkExtractor(allow="/stores/"), callback="parse_sd"),
+    ]

--- a/locations/spiders/la_salsa_us.py
+++ b/locations/spiders/la_salsa_us.py
@@ -1,6 +1,8 @@
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -14,3 +16,7 @@ class LaSalsaUSSpider(CrawlSpider, StructuredDataSpider):
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data["openingHours"] = None  # Requires fix, only a few locations, not worth the effort
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["ref"] = item.pop("name").removeprefix("La Salsa Store ")
+        yield item

--- a/locations/spiders/la_salsa_us.py
+++ b/locations/spiders/la_salsa_us.py
@@ -11,3 +11,6 @@ class LaSalsaUSSpider(CrawlSpider, StructuredDataSpider):
     rules = [
         Rule(LinkExtractor(allow="/stores/"), callback="parse_sd"),
     ]
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data["openingHours"] = None  # Requires fix, only a few locations, not worth the effort

--- a/locations/spiders/la_salsa_us.py
+++ b/locations/spiders/la_salsa_us.py
@@ -4,8 +4,8 @@ from scrapy.spiders import CrawlSpider, Rule
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class LaSalsaSpider(CrawlSpider, StructuredDataSpider):
-    name = "la_salsa"
+class LaSalsaUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "la_salsa_us"
     item_attributes = {"brand": "La Salsa", "brand_wikidata": "Q48835190"}
     start_urls = ["https://www.lasalsa.com/locator/index.php?brand=26&pagesize=1000&q=us"]
     rules = [


### PR DESCRIPTION
No. of locations reduced to `5`. 
Ref: https://en.wikipedia.org/wiki/La_Salsa 

![image](https://github.com/user-attachments/assets/b51a58c4-097e-4bf3-bf6f-5d26ea7f27ed)

```
{'atp/brand/La Salsa': 5,
 'atp/brand_wikidata/Q48835190': 5,
 'atp/category/amenity/fast_food': 5,
 'atp/field/branch/missing': 5,
 'atp/field/country/from_reverse_geocoding': 5,
 'atp/field/email/missing': 5,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/item_scraped_host_count/www.lasalsa.com': 5,
 'atp/nsi/perfect_match': 5,
 'downloader/request_bytes': 2710,
 'downloader/request_count': 7,
 'downloader/request_method_count/GET': 7,
 'downloader/response_bytes': 51576,
 'downloader/response_count': 7,
 'downloader/response_status_count/200': 6,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 7.859487,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 17, 13, 25, 16, 642017, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 179448,
 'httpcompression/response_count': 6,
 'item_scraped_count': 5,
 'log_count/DEBUG': 23,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 7,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 6,
 'scheduler/dequeued/memory': 6,
 'scheduler/enqueued': 6,
 'scheduler/enqueued/memory': 6,
 'start_time': datetime.datetime(2024, 10, 17, 13, 25, 8, 782530, tzinfo=datetime.timezone.utc)}
```