### PR TITLE
[AnacondaAU] Fix Spider

### DIFF
--- a/locations/spiders/anaconda_au.py
+++ b/locations/spiders/anaconda_au.py
@@ -1,16 +1,38 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any
+import scrapy
+from scrapy.http import Response
 
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import extract_phone
 
-
-class AnacondaAUSpider(SitemapSpider):
+class AnacondaAUSpider(scrapy.Spider):
     name = "anaconda_au"
     item_attributes = {"brand": "Anaconda", "brand_wikidata": "Q105981238"}
-    sitemap_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml?queueittoken=e_anacondastores~ts_1734696784~ce_true~rt_safetynet~h_ac92d04c49398e4c2ab95fe4feb139a25cbb1c5fef669943615738fd8b2d024b"]
-    sitemap_rules = [("https://www.anacondastores.com/store/.+","parse_store",)]
-    custom_settings = {"ROBOTSTXT_OBEY":False}
+    start_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml"]
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "REDIRECT_ENABLED" : True
+    }
+    handle_httpstatus_list = [302]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
+        yield scrapy.Request(url=token_request_url,callback=self.parse_token_request)
+
+    def parse_token_request(self,response):
+        token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
+        yield scrapy.Request(url=token_request_url, callback=self.parse_token)
+
+    def parse_token(self,response):
+        url = str(response.headers.getlist("Location")[0].decode("utf-8"))
+        token = str(response.headers.getlist("Set-Cookie")[0].decode("utf-8"))
+        yield scrapy.Request(url=url,headers={"cookie":token}, callback=self.parse_store_urls)
+
+    def parse_store_urls(self,response,**kwargs):
+        for link in response.xpath('//urlset//url//loc/text()').getall():
+            yield scrapy.Request(url = link, callback=self.parse_store)
+
 
     def parse_store(self, response):
         properties = {

--- a/locations/spiders/anaconda_au.py
+++ b/locations/spiders/anaconda_au.py
@@ -8,15 +8,9 @@ from locations.structured_data_spider import extract_phone
 class AnacondaAUSpider(SitemapSpider):
     name = "anaconda_au"
     item_attributes = {"brand": "Anaconda", "brand_wikidata": "Q105981238"}
-    allowed_domains = ["www.anacondastores.com"]
-    sitemap_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"^https://www.anacondastores.com/store/(?:queensland|new-south-wales|victoria|tasmania|western-australia|south-australia|northern-territory|australian-capital-territory)/[\w\-]+/a\d{3}$",
-            "parse_store",
-        )
-    ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    sitemap_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml?queueittoken=e_anacondastores~ts_1734696784~ce_true~rt_safetynet~h_ac92d04c49398e4c2ab95fe4feb139a25cbb1c5fef669943615738fd8b2d024b"]
+    sitemap_rules = [("https://www.anacondastores.com/store/.+","parse_store",)]
+    custom_settings = {"ROBOTSTXT_OBEY":False}
 
     def parse_store(self, response):
         properties = {

--- a/locations/spiders/anaconda_au.py
+++ b/locations/spiders/anaconda_au.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 import scrapy
 from scrapy.http import Response
 
@@ -6,33 +7,30 @@ from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import extract_phone
 
+
 class AnacondaAUSpider(scrapy.Spider):
     name = "anaconda_au"
     item_attributes = {"brand": "Anaconda", "brand_wikidata": "Q105981238"}
     start_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml"]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,
-        "REDIRECT_ENABLED" : True
-    }
+    custom_settings = {"ROBOTSTXT_OBEY": False, "REDIRECT_ENABLED": True}
     handle_httpstatus_list = [302]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
-        yield scrapy.Request(url=token_request_url,callback=self.parse_token_request)
+        yield scrapy.Request(url=token_request_url, callback=self.parse_token_request)
 
-    def parse_token_request(self,response):
+    def parse_token_request(self, response):
         token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
         yield scrapy.Request(url=token_request_url, callback=self.parse_token)
 
-    def parse_token(self,response):
+    def parse_token(self, response):
         url = str(response.headers.getlist("Location")[0].decode("utf-8"))
         token = str(response.headers.getlist("Set-Cookie")[0].decode("utf-8"))
-        yield scrapy.Request(url=url,headers={"cookie":token}, callback=self.parse_store_urls)
+        yield scrapy.Request(url=url, headers={"cookie": token}, callback=self.parse_store_urls)
 
-    def parse_store_urls(self,response,**kwargs):
-        for link in response.xpath('//urlset//url//loc/text()').getall():
-            yield scrapy.Request(url = link, callback=self.parse_store)
-
+    def parse_store_urls(self, response, **kwargs):
+        for link in response.xpath("//urlset//url//loc/text()").getall():
+            yield scrapy.Request(url=link, callback=self.parse_store)
 
     def parse_store(self, response):
         properties = {


### PR DESCRIPTION
`Fixes: updated start_urls to fix spider`

{'atp/brand/Anaconda': 88,
 'atp/brand_wikidata/Q105981238': 88,
 'atp/category/shop/outdoor': 88,
 'atp/field/branch/missing': 88,
 'atp/field/city/missing': 88,
 'atp/field/email/missing': 88,
 'atp/field/image/missing': 88,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 88,
 'atp/field/operator_wikidata/missing': 88,
 'atp/field/postcode/missing': 88,
 'atp/field/state/missing': 88,
 'atp/field/street_address/missing': 88,
 'atp/field/twitter/missing': 88,
 'atp/item_scraped_host_count/www.anacondastores.com': 88,
 'atp/nsi/perfect_match': 88,
 'downloader/request_bytes': 87639,
 'downloader/request_count': 96,
 'downloader/request_method_count/GET': 96,
 'downloader/response_bytes': 4546158,
 'downloader/response_count': 96,
 'downloader/response_status_count/200': 89,
 'downloader/response_status_count/302': 4,
 'downloader/response_status_count/404': 3,
 'elapsed_time_seconds': 117.327112,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 23, 5, 56, 29, 705373, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27920416,
 'httpcompression/response_count': 92,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/404': 3,
 'item_scraped_count': 88,
 'items_per_minute': None,
 'log_count/DEBUG': 195,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 92,
 'responses_per_minute': None,
 'scheduler/dequeued': 96,
 'scheduler/dequeued/memory': 96,
 'scheduler/enqueued': 96,
 'scheduler/enqueued/memory': 96,
 'start_time': datetime.datetime(2024, 12, 23, 5, 54, 32, 378261, tzinfo=datetime.timezone.utc)}