### PR TITLE
[Lasik Plus US] Flag as requires proxy

### DIFF
--- a/locations/spiders/lasik_plus_us.py
+++ b/locations/spiders/lasik_plus_us.py
@@ -10,6 +10,7 @@ class LasikPlusUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.lasikplus.com/robots.txt"]
     sitemap_follow = ["lasik_location.xml"]
     sitemap_rules = [(r"/location/([^/]+-lasik-center)/$", "parse")]
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["website"] = response.url


### PR DESCRIPTION
Works fine from `IN`, failed in previous runs. Might require proxy.

```
{'atp/brand/LasikPlus': 52,
 'atp/brand_wikidata/Q126111242': 52,
 'atp/category/amenity/clinic': 52,
 'atp/category/multiple': 52,
 'atp/cdn/cloudflare/response_count': 143,
 'atp/cdn/cloudflare/response_status_count/200': 143,
 'atp/field/branch/missing': 52,
 'atp/field/email/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/field/state/from_reverse_geocoding': 52,
 'atp/item_scraped_host_count/www.lasikplus.com': 52,
 'atp/nsi/perfect_match': 52,
 'atp/structured_data/unmapped/payment_accepted/Care Credit': 139,
 'atp/structured_data/unmapped/payment_accepted/etc.': 139,
 'atp/structured_data/unmapped/payment_accepted/in-house financing': 139,
 'atp/structured_data/unmapped/payment_accepted/personal check': 139,
 'downloader/request_bytes': 57193,
 'downloader/request_count': 143,
 'downloader/request_method_count/GET': 143,
 'downloader/response_bytes': 9748865,
 'downloader/response_count': 143,
 'downloader/response_status_count/200': 143,
 'elapsed_time_seconds': 177.619948,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 8, 6, 25, 9, 653803, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 56877281,
 'httpcompression/response_count': 143,
 'item_scraped_count': 52,
 'log_count/DEBUG': 768,
 'log_count/INFO': 568,
 'request_depth_max': 3,
 'response_received_count': 143,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 142,
 'scheduler/dequeued/memory': 142,
 'scheduler/enqueued': 142,
 'scheduler/enqueued/memory': 142,
 'start_time': datetime.datetime(2024, 11, 8, 6, 22, 12, 33855, tzinfo=datetime.timezone.utc)}
```