### PR TITLE
[fio_banka_atm] Drop Google Maps coordinates extraction

### DIFF
--- a/locations/spiders/fio_banka_atm.py
+++ b/locations/spiders/fio_banka_atm.py
@@ -35,15 +35,13 @@ class FioBankaAtmSpider(CrawlSpider):
             item["city"] = (
                 header.replace("(bankomat i vkladomat)", "").replace("(bankomat aj vkladomat)", "").strip(" -")
             )
-            extract_google_position(item, line1)
             item["street_address"] = line2.xpath(".//strong/text()").get()
 
             apply_category(Categories.ATM, item)
 
-            if "lat" not in item:
-                lat, lon = line1.xpath(".//td[contains(text(), 'GPS')]/text()").get().removeprefix("GPS:").split(",")
-                item["lat"] = self.parse_coordinates(lat)
-                item["lon"] = self.parse_coordinates(lon)
+            lat, lon = line1.xpath(".//td[contains(text(), 'GPS')]/text()").get().removeprefix("GPS:").split(",")
+            item["lat"] = self.parse_coordinates(lat)
+            item["lon"] = self.parse_coordinates(lon)
 
             if "fio.cz" in response.url:
                 item["country"] = "CZ"

--- a/locations/spiders/fio_banka_atm.py
+++ b/locations/spiders/fio_banka_atm.py
@@ -4,7 +4,6 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.google_url import extract_google_position
 from locations.hours import DAYS, DAYS_CZ, DAYS_SK, OpeningHours
 from locations.items import Feature
 


### PR DESCRIPTION
I originally thought that parsing the coordinates from the page might be prone to bugs. But is turns out that geocoding in Google Maps URL is far less accurate. Most locations remain unchanged, but 30 are moved a little, one confused Google Maps with the same street in a different city and one Czech ATM appeared in USA.