### PR TITLE
[JuicePressUS] Fix Spider

### DIFF
--- a/locations/spiders/juice_press_us.py
+++ b/locations/spiders/juice_press_us.py
@@ -1,7 +1,26 @@
-from locations.storefinders.storepoint import StorepointSpider
+import re
+from typing import Any
+
+import chompjs
+import scrapy
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
 
 
-class JuicePressUSSpider(StorepointSpider):
+class JuicePressUSSpider(scrapy.Spider):
     name = "juice_press_us"
     item_attributes = {"brand": "Juice Press", "brand_wikidata": "Q27150131"}
-    key = "15d4897d596fbd"
+    start_urls = ["https://www.juicepress.com/pages/location"]
+    no_refs = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = list(
+            chompjs.parse_js_objects(
+                re.search(r"JPSTORELOCATOR\.locations\.push\((.*)\);Object", response.text, re.DOTALL).group(1)
+            )
+        )
+        for store in raw_data:
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("name")
+            yield item

--- a/locations/spiders/juice_press_us.py
+++ b/locations/spiders/juice_press_us.py
@@ -2,17 +2,16 @@ import re
 from typing import Any
 
 import chompjs
-import scrapy
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 
 
-class JuicePressUSSpider(scrapy.Spider):
+class JuicePressUSSpider(Spider):
     name = "juice_press_us"
     item_attributes = {"brand": "Juice Press", "brand_wikidata": "Q27150131"}
     start_urls = ["https://www.juicepress.com/pages/location"]
-    no_refs = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         raw_data = list(
@@ -23,4 +22,6 @@ class JuicePressUSSpider(scrapy.Spider):
         for store in raw_data:
             item = DictParser.parse(store)
             item["street_address"] = item.pop("name")
+            item["image"] = store["image"]
+            item["ref"] = store["selector"]
             yield item

--- a/locations/spiders/juice_press_us.py
+++ b/locations/spiders/juice_press_us.py
@@ -6,6 +6,8 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.spiders.equinox import EquinoxSpider
+from locations.spiders.tesco_gb import set_located_in
 
 
 class JuicePressUSSpider(Spider):
@@ -21,10 +23,15 @@ class JuicePressUSSpider(Spider):
         )
         for store in raw_data:
             item = DictParser.parse(store)
+            item["addr_full"] = None
             item["street_address"] = item.pop("name")
             item["image"] = store["image"]
             item["ref"] = store["selector"]
 
             if float(item["lon"]) > 0:
                 item["lon"] = float(item["lon"]) * -1
+
+            if "Equinox" in item["street_address"]:
+                set_located_in(EquinoxSpider.item_attributes, item)
+
             yield item

--- a/locations/spiders/juice_press_us.py
+++ b/locations/spiders/juice_press_us.py
@@ -24,4 +24,7 @@ class JuicePressUSSpider(Spider):
             item["street_address"] = item.pop("name")
             item["image"] = store["image"]
             item["ref"] = store["selector"]
+
+            if float(item["lon"]) > 0:
+                item["lon"] = float(item["lon"]) * -1
             yield item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/Juice Press': 65,
 'atp/brand_wikidata/Q27150131': 65,
 'atp/category/amenity/fast_food': 65,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 65,
 'atp/field/city/missing': 65,
 'atp/field/country/from_spider_name': 65,
 'atp/field/email/missing': 65,
 'atp/field/image/missing': 65,
 'atp/field/opening_hours/missing': 65,
 'atp/field/operator/missing': 65,
 'atp/field/operator_wikidata/missing': 65,
 'atp/field/phone/missing': 65,
 'atp/field/postcode/missing': 65,
 'atp/field/state/from_reverse_geocoding': 65,
 'atp/field/state/missing': 3,
 'atp/field/twitter/missing': 65,
 'atp/field/website/missing': 65,
 'atp/item_scraped_host_count/www.juicepress.com': 65,
 'atp/nsi/perfect_match': 65,
 'downloader/request_bytes': 1433,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 69880,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.591038,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 10, 6, 44, 41, 238766, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 308576,
 'httpcompression/response_count': 2,
 'item_scraped_count': 65,
 'log_count/DEBUG': 78,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 10, 6, 44, 34, 647728, tzinfo=datetime.timezone.utc)}