### PR TITLE
[Frischs] Fix spider

### DIFF
--- a/locations/spiders/frischs.py
+++ b/locations/spiders/frischs.py
@@ -16,3 +16,4 @@ class FrischsSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"/\d+/$", "parse_sd"),
     ]
+    json_parser = "chompjs"

--- a/locations/spiders/frischs.py
+++ b/locations/spiders/frischs.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -17,3 +19,8 @@ class FrischsSpider(SitemapSpider, StructuredDataSpider):
         (r"/\d+/$", "parse_sd"),
     ]
     json_parser = "chompjs"
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        name = item.pop("name").split(" ", 1)  # remove store id from branch name
+        item["branch"] = name[1] if len(name) > 1 else name
+        yield item

--- a/locations/spiders/frischs_us.py
+++ b/locations/spiders/frischs_us.py
@@ -5,8 +5,8 @@ from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class FrischsSpider(SitemapSpider, StructuredDataSpider):
-    name = "frischs"
+class FrischsUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "frischs_us"
     item_attributes = {
         "brand": "Frisch's Big Boy",
         "brand_wikidata": "Q5504660",


### PR DESCRIPTION
There was some issue with `ld+json`  parsing due to that spider was failing, used  `chompjs` as a `json_parser` to fix the spider.
`downloader/response_status_count/302': 34`  too many redirects, investigated few links, they no longer are valid store pages, that's why redirecting.

```
{"atp/brand/Frisch's Big Boy": 54,
 'atp/brand_wikidata/Q5504660': 54,
 'atp/category/amenity/restaurant': 54,
 'atp/field/email/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/item_scraped_host_count/locations.frischs.com': 54,
 'atp/nsi/perfect_match': 54,
 'downloader/request_bytes': 39346,
 'downloader/request_count': 99,
 'downloader/request_method_count/GET': 99,
 'downloader/response_bytes': 2654641,
 'downloader/response_count': 99,
 'downloader/response_status_count/200': 65,
 'downloader/response_status_count/302': 34,
 'dupefilter/filtered': 16,
 'elapsed_time_seconds': 122.236327,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 11, 29, 10, 48, 25, 996869, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10102629,
 'httpcompression/response_count': 65,
 'item_scraped_count': 54,
 'log_count/DEBUG': 165,
 'log_count/INFO': 12,
 'request_depth_max': 2,
 'response_received_count': 65,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 98,
 'scheduler/dequeued/memory': 98,
 'scheduler/enqueued': 98,
 'scheduler/enqueued/memory': 98,
 'start_time': datetime.datetime(2024, 11, 29, 10, 46, 23, 760542, tzinfo=datetime.timezone.utc)}
```