### PR TITLE
[Maurices] Improve brand and branch

### DIFF
--- a/locations/spiders/maurices.py
+++ b/locations/spiders/maurices.py
@@ -9,7 +9,7 @@ class MauricesSpider(SitemapSpider, StructuredDataSpider):
     name = "maurices"
     item_attributes = {"brand": "Maurices", "brand_wikidata": "Q6793571"}
     sitemap_urls = ["https://locations.maurices.com/sitemap.xml"]
-    sitemap_rules = [("com/\w\w/\w\w/[^/]+/[^/]+$", "parse_sd")]
+    sitemap_rules = [(r"com/\w\w/\w\w/[^/]+/[^/]+$", "parse_sd")]
     drop_attributes = {"image"}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):

--- a/locations/spiders/maurices.py
+++ b/locations/spiders/maurices.py
@@ -1,12 +1,17 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class MauricesSpider(SitemapSpider, StructuredDataSpider):
     name = "maurices"
-    item_attributes = {"brand": "maurices", "brand_wikidata": "Q6793571"}
+    item_attributes = {"brand": "Maurices", "brand_wikidata": "Q6793571"}
     sitemap_urls = ["https://locations.maurices.com/sitemap.xml"]
-    sitemap_rules = [("", "parse_sd")]
-    download_delay = 0.2
+    sitemap_rules = [("com/\w\w/\w\w/[^/]+/[^/]+$", "parse_sd")]
     drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("maurices ")
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Maurices': 866,
 'atp/brand_wikidata/Q6793571': 866,
 'atp/category/shop/clothes': 866,
 'atp/cdn/cloudflare/response_count': 868,
 'atp/cdn/cloudflare/response_status_count/200': 868,
 'atp/field/email/missing': 866,
 'atp/field/image/missing': 866,
 'atp/field/operator/missing': 866,
 'atp/field/operator_wikidata/missing': 866,
 'atp/field/twitter/missing': 866,
 'atp/item_scraped_host_count/locations.maurices.com': 866,
 'atp/nsi/perfect_match': 866,
 'downloader/request_bytes': 483537,
 'downloader/request_count': 868,
 'downloader/request_method_count/GET': 868,
 'downloader/response_bytes': 19995451,
 'downloader/response_count': 868,
 'downloader/response_status_count/200': 868,
 'elapsed_time_seconds': 170.870837,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 12, 15, 1, 16, 858341, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 700,
 'httpcache/hit': 168,
 'httpcache/miss': 700,
 'httpcache/store': 700,
 'httpcompression/response_bytes': 112942140,
 'httpcompression/response_count': 868,
 'item_scraped_count': 866,
 'log_count/DEBUG': 1746,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 458903552,
 'memusage/startup': 263471104,
 'request_depth_max': 1,
 'response_received_count': 868,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 867,
 'scheduler/dequeued/memory': 867,
 'scheduler/enqueued': 867,
 'scheduler/enqueued/memory': 867,
 'start_time': datetime.datetime(2024, 12, 12, 14, 58, 25, 987504, tzinfo=datetime.timezone.utc)}
```