### PR TITLE
[Debra GB] Fix spider

### DIFF
--- a/locations/spiders/debra_gb.py
+++ b/locations/spiders/debra_gb.py
@@ -14,6 +14,7 @@ class DebraGBSpider(SitemapSpider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
+        item["branch"] = response.xpath('//meta[@property="og:title"]/@content').get()
         item["addr_full"] = response.xpath("//address/text()").get()
         item["lat"] = response.xpath("//@data-lat").get()
         item["lon"] = response.xpath("//@data-lng").get()

--- a/locations/spiders/debra_gb.py
+++ b/locations/spiders/debra_gb.py
@@ -10,7 +10,7 @@ class DebraGBSpider(SitemapSpider):
     name = "debra_gb"
     item_attributes = {"brand": "Debra", "brand_wikidata": "Q104535435"}
     sitemap_urls = ["https://www.debra.org.uk/sitemap.xml"]
-    sitemap_rules = [(r"uk/[^/]+-shop$", "parse")]
+    sitemap_rules = [(r"uk/charity-shop/[-\w]+", "parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         content = response.xpath("//meta[@property='og:description']/@content").get()

--- a/locations/spiders/debra_gb.py
+++ b/locations/spiders/debra_gb.py
@@ -3,6 +3,7 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.hours import OpeningHours
 from locations.items import Feature
 
 
@@ -21,4 +22,7 @@ class DebraGBSpider(SitemapSpider):
         item["ref"] = item["website"] = response.url
         item["email"] = response.xpath('//a[contains(@href,"mailto:")]/text()').get()
         item["phone"] = response.xpath('//a[contains(@href,"tel:")]/text()').get()
+        if hours := response.xpath('//*[contains(@class,"details-opening-times")]/text()').get():
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours)
         yield item

--- a/locations/spiders/debra_gb.py
+++ b/locations/spiders/debra_gb.py
@@ -13,15 +13,9 @@ class DebraGBSpider(SitemapSpider):
     sitemap_rules = [(r"uk/charity-shop/[-\w]+", "parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        content = response.xpath("//meta[@property='og:description']/@content").get()
-        if "Tel:" in content:
-            item = Feature()
-            address = content.split("Tel:")[0].strip()
-            item["addr_full"] = address
-            postcode = address.split(",")[-1].strip()
-            # Last address element should be postcode but comma between county and postcode is often missing
-            cleaner_postcode = postcode.split(" ")
-            postcode = " ".join(cleaner_postcode[-2:])
-            item["postcode"] = postcode
-            item["ref"] = item["website"] = response.url
-            yield item
+        item = Feature()
+        item["addr_full"] = response.xpath("//address/text()").get()
+        item["lat"] = response.xpath("//@data-lat").get()
+        item["lon"] = response.xpath("//@data-lng").get()
+        item["ref"] = item["website"] = response.url
+        yield item

--- a/locations/spiders/debra_gb.py
+++ b/locations/spiders/debra_gb.py
@@ -19,4 +19,6 @@ class DebraGBSpider(SitemapSpider):
         item["lat"] = response.xpath("//@data-lat").get()
         item["lon"] = response.xpath("//@data-lng").get()
         item["ref"] = item["website"] = response.url
+        item["email"] = response.xpath('//a[contains(@href,"mailto:")]/text()').get()
+        item["phone"] = response.xpath('//a[contains(@href,"tel:")]/text()').get()
         yield item


### PR DESCRIPTION
Updated `sitemap_rules` and `xpaths` to fix the spider.  Added more attributes available.

```
{'atp/brand/Debra': 89,
 'atp/brand_wikidata/Q104535435': 89,
 'atp/category/shop/charity': 89,
 'atp/field/city/missing': 89,
 'atp/field/country/from_spider_name': 89,
 'atp/field/image/missing': 89,
 'atp/field/operator/missing': 89,
 'atp/field/operator_wikidata/missing': 89,
 'atp/field/postcode/missing': 10,
 'atp/field/state/missing': 89,
 'atp/field/street_address/missing': 89,
 'atp/field/twitter/missing': 89,
 'atp/item_scraped_host_count/www.debra.org.uk': 89,
 'atp/nsi/perfect_match': 89,
 'downloader/request_bytes': 35826,
 'downloader/request_count': 97,
 'downloader/request_method_count/GET': 97,
 'downloader/response_bytes': 2307095,
 'downloader/response_count': 97,
 'downloader/response_status_count/200': 96,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 116.808241,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 11, 10, 43, 27, 183417, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11821670,
 'httpcompression/response_count': 96,
 'item_scraped_count': 89,
 'log_count/DEBUG': 197,
 'log_count/INFO': 10,
 'request_depth_max': 2,
 'response_received_count': 96,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 96,
 'scheduler/dequeued/memory': 96,
 'scheduler/enqueued': 96,
 'scheduler/enqueued/memory': 96,
 'start_time': datetime.datetime(2024, 11, 11, 10, 41, 30, 375176, tzinfo=datetime.timezone.utc)}
```