### PR TITLE
[BUILDFIX] Fix ReissGBSpider import

### DIFF
--- a/locations/spiders/reiss_gb.py
+++ b/locations/spiders/reiss_gb.py
@@ -3,7 +3,7 @@ import re
 from scrapy import Request
 from scrapy.http import JsonRequest
 
-from locations.spiders.john_lewis import JohnLewisSpider
+from locations.spiders.john_lewis_gb import JohnLewisGBSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -34,8 +34,8 @@ class ReissGBSpider(StructuredDataSpider):
         item.pop("facebook", None)
         item.pop("twitter", None)
         if "John Lewis" in item["name"]:
-            item["located_in"] = JohnLewisSpider.item_attributes["brand"]
-            item["located_in_wikidata"] = JohnLewisSpider.item_attributes["brand_wikidata"]
+            item["located_in"] = JohnLewisGBSpider.item_attributes["brand"]
+            item["located_in_wikidata"] = JohnLewisGBSpider.item_attributes["brand_wikidata"]
         elif "Fenwick" in item["name"]:
             item["located_in"] = "Fenwick"
             item["located_in_wikidata"] = "Q5443673"


### PR DESCRIPTION
When I renamed the John Lewis spider, I didn't catch this. This may not run without a proxy as it didn't in the last weekly, but it works locally.

```python
{'atp/brand/Reiss': 95,
 'atp/brand_wikidata/Q7310479': 95,
 'atp/category/shop/clothes': 95,
 'atp/field/branch/missing': 95,
 'atp/field/email/missing': 95,
 'atp/field/image/missing': 95,
 'atp/field/operator/missing': 95,
 'atp/field/operator_wikidata/missing': 95,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 14,
 'atp/field/state/missing': 95,
 'atp/field/twitter/missing': 95,
 'atp/item_scraped_host_count/www.reiss.com': 96,
 'atp/nsi/perfect_match': 95,
 'downloader/request_bytes': 142179,
 'downloader/request_count': 98,
 'downloader/request_method_count/GET': 98,
 'downloader/response_bytes': 4837321,
 'downloader/response_count': 98,
 'downloader/response_status_count/200': 98,
 'elapsed_time_seconds': 123.230778,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 5, 15, 15, 15, 748970, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 98,
 'httpcache/miss': 98,
 'httpcache/store': 98,
 'httpcompression/response_bytes': 30134070,
 'httpcompression/response_count': 98,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 95,
 'log_count/DEBUG': 206,
 'log_count/INFO': 11,
 'memusage/max': 339582976,
 'memusage/startup': 185294848,
 'request_depth_max': 1,
 'response_received_count': 98,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 97,
 'scheduler/dequeued/memory': 97,
 'scheduler/enqueued': 97,
 'scheduler/enqueued/memory': 97,
 'start_time': datetime.datetime(2024, 12, 5, 15, 13, 12, 518192, tzinfo=datetime.timezone.utc)}
```