### PR TITLE
[Dickeys Barbecue Pit] Fix spider and add CA locations

### DIFF
--- a/locations/spiders/dickeys_barbecue_pit.py
+++ b/locations/spiders/dickeys_barbecue_pit.py
@@ -45,4 +45,5 @@ class DickeysBarbecuePitSpider(Spider):
             item = DictParser.parse(store)
             item["street_address"] = item.pop("addr_full")
             item["addr_full"] = store.get("fullAddress")
+            item["branch"] = store.get("label")
             yield item

--- a/locations/spiders/dickeys_barbecue_pit.py
+++ b/locations/spiders/dickeys_barbecue_pit.py
@@ -5,6 +5,7 @@ from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, sanitise_day
 
 
 class DickeysBarbecuePitSpider(Spider):
@@ -52,4 +53,8 @@ class DickeysBarbecuePitSpider(Spider):
                     " ", "-"
                 )
             )
+            item["opening_hours"] = OpeningHours()
+            for rule in store.get("workingHours", []):
+                if day := sanitise_day(rule.get("label")):
+                    item["opening_hours"].add_range(day, rule.get("opened"), rule.get("closed"), time_format="%I:%M %p")
             yield item

--- a/locations/spiders/dickeys_barbecue_pit_us.py
+++ b/locations/spiders/dickeys_barbecue_pit_us.py
@@ -16,13 +16,14 @@ class DickeysBarbecuePitUSSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         location_data = chompjs.parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
         self.build_id = location_data.get("buildId")
-        for state_info in location_data["props"]["pageProps"]["locations"][0]["states"]:
-            state = state_info["stateName"].lower()
-            yield JsonRequest(
-                url=f"https://www.dickeys.com/_next/data/{self.build_id}/locations/{state}.json".replace(" ", "-"),
-                callback=self.parse_cities,
-                cb_kwargs=dict(state=state),
-            )
+        for state_info in location_data["props"]["pageProps"]["locations"]:
+            for state in state_info["states"]:
+                state = state["stateName"].lower()
+                yield JsonRequest(
+                    url=f"https://www.dickeys.com/_next/data/{self.build_id}/locations/{state}.json".replace(" ", "-"),
+                    callback=self.parse_cities,
+                    cb_kwargs=dict(state=state),
+                )
 
     def parse_cities(self, response: Response, state: str) -> Any:
         for city_info in response.json()["pageProps"]["stateCities"]:

--- a/locations/spiders/dickeys_barbecue_pit_us.py
+++ b/locations/spiders/dickeys_barbecue_pit_us.py
@@ -1,142 +1,43 @@
-import urllib.parse
+from typing import Any
 
+import chompjs
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_FULL, OpeningHours
-
-USA_STATES = {
-    "AK": "Alaska",
-    "AL": "Alabama",
-    "AR": "Arkansas",
-    "AS": "American Samoa",
-    "AZ": "Arizona",
-    "CA": "California",
-    "CO": "Colorado",
-    "CT": "Connecticut",
-    "DC": "District of Columbia",
-    "DE": "Delaware",
-    "FL": "Florida",
-    "GA": "Georgia",
-    "GU": "Guam",
-    "HI": "Hawaii",
-    "IA": "Iowa",
-    "ID": "Idaho",
-    "IL": "Illinois",
-    "IN": "Indiana",
-    "KS": "Kansas",
-    "KY": "Kentucky",
-    "LA": "Louisiana",
-    "MA": "Massachusetts",
-    "MD": "Maryland",
-    "ME": "Maine",
-    "MI": "Michigan",
-    "MN": "Minnesota",
-    "MO": "Missouri",
-    "MS": "Mississippi",
-    "MT": "Montana",
-    "NC": "North Carolina",
-    "ND": "North Dakota",
-    "NE": "Nebraska",
-    "NH": "New Hampshire",
-    "NJ": "New Jersey",
-    "NM": "New Mexico",
-    "NV": "Nevada",
-    "NY": "New York",
-    "OH": "Ohio",
-    "OK": "Oklahoma",
-    "OR": "Oregon",
-    "PA": "Pennsylvania",
-    "PR": "Puerto Rico",
-    "RI": "Rhode Island",
-    "SC": "South Carolina",
-    "SD": "South Dakota",
-    "TN": "Tennessee",
-    "TX": "Texas",
-    "UT": "Utah",
-    "VA": "Virginia",
-    "VI": "Virgin Islands",
-    "VT": "Vermont",
-    "WA": "Washington",
-    "WI": "Wisconsin",
-    "WV": "West Virginia",
-    "WY": "Wyoming",
-}
 
 
 class DickeysBarbecuePitUSSpider(Spider):
     name = "dickeys_barbecue_pit_us"
     item_attributes = {"brand": "Dickey's Barbecue Pit", "brand_wikidata": "Q19880747"}
-    allowed_domains = ["orders-api.dickeys.com"]
-    start_urls = ["https://orders-api.dickeys.com/graphql"]
+    start_urls = ["https://www.dickeys.com/locations"]
+    build_id = ""
 
