### PR TITLE
[DrummondGolfAU] Fix Spider

### DIFF
--- a/locations/spiders/drummond_golf_au.py
+++ b/locations/spiders/drummond_golf_au.py
@@ -18,7 +18,7 @@ class DrummondGolfAUSpider(scrapy.Spider):
             for store in json.loads(raw_data.group(1)):
                 item = DictParser.parse(store)
                 popup_html = Selector(text=store["popup_html"])
-                item["website"] = popup_html.xpath('//*[@class= "amlocator-link"]/@href').get()
+                item["website"] = popup_html.xpath('//*[@class= "amlocator-link"]/@href').get().replace(" ", "")
                 address_string = re.sub(r"\s+", " ", " ".join(filter(None, popup_html.xpath("//text()").getall())))
                 item["city"] = address_string.split("City: ", 1)[1].split(" Zip: ", 1)[0]
                 item["postcode"] = address_string.split("Zip: ", 1)[1].split(" Address: ", 1)[0]

--- a/locations/spiders/drummond_golf_au.py
+++ b/locations/spiders/drummond_golf_au.py
@@ -1,37 +1,30 @@
-from scrapy.spiders import XMLFeedSpider
+import json
+import re
 
-from locations.items import Feature
+import scrapy
+from scrapy import Selector
+
+from locations.categories import apply_category
+from locations.dict_parser import DictParser
 
 
-class DrummondGolfAUSpider(XMLFeedSpider):
+class DrummondGolfAUSpider(scrapy.Spider):
     name = "drummond_golf_au"
-    item_attributes = {
-        "brand": "Drummond Golf",
-        "brand_wikidata": "Q124065894",
-        "extras": {
-            "shop": "golf",
-        },
-    }
-    allowed_domains = ["www.drummondgolf.com.au"]
-    start_urls = [
-        "https://www.drummondgolf.com.au/storelocator/index/search/?lat=-33.870&lng=151.210&radius=20000&page_limit=10000"
-    ]
-    iterator = "xml"
-    itertag = "marker"
+    item_attributes = {"brand": "Drummond Golf", "brand_wikidata": "Q124065894"}
+    start_urls = ["https://www.drummondgolf.com.au/amlocator/index/ajax/?p=1"]
 
-    def parse_node(self, response, node):
-        properties = {
-            "ref": node.xpath("@storeid").get(),
-            "name": node.xpath("@name").get(),
-            "lat": node.xpath("@lat").get(),
-            "lon": node.xpath("@lng").get(),
-            "street_address": node.xpath("@address").get(),
-            "city": node.xpath("@city").get(),
-            "state": node.xpath("@region").get(),
-            "postcode": node.xpath("@postcode").get(),
-            "phone": node.xpath("@phone").get(),
-            "email": node.xpath("@email").get(),
-            "website": node.xpath("@view_url").get(),
-            "image": node.xpath("@logo").get().replace(".au/pub/", ".au/"),
-        }
-        yield Feature(**properties)
+    def parse(self, response, **kwargs):
+        if raw_data := re.search(r"items\":(\[.*\]),\"", response.text):
+            for store in json.loads(raw_data.group(1)):
+                item = DictParser.parse(store)
+                popup_html = Selector(text=store["popup_html"])
+                item["website"] = popup_html.xpath('//*[@class= "amlocator-link"]/@href').get()
+                address_string = re.sub(r"\s+", " ", " ".join(filter(None, popup_html.xpath("//text()").getall())))
+                item["city"] = address_string.split("City: ", 1)[1].split(" Zip: ", 1)[0]
+                item["postcode"] = address_string.split("Zip: ", 1)[1].split(" Address: ", 1)[0]
+                item["street_address"] = address_string.split("Address: ", 1)[1].split(" State: ", 1)[0]
+                item["state"] = address_string.split("State: ", 1)[1].split(" Description: ", 1)[0]
+                apply_category({"shop": "golf"}, item)
+                yield item
+            if next_url := re.search(r"action next.*href=\\\"(.*)\"\s*rel", response.text):
+                yield scrapy.Request(url=next_url.group(1).replace("\\", ""), callback=self.parse)


### PR DESCRIPTION
`Fixes : code refactored to fix spider`


{'atp/brand/Drummond Golf': 50,
 'atp/brand_wikidata/Q124065894': 50,
 'atp/category/shop/golf': 50,
 'atp/field/branch/missing': 50,
 'atp/field/country/from_spider_name': 50,
 'atp/field/email/missing': 50,
 'atp/field/image/missing': 50,
 'atp/field/opening_hours/missing': 50,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/phone/missing': 50,
 'atp/field/twitter/missing': 50,
 'atp/field/website/invalid': 1,
 'atp/item_scraped_host_count/www.drummondgolf.com.au': 50,
 'atp/nsi/brand_missing': 50,
 'downloader/request_bytes': 4217,
 'downloader/request_count': 11,
 'downloader/request_method_count/GET': 11,
 'downloader/response_bytes': 122898,
 'downloader/response_count': 11,
 'downloader/response_status_count/200': 11,
 'elapsed_time_seconds': 13.499845,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 9, 10, 57, 32, 384332, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 278972,
 'httpcompression/response_count': 11,
 'item_scraped_count': 50,
 'log_count/DEBUG': 72,
 'log_count/INFO': 9,
 'request_depth_max': 9,
 'response_received_count': 11,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2024, 12, 9, 10, 57, 18, 884487, tzinfo=datetime.timezone.utc)}
