### PR TITLE
Update White Castle spider

### DIFF
--- a/locations/spiders/white_castle.py
+++ b/locations/spiders/white_castle.py
@@ -2,66 +2,52 @@ import re
 
 import scrapy
 
-from locations.geo import point_locations
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
 
 
 class WhiteCastleSpider(scrapy.Spider):
     name = "white_castle"
     item_attributes = {"brand": "White Castle", "brand_wikidata": "Q1244034"}
-    allowed_domains = ["www.whitecastle.com"]
-    timeregex = re.compile("^([0-9:]+)(AM|PM)$")
+    start_urls = ["https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000"]
 
-    def start_requests(self):
-        for lat, lon in point_locations("us_centroids_100mile_radius.csv"):
-            url = f"https://www.whitecastle.com/wcapi/location-search?lat={lat}&lng={lon}&dist=100"
-            yield scrapy.Request(url, headers={"Accept": "application/json"})
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def store_hours(self, days):
+    def store_hours(self, store):
         o = OpeningHours()
 
-        for day in days:
-            day_name = day.get("day")
-            if not day_name:
+        for day_name in DAYS_FULL:
+            key = day_name.lower() + "Hours"
+            if key not in store:
                 continue
 
-            if day.get("closed"):
-                continue
-
-            if day.get("open24Hours"):
+            if store[key] == "24 hr":
                 o.add_range(day_name[:2], "00:00", "23:59")
                 continue
 
-            open_time, close_time = day.get("hours").split(" - ", 2)
+            open_time, close_time = store[key].split(" - ", 2)
 
-            if close_time in ("12:00 AM", "Midnight"):
-                close_time = "00:00 AM"
+            if close_time in ("12:00 AM", "12AM", "Midnight"):
+                close_time = "11:59 PM"
+
+            if bare_hour := re.match("([0-9]+)([AP]M)", open_time):
+                open_time = f"{bare_hour[1]}:00 {bare_hour[2]}"
+            if bare_hour := re.match("([0-9]+)([AP]M)", close_time):
+                close_time = f"{bare_hour[1]}:00 {bare_hour[2]}"
 
             o.add_range(day_name[:2], open_time, close_time, time_format="%I:%M %p")
 
         return o
 
     def parse(self, response):
-        for store in response.json():
-            properties = {
-                "ref": store.get("storeNumber"),
-                "name": store.get("name"),
-                "street_address": store.get("address"),
-                "city": store.get("city"),
-                "state": store.get("state"),
-                "postcode": store.get("zip"),
-                "phone": store.get("telephone"),
-                "website": f'https://www.whitecastle.com/locations/{store.get("storeNumber")}',
-                "lat": store.get("lat"),
-                "lon": store.get("lng"),
-            }
+        for store in response.json()["results"]:
+            # address is just the street address; here we correct it so DictParser chooses the right key
+            store["street_address"] = store["address"]
+            del store["address"]
 
-            if store.get("open24x7"):
-                properties["opening_hours"] = "24/7"
-            elif store.get("days"):
-                opening_hours = self.store_hours(store.get("days"))
-                if opening_hours:
-                    properties["opening_hours"] = opening_hours
+            item = DictParser.parse(store)
+            item["ref"] = store["storeNumber"]
+            item["website"] = f'https://www.whitecastle.com/locations/{store.get("storeNumber")}'
+            item["opening_hours"] = self.store_hours(store)
 
-            yield Feature(**properties)
+            yield item


### PR DESCRIPTION
Review notes/potential outstanding issues:

- https://whitecastle.com/locations/0000000 and https://www.whitecastle.com/locations/1402 seem to represent the same restaurant. They have "different addresses" in the sense that that is on "Daryl Carter Parkway" and the other "Daryl Carter Pkwy", and different `storeNumber`s (and, somehow, different hours?) but otherwise seem to represent the same store. Not sure if this is something alltheplaces wants to try to filter out somehow.
- I'm not sure I got all the date parsing right, though spot checks look okay.
- I _think_ their `robots.txt` is probably not intended to block everything (why would they block GoogleBot?), but regardless, are we okay with ignoring that? I wasn't able to find anything about alltheplaces' stance on that. I'm happy to remove the override if desired (though the crawler will revert to not working).
- The new data doesn't have a specific "is open 24/7" key, and while I probably could have derived it from "if for each day, it's open 24 hours", I figure `Mo-Su 00:00-24:00` is equally good, as OSM lists it as a valid way to represent it.

<details><summary> Here's the effect of the PR of a few stores' data (full <a href="https://github.com/user-attachments/files/17452377/before.txt">before</a> and <a href="https://github.com/user-attachments/files/17452378/after.txt">after</a> files; "before" data from last successful ATP run):

</summary>

```diff
5c5,6
<         "spider:collection_time": "2024-09-29T22:17:21.249848"
---
>         "spider:collection_time": "2024-10-20T23:04:03.670134",
>         "spider:robots_txt": "ignored"
13c14
<                 "@source_uri": "https://www.whitecastle.com/wcapi/location-search?lat=34.0868252297&lng=-111.5387508425&dist=100",
---
>                 "@source_uri": "https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000",
23c24
<                 "name": "ARIZ 10",
---
>                 "name": "DEST 10",
26c27
<                 "opening_hours": "24/7",
---
>                 "opening_hours": "Mo-Su 00:00-24:00",
34,35c35,36
<                     -111.880477,
<                     33.554924
---
>                     -111.880474,
>                     33.554902
44c45
<                 "@source_uri": "https://www.whitecastle.com/wcapi/location-search?lat=44.1512314287&lng=-94.0105903326&dist=100",
---
>                 "@source_uri": "https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000",
57c58
<                 "opening_hours": "24/7",
---
>                 "opening_hours": "Mo-Su 00:00-24:00",
75c76
<                 "@source_uri": "https://www.whitecastle.com/wcapi/location-search?lat=44.1512314287&lng=-94.0105903326&dist=100",
---
>                 "@source_uri": "https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000",
88c89
<                 "opening_hours": "24/7",
---
>                 "opening_hours": "Mo-Su 00:00-24:00",
106c107
<                 "@source_uri": "https://www.whitecastle.com/wcapi/location-search?lat=45.6866558354&lng=-92.7585788676&dist=100",
---
>                 "@source_uri": "https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000",
119c120
<                 "opening_hours": "24/7",
---
>                 "opening_hours": "Mo-Su 00:00-24:00",
137c138
<                 "@source_uri": "https://www.whitecastle.com/wcapi/location-search?lat=45.6866558354&lng=-92.7585788676&dist=100",
---
>                 "@source_uri": "https://www.whitecastle.com/api/vtl/get-nearest-location?lat=0&long=0distance=25000&count=1000",
```

</details>