### PR TITLE
[Zabka PL] Fix spider

### DIFF
--- a/locations/spiders/zabka_pl.py
+++ b/locations/spiders/zabka_pl.py
@@ -1,60 +1,18 @@
-from datetime import datetime
+from typing import Any
 
 import scrapy
-from scrapy.http import JsonRequest
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 
 
 class ZabkaPLSpider(scrapy.Spider):
     name = "zabka_pl"
     item_attributes = {"brand": "Żabka", "brand_wikidata": "Q2589061"}
+    start_urls = ["https://www.zabka.pl/app/uploads/locator-store-data.json"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    # URL extracted by observing request made by Żappka Android app (using HTTP Toolkit)
-    start_urls = ["https://partner-api.zabkamobile.pl/v2/shops"]
-
-    def start_requests(self):
-        # Authorization header is hard-coded into the Żappka app and does not appear to change (as of version 3.14.10).
-        headers = {
-            "Authorization": "PartnerKey 424A0B7AD0E9EA136510474D89061BBDC007B9BE5256A638EA28CC19D2BB15CD",
-        }
-        yield JsonRequest(url=self.start_urls[0], headers=headers)
-
-    def parse(self, response):
-        today = datetime.now()
-        for location in response.json():
-            item = DictParser.parse(location)
-            item["street_address"] = item.pop("addr_full", "")
-            # unset "state" field, it is taken from the "region" field which is some internal Żabka ID
-            item["state"] = None
-            item["opening_hours"] = OpeningHours()
-
-            # Each franchisee is required to be open Mon-Sat with the same hours
-            # But the hours for Sundays are set in the "nonTradingDays" field, which
-            # contains the opening hours for each specific Sunday.
-            item["opening_hours"].add_days_range(
-                ["Mo", "Tu", "We", "Th", "Fr", "Sa"], location["openTime"], location["closeTime"]
-            )
-
-            if location["nonTradingDays"]:
-                sunday_open = None
-                sunday_close = None
-                for rule in location["nonTradingDays"]:
-                    d = datetime.strptime(rule["date"], "%Y-%m-%d")
-                    if d.weekday() != 6 or d < today:
-                        continue  # In the past, ignore
-                    if sunday_open is None:
-                        sunday_open = rule["openTime"]
-                        sunday_close = rule["closeTime"]
-                    else:
-                        if sunday_open != rule["openTime"] or sunday_close != rule["closeTime"]:
-                            self.crawler.stats.inc_value("atp/zabka_pl/nonTradingDays/mismatching")
-                            break  # Mismatching future Sundays, skip
-                else:
-                    self.crawler.stats.inc_value("atp/zabka_pl/nonTradingDays/fine")
-                    item["opening_hours"].add_range("Su", sunday_open, sunday_close)
-            else:
-                self.crawler.stats.inc_value("atp/zabka_pl/nonTradingDays/missing")  # Sunday closed? Missing data?
-
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json():
+            item = DictParser.parse(store)
             yield item


### PR DESCRIPTION
New API utilized by the [POI locator](https://www.zabka.pl/znajdz-sklep/), used for fixing the spider.

```
{'atp/brand/Żabka': 11022,
 'atp/brand_wikidata/Q2589061': 11022,
 'atp/category/shop/convenience': 11022,
 'atp/field/branch/missing': 11022,
 'atp/field/country/from_spider_name': 11022,
 'atp/field/email/missing': 11022,
 'atp/field/image/missing': 11022,
 'atp/field/opening_hours/missing': 12,
 'atp/field/operator/missing': 11022,
 'atp/field/operator_wikidata/missing': 11022,
 'atp/field/phone/missing': 11022,
 'atp/field/postcode/missing': 11022,
 'atp/field/state/missing': 11022,
 'atp/field/street_address/missing': 11022,
 'atp/field/twitter/missing': 11022,
 'atp/item_scraped_host_count/www.zabka.pl': 11022,
 'atp/nsi/perfect_match': 11022,
 'downloader/request_bytes': 328,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 853321,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 24.437561,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'httpcompression/response_bytes': 5030288,
 'httpcompression/response_count': 1,
 'item_scraped_count': 11022,
 'log_count/DEBUG': 11034,
 'log_count/INFO': 10,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
```