### PR TITLE
[Hyundai EE FI LT LV] Remove state as not populated

### DIFF
--- a/locations/spiders/hyundai_ee_fi_lt_lv.py
+++ b/locations/spiders/hyundai_ee_fi_lt_lv.py
@@ -22,7 +22,6 @@ class HyundaiEEFILTLVSpider(JSONBlobSpider):
         item["street_address"] = feature["address"]["fi"]
         item["city"] = feature["city"]["fi"]
         item["postcode"] = feature["postcode"]
-        item["state"] = feature["region"]["fi"] or None
         item["country"] = feature["country"]["fi"]
         if item["country"] == "ET":
             # ISO 639 language code for Estonian is "ET"


### PR DESCRIPTION
Fix non running spider

File "/home/ubuntu/locations/spiders/hyundai_ee_fi_lt_lv.py", line 25, in post_process_item
    item["state"] = feature["region"]["fi"] or None
                    ~~~~~~~^^^^^^^^^^
KeyError: 'region'