### PR TITLE
[blackstore_fr] Add spider (114 locations)

### DIFF
--- a/locations/spiders/blackstore_fr.py
+++ b/locations/spiders/blackstore_fr.py
@@ -1,0 +1,45 @@
+import re
+
+from chompjs import parse_js_object
+from scrapy import Spider
+
+from locations.categories import Categories
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FR, OpeningHours, sanitise_day
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class BlackstoreFRSpider(Spider):
+    name = "blackstore_fr"
+    item_attributes = {"brand": "Blackstore", "brand_wikidata": "Q125446765", "extras": Categories.SHOP_CLOTHES.value}
+    start_urls = ["https://www.blackstore.fr/store-finder/"]
+    user_agent = BROWSER_DEFAULT
+
+    def parse(self, response, **kwargs):
+        js_blob = response.xpath('//script/text()[contains(., "var locationsMap")]').get()
+        for location in parse_js_object(js_blob):
+            item = DictParser.parse(location)
+            item["name"] = location["title"].strip().title()
+            if item["name"].startswith("Blackstore - "):
+                item["branch"] = item["name"].removeprefix("Blackstore - ")
+                item["name"] = "Blackstore"
+            item["addr_full"] = re.sub(r"\s*\n", ", ", item["addr_full"])
+            if not re.search("[a-z]", item["addr_full"]):
+                item["addr_full"] = item["addr_full"].title()
+            item["opening_hours"] = self.format_opening_hours(location["weekOpeningHours"])
+            yield item
+
+    def format_opening_hours(self, opening_hours):
+        hours = OpeningHours()
+        for day_definition in opening_hours:
+            if day_definition["closed"] == "false":
+                day = sanitise_day(day_definition["weekDay"], DAYS_FR)
+                for time_slot in (1, 2):
+                    if day_definition[f"openingTime{time_slot}"] and day_definition[f"closingTime{time_slot}"]:
+                        hours.add_range(
+                            day,
+                            day_definition[f"openingTime{time_slot}"],
+                            day_definition[f"closingTime{time_slot}"],
+                            "%H%M",
+                        )
+        return hours

--- a/locations/spiders/blackstore_fr.py
+++ b/locations/spiders/blackstore_fr.py
@@ -14,6 +14,7 @@ class BlackstoreFRSpider(Spider):
     item_attributes = {"brand": "Blackstore", "brand_wikidata": "Q125446765", "extras": Categories.SHOP_CLOTHES.value}
     start_urls = ["https://www.blackstore.fr/store-finder/"]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         js_blob = response.xpath('//script/text()[contains(., "var locationsMap")]').get()

--- a/locations/spiders/blackstore_fr.py
+++ b/locations/spiders/blackstore_fr.py
@@ -14,7 +14,7 @@ class BlackstoreFRSpider(Spider):
     item_attributes = {"brand": "Blackstore", "brand_wikidata": "Q125446765", "extras": Categories.SHOP_CLOTHES.value}
     start_urls = ["https://www.blackstore.fr/store-finder/"]
     user_agent = BROWSER_DEFAULT
-    requires_proxy = True
+    requires_proxy = "FR"
 
     def parse(self, response, **kwargs):
         js_blob = response.xpath('//script/text()[contains(., "var locationsMap")]').get()


### PR DESCRIPTION
Add [Blackstore](https://www.blackstore.fr/), a clothes chain in FR.

```
2024-12-22 22:05:09 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Blackstore': 114,
 'atp/brand_wikidata/Q125446765': 114,
 'atp/category/shop/clothes': 114,
 'atp/field/city/missing': 114,
 'atp/field/country/from_spider_name': 114,
 'atp/field/email/missing': 114,
 'atp/field/image/missing': 114,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 114,
 'atp/field/operator_wikidata/missing': 114,
 'atp/field/phone/missing': 114,
 'atp/field/postcode/missing': 114,
 'atp/field/state/missing': 114,
 'atp/field/street_address/missing': 114,
 'atp/field/twitter/missing': 114,
 'atp/field/website/missing': 114,
 'atp/item_scraped_host_count/www.blackstore.fr': 114,
 'atp/nsi/perfect_match': 114,
```