### PR TITLE
[GourmetGarageUS] Flag as requires proxy

### DIFF
--- a/locations/spiders/gourmet_garage_us.py
+++ b/locations/spiders/gourmet_garage_us.py
@@ -14,6 +14,7 @@ class GourmetGarageUSSpider(StorefrontgatewaySpider):
     }
     start_urls = ["https://storefrontgateway.brands.wakefern.com/api/stores"]
     custom_settings = {"DEFAULT_REQUEST_HEADERS": {"X-Site-Host": "https://www.gourmetgarage.com/"}}
+    requires_proxy = True
 
     def post_process_item(self, item, response, location):
         if location["type"] != "Regular":


### PR DESCRIPTION
Fails in previous runs, works fine from `IN`. Might require `proxy`.

```
{'atp/brand/Gourmet Garage': 3,
 'atp/brand_wikidata/Q16994340': 3,
 'atp/category/shop/supermarket': 3,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/country/from_spider_name': 3,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 3,
 'atp/field/operator/missing': 3,
 'atp/field/operator_wikidata/missing': 3,
 'atp/field/twitter/missing': 3,
 'atp/item_scraped_host_count/storefrontgateway.brands.wakefern.com': 3,
 'atp/nsi/brand_missing': 3,
 'downloader/request_bytes': 813,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1788,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.437583,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 15, 12, 20, 27, 924197, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2854,
 'httpcompression/response_count': 1,
 'item_scraped_count': 3,
 'log_count/DEBUG': 16,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 15, 12, 20, 25, 486614, tzinfo=datetime.timezone.utc)}
```