### PR TITLE
[FedEx] Disable proxy

### DIFF
--- a/locations/spiders/fedex.py
+++ b/locations/spiders/fedex.py
@@ -19,7 +19,6 @@ class FedexSpider(SitemapSpider, StructuredDataSpider):
     custom_settings = {  # Disable NSI matching
         "ITEM_PIPELINES": ITEM_PIPELINES | {"locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": None}
     }
-    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["email"] = response.xpath('//a[@class="Hero-emailLink Link--primary"]/@href').extract_first()


### PR DESCRIPTION
So, the proxy is actually breaking this one. It does something, presumably to the headers, that stops scrapy parsing the sitemap. After a test run, it works for me without a proxy at all now. If we still need a proxy for the weekly, we need to add the following:

```python
    def _get_sitemap_body(self, response):
        return response.body
```