### PR TITLE
[Decathlon TW] Fix spider

### DIFF
--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -4,6 +4,7 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
 
 
 class DecathlonTWSpider(Spider):
@@ -18,4 +19,7 @@ class DecathlonTWSpider(Spider):
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").strip("店")
             item["phone"] = store.get("phone1")
+            item["opening_hours"] = OpeningHours()
+            for rule in store.get("workingHours", []):
+                item["opening_hours"].add_range(DAYS[rule["day"] - 1], rule["open"], rule["close"])
             yield item

--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -17,4 +17,5 @@ class DecathlonTWSpider(Spider):
             item = DictParser.parse(store)
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").strip("店")
+            item["phone"] = store.get("phone1")
             yield item

--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -16,4 +16,5 @@ class DecathlonTWSpider(Spider):
             store.update(store.pop("address"))
             item = DictParser.parse(store)
             item["street_address"] = item.pop("street")
+            item["branch"] = item.pop("name").strip("店")
             yield item

--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -1,27 +1,19 @@
-from scrapy import Request, Spider
+from typing import Any
 
-from locations.categories import Categories
-from locations.items import Feature
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
 
 
 class DecathlonTWSpider(Spider):
     name = "decathlon_tw"
-    item_attributes = {"brand": "Decathlon", "brand_wikidata": "Q509349", "extras": Categories.SHOP_SPORTS.value}
-    start_urls = ["https://decathlon.tw/store/taipei_guilin_store"]
+    item_attributes = {"brand": "Decathlon", "brand_wikidata": "Q509349"}
+    start_urls = ["https://www.decathlon.tw/api/store-setting?countryCode=TW"]
 
-    def parse(self, response):
-        store_urls = response.xpath('//select[@id="store-selector"]/option/@value').extract()
-        for store_url in store_urls:
-            if store_url == "#":
-                continue
-            else:
-                yield Request(response.urljoin(store_url), self.parse_store)
-
-    def parse_store(self, response):
-        item = Feature()
-        item["ref"] = response.url
-        item["name"] = response.xpath('//span[@data-ui-id="page-title-wrapper"]/text()').extract_first()
-        store_info = response.xpath('//div[@class="store-info mb-4"]')
-        item["addr_full"] = store_info.xpath('.//div[@class="col-md-4 col-12"]/p[1]/text()').extract_first()
-        item["phone"] = store_info.xpath('.//div[@class="col-md-4 col-12"]/p/a/text()').extract_first()
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json():
+            store.update(store.pop("address"))
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("street")
+            yield item

--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -1,6 +1,7 @@
+import json
 from typing import Any
 
-from scrapy import Spider
+from scrapy import Request, Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
@@ -13,13 +14,31 @@ class DecathlonTWSpider(Spider):
     start_urls = ["https://www.decathlon.tw/api/store-setting?countryCode=TW"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json():
+        yield Request(
+            url="https://www.decathlon.tw/s/門市資訊",
+            callback=self.parse_store_details,
+            meta=dict(stores=response.json()),
+        )
+
+    def parse_store_details(self, response: Response, **kwargs: Any) -> Any:
+        store_list_with_extra_info = []
+        for obj in json.loads(response.xpath('//*[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"]["content"][
+            "floor"
+        ]:
+            if store_list := obj.get("fields", {}).get("storeList"):
+                store_list_with_extra_info.extend(store_list)
+        store_pages = {
+            store["fields"]["storeId"]: store["fields"]["ctaLink"]
+            for store in store_list_with_extra_info
+            if store.get("fields")
+        }
+        for store in response.meta["stores"]:
             store.update(store.pop("address"))
             item = DictParser.parse(store)
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").strip("店")
             item["phone"] = store.get("phone1")
-            item["website"] = "https://www.decathlon.tw/s/門市資訊"
+            item["website"] = response.urljoin(store_pages.get(store["id"]))
             item["opening_hours"] = OpeningHours()
             for rule in store.get("workingHours", []):
                 item["opening_hours"].add_range(DAYS[rule["day"] - 1], rule["open"], rule["close"])

--- a/locations/spiders/decathlon_tw.py
+++ b/locations/spiders/decathlon_tw.py
@@ -19,6 +19,7 @@ class DecathlonTWSpider(Spider):
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").strip("店")
             item["phone"] = store.get("phone1")
+            item["website"] = "https://www.decathlon.tw/s/門市資訊"
             item["opening_hours"] = OpeningHours()
             for rule in store.get("workingHours", []):
                 item["opening_hours"].add_range(DAYS[rule["day"] - 1], rule["open"], rule["close"])


### PR DESCRIPTION
Code refactored using `API` to fix the broken spider.

```
{'atp/brand/Decathlon': 19,
 'atp/brand_wikidata/Q509349': 19,
 'atp/category/shop/sports': 19,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/country/from_spider_name': 19,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/item_scraped_host_count/www.decathlon.tw': 19,
 'atp/nsi/cc_match': 19,
 'downloader/request_bytes': 729,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4005,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.609389,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 19, 7, 22, 7, 916602, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 19236,
 'httpcompression/response_count': 2,
 'item_scraped_count': 19,
 'log_count/DEBUG': 32,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 19, 7, 22, 5, 307213, tzinfo=datetime.timezone.utc)}
```