### PR TITLE
[Kruidvat] Fix Spider

### DIFF
--- a/locations/spiders/kruidvat.py
+++ b/locations/spiders/kruidvat.py
@@ -1,58 +1,42 @@
-from typing import Any, Iterable
-from urllib.parse import urlencode
+from typing import Any
 
 import scrapy
-from scrapy import Request
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Response
 
-from locations.hours import DAYS_NL, OpeningHours, sanitise_day
+from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class KruidvatSpider(scrapy.Spider):
     name = "kruidvat"
     item_attributes = {"brand": "Kruidvat", "brand_wikidata": "Q2226366"}
-    allowed_domains = ["kruidvat.nl"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-
-    def make_request(self, api: str, page: int) -> JsonRequest:
-        return JsonRequest(
-            url="{}?{}".format(
-                api, urlencode({"fields": "FULL", "radius": "100000", "pageSize": "100", "currentPage": str(page)})
-            ),
-            meta={"api": api, "page": page},
-        )
-
-    def start_requests(self) -> Iterable[Request]:
-        yield self.make_request("https://www.kruidvat.be/api/v2/kvb/stores", 0)
-        yield self.make_request("https://www.kruidvat.nl/api/v2/kvn/stores", 0)
+    start_urls = [
+        "https://www.kruidvat.be/api/v2/kvb/stores?lang=nl_BE&radius=100000&pageSize=10000&fields=FULL",
+        "https://www.kruidvat.nl/api/v2/kvn/stores?lang=nl&radius=100000&pageSize=10000&fields=FULL",
+    ]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        pagination = response.json()["pagination"]
-        if pagination["currentPage"] < pagination["totalPages"]:
-            yield self.make_request(response.meta["api"], pagination["currentPage"] + 1)
+        for store in response.xpath("//stores"):
+            item = Feature()
+            item["name"] = store.xpath(".//displayName/text()").get()
+            item["state"] = store.xpath(".//province/text()").get()
+            item["postcode"] = store.xpath(".//postalCode/text()").get()
+            item["street"] = store.xpath(".//line1/text()").get()
+            item["lat"] = store.xpath(".//latitude/text()").get()
+            item["lon"] = store.xpath(".//longitude/text()").get()
+            item["addr_full"] = store.xpath(".//formattedAddress/text()").get()
+            item["opening_hours"] = OpeningHours()
+            for day_time in store.xpath(".//weekDayOpeningList"):
+                open_time = day_time.xpath("./openingTime/formattedHour/text()").get()
+                close_time = day_time.xpath("./closingTime/formattedHour/text()").get()
+                day = day_time.xpath(".//shortenedWeekDay/text()").get()
+                if day:
+                    item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
 
-        for store in response.json().get("stores"):
-            oh = OpeningHours()
-            for day in store.get("openingHours", {}).get("weekDayOpeningList"):
-                oh.add_range(
-                    day=sanitise_day(day.get("weekDay")[:2], DAYS_NL),
-                    open_time=day.get("openingTime", {}).get("formattedHour"),
-                    close_time=day.get("closingTime", {}).get("formattedHour"),
-                )
-
-            properties = {
-                "ref": store.get("externalId"),
-                "addr_full": store.get("address", {}).get("formattedAddress"),
-                "street_address": store.get("address", {}).get("line1"),
-                "country": store.get("address", {}).get("country").get("isocode"),
-                "city": store.get("address").get("town"),
-                "state": store["address"].get("province"),
-                "postcode": store.get("address", {}).get("postalCode"),
-                "lat": store.get("geoPoint", {}).get("latitude"),
-                "lon": store.get("geoPoint", {}).get("longitude"),
-                "website": response.urljoin(store.get("url")),
-                "opening_hours": oh.as_opening_hours(),
-            }
-
-            yield Feature(**properties)
+            if ".nl" in response.url:
+                item["ref"] = item["website"] = "https://www.kruidvat.nl/" + store.xpath(".//url/text()").get()
+            else:
+                item["ref"] = item["website"] = "https://www.kruidvat.be/" + store.xpath(".//url/text()").get()
+            yield item

--- a/locations/spiders/metro_cash_and_carry.py
+++ b/locations/spiders/metro_cash_and_carry.py
@@ -8,7 +8,6 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.items import Feature
-from locations.user_agents import FIREFOX_LATEST
 
 
 class MetroCashAndCarrySpider(SitemapSpider):


### PR DESCRIPTION
`Fixes : code refactored to fix spider`


{'atp/brand/Kruidvat': 1462,
 'atp/brand_wikidata/Q2226366': 1462,
 'atp/category/missing': 1462,
 'atp/field/branch/missing': 1462,
 'atp/field/city/missing': 1462,
 'atp/field/country/from_website_url': 1462,
 'atp/field/email/missing': 1462,
 'atp/field/image/missing': 1462,
 'atp/field/lat/missing': 178,
 'atp/field/lon/missing': 178,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 1462,
 'atp/field/operator_wikidata/missing': 1462,
 'atp/field/phone/missing': 1462,
 'atp/field/state/missing': 12,
 'atp/field/street_address/missing': 1462,
 'atp/field/twitter/missing': 1462,
 'atp/geometry/null_island': 178,
 'atp/item_scraped_host_count/www.kruidvat.be': 340,
 'atp/item_scraped_host_count/www.kruidvat.nl': 1122,
 'atp/nsi/match_failed': 1462,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 951,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 202323,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 20.14011,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 23, 11, 59, 6, 981706, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5250934,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1462,
 'log_count/DEBUG': 1476,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 10, 23, 11, 58, 46, 841596, tzinfo=datetime.timezone.utc)}