### PR TITLE
[DOCS] Add apply_category info

### DIFF
--- a/contrib/hooks/pre-commit
+++ b/contrib/hooks/pre-commit
@@ -6,4 +6,5 @@ if ! [ -z "${FILES}" ]; then
     pipenv run autoflake8 --in-place $FILES
     pipenv run isort $FILES
     pipenv run black $FILES
+    pipenv run python ci/check_spider_naming_consistency.py $FILES
 fi

--- a/docs/CATEGORIES.md
+++ b/docs/CATEGORIES.md
@@ -1,0 +1,9 @@
+## Categories
+
+For the most part we can automatically get the category from [NSI](https://nsi.guide/) after a successful match with `brand:wikidata`.
+However, this is not always possible.
+When it isn't automatically applied, it should be explicitly set in the spider, for this we have the helper function `apply_category`,
+which takes a category from the `Categories` enum and the POI.
+
+The `Categories` enum can be extended with [OSM categories](https://wiki.openstreetmap.org/wiki/Map_features), this
+should be the "top level" tag, additional attributes can be added with `apply_yes_no` or directly to `extras`.

--- a/docs/EXTRA_ATTRIBUTES.md
+++ b/docs/EXTRA_ATTRIBUTES.md
@@ -2,7 +2,7 @@
 
 We provide the `Extras` enum from `location.categories`, as well as the `apply_yes_no` helper.
 
-This is great for modelling common (or even uncommon) atrributes like:
+This is great for modelling common (or even uncommon) attributes like:
 
 * Wheelchair accessibility
 * Wifi

--- a/templates/spiders/basic.tmpl
+++ b/templates/spiders/basic.tmpl
@@ -10,8 +10,7 @@ class $classname(scrapy.Spider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
 
     def parse(self, response):

--- a/templates/spiders/basic.tmpl
+++ b/templates/spiders/basic.tmpl
@@ -10,7 +10,7 @@ class $classname(scrapy.Spider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
 
     def parse(self, response):

--- a/templates/spiders/crawl.tmpl
+++ b/templates/spiders/crawl.tmpl
@@ -22,6 +22,6 @@ class $classname(CrawlSpider):
 
     def parse_item(self, response):
         item = Feature()
-        # item["name"] = response.xpath('//div[@id="name"]').get()
+        # item["ref"] = response.xpath('//div[@id="store_id"]').get()
         # apply_category(Categories.SHOP_XYZ, item)
-        return item
+        yield item

--- a/templates/spiders/crawl.tmpl
+++ b/templates/spiders/crawl.tmpl
@@ -3,6 +3,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 
 
 class $classname(CrawlSpider):
@@ -20,7 +21,7 @@ class $classname(CrawlSpider):
     rules = (Rule(LinkExtractor(allow=r"Items/"), callback="parse_item", follow=True),)
 
     def parse_item(self, response):
-        item = {}
+        item = Feature()
         # item["domain_id"] = response.xpath('//input[@id="sid"]/@value').get()
         # item["name"] = response.xpath('//div[@id="name"]').get()
         # item["description"] = response.xpath('//div[@id="description"]').get()

--- a/templates/spiders/crawl.tmpl
+++ b/templates/spiders/crawl.tmpl
@@ -12,8 +12,7 @@ class $classname(CrawlSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
 
     rules = (Rule(LinkExtractor(allow=r"Items/"), callback="parse_item", follow=True),)

--- a/templates/spiders/crawl.tmpl
+++ b/templates/spiders/crawl.tmpl
@@ -22,8 +22,6 @@ class $classname(CrawlSpider):
 
     def parse_item(self, response):
         item = Feature()
-        # item["domain_id"] = response.xpath('//input[@id="sid"]/@value').get()
         # item["name"] = response.xpath('//div[@id="name"]').get()
-        # item["description"] = response.xpath('//div[@id="description"]').get()
         # apply_category(Categories.SHOP_XYZ, item)
         return item

--- a/templates/spiders/crawl.tmpl
+++ b/templates/spiders/crawl.tmpl
@@ -2,6 +2,8 @@ import scrapy
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
+
 
 class $classname(CrawlSpider):
     name = "$name"
@@ -12,14 +14,15 @@ class $classname(CrawlSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
 
     rules = (Rule(LinkExtractor(allow=r"Items/"), callback="parse_item", follow=True),)
 
     def parse_item(self, response):
         item = {}
-        #item["domain_id"] = response.xpath('//input[@id="sid"]/@value').get()
-        #item["name"] = response.xpath('//div[@id="name"]').get()
-        #item["description"] = response.xpath('//div[@id="description"]').get()
+        # item["domain_id"] = response.xpath('//input[@id="sid"]/@value').get()
+        # item["name"] = response.xpath('//div[@id="name"]').get()
+        # item["description"] = response.xpath('//div[@id="description"]').get()
+        # apply_category(Categories.SHOP_XYZ, item)
         return item

--- a/templates/spiders/csvfeed.tmpl
+++ b/templates/spiders/csvfeed.tmpl
@@ -26,6 +26,6 @@ class $classname(CSVFeedSpider):
     def parse_row(self, response, row):
         i = Feature()
         # i["website"] = row["url"]
-        # i["name"] = row["name"]
+        # i["ref"] = row["@id"]
         # apply_category(Categories.SHOP_XYZ, i)
         return i

--- a/templates/spiders/csvfeed.tmpl
+++ b/templates/spiders/csvfeed.tmpl
@@ -1,5 +1,7 @@
 from scrapy.spiders import CSVFeedSpider
 
+from locations.categories import Categories, apply_category
+
 
 class $classname(CSVFeedSpider):
     name = "$name"
@@ -13,7 +15,7 @@ class $classname(CSVFeedSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
 
     # Do any adaptations you need here
@@ -22,7 +24,8 @@ class $classname(CSVFeedSpider):
 
     def parse_row(self, response, row):
         i = {}
-        #i["url"] = row["url"]
-        #i["name"] = row["name"]
-        #i["description"] = row["description"]
+        # i["url"] = row["url"]
+        # i["name"] = row["name"]
+        # i["description"] = row["description"]
+        # apply_category(Categories.SHOP_XYZ, i)
         return i

--- a/templates/spiders/csvfeed.tmpl
+++ b/templates/spiders/csvfeed.tmpl
@@ -25,8 +25,7 @@ class $classname(CSVFeedSpider):
 
     def parse_row(self, response, row):
         i = Feature()
-        # i["url"] = row["url"]
+        # i["website"] = row["url"]
         # i["name"] = row["name"]
-        # i["description"] = row["description"]
         # apply_category(Categories.SHOP_XYZ, i)
         return i

--- a/templates/spiders/csvfeed.tmpl
+++ b/templates/spiders/csvfeed.tmpl
@@ -1,6 +1,7 @@
 from scrapy.spiders import CSVFeedSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 
 
 class $classname(CSVFeedSpider):
@@ -23,7 +24,7 @@ class $classname(CSVFeedSpider):
     #    return response
 
     def parse_row(self, response, row):
-        i = {}
+        i = Feature()
         # i["url"] = row["url"]
         # i["name"] = row["name"]
         # i["description"] = row["description"]

--- a/templates/spiders/csvfeed.tmpl
+++ b/templates/spiders/csvfeed.tmpl
@@ -13,8 +13,7 @@ class $classname(CSVFeedSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
 
     # Do any adaptations you need here

--- a/templates/spiders/json_blob.tmpl
+++ b/templates/spiders/json_blob.tmpl
@@ -14,7 +14,6 @@ class $classname(JSONBlobSpider):
         # "operator_wikidata": "$operator_wikidata",
     }
     start_urls = ["$url"]
-    # no_refs = True
 
     def extract_json(self, response):
         return chompjs.parse_js_object(

--- a/templates/spiders/json_blob.tmpl
+++ b/templates/spiders/json_blob.tmpl
@@ -10,8 +10,7 @@ class $classname(JSONBlobSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
     start_urls = ["$url"]
     # no_refs = True

--- a/templates/spiders/json_blob.tmpl
+++ b/templates/spiders/json_blob.tmpl
@@ -1,5 +1,6 @@
 import chompjs
 
+from locations.categories import Categories, apply_category
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -10,7 +11,7 @@ class $classname(JSONBlobSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
     start_urls = ["$url"]
     # no_refs = True
@@ -21,4 +22,5 @@ class $classname(JSONBlobSpider):
         )
 
     def post_process_item(self, item, response, location):
+        # apply_category(Categories.SHOP_XYZ, item)
         yield item

--- a/templates/spiders/structured_data_crawl.tmpl
+++ b/templates/spiders/structured_data_crawl.tmpl
@@ -2,7 +2,7 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 
 
 class $classname(CrawlSpider, StructuredDataSpider):
@@ -12,7 +12,7 @@ class $classname(CrawlSpider, StructuredDataSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
     allowed_domains = ["$domain"]
     start_urls = ["$url"]
@@ -24,4 +24,5 @@ class $classname(CrawlSpider, StructuredDataSpider):
     ]
 
     def post_process_item(self, item, response, ld_data):
+        # apply_category(Categories.SHOP_XYZ, item)
         yield item

--- a/templates/spiders/structured_data_crawl.tmpl
+++ b/templates/spiders/structured_data_crawl.tmpl
@@ -12,8 +12,7 @@ class $classname(CrawlSpider, StructuredDataSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
     allowed_domains = ["$domain"]
     start_urls = ["$url"]

--- a/templates/spiders/structured_data_sitemap.tmpl
+++ b/templates/spiders/structured_data_sitemap.tmpl
@@ -11,8 +11,7 @@ class $classname(SitemapSpider, StructuredDataSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
     sitemap_urls = ["https://$domain/robots.txt"]
     sitemap_rules = [

--- a/templates/spiders/structured_data_sitemap.tmpl
+++ b/templates/spiders/structured_data_sitemap.tmpl
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 
 
 class $classname(SitemapSpider, StructuredDataSpider):
@@ -11,7 +11,7 @@ class $classname(SitemapSpider, StructuredDataSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
     sitemap_urls = ["https://$domain/robots.txt"]
     sitemap_rules = [
@@ -20,4 +20,5 @@ class $classname(SitemapSpider, StructuredDataSpider):
     # wanted_types = ["GroceryStore"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        # apply_category(Categories.SHOP_XYZ, item)
         yield item

--- a/templates/spiders/wp_go_maps.tmpl
+++ b/templates/spiders/wp_go_maps.tmpl
@@ -9,7 +9,6 @@ class $classname(WpGoMapsSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
     allowed_domains = ["$domain"]

--- a/templates/spiders/wp_go_maps.tmpl
+++ b/templates/spiders/wp_go_maps.tmpl
@@ -9,6 +9,6 @@ class $classname(WpGoMapsSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
     allowed_domains = ["$domain"]

--- a/templates/spiders/xmlfeed.tmpl
+++ b/templates/spiders/xmlfeed.tmpl
@@ -20,7 +20,7 @@ class $classname(XMLFeedSpider):
 
     def parse_node(self, response, selector):
         item = Feature()
-        # item["name"] = selector.select("name").get()
+        # item["ref"] = selector.select("id").get()
         # item["website"] = selector.select("url").get()
         # apply_category(Categories.SHOP_XYZ, item)
         return item

--- a/templates/spiders/xmlfeed.tmpl
+++ b/templates/spiders/xmlfeed.tmpl
@@ -12,8 +12,7 @@ class $classname(XMLFeedSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata",
-        # "extras": Categories.SHOP_XYZ.value
+        # "operator_wikidata": "$operator_wikidata"
     }
 
     def parse_node(self, response, selector):

--- a/templates/spiders/xmlfeed.tmpl
+++ b/templates/spiders/xmlfeed.tmpl
@@ -15,7 +15,7 @@ class $classname(XMLFeedSpider):
         # "brand": "$brand",
         # "brand_wikidata": "$brand_wikidata",
         # "operator": "$operator",
-        # "operator_wikidata": "$operator_wikidata"
+        # "operator_wikidata": "$operator_wikidata",
     }
 
     def parse_node(self, response, selector):

--- a/templates/spiders/xmlfeed.tmpl
+++ b/templates/spiders/xmlfeed.tmpl
@@ -20,7 +20,7 @@ class $classname(XMLFeedSpider):
 
     def parse_node(self, response, selector):
         item = Feature()
-        #item["url"] = selector.select("url").get()
-        #item["name"] = selector.select("name").get()
-        #item["description"] = selector.select("description").get()
+        # item["name"] = selector.select("name").get()
+        # item["website"] = selector.select("url").get()
+        # apply_category(Categories.SHOP_XYZ, item)
         return item

--- a/templates/spiders/xmlfeed.tmpl
+++ b/templates/spiders/xmlfeed.tmpl
@@ -1,5 +1,8 @@
 from scrapy.spiders import XMLFeedSpider
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
 
 class $classname(XMLFeedSpider):
     name = "$name"
@@ -16,7 +19,7 @@ class $classname(XMLFeedSpider):
     }
 
     def parse_node(self, response, selector):
-        item = {}
+        item = Feature()
         #item["url"] = selector.select("url").get()
         #item["name"] = selector.select("name").get()
         #item["description"] = selector.select("description").get()


### PR DESCRIPTION
`item_attributes = {"extras": Categories.XYZ.value}` should be discouraged.

1. In cases where we do `item.update(SpecificSpider.item_attributes)` it will nuke any already given `extras`.
2. And for future proofing `apply_category` should be centralised so we can change it once for everything not have to edit 4k spiders. Otherwise we'll be heading back to when some spiders we're assigning things like `amenity:atm=True`.