### PR TITLE
[Hipermaxi BO] Fix spider

### DIFF
--- a/locations/spiders/hipermaxi_bo.py
+++ b/locations/spiders/hipermaxi_bo.py
@@ -3,6 +3,7 @@ from typing import Any, Iterable
 from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
@@ -33,4 +34,9 @@ class HipermaxiBOSpider(Spider):
                     location_info.get("Descripcion", "").removeprefix("FARMACIA ").removeprefix("HIPERMAXI ")
                 )
                 item["street_address"] = clean_address(location_info.get("Direccion"), min_length=3)
+                if location_info.get("TipoServicio", {}).get("Descripcion") == "Farmacia":
+                    apply_category(Categories.PHARMACY, item)
+                    item["nsi_id"] = "N/A"
+                elif location_info.get("TipoServicio", {}).get("Descripcion") == "Supermercado":
+                    apply_category(Categories.SHOP_SUPERMARKET, item)
                 yield item

--- a/locations/spiders/hipermaxi_bo.py
+++ b/locations/spiders/hipermaxi_bo.py
@@ -3,7 +3,7 @@ from typing import Any, Iterable
 from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
@@ -39,4 +39,7 @@ class HipermaxiBOSpider(Spider):
                     item["nsi_id"] = "N/A"
                 elif location_info.get("TipoServicio", {}).get("Descripcion") == "Supermercado":
                     apply_category(Categories.SHOP_SUPERMARKET, item)
+                services = [service.get("Descripcion", "").upper() for service in location_info.get("TipoEntregas", [])]
+                apply_yes_no(Extras.DELIVERY, item, "DELIVERY" in services)
+                apply_yes_no(Extras.TAKEAWAY, item, "RECOGER EN SUCURSAL" in services)
                 yield item

--- a/locations/spiders/hipermaxi_bo.py
+++ b/locations/spiders/hipermaxi_bo.py
@@ -4,6 +4,7 @@ from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 
 
 class HipermaxiBOSpider(Spider):
@@ -31,5 +32,5 @@ class HipermaxiBOSpider(Spider):
                 item["branch"] = (
                     location_info.get("Descripcion", "").removeprefix("FARMACIA ").removeprefix("HIPERMAXI ")
                 )
-                item["street_address"] = location_info.get("Direccion")
+                item["street_address"] = clean_address(location_info.get("Direccion"), min_length=3)
                 yield item

--- a/locations/spiders/hipermaxi_bo.py
+++ b/locations/spiders/hipermaxi_bo.py
@@ -4,7 +4,7 @@ from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.items import Feature
+from locations.items import Feature, SocialMedia, set_social_media
 from locations.pipelines.address_clean_up import clean_address
 
 
@@ -42,4 +42,6 @@ class HipermaxiBOSpider(Spider):
                 services = [service.get("Descripcion", "").upper() for service in location_info.get("TipoEntregas", [])]
                 apply_yes_no(Extras.DELIVERY, item, "DELIVERY" in services)
                 apply_yes_no(Extras.TAKEAWAY, item, "RECOGER EN SUCURSAL" in services)
+                if whatsapp := location_info.get("ContactoWhatsapp"):
+                    set_social_media(item, SocialMedia.WHATSAPP, whatsapp)
                 yield item

--- a/locations/spiders/hipermaxi_bo.py
+++ b/locations/spiders/hipermaxi_bo.py
@@ -44,4 +44,5 @@ class HipermaxiBOSpider(Spider):
                 apply_yes_no(Extras.TAKEAWAY, item, "RECOGER EN SUCURSAL" in services)
                 if whatsapp := location_info.get("ContactoWhatsapp"):
                     set_social_media(item, SocialMedia.WHATSAPP, whatsapp)
+                item["website"] = "https://www.hipermaxi.com/sucursales"
                 yield item


### PR DESCRIPTION
The new API used, requires `access_token`, couldn't find any working way to remove the dependency on the hard coded token, but looks like not going to expire soon. `street_address` for few POIs don't have sufficient info, but coordinates are consistently present.

```
{'atp/brand/Hipermaxi': 44,
 'atp/brand_wikidata/Q81968262': 44,
 'atp/category/amenity/pharmacy': 26,
 'atp/category/multiple': 26,
 'atp/category/shop/supermarket': 18,
 'atp/field/city/missing': 44,
 'atp/field/country/from_spider_name': 44,
 'atp/field/email/missing': 44,
 'atp/field/image/missing': 44,
 'atp/field/name/missing': 26,
 'atp/field/opening_hours/missing': 44,
 'atp/field/operator/missing': 44,
 'atp/field/operator_wikidata/missing': 44,
 'atp/field/phone/missing': 44,
 'atp/field/postcode/missing': 44,
 'atp/field/state/missing': 44,
 'atp/field/street_address/missing': 6,
 'atp/field/twitter/missing': 44,
 'atp/item_scraped_host_count/tienda-api.hipermaxi.com': 44,
 'atp/nsi/perfect_match': 18,
 'downloader/request_bytes': 1154,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 58729,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.797892,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 11, 9, 47, 32, 177152, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 472609,
 'httpcompression/response_count': 1,
 'item_scraped_count': 44,
 'log_count/DEBUG': 57,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 11, 9, 47, 28, 379260, tzinfo=datetime.timezone.utc)}
```