### PR TITLE
Add CycleBar (204 locations)

### DIFF
--- a/locations/spiders/cyclebar.py
+++ b/locations/spiders/cyclebar.py
@@ -1,0 +1,17 @@
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class CyclebarSpider(JSONBlobSpider):
+    name = "cyclebar"
+    item_attributes = {
+        "brand": "CycleBar",
+        "brand_wikidata": "Q121459827",
+    }
+    start_urls = ["https://members.cyclebar.com/api/brands/cyclebar/locations?open_status=external"]
+    locations_key = "locations"
+
+    def post_process_item(self, item, response, location):
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = item.pop("name")
+        item["website"] = location["site_url"]
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/CycleBar': 204,
 'atp/brand_wikidata/Q121459827': 204,
 'atp/category/leisure/fitness_centre': 204,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 204,
 'atp/field/opening_hours/missing': 204,
 'atp/field/operator/missing': 204,
 'atp/field/operator_wikidata/missing': 204,
 'atp/field/twitter/missing': 204,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/members.cyclebar.com': 204,
 'atp/nsi/perfect_match': 204,
 'downloader/request_bytes': 662,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 39251,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.415844,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 16, 20, 8, 26, 324622, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 484773,
 'httpcompression/response_count': 2,
 'item_scraped_count': 204,
 'items_per_minute': None,
 'log_count/DEBUG': 217,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 251211776,
 'memusage/startup': 251211776,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 16, 20, 8, 23, 908778, tzinfo=datetime.timezone.utc)}
```