### PR TITLE
[LeenBakkerNL] Fix Spider

### DIFF
--- a/locations/spiders/leen_bakker_nl.py
+++ b/locations/spiders/leen_bakker_nl.py
@@ -27,6 +27,6 @@ class LeenBakkerNLSpider(Spider):
                 if rule["displayValue"] == "Gesloten":
                     continue
                 if day := sanitise_day(rule["label"], DAYS_NL):
-                    item["opening_hours"].add_range(day, *rule["displayValue"].split("-"))
+                    item["opening_hours"].add_range(day, *rule["displayValue"].replace(" ", "").split("-"))
 
             yield item


### PR DESCRIPTION
Fixes : removed redundant spaces using replace to update the time for opening_hours

{'atp/brand/Leen Bakker': 101,
 'atp/brand_wikidata/Q3333662': 101,
 'atp/category/shop/furniture': 101,
 'atp/field/country/from_spider_name': 101,
 'atp/field/email/missing': 101,
 'atp/field/image/missing': 101,
 'atp/field/operator/missing': 101,
 'atp/field/operator_wikidata/missing': 101,
 'atp/field/state/missing': 101,
 'atp/field/twitter/missing': 101,
 'atp/item_scraped_host_count/www.leenbakker.nl': 101,
 'atp/nsi/perfect_match': 101,
 'downloader/request_bytes': 622,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8134,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.765944,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 11, 9, 44, 26, 116764, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 90170,
 'httpcompression/response_count': 2,
 'item_scraped_count': 101,
 'log_count/DEBUG': 114,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 11, 9, 44, 23, 350820, tzinfo=datetime.timezone.utc)}