### PR TITLE
[Nordsee] Fix spider

### DIFF
--- a/locations/spiders/nordsee.py
+++ b/locations/spiders/nordsee.py
@@ -1,31 +1,23 @@
-from scrapy import Selector, Spider
-from scrapy.http import JsonRequest
+from typing import Iterable
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+import chompjs
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class NordseeSpider(Spider):
+class NordseeSpider(JSONBlobSpider):
     name = "nordsee"
     item_attributes = {"brand": "Nordsee", "brand_wikidata": "Q74866"}
-    allowed_domains = ["www.nordsee.com"]
-    start_urls = ["https://www.nordsee.com/en/?type=2001"]
+    start_urls = ["https://www.nordsee.com/de/filialen"]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def extract_json(self, response: Response) -> list:
+        return chompjs.parse_js_object(
+            response.xpath('//script[contains(text(),"latitude")]/text()').get(), unicode_escape=True
+        )["stores"]
 
-    def parse(self, response):
-        for location in response.json()["stores"]:
-            item = DictParser.parse(location)
-            item["ref"] = location["uid"]
-            item["street_address"] = item.pop("housenumber", None)
-            item["opening_hours"] = OpeningHours()
-            for day_abbrev, hours_range in location.get("opening").items():
-                if isinstance(hours_range, str) and "------" not in hours_range:
-                    item["opening_hours"].add_range(day_abbrev.title(), *hours_range.split(" - ", 1), "%H:%M")
-            item["website"] = (
-                "https://www.nordsee.com"
-                + Selector(text=location["listItem"]).xpath('//a[@class="storeListItem__link"]/@href').get()
-            )
-            yield item
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if item.get("state") in ["AT", "DE"]:
+            item["country"] = item.pop("state")
+        yield item

--- a/locations/spiders/nordsee.py
+++ b/locations/spiders/nordsee.py
@@ -21,4 +21,5 @@ class NordseeSpider(JSONBlobSpider):
         if item.get("state") in ["AT", "DE"]:
             item["country"] = item.pop("state")
         item["website"] = response.url
+        item["phone"] = item["phone"].replace("\\/", "") if item.get("phone") else None
         yield item

--- a/locations/spiders/nordsee.py
+++ b/locations/spiders/nordsee.py
@@ -20,4 +20,5 @@ class NordseeSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         if item.get("state") in ["AT", "DE"]:
             item["country"] = item.pop("state")
+        item["website"] = response.url
         yield item


### PR DESCRIPTION
`JsonBlob` utilized to fix the broken spider. Covers `DE` & `AT` both. `NSI` suggests that brand has presence in other countries  as well like [SK](https://www.nordsee.sk/prevadzky/) etc, but they can't be added in this spider, also not much count count is there.

```
{'atp/brand/Nordsee': 217,
 'atp/brand_wikidata/Q74866': 217,
 'atp/category/amenity/fast_food': 217,
 'atp/field/branch/missing': 217,
 'atp/field/city/missing': 217,
 'atp/field/email/missing': 217,
 'atp/field/image/missing': 217,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 217,
 'atp/field/operator_wikidata/missing': 217,
 'atp/field/phone/missing': 17,
 'atp/field/postcode/missing': 217,
 'atp/field/state/missing': 217,
 'atp/field/street_address/missing': 217,
 'atp/field/twitter/missing': 217,
 'atp/item_scraped_host_count/www.nordsee.com': 217,
 'atp/nsi/perfect_match': 217,
 'downloader/request_bytes': 613,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 35398,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.093803,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 13, 10, 12, 36, 671158, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 479919,
 'httpcompression/response_count': 1,
 'item_scraped_count': 217,
 'log_count/DEBUG': 230,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 13, 10, 12, 33, 577355, tzinfo=datetime.timezone.utc)}
```