-    def start_requests(self):
-        graphql_query = """query {
-    viewer {
-        locationConnection(first: 2000, filter: { isOpened: { eq: true } active: { eq: true } }) {
-            edges {
-                node {
-                    name: label
-                    slug
-                    ref: storeNumber
-                    locationWeekdayConnection(filter: { showHoliday: { eq: true } }) {
-                        edges {
-                            node {
-                                open_time: opened
-                                close_time: closed
-                                weekday {
-                                    day_name: label
-                                }
-                            }
-                        }
-                    }
-                    address {
-                        street_address: address
-                        city
-                        state {
-                            abbreviation
-                        }
-                        zip
-                        latitude
-                        longitude
-                    }
-                    phone {
-                        phone
-                    }
-                    email
-                }
-            }
-        }
-    }
-}"""
-        data = {"query": graphql_query}
-        for url in self.start_urls:
-            yield JsonRequest(url=url, data=data, method="POST")
-
-    def parse(self, response):
-        for location in response.json()["data"]["viewer"]["locationConnection"]["edges"]:
-            location["node"]["address"]["state"] = location["node"]["address"]["state"]["abbreviation"]
-            location["node"]["phone"] = location["node"]["phone"]["phone"]
-            item = DictParser.parse(location["node"])
-            item["lat"] = location["node"]["address"]["latitude"]
-            item["lon"] = location["node"]["address"]["longitude"]
-            item["website"] = (
-                "https://www.dickeys.com/locations/"
-                + USA_STATES[item["state"]].lower()
-                + "/"
-                + urllib.parse.quote(item["city"].lower())
-                + "/"
-                + location["node"]["slug"]
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location_data = chompjs.parse_js_object(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
+        self.build_id = location_data.get("buildId")
+        for state_info in location_data["props"]["pageProps"]["locations"][0]["states"]:
+            state = state_info["stateName"].lower()
+            yield JsonRequest(
+                url=f"https://www.dickeys.com/_next/data/{self.build_id}/locations/{state}.json".replace(" ", "-"),
+                callback=self.parse_cities,
+                cb_kwargs=dict(state=state),
             )
-            item["opening_hours"] = OpeningHours()
-            for hours_range in location["node"]["locationWeekdayConnection"]["edges"]:
-                if hours_range["node"]["weekday"]["day_name"].title() not in DAYS_FULL:
-                    continue
-                item["opening_hours"].add_range(
-                    hours_range["node"]["weekday"]["day_name"],
-                    hours_range["node"]["open_time"],
-                    hours_range["node"]["close_time"],
-                    "%H:%M:%S",
-                )
+
+    def parse_cities(self, response: Response, state: str) -> Any:
+        for city_info in response.json()["pageProps"]["stateCities"]:
+            yield JsonRequest(
+                url=f"https://www.dickeys.com/_next/data/{self.build_id}/locations/{state}/{city_info['city'].lower()}.json".replace(
+                    " ", "-"
+                ),
+                callback=self.parse_stores,
+            )
+
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["pageProps"]["data"]["locations"]:
+            store.update(store.pop("address"))
+            store["state"] = store.pop("state", {}).get("abbreviation")
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("addr_full")
+            item["addr_full"] = store.get("fullAddress")
             yield item


### PR DESCRIPTION
[Sitemap](https://www.dickeys.com/sitemap.xml) is also there but store [pages](https://www.dickeys.com/locations/texas/dallas/highland-park-hillcrest-ave) have `Structured Data` that is different from convention and requires code adjustment/fix, hence ignored and used `API` approach to fix the spider. Also added `CA` locations. Checked other countries like [JP](https://www.dickeys.com/jp/en-jp/locations), [SG](https://dickeys.com.sg/) etc , either they don't have POI info or can't be added to this spider.

```
{"atp/brand/Dickey's Barbecue Pit": 398,
 'atp/brand_wikidata/Q19880747': 398,
 'atp/category/amenity/restaurant': 398,
 'atp/field/image/missing': 398,
 'atp/field/opening_hours/missing': 30,
 'atp/field/operator/missing': 398,
 'atp/field/operator_wikidata/missing': 398,
 'atp/field/phone/invalid': 2,
 'atp/field/twitter/missing': 398,
 'atp/item_scraped_host_count/www.dickeys.com': 398,
 'atp/nsi/perfect_match': 398,
 'downloader/request_bytes': 174433,
 'downloader/request_count': 379,
 'downloader/request_method_count/GET': 379,
 'downloader/response_bytes': 1051013,
 'downloader/response_count': 379,
 'downloader/response_status_count/200': 379,
 'elapsed_time_seconds': 4.814634,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 10, 10, 24, 30, 146456, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 379,
 'httpcompression/response_bytes': 2482339,
 'httpcompression/response_count': 378,
 'item_scraped_count': 398,
 'log_count/DEBUG': 789,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 379,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 378,
 'scheduler/dequeued/memory': 378,
 'scheduler/enqueued': 378,
 'scheduler/enqueued/memory': 378,
 'start_time': datetime.datetime(2024, 12, 10, 10, 24, 25, 331822, tzinfo=datetime.timezone.utc)}
```