### PR TITLE
[Mcgrath AU] Fix spider

### DIFF
--- a/locations/spiders/mcgrath_au.py
+++ b/locations/spiders/mcgrath_au.py
@@ -25,4 +25,5 @@ class McgrathAUSpider(SitemapSpider):
             )[-1]
         )[0][-1]["profile"]
         item = DictParser.parse(office)
+        item["branch"] = item.pop("name")
         yield item

--- a/locations/spiders/mcgrath_au.py
+++ b/locations/spiders/mcgrath_au.py
@@ -28,4 +28,5 @@ class McgrathAUSpider(SitemapSpider):
         item["branch"] = item.pop("name")
         item["website"] = response.url
         item["phone"] = "; ".join(filter(None, [office.get("phoneNumber"), office.get("phoneNumber2")]))
+        item["facebook"] = office.get("facebookUrl")
         yield item

--- a/locations/spiders/mcgrath_au.py
+++ b/locations/spiders/mcgrath_au.py
@@ -26,4 +26,5 @@ class McgrathAUSpider(SitemapSpider):
         )[0][-1]["profile"]
         item = DictParser.parse(office)
         item["branch"] = item.pop("name")
+        item["website"] = response.url
         yield item

--- a/locations/spiders/mcgrath_au.py
+++ b/locations/spiders/mcgrath_au.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
 class McgrathAUSpider(SitemapSpider):
@@ -29,4 +30,7 @@ class McgrathAUSpider(SitemapSpider):
         item["website"] = response.url
         item["phone"] = "; ".join(filter(None, [office.get("phoneNumber"), office.get("phoneNumber2")]))
         item["facebook"] = office.get("facebookUrl")
+        if hours := office.get("openingHours"):
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours)
         yield item

--- a/locations/spiders/mcgrath_au.py
+++ b/locations/spiders/mcgrath_au.py
@@ -27,4 +27,5 @@ class McgrathAUSpider(SitemapSpider):
         item = DictParser.parse(office)
         item["branch"] = item.pop("name")
         item["website"] = response.url
+        item["phone"] = "; ".join(filter(None, [office.get("phoneNumber"), office.get("phoneNumber2")]))
         yield item


### PR DESCRIPTION
API is no longer working, hence code refactored using `Sitemap` to fix the spider. Couldn't find any alternative API. 

```
{'atp/brand/McGrath': 139,
 'atp/brand_wikidata/Q105290661': 139,
 'atp/category/office/estate_agent': 139,
 'atp/field/country/from_spider_name': 139,
 'atp/field/image/missing': 139,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 139,
 'atp/field/operator_wikidata/missing': 139,
 'atp/field/twitter/missing': 139,
 'atp/item_scraped_host_count/www.mcgrath.com.au': 140,
 'atp/nsi/perfect_match': 139,
 'downloader/request_bytes': 59409,
 'downloader/request_count': 149,
 'downloader/request_method_count/GET': 149,
 'downloader/response_bytes': 3541610,
 'downloader/response_count': 149,
 'downloader/response_status_count/200': 145,
 'downloader/response_status_count/307': 3,
 'downloader/response_status_count/308': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 2.625094,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 5, 7, 32, 17, 128842, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 149,
 'httpcompression/response_bytes': 25802508,
 'httpcompression/response_count': 144,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 139,
 'log_count/DEBUG': 302,
 'log_count/INFO': 10,
 'request_depth_max': 2,
 'response_received_count': 145,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 148,
 'scheduler/dequeued/memory': 148,
 'scheduler/enqueued': 148,
 'scheduler/enqueued/memory': 148,
 'start_time': datetime.datetime(2024, 12, 5, 7, 32, 14, 503748, tzinfo=datetime.timezone.utc)}
```