### PR TITLE
[gbfs] Update Brand Mapping for Dott

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -156,20 +156,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:5970b62c1ec8177501e02520f0d41839ca5fc549b30bac4e8c0c0882ae776217",
-                "sha256:670f811c65e3c5fe4ed8c8d69be0b44b1d649e992c0fc16de43816d1188f88f1"
+                "sha256:2bf7e7f376aee52155fc4ae4487f29333a6bcdf3a05c3bc4fede10b972d951a6",
+                "sha256:e74bc6d69c04ca611b7f58afe08e2ded6cb6504a4a80557b656abeefee395f88"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.39"
+            "version": "==1.35.41"
         },
         "botocore": {
             "hashes": [
-                "sha256:781c547eb6a79c0e4b0bedd87b81fbfed957816b4841d33e20c8f1989c7c19ce",
-                "sha256:cb7f851933b5ccc2fba4f0a8b846252410aa0efac5bfbe93b82d10801f5f8e90"
+                "sha256:8a09a32136df8768190a6c92f0240cd59c30deb99c89026563efadbbed41fa00",
+                "sha256:915c4d81e3a0be3b793c1e2efdf19af1d0a9cd4a2d8de08ee18216c14d67764b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.39"
+            "version": "==1.35.41"
         },
         "brotli": {
             "hashes": [

--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -384,7 +384,6 @@ class GbfsSpider(CSVFeedSpider):
                 return
             else:
                 url = "{}?{}".format(url, auth)
-
         yield JsonRequest(url=url, cb_kwargs=row, callback=self.parse_gbfs)
 
     def parse_gbfs(self, response, **kwargs):

--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -392,6 +392,7 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
+        
         for feed in DictParser.get_nested_key(data, "feeds") or []:
             if feed["name"] == "station_information":
                 url = feed["url"]
@@ -405,6 +406,7 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
+        
         for station in DictParser.get_nested_key(data, "stations") or []:
             if station.get("address"):
                 station["street_address"] = station.pop("address")

--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -391,7 +391,7 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
-        
+
         for feed in DictParser.get_nested_key(data, "feeds") or []:
             if feed["name"] == "station_information":
                 url = feed["url"]
@@ -405,7 +405,7 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
-        
+
         for station in DictParser.get_nested_key(data, "stations") or []:
             if station.get("address"):
                 station["street_address"] = station.pop("address")

--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -153,7 +153,55 @@ BRAND_MAPPING = {
         "wikidata": "Q63753939",
     },
     "Dott": {
-        "names": ["Dott Stockholm"],
+        "names": [
+            "Dott Aalst",
+            "Dott Brussels",
+            "Dott Charleroi",
+            "Dott Ghent",
+            "Dott Liege",
+            "Dott Namur",
+            "Dott Estepona",
+            "Dott Madrid",
+            "Dott Malaga",
+            "Dott Seville",
+            "Dott Bordeaux",
+            "Dott Grenoble",
+            "Dott Lyon",
+            "Dott Marseille",
+            "Dott Ol-Vallee",
+            "Dott Paris",
+            "Dott Tignes",
+            "Dott Val-d’isere",
+            "Dott Bristol",
+            "Dott London",
+            "Dott Petah-Tikva",
+            "Dott Tel-Aviv",
+            "Dott Alghero",
+            "Dott Arzachena",
+            "Dott Cagliari",
+            "Dott Catania",
+            "Dott Ferrara",
+            "Dott Milan",
+            "Dott Monza",
+            "Dott Padua",
+            "Dott Palermo",
+            "Dott Riccione",
+            "Dott Rome",
+            "Dott Turin",
+            "Dott Varese",
+            "Dott Verona",
+            "Dott elblag",
+            "Dott Iława",
+            "Dott Kwidzyn",
+            "Dott Malbork",
+            "Dott Ostroda",
+            "Dott Poznan",
+            "Dott Sobieszewo-Island",
+            "Dott Tczew",
+            "Dott Tricity",
+            "Dott Warsaw",
+            "Dott Stockholm"
+        ],
         "category": {"amenity": "bicycle_rental"},
         "secondary_category": {"amenity": "kick-scooter_rental"},
         "wikidata": "Q107463014",
@@ -336,6 +384,7 @@ class GbfsSpider(CSVFeedSpider):
                 return
             else:
                 url = "{}?{}".format(url, auth)
+
         yield JsonRequest(url=url, cb_kwargs=row, callback=self.parse_gbfs)
 
     def parse_gbfs(self, response, **kwargs):
@@ -343,7 +392,6 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
-
         for feed in DictParser.get_nested_key(data, "feeds") or []:
             if feed["name"] == "station_information":
                 url = feed["url"]
@@ -357,7 +405,6 @@ class GbfsSpider(CSVFeedSpider):
             data = response.json()
         except:
             return
-
         for station in DictParser.get_nested_key(data, "stations") or []:
             if station.get("address"):
                 station["street_address"] = station.pop("address")


### PR DESCRIPTION
There has been a [PR](https://github.com/alltheplaces/alltheplaces/pull/10217) open for a while related to improving brand mapping.

The brand Dott represents a large number of POIs (65k +) in this spider.  The master .csv contains links to station information that include several duplicates under different "Name".  (eg. Dott Marseille, Dott Seville, Dott Namur, amongst many others, all link to the same station information jsons)   "Name" is being applied as brand if not provided in the brand mapping dict.  Causing incorrect brand names to be applied to various locations.  

My thought was to quickly fix this brand for now, and in the above mentioned PR other work could still be done to streamline branding.


```
{'atp/brand/2EM Car Sharing': 1779,
 'atp/brand/AAR Bike': 120,
 'atp/brand/AB mit Lara': 11,
 'atp/brand/ARVAL': 1,
 'atp/brand/AW-bike': 17,
 'atp/brand/Accès Vélo': 14,
 'atp/brand/Ambici': 204,
 'atp/brand/Arizona': 119,
 'atp/brand/Arriva Nitra Slovakia': 13,
 'atp/brand/Austin B-cycle': 78,
 'atp/brand/Aventura BCycle': 5,
 'atp/brand/BARshare Barnim All': 22,
 'atp/brand/BARshare Barnim Cars': 22,
 'atp/brand/BBK Klimabizi': 4,
 'atp/brand/BIKER Białystok Poland': 64,
 'atp/brand/BIKETOWN': 243,
 'atp/brand/BL bike': 5,
 'atp/brand/Bay Wheels': 553,
 'atp/brand/BelfastBikes': 58,
 'atp/brand/Bergen City Bike': 106,
 'atp/brand/Bergisches e-Bike': 57,
 'atp/brand/Beryl - BCP': 469,
 'atp/brand/Beryl - Brighton': 108,
 'atp/brand/Beryl - Cornwall': 107,
 'atp/brand/Beryl - Greater Manchester': 280,
 'atp/brand/Beryl - Hackney Cargo Bike': 4,
 'atp/brand/Beryl - Hereford': 74,
 'atp/brand/Beryl - Hertsmere': 27,
 'atp/brand/Beryl - Isle of Wight': 88,
 'atp/brand/Beryl - Leeds': 82,
 'atp/brand/Beryl - Norwich': 176,
 'atp/brand/Beryl - Plymouth': 133,
 'atp/brand/Beryl - Portsmouth': 104,
 'atp/brand/Beryl - Southampton': 105,
 'atp/brand/Beryl - Watford': 90,
 'atp/brand/Beryl - West Midlands': 411,
 'atp/brand/Beryl - Westminster Cargo Bike': 4,
 'atp/brand/Beryl - Wool': 7,
 'atp/brand/BiciMAD': 1257,
 'atp/brand/BiciMislata Mislata': 21,
 'atp/brand/BiciPalma': 84,
 'atp/brand/Bicicoruña': 53,
 'atp/brand/Bicing': 516,
 'atp/brand/Bike Chattanooga': 43,
 'atp/brand/Bike Itaú - Pernambuco': 90,
 'atp/brand/Bike Itaú - Poa': 90,
 'atp/brand/Bike Itaú - Rio': 403,
 'atp/brand/Bike Itaú - Riviera': 7,
 'atp/brand/Bike Itaú - Salvador': 60,
 'atp/brand/Bike Itaú - Sampa': 241,
 'atp/brand/Bike Itaú - Santiago': 229,
 'atp/brand/Bike Nordelta': 21,
 'atp/brand/Bike Share Toronto': 852,
 'atp/brand/BikeKIA': 32,
 'atp/brand/BikeLNK': 21,
 'atp/brand/Bikeshare Kona': 23,
 'atp/brand/Biki': 133,
 'atp/brand/Bilbaobizi (Bilbao)': 46,
 'atp/brand/Bird': 3874,
 'atp/brand/Bizkaibizi Spain': 80,
 'atp/brand/Blue Bikes': 509,
 'atp/brand/Blue-bike': 201,
 'atp/brand/Boaz Bikes': 1,
 'atp/brand/Bogotá': 296,
 'atp/brand/Bolt': 2163,
 'atp/brand/Bolt Karlsruhe': 30,
 'atp/brand/Bolt Stuttgart': 25,
 'atp/brand/Bolt Zurich': 3,
 'atp/brand/Bonn nextbike': 76,
 'atp/brand/Boulder BCycle': 55,
 'atp/brand/Broward B-cycle': 21,
 'atp/brand/Bublr Bikes': 115,
 'atp/brand/Buzau VeloCity': 49,
 'atp/brand/C-Vélo': 57,
 'atp/brand/Call a Bike': 1262,
 'atp/brand/Capital Bikeshare': 781,
 'atp/brand/Careem BIKE': 278,
 'atp/brand/Castletroy Bikes (Ireland)': 38,
 'atp/brand/Charlotte B-cycle': 30,
 'atp/brand/Chełmski Rower': 17,
 'atp/brand/Cincy Red Bike': 72,
 'atp/brand/Citi Bike': 2227,
 'atp/brand/Clemson BikeShare': 11,
 'atp/brand/Co-bikes': 2,
 'atp/brand/CoGo': 92,
 'atp/brand/Cykl': 13,
 'atp/brand/Częstochowski Rower Miejski Poland': 26,
 'atp/brand/DCS Bike': 5,
 'atp/brand/Dbizi': 69,
 'atp/brand/Deer': 366,
 'atp/brand/Demoland': 5,
 'atp/brand/Des Moines B-cycle': 31,
 'atp/brand/Docomo Bike Share': 5481,
 'atp/brand/Donkey Republic': 7537,
 'atp/brand/Dott': 67605,
 'atp/brand/Drobeta Velopark': 2,
 'atp/brand/EDEKA Grünheide': 15,
 'atp/brand/Ecobici': 1054,
 'atp/brand/Eifel e-Bike': 53,
 'atp/brand/EinfachMobil': 63,
 'atp/brand/El Paso B-cycle': 19,
 'atp/brand/Explore Bike Share': 35,
 'atp/brand/Fa.Mo.Se': 25,
 'atp/brand/Flamingo Dunedin': 34,
 'atp/brand/Flamingo Palerston North': 53,
 'atp/brand/Flamingo Porirua': 17,
 'atp/brand/Flamingo Waimakariri': 6,
 'atp/brand/Flamingo Wellington': 34,
 'atp/brand/Fort Worth Bike Sharing': 59,
 'atp/brand/Frelo Freiburg': 121,
 'atp/brand/GREENbike': 58,
 'atp/brand/GRM Grodzisk Poland': 17,
 'atp/brand/GoAbout': 71,
 'atp/brand/Graben - ready4green': 2,
 'atp/brand/Grad Drniš (Croatia)': 6,
 'atp/brand/Grad Ivanić-Grad (Croatia)': 5,
 'atp/brand/Grad Karlovac (Croatia)': 13,
 'atp/brand/Grad Križevci (Croatia)': 11,
 'atp/brand/Grad Metković (Croatia)': 5,
 'atp/brand/Grad Sisak (Croatia)': 5,
 'atp/brand/Grad Slavonski Brod (Croatia)': 10,
 'atp/brand/Grad Split (Croatia)': 96,
 'atp/brand/Grad Velika Gorica (Croatia)': 4,
 'atp/brand/Grad Vukovar (Croatia)': 2,
 'atp/brand/Grad Zadar (Croatia)': 8,
 'atp/brand/Grad Zaprešić (Croatia)': 7,
 'atp/brand/Grad Šibenik (Croatia)': 12,
 'atp/brand/Greenbike Aruba': 8,
 'atp/brand/Greenville B-cycle': 13,
 'atp/brand/HELLO CYCLING': 9386,
 'atp/brand/HOPR Atlanta': 113,
 'atp/brand/HOPR Bishop Ranch': 61,
 'atp/brand/Heartland B-cycle': 84,
 'atp/brand/Heraeus Hanau': 5,
 'atp/brand/Hertz Bildeling': 25,
 'atp/brand/Hvar': 2,
 'atp/brand/Hyre': 442,
 'atp/brand/Indego': 244,
 'atp/brand/Indy - Pacers Bikeshare': 49,
 'atp/brand/Jackson County': 1,
 'atp/brand/Jastrebarsko (Croatia)': 1,
 'atp/brand/KARBIS Turkey': 4,
 'atp/brand/KVB Rad Germany': 179,
 'atp/brand/KVV.nextbike': 111,
 'atp/brand/Knot Strasbourg': 26,
 'atp/brand/Kolumbus Bysykkel': 216,
 'atp/brand/Koniński Rower Miejski Poland': 12,
 'atp/brand/Koszaliński Rower Miejski Poland': 20,
 'atp/brand/Koło Marek Poland': 7,
 'atp/brand/Kołobrzeski Rower Miejski Poland': 12,
 'atp/brand/LE vélo STAR': 57,
 'atp/brand/LIEmobil Liechtenstein': 35,
 'atp/brand/LOVELO Libre-service': 117,
 'atp/brand/Landkreis Nordsachsen - Deutschland': 7,
 'atp/brand/LastenVelo Freiburg': 37,
 'atp/brand/Le Vélo par TBM': 200,
 'atp/brand/Leipzig Sandkasten': 5,
 'atp/brand/Levélo': 197,
 'atp/brand/Libélo': 52,
 'atp/brand/Lime Antwerp': 1,
 'atp/brand/Lime Arlington': 1,
 'atp/brand/Lime Brussels': 1,
 'atp/brand/Lime Calgary': 1,
 'atp/brand/Lime Chicago': 1,
 'atp/brand/Lime Cleveland': 1,
 'atp/brand/Lime Colorado Springs': 1,
 'atp/brand/Lime Detroit': 1,
 'atp/brand/Lime Edmonton': 1,
 'atp/brand/Lime Frankfurt': 1,
 'atp/brand/Lime Grand Rapids': 1,
 'atp/brand/Lime Hamburg': 1,
 'atp/brand/Lime Kelowna': 1,
 'atp/brand/Lime Louisville': 1,
 'atp/brand/Lime Marseille': 1,
 'atp/brand/Lime New York': 1,
 'atp/brand/Lime Oakland': 1,
 'atp/brand/Lime Oberhausen': 1,
 'atp/brand/Lime Opfikon': 1,
 'atp/brand/Lime Ottawa': 1,
 'atp/brand/Lime Paris': 1,
 'atp/brand/Lime Portland': 1,
 'atp/brand/Lime Reutlingen': 1,
 'atp/brand/Lime San Francisco': 1,
 'atp/brand/Lime San Jose': 1,
 'atp/brand/Lime Seattle': 1,
 'atp/brand/Lime Solingen': 1,
 'atp/brand/Lime Tel Aviv': 1,
 'atp/brand/Lime Washington DC': 1,
 'atp/brand/Lime Zug': 1,
 'atp/brand/Lovesharing': 12,
 'atp/brand/Lyft': 1907,
 'atp/brand/MOBIbike': 483,
 'atp/brand/MOL Bubi': 211,
 'atp/brand/MV-Rad': 45,
 'atp/brand/Madison B-cycle': 98,
 'atp/brand/Mein konrad': 37,
 'atp/brand/Metro Bike Share': 224,
 'atp/brand/Metrorower': 925,
 'atp/brand/Mevo': 737,
 'atp/brand/MiBiciTuBici': 90,
 'atp/brand/Mibici Guadalajara': 360,
 'atp/brand/Milan Bikemi': 322,
 'atp/brand/Mobi Bike Share': 260,
 'atp/brand/Mogo Detroit': 82,
 'atp/brand/MonaBike': 52,
 'atp/brand/Movemix Bike': 104,
 'atp/brand/NEW MöBus nextbike': 46,
 'atp/brand/NS OV Fiets': 284,
 'atp/brand/Nashville BCycle': 35,
 'atp/brand/Navan Bikes (Ireland)': 46,
 'atp/brand/Neuron Mobility': 1771,
 'atp/brand/Neuron Oshawa': 81,
 'atp/brand/Nextbike': 9827,
 'atp/brand/Nextbike Prishtina': 10,
 'atp/brand/Nibelungen-Bike': 38,
 'atp/brand/Nomago Bikes - GO2GO': 21,
 'atp/brand/Nomago Bikes - GO2GO Gorizia': 3,
 'atp/brand/Nomago Bikes - KOLESCE': 79,
 'atp/brand/Nomago Bikes - LJUBLJANA': 44,
 'atp/brand/Nomago Bikes - SLOVENIA': 2,
 'atp/brand/Nomago Bikes - ZANAPREJ': 7,
 'atp/brand/OK Bike Poland': 14,
 'atp/brand/OLi-Bike': 29,
 'atp/brand/OVO Bikes Glasgow': 113,
 'atp/brand/Ontibici': 24,
 'atp/brand/Općina Brinje (Croatia)': 2,
 'atp/brand/Općina Pitomača (Croatia)': 3,
 'atp/brand/Oslo Bysykkel': 265,
 'atp/brand/Otto': 22,
 'atp/brand/Otwocki Rower Miejski Poland': 10,
 'atp/brand/Piaseczyński Rower Miejski Poland': 7,
 'atp/brand/PickeBike Aubonne': 14,
 'atp/brand/PickeBike Basel': 67,
 'atp/brand/PickeBike Fribourg': 53,
 'atp/brand/Pobiedziski Rower Gminny Poland': 3,
 'atp/brand/Pogoh': 61,
 'atp/brand/Pony': 12438,
 'atp/brand/Potsdam Rad': 123,
 'atp/brand/PubliBike': 665,
 'atp/brand/RSVG-Bike': 172,
 'atp/brand/RTC Bike Share': 29,
 'atp/brand/RVK': 48,
 'atp/brand/Rad Sharing Fleet': 3,
 'atp/brand/Redding Bikeshare': 22,
 'atp/brand/RegioRadStuttgart': 232,
 'atp/brand/Rower Miejski Szamotuły Poland (RMS) Poland': 7,
 'atp/brand/Rowerowe Łódzkie Poland (RL)': 136,
 'atp/brand/Ryde Trondheim': 201,
 'atp/brand/Ryde_Oslo': 721,
 'atp/brand/SAP Walldorf': 10,
 'atp/brand/SBU Wolf Ride Bike Share': 14,
 'atp/brand/San Antonio B-cycle': 15,
 'atp/brand/Santa Barbara BCycle': 87,
 'atp/brand/Santa Cruz BCycle': 104,
 'atp/brand/Santander Cycles - Brunel': 9,
 'atp/brand/Santander Cycles - Milton Keynes': 48,
 'atp/brand/Santander Cycles - Swansea': 4,
 'atp/brand/Saturn': 2,
 'atp/brand/Senica bajk': 24,
 'atp/brand/Share Birrer': 21,
 'atp/brand/Shared Mobility': 7395,
 'atp/brand/Sibiu BikeCity': 57,
 'atp/brand/Sitycleta (Las Palmas)': 71,
 'atp/brand/Slatina Velo City': 5,
 'atp/brand/StadtRad Greifswald': 20,
 'atp/brand/Stadtmobil Karlsruhe': 497,
 'atp/brand/Stadtmobil Stuttgart': 323,
 'atp/brand/Stadtmobil Südbaden': 298,
 'atp/brand/Stadtrad Innsbruck Austria': 51,
 'atp/brand/Stadtwerk Tauberfranken': 11,
 'atp/brand/Styr & Ställ (Sweden, Göteborg)': 137,
 'atp/brand/System Rowerów Miejskich w Pszczynie Poland': 9,
 'atp/brand/TIER': 225,
 'atp/brand/TUeBICI': 26,
 'atp/brand/Tarnowski Rower Miejski Poland': 18,
 'atp/brand/Topoloveni Bike': 3,
 'atp/brand/Trondheim Bysykkel': 67,
 'atp/brand/Truckee BCycle': 16,
 'atp/brand/Tugo': 41,
 'atp/brand/Tychowski Rower Miejski Poland': 2,
 'atp/brand/UBC': 108,
 'atp/brand/UsedomRad Germany': 98,
 'atp/brand/VAG_Rad': 100,
 'atp/brand/VETURILO Poland': 332,
 'atp/brand/VRNnextbike': 420,
 'atp/brand/VVT REGIORAD Tirol': 26,
 'atp/brand/Valentine Bike Share': 1,
 'atp/brand/Valladolid': 98,
 'atp/brand/Velespeed': 43,
 'atp/brand/Velo Antwerpen': 309,
 'atp/brand/Velo Sântana': 8,
 'atp/brand/Velocity Aachen': 142,
 'atp/brand/Velospot': 878,
 'atp/brand/Verona Bike': 39,
 'atp/brand/Voi': 1490,
 'atp/brand/Vélhop - Strasbourg': 32,
 "atp/brand/Vélib' Metropole": 1485,
 'atp/brand/Vélivert': 99,
 'atp/brand/VéloZef': 29,
 'atp/brand/Vélopop': 28,
 'atp/brand/WE-cycle': 89,
 'atp/brand/WESTcargo powered by nextbike': 10,
 'atp/brand/WK-Bike (Bremen)': 88,
 'atp/brand/WRM nextbike Poland': 239,
 'atp/brand/WienMobil Rad': 233,
 'atp/brand/WinsenRad': 21,
 'atp/brand/Wolsztyński Rower Miejski': 3,
 'atp/brand/Zenica': 15,
 'atp/brand/biciArteixo': 8,
 'atp/brand/carvelo eCargo-Bike Sharing': 331,
 'atp/brand/city bike Linz': 50,
 'atp/brand/eMobi (Croatia)': 26,
 'atp/brand/edrive carsharing': 68,
 'atp/brand/fLotte Brandenburg': 49,
 'atp/brand/ibizi': 5,
 'atp/brand/kotobike': 154,
 'atp/brand/meinRad': 180,
 'atp/brand/meinSiggi': 64,
 'atp/brand/metropolradruhr Germany': 508,
 'atp/brand/mobic': 149,
 'atp/brand/my-e-car': 5,
 'atp/brand/sprintRAD': 53,
 'atp/brand/swu2go Carsharing': 49,
 'atp/brand/westBike': 20,
 'atp/brand/wupsiRad Leverkusen': 100,
 'atp/brand/àVélo': 115,
 'atp/brand/ŁoKeR - Łomża': 15,
 'atp/brand/Łódzki Rower Publiczny': 121,
 'atp/brand/Żyrardowski Rower Miejski Poland': 7,
 'atp/brand_wikidata/Q1034635': 781,
 'atp/brand_wikidata/Q1060525': 1262,
 'atp/brand_wikidata/Q107463014': 67605,
 'atp/brand_wikidata/Q1120762': 1485,
 'atp/brand_wikidata/Q123507620': 925,
 'atp/brand_wikidata/Q16971391': 553,
 'atp/brand_wikidata/Q17018523': 852,
 'atp/brand_wikidata/Q17077936': 1907,
 'atp/brand_wikidata/Q17402113': 1257,
 'atp/brand_wikidata/Q1833385': 516,
 'atp/brand_wikidata/Q20529164': 2163,
 'atp/brand_wikidata/Q2351279': 9827,
 'atp/brand_wikidata/Q2974438': 2227,
 'atp/brand_wikidata/Q3555363': 665,
 'atp/brand_wikidata/Q55533296': 5481,
 'atp/brand_wikidata/Q56314221': 878,
 'atp/brand_wikidata/Q5817067': 1054,
 'atp/brand_wikidata/Q60860236': 737,
 'atp/brand_wikidata/Q61650427': 1490,
 'atp/brand_wikidata/Q63386916': 225,
 'atp/brand_wikidata/Q63753939': 7537,
 'atp/brand_wikidata/Q91231927': 9386,
 'atp/category/amenity/bicycle_rental': 135994,
 'atp/category/amenity/kick-scooter_rental': 9042,
 'atp/category/missing': 7395,
 'atp/category/public_transport/stop_position': 16615,
 'atp/cdn/cloudflare/response_count': 76,
 'atp/cdn/cloudflare/response_status_count/200': 74,
 'atp/cdn/cloudflare/response_status_count/404': 2,
 'atp/field/branch/missing': 169046,
 'atp/field/brand_wikidata/missing': 50233,
 'atp/field/city/missing': 168953,
 'atp/field/email/missing': 169046,
 'atp/field/image/missing': 169046,
 'atp/field/lat/missing': 8,
 'atp/field/lon/missing': 8,
 'atp/field/name/missing': 6,
 'atp/field/opening_hours/missing': 169046,
 'atp/field/operator/missing': 145749,
 'atp/field/operator_wikidata/missing': 147883,
 'atp/field/phone/missing': 159638,
 'atp/field/postcode/missing': 161926,
 'atp/field/state/from_reverse_geocoding': 11668,
 'atp/field/state/missing': 157381,
 'atp/field/street_address/missing': 139767,
 'atp/field/twitter/missing': 169046,
 'atp/item_scraped_host_count/abmitlara.de': 11,
 'atp/item_scraped_host_count/acoruna.publicbikesystem.net': 53,
 'atp/item_scraped_host_count/api-public.odpt.org': 14867,
 'atp/item_scraped_host_count/api.delijn.be': 201,
 'atp/item_scraped_host_count/api.entur.io': 1959,
 'atp/item_scraped_host_count/api.knotcity.io': 26,
 'atp/item_scraped_host_count/api.mobidata-bw.de': 6834,
 'atp/item_scraped_host_count/api.omega.fifteen.eu': 197,
 'atp/item_scraped_host_count/api.publibike.ch': 665,
 'atp/item_scraped_host_count/api.saint-etienne-metropole.fr': 99,
 'atp/item_scraped_host_count/api.voiapp.io': 1195,
 'atp/item_scraped_host_count/app.kotobike.jp': 154,
 'atp/item_scraped_host_count/app.linkalock.com': 120,
 'atp/item_scraped_host_count/aruba.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/aspen.publicbikesystem.net': 89,
 'atp/item_scraped_host_count/auto-birrer.ch': 21,
 'atp/item_scraped_host_count/barcelona.publicbikesystem.net': 516,
 'atp/item_scraped_host_count/bdx.mecatran.com': 200,
 'atp/item_scraped_host_count/beryl-gbfs-production.web.app': 2269,
 'atp/item_scraped_host_count/bogota.publicbikesystem.net': 296,
 'atp/item_scraped_host_count/buenosaires.publicbikesystem.net': 377,
 'atp/item_scraped_host_count/chattanooga.publicbikesystem.net': 43,
 'atp/item_scraped_host_count/clermontferrand.publicbikesystem.net': 57,
 'atp/item_scraped_host_count/data.lime.bike': 30,
 'atp/item_scraped_host_count/data.rideflamingo.com': 144,
 'atp/item_scraped_host_count/detroit.publicbikesystem.net': 82,
 'atp/item_scraped_host_count/dubai.publicbikesystem.net': 278,
 'atp/item_scraped_host_count/eu.ftp.opendatasoft.com': 57,
 'atp/item_scraped_host_count/gateway.prod.partners-fs37hd8.fifteen.eu': 57,
 'atp/item_scraped_host_count/gbfs.api.ridedott.com': 67605,
 'atp/item_scraped_host_count/gbfs.bcycle.com': 1632,
 'atp/item_scraped_host_count/gbfs.bici.madrid': 629,
 'atp/item_scraped_host_count/gbfs.getapony.com': 12438,
 'atp/item_scraped_host_count/gbfs.goabout.com': 71,
 'atp/item_scraped_host_count/gbfs.hopr.city': 404,
 'atp/item_scraped_host_count/gbfs.lyft.com': 6312,
 'atp/item_scraped_host_count/gbfs.mex.lyftbikes.com': 677,
 'atp/item_scraped_host_count/gbfs.nextbike.net': 17744,
 'atp/item_scraped_host_count/gbfs.openov.nl': 284,
 'atp/item_scraped_host_count/gbfs.smartbike.com': 309,
 'atp/item_scraped_host_count/gbfs.urbansharing.com': 1321,
 'atp/item_scraped_host_count/gbsf.movatic.co': 1,
 'atp/item_scraped_host_count/guadalajara.publicbikesystem.net': 360,
 'atp/item_scraped_host_count/honolulu.publicbikesystem.net': 133,
 'atp/item_scraped_host_count/ixsi.swu.de': 49,
 'atp/item_scraped_host_count/kona.publicbikesystem.net': 23,
 'atp/item_scraped_host_count/madrid.publicbikesystem.net': 628,
 'atp/item_scraped_host_count/mds.bird.co': 3874,
 'atp/item_scraped_host_count/mds.bolt.eu': 2163,
 'atp/item_scraped_host_count/mds.neuron-mobility.com': 1852,
 'atp/item_scraped_host_count/monaco.publicbikesystem.net': 52,
 'atp/item_scraped_host_count/nicosia.publicbikesystem.net': 43,
 'atp/item_scraped_host_count/nitro.openvelo.org': 142,
 'atp/item_scraped_host_count/nordelta.publicbikesystem.net': 21,
 'atp/item_scraped_host_count/opendata.bbnavi.de': 93,
 'atp/item_scraped_host_count/pittsburgh.publicbikesystem.net': 61,
 'atp/item_scraped_host_count/portoalegre.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/quebec.publicbikesystem.net': 115,
 'atp/item_scraped_host_count/recife.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/riodejaneiro.publicbikesystem.net': 403,
 'atp/item_scraped_host_count/riviera.publicbikesystem.net': 7,
 'atp/item_scraped_host_count/saguenay.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/salvador.publicbikesystem.net': 60,
 'atp/item_scraped_host_count/sansebastian.publicbikesystem.net': 69,
 'atp/item_scraped_host_count/santana.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/santiago.publicbikesystem.net': 229,
 'atp/item_scraped_host_count/saopaulo.publicbikesystem.net': 241,
 'atp/item_scraped_host_count/sibiu.publicbikesystem.net': 57,
 'atp/item_scraped_host_count/stables.donkey.bike': 7537,
 'atp/item_scraped_host_count/stonybrook.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/toronto.publicbikesystem.net': 852,
 'atp/item_scraped_host_count/tucson.publicbikesystem.net': 41,
 'atp/item_scraped_host_count/valence.publicbikesystem.net': 52,
 'atp/item_scraped_host_count/valladolid.publicbikesystem.net': 98,
 'atp/item_scraped_host_count/vancouver-gbfs.smoove.pro': 260,
 'atp/item_scraped_host_count/velib-metropole-opendata.smovengo.cloud': 1485,
 'atp/item_scraped_host_count/www.cykl.nl': 13,
 'atp/item_scraped_host_count/www.mibicitubici.gob.ar': 90,
 'atp/item_scraped_host_count/www.sharedmobility.ch': 7395,
 'atp/nsi/brand_missing': 71483,
 'atp/nsi/cc_match': 1384,
 'atp/nsi/match_failed': 24033,
 'atp/nsi/perfect_match': 21913,
 'atp/operator/5M2-BKT': 1054,
 'atp/operator/CityBike Global': 737,
 'atp/operator/Deutsche Bahn Connect': 1262,
 'atp/operator/Donkey Republic': 335,
 'atp/operator/EMT Madrid': 1257,
 'atp/operator/Lyft': 3561,
 'atp/operator/Nextbike GZM': 925,
 'atp/operator/OpenStreet': 9386,
 'atp/operator/Pedalem Barcelona': 516,
 'atp/operator/PubliBike': 1543,
 'atp/operator/Smovengo': 1485,
 'atp/operator/Toronto Parking Authority': 852,
 'atp/operator/nextbike': 41,
 'atp/operator/nextbike Cy Ltd': 273,
 'atp/operator/ТОВ Некстбайк Україна': 70,
 'atp/operator_wikidata/Q1094755': 1257,
 'atp/operator_wikidata/Q1152100': 1262,
 'atp/operator_wikidata/Q123614695': 516,
 'atp/operator_wikidata/Q127573015': 925,
 'atp/operator_wikidata/Q17077936': 3561,
 'atp/operator_wikidata/Q2351279': 41,
 'atp/operator_wikidata/Q3555363': 1543,
 'atp/operator_wikidata/Q43593262': 9386,
 'atp/operator_wikidata/Q47008427': 1485,
 'atp/operator_wikidata/Q63753939': 335,
 'atp/operator_wikidata/Q7826466': 852,
 'downloader/exception_count': 86,
 'downloader/exception_type_count/twisted.internet.error.DNSLookupError': 30,
 'downloader/exception_type_count/twisted.internet.error.NoRouteError': 10,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 46,
 'downloader/request_bytes': 894795,
 'downloader/request_count': 1945,
 'downloader/request_method_count/GET': 1945,
 'downloader/response_bytes': 13520212,
 'downloader/response_count': 1859,
 'downloader/response_status_count/200': 1689,
 'downloader/response_status_count/301': 12,
 'downloader/response_status_count/302': 2,
 'downloader/response_status_count/307': 1,
 'downloader/response_status_count/400': 4,
 'downloader/response_status_count/401': 2,
 'downloader/response_status_count/404': 39,
 'downloader/response_status_count/502': 14,
 'downloader/response_status_count/503': 96,
 'dupefilter/filtered': 2413,
 'elapsed_time_seconds': 2155.416344,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 25, 14, 18, 59, 233305, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 53016306,
 'httpcompression/response_count': 1204,
 'httperror/response_ignored_count': 82,
 'httperror/response_ignored_status_count/400': 4,
 'httperror/response_ignored_status_count/401': 2,
 'httperror/response_ignored_status_count/404': 39,
 'httperror/response_ignored_status_count/502': 5,
 'httperror/response_ignored_status_count/503': 32,
 'item_scraped_count': 169046,
 'log_count/ERROR': 49,
 'log_count/INFO': 126,
 'memusage/max': 441393152,
 'memusage/startup': 181645312,
 'request_depth_max': 2,
 'response_received_count': 1771,
 'retry/count': 153,
 'retry/max_reached': 43,
 'retry/reason_count/502 Bad Gateway': 9,
 'retry/reason_count/503 Service Unavailable': 64,
 'retry/reason_count/twisted.internet.error.DNSLookupError': 30,
 'retry/reason_count/twisted.internet.error.NoRouteError': 10,
 'retry/reason_count/twisted.internet.error.TimeoutError': 40,
 'scheduler/dequeued': 1945,
 'scheduler/dequeued/memory': 1945,
 'scheduler/enqueued': 1945,
 'scheduler/enqueued/memory': 1945,
 'start_time': datetime.datetime(2024, 10, 25, 13, 43, 3, 816961, tzinfo=datetime.timezone.utc)}
```