### PR TITLE
[FreshstopZA] Add protection against error as NoneType is not iterable

### DIFF
--- a/locations/spiders/freshstop_za.py
+++ b/locations/spiders/freshstop_za.py
@@ -29,7 +29,13 @@ class FreshstopZASpider(JSONBlobSpider):
             set_social_media(
                 item, SocialMedia.WHATSAPP, "+27 " + location.get("store_contact_info_whatsapp").lstrip("0")
             )
-        apply_yes_no(Extras.WIFI, item, "yes" in location.get("amenities_wifi"))
-        apply_yes_no(Extras.TOILETS, item, "yes" in location.get("amenities_bathroom"))
+        apply_yes_no(
+            Extras.WIFI, item, "yes" in location["amenities_wifi"] if location.get("amenities_wifi") else False
+        )
+        apply_yes_no(
+            Extras.TOILETS,
+            item,
+            "yes" in location["amenities_bathroom"] if location.get("amenities_bathroom") else False,
+        )
         apply_category(Categories.SHOP_CONVENIENCE, item)
         yield item


### PR DESCRIPTION
Currently works fine without the code update but previously failed, so better to add protection.

```
{'atp/brand/FreshStop': 353,
 'atp/brand_wikidata/Q116620734': 353,
 'atp/category/shop/convenience': 353,
 'atp/field/city/missing': 2,
 'atp/field/country/from_spider_name': 349,
 'atp/field/email/missing': 327,
 'atp/field/image/missing': 353,
 'atp/field/opening_hours/missing': 353,
 'atp/field/operator/missing': 353,
 'atp/field/operator_wikidata/missing': 353,
 'atp/field/phone/invalid': 351,
 'atp/field/phone/missing': 16,
 'atp/field/postcode/missing': 310,
 'atp/field/state/missing': 304,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 353,
 'atp/item_scraped_host_count/freshstop.co.za': 353,
 'atp/nsi/perfect_match': 353,
 'downloader/request_bytes': 616,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 88193,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.623855,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 5, 9, 43, 16, 894980, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 867861,
 'httpcompression/response_count': 1,
 'item_scraped_count': 353,
 'log_count/DEBUG': 366,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 5, 9, 43, 10, 271125, tzinfo=datetime.timezone.utc)}
```