### PR TITLE
[call_a_pizza_de] Add spider (127 locations)

### DIFF
--- a/locations/spiders/call_a_pizza_de.py
+++ b/locations/spiders/call_a_pizza_de.py
@@ -1,53 +1,57 @@
 import json
 import re
+from typing import Iterable
 
-from scrapy.spiders import Spider
+from scrapy.http import Response
+from scrapy.selector.unified import Selector
 
 from locations.hours import OpeningHours, DAYS_DE, DELIMITERS_DE
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CallAPizzaDESpider(Spider):
+class CallAPizzaDESpider(StructuredDataSpider):
     name = "call_a_pizza_de"
     item_attributes = {"brand": "Call a Pizza", "brand_wikidata": "Q1027107"}
     start_urls = ["https://www.call-a-pizza.de/bestellen"]
+    store_ids = dict()  # Mapping from ref (URL) to internal store ID
+    store_data = dict()  # Store ID to lon/lat
+    opening_hours = dict()  # ref (URL) to parsed opening hours
     RE_OPENING_DAYS = re.compile(OpeningHours.any_day_extraction_regex(days=DAYS_DE, delimiters=DELIMITERS_DE))
     RE_DELIMITERS = re.compile(OpeningHours.delimiters_regex(delimiters=DELIMITERS_DE))
     RE_HOURS = re.compile(r"(\d\d:\d\d) - (\d\d:\d\d)")
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
         # Coordinates are stored separately in a JavaScript call.
         store_data_json = response.xpath('//script[contains(., "store_data_map")]').re_first(
             r"JSON.parse\('(\[.*?\])'\);"
         )
-        store_data = json.loads(store_data_json)
-        store_data = {s["store_id"]: s for s in store_data}
-        for store in response.xpath('//tr[@class="bestellen_store"]'):
-            ref = store.attrib["data-id"]
-            properties = {
-                "ref": ref,
-            }
-            fields = {
-                "name": "name",
-                "street_address": "streetAddress",
-                "postcode": "postalCode",
-                "city": "addressLocality",
-                "phone": "telephone",
-            }
-            for atp_key, site_key in fields.items():
-                properties[atp_key] = store.xpath(f'descendant::span[@itemprop="{site_key}"]/text()').get().strip()
-            if properties["name"].startswith("Call a Pizza "):
-                properties["branch"] = properties["name"].removeprefix("Call a Pizza ")
-                properties["name"] = "Call a Pizza"
-            properties["website"] = response.urljoin(store.xpath('descendant::a[@class="storelink"]/@href').get())
-            properties["lon"] = store_data[ref]["longitude"]
-            properties["lat"] = store_data[ref]["latitude"]
-            properties["opening_hours"] = self.extract_opening_hours(store)
-            # Empty opening hours -> closed on all days
-            if properties["opening_hours"]:
-                yield Feature(properties)
+        store_list = json.loads(store_data_json)
+        self.store_data = {s["store_id"]: s for s in store_list}
 
-    def extract_opening_hours(self, store):
+        # Parse and store opening hours. The microdata parser can't extract them.
+        self.opening_hours = dict()
+        for store in response.xpath('//tr[contains(@class, "bestellen_store")]'):
+            ref = store.xpath('descendant::span[@itemprop="url"]/text()').get()
+            store_id = store.attrib["data-id"]
+            self.store_ids[ref] = store_id
+            self.opening_hours[ref] = self.extract_opening_hours(store)
+
+        yield from self.parse_sd(response)
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        # Merge item from StructuredDataSpider with lon/lat and opening hours parsed separately
+        item["ref"] = ld_data["url"]
+        if item["name"].startswith("Call a Pizza "):
+            item["branch"] = item["name"].removeprefix("Call a Pizza ")
+            item["name"] = "Call a Pizza"
+        store_id = self.store_ids[item["ref"]]
+        item["lon"] = self.store_data[store_id]["longitude"]
+        item["lat"] = self.store_data[store_id]["latitude"]
+        item["opening_hours"] = self.opening_hours[item["ref"]]
+        yield item
+
+    def extract_opening_hours(self, store: Selector) -> OpeningHours:
         opening = OpeningHours()
         for days_line in store.xpath('descendant::div[@class="bestellen_oph_left"]'):
             opening_days = "".join(days_line.xpath("(b|.)/text()").getall())

