### PR TITLE
[FarmhouseInns] Fix Spider

### DIFF
--- a/locations/spiders/farmhouse_inns.py
+++ b/locations/spiders/farmhouse_inns.py
@@ -1,17 +1,15 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FarmhouseInnsSpider(SitemapSpider):
+class FarmhouseInnsSpider(SitemapSpider, StructuredDataSpider):
     name = "farmhouse_inns"
     item_attributes = {
         "brand": "Farmhouse Inns",
         "brand_wikidata": "Q105504972",
         "country": "GB",
     }
-    sitemap_urls = ["https://www.farmhouseinns.co.uk/xml-sitemap"]
-    sitemap_rules = [(r"https:\/\/www\.farmhouseinns\.co\.uk\/pubs\/([-\w]+)\/([-\w]+)\/$", "parse")]
-
-    def parse(self, response):
-        yield LinkedDataParser.parse(response, "BarOrPub")
+    sitemap_urls = ["https://www.farmhouseinns.co.uk/sitemap.xml"]
+    sitemap_rules = [(r"https:\/\/www\.farmhouseinns\.co\.uk\/pubs\/([-\w]+)\/([-\w]+)$", "parse_sd")]
+    wanted_types = ["BarOrPub"]

--- a/locations/spiders/farmhouse_inns_gb.py
+++ b/locations/spiders/farmhouse_inns_gb.py
@@ -3,7 +3,7 @@ from scrapy.spiders import SitemapSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class FarmhouseInnsSpider(SitemapSpider, StructuredDataSpider):
+class FarmhouseInnsGBSpider(SitemapSpider, StructuredDataSpider):
     name = "farmhouse_inns_gb"
     item_attributes = {"brand": "Farmhouse Inns", "brand_wikidata": "Q105504972"}
     sitemap_urls = ["https://www.farmhouseinns.co.uk/sitemap.xml"]

--- a/locations/spiders/farmhouse_inns_gb.py
+++ b/locations/spiders/farmhouse_inns_gb.py
@@ -4,12 +4,8 @@ from locations.structured_data_spider import StructuredDataSpider
 
 
 class FarmhouseInnsSpider(SitemapSpider, StructuredDataSpider):
-    name = "farmhouse_inns"
-    item_attributes = {
-        "brand": "Farmhouse Inns",
-        "brand_wikidata": "Q105504972",
-        "country": "GB",
-    }
+    name = "farmhouse_inns_gb"
+    item_attributes = {"brand": "Farmhouse Inns", "brand_wikidata": "Q105504972"}
     sitemap_urls = ["https://www.farmhouseinns.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.farmhouseinns\.co\.uk\/pubs\/([-\w]+)\/([-\w]+)$", "parse_sd")]
+    sitemap_rules = [(r"/pubs/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["BarOrPub"]


### PR DESCRIPTION
`Fixes : updated sitemap_url and sitemap_rules to fix spider`

{'atp/brand/Farmhouse Inns': 66,
 'atp/brand_wikidata/Q105504972': 66,
 'atp/category/amenity/restaurant': 66,
 'atp/field/branch/missing': 66,
 'atp/field/city/missing': 66,
 'atp/field/operator/missing': 66,
 'atp/field/operator_wikidata/missing': 66,
 'atp/field/state/missing': 66,
 'atp/field/street_address/missing': 66,
 'atp/field/twitter/missing': 66,
 'atp/item_scraped_host_count/www.farmhouseinns.co.uk': 66,
 'atp/nsi/perfect_match': 66,
 'downloader/request_bytes': 38785,
 'downloader/request_count': 68,
 'downloader/request_method_count/GET': 68,
 'downloader/response_bytes': 2785197,
 'downloader/response_count': 68,
 'downloader/response_status_count/200': 68,
 'elapsed_time_seconds': 83.358586,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 28, 7, 30, 19, 637162, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10015768,
 'httpcompression/response_count': 68,
 'item_scraped_count': 66,
 'log_count/DEBUG': 145,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 68,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 67,
 'scheduler/dequeued/memory': 67,
 'scheduler/enqueued': 67,
 'scheduler/enqueued/memory': 67,
 'start_time': datetime.datetime(2024, 11, 28, 7, 28, 56, 278576, tzinfo=datetime.timezone.utc)}