### PR TITLE
[Harvester GB] Fix spider

### DIFF
--- a/locations/spiders/harvester_gb.py
+++ b/locations/spiders/harvester_gb.py
@@ -9,4 +9,3 @@ class HarvesterGBSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "Harvester", "brand_wikidata": "Q5676915"}
     start_urls = ["https://www.harvester.co.uk/restaurants/"]
     rules = [Rule(LinkExtractor(allow="/restaurants/"), callback="parse_sd")]
-    wanted_types = ["Restaurant"]

--- a/locations/spiders/harvester_gb.py
+++ b/locations/spiders/harvester_gb.py
@@ -1,11 +1,12 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class HarvesterGBSpider(SitemapSpider, StructuredDataSpider):
+class HarvesterGBSpider(CrawlSpider, StructuredDataSpider):
     name = "harvester_gb"
     item_attributes = {"brand": "Harvester", "brand_wikidata": "Q5676915"}
-    sitemap_urls = ["https://www.harvester.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.harvester\.co\.uk\/restaurants\/[\w]+\/[\w]+$", "parse_sd")]
+    start_urls = ["https://www.harvester.co.uk/restaurants/"]
+    rules = [Rule(LinkExtractor(allow="/restaurants/"), callback="parse_sd")]
     wanted_types = ["Restaurant"]


### PR DESCRIPTION
[Sitemap](https://www.harvester.co.uk/sitemap.xml) is not reachable, hence switched to `CrawlSpider` .
```

{'atp/brand/Harvester': 150,
 'atp/brand_wikidata/Q5676915': 150,
 'atp/category/amenity/restaurant': 150,
 'atp/cdn/cloudflare/response_count': 157,
 'atp/cdn/cloudflare/response_status_count/200': 157,
 'atp/field/branch/missing': 150,
 'atp/field/email/missing': 150,
 'atp/field/image/dropped': 150,
 'atp/field/image/missing': 150,
 'atp/field/operator/missing': 150,
 'atp/field/operator_wikidata/missing': 150,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 5,
 'atp/item_scraped_host_count/www.harvester.co.uk': 150,
 'atp/nsi/perfect_match': 150,
 'downloader/request_bytes': 88451,
 'downloader/request_count': 157,
 'downloader/request_method_count/GET': 157,
 'downloader/response_bytes': 3181981,
 'downloader/response_count': 157,
 'downloader/response_status_count/200': 157,
 'elapsed_time_seconds': 195.340895,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 11, 8, 58, 57, 178439, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12503782,
 'httpcompression/response_count': 157,
 'item_scraped_count': 150,
 'log_count/DEBUG': 318,
 'log_count/INFO': 13,
 'request_depth_max': 1,
 'response_received_count': 157,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 156,
 'scheduler/dequeued/memory': 156,
 'scheduler/enqueued': 156,
 'scheduler/enqueued/memory': 156,
 'start_time': datetime.datetime(2024, 11, 11, 8, 55, 41, 837544, tzinfo=datetime.timezone.utc)}
```