### PR TITLE
[GalitosZA] Fix Spider

### DIFF
--- a/locations/storefinders/go_review_api.py
+++ b/locations/storefinders/go_review_api.py
@@ -33,8 +33,9 @@ class GoReviewApiSpider(JSONBlobSpider):
 
     def parse_feature_array(self, response: Response, feature_array: list) -> Iterable[Feature]:
         for feature in feature_array:
-            if feature.get("trading_status") == True and feature.get("trading_status") != "Open":
-                continue
+            if feature.get("trading_status"):
+                if feature.get("trading_status") != "Open":
+                    continue
             self.pre_process_data(feature)
             item = DictParser.parse(feature)
 

--- a/locations/storefinders/go_review_api.py
+++ b/locations/storefinders/go_review_api.py
@@ -41,7 +41,7 @@ class GoReviewApiSpider(JSONBlobSpider):
 
             item["website"] = feature["local_page_url"]
 
-            if item.get("attributes") is not None:
+            if feature.get("attributes") is not None:
                 apply_yes_no(Extras.DELIVERY, item, "Delivery" in feature.get("attributes"))
                 apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive-through" in feature.get("attributes"))
                 apply_yes_no(Extras.TAKEAWAY, item, "Takeaway" in feature.get("attributes"))

--- a/locations/storefinders/go_review_api.py
+++ b/locations/storefinders/go_review_api.py
@@ -33,7 +33,7 @@ class GoReviewApiSpider(JSONBlobSpider):
 
     def parse_feature_array(self, response: Response, feature_array: list) -> Iterable[Feature]:
         for feature in feature_array:
-            if feature["trading_status"] != "Open":
+            if feature.get("trading_status") == True and feature.get("trading_status") != "Open":
                 continue
             self.pre_process_data(feature)
             item = DictParser.parse(feature)


### PR DESCRIPTION
`Fixes : updated go_review_api module to fix galitos_za spider`

{"atp/brand/Galito's": 177,
'atp/brand_wikidata/Q116619555': 177,
'atp/category/amenity/fast_food': 177,
'atp/field/city/missing': 177,
'atp/field/country/from_spider_name': 177,
'atp/field/email/missing': 177,
'atp/field/opening_hours/missing': 177,
'atp/field/operator/missing': 177,
'atp/field/operator_wikidata/missing': 177,
'atp/field/phone/missing': 177,
'atp/field/postcode/missing': 177,
'atp/field/state/missing': 177,
'atp/field/street_address/missing': 177,
'atp/field/twitter/missing': 177,
'atp/item_scraped_host_count/admin.goreview.co.za': 177,
'atp/nsi/perfect_match': 177,
'downloader/request_bytes': 501,
'downloader/request_count': 1,
'downloader/request_method_count/POST': 1,
'downloader/response_bytes': 51101,
'downloader/response_count': 1,
'downloader/response_status_count/200': 1,
'elapsed_time_seconds': 2.615207,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2024, 11, 27, 6, 18, 8, 479300, tzinfo=datetime.timezone.utc),
'item_scraped_count': 177,
'log_count/DEBUG': 209,
'log_count/INFO': 9,
'response_received_count': 1,
'scheduler/dequeued': 1,
'scheduler/dequeued/memory': 1,
'scheduler/enqueued': 1,
'scheduler/enqueued/memory': 1,
'start_time': datetime.datetime(2024, 11, 27, 6, 18, 5, 864093, tzinfo=datetime.timezone.utc)}