### PR TITLE
[Fatface] Fix spider

### DIFF
--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -37,4 +37,5 @@ class FatfaceSpider(CrawlSpider):
                 item["phone"] = address[-1]
                 address = address[:-1]
             item["addr_full"] = clean_address(address)
+            item["country"] = response.url.split("/")[3]
             yield item

--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -38,4 +38,5 @@ class FatfaceSpider(CrawlSpider):
                 address = address[:-1]
             item["addr_full"] = clean_address(address)
             item["country"] = response.url.split("/")[3]
+            item["website"] = response.url
             yield item

--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -1,41 +1,40 @@
+import re
+from typing import Any
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Request, Rule
 
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from locations.hours import DAYS_3_LETTERS
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 
 
 class FatfaceSpider(CrawlSpider):
     name = "fatface"
     item_attributes = {"brand": "FATFACE", "brand_wikidata": "Q5437186"}
-    allowed_domains = ["www.fatface.com", "us.fatface.com"]
-    start_urls = [
-        "https://www.fatface.com/stores",  # GB
-        "https://us.fatface.com/stores",  # US and CA
-        "https://www.fatface.com/international/stores",  # IE
-    ]
+    start_urls = ["https://www.fatface.com/countryselect"]
     rules = [
-        Rule(LinkExtractor(allow="/store/"), callback="parse", follow=False),
-        Rule(LinkExtractor(allow="/international/store/"), callback="parse", follow=False),
+        Rule(LinkExtractor(allow="https://www.fatface.com/[a-z]{2}/en"), callback="parse"),
     ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
-        for url in self.start_urls:
-            if "/international/" in url:
-                yield Request(url=url, cookies={"selectedLocale": "en_IE"})
-            elif "us.fatface.com" in url:
-                yield Request(url=url, cookies={"selectedLocale": "en_US"})
-            else:
-                yield Request(url)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield Request(url=f'{response.url.strip("/")}/store-locator', callback=self.parse_stores)
 
-    def parse(self, response):
-        MicrodataParser.convert_to_json_ld(response.selector)
-        item = LinkedDataParser.parse(response, "Store")
-        if item:
-            item["ref"] = response.url
-            item["name"] = item["name"].strip()
-            item["lat"] = response.xpath("//@data-latitude").get()
-            item["lon"] = response.xpath("//@data-longitude").get()
-            item.pop("image")
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.xpath('//li[@class="vs-store"]'):
+            item = Feature()
+            item["ref"] = item["branch"] = store.xpath(".//button/strong/text()").get()
+            store_details = store.xpath('.//*[@class="vs-store-address"]/text()').getall()
+            hours_start_index = len(store_details)
+            for index, info in enumerate(store_details):
+                if any(day in info for day in DAYS_3_LETTERS):
+                    hours_start_index = index
+                    break
+            address = store_details[:hours_start_index]
+            # check for phone
+            if not re.search(r"[A-Za-z]+", address[-1]):
+                item["phone"] = address[-1]
+                address = address[:-1]
+            item["addr_full"] = clean_address(address)
             yield item

--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -5,7 +5,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Request, Rule
 
-from locations.hours import DAYS_3_LETTERS
+from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
@@ -39,4 +39,8 @@ class FatfaceSpider(CrawlSpider):
             item["ref"] = item["addr_full"] = clean_address(address)
             item["country"] = response.url.split("/")[3]
             item["website"] = response.url
+            if hours_start_index < len(store_details):
+                item["opening_hours"] = OpeningHours()
+                for rule in store_details[hours_start_index:]:
+                    item["opening_hours"].add_ranges_from_string(rule)
             yield item

--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -15,7 +15,7 @@ class FatfaceSpider(CrawlSpider):
     item_attributes = {"brand": "FATFACE", "brand_wikidata": "Q5437186"}
     start_urls = ["https://www.fatface.com/countryselect"]
     rules = [
-        Rule(LinkExtractor(allow="https://www.fatface.com/[a-z]{2}/en"), callback="parse"),
+        Rule(LinkExtractor(allow=r"https://www.fatface.com/[a-z]{2}/en"), callback="parse"),
     ]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/fatface.py
+++ b/locations/spiders/fatface.py
@@ -24,7 +24,7 @@ class FatfaceSpider(CrawlSpider):
     def parse_stores(self, response: Response, **kwargs: Any) -> Any:
         for store in response.xpath('//li[@class="vs-store"]'):
             item = Feature()
-            item["ref"] = item["branch"] = store.xpath(".//button/strong/text()").get()
+            item["branch"] = store.xpath(".//button/strong/text()").get()
             store_details = store.xpath('.//*[@class="vs-store-address"]/text()').getall()
             hours_start_index = len(store_details)
             for index, info in enumerate(store_details):
@@ -36,7 +36,7 @@ class FatfaceSpider(CrawlSpider):
             if not re.search(r"[A-Za-z]+", address[-1]):
                 item["phone"] = address[-1]
                 address = address[:-1]
-            item["addr_full"] = clean_address(address)
+            item["ref"] = item["addr_full"] = clean_address(address)
             item["country"] = response.url.split("/")[3]
             item["website"] = response.url
             yield item

--- a/locations/spiders/fatface_gb.py
+++ b/locations/spiders/fatface_gb.py
@@ -3,6 +3,7 @@ from typing import Any
 from scrapy import Request
 from scrapy.http import Response
 
+from locations.items import Feature
 from locations.spiders.fatface import FatfaceSpider
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -18,3 +19,9 @@ class FatfaceGBSpider(StructuredDataSpider):
             yield Request(
                 url=response.urljoin(slug).replace("/data", ""), callback=self.parse_sd, meta=dict(store_info=store)
             )
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        store = response.meta["store_info"]
+        item["lat"] = store.get("LT")
+        item["lon"] = store.get("LN")
+        yield item

--- a/locations/spiders/fatface_gb.py
+++ b/locations/spiders/fatface_gb.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.spiders.fatface import FatfaceSpider
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class FatfaceGBSpider(StructuredDataSpider):
+    name = "fatface_gb"
+    item_attributes = FatfaceSpider.item_attributes
+    start_urls = ["https://www.fatface.com/storelocator/data/stores"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["Stores"]:
+            slug = f'{store["NA"].replace(" ", "").lower()}/{store["BR"]}'
+            yield Request(
+                url=response.urljoin(slug).replace("/data", ""), callback=self.parse_sd, meta=dict(store_info=store)
+            )

--- a/locations/spiders/fatface_gb.py
+++ b/locations/spiders/fatface_gb.py
@@ -22,6 +22,7 @@ class FatfaceGBSpider(StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         store = response.meta["store_info"]
+        item["ref"] = store.get("BR")
         item["lat"] = store.get("LT")
         item["lon"] = store.get("LN")
         yield item

--- a/locations/spiders/fatface_gb.py
+++ b/locations/spiders/fatface_gb.py
@@ -25,4 +25,5 @@ class FatfaceGBSpider(StructuredDataSpider):
         item["ref"] = store.get("BR")
         item["lat"] = store.get("LT")
         item["lon"] = store.get("LN")
+        item["branch"] = item.pop("name").split("-")[0].strip()
         yield item


### PR DESCRIPTION
Fix done by splitting into two separate spiders one for [GB](https://www.fatface.com/storelocator) and another for rest of the countries (currently only [US](https://www.fatface.com/us/en/store-locator) and [IE](https://www.fatface.com/ie/en/store-locator) is there), because they need different approach. `coordinates` are available only for `GB` spider.
`GB`:
```
{'atp/brand/FATFACE': 183,
 'atp/brand_wikidata/Q5437186': 183,
 'atp/category/shop/clothes': 183,
 'atp/field/email/missing': 183,
 'atp/field/image/missing': 183,
 'atp/field/operator/missing': 183,
 'atp/field/operator_wikidata/missing': 183,
 'atp/field/state/missing': 183,
 'atp/field/street_address/missing': 1,
 'atp/item_scraped_host_count/www.fatface.com': 183,
 'atp/nsi/perfect_match': 183,
 'downloader/request_bytes': 279202,
 'downloader/request_count': 185,
 'downloader/request_method_count/GET': 185,
 'downloader/response_bytes': 8654755,
 'downloader/response_count': 185,
 'downloader/response_status_count/200': 185,
 'elapsed_time_seconds': 3.375071,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 29, 4, 16, 39, 213311, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 185,
 'httpcompression/response_bytes': 51754816,
 'httpcompression/response_count': 185,
 'item_scraped_count': 183,
 'log_count/DEBUG': 380,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 185,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 184,
 'scheduler/dequeued/memory': 184,
 'scheduler/enqueued': 184,
 'scheduler/enqueued/memory': 184,
 'start_time': datetime.datetime(2024, 11, 29, 4, 16, 35, 838240, tzinfo=datetime.timezone.utc)}
```
`US` & `IE`:
```
{'atp/brand/FATFACE': 62,
 'atp/brand_wikidata/Q5437186': 62,
 'atp/category/shop/clothes': 62,
 'atp/field/city/missing': 62,
 'atp/field/email/missing': 62,
 'atp/field/image/missing': 62,
 'atp/field/lat/missing': 62,
 'atp/field/lon/missing': 62,
 'atp/field/operator/missing': 62,
 'atp/field/operator_wikidata/missing': 62,
 'atp/field/phone/missing': 36,
 'atp/field/postcode/missing': 56,
 'atp/field/state/missing': 62,
 'atp/field/street_address/missing': 62,
 'atp/field/twitter/missing': 62,
 'atp/item_scraped_host_count/www.fatface.com': 62,
 'atp/nsi/perfect_match': 62,
 'downloader/request_bytes': 6512,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 206346,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 8.064635,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 29, 4, 10, 16, 977988, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 6,
 'httpcache/miss': 6,
 'httpcache/store': 6,
 'httpcompression/response_bytes': 1223228,
 'httpcompression/response_count': 6,
 'item_scraped_count': 62,
 'log_count/DEBUG': 80,
 'log_count/INFO': 10,
 'request_depth_max': 2,
 'response_received_count': 6,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2024, 11, 29, 4, 10, 8, 913353, tzinfo=datetime.timezone.utc)}
```
