### PR TITLE
woolworths_au: fix, countdown_nz: fix and rebrand to woolworths_nz

### DIFF
--- a/locations/spiders/woolworths_au.py
+++ b/locations/spiders/woolworths_au.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class WoolworthsAUSpider(scrapy.Spider):
@@ -16,6 +17,7 @@ class WoolworthsAUSpider(scrapy.Spider):
     start_urls = [
         "https://www.woolworths.com.au/apis/ui/StoreLocator/Stores?Max=10000&Division=SUPERMARKETS&Facility=&postcode=*"
     ]
+    user_agent = BROWSER_DEFAULT
     requires_proxy = "AU"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/woolworths_nz.py
+++ b/locations/spiders/woolworths_nz.py
@@ -1,6 +1,7 @@
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.user_agents import BROWSER_DEFAULT
@@ -9,7 +10,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class WoolworthsNZSpider(Spider):
     name = "woolworths_nz"
     METRO = {"brand": "Woolworths Metro", "brand_wikidata": "Q123699264"}
-    item_attributes = {"brand": "Woolworths", "brand_wikidata": "Q5176845"}
+    item_attributes = {"brand": "Woolworths", "brand_wikidata": "Q5176845", "extras": Categories.SHOP_SUPERMARKET.value}
     allowed_domains = ["api.cdx.nz"]
     start_urls = ["https://api.cdx.nz/site-location/api/v1/sites?latitude=-42&longitude=174&maxResults=10000"]
     user_agent = BROWSER_DEFAULT

--- a/locations/spiders/woolworths_nz.py
+++ b/locations/spiders/woolworths_nz.py
@@ -1,17 +1,18 @@
-from json import loads
-
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class CountdownNZSpider(Spider):
-    name = "countdown_nz"
-    item_attributes = {"brand": "Countdown", "brand_wikidata": "Q5176845"}
+class WoolworthsNZSpider(Spider):
+    name = "woolworths_nz"
+    METRO = {"brand": "Woolworths Metro", "brand_wikidata": "Q123699264"}
+    item_attributes = {"brand": "Woolworths", "brand_wikidata": "Q5176845"}
     allowed_domains = ["api.cdx.nz"]
     start_urls = ["https://api.cdx.nz/site-location/api/v1/sites?latitude=-42&longitude=174&maxResults=10000"]
+    user_agent = BROWSER_DEFAULT
     requires_proxy = "NZ"
 
     def start_requests(self):
@@ -19,14 +20,16 @@ class CountdownNZSpider(Spider):
             yield JsonRequest(url=url)
 
     def parse(self, response):
-        # Playwright page responses for JSON data get wrapped in HTML.
-        json_blob = loads(response.xpath("//pre/text()").get())
-        for location in json_blob["siteDetail"]:
+        for location in response.json()["siteDetail"]:
             item = DictParser.parse(location["site"])
+            if item["name"].startswith("Metro "):
+                item["brand"] = self.METRO["brand"]
+                item["brand_wikidata"] = self.METRO["brand_wikidata"]
+            item.pop("state", None)
             if location["site"].get("email") == "null":
                 item.pop("email", None)
             item["website"] = (
-                "https://www.countdown.co.nz/store-finder/"
+                "https://www.woolworths.co.nz/store-finder/"
                 + str(item["ref"])
                 + "/"
                 + item["city"].lower().replace(" ", "-").replace(",", "")


### PR DESCRIPTION
User agent spoofing required for both spiders or else timeouts occur.

Countdown was rebranded to Woolworths per
https://www.woolworthsgroup.com.au/au/en/media/latest-news/2023/countdown-to-woolworths.html and this process has partially completed, even though the old Countdown store locator API is still being used for the timebeing.