### PR TITLE
[Nandos GB] Split and improve branding

### DIFF
--- a/locations/spiders/nandos.py
+++ b/locations/spiders/nandos.py
@@ -27,6 +27,7 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
         data = json.loads(script)
         site = DictParser.get_nested_key(data, "restaurants")[0]
         item = DictParser.parse(site)
+        item["branch"] = item.pop("name")
         item["website"] = item["ref"] = response.url
         yield item
 
@@ -35,5 +36,6 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
         data = json.loads(script)
         if site := DictParser.get_nested_key(data, "restaurant"):
             item = DictParser.parse(site)
+            item["branch"] = item.pop("name")
             item["website"] = item["ref"] = response.url
             yield item

--- a/locations/spiders/nandos.py
+++ b/locations/spiders/nandos.py
@@ -3,7 +3,6 @@ import json
 import scrapy
 
 from locations.dict_parser import DictParser
-from locations.linked_data_parser import LinkedDataParser
 
 NANDOS_SHARED_ATTRIBUTES = {"brand": "Nando's", "brand_wikidata": "Q3472954"}
 
@@ -12,37 +11,16 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
     name = "nandos"
     item_attributes = NANDOS_SHARED_ATTRIBUTES
     sitemap_urls = [
-        "https://www.nandos.co.uk/sitemap.xml",  # This is GB and IE
         "https://www.nandos.com.au/sitemap.xml",
         "https://www.nandos.co.nz/sitemap.xml",
         "https://www.nandos.ca/sitemap.xml",
     ]
     # Different Nando's estates have slightly different approaches.
     sitemap_rules = [
-        (".co.uk/restaurants/", "parse_ldjson"),
         (".com.au/restaurants/", "parse_json2"),
         (".co.nz/restaurants/", "parse_json2"),
         ("nandos.ca/find/", "parse_json1"),
     ]
-    download_delay = 0.5
-    skip_auto_cc_domain = True
-
-    @staticmethod
-    def country_from_url(response):
-        country = response.url.split("/")[2].split(".")[-1].upper()
-        if "COM" == country:
-            return "US"
-        elif "UK" == country:
-            # Nando's does IE and GB with .uk!
-            return None
-        else:
-            return country
-
-    def parse_ldjson(self, response):
-        if item := LinkedDataParser.parse(response, "Restaurant"):
-            item["country"] = self.country_from_url(response)
-            item["ref"] = response.url
-            yield item
 
     def parse_json1(self, response):
         script = response.xpath('//script[@id="__NEXT_DATA__"]//text()').get()
@@ -50,7 +28,6 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
         site = DictParser.get_nested_key(data, "restaurants")[0]
         item = DictParser.parse(site)
         item["website"] = item["ref"] = response.url
-        item["country"] = self.country_from_url(response)
         yield item
 
     def parse_json2(self, response):
@@ -59,5 +36,4 @@ class NandosSpider(scrapy.spiders.SitemapSpider):
         if site := DictParser.get_nested_key(data, "restaurant"):
             item = DictParser.parse(site)
             item["website"] = item["ref"] = response.url
-            item["country"] = self.country_from_url(response)
             yield item

--- a/locations/spiders/nandos_gb_ie.py
+++ b/locations/spiders/nandos_gb_ie.py
@@ -1,0 +1,25 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
+from locations.structured_data_spider import StructuredDataSpider
+
+NINO_NANDOS = {"name": "Nino Nando's", "brand": "Nino Nando's", "brand_wikidata": "Q111753283"}
+
+
+class NandosGBIESpider(SitemapSpider, StructuredDataSpider):
+    name = "nandos_gb_ie"
+    item_attributes = NANDOS_SHARED_ATTRIBUTES
+    sitemap_urls = ["https://www.nandos.co.uk/robots.txt"]
+    sitemap_rules = [(".co.uk/restaurants/", "parse")]
+    wanted_types = ["Restaurant"]
+    skip_auto_cc_domain = True
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name")
+        if "our Nino restaurant" in response.text:
+            item.update(NINO_NANDOS)
+            apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
```python
{"atp/brand/Nando's": 486,
 "atp/brand/Nino Nando's": 1,
 'atp/brand_wikidata/Q111753283': 1,
 'atp/brand_wikidata/Q3472954': 486,
 'atp/category/amenity/fast_food': 1,
 'atp/category/amenity/restaurant': 486,
 'atp/field/country/from_reverse_geocoding': 486,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 487,
 'atp/field/image/missing': 487,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 487,
 'atp/field/operator_wikidata/missing': 487,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 12,
 'atp/field/state/missing': 1,
 'atp/item_scraped_host_count/www.nandos.co.uk': 990,
 'atp/nsi/perfect_match': 487,
 'downloader/request_bytes': 331013,
 'downloader/request_count': 491,
 'downloader/request_method_count/GET': 491,
 'downloader/response_bytes': 7381472,
 'downloader/response_count': 491,
 'downloader/response_status_count/200': 490,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 6.63977,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 5, 9, 36, 33, 925335, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 491,
 'httpcompression/response_bytes': 35357379,
 'httpcompression/response_count': 490,
 'item_dropped_count': 503,
 'item_dropped_reasons_count/DropItem': 503,
 'item_scraped_count': 487,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 257269760,
 'memusage/startup': 257269760,
 'request_depth_max': 2,
 'response_received_count': 490,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 490,
 'scheduler/dequeued/memory': 490,
 'scheduler/enqueued': 490,
 'scheduler/enqueued/memory': 490,
 'start_time': datetime.datetime(2024, 12, 5, 9, 36, 27, 285565, tzinfo=datetime.timezone.utc)}
```