### PR TITLE
[Five Guys CN] Fix Spider

### DIFF
--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -1,13 +1,12 @@
-from locations.spiders.five_guys_au import FiveGuysAUSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.spiders.five_guys_us import FIVE_GUYS_SHARED_ATTRIBUTES
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FiveGuysCNSpider(FiveGuysAUSpider):
+class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
     name = "five_guys_cn"
-    experience_key = "search-backend-cn"
-    locale = (
-        "en-CN"  # Using en because it has google attributes which gives lots of extra details (not present in zh-Hans)
-    )
-
-    def process_websites(self, item) -> None:
-        item["extras"]["website:en"] = item["website"].replace("fiveguys.cn/", "fiveguys.cn/en_cn/")
-        item["extras"]["website:zh"] = item["website"]
+    item_attributes = FIVE_GUYS_SHARED_ATTRIBUTES
+    sitemap_urls = ["https://restaurants.fiveguys.cn/sitemap.xml"]
+    sitemap_rules = [(r"https://restaurants.fiveguys.cn/en_cn/[-\w]+$", "parse_sd")]
+    wanted_types = ["FastFoodRestaurant"]  # Explicitly mention the type to ignore duplicate linked data

--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -8,5 +8,5 @@ class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
     name = "five_guys_cn"
     item_attributes = FIVE_GUYS_SHARED_ATTRIBUTES
     sitemap_urls = ["https://restaurants.fiveguys.cn/sitemap.xml"]
-    sitemap_rules = [(r"https://restaurants.fiveguys.cn/en_cn/[-\w]+$", "parse_sd")]
+    sitemap_rules = [(r"https://restaurants.fiveguys.cn/en_cn/[-\w&]+$", "parse_sd")]
     wanted_types = ["FastFoodRestaurant"]  # Explicitly mention the type to ignore duplicate linked data

--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -22,4 +22,5 @@ class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
             coordinates = chompjs.parse_js_object(parse.unquote(match.group(0)))
             item["lat"] = coordinates["latitude"]
             item["lon"] = coordinates["longitude"]
+        item["website"] = response.url
         yield item

--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -1,5 +1,11 @@
+import re
+from urllib import parse
+
+import chompjs
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.spiders.five_guys_us import FIVE_GUYS_SHARED_ATTRIBUTES
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -10,3 +16,10 @@ class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://restaurants.fiveguys.cn/sitemap.xml"]
     sitemap_rules = [(r"https://restaurants.fiveguys.cn/en_cn/[-\w&]+$", "parse_sd")]
     wanted_types = ["FastFoodRestaurant"]  # Explicitly mention the type to ignore duplicate linked data
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if match := re.search(r"yextDisplay.+?,", response.text):
+            coordinates = chompjs.parse_js_object(parse.unquote(match.group(0)))
+            item["lat"] = coordinates["latitude"]
+            item["lon"] = coordinates["longitude"]
+        yield item


### PR DESCRIPTION
The previously used `Yext API` is no longer working. The changed [version](https://cdn.yextapis.com/v2/accounts/me/search/vertical/query?experienceKey=search-backend-cn&api_key=e9a586fc4400f344829f350f07a7e367&v=20220511&locale=en-CN&input=&verticalKey=locations) is also an option but doesn't directly support the existed `yext` store_finders, also in future might get change again, hence used `sitemap` and `SD` to fix the spider.

```
{'atp/brand/Five Guys': 5,
 'atp/brand_wikidata/Q1131810': 5,
 'atp/category/amenity/fast_food': 5,
 'atp/cdn/cloudflare/response_count': 9,
 'atp/cdn/cloudflare/response_status_count/200': 8,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/branch/missing': 5,
 'atp/field/image/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/field/postcode/missing': 3,
 'atp/field/twitter/missing': 5,
 'atp/item_scraped_host_count/restaurants.fiveguys.cn': 5,
 'atp/nsi/perfect_match': 5,
 'downloader/request_bytes': 4746,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 53410,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 8,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 9.275797,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 9, 7, 15, 24, 452770, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 204683,
 'httpcompression/response_count': 9,
 'item_scraped_count': 5,
 'log_count/DEBUG': 25,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 9,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2024, 12, 9, 7, 15, 15, 176973, tzinfo=datetime.timezone.utc)}
```