### PR TITLE
[Ibis NL] Delete  broken spider, locations already covered by Accor Spider

### DIFF
--- a/locations/spiders/ibis_nl.py
+++ b/locations/spiders/ibis_nl.py
@@ -1,9 +1,0 @@
-from locations.storefinders.yext import YextSpider
-
-
-class IbisNLSpider(YextSpider):
-    name = "ibis_nl"
-    item_attributes = {"brand": "Ibis", "brand_wikidata": "Q920166"}
-    api_key = "f60a800cdb7af0904b988d834ffeb221"
-    wanted_types = ["hotel"]
-    search_filter = {"name": {"$contains": "Ibis"}, "countryCode": "NL"}


### PR DESCRIPTION
We get desired 25 POIs from `Accor` spider. Broken `Ibis NL` spider can be deleted, instead of fixing.