### PR TITLE
[sushi_daily] Add spider (1584 locations)

### DIFF
--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -5,6 +5,7 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.items import set_closed
 
 
 class SushiDailySpider(scrapy.Spider):
@@ -30,6 +31,9 @@ class SushiDailySpider(scrapy.Spider):
             for key in "lon", "lat":
                 shop[key] = re.sub("[,°].*", "", shop[key])
             item = DictParser.parse(shop)
+
+            if shop["closed"] is True:
+                set_closed(item)
 
             item["located_in"] = shop["distributorGroup"]
             item["extras"]["kioskType"] = str(shop["kioskType"])

--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -24,6 +24,13 @@ class SushiDailySpider(scrapy.Spider):
             "gpsLatitude": "lat",
         }
         for shop in locations:
+            if (
+                shop["name"].startswith("DELIVEROO - ")
+                or shop["name"].startswith("UBER EATS - ")
+                or shop["name"].startswith("JUST EAT - ")
+            ):
+                continue
+
             for old, new in RENAME.items():
                 shop[new] = shop.pop(old)
             shop["url"] = response.urljoin(shop["url"])

--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -3,14 +3,14 @@ import re
 
 import scrapy
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class SushiDailySpider(scrapy.Spider):
     name = "sushi_daily"
     start_urls = ["https://sushidaily.com/gb-en/find-us/"]
-    item_attributes = {"brand": "Sushi Daily", "brand_wikidata": "Q124301611", "extras": Categories.FAST_FOOD.value}
+    item_attributes = {"brand": "Sushi Daily", "brand_wikidata": "Q124301611"}
 
     def parse(self, response):
         script = response.xpath('//script[contains(text(), "window.SD_KIOSKS")]/text()').re(
@@ -37,4 +37,7 @@ class SushiDailySpider(scrapy.Spider):
             item = DictParser.parse(shop)
             for tag in EXTRA_TAGS:
                 item["extras"][tag] = shop.pop(tag)
+
+            apply_category(Categories.FAST_FOOD, item)
+
             yield item

--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -22,8 +22,6 @@ class SushiDailySpider(scrapy.Spider):
             "gpsLongitude": "lon",
             "gpsLatitude": "lat",
         }
-        # distributorGroup = supermarket brand
-        EXTRA_TAGS = ["distributorGroup", "kioskType"]
         for shop in locations:
             for old, new in RENAME.items():
                 shop[new] = shop.pop(old)
@@ -35,8 +33,9 @@ class SushiDailySpider(scrapy.Spider):
             for key in "lon", "lat":
                 shop[key] = re.sub("[,°].*", "", shop[key])
             item = DictParser.parse(shop)
-            for tag in EXTRA_TAGS:
-                item["extras"][tag] = shop.pop(tag)
+
+            item["located_in"] = shop["distributorGroup"]
+            item["extras"]["kioskType"] = str(shop["kioskType"])
 
             apply_category(Categories.FAST_FOOD, item)
 

--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -26,9 +26,6 @@ class SushiDailySpider(scrapy.Spider):
             for old, new in RENAME.items():
                 shop[new] = shop.pop(old)
             shop["url"] = response.urljoin(shop["url"])
-            # There are some unfixable coordinates
-            if type(shop["lat"]) == str and shop["lat"].startswith("N"):
-                continue
             # Some shop data contains hacks like "gpsLongitude": "10.719548,16.25z"
             for key in "lon", "lat":
                 shop[key] = re.sub("[,°].*", "", shop[key])

--- a/locations/spiders/sushi_daily.py
+++ b/locations/spiders/sushi_daily.py
@@ -1,0 +1,40 @@
+import json
+import re
+
+import scrapy
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+
+
+class SushiDailySpider(scrapy.Spider):
+    name = "sushi_daily"
+    start_urls = ["https://sushidaily.com/gb-en/find-us/"]
+    item_attributes = {"brand": "Sushi Daily", "brand_wikidata": "Q124301611", "extras": Categories.FAST_FOOD.value}
+
+    def parse(self, response):
+        script = response.xpath('//script[contains(text(), "window.SD_KIOSKS")]/text()').re(
+            r"window.SD_KIOSKS *= *(\[.*\]);"
+        )[0]
+        locations = json.loads(script)
+        RENAME = {
+            "address": "street_address",
+            "gpsLongitude": "lon",
+            "gpsLatitude": "lat",
+        }
+        # distributorGroup = supermarket brand
+        EXTRA_TAGS = ["distributorGroup", "kioskType"]
+        for shop in locations:
+            for old, new in RENAME.items():
+                shop[new] = shop.pop(old)
+            shop["url"] = response.urljoin(shop["url"])
+            # There are some unfixable coordinates
+            if type(shop["lat"]) == str and shop["lat"].startswith("N"):
+                continue
+            # Some shop data contains hacks like "gpsLongitude": "10.719548,16.25z"
+            for key in "lon", "lat":
+                shop[key] = re.sub("[,°].*", "", shop[key])
+            item = DictParser.parse(shop)
+            for tag in EXTRA_TAGS:
+                item["extras"][tag] = shop.pop(tag)
+            yield item


### PR DESCRIPTION
Add [Sushi Daily](https://sushidaily.com/), a sushi store-in-store chain in GB, FR, IT, NL, ES, DE, PT, BE, MX, SE, FI, AE.