### PR TITLE
New spider: The Coffee Bean & Tea Leaf (860 locations)

### DIFF
--- a/locations/spiders/the_coffee_bean_and_tea_leaf.py
+++ b/locations/spiders/the_coffee_bean_and_tea_leaf.py
@@ -1,0 +1,61 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Extras, PaymentMethods, apply_yes_no
+from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TheCoffeeBeanAndTeaLeafSpider(SitemapSpider, StructuredDataSpider):
+    name = "the_coffee_bean_and_tea_leaf"
+    item_attributes = {
+        "brand": "The Coffee Bean & Tea Leaf",
+        "brand_wikidata": "Q1141384",
+    }
+    sitemap_urls = ["https://www.coffeebean.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"/stores?/.+", "parse"),
+        (r"/node/\d+", "parse"),
+    ]
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def parse(self, response):
+        geolist = response.xpath("//span[@property='geo']")
+        if geolist:
+            geo = geolist[0]
+            geo.drop()
+            response.xpath("//div[@vocab]")[0].root.append(geo.root)
+            response.xpath("//div[@typeof='Place']")[0].drop()
+        yield from self.parse_sd(response)
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item.get("name"):
+            item["branch"] = item.pop("name").removeprefix("The Coffee Bean & Tea Leaf ")
+        else:
+            item["branch"] = response.css(".field--name-title::text").get()
+
+        if item.get("country") == "NULL":
+            del item["country"]
+
+        oh = OpeningHours()
+        for hours in response.css(".paragraph--type--store-hours"):
+            if weekday := hours.css(".field--name-field-weekday::text").get():
+                if weekday.endswith(" CLOSED"):
+                    oh.set_closed(weekday.removesuffix(" CLOSED"))
+                else:
+                    hours_open = hours.css(".field--name-field-store-open::text").get()
+                    hours_close = hours.css(".field--name-field-store-closed::text").get()
+                    try:
+                        oh.add_range(weekday, hours_open, hours_close, "%I:%M%p")
+                    except ValueError:
+                        oh.add_ranges_from_string(f"{weekday} {hours_open}-{hours_close}")
+        item["opening_hours"] = oh
+
+        yield item
+
+    def extract_amenity_features(self, item, response, ld_item):
+        features = set(ld_item.get("amenityFeature", []))
+        apply_yes_no(Extras.WIFI, item, "Wifi" in features)
+        apply_yes_no("payment:gift_card", item, "Gift Cards Accepted" in features)
+        apply_yes_no(PaymentMethods.CONTACTLESS, item, "Mobile Payments" in features)
+        apply_yes_no(Extras.OUTDOOR_SEATING, item, "Outdoor Seating" in features)


### PR DESCRIPTION
This does overlap some with the_coffee_bean_and_tea_leaf_sg, but that has more locations inside Singapore and this has more locations inside Singapore. Depends on #11171.

```py
{'atp/brand/The Coffee Bean & Tea Leaf': 860,
 'atp/brand_wikidata/Q1141384': 860,
 'atp/category/amenity/cafe': 860,
 'atp/field/city/missing': 119,
 'atp/field/country/from_reverse_geocoding': 333,
 'atp/field/email/missing': 860,
 'atp/field/image/dropped': 110,
 'atp/field/image/missing': 860,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 774,
 'atp/field/operator/missing': 860,
 'atp/field/operator_wikidata/missing': 860,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 693,
 'atp/field/postcode/missing': 243,
 'atp/field/state/missing': 82,
 'atp/field/street_address/missing': 64,
 'atp/field/twitter/missing': 860,
 'atp/item_scraped_host_count/coffeebean.com': 857,
 'atp/item_scraped_host_count/www.coffeebean.com': 3,
 'atp/nsi/perfect_match': 860,
 'downloader/request_bytes': 339893,
 'downloader/request_count': 890,
 'downloader/request_method_count/GET': 890,
 'downloader/response_bytes': 23375705,
 'downloader/response_count': 890,
 'downloader/response_status_count/200': 866,
 'downloader/response_status_count/301': 4,
 'downloader/response_status_count/403': 17,
 'downloader/response_status_count/404': 3,
 'elapsed_time_seconds': 1079.577332,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 19, 4, 15, 10, 608213, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 109053516,
 'httpcompression/response_count': 886,
 'httperror/response_ignored_count': 20,
 'httperror/response_ignored_status_count/403': 17,
 'httperror/response_ignored_status_count/404': 3,
 'item_scraped_count': 860,
 'log_count/DEBUG': 1761,
 'log_count/INFO': 47,
 'memusage/max': 497192960,
 'memusage/startup': 248774656,
 'request_depth_max': 1,
 'response_received_count': 886,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 888,
 'scheduler/dequeued/memory': 888,
 'scheduler/enqueued': 888,
 'scheduler/enqueued/memory': 888,
 'start_time': datetime.datetime(2024, 10, 19, 3, 57, 11, 30881, tzinfo=datetime.timezone.utc)}
```

Also can I just complain about how inconsistent their site is? At first I thought I'd use the "directory" page, but that only has locations in the US, and not all of them. They also have a storefinder with an API, but that doesn't include phone numbers or opening hours, and the response is HTML anyway. And it doesn't always return all locations. For some reason the `sitemap` command didn't find the sitemap, but it works. Except there are 3 different URL formats for stores, and at least 2 different page layouts for the store pages.