### PR TITLE
[cdnstats middleware] count CloudFront

### DIFF
--- a/locations/middlewares/cdnstats.py
+++ b/locations/middlewares/cdnstats.py
@@ -17,4 +17,7 @@ class CDNStatsMiddleware:
         elif response.headers.get(b"Server") == b"AkamaiGHost":
             self.crawler.stats.inc_value("atp/cdn/akamai/response_count")
             self.crawler.stats.inc_value(f"atp/cdn/akamai/response_status_count/{response.status}")
+        elif response.headers.get(b"Server") == b"CloudFront":
+            self.crawler.stats.inc_value("atp/cdn/cloudfront/response_count")
+            self.crawler.stats.inc_value(f"atp/cdn/cloudfront/response_status_count/{response.status}")
         return response


### PR DESCRIPTION
While looking at starbucks_ar_cl which doesn't run from my location but works on weeklys I noticed that this website is under CloudFront CDN. It would be interesting to see stats for it.