### PR TITLE
[Sports Direct] Add spider

### DIFF
--- a/locations/spiders/fraser_gb.py
+++ b/locations/spiders/fraser_gb.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class FraserGBSpider(Spider):
+    name = "fraser_gb"
+    item_attributes = {"brand": "House of Fraser", "brand_wikidata": "Q5928422"}
+    start_urls = [
+        "https://www.houseoffraser.co.uk/stores/search?countryName=United%20Kingdom&countryCode=GB&lat=0&long=0&sd=40"
+    ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.xpath('//*[@class="StoreFinderStore"]'):
+            item = Feature()
+            item["ref"] = location.xpath("@data-store-code").get()
+            item["lat"] = location.xpath("@data-latitude").get()
+            item["lon"] = location.xpath("@data-longitude").get()
+            item["website"] = response.urljoin(location.xpath(".//a/@href").get())
+
+            name = location.xpath(".//span/text()").get()
+            if name.startswith("Frasers"):
+                item["name"] = "Frasers"
+            else:
+                item["name"] = "House of Fraser"
+            item["branch"] = name.removeprefix("Frasers ").removeprefix("House of Fraser ").removesuffix(" FRA")
+
+            apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+
+            yield item

--- a/locations/spiders/frasers_gb.py
+++ b/locations/spiders/frasers_gb.py
@@ -7,8 +7,8 @@ from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
-class FraserGBSpider(Spider):
-    name = "fraser_gb"
+class FrasersGBSpider(Spider):
+    name = "frasers_gb"
     item_attributes = {"brand": "House of Fraser", "brand_wikidata": "Q5928422"}
     start_urls = [
         "https://www.houseoffraser.co.uk/stores/search?countryName=United%20Kingdom&countryCode=GB&lat=0&long=0&sd=40"

--- a/locations/spiders/frasers_gb.py
+++ b/locations/spiders/frasers_gb.py
@@ -14,6 +14,7 @@ class FrasersGBSpider(Spider):
         "https://www.houseoffraser.co.uk/stores/search?countryName=United%20Kingdom&countryCode=GB&lat=0&long=0&sd=40"
     ]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.xpath('//*[@class="StoreFinderStore"]'):

--- a/locations/spiders/sports_direct.py
+++ b/locations/spiders/sports_direct.py
@@ -1,0 +1,40 @@
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.spiders.sport_master_dk import SportMasterDKSpider
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SportsDirectSpider(CrawlSpider, StructuredDataSpider):
+    name = "sports_direct"
+    SPORTS_DIRECT = {"brand": "Sports Direct", "brand_wikidata": "Q7579661"}
+    start_urls = ["https://www.sportsdirect.com/stores/all"]
+    rules = [Rule(LinkExtractor(allow=r"store\-([\d]+)$"), callback="parse_sd")]
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item["name"].startswith("Sportmaster "):
+            item.update(SportMasterDKSpider.item_attributes)
+            item["branch"] = item.pop("name").removeprefix("Sportmaster ")
+        elif item["name"].startswith("Field & Trek "):
+            item.update(SportMasterDKSpider.item_attributes)
+            item["branch"] = item.pop("name").removeprefix("Field & Trek ")
+            item["name"] = item["brand"] = "Field & Trek"
+            apply_category(Categories.SHOP_SPORTS, item)
+        else:
+            item["branch"] = item.pop("name").removeprefix("Sports Direct ")
+            item.update(self.SPORTS_DIRECT)
+
+        item["lat"] = response.xpath("//@data-latitude").get()
+        item["lon"] = response.xpath("//@data-longitude").get()
+        item["street_address"] = merge_address_lines(
+            response.xpath('//*[@itemprop="address"]/following-sibling::div[1]/text()').getall()
+        )
+        item["addr_full"] = merge_address_lines(
+            response.xpath('//*[@itemprop="address"]/following-sibling::div/text()').getall()
+        )
+        yield item

--- a/locations/spiders/sports_direct.py
+++ b/locations/spiders/sports_direct.py
@@ -15,6 +15,7 @@ class SportsDirectSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.sportsdirect.com/stores/all"]
     rules = [Rule(LinkExtractor(allow=r"store\-([\d]+)$"), callback="parse_sd")]
     wanted_types = ["LocalBusiness"]
+    requires_proxy = "GB"
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if item["name"].startswith("Sportmaster "):


### PR DESCRIPTION
```python
{'atp/brand/Field & Trek': 13,
 'atp/brand/Sportmaster': 24,
 'atp/brand/Sports Direct': 757,
 'atp/brand_wikidata/Q61062124': 37,
 'atp/brand_wikidata/Q7579661': 757,
 'atp/category/shop/sports': 794,
 'atp/field/city/missing': 794,
 'atp/field/country/from_reverse_geocoding': 794,
 'atp/field/email/missing': 794,
 'atp/field/image/missing': 794,
 'atp/field/operator/missing': 794,
 'atp/field/operator_wikidata/missing': 794,
 'atp/field/phone/invalid': 8,
 'atp/field/phone/missing': 23,
 'atp/field/postcode/missing': 278,
 'atp/field/state/missing': 4,
 'atp/field/twitter/missing': 794,
 'atp/item_scraped_host_count/www.sportsdirect.com': 794,
 'atp/nsi/perfect_match': 794,
 'downloader/request_bytes': 1480638,
 'downloader/request_count': 809,
 'downloader/request_method_count/GET': 809,
 'downloader/response_bytes': 44062144,
 'downloader/response_count': 809,
 'downloader/response_status_count/200': 808,
 'downloader/response_status_count/301': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 10.803215,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 24, 13, 4, 5, 970301, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 809,
 'httpcompression/response_bytes': 211394094,
 'httpcompression/response_count': 808,
 'item_scraped_count': 794,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 246669312,
 'memusage/startup': 246669312,
 'request_depth_max': 1,
 'response_received_count': 808,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 808,
 'scheduler/dequeued/memory': 808,
 'scheduler/enqueued': 808,
 'scheduler/enqueued/memory': 808,
 'start_time': datetime.datetime(2024, 10, 24, 13, 3, 55, 167086, tzinfo=datetime.timezone.utc)}
```