### PR TITLE
[vodafone_cz] Add spider (80 locations)

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -86,6 +86,7 @@ class DictParser:
         "address-line1",
         "line1",
         "address-line-one",
+        "address-street",
         # JP
         "町域以下住所",  # "address below town limits"
         # IT
@@ -166,6 +167,7 @@ class DictParser:
         "store-zip",
         "store-zip-code",
         "store-zipcode",
+        "address-zip",
         # JP
         "郵便番号",  # "post code"
         # DE

--- a/locations/spiders/vodafone_cz.py
+++ b/locations/spiders/vodafone_cz.py
@@ -1,0 +1,38 @@
+import re
+
+import scrapy
+from chompjs import parse_js_object
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class VodafoneCzSpider(scrapy.Spider):
+    name = "vodafone_cz"
+    allowed_domains = ["www.vodafone.cz"]
+    start_urls = ["https://www.vodafone.cz/prodejny/"]
+    item_attributes = {
+        "brand": "Vodafone",
+        "brand_wikidata": "Q122141",
+    }
+
+    def extract_json(self, repsonse):
+        js_blob = re.search(r"var stores = (.*)\n", repsonse.text)[1]
+        return parse_js_object(js_blob)
+
+    def parse(self, response):
+        for location in self.extract_json(response):
+            item = DictParser.parse(location)
+            item["website"] = "https://www.vodafone.cz/prodejny/detail-prodejny/" + location["identifier"]
+            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+
+            apply_yes_no(Extras.WHEELCHAIR_LIMITED, item, location["disabled_access"] == 2)
+            apply_yes_no(Extras.WHEELCHAIR, item, location["disabled_access"] == 1)
+
+            oh = OpeningHours()
+            for key, values in location["opening_hours"].items():
+                for value in values:
+                    oh.add_range(value["day"], value["from"], value["till"])
+            item["opening_hours"] = oh.as_opening_hours()
+            yield item

--- a/locations/spiders/vodafone_cz.py
+++ b/locations/spiders/vodafone_cz.py
@@ -8,7 +8,7 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
-class VodafoneCzSpider(scrapy.Spider):
+class VodafoneCZSpider(scrapy.Spider):
     name = "vodafone_cz"
     allowed_domains = ["www.vodafone.cz"]
     start_urls = ["https://www.vodafone.cz/prodejny/"]


### PR DESCRIPTION
```python
{'atp/brand/Vodafone': 80,
 'atp/brand_wikidata/Q122141': 80,
 'atp/category/shop/mobile_phone': 80,
 'atp/field/branch/missing': 80,
 'atp/field/country/from_spider_name': 80,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 80,
 'atp/field/operator/missing': 80,
 'atp/field/operator_wikidata/missing': 80,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 80,
 'atp/field/twitter/missing': 80,
 'atp/item_scraped_host_count/www.vodafone.cz': 80,
 'atp/nsi/cc_match': 80,
 'downloader/request_bytes': 833,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 38417,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.35174,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 10, 16, 36, 59, 377189, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 283707,
 'httpcompression/response_count': 2,
 'item_scraped_count': 80,
 'log_count/DEBUG': 93,
 'log_count/INFO': 10,
 'memusage/max': 256262144,
 'memusage/startup': 256262144,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 10, 16, 36, 57, 25449, tzinfo=datetime.timezone.utc)}
```