### PR TITLE
[wycon_cosmetics] Add spider (252 locations)

### DIFF
--- a/locations/spiders/wycon_cosmetics.py
+++ b/locations/spiders/wycon_cosmetics.py
@@ -10,7 +10,7 @@ class WyconCosmeticsSpider(Spider):
 
     def start_requests(self):
         yield scrapy.FormRequest(
-            url=f"https://www.wyconcosmetics.com/index.php",
+            url="https://www.wyconcosmetics.com/index.php",
             formdata={
                 "extension": "geo",
                 "controller": "places",

--- a/locations/spiders/wycon_cosmetics.py
+++ b/locations/spiders/wycon_cosmetics.py
@@ -1,0 +1,51 @@
+import scrapy
+from scrapy import Spider
+
+from locations.items import Feature
+
+
+class WyconCosmeticsSpider(Spider):
+    name = "wycon_cosmetics"
+    item_attributes = {"brand": "Wycon Cosmetics", "brand_wikidata": "Q55831243"}
+
+    def start_requests(self):
+        yield scrapy.FormRequest(
+            url=f"https://www.wyconcosmetics.com/index.php",
+            formdata={
+                "extension": "geo",
+                "controller": "places",
+                "action": "search_by_city",
+                "depth": "1",
+                "cityId": "2",
+                "language": "EN",
+                "zone": "eu",
+                "version": "1026",
+                "cookieVersion": "1",
+                "ajax_referer": "https%3A%2F%2Fwww.wyconcosmetics.com%2Fen%2Fstores",
+                "distance": "40000",
+            },
+            callback=self.parse,
+            headers={
+                "Referer": "https://www.wyconcosmetics.com/en/stores",
+                "Origin": "https://www.wyconcosmetics.com",
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        )
+
+    def parse(self, response, **kwargs):
+        for store in response.json()["payload"]["places"]:
+            address = store["geoTag"]
+            properties = {
+                "ref": store["id"],
+                "name": store["title"],
+                "website": store["permalink"],
+                "phone": store["phone"],
+                "street_address": address["street_address"],
+                "postcode": address["zipcode"],
+                "city": address["cityName"],
+                "country": address["countryName"],
+                "lon": address["longitude"],
+                "lat": address["latitude"],
+            }
+            yield Feature(**properties)


### PR DESCRIPTION
Add [Wycon Cosmetics](https://www.wyconcosmetics.com/), a cosmetics chain from IT but also present in several other countries.

```
2024-12-17 22:26:12 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Wycon Cosmetics': 252,
 'atp/brand_wikidata/Q55831243': 252,
 'atp/category/shop/cosmetics': 252,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/branch/missing': 252,
 'atp/field/city/missing': 2,
 'atp/field/email/missing': 252,
 'atp/field/image/missing': 252,
 'atp/field/opening_hours/missing': 252,
 'atp/field/operator/missing': 252,
 'atp/field/operator_wikidata/missing': 252,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 38,
 'atp/field/postcode/missing': 15,
 'atp/field/state/missing': 252,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 252,
 'atp/item_scraped_host_count/www.wyconcosmetics.com': 252,
 'atp/nsi/perfect_match': 252,
```