### PR TITLE
[ElysiumHealthcare] Fix Spider

### DIFF
--- a/locations/spiders/elysium_healthcare.py
+++ b/locations/spiders/elysium_healthcare.py
@@ -22,6 +22,7 @@ class ElysiumHealthcareSpider(scrapy.Spider):
         "https://www.elysiumhealthcare.co.uk/locations/",
     ]
     download_delay = 0.3
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response):
         urls = response.xpath('//li[@class="elementor-icon-list-item"]/a/@href').extract()


### PR DESCRIPTION
`Fixes : set robots.txt as False to fix spider`

{'atp/brand/Elysium Healthcare': 98,
 'atp/brand_wikidata/Q39086513': 98,
 'atp/category/amenity/social_facility': 44,
 'atp/category/healthcare/centre': 54,
 'atp/category/multiple': 5,
 'atp/closed_check': 1,
 'atp/field/branch/missing': 98,
 'atp/field/city/missing': 98,
 'atp/field/email/missing': 98,
 'atp/field/image/missing': 98,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 98,
 'atp/field/operator/missing': 98,
 'atp/field/operator_wikidata/missing': 98,
 'atp/field/phone/missing': 49,
 'atp/field/postcode/missing': 24,
 'atp/field/state/missing': 98,
 'atp/field/street_address/missing': 98,
 'atp/field/twitter/missing': 98,
 'atp/item_scraped_host_count/www.elysiumhealthcare.co.uk': 98,
 'atp/nsi/brand_missing': 98,
 'downloader/request_bytes': 41692,
 'downloader/request_count': 107,
 'downloader/request_method_count/GET': 107,
 'downloader/response_bytes': 6348094,
 'downloader/response_count': 107,
 'downloader/response_status_count/200': 99,
 'downloader/response_status_count/301': 8,
 'elapsed_time_seconds': 41.640841,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 20, 9, 55, 8, 89331, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27764685,
 'httpcompression/response_count': 99,
 'item_scraped_count': 98,
 'log_count/DEBUG': 216,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 99,
 'scheduler/dequeued': 107,
 'scheduler/dequeued/memory': 107,
 'scheduler/enqueued': 107,
 'scheduler/enqueued/memory': 107,
 'start_time': datetime.datetime(2024, 11, 20, 9, 54, 26, 448490, tzinfo=datetime.timezone.utc)}