### PR TITLE
[Banxico MX ] Add  Spider (67287 locations)

### DIFF
--- a/locations/spiders/banxico_mx.py
+++ b/locations/spiders/banxico_mx.py
@@ -1,0 +1,112 @@
+import io
+import zipfile
+from typing import Any, Iterable
+
+from scrapy import FormRequest, Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+"""
+Banco de México (Banxico) : Q806208
+The Bank of Mexico (Spanish: Banco de México), abbreviated BdeM or Banxico, is Mexico's central bank, monetary authority and lender of last resort.
+https://en.wikipedia.org/wiki/Bank_of_Mexico
+"""
+
+
+class BanxicoMXSpider(Spider):
+    name = "banxico_mx"
+    BRANDS_MAPPING = {
+        "37166": ("Banco del Bienestar", "Q5719137"),
+        "40014": ("Santander", "Q8965165"),
+        "40127": ("Banco Azteca", "Q4854076"),
+        "40137": ("BanCoppel", "Q126192396"),
+        "37019": ("Banjercito", "Q24655074"),
+        "40030": ("BanBajío", "Q5718183"),
+        "40002": ("Banamex", "Q2646652"),
+        "40072": ("Banorte", "Q806914"),
+        "40012": ("BBVA", "Q2876794"),
+        "40021": ("HSBC", "Q5635881"),
+        "40130": ("Compartamos Banco ICR", "Q2990370"),
+        "40036": ("ICR Inbursa", "Q731123"),
+        "40044": ("Scotiabank", "Q451476"),
+        "40136": ("Intercam Banco", "Q30915645"),
+        "40143": ("CIBanco", "Q126539570"),
+        "40058": ("BanRegio", "Q4853573"),
+        "40132": ("Banco Multiva", "Q2885364"),
+        "40106": ("Bank of America", "Q487907"),
+        "40042": ("Banca Mifel", "Q5717818"),
+        "40062": ("Afirme", "Q60825526"),
+        "40060": ("Bansí", "Q5719140"),
+        "40133": ("Actinver", None),
+        "40128": ("Autofin", None),
+        "40037": ("Interacciones", None),
+        "40140": ("Consubanco", None),
+    }
+
+    def start_requests(self) -> Iterable[Request]:
+        yield Request(url="https://www.banxico.org.mx/canje-efectivo/web/ubica-cc")  # branches
+        yield Request(
+            url="https://www.banxico.org.mx/services/ubicajeros-banxico-mobile-app.html", callback=self.parse_atms
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for state_id in response.xpath('//select[@id="listaEntidadFederativa"]//option/@value').getall():
+            yield JsonRequest(
+                url=f"https://www.banxico.org.mx/canje-efectivo/web/municipios-de-estado?idEstado={state_id}",
+                callback=self.parse_municipalities,
+                cb_kwargs=dict(state_id=state_id),
+            )
+
+    def parse_municipalities(self, response: Response, state_id: str) -> Any:
+        for municipality in response.json():
+            yield FormRequest(
+                url="https://www.banxico.org.mx/canje-efectivo/web/busca-cc",
+                formdata={"estado": state_id, "municipio": municipality["id"], "codigoPostal": "0"},
+                callback=self.parse_locations,
+                cb_kwargs=dict(city=municipality["nombre"]),
+            )
+
+    def parse_locations(self, response: Response, city: str) -> Any:
+        for location in response.json():
+            location_details = location["domicilio"]
+            item = Feature()
+            item["ref"] = str(location["id"]) + "-" + location_details["codigoPostal"]
+            item["branch"] = location["nombre"]
+            item["lat"] = location_details["ubicacion"]["latitud"]
+            item["lon"] = location_details["ubicacion"]["longitud"]
+            item["housenumber"] = location_details["numeroExterior"].replace("SN", "")
+            item["street"] = location_details["calle"]
+            item["city"] = city
+            item["postcode"] = location_details["codigoPostal"]
+            item["state"] = location_details["estado"]["nombre"]
+            if brand_info := self.BRANDS_MAPPING.get(location["institucion"]["insititucion"].removeprefix("0")):
+                item["brand"], item["brand_wikidata"] = brand_info
+            apply_category(Categories.BANK, item)
+            yield item
+
+    def parse_atms(self, response: Response, **kwargs: Any) -> Any:
+        # Access zip file containing ATM details
+        yield response.follow(
+            url=response.xpath('//a[contains(@href,".zip")]/@href').get(""), callback=self.parse_atm_details
+        )
+
+    def parse_atm_details(self, response: Response, **kwargs: Any) -> Any:
+        with zipfile.ZipFile(io.BytesIO(response.body)) as feed_zip:
+            for file_name in feed_zip.namelist():
+                if file_name.endswith(".txt"):
+                    with feed_zip.open(file_name) as file:
+                        for line in file.read().decode("utf-8").splitlines():
+                            # Refer https://www.banxico.org.mx/servicios/d/%7BD18A66F7-26AF-4BA0-C215-83531E401657%7D.pdf
+                            # for fields description
+                            location_info = line.split("|")
+                            item = Feature()
+                            bank_id = location_info[0]
+                            item["ref"] = bank_id + "-" + location_info[1]
+                            item["addr_full"], item["postcode"], item["lat"], item["lon"] = location_info[2:6]
+                            # location_info[7] : opening_hours don't look reliable, hence ignored.
+                            if brand_info := self.BRANDS_MAPPING.get(bank_id.removeprefix("0")):
+                                item["brand"], item["brand_wikidata"] = brand_info
+                            apply_category(Categories.ATM, item)
+                            yield item


### PR DESCRIPTION
```
{'atp/brand/Actinver': 16,
 'atp/brand/Afirme': 1922,
 'atp/brand/Autofin': 28,
 'atp/brand/BBVA': 14212,
 'atp/brand/BanBajío': 941,
 'atp/brand/BanCoppel': 3141,
 'atp/brand/BanRegio': 618,
 'atp/brand/Banamex': 8322,
 'atp/brand/Banca Mifel': 103,
 'atp/brand/Banco Azteca': 3281,
 'atp/brand/Banco Multiva': 214,
 'atp/brand/Banco del Bienestar': 6103,
 'atp/brand/Banjercito': 931,
 'atp/brand/Bank of America': 1,
 'atp/brand/Banorte': 10101,
 'atp/brand/Bansí': 217,
 'atp/brand/CIBanco': 482,
 'atp/brand/Compartamos Banco ICR': 85,
 'atp/brand/Consubanco': 1,
 'atp/brand/HSBC': 3929,
 'atp/brand/ICR Inbursa': 747,
 'atp/brand/Interacciones': 1,
 'atp/brand/Intercam Banco': 511,
 'atp/brand/Santander': 8612,
 'atp/brand/Scotiabank': 2025,
 'atp/brand_wikidata/Q126192396': 3141,
 'atp/brand_wikidata/Q126539570': 482,
 'atp/brand_wikidata/Q24655074': 931,
 'atp/brand_wikidata/Q2646652': 8322,
 'atp/brand_wikidata/Q2876794': 14212,
 'atp/brand_wikidata/Q2885364': 214,
 'atp/brand_wikidata/Q2990370': 85,
 'atp/brand_wikidata/Q30915645': 511,
 'atp/brand_wikidata/Q451476': 2025,
 'atp/brand_wikidata/Q4853573': 618,
 'atp/brand_wikidata/Q4854076': 3281,
 'atp/brand_wikidata/Q487907': 1,
 'atp/brand_wikidata/Q5635881': 3929,
 'atp/brand_wikidata/Q5717818': 103,
 'atp/brand_wikidata/Q5718183': 941,
 'atp/brand_wikidata/Q5719137': 6103,
 'atp/brand_wikidata/Q5719140': 217,
 'atp/brand_wikidata/Q60825526': 1922,
 'atp/brand_wikidata/Q731123': 747,
 'atp/brand_wikidata/Q806914': 10101,
 'atp/brand_wikidata/Q8965165': 8612,
 'atp/category/amenity/atm': 57193,
 'atp/category/amenity/bank': 10094,
 'atp/field/branch/missing': 57193,
 'atp/field/brand/missing': 743,
 'atp/field/brand_wikidata/missing': 789,
 'atp/field/city/missing': 57193,
 'atp/field/country/from_spider_name': 67287,
 'atp/field/email/missing': 67287,
 'atp/field/image/missing': 67287,
 'atp/field/name/missing': 61705,
 'atp/field/opening_hours/missing': 67287,
 'atp/field/operator/missing': 33860,
 'atp/field/operator_wikidata/missing': 33860,
 'atp/field/phone/missing': 67287,
 'atp/field/state/missing': 57193,
 'atp/field/street_address/missing': 67287,
 'atp/field/twitter/missing': 67287,
 'atp/field/website/missing': 67287,
 'atp/item_scraped_host_count/www.banxico.org.mx': 67287,
 'atp/nsi/brand_missing': 27488,
 'atp/nsi/cc_match': 39009,
 'atp/nsi/match_failed': 1,
 'atp/operator/BBVA México': 13910,
 'atp/operator/Banca Afirme': 1914,
 'atp/operator/Banco Azteca': 2616,
 'atp/operator/Banco del Bienestar': 2943,
 'atp/operator/Banorte': 9007,
 'atp/operator/Banregio': 527,
 'atp/operator/Inbursa': 625,
 'atp/operator/Scotiabank': 1885,
 'atp/operator_wikidata/Q2876794': 13910,
 'atp/operator_wikidata/Q451476': 1885,
 'atp/operator_wikidata/Q4853573': 527,
 'atp/operator_wikidata/Q4854076': 2616,
 'atp/operator_wikidata/Q5719137': 2943,
 'atp/operator_wikidata/Q60825526': 1914,
 'atp/operator_wikidata/Q731123': 625,
 'atp/operator_wikidata/Q806914': 9007,
 'downloader/request_bytes': 1781457,
 'downloader/request_count': 2016,
 'downloader/request_method_count/GET': 37,
 'downloader/request_method_count/POST': 1979,
 'downloader/response_bytes': 7450303,
 'downloader/response_count': 2016,
 'downloader/response_status_count/200': 2015,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 70.775332,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 20, 13, 1, 49, 407678, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2016,
 'item_scraped_count': 67287,
 'log_count/DEBUG': 69315,
 'log_count/INFO': 11,
 'request_depth_max': 2,
 'response_received_count': 2015,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2014,
 'scheduler/dequeued/memory': 2014,
 'scheduler/enqueued': 2014,
 'scheduler/enqueued/memory': 2014,
 'start_time': datetime.datetime(2024, 12, 20, 13, 0, 38, 632346, tzinfo=datetime.timezone.utc)}
```