### PR TITLE
New spider: Avalon apartments (263 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -509,6 +509,7 @@ class Extras(Enum):
     SELF_CHECKOUT = "self_checkout"
     SCANING = "service:scan"
     SHOWERS = "shower"
+    SMOKING = "smoking"
     SMOKING_AREA = "smoking=isolated"
     SWIMMING_POOL = "swimming_pool"
     TAKEAWAY = "takeaway"

--- a/locations/spiders/avalon_us.py
+++ b/locations/spiders/avalon_us.py
@@ -1,0 +1,45 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Extras, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class AvalonUSSpider(SitemapSpider):
+    name = "avalon_us"
+    item_attributes = {"brand": "Avalon", "brand_wikidata": "Q64665938"}
+    sitemap_urls = [
+        "https://www.avaloncommunities.com/arc/outboundfeeds/avb-sitemap/?outputType=xml&_website=avalon-communities"
+    ]
+    sitemap_rules = [(r"^https:\/\/www\.avaloncommunities\.com\/[\w-]+/[\w-]+-apartments/[\w-]+/$", "parse")]
+
+    def parse(self, response):
+        script = response.xpath("//script[@id='fusion-metadata']/text()").get()
+        start = script.find("Fusion.globalContent=") + len("Fusion.globalContent=")
+        end = script.find(";Fusion.globalContentConfig", start)
+        location = json.loads(script[start:end])
+        item = DictParser.parse(location)
+        item["ref"] = location["communityId"]
+        item["brand"] = location["classification"]
+        item["image"] = response.css("img.communitybanner-img::attr(src)").get()
+
+        oh = OpeningHours()
+        for line in location["officeHours"]:
+            oh.add_ranges_from_string(line)
+        item["extras"]["opening_hours:office"] = oh.as_opening_hours()
+
+        features = {f["icon"].removesuffix(".svg") for f in location["features"]}
+        apply_yes_no(Extras.AIR_CONDITIONING, item, "/attribute-icons/airconditioning" in features)
+        apply_yes_no(Extras.AIR_CONDITIONING, item, "airconditioning" in features)
+        apply_yes_no(Extras.WHEELCHAIR, item, "adaaccessible" in features)
+        apply_yes_no(Extras.WIFI, item, "highspeedwifi" in features)
+        apply_yes_no(Extras.INDOOR_SEATING, item, "lounge" in features)
+        apply_yes_no(Extras.PARCEL_PICKUP, item, "packageacceptance" in features)
+        apply_yes_no(Extras.PETS_ALLOWED, item, "petfriendly" in features)
+        apply_yes_no(Extras.SWIMMING_POOL, item, "pool" in features)
+        if "smokefree" in features:
+            apply_yes_no(Extras.SMOKING, item, False, False)
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/AVA': 30,
 'atp/brand/Avalon': 185,
 'atp/brand/Kanso': 3,
 'atp/brand/eaves': 45,
 'atp/brand_wikidata/Q64665938': 263,
 'atp/category/landuse/residential': 263,
 'atp/field/branch/missing': 263,
 'atp/field/country/from_spider_name': 263,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 263,
 'atp/field/operator/missing': 263,
 'atp/field/operator_wikidata/missing': 263,
 'atp/field/twitter/missing': 263,
 'atp/item_scraped_host_count/www.avaloncommunities.com': 263,
 'atp/nsi/perfect_match': 263,
 'downloader/request_bytes': 131525,
 'downloader/request_count': 267,
 'downloader/request_method_count/GET': 267,
 'downloader/response_bytes': 23585799,
 'downloader/response_count': 267,
 'downloader/response_status_count/200': 265,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 329.654107,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 25, 23, 1, 31, 46734, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 172898942,
 'httpcompression/response_count': 265,
 'item_scraped_count': 263,
 'log_count/DEBUG': 541,
 'log_count/INFO': 15,
 'memusage/max': 511623168,
 'memusage/startup': 248815616,
 'request_depth_max': 1,
 'response_received_count': 265,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 266,
 'scheduler/dequeued/memory': 266,
 'scheduler/enqueued': 266,
 'scheduler/enqueued/memory': 266,
 'start_time': datetime.datetime(2024, 10, 25, 22, 56, 1, 392627, tzinfo=datetime.timezone.utc)}
```