### PR TITLE
[fit_active] Add spider (145 locations)

### DIFF
--- a/locations/spiders/fit_active.py
+++ b/locations/spiders/fit_active.py
@@ -19,10 +19,11 @@ class FitActiveSpider(scrapy.Spider):
             name = link.xpath("descendant::text()").extract_first()
             website[name] = link.attrib["href"]
             phone[name] = item.xpath('descendant::a[contains(@href, "tel:")]/text()').extract_first()
+
         # The main information is in a JavaScript call
         javascript = response.xpath(
             '//script[@type="text/javascript" and contains(text(), "mainMap(")]/text()'
-        ).re_first("mainMap\((.*)\);")
+        ).re_first(r"mainMap\((.*)\);")
         map_data = json.loads(javascript)
         for shop in map_data:
             name = shop["title"]

--- a/locations/spiders/fit_active.py
+++ b/locations/spiders/fit_active.py
@@ -1,0 +1,41 @@
+import json
+
+import scrapy
+
+from locations.items import Feature
+
+
+class FitActiveSpider(scrapy.Spider):
+    name = "fit_active"
+    item_attributes = {"brand": "FitActive", "brand_wikidata": "Q123807531"}
+    start_urls = ["https://www.fitactive.it/Club/Club"]
+
+    def parse(self, response):
+        # Website and phone number are in a separate section of the website
+        website = {}
+        phone = {}
+        for item in response.xpath('//ul[@class="menu-club"]/li'):
+            link = item.xpath('descendant::a[not(contains(@href, "tel:"))]')
+            name = link.xpath("descendant::text()").extract_first()
+            website[name] = link.attrib["href"]
+            phone[name] = item.xpath('descendant::a[contains(@href, "tel:")]/text()').extract_first()
+        # The main information is in a JavaScript call
+        javascript = response.xpath(
+            '//script[@type="text/javascript" and contains(text(), "mainMap(")]/text()'
+        ).re_first("mainMap\((.*)\);")
+        map_data = json.loads(javascript)
+        for shop in map_data:
+            name = shop["title"]
+            yield Feature(
+                {
+                    "ref": shop["id"],
+                    "name": name,
+                    "addr_full": shop["address"].strip(),
+                    "country": shop["state"],
+                    "lat": shop["latitude"],
+                    "lon": shop["longitude"],
+                    "email": shop["email"],
+                    "phone": phone[name],
+                    "website": response.urljoin(website[name]),
+                }
+            )


### PR DESCRIPTION
Add [FitActive](https://www.fitactive.it/), a fitness chain from IT.

141 locations are in IT (of which 2 with invalid coordinates), but also 2 in RO, 1 in ES and 1 in BR.

```
2024-11-20 21:30:27 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/FitActive': 145,
 'atp/brand_wikidata/Q123807531': 145,
 'atp/category/leisure/fitness_centre': 145,
 'atp/field/branch/missing': 145,
 'atp/field/city/missing': 145,
 'atp/field/country/from_website_url': 143,
 'atp/field/image/missing': 145,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 145,
 'atp/field/operator/missing': 145,
 'atp/field/operator_wikidata/missing': 145,
 'atp/field/phone/invalid': 3,
 'atp/field/postcode/missing': 145,
 'atp/field/state/missing': 145,
 'atp/field/street_address/missing': 145,
 'atp/field/twitter/missing': 145,
 'atp/item_scraped_host_count/www.fitactive.it': 145,
 'atp/nsi/perfect_match': 145,
```