### PR TITLE
[Fitness19 US] Fix spider

### DIFF
--- a/locations/spiders/fitness19_us.py
+++ b/locations/spiders/fitness19_us.py
@@ -6,14 +6,13 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.categories import Categories
 from locations.dict_parser import DictParser
 from locations.items import Feature
 
 
 class Fitness19USSpider(CrawlSpider):
     name = "fitness19_us"
-    item_attributes = {"brand": "Fitness 19", "brand_wikidata": "Q121787953", "extras": Categories.GYM.value}
+    item_attributes = {"brand": "Fitness 19", "brand_wikidata": "Q121787953"}
     start_urls = ["https://www.fitness19.com/convenient-locations/"]
     rules = [Rule(LinkExtractor(allow="/centers/"), callback="parse")]
 

--- a/locations/spiders/fitness19_us.py
+++ b/locations/spiders/fitness19_us.py
@@ -1,19 +1,45 @@
-import re
+import json
+from typing import Any
 
-from scrapy.spiders import SitemapSpider
+import chompjs
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.items import Feature
 
 
-class Fitness19USSpider(SitemapSpider, StructuredDataSpider):
+class Fitness19USSpider(CrawlSpider):
     name = "fitness19_us"
     item_attributes = {"brand": "Fitness 19", "brand_wikidata": "Q121787953", "extras": Categories.GYM.value}
-    sitemap_urls = ["https://www.fitness19.com/location-sitemap.xml"]
-    wanted_types = ["LocalBusiness"]
+    start_urls = ["https://www.fitness19.com/convenient-locations/"]
+    rules = [Rule(LinkExtractor(allow="/centers/"), callback="parse")]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        if m := re.search(r"LatLng\((-?\d+\.\d+) ,(-?\d+\.\d+)\);", response.text):
-            item["lat"], item["lon"] = m.groups()
-
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if location := response.xpath('//*[@class="jet-map"]/@data-init').get():
+            item = Feature()
+            item["ref"] = item["website"] = response.url
+            item["branch"] = (
+                response.xpath('//meta[@property="og:title"]/@content')
+                .get()
+                .split(" |")[0]
+                .removeprefix("Fitness 19 Gym ")
+            )
+            coordinates = json.loads(location).pop("center")
+            item["lat"] = coordinates["lat"]
+            item["lon"] = coordinates["lng"]
+            location_info = response.xpath('//span[@class="elementor-icon-list-text"]/text()').getall()
+            item["addr_full"], item["phone"] = location_info[:2]
+            yield item
+        else:
+            # Collect POIs for urls redirecting to alternate website, https://www.fit19.com/locations/.
+            # This website also doesn't list all POIs, so we are relying upon two websites, to collect them all.
+            location = chompjs.parse_js_object(response.xpath('//script[contains(text(),"geolocation")]').get())
+            item = DictParser.parse(location)
+            item["ref"] = location.get("club_number")
+            item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("addr_full")
+            item["website"] = response.url
+            yield item

--- a/locations/spiders/fitness19_us.py
+++ b/locations/spiders/fitness19_us.py
@@ -32,7 +32,7 @@ class Fitness19USSpider(CrawlSpider):
             location_info = response.xpath('//span[@class="elementor-icon-list-text"]/text()').getall()
             item["addr_full"], item["phone"] = location_info[:2]
             yield item
-        else:
+        elif "fit19.com" in response.url:
             # Collect POIs for urls redirecting to alternate website, https://www.fit19.com/locations/.
             # This website also doesn't list all POIs, so we are relying upon two websites, to collect them all.
             location = chompjs.parse_js_object(response.xpath('//script[contains(text(),"geolocation")]').get())


### PR DESCRIPTION
`Structured Data` is no longer available, hence code refactored to adapt website changes. Also [sitemap](https://www.fitness19.com/page-sitemap.xml) doesn't contain ultimate POI urls.
Some `urls` redirect to alternate [website](https://www.fit19.com/locations) of this brand, e.g. https://www.fitness19.com/centers/american-canyon/


```
{'atp/brand/Fitness 19': 64,
 'atp/brand_wikidata/Q121787953': 64,
 'atp/category/leisure/fitness_centre': 64,
 'atp/cdn/cloudflare/response_count': 68,
 'atp/cdn/cloudflare/response_status_count/200': 68,
 'atp/field/city/missing': 34,
 'atp/field/country/from_spider_name': 64,
 'atp/field/email/missing': 64,
 'atp/field/image/missing': 64,
 'atp/field/opening_hours/missing': 64,
 'atp/field/operator/missing': 64,
 'atp/field/operator_wikidata/missing': 64,
 'atp/field/postcode/missing': 34,
 'atp/field/state/from_reverse_geocoding': 34,
 'atp/field/street_address/missing': 34,
 'atp/field/twitter/missing': 64,
 'atp/item_scraped_host_count/www.fit19.com': 30,
 'atp/item_scraped_host_count/www.fitness19.com': 34,
 'atp/nsi/perfect_match': 64,
 'downloader/request_bytes': 44133,
 'downloader/request_count': 100,
 'downloader/request_method_count/GET': 100,
 'downloader/response_bytes': 2787641,
 'downloader/response_count': 100,
 'downloader/response_status_count/200': 68,
 'downloader/response_status_count/301': 32,
 'elapsed_time_seconds': 119.309941,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 15, 6, 37, 1, 531579, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25017915,
 'httpcompression/response_count': 68,
 'item_scraped_count': 64,
 'log_count/DEBUG': 175,
 'log_count/INFO': 11,
 'request_depth_max': 1,
 'response_received_count': 68,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 98,
 'scheduler/dequeued/memory': 98,
 'scheduler/enqueued': 98,
 'scheduler/enqueued/memory': 98,
 'start_time': datetime.datetime(2024, 11, 15, 6, 35, 2, 221638, tzinfo=datetime.timezone.utc)}
```