### PR TITLE
[pennsylvania_dot_us] add 1321 cameras in Pennsylvania

### DIFF
--- a/locations/spiders/pennsylvania_dot_us.py
+++ b/locations/spiders/pennsylvania_dot_us.py
@@ -1,0 +1,19 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.spiders.nevada_dot_us import NevadaDotUSSpider
+
+
+class PennsylvaniaDotUSSpider(NevadaDotUSSpider):
+    name = "pennsylvania_dot_us"
+    item_attributes = {"operator": "Pennsylvania DOT", "operator_wikidata": "Q5569650"}
+    start_urls = ["https://www.511pa.com/map/mapIcons/Cameras"]
+
+    # TODO: better solved with a "dot_pa_us.py" naming convention and handled in pipeline?
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # make sure state is PA, some get mis-coded.
+        for item in super().post_process_item(item, response, feature):
+            item["state"] = "PA"
+            yield item


### PR DESCRIPTION
@iandees here's another one and I'd like your view on us extending the pipeline code to handle a naming convention of `_state_country.py` i.e. here I would suggest `dot_pa_us.py`. The pipeline in the rare case that we did not want it to stamp out the state / country if not already set could be disabled i.e. `skip_auto_cc_spider_name`. The US is where this works well and it would enable things like:

``
$ ls locations/spiders/*_al_us.py
``

.. the more we organise the spiders by convention the better? Let me know what you think and I am happy to work something up either in this PR or outside it.