### PR TITLE
feat: improve Poste Italiane (IT, 74/98k)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -89,6 +89,7 @@ class Categories(Enum):
     SHOP_CHOCOLATE = {"shop": "chocolate"}
     SHOP_CLOTHES = {"shop": "clothes"}
     SHOP_COFFEE = {"shop": "coffee"}
+    SHOP_COLLECTOR = {"shop": "collector"}
     SHOP_COMPUTER = {"shop": "computer"}
     SHOP_CONFECTIONERY = {"shop": "confectionery"}
     SHOP_CONVENIENCE = {"shop": "convenience"}

--- a/locations/json_blob_spider.py
+++ b/locations/json_blob_spider.py
@@ -104,6 +104,8 @@ class JSONBlobSpider(Spider):
 
     def parse_feature_array(self, response: Response, feature_array: list) -> Iterable[Feature]:
         for feature in feature_array:
+            if feature is None:
+                continue
             self.pre_process_data(feature)
             item = DictParser.parse(feature)
             yield from self.post_process_item(item, response, feature) or []

--- a/locations/spiders/poste_italiane_it.py
+++ b/locations/spiders/poste_italiane_it.py
@@ -2,7 +2,7 @@ import re
 
 from scrapy.http import JsonRequest
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.hours import CLOSED_IT, DAYS_IT, DELIMITERS_IT, NAMED_DAY_RANGES_IT, NAMED_TIMES_IT, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -10,7 +10,12 @@ from locations.json_blob_spider import JSONBlobSpider
 class PosteItalianeITSpider(JSONBlobSpider):
     name = "poste_italiane_it"
     # web page: https://www.poste.it/cerca/index.html#/vieni-in-poste
-    start_urls = ["https://mapcollection.poste.it/v2/map/geoList"]
+    # if grouped differently, they group separate but near points losing information
+    point_groups = [
+        ["UfficioPostale", "PuntoPoste", "PuntoPosteLocker"],
+        ["CassettaPostale", "SpazioFilatelico"],
+        ["Merchant"],
+    ]
     locations_key = ["data", "listaPunti"]
     POSTE_BRAND = {"brand": "Poste Italiane", "brand_wikidata": "Q495026"}
     PUNTO_POSTE_BRAND = {
@@ -18,25 +23,30 @@ class PosteItalianeITSpider(JSONBlobSpider):
         "post_office:brand:wikidata": "Q495026",
     }
     TOBACCO_MATCH = re.compile(r"^Tabacc.+\s*N\.\s*(\d+)$")
+    merchant_types = {
+        "ABBIGLIAMENTO": Categories.SHOP_CLOTHES,
+        "CARBURANTE": Categories.FUEL_STATION,
+        "SPESA_E_CUCINA": Categories.SHOP_SUPERMARKET,
+    }
 
     def start_requests(self):
-        for url in self.start_urls:
+        for group in self.point_groups:
             yield JsonRequest(
-                url,
+                "https://mapcollection.poste.it/v2/map/geoList",
                 data={
                     "lon": 12.480178129359274,
                     "lat": 41.89637400808064,
                     "spanLon": 7,
                     "spanLat": 7,
-                    "tipoPunto": ["UfficioPostale", "PuntoPoste", "PuntoPosteLocker"],
+                    "tipoPunto": group,
                     "limit": 100000,
                 },
                 meta={"download_timeout": 30},
             )
 
     def pre_process_data(self, location):
-        location["indirizzo"] = location.pop("indirizzoPunto")
-        location["name"] = location.pop("nomePunto")
+        location["indirizzo"] = location.get("indirizzoPunto")
+        location["name"] = location.get("nomePunto")
         location["phone"] = location.get("numeroTelefono")
 
     def post_process_item(self, item, response, location):
@@ -50,6 +60,11 @@ class PosteItalianeITSpider(JSONBlobSpider):
                 apply_yes_no(Extras.WIFI, item, s["codice"] == "WIFI")
                 apply_yes_no(Extras.ATM, item, s["codice"] == "ATMNONH24")
                 apply_yes_no(Extras.ATM, item, s["codice"] == "ATMH24")
+        elif location["tipoPunto"] == "SpazioFilatelico":
+            item.update(self.POSTE_BRAND)
+            apply_category(Categories.SHOP_COLLECTOR, item)
+            item["extras"]["collector"] = "coins;medals;postcards;stamps"
+            self.apply_hours(item, location["orari"])
         elif location["tipoPunto"] == "PuntoPoste":
             apply_category(Categories.POST_PARTNER, item)
             item["extras"].update(self.PUNTO_POSTE_BRAND)
