### PR TITLE
[Homesense] Fix Spider

### DIFF
--- a/locations/spiders/homesense.py
+++ b/locations/spiders/homesense.py
@@ -1,11 +1,44 @@
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Any
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class HomesenseSpider(SitemapSpider, StructuredDataSpider):
+class HomesenseSpider(CrawlSpider):
     name = "homesense"
     item_attributes = {"brand": "HomeSense", "brand_wikidata": "Q16844433"}
-    sitemap_urls = ["https://locations.us.homesense.com/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/locations\.us\.homesense\.com\/\w{2}\/[-\w]+$", "parse_sd")]
-    wanted_types = ["DepartmentStore"]
+    start_urls = ["https://us.homesense.com/all-stores"]
+    rules = [
+        Rule(
+            LinkExtractor(
+                allow="/store-details/",
+                deny=[
+                    "yonkers-ny-10710",
+                    "totowa-nj-07512",
+                    "paramus-nj-07652",
+                    "mohegan-lake-ny-10547",
+                ],
+            ),
+            callback="parse",
+        )
+    ]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["name"] = "-".join(
+            [
+                response.xpath('//*[@id="store-details-hero"]//h1/text()').get(),
+                response.xpath('//*[@id="store-details-hero"]//h2/text()').get(),
+            ]
+        )
+        item["addr_full"] = response.xpath('//*[@id="store-details-amenities"]//p').xpath("normalize-space()").get()
+        item["ref"] = item["website"] = response.url
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        item["lat"], item["lon"] = re.search(r"initMap\(([0-9-\.]+),\s*([0-9-\.]+)\);", response.text).groups()
+        yield item

--- a/locations/spiders/homesense_us.py
+++ b/locations/spiders/homesense_us.py
@@ -9,8 +9,8 @@ from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class HomesenseSpider(CrawlSpider):
-    name = "homesense"
+class HomesenseUSSpider(CrawlSpider):
+    name = "homesense_us"
     item_attributes = {"brand": "HomeSense", "brand_wikidata": "Q16844433"}
     start_urls = ["https://us.homesense.com/all-stores"]
     rules = [Rule(LinkExtractor(allow="/store-details/"), callback="parse")]


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/HomeSense': 67,
 'atp/brand_wikidata/Q16844433': 67,
 'atp/category/shop/interior_decoration': 67,
 'atp/field/branch/missing': 67,
 'atp/field/city/missing': 67,
 'atp/field/country/from_reverse_geocoding': 67,
 'atp/field/email/missing': 67,
 'atp/field/image/missing': 67,
 'atp/field/opening_hours/missing': 67,
 'atp/field/operator/missing': 67,
 'atp/field/operator_wikidata/missing': 67,
 'atp/field/postcode/missing': 67,
 'atp/field/street_address/missing': 67,
 'atp/field/twitter/missing': 67,
 'atp/item_scraped_host_count/us.homesense.com': 67,
 'atp/nsi/perfect_match': 67,
 'downloader/request_bytes': 104789,
 'downloader/request_count': 69,
 'downloader/request_method_count/GET': 69,
 'downloader/response_bytes': 1115053,
 'downloader/response_count': 69,
 'downloader/response_status_count/200': 68,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 86.561772,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 3, 16, 10, 22, 700726, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4830959,
 'httpcompression/response_count': 68,
 'item_scraped_count': 67,
 'log_count/DEBUG': 154,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 69,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 68,
 'scheduler/dequeued/memory': 68,
 'scheduler/enqueued': 68,
 'scheduler/enqueued/memory': 68,
 'start_time': datetime.datetime(2024, 12, 3, 16, 8, 56, 138954, tzinfo=datetime.timezone.utc)}