### PR TITLE
[Pioneer CA] Add spider

### DIFF
--- a/locations/spiders/pioneer_ca.py
+++ b/locations/spiders/pioneer_ca.py
@@ -1,0 +1,29 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class PioneerCASpider(SitemapSpider, StructuredDataSpider):
+    name = "pioneer_ca"
+    item_attributes = {"brand": "Pioneer", "brand_wikidata": "Q7196684"}
+    sitemap_urls = ["https://www.pioneer.ca/sitemap-stores.xml"]
+    sitemap_rules = [(r"/en/find-station/[^/]+/[^/]+/$", "parse")]
+    wanted_types = ["GasStation"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["name"] = None
+
+        services = response.xpath('//h4[@class="station__icons-list-icon-title"]/text()').getall()
+        apply_yes_no(Extras.ATM, item, "ATM" in services)
+        apply_yes_no(Fuel.DIESEL, item, "Diesel" in services)
+        apply_yes_no(Extras.SELF_CHECKOUT, item, "Pay at pump" in services)
+
+        if "Open 24h" in services:
+            item["opening_hours"] = "24/7"
+
+        apply_category(Categories.FUEL_STATION, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Pioneer': 214,
 'atp/brand_wikidata/Q7196684': 214,
 'atp/category/amenity/fuel': 214,
 'atp/cdn/cloudflare/response_count': 216,
 'atp/cdn/cloudflare/response_status_count/200': 216,
 'atp/field/branch/missing': 214,
 'atp/field/country/from_spider_name': 214,
 'atp/field/email/missing': 214,
 'atp/field/image/missing': 214,
 'atp/field/opening_hours/missing': 214,
 'atp/field/operator/missing': 214,
 'atp/field/operator_wikidata/missing': 214,
 'atp/item_scraped_host_count/www.pioneer.ca': 214,
 'atp/nsi/cc_match': 214,
 'downloader/request_bytes': 133397,
 'downloader/request_count': 216,
 'downloader/request_method_count/GET': 216,
 'downloader/response_bytes': 1093351,
 'downloader/response_count': 216,
 'downloader/response_status_count/200': 216,
 'elapsed_time_seconds': 1.471654,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 24, 9, 16, 3, 825558, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 216,
 'httpcompression/response_bytes': 3472770,
 'httpcompression/response_count': 216,
 'item_scraped_count': 214,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 257105920,
 'memusage/startup': 257105920,
 'request_depth_max': 1,
 'response_received_count': 216,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 215,
 'scheduler/dequeued/memory': 215,
 'scheduler/enqueued': 215,
 'scheduler/enqueued/memory': 215,
 'start_time': datetime.datetime(2024, 11, 24, 9, 16, 2, 353904, tzinfo=datetime.timezone.utc)}
```