### PR TITLE
Allow alternative Google domains

### DIFF
--- a/locations/google_url.py
+++ b/locations/google_url.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, urlsplit, unquote
 
 from scrapy import Selector
 from scrapy.http import Response
@@ -38,7 +38,10 @@ def url_to_coords(url: str) -> (float, float):  # noqa: C901
         queries = parse_qs(parsed_link.query)
         return queries.get(query_param, [])
 
-    url = url.replace("google.co.uk", "google.com")
+    url = unquote(url)
+
+    # replace alternative domains such as google.cz or google.co.uk with google.com
+    url = re.sub(r"google(\.[a-z]{2,3})?\.[a-z]{2,3}/", "google.com/", url)
 
     if match := re.search(r"@(-?\d+.\d+),\s?(-?\d+.\d+),[\d.]+[zm]", url):
         return float(match.group(1)), float(match.group(2))

--- a/locations/google_url.py
+++ b/locations/google_url.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import parse_qs, urlsplit, unquote
+from urllib.parse import parse_qs, unquote, urlsplit
 
 from scrapy import Selector
 from scrapy.http import Response

--- a/tests/test_google_url.py
+++ b/tests/test_google_url.py
@@ -103,6 +103,17 @@ def test_search():
     )
 
 
+def test_alternative_domain():
+    assert url_to_coords("https://www.google.co.uk/maps/search/?api=1&query=48.929153%2C21.911026") == (
+        48.929153,
+        21.911026,
+    )
+    assert url_to_coords("https://www.google.cz/maps/search/?api=1&query=48.929153,21.911026") == (
+        48.929153,
+        21.911026,
+    )
+
+
 def test_apple_maps():
     assert url_to_coords("http://maps.apple.com/?q=53.26471,-2.88613") == (53.26471, -2.88613)
     assert url_to_coords("https://maps.apple.com/?q=53.26471,-2.88613") == (53.26471, -2.88613)


### PR DESCRIPTION
I encountered some sites in Czechia which use `maps.google.cz` domain instead of `maps.google.com`. There are probably many, so it would make sense to allow unified parsing for all of them.
I chose the regex `google(\.[a-z]{2,3})?\.[a-z]{2,3}/` to account also for two-level domains such as `.co.uk`.

Also, I saw that URL are often percent-encoded. I hope it does not break anything to run `urllib.parse.unquote` before any parsing starts. It passes the test suite.