### PR TITLE
[LeadersRomansGroupGB] Fix Leaders Spider and update it to add Romans brand  belonging to Leaders Romans Group

### DIFF
--- a/locations/spiders/leaders_gb.py
+++ b/locations/spiders/leaders_gb.py
@@ -1,32 +1,20 @@
-from urllib.parse import urljoin
+import json
+from typing import Iterable
 
-from scrapy.spiders import Spider
+from scrapy.http import Response
 
 from locations.items import Feature
-from locations.structured_data_spider import extract_email, extract_phone
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class LeadersGBSpider(Spider):
+class LeadersGBSpider(JSONBlobSpider):
     name = "leaders_gb"
     item_attributes = {"brand": "Leaders", "brand_wikidata": "Q111522674"}
     start_urls = ["https://www.leaders.co.uk/contact-us"]
 
-    def parse(self, response, **kwargs):
-        for location in response.xpath(
-            '//div[contains(@class, "branch-dept-Sales") or contains(@class, "branch-dept-Lettings")]'
-        ):
-            item = Feature()
-            item["addr_full"] = location.xpath("./p/text()").get()
+    def extract_json(self, response: Response) -> list:
+        return json.loads(response.xpath("//@data-branches").get())
 
-            if "Covering" in item["addr_full"]:
-                continue
-
-            item["ref"] = location.xpath("./@data-history-node-id").get()
-            item["image"] = urljoin(response.url, location.xpath("./img/@src").get())
-            item["lat"], item["lon"] = location.xpath(".//@data-location").get().split(",")
-            item["name"] = location.xpath("./h5/span/text()").get()
-            extract_email(item, location)
-            extract_phone(item, location)
-            item["website"] = urljoin(response.url, location.xpath('.//p[@class="branch-link"]/a/@href').get())
-
-            yield item
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = item["website"]
+        yield item

--- a/locations/spiders/leaders_gb.py
+++ b/locations/spiders/leaders_gb.py
@@ -22,4 +22,5 @@ class LeadersGBSpider(JSONBlobSpider):
             f'//img[contains(@alt, "{item["branch"]}")]/ancestor::div[@class="slider-item properties-contacts-slider-item"]'
         )
         item["addr_full"] = item_properties.xpath('.//*[@class="slider-item-description"]/text()').get()
+        item["phone"] = item_properties.xpath('.//a[contains(@href,"tel:")]/@href').get()
         yield item

--- a/locations/spiders/leaders_gb.py
+++ b/locations/spiders/leaders_gb.py
@@ -17,4 +17,5 @@ class LeadersGBSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = item["website"]
+        item["branch"] = item.pop("name")
         yield item

--- a/locations/spiders/leaders_gb.py
+++ b/locations/spiders/leaders_gb.py
@@ -18,4 +18,8 @@ class LeadersGBSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = item["website"]
         item["branch"] = item.pop("name")
+        item_properties = response.xpath(
+            f'//img[contains(@alt, "{item["branch"]}")]/ancestor::div[@class="slider-item properties-contacts-slider-item"]'
+        )
+        item["addr_full"] = item_properties.xpath('.//*[@class="slider-item-description"]/text()').get()
         yield item

--- a/locations/spiders/leaders_romans_group_gb.py
+++ b/locations/spiders/leaders_romans_group_gb.py
@@ -7,10 +7,16 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class LeadersGBSpider(JSONBlobSpider):
-    name = "leaders_gb"
-    item_attributes = {"brand": "Leaders", "brand_wikidata": "Q111522674"}
-    start_urls = ["https://www.leaders.co.uk/contact-us"]
+class LeadersRomansGroupGBSpider(JSONBlobSpider):
+    name = "leaders_romans_group_gb"
+    BRANDS = {
+        "leaders": {"brand": "Leaders", "brand_wikidata": "Q111522674"},
+        "romans": {"brand": "Romans", "brand_wikidata": "Q113562519"},
+    }
+    start_urls = [
+        "https://www.leaders.co.uk/contact-us",
+        "https://www.romans.co.uk/contact-us",
+    ]
 
     def extract_json(self, response: Response) -> list:
         return json.loads(response.xpath("//@data-branches").get())
@@ -23,4 +29,7 @@ class LeadersGBSpider(JSONBlobSpider):
         )
         item["addr_full"] = item_properties.xpath('.//*[@class="slider-item-description"]/text()').get()
         item["phone"] = item_properties.xpath('.//a[contains(@href,"tel:")]/@href').get()
+        brand_key = response.url.split(".")[1]
+        if brand := self.BRANDS.get(brand_key):
+            item.update(brand)
         yield item


### PR DESCRIPTION
Fixed `LeadersGBSpider` and modified it to add [Romans](https://www.wikidata.org/wiki/Q113562519) brand locations, which belongs to the same parent group called [Leaders Romans Group](https://www.wikidata.org/wiki/Q113562584).

```
{'atp/brand/Leaders': 96,
 'atp/brand/Romans': 30,
 'atp/brand_wikidata/Q111522674': 96,
 'atp/brand_wikidata/Q113562519': 30,
 'atp/category/office/estate_agent': 126,
 'atp/field/city/missing': 126,
 'atp/field/country/from_spider_name': 126,
 'atp/field/email/missing': 126,
 'atp/field/image/missing': 126,
 'atp/field/opening_hours/missing': 126,
 'atp/field/operator/missing': 126,
 'atp/field/operator_wikidata/missing': 126,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 126,
 'atp/field/street_address/missing': 126,
 'atp/field/twitter/missing': 126,
 'atp/item_scraped_host_count/www.leaders.co.uk': 96,
 'atp/item_scraped_host_count/www.romans.co.uk': 30,
 'atp/nsi/perfect_match': 126,
 'downloader/request_bytes': 1230,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 40962,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 3.687569,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 18, 11, 29, 47, 998946, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 273471,
 'httpcompression/response_count': 4,
 'item_scraped_count': 126,
 'log_count/DEBUG': 141,
 'log_count/INFO': 9,
 'response_received_count': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2024, 10, 18, 11, 29, 44, 311377, tzinfo=datetime.timezone.utc)}
```