### PR TITLE
[klier_hair_group] Add spiders (728 locations)

### DIFF
--- a/locations/spiders/cosmo_de.py
+++ b/locations/spiders/cosmo_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class CosmoDESpider(KlierHairGroupSpider):
+    name = "cosmo_de"
+    start_urls = ["https://www.cosmo-hairshop.de/shops/"]
+    item_attributes = {"brand": "Cosmo", "brand_wikidata": "Q121888284"}

--- a/locations/spiders/essanelle_de.py
+++ b/locations/spiders/essanelle_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class EssanelleDESpider(KlierHairGroupSpider):
+    name = "essanelle_de"
+    start_urls = ["https://www.essanelle.de/salons/"]
+    item_attributes = {"brand": "essanelle", "brand_wikidata": "Q121888190"}

--- a/locations/spiders/hair_express_de.py
+++ b/locations/spiders/hair_express_de.py
@@ -2,6 +2,6 @@ from locations.storefinders.klier_hair_group import KlierHairGroupSpider
 
 
 class HairExpressDESpider(KlierHairGroupSpider):
-    name = "hairexpress_de"
+    name = "hair_express_de"
     start_urls = ["https://www.hairexpress-friseur.de/salons/"]
     item_attributes = {"brand": "Hair Express", "brand_wikidata": "Q57550814"}

--- a/locations/spiders/hair_express_de.py
+++ b/locations/spiders/hair_express_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class HairExpressDESpider(KlierHairGroupSpider):
+    name = "hairexpress_de"
+    start_urls = ["https://www.hairexpress-friseur.de/salons/"]
+    item_attributes = {"brand": "Hair Express", "brand_wikidata": "Q57550814"}

--- a/locations/spiders/klier_de.py
+++ b/locations/spiders/klier_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class KlierDESpider(KlierHairGroupSpider):
+    name = "klier_de"
+    start_urls = ["https://www.klier.de/salons/"]
+    item_attributes = {"brand": "Klier", "brand_wikidata": "Q121888036"}

--- a/locations/spiders/supercut_de.py
+++ b/locations/spiders/supercut_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class SupercutDESpider(KlierHairGroupSpider):
+    name = "supercut_de"
+    start_urls = ["https://www.supercut.de/salonfinder/"]
+    item_attributes = {"brand": "Super Cut", "brand_wikidata": "Q64139077"}

--- a/locations/storefinders/klier_hair_group.py
+++ b/locations/storefinders/klier_hair_group.py
@@ -1,0 +1,39 @@
+import re
+
+import scrapy
+from chompjs import chompjs
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class KlierHairGroupSpider(scrapy.Spider):
+    """
+    Klier Hair Group is a chain of hairdressers in Germany with several brands.
+
+    See https://www.wikidata.org/wiki/Q1465159
+
+    This class contains the common code to scrape all their brands.
+    """
+
+    def parse(self, response, **kwargs):
+        locations_re = re.compile(r"locations\.push\(\s*({.*?})\);", re.DOTALL)
+        locations_javascript = response.xpath('//script/text()[contains(., "locations.push")]').re(locations_re)
+        for location_javascript in locations_javascript:
+            location = next(chompjs.parse_js_objects(location_javascript))
+            location["id"] = location.pop("internal_id")
+            location["street_address"] = location.pop("street")
+            location["website"] = location.pop("sanitized")
+            item = DictParser.parse(location)
+            item["opening_hours"] = self.parse_opening_hours(location["business_hours"])
+            apply_category(Categories.SHOP_HAIRDRESSER, item)
+            yield item
+
+    @staticmethod
+    def parse_opening_hours(business_hours):
+        hours = OpeningHours()
+        for day in business_hours:
+            if not day["closed"]:
+                hours.add_range(day["openDay"], day["openTime"], day["closeTime"])
+        return hours


### PR DESCRIPTION
Klier Hair Group is a hairdresser chain in DE with several brands:

- Cosmo
- Essanelle
- Hair Express
- Klier
- Supercut

They share the same website structure, so they can be scraped using a common storefinder class.