### PR TITLE
[Cinemark] Fix coords

### DIFF
--- a/locations/spiders/cinemark.py
+++ b/locations/spiders/cinemark.py
@@ -1,35 +1,30 @@
 from urllib.parse import parse_qs, urlparse
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.items import set_closed
-from locations.linked_data_parser import LinkedDataParser
+from locations.items import Feature, set_closed
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CinemarkSpider(SitemapSpider):
+class CinemarkSpider(SitemapSpider, StructuredDataSpider):
     name = "cinemark"
     item_attributes = {"brand": "Cinemark", "brand_wikidata": "Q707530"}
     allowed_domains = ["cinemark.com"]
     sitemap_urls = ["https://www.cinemark.com/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/www\.cinemark\.com\/theatres\/.",
-            "parse",
-        ),
-    ]
+    sitemap_rules = [(r"/theatres/[^/]+/[^/]+$", "parse")]
+    wanted_types = ["MovieTheater"]
     download_delay = 10  # Requested by robots.txt
 
-    def parse(self, response):
-        item = LinkedDataParser.parse(response, "MovieTheater")
-
-        if item is None:
-            return
-
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["ref"] = "/".join(response.url.rsplit("/")[-2:])
-        item["lat"], item["lon"] = parse_qs(
-            urlparse(response.css(".theatreInfoCollapseMap").xpath("//a/img/@data-src").extract_first()).query
-        )["pp"][0].split(",")
-
+        item["lat"], item["lon"] = (
+            parse_qs(
+                urlparse(response.xpath('//img[contains(@data-src, "dev.virtualearth.net")]/@data-src').get()).query
+            )["pp"][0]
+            .split(";", 1)[0]
+            .split(",")
+        )
         if item["name"].endswith(" - NOW CLOSED"):
             set_closed(item)
 


### PR DESCRIPTION
```python
{'atp/brand/Cinemark': 329,
 'atp/brand_wikidata/Q707530': 329,
 'atp/category/amenity/cinema': 329,
 'atp/cdn/cloudflare/response_count': 332,
 'atp/cdn/cloudflare/response_status_count/200': 332,
 'atp/closed_poi': 21,
 'atp/field/branch/missing': 329,
 'atp/field/email/invalid': 28,
 'atp/field/email/missing': 29,
 'atp/field/image/missing': 329,
 'atp/field/opening_hours/missing': 329,
 'atp/field/operator/missing': 329,
 'atp/field/operator_wikidata/missing': 329,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 29,
 'atp/item_scraped_host_count/www.cinemark.com': 329,
 'atp/nsi/perfect_match': 329,
 'downloader/request_bytes': 333967,
 'downloader/request_count': 334,
 'downloader/request_method_count/GET': 334,
 'downloader/response_bytes': 11601163,
 'downloader/response_count': 334,
 'downloader/response_status_count/200': 332,
 'downloader/response_status_count/307': 2,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 3646.578029,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 2, 17, 8, 4, 720208, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 297,
 'httpcache/hit': 37,
 'httpcache/miss': 297,
 'httpcache/store': 297,
 'httpcompression/response_bytes': 109295366,
 'httpcompression/response_count': 332,
 'item_scraped_count': 329,
 'log_count/DEBUG': 678,
 'log_count/INFO': 69,
 'memusage/max': 464584704,
 'memusage/startup': 185122816,
 'request_depth_max': 1,
 'response_received_count': 332,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 333,
 'scheduler/dequeued/memory': 333,
 'scheduler/enqueued': 333,
 'scheduler/enqueued/memory': 333,
 'start_time': datetime.datetime(2024, 12, 2, 16, 7, 18, 142179, tzinfo=datetime.timezone.utc)}
```