### PR TITLE
[Dangerfield] Fix Spider

### DIFF
--- a/locations/spiders/dangerfield.py
+++ b/locations/spiders/dangerfield.py
@@ -1,5 +1,3 @@
-import re
-
 from locations.hours import OpeningHours
 from locations.storefinders.stockist import StockistSpider
 
@@ -15,5 +13,6 @@ class DangerfieldSpider(StockistSpider):
         else:
             item["country"] = "AU"
         item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_ranges_from_string(re.sub(r"\s+", " ", location.get("description")))
+        if location.get("description"):
+            item["opening_hours"].add_ranges_from_string(location.get("description"))
         yield item


### PR DESCRIPTION
`Fixes : added condition to opening_hours to fix spider`

{'atp/brand/Dangerfield': 63,
 'atp/brand_wikidata/Q119220880': 63,
 'atp/category/shop/clothes': 63,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 63,
 'atp/field/email/missing': 63,
 'atp/field/image/missing': 63,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 63,
 'atp/field/operator_wikidata/missing': 63,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 7,
 'atp/field/twitter/missing': 63,
 'atp/field/website/missing': 61,
 'atp/item_scraped_host_count/stockist.co': 63,
 'atp/nsi/perfect_match': 63,
 'downloader/request_bytes': 636,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 9674,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.473074,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 21, 9, 59, 12, 316090, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 67707,
 'httpcompression/response_count': 2,
 'item_scraped_count': 63,
 'log_count/DEBUG': 76,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 21, 9, 59, 8, 843016, tzinfo=datetime.timezone.utc)}
