### PR TITLE
[intersport_es] Add spider (131 locations)

### DIFF
--- a/locations/spiders/intersport_es.py
+++ b/locations/spiders/intersport_es.py
@@ -1,0 +1,40 @@
+import json
+import re
+
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_ES, OpeningHours
+
+
+class IntersportESSpider(scrapy.Spider):
+    start_urls = ["https://www.intersport.es/tiendas"]
+
+    name = "intersport_es"
+    item_attributes = {"brand": "Intersport", "brand_wikidata": "Q666888"}
+
+    def parse(self, response, **kwargs):
+        store_json = response.xpath('//script/text()[contains(., "stores")]').re_first(r"var stores\s*=\s*(.*);")
+        stores = json.loads(store_json)
+        for store in stores:
+            store["ref"] = store.pop("id_store")
+            store["name"] = store["name"].title()
+            store["website"] = "https://www.intersport.es/tiendas?idStore=" + str(store["ref"])
+            item = DictParser.parse(store)
+            if "business_hours" in store and store["business_hours"] is not None:
+                item["opening_hours"] = self.parse_opening_hours(store["business_hours"])
+            yield item
+
+    def parse_opening_hours(self, hours_definition):
+        closed = {"", "Cerrado", "Cerrada"}
+        re_list = re.compile(r" y |, ")
+        re_interval = re.compile(r" a |-")
+        hours = OpeningHours()
+        for day_definition in hours_definition:
+            day_en = DAYS_ES[day_definition["day"].strip()]
+            for intervals in day_definition["hours"]:
+                for interval in re_list.split(intervals):
+                    if interval not in closed:
+                        open_time, close_time = re_interval.split(interval)
+                        hours.add_range(day_en, open_time.strip(), close_time.strip())
+        return hours


### PR DESCRIPTION
https://www.intersport.es/tiendas – Spanish shops of the sport goods chain

```
2024-11-05 20:16:24 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Intersport': 131,
 'atp/brand_wikidata/Q666888': 131,
 'atp/category/shop/sports': 131,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 131,
 'atp/field/email/missing': 76,
 'atp/field/image/missing': 131,
 'atp/field/opening_hours/missing': 25,
 'atp/field/operator/missing': 131,
 'atp/field/operator_wikidata/missing': 131,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 131,
 'atp/field/twitter/missing': 131,
 'atp/item_scraped_host_count/www.intersport.es': 131,
 'atp/nsi/cc_match': 131,
```