### PR TITLE
[Fuzzys Taco Shop US] Fix spider

### DIFF
--- a/locations/spiders/fuzzys_taco_shop_us.py
+++ b/locations/spiders/fuzzys_taco_shop_us.py
@@ -1,3 +1,7 @@
+import re
+from typing import Any
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
@@ -11,13 +15,19 @@ class FuzzysTacoShopUSSpider(CrawlSpider, StructuredDataSpider):
     allowed_domains = ["fuzzystacoshop.com"]
     start_urls = ["https://fuzzystacoshop.com/locations/list/"]
     rules = [
-        Rule(LinkExtractor(allow=r"https:\/\/fuzzystacoshop\.com\/locations\/list\/.+")),
         Rule(
-            LinkExtractor(allow=r"https:\/\/fuzzystacoshop\.com\/locations\/(?!list\/).+"),
-            callback="parse_sd",
-            follow=False,
+            LinkExtractor(allow=r"/list/[a-z]{2}/$"),
+            callback="parse",
         ),
     ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # POI page url is generated dynamically through javascript code, not available for CrawlSpider.
+        for link in set(re.findall(r"onclick=\"window\.open\(\'(.+?)\'", response.text)):
+            if "list" in link:  # city page having multiple locations
+                yield response.follow(link, callback=self.parse)
+            else:  # POI page
+                yield response.follow(link, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data):
         item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data, time_format="%H:%M:%S")

--- a/locations/spiders/fuzzys_taco_shop_us.py
+++ b/locations/spiders/fuzzys_taco_shop_us.py
@@ -5,7 +5,6 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -28,7 +27,3 @@ class FuzzysTacoShopUSSpider(CrawlSpider, StructuredDataSpider):
                 yield response.follow(link, callback=self.parse)
             else:  # POI page
                 yield response.follow(link, callback=self.parse_sd)
-
-    def post_process_item(self, item, response, ld_data):
-        item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data, time_format="%H:%M:%S")
-        yield item


### PR DESCRIPTION
Ultimate POI page url is no longer available for `CrawlSpider` , hence code updated to fix the spider.

```
{"atp/brand/Fuzzy's Taco Shop": 117,
 'atp/brand_wikidata/Q85762348': 117,
 'atp/category/amenity/fast_food': 117,
 'atp/field/branch/missing': 117,
 'atp/field/email/missing': 117,
 'atp/field/image/missing': 117,
 'atp/field/opening_hours/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/twitter/missing': 117,
 'atp/item_scraped_host_count/fuzzystacoshop.com': 117,
 'atp/nsi/perfect_match': 117,
 'downloader/request_bytes': 88709,
 'downloader/request_count': 229,
 'downloader/request_method_count/GET': 229,
 'downloader/response_bytes': 10177697,
 'downloader/response_count': 229,
 'downloader/response_status_count/200': 229,
 'elapsed_time_seconds': 287.815739,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 13, 9, 7, 1, 769119, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 43115548,
 'httpcompression/response_count': 229,
 'item_scraped_count': 117,
 'log_count/DEBUG': 357,
 'log_count/INFO': 14,
 'request_depth_max': 3,
 'response_received_count': 229,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 228,
 'scheduler/dequeued/memory': 228,
 'scheduler/enqueued': 228,
 'scheduler/enqueued/memory': 228,
 'start_time': datetime.datetime(2024, 11, 13, 9, 2, 13, 953380, tzinfo=datetime.timezone.utc)}
```