### PR TITLE
 New spider: Comerica Bank (474 locations) 

### DIFF
--- a/locations/spiders/comerica_bank_us.py
+++ b/locations/spiders/comerica_bank_us.py
@@ -1,0 +1,40 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+CATEGORY_MAP = {
+    "BankOrCreditUnion": Categories.BANK,
+    "AutomatedTeller": Categories.ATM,
+    "FinancialService": Categories.OFFICE_FINANCIAL,
+}
+
+
+class ComericaBankUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "comerica_bank_us"
+    item_attributes = {"brand": "Comerica Bank", "brand_wikidata": "Q1114148"}
+    sitemap_urls = ["https://locations.comerica.com/sitemap.xml"]
+    sitemap_rules = [("/location/", "parse_sd")]
+    wanted_types = list(CATEGORY_MAP.keys())
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def pre_process_data(self, ld_data, **kwargs):
+        if ld_data["location"]["branchCode"] == "None":
+            del ld_data["location"]["branchCode"]
+        ld_data["location"]["geo"] = ld_data["location"]["address"].pop("geo")
+        del ld_data["location"]["@type"]
+        ld_data.update(ld_data.pop("location"))
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["extras"]["fax"] = ld_data.get("faxNumber")
+        item["extras"]["addr:unit"] = response.xpath("//div[@class='extended-address']/text()").get()
+        apply_category(CATEGORY_MAP[ld_data["@type"]], item)
+
+        if ld_data["@type"] == "AutomatedTeller":
+            del item["name"]
+        else:
+            item["branch"] = item.pop("name").strip()
+            apply_yes_no(Extras.ATM, item, bool(response.xpath("//h3[text()='ATM']")))
+
+        yield item


### PR DESCRIPTION
Depends on  #11171.
```py
{'atp/brand/Comerica Bank': 474,
 'atp/brand_wikidata/Q1114148': 474,
 'atp/category/amenity/atm': 83,
 'atp/category/amenity/bank': 381,
 'atp/category/office/financial': 10,
 'atp/field/branch/missing': 83,
 'atp/field/email/missing': 474,
 'atp/field/image/missing': 474,
 'atp/field/name/missing': 93,
 'atp/field/opening_hours/missing': 101,
 'atp/field/operator/missing': 391,
 'atp/field/operator_wikidata/missing': 391,
 'atp/field/phone/missing': 5,
 'atp/field/twitter/missing': 474,
 'atp/item_scraped_host_count/locations.comerica.com': 475,
 'atp/nsi/cc_match': 464,
 'atp/nsi/match_failed': 10,
 'atp/operator/Comerica Bank': 83,
 'atp/operator_wikidata/Q1114148': 83,
 'downloader/request_bytes': 180778,
 'downloader/request_count': 477,
 'downloader/request_method_count/GET': 477,
 'downloader/response_bytes': 12037351,
 'downloader/response_count': 477,
 'downloader/response_status_count/200': 477,
 'elapsed_time_seconds': 583.527356,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 19, 5, 29, 56, 278522, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 38941801,
 'httpcompression/response_count': 476,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 474,
 'log_count/DEBUG': 963,
 'log_count/INFO': 19,
 'memusage/max': 390557696,
 'memusage/startup': 249094144,
 'request_depth_max': 1,
 'response_received_count': 477,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 476,
 'scheduler/dequeued/memory': 476,
 'scheduler/enqueued': 476,
 'scheduler/enqueued/memory': 476,
 'start_time': datetime.datetime(2024, 10, 19, 5, 20, 12, 751166, tzinfo=datetime.timezone.utc)}
```