### PR TITLE
Add Út alias for Tuesday in Slovak

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -463,6 +463,7 @@ DAYS_SK = {
     "Po": "Mo",
     "Pondelok": "Mo",
     "Ut": "Tu",
+    "Út": "Tu",
     "Utorok": "Tu",
     "Útorok": "Tu",
     "St": "We",


### PR DESCRIPTION
In Slovak, `Utorok` and `Ut` is the correct spelling of Tuesday, but I found `Útorok` and `Út` in the wid. We already allow `Útorok`, so it makes sense to also accept `Út`.