### PR TITLE
[NewspowerAU] Fix Spider

### DIFF
--- a/locations/spiders/newspower_au.py
+++ b/locations/spiders/newspower_au.py
@@ -1,9 +1,4 @@
-from chompjs import parse_js_object
-from scrapy.spiders import SitemapSpider
 
-from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
 from locations.storefinders.storeify import StoreifySpider
 
 

--- a/locations/spiders/newspower_au.py
+++ b/locations/spiders/newspower_au.py
@@ -4,50 +4,11 @@ from scrapy.spiders import SitemapSpider
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.storefinders.storeify import StoreifySpider
 
 
-class NewspowerAUSpider(SitemapSpider):
-    # Whilst WP Store Locator is used for this brand, it is set to
-    # return at most the 5 closest points to a provided search
-    # coordinate. There is an impractical number of search requests
-    # thus required to use the WP Store Locator store finder API.
-    # A Sitemap spider is used instead.
+class NewspowerAUSpider(StoreifySpider):
     name = "newspower_au"
     item_attributes = {"brand": "Newspower", "brand_wikidata": "Q120670137"}
-    allowed_domains = ["newspower.com.au"]
-    sitemap_urls = [
-        "https://newspower.com.au/wpsl_stores-sitemap1.xml",
-        "https://newspower.com.au/wpsl_stores-sitemap2.xml",
-    ]
-    sitemap_rules = [(r"^https:\/\/newspower\.com\.au\/stores/[^/]+\/$", "parse")]
-    # Server will redirect wpsl_stores-sitemap2.xml to
-    # https://newspower.com.au/store-locator/ if it doesn't like
-    # the country/netblock requesting the page.
-    requires_proxy = True
-
-    def parse(self, response):
-        map_marker_js_blob = response.xpath('//script[contains(text(), "var wpslMap_0 = ")]/text()').get()
-        map_marker_js_blob = map_marker_js_blob.split("var wpslMap_0 = ", 1)[1].split("]};", 1)[0] + "]}"
-        map_marker_dict = parse_js_object(map_marker_js_blob)["locations"][0]
-        properties = {
-            "ref": map_marker_dict["id"],
-            "name": response.xpath('//div[@class="wpsl-locations-details"]/span/strong/text()').get().strip(),
-            "addr_full": clean_address(response.xpath('//div[@class="wpsl-location-address"]//text()').getall()),
-            "street_address": clean_address([map_marker_dict["address"], map_marker_dict["address2"]]),
-            "city": map_marker_dict["city"],
-            "state": map_marker_dict["state"],
-            "postcode": map_marker_dict["zip"],
-            "lat": map_marker_dict["lat"],
-            "lon": map_marker_dict["lng"],
-            "phone": response.xpath('//div[@class="wpsl-contact-details"]//a[contains(@href, "tel:")]/@href').get(),
-            "website": response.url,
-            "facebook": response.xpath(
-                '//div[@class="entry-content"]//a[contains(@href, "https://www.facebook.com/")]/@href'
-            ).get(),
-        }
-        if properties.get("phone") and "tel:" in properties.get("phone"):
-            properties["phone"] = properties["phone"].replace("tel:", "")
-        hours_string = " ".join(filter(None, response.xpath('//table[@class="wpsl-opening-hours"]//text()').getall()))
-        properties["opening_hours"] = OpeningHours()
-        properties["opening_hours"].add_ranges_from_string(hours_string)
-        yield Feature(**properties)
+    api_key = "newspower-australia.myshopify.com"
+    domain = "https://newspower.com.au/"

--- a/locations/spiders/newspower_au.py
+++ b/locations/spiders/newspower_au.py
@@ -1,4 +1,3 @@
-
 from locations.storefinders.storeify import StoreifySpider
 
 


### PR DESCRIPTION
`Fixes : code refactored to use StoreifySpider to fix spider`

{'atp/brand/Newspower': 326,
 'atp/brand_wikidata/Q120670137': 326,
 'atp/category/shop/newsagent': 326,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/field/branch/missing': 326,
 'atp/field/email/missing': 326,
 'atp/field/image/invalid': 3,
 'atp/field/image/missing': 215,
 'atp/field/opening_hours/missing': 326,
 'atp/field/operator/missing': 326,
 'atp/field/operator_wikidata/missing': 326,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 326,
 'atp/field/state/missing': 326,
 'atp/field/street_address/missing': 326,
 'atp/field/twitter/missing': 326,
 'atp/item_scraped_host_count/sl.storeify.app': 326,
 'atp/nsi/perfect_match': 326,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 56032,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.078192,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 26, 6, 52, 3, 246362, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 527571,
 'httpcompression/response_count': 2,
 'item_scraped_count': 326,
 'items_per_minute': None,
 'log_count/DEBUG': 352,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 26, 6, 52, 0, 168170, tzinfo=datetime.timezone.utc)}