### PR TITLE
Add mapy_cz_url extractor

### DIFF
--- a/locations/mapy_cz_url.py
+++ b/locations/mapy_cz_url.py
@@ -1,0 +1,64 @@
+from urllib.parse import parse_qs, unquote, urlsplit
+
+from scrapy import Selector
+from scrapy.http import Response
+
+from locations.items import Feature
+
+
+def _get_possible_links(response: Response | Selector):
+    yield from response.xpath(".//a[contains(@href, 'mapy.cz')]/@href").getall()
+
+
+def extract_mapy_cz_position(item: Feature, response: Response | Selector):
+    for link in _get_possible_links(response):
+        try:
+            coords = url_to_coords(link)
+            if coords != (None, None):
+                item["lat"], item["lon"] = coords
+                return
+        except ValueError:
+            return
+
+
+def url_to_coords(url: str) -> (float, float):
+    def get_query_param(link, query_param):
+        parsed_link = urlsplit(link)
+        queries = parse_qs(parsed_link.query)
+        return queries.get(query_param, [])
+
+    url = unquote(url)
+
+    # https://mapy.cz/zakladni?source=base&id=1892282&x=14.4044792&y=50.0921223&z=17
+    for x in get_query_param(url, "x"):
+        for y in get_query_param(url, "y"):
+            return float(y), float(x)
+
+    # https://mapy.cz/zakladni?q=50.1222139N,14.4138156E
+    for q in get_query_param(url, "q"):
+        lat, lon = None, None
+        for coord in q.split(","):
+            if coord.endswith("N") or coord.endswith("S"):
+                lat = coord.removesuffix("N").removesuffix("S")
+            if coord.endswith("E") or coord.endswith("W"):
+                lon = coord.removesuffix("E").removesuffix("W")
+        if lat and lon:
+            return float(lat), float(lon)
+
+    # https://developer.mapy.cz/en/further-uses-of-mapycz/mapy-cz-url/
+    for center in get_query_param(url, "center"):
+        lon, lat = center.split(",")
+        return float(lat), float(lon)
+
+    if url.startswith("https://mapy.cz/fnc/v1/route"):
+        starts = get_query_param(url, "start")
+        ends = get_query_param(url, "end")
+        # extract either start or end, but not both
+        if len(starts) == 0 and len(ends) == 1:
+            lon, lat = ends[0].split(",")
+            return float(lat), float(lon)
+        if len(starts) == 1 and len(ends) == 0:
+            lon, lat = starts[0].split(",")
+            return float(lat), float(lon)
+
+    return None, None

--- a/tests/test_mapy_cz_url.py
+++ b/tests/test_mapy_cz_url.py
@@ -1,0 +1,78 @@
+from scrapy import Selector
+
+from locations.items import Feature
+from locations.mapy_cz_url import extract_mapy_cz_position, url_to_coords
+
+
+def test_web_url():
+    assert url_to_coords("https://mapy.cz/zakladni?source=base&id=1892282&x=14.4044792&y=50.0921223&z=17") == (
+        50.0921223,
+        14.4044792,
+    )
+    assert url_to_coords(
+        "https://mapy.cz/turisticka?x=18.0850036&y=48.307636&z=18&source=coor&id=18.0850036,48.307636"
+    ) == (
+        48.307636,
+        18.0850036,
+    )
+
+
+def test_encoded_url():
+    assert url_to_coords("https://mapy.cz/zakladni?q=50.1222139N%2C14.4138156E") == (
+        50.1222139,
+        14.4138156,
+    )
+    assert url_to_coords("https://mapy.cz/zakladni?q=liberec") == (None, None)
+
+
+def test_showmap():
+    assert url_to_coords("https://mapy.cz/fnc/v1/showmap?mapset=winter&center=14.4203523,50.0313731") == (
+        50.0313731,
+        14.4203523,
+    )
+    assert url_to_coords(
+        "https://mapy.cz/fnc/v1/showmap?mapset=winter&center=14.4203523,50.0313731&zoom=16&marker=true"
+    ) == (
+        50.0313731,
+        14.4203523,
+    )
+    assert url_to_coords("https://mapy.cz/fnc/v1/showmap?mapset=winter") == (None, None)
+
+
+def test_search():
+    assert url_to_coords(
+        "https://mapy.cz/fnc/v1/search?query=restaurace&mapset=outdoor&center=14.4203523,50.0313731"
+    ) == (
+        50.0313731,
+        14.4203523,
+    )
+    assert url_to_coords(
+        "https://mapy.cz/fnc/v1/search?query=restaurace&mapset=outdoor&center=14.4203523,50.0313731&zoom=16"
+    ) == (
+        50.0313731,
+        14.4203523,
+    )
+    assert url_to_coords("https://mapy.cz/fnc/v1/search?query=restaurace&mapset=outdoor") == (None, None)
+
+
+def test_route():
+    assert url_to_coords("https://mapy.cz/fnc/v1/route?mapset=traffic&end=14.3681,50.0292") == (
+        50.0292,
+        14.3681,
+    )
+    assert url_to_coords("https://mapy.cz/fnc/v1/route?mapset=traffic&start=14.4606,50.0878&end=14.3681,50.0292") == (
+        None,
+        None,
+    )
+    assert url_to_coords(
+        "https://mapy.cz/fnc/v1/route?mapset=traffic&start=14.4606,50.0878&end=14.3681,50.0292&routeType=car_fast_traffic&waypoints=14.5377,50.0831;14.5087,50.0335&navigate=true"
+    ) == (None, None)
+
+
+def test_extract():
+    item = Feature()
+    button = Selector(
+        text='<a href="https://mapy.cz/turisticka?x=18.0850036&amp;y=48.307636&amp;z=18&amp;source=coor&amp;id=18.0850036,48.307636" target="_blank" rel="noreferrer">Display on the map</a>'
+    )
+    extract_mapy_cz_position(item, button)
+    assert item == {"extras": {}, "lat": 48.307636, "lon": 18.0850036}


### PR DESCRIPTION
[Mapy.cz](https://mapy.cz) is a popular online map in Central Europe built upon OSM data. I have seen some website using it instead of Google Maps to link to the coordinates. Their "share" feature and [iframe](https://developer.mapy.cz/en/further-uses-of-mapycz/iframe/) both use magic short-links, but they support URL with [coordinates](https://developer.mapy.cz/en/further-uses-of-mapycz/mapy-cz-url/) as well (e.g. [here](https://manufakturashop.com/stores/506)).

I built an implementation prototype which covers my use case. Happy to hear comments whether this is desired in ATP.