### PR TITLE
Update House AU spider for additional B&B locations

### DIFF
--- a/locations/spiders/house_au.py
+++ b/locations/spiders/house_au.py
@@ -17,6 +17,11 @@ class HouseAUSpider(Spider):
             "brand_wikidata": "",
             "extras": Categories.SHOP_HOUSEHOLD_LINEN.value,
         },
+        "HOUSEB&B -": {
+            "brand": "House Bed & Bath",
+            "brand_wikidata": "",
+            "extras": Categories.SHOP_HOUSEHOLD_LINEN.value,
+        },
         "House": {"brand": "House", "brand_wikidata": "Q117921987", "extras": Categories.SHOP_HOUSEWARE.value},
     }
 


### PR DESCRIPTION
Resolves #10985

I used `shop=household_linen` to match the other House Bed & Bath locations, but I can update to `shop=houseware` (across the board?) if that's preferred, per the comments on #10985