### PR TITLE
[Meta] Fix  Spider

### DIFF
--- a/locations/spiders/meta.py
+++ b/locations/spiders/meta.py
@@ -1,6 +1,6 @@
-import json
 import re
 
+import chompjs
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category
@@ -16,7 +16,7 @@ class MetaSpider(Spider):
     def parse(self, response, **kwargs):
         script = response.xpath('//script[contains(text(), "jobCount")]/text()').get()
         blob = re.search(r"handle\((.+)\);", script)
-        data = json.loads(blob.group(1))
+        data = chompjs.parse_js_object(blob.group(1))
 
         for location in DictParser.get_nested_key(data, "locations"):
             item = Feature()


### PR DESCRIPTION
Used `chompjs` to fix JSON decode error.

```
{'atp/brand/Meta': 127,
 'atp/brand_wikidata/Q380': 127,
 'atp/category/office/it': 81,
 'atp/category/telecom/data_center': 46,
 'atp/field/city/missing': 127,
 'atp/field/country/from_reverse_geocoding': 127,
 'atp/field/email/missing': 127,
 'atp/field/image/missing': 127,
 'atp/field/opening_hours/missing': 127,
 'atp/field/operator/missing': 81,
 'atp/field/operator_wikidata/missing': 81,
 'atp/field/phone/missing': 127,
 'atp/field/postcode/missing': 127,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 127,
 'atp/field/twitter/missing': 127,
 'atp/item_scraped_host_count/www.metacareers.com': 127,
 'atp/nsi/cc_match': 127,
 'atp/operator/Meta': 46,
 'atp/operator_wikidata/Q380': 46,
 'downloader/request_bytes': 619,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 65372,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.185388,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 28, 10, 50, 21, 10994, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 343099,
 'httpcompression/response_count': 2,
 'item_scraped_count': 127,
 'log_count/DEBUG': 140,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 28, 10, 50, 16, 825606, tzinfo=datetime.timezone.utc)}
```