### PR TITLE
[DavidsTea] Fix spider

### DIFF
--- a/locations/spiders/davids_tea.py
+++ b/locations/spiders/davids_tea.py
@@ -1,17 +1,31 @@
-from scrapy.spiders import SitemapSpider
+import json
+import re
+from typing import Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy import Selector
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import clean_address
 
 
-class DavidsTeaSpider(SitemapSpider, StructuredDataSpider):
+class DavidsTeaSpider(JSONBlobSpider):
     name = "davids_tea"
     item_attributes = {"brand": "David's Tea", "brand_wikidata": "Q3019129"}
-    allowed_domains = [
-        "locations.davidstea.com",
-    ]
-    sitemap_urls = ["https://locations.davidstea.com/robots.txt"]
-    sitemap_rules = [("", "parse_sd")]
+    start_urls = ["https://davidstea.com/apps/store-locator/"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def extract_json(self, response: Response) -> list:
+        return [
+            json.loads(store)
+            for store in re.findall(
+                r"markersCoords.push\(({\".+?)\);",
+                response.xpath('//script[contains(text(),"markersCoords")]/text()').get(""),
+            )
+        ]
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        store_info = Selector(text=item.pop("addr_full"))
+        item["street_address"] = clean_address(store_info.xpath('//*[contains(@class, "address")]/text()').getall())
         item["website"] = response.url
         yield item

--- a/locations/spiders/davids_tea.py
+++ b/locations/spiders/davids_tea.py
@@ -26,6 +26,11 @@ class DavidsTeaSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         store_info = Selector(text=item.pop("addr_full"))
+        item["branch"] = store_info.xpath('//*[@class="name"]/text()').get("").strip()
         item["street_address"] = clean_address(store_info.xpath('//*[contains(@class, "address")]/text()').getall())
+        item["city"] = store_info.xpath('//*[@class="city"]/text()').get()
+        item["state"] = store_info.xpath('//*[@class="prov_state"]/text()').get()
+        item["postcode"] = store_info.xpath('//*[@class="postal_zip"]/text()').get()
+        item["country"] = store_info.xpath('//*[@class="country"]/text()').get()
         item["website"] = response.url
         yield item


### PR DESCRIPTION
`Sitemap` and `Structured Data` are no longer available. Hence, code refactored to fix the spider.

```
{"atp/brand/David's Tea": 20,
 'atp/brand_wikidata/Q3019129': 20,
 'atp/category/shop/tea': 20,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 20,
 'atp/field/image/missing': 20,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 20,
 'atp/field/operator_wikidata/missing': 20,
 'atp/field/phone/missing': 20,
 'atp/field/state/from_reverse_geocoding': 20,
 'atp/field/twitter/missing': 20,
 'atp/item_scraped_host_count/davidstea.com': 20,
 'atp/nsi/perfect_match': 20,
 'downloader/request_bytes': 1428,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 73296,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.633524,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 26, 12, 28, 42, 105549, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 299101,
 'httpcompression/response_count': 2,
 'item_scraped_count': 20,
 'log_count/DEBUG': 33,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 11, 26, 12, 28, 37, 472025, tzinfo=datetime.timezone.utc)}
```