### PR TITLE
[Pizza Hut IN] Fix spider

### DIFF
--- a/locations/spiders/pizza_hut_in.py
+++ b/locations/spiders/pizza_hut_in.py
@@ -1,31 +1,38 @@
+import json
 from typing import Any
 
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import Spider
 
-from locations.categories import Categories, apply_category
-from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.dict_parser import DictParser
+from locations.linked_data_parser import LinkedDataParser
 
 
-class PizzaHutINSpider(CrawlSpider):
+# https://restaurants.pizzahut.co.in/sitemap.xml gives lesser count, hence ignored.
+class PizzaHutINSpider(Spider):
     name = "pizza_hut_in"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
     start_urls = ["https://restaurants.pizzahut.co.in/?page=1"]
-    rules = [Rule(LinkExtractor(r"/\?page=\d+$"), callback="parse", follow=True)]
+    final_page = 0
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//div[@class="store-info-box"]'):
-            item = Feature()
-            item["ref"] = item["website"] = location.xpath('.//a[contains(@href, "/Home")]/@href').get()
-            item["lat"] = location.xpath('input[@class="outlet-latitude"]/@value').get()
-            item["lon"] = location.xpath('input[@class="outlet-longitude"]/@value').get()
-            item["addr_full"] = merge_address_lines(
-                location.xpath('.//li[@class="outlet-address"]/div[@class="info-text"]/span/text()').getall()
+        if not self.final_page:
+            self.final_page = int(
+                response.xpath(
+                    '//button[contains(@class,"mantine-Pagination-control")][@data-with-padding="true"]/text()'
+                ).getall()[-1]
             )
-            item["phone"] = location.xpath('.//li[@class="outlet-phone"]/div[@class="info-text"]/a/text()').get()
+        current_page = int(response.xpath('//button[@aria-current="page"]/text()').get())
+        linked_data = json.loads(response.xpath('//script[@type="application/ld+json"]/text()').get())
+        if isinstance(linked_data, list):
+            for ld in linked_data:
+                if not DictParser.get_nested_key(ld, "itemListElement"):
+                    continue
+                for item_element in DictParser.get_nested_key(ld, "itemListElement"):
+                    if ld_item := item_element.get("item"):
+                        item = LinkedDataParser.parse_ld(ld_item)
+                        item["ref"] = item["website"] = ld_item["url"].split("?utm_source")[0]
+                        yield item
 
-            apply_category(Categories.RESTAURANT, item)
-
-            yield item
+        if current_page < self.final_page:
+            yield response.follow(f"/?page={current_page + 1}")

--- a/locations/spiders/pizza_hut_in.py
+++ b/locations/spiders/pizza_hut_in.py
@@ -1,40 +1,7 @@
-import json
-from typing import Any
-
-from scrapy.http import Response
-from scrapy.spiders import Spider
-
-from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.linked_data_parser import LinkedDataParser
+from locations.spiders.pizza_hut_gb import PizzaHutGBSpider
 
 
-# https://restaurants.pizzahut.co.in/sitemap.xml gives lesser count, hence ignored.
-class PizzaHutINSpider(Spider):
+class PizzaHutINSpider(PizzaHutGBSpider):
     name = "pizza_hut_in"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
-    start_urls = ["https://restaurants.pizzahut.co.in/?page=1"]
-    final_page = 0
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        if not self.final_page:
-            self.final_page = int(
-                response.xpath(
-                    '//button[contains(@class,"mantine-Pagination-control")][@data-with-padding="true"]/text()'
-                ).getall()[-1]
-            )
-        current_page = int(response.xpath('//button[@aria-current="page"]/text()').get())
-        linked_data = json.loads(response.xpath('//script[@type="application/ld+json"]/text()').get())
-        if isinstance(linked_data, list):
-            for ld in linked_data:
-                if not DictParser.get_nested_key(ld, "itemListElement"):
-                    continue
-                for item_element in DictParser.get_nested_key(ld, "itemListElement"):
-                    if ld_item := item_element.get("item"):
-                        item = LinkedDataParser.parse_ld(ld_item)
-                        item["ref"] = item["website"] = ld_item["url"].split("?utm_source")[0]
-                        apply_category(Categories.RESTAURANT, item)
-                        yield item
-
-        if current_page < self.final_page:
-            yield response.follow(f"/?page={current_page + 1}")
+    start_urls = ["https://api.pizzahut.io/v1/huts?sectors=in-1"]

--- a/locations/spiders/pizza_hut_in.py
+++ b/locations/spiders/pizza_hut_in.py
@@ -4,6 +4,7 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.linked_data_parser import LinkedDataParser
 
@@ -32,6 +33,7 @@ class PizzaHutINSpider(Spider):
                     if ld_item := item_element.get("item"):
                         item = LinkedDataParser.parse_ld(ld_item)
                         item["ref"] = item["website"] = ld_item["url"].split("?utm_source")[0]
+                        apply_category(Categories.RESTAURANT, item)
                         yield item
 
         if current_page < self.final_page:


### PR DESCRIPTION
[Sitemap](https://restaurants.pizzahut.co.in/sitemap.xml) gives count less than `400`. [Store pages](https://restaurants.pizzahut.co.in/?page=1) give around `460`, but the [API](https://api.pizzahut.io/v1/huts?sectors=in-1) gives the max count, same API `GB` Spider utilizes, only the parameter `sectors` varies for the two countries.

```
{'atp/brand/Pizza Hut': 194,
 'atp/brand/Pizza Hut Delivery': 811,
 'atp/brand_wikidata/Q107293079': 811,
 'atp/brand_wikidata/Q191615': 194,
 'atp/category/amenity/fast_food': 811,
 'atp/category/amenity/restaurant': 194,
 'atp/field/city/missing': 1005,
 'atp/field/country/from_spider_name': 1005,
 'atp/field/email/missing': 1005,
 'atp/field/image/missing': 1005,
 'atp/field/opening_hours/missing': 1005,
 'atp/field/operator/missing': 1005,
 'atp/field/operator_wikidata/missing': 1005,
 'atp/field/twitter/missing': 1005,
 'atp/field/website/missing': 1005,
 'atp/item_scraped_host_count/api.pizzahut.io': 1005,
 'atp/nsi/cc_match': 194,
 'atp/nsi/perfect_match': 811,
 'downloader/request_bytes': 622,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 100007,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 6.188171,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 18, 14, 37, 1, 486359, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1103292,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1005,
 'log_count/DEBUG': 1018,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 18, 14, 36, 55, 298188, tzinfo=datetime.timezone.utc)}
```