### PR TITLE
[skoda] Nullify Coordinate if not in correct country

### DIFF
--- a/locations/spiders/skoda.py
+++ b/locations/spiders/skoda.py
@@ -86,9 +86,7 @@ class SkodaSpider(scrapy.Spider):
             item["state"] = store["District"]
             item["country"] = response.meta["country_code"]
 
-            # Some of the coordinates have lat and lon switched. I noticed it in Austria.
-            # Thus if the country is different than the one returned by reverse geocoder, we nullify the coordinates.
-            # Chose nullification over switching because the sample I looked into even when switching back were not correct addresses were though
+            # Some of the coordinates have lat and lon switched and are usually bad.
             if result := reverse_geocoder.get((item["lat"], item["lon"]), mode=1, verbose=False):
                 if item["country"] != result["cc"]:
                     item["lon"] = None


### PR DESCRIPTION
I found in Austria that some of the latitude and longitudes were switched. I checked some of them and when I flip back they are in the country, but most were anywhere from 100 meters to 50 kilometers away from the actual point. All the addresses were correct though. I am not sure if this is a problem in other countries, but I added a check using the reverse geocoder and if the lat and lon are not in the correct country then nullify the coordinates.