### PR TITLE
[douglas] Add spider (1096 locations)

### DIFF
--- a/locations/spiders/douglas.py
+++ b/locations/spiders/douglas.py
@@ -42,7 +42,8 @@ class DouglasSpider(Spider):
             item = DictParser().parse(feature)
             item["opening_hours"] = self.parse_opening_hours(feature["openingHours"]["weekDayOpeningList"])
             apply_category(Categories.SHOP_PERFUMERY, item)
-            yield item
+            if item["lat"] is not None and item["lon"] is not None:
+                yield item
 
     def parse_opening_hours(self, opening_list):
         hours = OpeningHours()

--- a/locations/spiders/douglas.py
+++ b/locations/spiders/douglas.py
@@ -33,11 +33,12 @@ class DouglasSpider(Spider):
                 feature["branch"] = feature.pop("displayName")
             else:
                 feature["branch"] = feature["address"]["town"] + ", " + feature["address"]["line1"]
-            feature["address"]["house_number"] = feature["address"].get("line2")
+            if "address" in feature:
+                feature["address"]["house_number"] = feature["address"].get("line2")
+                feature["address"]["country"] = feature["address"]["country"]["isocode"]
+                if "region" in feature["address"]:
+                    feature["address"]["region"] = feature["address"]["region"]["isocodeShort"]
             feature["website"] = response.urljoin(feature.pop("url"))
-            feature["address"]["country"] = feature["address"]["country"]["isocode"]
-            if "region" in feature["address"]:
-                feature["address"]["region"] = feature["address"]["region"]["isocodeShort"]
             item = DictParser().parse(feature)
             item["opening_hours"] = self.parse_opening_hours(feature["openingHours"]["weekDayOpeningList"])
             apply_category(Categories.SHOP_PERFUMERY, item)

--- a/locations/spiders/douglas.py
+++ b/locations/spiders/douglas.py
@@ -1,0 +1,55 @@
+from scrapy import Request, Spider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class DouglasSpider(Spider):
+    name = "douglas"
+    item_attributes = {
+        "brand": "Douglas",
+        "brand_wikidata": "Q2052213",
+    }
+    user_agent = BROWSER_DEFAULT
+
+    def start_requests(self):
+        for tld in ("at", "be", "ch", "de", "es", "it", "nl", "pl"):
+            yield Request(
+                f"https://www.douglas.{tld}/api/v2/stores?fields=FULL&pageSize=1000&sort=asc",
+                headers={
+                    # Need to make the requests more browser-like
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.8",
+                },
+            )
+
+    def parse(self, response, **kwargs):
+        for feature in response.json()["stores"]:
+            feature["ref"] = feature.pop("name")
+            if "displayName" in feature:
+                feature["branch"] = feature.pop("displayName")
+            else:
+                feature["branch"] = feature["address"]["town"] + ", " + feature["address"]["line1"]
+            feature["address"]["house_number"] = feature["address"].get("line2")
+            feature["website"] = response.urljoin(feature.pop("url"))
+            feature["address"]["country"] = feature["address"]["country"]["isocode"]
+            if "region" in feature["address"]:
+                feature["address"]["region"] = feature["address"]["region"]["isocodeShort"]
+            item = DictParser().parse(feature)
+            item["opening_hours"] = self.parse_opening_hours(feature["openingHours"]["weekDayOpeningList"])
+            apply_category(Categories.SHOP_PERFUMERY, item)
+            yield item
+
+    def parse_opening_hours(self, opening_list):
+        hours = OpeningHours()
+        days_zero_based = ["Su"] + DAYS
+        for day_definition in opening_list:
+            if "openingTime" in day_definition:
+                hours.add_range(
+                    days_zero_based[day_definition["dayOfWeek"]],
+                    day_definition["openingTime"]["formattedHour"],
+                    day_definition["closingTime"]["formattedHour"],
+                )
+        return hours

--- a/locations/spiders/douglas.py
+++ b/locations/spiders/douglas.py
@@ -13,6 +13,7 @@ class DouglasSpider(Spider):
         "brand_wikidata": "Q2052213",
     }
     user_agent = BROWSER_DEFAULT
+    requires_proxy = "DE"
 
     def start_requests(self):
         for tld in ("at", "be", "ch", "de", "es", "it", "nl", "pl"):


### PR DESCRIPTION
Add [Douglas](https://www.douglas.de/), a perfumery/cosmetics chain in Europe.

| country | count |
| ------- | -----:|
| IT      |   371 |
| DE      |   333 |
| PL      |   154 |
| NL      |   106 |
| ES      |    76 |
| AT      |    36 |
| CH      |    11 |
| BE      |     5 |
| AD      |     4 |


```
2024-11-14 21:01:12 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Douglas': 1095,
 'atp/brand_wikidata/Q2052213': 1095,
 'atp/category/shop/perfumery': 1095,
 'atp/field/branch/missing': 1095,
 'atp/field/email/missing': 1095,
 'atp/field/image/missing': 1095,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 1095,
 'atp/field/operator_wikidata/missing': 1095,
 'atp/field/phone/missing': 1095,
 'atp/field/state/missing': 901,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 1095,
 'atp/item_scraped_host_count/www.douglas.at': 36,
 'atp/item_scraped_host_count/www.douglas.be': 5,
 'atp/item_scraped_host_count/www.douglas.ch': 11,
 'atp/item_scraped_host_count/www.douglas.de': 333,
 'atp/item_scraped_host_count/www.douglas.es': 80,
 'atp/item_scraped_host_count/www.douglas.it': 370,
 'atp/item_scraped_host_count/www.douglas.nl': 106,
 'atp/item_scraped_host_count/www.douglas.pl': 154,
 'atp/nsi/perfect_match': 1095,
```