### PR TITLE
[Publix US] Fix spider

### DIFF
--- a/locations/spiders/publix_us.py
+++ b/locations/spiders/publix_us.py
@@ -5,6 +5,7 @@ from scrapy import Spider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import set_closed
 
 
 class PublixUSSpider(Spider):
@@ -26,6 +27,9 @@ class PublixUSSpider(Spider):
             item["phone"] = location["phoneNumbers"].get("Store")
             item["image"] = location["image"]["hero"]
             item["extras"]["start_date"] = location["openingDate"]
+
+            if location["closingDate"]:
+                set_closed(item, datetime.fromisoformat(location["closingDate"]))
 
             item["opening_hours"] = OpeningHours()
             for rule in location["hours"]:

--- a/locations/spiders/publix_us.py
+++ b/locations/spiders/publix_us.py
@@ -13,7 +13,7 @@ class PublixUSSpider(Spider):
     item_attributes = {"brand": "Publix", "brand_wikidata": "Q672170"}
     allowed_domains = ["publix.com"]
     start_urls = [
-        "https://services.publix.com/storelocator/api/v1/stores/?count=3000&distance=5000&includeOpenAndCloseDates=true&city=AL&isWebsite=true"
+        "https://services.publix.com/storelocator/api/v1/stores/?count=3000&distance=5000&includeOpenAndCloseDates=true&isWebsite=true&latitude=39.8422945&longitude=-74.8828235"
     ]
     requires_proxy = True
 

--- a/locations/spiders/publix_us.py
+++ b/locations/spiders/publix_us.py
@@ -31,13 +31,7 @@ class PublixUSSpider(Spider):
             if location["closingDate"]:
                 set_closed(item, datetime.fromisoformat(location["closingDate"]))
 
-            item["opening_hours"] = OpeningHours()
-            for rule in location["hours"]:
-                if rule["isClosed"]:
-                    continue
-                start_time = datetime.fromisoformat(rule["openTime"])
-                end_time = datetime.fromisoformat(rule["openTime"])
-                item["opening_hours"].add_range(start_time.strftime("%a"), start_time.timetuple(), end_time.timetuple())
+            item["opening_hours"] = self.parse_opening_hours(location["hours"])
 
             if location["type"] == "P":
                 item["branch"] = item.pop("name").removeprefix("Publix Pharmacy at ")
@@ -52,3 +46,13 @@ class PublixUSSpider(Spider):
                 self.crawler.stats.inc_value(f'atp/publix_us/unmapped_category/{location["type"]}')
 
             yield item
+
+    def parse_opening_hours(self, hours: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in hours:
+            if rule["isClosed"]:
+                continue
+            start_time = datetime.fromisoformat(rule["openTime"])
+            end_time = datetime.fromisoformat(rule["openTime"])
+            oh.add_range(start_time.strftime("%a"), start_time.timetuple(), end_time.timetuple())
+        return oh

--- a/locations/spiders/publix_us.py
+++ b/locations/spiders/publix_us.py
@@ -40,11 +40,13 @@ class PublixUSSpider(Spider):
                 item["opening_hours"].add_range(start_time.strftime("%a"), start_time.timetuple(), end_time.timetuple())
 
             if location["type"] == "P":
+                item["branch"] = item.pop("name").removeprefix("Publix Pharmacy at ")
                 apply_category(Categories.PHARMACY, item)
             elif location["type"] == "R":
+                item["branch"] = item.pop("name").removeprefix("Publix ").removeprefix("Super Market ")
                 apply_category(Categories.SHOP_SUPERMARKET, item)
             elif location["type"] == "W":
-                item["brand"] = "Publix GreenWise Market"
+                item["name"] = "Publix GreenWise Market"
                 apply_category(Categories.SHOP_SUPERMARKET, item)
             else:
                 self.crawler.stats.inc_value(f'atp/publix_us/unmapped_category/{location["type"]}')

--- a/locations/spiders/publix_us.py
+++ b/locations/spiders/publix_us.py
@@ -26,8 +26,9 @@ class PublixUSSpider(Spider):
             item["website"] = f'https://www.publix.com/locations/{location["storeNumber"]}'
             item["phone"] = location["phoneNumbers"].get("Store")
             item["image"] = location["image"]["hero"]
-            item["extras"]["start_date"] = location["openingDate"]
 
+            if location["openingDate"]:
+                item["extras"]["start_date"] = location["openingDate"].split("T", 1)[0]
             if location["closingDate"]:
                 set_closed(item, datetime.fromisoformat(location["closingDate"]))
 


### PR DESCRIPTION
```python
{'atp/brand/Publix': 3114,
 'atp/brand_wikidata/Q672170': 3114,
 'atp/category/amenity/pharmacy': 1305,
 'atp/category/multiple': 1305,
 'atp/category/shop/alcohol': 371,
 'atp/category/shop/supermarket': 1438,
 'atp/closed_poi': 3,
 'atp/field/branch/missing': 1665,
 'atp/field/country/from_spider_name': 3114,
 'atp/field/email/missing': 3114,
 'atp/field/opening_hours/missing': 68,
 'atp/field/operator/missing': 3114,
 'atp/field/operator_wikidata/missing': 3114,
 'atp/field/phone/missing': 58,
 'atp/field/twitter/missing': 3114,
 'atp/item_scraped_host_count/services.publix.com': 3114,
 'atp/nsi/cc_match': 2743,
 'atp/nsi/match_failed': 371,
 'downloader/request_bytes': 749,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 408134,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.17453,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 24, 14, 59, 28, 880756, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'httpcompression/response_bytes': 6974120,
 'httpcompression/response_count': 1,
 'item_scraped_count': 3114,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 246796288,
 'memusage/startup': 246796288,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 24, 14, 59, 26, 706226, tzinfo=datetime.timezone.utc)}
```