### PR TITLE
[Dusk NZ] Fix spider

### DIFF
--- a/locations/spiders/dusk_nz.py
+++ b/locations/spiders/dusk_nz.py
@@ -12,6 +12,9 @@ class DuskNZSpider(AmastyStoreLocatorSpider):
     name = "dusk_nz"
     item_attributes = {"brand": "dusk", "brand_wikidata": "Q120669167", "extras": Categories.SHOP_HOUSEWARE.value}
     allowed_domains = ["www.duskcandles.co.nz"]
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+    }
 
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
         address_string = re.sub(r"\s+", " ", " ".join(filter(None, popup_html.xpath("//text()").getall())))

--- a/locations/spiders/dusk_nz.py
+++ b/locations/spiders/dusk_nz.py
@@ -1,10 +1,10 @@
-import re
 from typing import Iterable
 
 from scrapy import Selector
 
 from locations.categories import Categories
 from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
 
 
@@ -17,8 +17,5 @@ class DuskNZSpider(AmastyStoreLocatorSpider):
     }
 
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
-        address_string = re.sub(r"\s+", " ", " ".join(filter(None, popup_html.xpath("//text()").getall())))
-        item["city"] = address_string.split("City: ", 1)[1].split(" Postcode: ", 1)[0]
-        item["postcode"] = address_string.split("Postcode: ", 1)[1].split(" Address: ", 1)[0]
-        item["street_address"] = address_string.split("Address: ", 1)[1].split(" Region: ", 1)[0]
+        item["addr_full"] = clean_address(popup_html.xpath("//text()").getall())
         yield item

--- a/locations/spiders/dusk_nz.py
+++ b/locations/spiders/dusk_nz.py
@@ -18,4 +18,5 @@ class DuskNZSpider(AmastyStoreLocatorSpider):
 
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
         item["addr_full"] = clean_address(popup_html.xpath("//text()").getall())
+        item["branch"] = item.pop("name")
         yield item

--- a/locations/spiders/dusk_nz.py
+++ b/locations/spiders/dusk_nz.py
@@ -19,4 +19,5 @@ class DuskNZSpider(AmastyStoreLocatorSpider):
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
         item["addr_full"] = clean_address(popup_html.xpath("//text()").getall())
         item["branch"] = item.pop("name")
+        item["website"] = f'https://www.duskcandles.co.nz/store-locator/dusk-{item["branch"].lower()}/'
         yield item


### PR DESCRIPTION
`robotstxt` ignored to remove the spider blockage. Fixed error due to change in the address string. Few more changes added.

```
{'atp/brand/dusk': 3,
 'atp/brand_wikidata/Q120669167': 3,
 'atp/category/shop/houseware': 3,
 'atp/field/city/missing': 3,
 'atp/field/country/from_spider_name': 3,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 3,
 'atp/field/name/missing': 3,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 3,
 'atp/field/operator_wikidata/missing': 3,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 3,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 3,
 'atp/item_scraped_host_count/www.duskcandles.co.nz': 3,
 'atp/nsi/brand_missing': 3,
 'downloader/request_bytes': 323,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 12169,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.520263,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 11, 12, 44, 36, 483465, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9953,
 'httpcompression/response_count': 1,
 'item_scraped_count': 3,
 'log_count/DEBUG': 15,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 11, 12, 44, 34, 963202, tzinfo=datetime.timezone.utc)}
```