### PR TITLE
[Homesense] Fix Spider

### DIFF
--- a/locations/spiders/homesense.py
+++ b/locations/spiders/homesense.py
@@ -1,11 +1,47 @@
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Any
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class HomesenseSpider(SitemapSpider, StructuredDataSpider):
+class HomesenseSpider(CrawlSpider):
     name = "homesense"
     item_attributes = {"brand": "HomeSense", "brand_wikidata": "Q16844433"}
-    sitemap_urls = ["https://locations.us.homesense.com/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/locations\.us\.homesense\.com\/\w{2}\/[-\w]+$", "parse_sd")]
-    wanted_types = ["DepartmentStore"]
+    start_urls = ["https://us.homesense.com/all-stores"]
+    rules = [
+        Rule(
+            LinkExtractor(
+                allow="/store-details/",
+                deny=[
+                    "yonkers-ny-10710/0019",
+                    "totowa-nj-07512/0043",
+                    "paramus-nj-07652/0008",
+                    "mohegan-lake-ny-10547/0018",
+                ],
+            ),
+            callback="parse",
+        )
+    ]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # if "yonkers-ny-10710/0019" not in response.url or "totowa-nj-07512/0043" not in response.url:
+        item = Feature()
+        item["name"] = "-".join(
+            [
+                response.xpath('//*[@id="store-details-hero"]//h1/text()').get(),
+                response.xpath('//*[@id="store-details-hero"]//h1/text()').get(),
+            ]
+        )
+        item["addr_full"] = response.xpath('//*[@id="store-details-amenities"]//p').xpath("normalize-space()").get()
+        item["ref"] = item["website"] = response.url
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        item["lat"], item["lon"] = re.search(r"initMap\(([0-9-\.]+),\s*([0-9-\.]+)\);", response.text).groups()
+        item["opening_hours"] = OpeningHours()
+        yield item

--- a/locations/spiders/homesense.py
+++ b/locations/spiders/homesense.py
@@ -5,7 +5,6 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -31,7 +30,6 @@ class HomesenseSpider(CrawlSpider):
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        # if "yonkers-ny-10710/0019" not in response.url or "totowa-nj-07512/0043" not in response.url:
         item = Feature()
         item["name"] = "-".join(
             [
@@ -43,5 +41,4 @@ class HomesenseSpider(CrawlSpider):
         item["ref"] = item["website"] = response.url
         item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
         item["lat"], item["lon"] = re.search(r"initMap\(([0-9-\.]+),\s*([0-9-\.]+)\);", response.text).groups()
-        item["opening_hours"] = OpeningHours()
         yield item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/HomeSense': 67,
 'atp/brand_wikidata/Q16844433': 67,
 'atp/category/shop/interior_decoration': 67,
 'atp/field/branch/missing': 67,
 'atp/field/city/missing': 67,
 'atp/field/country/from_reverse_geocoding': 67,
 'atp/field/email/missing': 67,
 'atp/field/image/missing': 67,
 'atp/field/opening_hours/missing': 67,
 'atp/field/operator/missing': 67,
 'atp/field/operator_wikidata/missing': 67,
 'atp/field/postcode/missing': 67,
 'atp/field/street_address/missing': 67,
 'atp/field/twitter/missing': 67,
 'atp/item_scraped_host_count/us.homesense.com': 67,
 'atp/nsi/perfect_match': 67,
 'downloader/request_bytes': 105133,
 'downloader/request_count': 69,
 'downloader/request_method_count/GET': 69,
 'downloader/response_bytes': 1113507,
 'downloader/response_count': 69,
 'downloader/response_status_count/200': 68,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 88.476829,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 3, 15, 28, 32, 258987, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4830210,
 'httpcompression/response_count': 68,
 'item_scraped_count': 67,
 'log_count/DEBUG': 154,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 69,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 68,
 'scheduler/dequeued/memory': 68,
 'scheduler/enqueued': 68,
 'scheduler/enqueued/memory': 68,
 'start_time': datetime.datetime(2024, 12, 3, 15, 27, 3, 782158, tzinfo=datetime.timezone.utc)}