### PR TITLE
[opentransportdata.swiss] Change dataset attribution to optional

### DIFF
--- a/locations/spiders/opentransportdata_swiss.py
+++ b/locations/spiders/opentransportdata_swiss.py
@@ -17,7 +17,9 @@ class OpentransportdataSwissSpider(scrapy.Spider):
     name = "opentransportdata_swiss"
     allowed_domains = ["opentransportdata.swiss"]
     dataset_attributes = {
-        "attribution": "required",
+        # https://opentransportdata.swiss/en/authorised-databases/
+        # https://opentransportdata.swiss/en/terms-of-use/#511_Exemption_for_databases
+        "attribution": "optional",
         "attribution:name": "OpenTransportData.swiss",
         "attribution:wikidata": "Q97319754",
         "license:website": "https://opentransportdata.swiss/en/terms-of-use/",


### PR DESCRIPTION
The upstream data source has waived the attribution requirement for All The Places (”database”) and its data consumers (“licence holders of the database”).

* https://opentransportdata.swiss/en/authorised-databases/
* https://opentransportdata.swiss/en/terms-of-use/#511_Exemption_for_databases