### PR TITLE
[Burger King GT] Fix spider

### DIFF
--- a/locations/spiders/burger_king_gt.py
+++ b/locations/spiders/burger_king_gt.py
@@ -25,6 +25,7 @@ class BurgerKingGTSpider(Spider):
             location = result.get("restaurant")
             item = DictParser.parse(location)
             item["geometry"] = location.get("point")
+            item["branch"] = item.pop("name").removeprefix("BK ").removeprefix("Burger King ")
             apply_yes_no(Extras.KIDS_AREA, item, location.get("kidsZone"))
             apply_yes_no(Extras.BREAKFAST, item, location.get("breakfast"))
             apply_yes_no(Extras.DELIVERY, item, location.get("delivery"))

--- a/locations/spiders/burger_king_gt.py
+++ b/locations/spiders/burger_king_gt.py
@@ -26,6 +26,7 @@ class BurgerKingGTSpider(Spider):
             item = DictParser.parse(location)
             item["geometry"] = location.get("point")
             item["branch"] = item.pop("name").removeprefix("BK ").removeprefix("Burger King ")
+            item["website"] = "https://app.bk.gt/#/"
             apply_yes_no(Extras.KIDS_AREA, item, location.get("kidsZone"))
             apply_yes_no(Extras.BREAKFAST, item, location.get("breakfast"))
             apply_yes_no(Extras.DELIVERY, item, location.get("delivery"))

--- a/locations/spiders/burger_king_gt.py
+++ b/locations/spiders/burger_king_gt.py
@@ -23,4 +23,5 @@ class BurgerKingGTSpider(Spider):
         if result := response.json().get("data"):
             location = result.get("restaurant")
             item = DictParser.parse(location)
+            item["geometry"] = location.get("point")
             yield item

--- a/locations/spiders/burger_king_gt.py
+++ b/locations/spiders/burger_king_gt.py
@@ -14,6 +14,8 @@ class BurgerKingGTSpider(Spider):
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
 
     def start_requests(self) -> Iterable[Request]:
+        # https://api.bk.gt/v1/restaurant/nearby?latitude=14.587041&longitude=-90.5210362 this API currently leads to
+        # HTTP Error 500, but might fetch more POIs if works.
         for city in city_locations("GT", 1000):
             yield JsonRequest(
                 url="https://api.bk.gt/v1/geolocation/verifyLatLng",

--- a/locations/spiders/burger_king_gt.py
+++ b/locations/spiders/burger_king_gt.py
@@ -3,6 +3,7 @@ from typing import Any, Iterable
 from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
+from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
@@ -24,4 +25,9 @@ class BurgerKingGTSpider(Spider):
             location = result.get("restaurant")
             item = DictParser.parse(location)
             item["geometry"] = location.get("point")
+            apply_yes_no(Extras.KIDS_AREA, item, location.get("kidsZone"))
+            apply_yes_no(Extras.BREAKFAST, item, location.get("breakfast"))
+            apply_yes_no(Extras.DELIVERY, item, location.get("delivery"))
+            apply_yes_no(Extras.WIFI, item, location.get("wifi"))
+            apply_yes_no(Extras.SELF_CHECKOUT, item, location.get("selfService"))
             yield item


### PR DESCRIPTION
Playing with the [Locator](https://app.bk.gt/#/geolocation/address?latitude=25.6180224&longitude=85.2000768), only gives one API that gives POI details, used in the spider for the fix. Not sure about the POI count, one more [API](https://api.bk.gt/v1/restaurant/nearby?latitude=14.587041&longitude=-90.5210362) is there which might give better count but unfortunately not working and results in HTTP Error `500`.
`Opening Hours` don't match with google maps data, didn't look reliable, hence ignored.

```
{'atp/brand/Burger King': 16,
 'atp/brand_wikidata/Q177054': 16,
 'atp/category/amenity/fast_food': 16,
 'atp/cdn/cloudflare/response_count': 103,
 'atp/cdn/cloudflare/response_status_count/201': 102,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/city/missing': 16,
 'atp/field/country/from_spider_name': 16,
 'atp/field/email/missing': 16,
 'atp/field/image/missing': 16,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 16,
 'atp/field/operator_wikidata/missing': 16,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 16,
 'atp/field/state/missing': 16,
 'atp/field/street_address/missing': 16,
 'atp/field/twitter/missing': 16,
 'atp/item_scraped_host_count/api.bk.gt': 25,
 'atp/nsi/cc_match': 16,
 'downloader/request_bytes': 37810,
 'downloader/request_count': 103,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 102,
 'downloader/response_bytes': 237374,
 'downloader/response_count': 103,
 'downloader/response_status_count/201': 102,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 124.548002,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 16, 14, 31, 49, 393217, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 73,
 'httpcompression/response_count': 1,
 'item_dropped_count': 9,
 'item_dropped_reasons_count/DropItem': 9,
 'item_scraped_count': 16,
 'log_count/DEBUG': 140,
 'log_count/INFO': 12,
 'response_received_count': 103,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 102,
 'scheduler/dequeued/memory': 102,
 'scheduler/enqueued': 102,
 'scheduler/enqueued/memory': 102,
 'start_time': datetime.datetime(2024, 12, 16, 14, 29, 44, 845215, tzinfo=datetime.timezone.utc)}
```