### PR TITLE
[brillen_de] Add spider (198 locations)

### DIFF
--- a/locations/spiders/brillen_de.py
+++ b/locations/spiders/brillen_de.py
@@ -1,0 +1,38 @@
+from typing import Any, Iterable
+
+import scrapy
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.geo import point_locations
+from locations.items import Feature
+
+
+class BrillenDESpider(scrapy.Spider):
+
+    name = "brillen_de"
+    item_attributes = {"brand": "brillen.de", "brand_wikidata": "Q105275794"}
+
+    def start_requests(self):
+        for lat, lon in point_locations("eu_centroids_40km_radius_country.csv", "DE"):
+            # The api has some unknown maximum radius and doesn't respect
+            # arbitrarily large radius values, so we use a latlng grid
+            yield JsonRequest(
+                f"https://cal.supervista.de/public/store/nearby?longitude={lon}&latitude={lat}&radius=99999999&unit=km&limit=10000",
+                headers={"X-Country-Code": "de"},
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for location in response.json()["data"]["stores"]:
+
+            # They also have "normal" opticians as partner stores. We're only
+            # interested in their own branded shops.
+            if location["store_name"].startswith("brillen.de"):
+                location["name"] = location.pop("store_name")
+                location["ref"] = location.pop("store_id")
+                location["postcode"] = location.pop("zip")
+                location["street_address"] = location.pop("street")
+                location["country"] = "DE"
+                item = DictParser.parse(location)
+
+                yield item

--- a/locations/spiders/brillen_de.py
+++ b/locations/spiders/brillen_de.py
@@ -14,7 +14,7 @@ class BrillenDESpider(scrapy.Spider):
     item_attributes = {"brand": "brillen.de", "brand_wikidata": "Q105275794"}
 
     def start_requests(self):
-        for lat, lon in point_locations("eu_centroids_40km_radius_country.csv", "DE"):
+        for lat, lon in point_locations("eu_centroids_120km_radius_country.csv", "DE"):
             # The api has some unknown maximum radius and doesn't respect
             # arbitrarily large radius values, so we use a latlng grid
             yield JsonRequest(
@@ -28,11 +28,13 @@ class BrillenDESpider(scrapy.Spider):
             # They also have "normal" opticians as partner stores. We're only
             # interested in their own branded shops.
             if location["store_name"].startswith("brillen.de"):
-                location["name"] = location.pop("store_name")
                 location["ref"] = location.pop("store_id")
                 location["postcode"] = location.pop("zip")
                 location["street_address"] = location.pop("street")
                 location["country"] = "DE"
                 item = DictParser.parse(location)
+                item["branch"] = item.pop("name").removeprefix("brillen.de ")
+                item["housenumber"] = location["street2"]
+                item["street"] = location["street1"]
 
                 yield item


### PR DESCRIPTION
Add [brillen.de](https://www.brillen.de/), an optician chain in DE.

```
2024-12-02 00:39:12 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/brillen.de': 198,
 'atp/brand_wikidata/Q105275794': 198,
 'atp/category/shop/optician': 198,
 'atp/field/branch/missing': 198,
 'atp/field/image/missing': 198,
 'atp/field/opening_hours/missing': 198,
 'atp/field/operator/missing': 198,
 'atp/field/operator_wikidata/missing': 198,
 'atp/field/phone/missing': 14,
 'atp/field/state/missing': 6,
 'atp/field/twitter/missing': 198,
 'atp/field/website/missing': 198,
 'atp/item_scraped_host_count/cal.supervista.de': 30353,
 'atp/nsi/perfect_match': 198,
```