### PR TITLE
[Mavis US] Fix spider

### DIFF
--- a/locations/spiders/mavis_us.py
+++ b/locations/spiders/mavis_us.py
@@ -1,31 +1,30 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from typing import Iterable
+
+import chompjs
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class MavisUSSpider(CrawlSpider, StructuredDataSpider):
+class MavisUSSpider(JSONBlobSpider):
     name = "mavis_us"
     item_attributes = {"brand": "Mavis", "brand_wikidata": "Q65058420"}
     start_urls = ["https://www.mavis.com/locations/all-stores/"]
-    rules = [
-        Rule(
-            LinkExtractor(allow=r"/locations/[^/]+/$", restrict_xpaths=['//a[starts-with(text(), "Mavis")]']),
-            callback="parse",
-        )
-    ]
-    wanted_types = ["Store"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["addr_full"] = item.pop("street_address")
+    def extract_json(self, response: Response) -> list:
+        stores = []
+        for state_wise_stores_list in chompjs.parse_js_object(
+            (chompjs.parse_js_object(response.xpath('//script[contains(text(),"fullAddress")]/text()').get())[-1])
+        )[-1]["children"][-1]["stores"].values():
+            stores.extend(state_wise_stores_list)
+        return stores
 
-        label = item.pop("name")
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        label = feature.get("storeHeader", {}).get("fields", {}).get("myStoreLabel")
         if label.startswith("Mavis Tire"):
             item["name"] = "Mavis Tires & Brakes"
         elif label.startswith("Mavis Discount"):
             item["name"] = "Mavis Discount Tire"
-
-        apply_category(Categories.SHOP_TYRES, item)
-
         yield item

--- a/locations/spiders/mavis_us.py
+++ b/locations/spiders/mavis_us.py
@@ -25,7 +25,7 @@ class MavisUSSpider(JSONBlobSpider):
         feature.update(feature.pop("latLng"))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        label = feature.get("storeHeader", {}).get("fields", {}).get("myStoreLabel")
+        label = feature.get("storeHeader", {}).get("fields", {}).get("myStoreLabel", "")
         if label.startswith("Mavis Tire"):
             item["name"] = "Mavis Tires & Brakes"
         elif label.startswith("Mavis Discount"):

--- a/locations/spiders/mavis_us.py
+++ b/locations/spiders/mavis_us.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+from urllib.parse import urljoin
 
 import chompjs
 from scrapy.http import Response
@@ -29,4 +30,5 @@ class MavisUSSpider(JSONBlobSpider):
             item["name"] = "Mavis Tires & Brakes"
         elif label.startswith("Mavis Discount"):
             item["name"] = "Mavis Discount Tire"
+        item["website"] = urljoin("https://www.mavis.com/locations/", feature.get("slug"))
         yield item

--- a/locations/spiders/mavis_us.py
+++ b/locations/spiders/mavis_us.py
@@ -4,14 +4,31 @@ from urllib.parse import urljoin
 import chompjs
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.spiders.ntb_us import NtbUSSpider
+
+MAVIS_TIRES = {"name": "Mavis Tires & Brakes", "brand": "Mavis", "brand_wikidata": "Q65058420"}
+MAVIS_DISCOUNT = {"name": "Mavis Discount Tire", "brand": "Mavis", "brand_wikidata": "Q65058420"}
+TIRE_KINGDOM = {"brand": "Tire Kingdom", "brand_wikidata": "Q17090159"}
+TUFFY = {"brand": "Tuffy", "brand_wikidata": "Q17125314"}
+JACK_WILLIAMS = {"name": "Jack Williams Tire & Auto", "brand": "Jack Williams Tire & Auto"}
 
 
 class MavisUSSpider(JSONBlobSpider):
     name = "mavis_us"
-    item_attributes = {"brand": "Mavis", "brand_wikidata": "Q65058420"}
     start_urls = ["https://www.mavis.com/locations/all-stores/"]
+
+    brands = {
+        "Mavis Tire": (MAVIS_TIRES, Categories.SHOP_TYRES),
+        "Melvin's Tire": (MAVIS_TIRES, Categories.SHOP_TYRES),
+        "Mavis Discount": (MAVIS_DISCOUNT, Categories.SHOP_TYRES),
+        "NTB Tire & Service Centers": (NtbUSSpider.item_attributes, Categories.SHOP_CAR_REPAIR),
+        "Tire Kingdom Service Centers": (TIRE_KINGDOM, Categories.SHOP_TYRES),
+        "Tuffy Tire & Auto": (TUFFY, Categories.SHOP_TYRES),
+        "Jack Williams Tire & Auto": (JACK_WILLIAMS, Categories.SHOP_CAR_REPAIR),
+    }
 
     def extract_json(self, response: Response) -> list:
         stores = []
@@ -25,10 +42,16 @@ class MavisUSSpider(JSONBlobSpider):
         feature.update(feature.pop("latLng"))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        label = feature.get("storeHeader", {}).get("fields", {}).get("myStoreLabel", "")
-        if label.startswith("Mavis Tire"):
-            item["name"] = "Mavis Tires & Brakes"
-        elif label.startswith("Mavis Discount"):
-            item["name"] = "Mavis Discount Tire"
+        label = feature["storeHeader"]["fields"]["myStoreLabel"]
+        for prefix in self.brands.keys():
+            if label.startswith(prefix):
+                brand, cat = self.brands[prefix]
+                item.update(brand)
+                apply_category(cat, item)
+                break
+        else:
+            item["name"] = label
+            apply_category(Categories.SHOP_TYRES, item)
+
         item["website"] = urljoin("https://www.mavis.com/locations/", feature.get("slug"))
         yield item

--- a/locations/spiders/mavis_us.py
+++ b/locations/spiders/mavis_us.py
@@ -3,7 +3,6 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -20,6 +19,9 @@ class MavisUSSpider(JSONBlobSpider):
         )[-1]["children"][-1]["stores"].values():
             stores.extend(state_wise_stores_list)
         return stores
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("latLng"))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         label = feature.get("storeHeader", {}).get("fields", {}).get("myStoreLabel")


### PR DESCRIPTION
`Structured Data` is no longer present, hence spider code refactored to utilize `JSON Blob`.

```
{'atp/brand/Mavis': 1553,
 'atp/brand_wikidata/Q65058420': 1553,
 'atp/category/shop/tyres': 1553,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 1553,
 'atp/field/city/missing': 1553,
 'atp/field/country/from_spider_name': 1553,
 'atp/field/email/missing': 1553,
 'atp/field/image/missing': 1553,
 'atp/field/opening_hours/missing': 1553,
 'atp/field/operator/missing': 1553,
 'atp/field/operator_wikidata/missing': 1553,
 'atp/field/postcode/missing': 1553,
 'atp/field/street_address/missing': 1553,
 'atp/field/twitter/missing': 1553,
 'atp/item_scraped_host_count/www.mavis.com': 1553,
 'atp/nsi/perfect_match': 1553,
 'downloader/request_bytes': 641,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 203609,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.781334,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 21, 11, 51, 42, 701428, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2351197,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1553,
 'log_count/DEBUG': 1566,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 21, 11, 51, 37, 920094, tzinfo=datetime.timezone.utc)}
```