### PR TITLE
[Dixy RU] Fix Spider

### DIFF
--- a/locations/spiders/dixy_ru.py
+++ b/locations/spiders/dixy_ru.py
@@ -1,33 +1,28 @@
-import scrapy
-from scrapy.http import JsonRequest
+from typing import Any
 
-from locations.dict_parser import DictParser
+import scrapy
+from scrapy.http import Response
+
+from locations.hours import OpeningHours
+from locations.items import Feature
 
 
 class DixyRUSpider(scrapy.Spider):
     name = "dixy_ru"
     item_attributes = {"brand": "Дикси", "brand_wikidata": "Q4161561"}
-    allowed_domains = ["dixy.ru"]
+    start_urls = ["https://dixy.ru/ajax/stores-json.php"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
-        yield JsonRequest("https://dixy.ru/local/ajax/components/dixy_shop_points.php")
-
-    def parse(self, response):
-        for store in response.json()["features"]:
-            properties = store.get("properties", {})
-            geometry = store.get("geometry", {})
-            item = DictParser.parse(properties)
-            item["addr_full"] = None
-            item["street_address"] = properties.get("address")
-            item["lat"] = geometry.get("coordinates")[0]
-            item["lon"] = geometry.get("coordinates")[1]
-            self.parse_hours(item, properties.get("workingHours"))
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json():
+            store.update(store.pop("properties"))
+            item = Feature()
+            item["ref"] = store["id"]
+            item["addr_full"] = store["balloonContentBody"]
+            item["lat"], item["lon"] = store["geometry"]["coordinates"]
+            item["opening_hours"] = OpeningHours()
+            if store["balloonContentFooter"] == "Круглосуточно":
+                item["opening_hours"] = "24/7"
+            else:
+                item["opening_hours"].add_ranges_from_string(f'Mo-Su {store["balloonContentFooter"]}')
             yield item
-
-    def parse_hours(self, item, hours):
-        if hours == "24 часа":
-            item["opening_hours"] = "24/7"
-        else:
-            item["opening_hours"] = f"Mo-Su {hours}"
-        return item

--- a/locations/spiders/dixy_ru.py
+++ b/locations/spiders/dixy_ru.py
@@ -20,6 +20,7 @@ class DixyRUSpider(scrapy.Spider):
             item["ref"] = store["id"]
             item["addr_full"] = store["balloonContentBody"]
             item["lat"], item["lon"] = store["geometry"]["coordinates"]
+            item["website"] = "https://dixy.ru/"
             item["opening_hours"] = OpeningHours()
             if store["balloonContentFooter"] == "Круглосуточно":
                 item["opening_hours"] = "24/7"


### PR DESCRIPTION
API updated to fix the spider.
```
{'atp/brand/Дикси': 2179,
 'atp/brand_wikidata/Q4161561': 2179,
 'atp/category/shop/supermarket': 2179,
 'atp/field/branch/missing': 2179,
 'atp/field/city/missing': 2179,
 'atp/field/country/from_spider_name': 2179,
 'atp/field/email/missing': 2179,
 'atp/field/image/missing': 2179,
 'atp/field/operator/missing': 2179,
 'atp/field/operator_wikidata/missing': 2179,
 'atp/field/phone/missing': 2179,
 'atp/field/postcode/missing': 2179,
 'atp/field/state/missing': 2179,
 'atp/field/street_address/missing': 2179,
 'atp/field/twitter/missing': 2179,
 'atp/field/website/missing': 2179,
 'atp/item_scraped_host_count/dixy.ru': 2179,
 'atp/nsi/perfect_match': 2179,
 'downloader/request_bytes': 308,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 164936,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.312539,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 20, 14, 21, 39, 5819, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1166427,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2179,
 'log_count/DEBUG': 2191,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 20, 14, 21, 33, 693280, tzinfo=datetime.timezone.utc)}
```