### PR TITLE
[Golf Town CA] Fix Spider

### DIFF
--- a/locations/spiders/golf_town_ca.py
+++ b/locations/spiders/golf_town_ca.py
@@ -1,11 +1,10 @@
-from locations.storefinders.sweetiq import SweetIQSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class GolfTownCASpider(SweetIQSpider):
+class GolfTownCASpider(SitemapSpider, StructuredDataSpider):
     name = "golf_town_ca"
     item_attributes = {"brand": "Golf Town", "brand_wikidata": "Q112966691"}
-    start_urls = ["https://stores.golftown.com/"]
-
-    def parse_item(self, item, location):
-        item.pop("website")
-        yield item
+    sitemap_urls = ["https://locations.golftown.com/sitemap.xml"]
+    sitemap_rules = [(r"https://locations.golftown.com/golf-town-[-\w]+$", "parse_sd")]


### PR DESCRIPTION
API earlier used by spider is no longer working. Code refactored using `Sitemap` and `Structured Data`. Alternate [API](https://liveapi.yext.com/v2/accounts/me/entities/geosearch?radius=500&location=Canada&limit=50&api_key=0adeda99c3ae3befa04d7a409e35e26a&v=20181201&resolvePlaceholders=true&languages=en&entityTypes=location&savedFilterIds=117937) is also there.

```
{'atp/brand/Golf Town': 47,
 'atp/brand_wikidata/Q112966691': 47,
 'atp/category/shop/sports': 47,
 'atp/cdn/cloudflare/response_count': 49,
 'atp/cdn/cloudflare/response_status_count/200': 48,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/branch/missing': 47,
 'atp/field/country/from_spider_name': 47,
 'atp/field/operator/missing': 47,
 'atp/field/operator_wikidata/missing': 47,
 'atp/item_scraped_host_count/locations.golftown.com': 47,
 'atp/nsi/perfect_match': 47,
 'downloader/request_bytes': 26409,
 'downloader/request_count': 49,
 'downloader/request_method_count/GET': 49,
 'downloader/response_bytes': 2040948,
 'downloader/response_count': 49,
 'downloader/response_status_count/200': 48,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.515617,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 4, 6, 13, 54, 782167, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 49,
 'httpcompression/response_bytes': 15852582,
 'httpcompression/response_count': 49,
 'item_scraped_count': 47,
 'log_count/DEBUG': 108,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 49,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 48,
 'scheduler/dequeued/memory': 48,
 'scheduler/enqueued': 48,
 'scheduler/enqueued/memory': 48,
 'start_time': datetime.datetime(2024, 12, 4, 6, 13, 53, 266550, tzinfo=datetime.timezone.utc)}
```