### PR TITLE
Workaround to fix Guitar Center

### DIFF
--- a/locations/spiders/guitar_center.py
+++ b/locations/spiders/guitar_center.py
@@ -9,7 +9,7 @@ class GuitarCenterSpider(RioSeoSpider):
     end_point = "https://maps.stores.guitarcenter.com"
 
     def start_requests(self):
-        yield JsonRequest(f"https://stores.guitarcenter.com/api/getAutocompleteData", callback=self.parse_autocomplete)
+        yield JsonRequest("https://stores.guitarcenter.com/api/getAutocompleteData", callback=self.parse_autocomplete)
 
     def post_process_feature(self, feature, location):
         feature["branch"] = feature.pop("name")

--- a/locations/spiders/guitar_center.py
+++ b/locations/spiders/guitar_center.py
@@ -1,3 +1,5 @@
+from scrapy.http import JsonRequest
+
 from locations.storefinders.rio_seo import RioSeoSpider
 
 
@@ -5,6 +7,9 @@ class GuitarCenterSpider(RioSeoSpider):
     name = "guitar_center"
     item_attributes = {"brand": "Guitar Center", "brand_wikidata": "Q3622794"}
     end_point = "https://maps.stores.guitarcenter.com"
+
+    def start_requests(self):
+        yield JsonRequest(f"https://stores.guitarcenter.com/api/getAutocompleteData", callback=self.parse_autocomplete)
 
     def post_process_feature(self, feature, location):
         feature["branch"] = feature.pop("name")

--- a/locations/storefinders/rio_seo.py
+++ b/locations/storefinders/rio_seo.py
@@ -35,8 +35,8 @@ class RioSeoSpider(Spider):
         yield JsonRequest(f"{self.end_point}/api/getAutocompleteData", callback=self.parse_autocomplete)
 
     def parse_autocomplete(self, response: Response, **kwargs: Any) -> Any:
-        yield response.follow(
-            f"getAsyncLocations?template={self.template}&level={self.template}&search={response.json()['data'][0]}&radius={self.radius}&limit={self.limit}"
+        yield JsonRequest(
+            f"{self.end_point}/api/getAsyncLocations?template={self.template}&level={self.template}&search={response.json()['data'][0]}&radius={self.radius}&limit={self.limit}"
         )
 
     def parse(self, response: Response, **kwargs) -> Iterable[Feature]:


### PR DESCRIPTION
This is something I noticed while developing RioSeoSpider. Most, but not all, Rio sites use the "maps"-less domain for the initial getAutocompleteData request. I saw that the "maps"-ful domain worked the same for that request so used it instead, to make the code simpler. Apparently it doesn't always work. If this also changes for other spiders I/we might want to find some way to encode the differences.

Since this affects all RioSeo spiders, I re-ran all of them to make sure they don't error.