### PR TITLE
[Taco Bell IN] Flag as requires proxy, might fix cloudflare blockage

### DIFF
--- a/locations/spiders/taco_bell_in.py
+++ b/locations/spiders/taco_bell_in.py
@@ -13,6 +13,7 @@ class TacoBellINSpider(Spider):
     name = "taco_bell_in"
     item_attributes = TACO_BELL_SHARED_ATTRIBUTES
     start_urls = ["https://www.tacobell.co.in/find-us"]
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.xpath('//div[@class="find-Us-Branches"]'):


### PR DESCRIPTION
Cloudflare is blocking the [POI locator](https://www.tacobell.co.in/find-us). [API](https://www.tacobell.co.in/storelocator/storelocator/advancesearch
) with post data e.g.` queryType=findStore&state=Delhi&city=allCity&locality=allLocality
` also getting blocked. One more [store page](https://www.tacobell.co.in/store-locator
) is there, but that is also blocked.