### PR TITLE
[kiko_milano] Add spider (1082 locations)

### DIFF
--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -1,0 +1,22 @@
+from scrapy.http import JsonRequest
+
+from locations.json_blob_spider import JSONBlobSpider
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class KikoMilanoSpider(JSONBlobSpider):
+    name = "kiko_milano"
+    item_attributes = {"brand": "KIKO Milano", "brand_wikidata": "Q3812045"}
+    user_agent = BROWSER_DEFAULT
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://api.retailtune.com/storelocator/v1/stores/get",
+            data={"language": "en"},
+            headers={
+                "Accept": "application/json",
+                "Authorization": "Bearer 0WNG4nqY725RhWGuaIjlPq8T2NnPxcRwNr1I1Oe4C6pJrrHomfslKXzLpgZKT02y6W0yKnc2SC4",
+                "Origin": "https://kiko-stores.kikocosmetics.com",
+                "Referer": "https://kiko-stores.kikocosmetics.com/",
+            },
+        )


### PR DESCRIPTION
Add [KIKO Milano](https://www.kikocosmetics.com/), a global cosmetics store chain.

```
2024-12-22 22:11:56 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/KIKO Milano': 1082,
 'atp/brand_wikidata/Q3812045': 1082,
 'atp/category/shop/cosmetics': 1082,
 'atp/field/branch/missing': 1082,
 'atp/field/country/from_reverse_geocoding': 1082,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 154,
 'atp/field/image/missing': 1082,
 'atp/field/lon/invalid': 1,
 'atp/field/opening_hours/missing': 1082,
 'atp/field/operator/missing': 1082,
 'atp/field/operator_wikidata/missing': 1082,
 'atp/field/phone/invalid': 13,
 'atp/field/phone/missing': 94,
 'atp/field/postcode/missing': 54,
 'atp/field/state/missing': 15,
 'atp/field/twitter/missing': 1082,
 'atp/item_scraped_host_count/api.retailtune.com': 1082,
 'atp/nsi/perfect_match': 1082,
```

Fixes #11281