@@ -62,6 +77,39 @@ class PosteItalianeITSpider(JSONBlobSpider):
             apply_category(Categories.PARCEL_LOCKER, item)
             item.update(self.POSTE_BRAND)
             self.apply_hours(item, location["orari"])
+        elif location["tipoPunto"] == "CassettaPostale":
+            apply_category(Categories.POST_BOX, item)
+            item["extras"]["ref:poste_italiane"] = item["ref"]
+            item["ref"] = item.pop("name")
+            item.update(self.POSTE_BRAND)
+            if coll := location.get("orarioVuotatura"):
+                oh = OpeningHours()
+                oh.add_ranges_from_string(
+                    f"{coll} - {coll[-5:]}",
+                    days=DAYS_IT,
+                    named_day_ranges=NAMED_DAY_RANGES_IT,
+                    named_times=NAMED_TIMES_IT,
+                    closed=CLOSED_IT,
+                    delimiters=DELIMITERS_IT,
+                )
+                item["extras"]["collection_times"] = oh.as_opening_hours()
+                # self.crawler.stats.inc_value(f"atp/{self.name}/collection_times/{coll}")
+                # self.crawler.stats.inc_value(f"atp/{self.name}/collection_times/{item['extras']['collection_times']}")
+        elif location["tipoPunto"] == "Merchant":
+            item["extras"]["ref:vatin"] = "IT" + location["partitaIva"]
+            apply_yes_no(PaymentMethods.BANCOPOSTA, item, True)
+            apply_yes_no(PaymentMethods.POSTEPAY, item, True)
+            if category := self.merchant_types.get(location["categoriaMerchant"]["codice"]):
+                apply_category(category, item)
+            else:
+                self.crawler.stats.inc_value(
+                    f"atp/{self.name}/unknown_merchant/{location['categoriaMerchant']['codice']}"
+                )
+                self.crawler.stats.inc_value(
+                    f"atp/{self.name}/unknown_merchant/{location['categoriaMerchant']['descrizione']}"
+                )
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unknown_type/{location['tipoPunto']}")
         if fax := location.get("fax"):
             item["extras"]["contact:fax"] = fax
         yield item


### PR DESCRIPTION
```js
{'atp/brand/Poste Italiane': 41405,
 'atp/brand_wikidata/Q495026': 41405,
 'atp/category/amenity/fuel': 4086,
 'atp/category/amenity/parcel_locker': 41,
 'atp/category/amenity/post_box': 28400,
 'atp/category/amenity/post_office': 12954,
 'atp/category/missing': 24251,
 'atp/category/shop/clothes': 1157,
 'atp/category/shop/collector': 10,
 'atp/category/shop/supermarket': 11563,
 'atp/category/shop/tobacco': 16488,
 'atp/field/branch/missing': 85996,
 'atp/field/brand/missing': 57545,
 'atp/field/brand_wikidata/missing': 57545,
 'atp/field/city/missing': 20,
 'atp/field/country/from_spider_name': 98950,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 98176,
 'atp/field/image/missing': 98950,
 'atp/field/name/missing': 28443,
 'atp/field/opening_hours/missing': 67570,
 'atp/field/operator/missing': 57555,
 'atp/field/operator_wikidata/missing': 57555,
 'atp/field/phone/invalid': 128,
 'atp/field/phone/missing': 66942,
 'atp/field/state/missing': 98950,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 98950,
 'atp/field/website/missing': 98950,
 'atp/item_scraped_host_count/mapcollection.poste.it': 98950,
 'atp/nsi/cc_match': 41395,
 'atp/nsi/match_failed': 10,
 'atp/operator/Poste Italiane': 41395,
 'atp/operator_wikidata/Q495026': 41395,
 'downloader/request_bytes': 1979,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 3,
 'downloader/response_bytes': 66418390,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 650.186025,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 18, 1, 9, 37, 708633, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 4,
 'item_scraped_count': 98950,
 'items_per_minute': None,
 'log_count/INFO': 20,
 'log_count/WARNING': 1,
 'memusage/max': 697360384,
 'memusage/startup': 267677696,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 12, 18, 0, 58, 47, 522608, tzinfo=datetime.timezone.utc)}
```