--- a/locations/spiders/call_a_pizza_de.py
+++ b/locations/spiders/call_a_pizza_de.py
@@ -1,0 +1,73 @@
+import json
+import re
+
+from scrapy.spiders import Spider
+
+from locations import hours
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class CallAPizzaDESpider(Spider):
+    name = "call_a_pizza_de"
+    item_attributes = {"brand": "Call a Pizza", "brand_wikidata": "Q1027107"}
+    start_urls = ["https://www.call-a-pizza.de/bestellen"]
+    DAYS_DE = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
+    DAYS2EN = dict(zip(DAYS_DE, hours.DAYS))
+    RE_DAYS_DE = "(:?" + "|".join(DAYS_DE) + ")"
+    RE_OPENING_DAYS = re.compile(f"{DAYS_DE}|{DAYS_DE} - {DAYS_DE}")
+    RE_HOURS = re.compile(r"(\d\d:\d\d) - (\d\d:\d\d)")
+
+    def parse(self, response, **kwargs):
+        # Coordinates are stored separately in a JavaScript call.
+        store_data_json = response.xpath('//script[contains(., "store_data_map")]').re_first(
+            r"JSON.parse\('(\[.*?\])'\);"
+        )
+        store_data = json.loads(store_data_json)
+        store_data = {s["store_id"]: s for s in store_data}
+        for store in response.xpath('//tr[@class="bestellen_store"]'):
+            ref = store.attrib["data-id"]
+            properties = {
+                "ref": ref,
+            }
+            fields = {
+                "name": "name",
+                "street_address": "streetAddress",
+                "postcode": "postalCode",
+                "city": "addressLocality",
+                "phone": "telephone",
+            }
+            for atp_key, site_key in fields.items():
+                properties[atp_key] = store.xpath(f'descendant::span[@itemprop="{site_key}"]/text()').get().strip()
+            if properties["name"].startswith("Call a Pizza "):
+                properties["branch"] = properties["name"].removeprefix("Call a Pizza ")
+                properties["name"] = "Call a Pizza"
+            properties["website"] = response.urljoin(store.xpath('descendant::a[@class="storelink"]/@href').get())
+            properties["lon"] = store_data[ref]["longitude"]
+            properties["lat"] = store_data[ref]["latitude"]
+            properties["opening_hours"] = self.extract_opening_hours(store)
+            # Empty opening hours -> closed on all days
+            if properties["opening_hours"]:
+                yield Feature(properties)
+
+    def extract_opening_hours(self, store):
+        opening = OpeningHours()
+        for days_line in store.xpath('descendant::div[@class="bestellen_oph_left"]'):
+            opening_days = days_line.xpath("(b|.)/text()").get().strip()
+            if self.RE_OPENING_DAYS.match(opening_days):
+                hours_line = (
+                    days_line.xpath('following-sibling::div[@class="bestellen_oph_right"]/text()').get().strip()
+                )
+                match = self.RE_HOURS.match(hours_line)
+                if match:
+                    opening.add_days_range(self.map_opening_days(opening_days), match.group(1), match.group(2))
+        return opening
+
+    def map_opening_days(self, days_string):
+        days = days_string.split(" - ")
+        if len(days) == 1:
+            return [self.DAYS2EN[days[0]]]
+        else:
+            from_index = self.DAYS_DE.index(days[0])
+            to_index = self.DAYS_DE.index(days[1])
+            return list(map(lambda i: hours.DAYS[i], range(from_index, to_index)))

--- a/locations/spiders/call_a_pizza_de.py
+++ b/locations/spiders/call_a_pizza_de.py
@@ -5,7 +5,7 @@ from typing import Iterable
 from scrapy.http import Response
 from scrapy.selector.unified import Selector
 
-from locations.hours import OpeningHours, DAYS_DE, DELIMITERS_DE
+from locations.hours import DAYS_DE, DELIMITERS_DE, OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 


### PR DESCRIPTION
Add [Call a Pizza](https://www.call-a-pizza.de/bestellen), a pizza chain in DE.

```
2024-12-10 08:32:00 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Call a Pizza': 116,
 'atp/brand_wikidata/Q1027107': 116,
 'atp/category/amenity/fast_food': 116,
 'atp/field/country/from_spider_name': 116,
 'atp/field/email/missing': 116,
 'atp/field/image/missing': 116,
 'atp/field/operator/missing': 116,
 'atp/field/operator_wikidata/missing': 116,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 116,
 'atp/field/twitter/missing': 116,
 'atp/item_scraped_host_count/www.call-a-pizza.de': 116,
 'atp/nsi/perfect_match': 116,
```