### PR TITLE
[burgerme_de] Add spider (140 locations)

### DIFF
--- a/locations/spiders/burgerme_de.py
+++ b/locations/spiders/burgerme_de.py
@@ -1,0 +1,33 @@
+import json
+
+from scrapy.spiders import Spider
+
+from locations.items import Feature
+
+
+class BurgermeDESpider(Spider):
+    name = "burgerme_de"
+    item_attributes = {"brand": "burgerme", "brand_wikidata": "Q108866856"}
+    start_urls = ["https://www.burgerme.de/"]
+
+    def parse(self, response, **kwargs):
+        store_data_json = response.xpath('//script[@id="storelocator_new-js-extra"]').re_first(
+            r"var storelocator\s*=\s*({.*});"
+        )
+        # GeoJSON as quoted string
+        store_geojson = json.loads(json.loads(store_data_json)["stores"])
+
+        properties_map = {
+            "ref": "id",
+            "name": "name",
+            "street_address": "address",
+            "postcode": "plz",
+            "city": "city",
+            "website": "permalink",
+        }
+        # Non-standard GeoJSON
+        for feature in store_geojson["features"].values():
+            properties = {k: feature["properties"][v] for k, v in properties_map.items()}
+            properties["lon"] = feature["geometry"]["coordinates"][0]
+            properties["lat"] = feature["geometry"]["coordinates"][1]
+            yield Feature(properties)


### PR DESCRIPTION
Add [burgerme](https://www.burgerme.de/), a burger chain in DE.

```
2024-11-17 17:43:57 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/burgerme': 140,
 'atp/brand_wikidata/Q108866856': 140,
 'atp/category/amenity/fast_food': 140,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 140,
 'atp/field/country/from_spider_name': 140,
 'atp/field/email/missing': 140,
 'atp/field/image/missing': 140,
 'atp/field/opening_hours/missing': 140,
 'atp/field/operator/missing': 140,
 'atp/field/operator_wikidata/missing': 140,
 'atp/field/phone/missing': 140,
 'atp/field/state/missing': 140,
 'atp/field/twitter/missing': 140,
 'atp/item_scraped_host_count/www.burgerme.de': 140,
 'atp/nsi/perfect_match': 140,
```