### PR TITLE
[MensWearhouse] Fix Spider

### DIFF
--- a/locations/spiders/mens_wearhouse.py
+++ b/locations/spiders/mens_wearhouse.py
@@ -1,37 +1,14 @@
-import scrapy
+from scrapy.spiders import SitemapSpider
 
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class MensWearhouseSpider(scrapy.Spider):
+class MensWearhouseSpider(SitemapSpider, StructuredDataSpider):
     name = "mens_wearhouse"
     item_attributes = {"brand": "Men's Wearhouse", "brand_wikidata": "Q57405513"}
-    allowed_domains = ["menswearhouse.com"]
-    start_urls = [
-        "https://www.menswearhouse.com/store-locator/directory",
+    sitemap_urls = [
+        "https://www.menswearhouse.com/sitemap-store-locator.xml",
     ]
-
-    def parse_store(self, response):
-        address2 = response.xpath('//span[@itemprop="addressRegion"]/text()').extract_first()
-        city, statezip = address2.split(",")
-        state, zip = statezip.strip().split(" ")
-
-        properties = {
-            "ref": response.url,
-            "name": response.xpath('//h1[@itemprop="name"]/text()').extract_first(),
-            "addr_full": response.xpath('//span[@itemprop="streetAddress"]/text()').extract_first(),
-            "city": city,
-            "state": state,
-            "postcode": zip,
-            "phone": response.xpath('//span[@itemprop="telephone"]/text()').extract_first(),
-            "website": response.url,
-            "opening_hours": response.xpath('//time[@itemprop="openingHours"]/@datetime').extract(),
-        }
-
-        yield Feature(**properties)
-
-    def parse(self, response):
-        urls = response.xpath('//li[@class="directory__state-item"]/a/@href').extract()
-
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
+    sitemap_rules = [(r"/store-locator/[0-9]+", "parse_sd")]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
`Fixes : Code has been refactored to fix spider`

{"atp/brand/Men's Wearhouse": 629,
 'atp/brand_wikidata/Q57405513': 629,
 'atp/category/shop/clothes': 629,
 'atp/cdn/cloudflare/response_count': 630,
 'atp/cdn/cloudflare/response_status_count/200': 630,
 'atp/field/branch/missing': 629,
 'atp/field/email/missing': 629,
 'atp/field/image/dropped': 629,
 'atp/field/image/missing': 629,
 'atp/field/operator/missing': 629,
 'atp/field/operator_wikidata/missing': 629,
 'atp/field/twitter/missing': 629,
 'atp/item_scraped_host_count/www.menswearhouse.com': 629,
 'atp/nsi/perfect_match': 629,
 'downloader/request_bytes': 1755872,
 'downloader/request_count': 642,
 'downloader/request_method_count/GET': 642,
 'downloader/response_bytes': 52729641,
 'downloader/response_count': 642,
 'downloader/response_status_count/200': 631,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/302': 10,
 'dupefilter/filtered': 9,
 'elapsed_time_seconds': 785.362764,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 21, 8, 52, 31, 906998, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 452467229,
 'httpcompression/response_count': 631,
 'item_scraped_count': 629,
 'log_count/DEBUG': 1283,
 'log_count/INFO': 22,
 'request_depth_max': 1,
 'response_received_count': 631,
 'scheduler/dequeued': 642,
 'scheduler/dequeued/memory': 642,
 'scheduler/enqueued': 642,
 'scheduler/enqueued/memory': 642,
 'start_time': datetime.datetime(2024, 10, 21, 8, 39, 26, 544234, tzinfo=datetime.timezone.utc)}