### PR TITLE
[Montblanc] Fix Spider

### DIFF
--- a/locations/spiders/montblanc.py
+++ b/locations/spiders/montblanc.py
@@ -4,7 +4,6 @@ from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, day_range
 
 
 class MontblancSpider(Spider):
@@ -51,17 +50,9 @@ class MontblancSpider(Spider):
         for location in response.json()["data"]["publicBoutiques"]:
             if location["type"]["defaultName"] not in ["Boutique", "Outlet"]:
                 continue
-
             item = DictParser.parse(location)
             item["city"] = None
             item["state"] = (location.get("state") or {}).get("defaultName")
             item["country"] = ((location.get("city") or {}).get("country") or {}).get("defaultName")
             item["website"] = "https://stores.montblanc.com/boutique/{}".format(location["id"])
-
-            item["opening_hours"] = OpeningHours()
-            for rule in location["openTimes"]:
-                item["opening_hours"].add_days_range(
-                    day_range(rule["startDay"], rule["endDay"]), rule["startTime"], rule["endTime"]
-                )
-
             yield item


### PR DESCRIPTION
`Fixes : opening_hours has been removed to fix spider`

{'atp/brand/Montblanc': 444,
 'atp/brand_wikidata/Q142691': 444,
 'atp/category/shop/fashion_accessories': 444,
 'atp/field/branch/missing': 444,
 'atp/field/city/missing': 444,
 'atp/field/country/from_reverse_geocoding': 26,
 'atp/field/country/invalid': 1,
 'atp/field/email/missing': 444,
 'atp/field/image/missing': 444,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 6,
 'atp/field/lon/missing': 6,
 'atp/field/opening_hours/missing': 444,
 'atp/field/operator/missing': 444,
 'atp/field/operator_wikidata/missing': 444,
 'atp/field/phone/missing': 444,
 'atp/field/postcode/missing': 444,
 'atp/field/state/from_reverse_geocoding': 33,
 'atp/field/state/missing': 386,
 'atp/field/street_address/missing': 444,
 'atp/field/twitter/missing': 444,
 'atp/item_scraped_host_count/stores.montblanc.com': 444,
 'atp/nsi/perfect_match': 444,
 'downloader/request_bytes': 1592,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 92173,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.902041,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 10, 30, 15, 56, 11, 272388, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 573460,
 'httpcompression/response_count': 2,
 'item_scraped_count': 444,
 'log_count/DEBUG': 863,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 10, 30, 15, 56, 6, 370347, tzinfo=datetime.timezone.utc)}
2024-10-30 21:26:11 [scrapy.core.engine] INFO: Spider closed (finished)