### PR TITLE
[Intersport GR] Fix spider

### DIFF
--- a/locations/spiders/intersport_gr.py
+++ b/locations/spiders/intersport_gr.py
@@ -5,12 +5,14 @@ import scrapy
 from scrapy.http import Response
 
 from locations.linked_data_parser import LinkedDataParser
+from locations.user_agents import FIREFOX_LATEST
 
 
 class IntersportGRSpider(scrapy.Spider):
     name = "intersport_gr"
     item_attributes = {"brand": "Intersport", "brand_wikidata": "Q666888"}
     start_urls = ["https://www.intersport.gr/el/etairia/katastimata/"]
+    custom_settings = {"USER_AGENT": FIREFOX_LATEST}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.xpath('//*[@data-control="box"]'):

--- a/locations/spiders/intersport_gr.py
+++ b/locations/spiders/intersport_gr.py
@@ -24,5 +24,4 @@ class IntersportGRSpider(scrapy.Spider):
                 store.xpath('.//a[contains(text(),"Περισσότερα")]/@href').get()
             )
             item["branch"] = store.xpath('.//li[@class="name"]/text()').get()
-            item["name"] = None
             yield item

--- a/locations/spiders/intersport_gr.py
+++ b/locations/spiders/intersport_gr.py
@@ -5,14 +5,13 @@ import scrapy
 from scrapy.http import Response
 
 from locations.linked_data_parser import LinkedDataParser
-from locations.user_agents import FIREFOX_LATEST
 
 
 class IntersportGRSpider(scrapy.Spider):
     name = "intersport_gr"
     item_attributes = {"brand": "Intersport", "brand_wikidata": "Q666888"}
     start_urls = ["https://www.intersport.gr/el/etairia/katastimata/"]
-    custom_settings = {"USER_AGENT": FIREFOX_LATEST}
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.xpath('//*[@data-control="box"]'):

--- a/locations/spiders/metro_cash_and_carry.py
+++ b/locations/spiders/metro_cash_and_carry.py
@@ -8,7 +8,6 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.items import Feature
-from locations.user_agents import FIREFOX_LATEST
 
 
 class MetroCashAndCarrySpider(SitemapSpider):


### PR DESCRIPTION
```
{'atp/brand/Intersport': 61,
 'atp/brand_wikidata/Q666888': 61,
 'atp/category/shop/sports': 61,
 'atp/field/country/from_spider_name': 61,
 'atp/field/image/missing': 61,
 'atp/field/opening_hours/missing': 61,
 'atp/field/operator/missing': 61,
 'atp/field/operator_wikidata/missing': 61,
 'atp/field/twitter/missing': 61,
 'atp/item_scraped_host_count/www.intersport.gr': 122,
 'atp/nsi/cc_match': 61,
 'downloader/request_bytes': 547,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 116614,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.171875,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 23, 15, 48, 35, 486563, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1604770,
 'httpcompression/response_count': 2,
 'item_dropped_count': 61,
 'item_dropped_reasons_count/DropItem': 61,
 'item_scraped_count': 61,
 'log_count/DEBUG': 135,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 23, 15, 48, 33, 314688, tzinfo=datetime.timezone.utc)}
```