### PR TITLE
[Dino PL] Fix spider

### DIFF
--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -29,7 +29,7 @@ class DinoPLSpider(Spider):
             key = m.group(1)
         if m := re.search(r"""\.from\([\n ]*['"]([0-9a-f]{32})['"],[\n ]*['"]hex['"][\n ]*\)""", response.text):
             iv = m.group(1)
-        if m := re.search(r"a[\s=]+\"(.+?)\",", response.text):
+        if m := re.search(r"[a-z]\s*=\s*\"([0-9a-f]{40})\",", response.text):
             access_token = m.group(1)
         yield Request(
             url="https://api.marketdino.pl/api/v1/dino_content/geofile/",

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -49,6 +49,7 @@ class DinoPLSpider(Spider):
             item = DictParser.parse(location["properties"])
             item.pop("name", None)
             item["geometry"] = location["geometry"]
+            item["website"] = "https://marketdino.pl/map"
             item["opening_hours"] = OpeningHours()
             if week_hours := location["properties"].get("weekHours"):
                 item["opening_hours"].add_days_range(["Mo", "Tu", "We", "Th", "Fr", "Sa"], *week_hours.split("-", 1))

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -1,8 +1,10 @@
 import json
 import re
+from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -13,10 +15,12 @@ class DinoPLSpider(Spider):
     item_attributes = {"brand": "Dino", "brand_wikidata": "Q11694239"}
     allowed_domains = ["marketdino.pl"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://marketdino.pl/external/map/index.html"]
 
-    def start_requests(self):
-        yield Request(
-            url="https://marketdino.pl/external/map/_next/static/chunks/pages/index-484403574d28a5a1.js",
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Search for the desired JavaScript file
+        yield response.follow(
+            url=response.xpath('//script[contains(@src,"_next/static/chunks/pages/index-")]/@src').get(""),
             callback=self.parse_decryption_params,
         )
 

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -25,8 +25,11 @@ class DinoPLSpider(Spider):
             key = m.group(1)
         if m := re.search(r"""\.from\([\n ]*['"]([0-9a-f]{32})['"],[\n ]*['"]hex['"][\n ]*\)""", response.text):
             iv = m.group(1)
+        if m := re.search(r"a[\s=]+\"(.+?)\",", response.text):
+            access_token = m.group(1)
         yield Request(
             url="https://api.marketdino.pl/api/v1/dino_content/geofile/",
+            headers={"Authorization": f"token {access_token}"},
             meta={"key": key, "iv": iv},
             callback=self.parse_encrypted_geojson,
         )

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -16,7 +16,7 @@ class DinoPLSpider(Spider):
 
     def start_requests(self):
         yield Request(
-            url="https://marketdino.pl/external/map/_next/static/chunks/pages/index-d599ac5e0a5fa37c.js",
+            url="https://marketdino.pl/external/map/_next/static/chunks/pages/index-484403574d28a5a1.js",
             callback=self.parse_decryption_params,
         )
 

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -49,7 +49,6 @@ class DinoPLSpider(Spider):
             item = DictParser.parse(location["properties"])
             item.pop("name", None)
             item["geometry"] = location["geometry"]
-            item["website"] = "https://marketdino.pl/map"
             item["opening_hours"] = OpeningHours()
             if week_hours := location["properties"].get("weekHours"):
                 item["opening_hours"].add_days_range(["Mo", "Tu", "We", "Th", "Fr", "Sa"], *week_hours.split("-", 1))


### PR DESCRIPTION
Updated start request url and added authorization token for accessing  the API to fix the spider.

```
{'atp/brand/Dino': 2663,
 'atp/brand_wikidata/Q11694239': 2663,
 'atp/category/shop/supermarket': 2663,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/field/branch/missing': 2663,
 'atp/field/city/missing': 2663,
 'atp/field/country/from_spider_name': 2663,
 'atp/field/email/missing': 2663,
 'atp/field/image/missing': 2663,
 'atp/field/operator/missing': 2663,
 'atp/field/operator_wikidata/missing': 2663,
 'atp/field/phone/missing': 2663,
 'atp/field/postcode/missing': 2663,
 'atp/field/state/missing': 2663,
 'atp/field/street_address/missing': 2663,
 'atp/field/twitter/missing': 2663,
 'atp/item_scraped_host_count/api.marketdino.pl': 2663,
 'atp/nsi/perfect_match': 2663,
 'downloader/request_bytes': 1217,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 2016756,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 15.794867,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 23, 13, 16, 56, 968874, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3704372,
 'httpcompression/response_count': 3,
 'item_scraped_count': 2663,
 'log_count/DEBUG': 2677,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2024, 12, 23, 13, 16, 41, 174007, tzinfo=datetime.timezone.utc)}
```