### PR TITLE
[NoodlesAndCompanyUS] Fix Spider

### DIFF
--- a/locations/spiders/noodles_and_company_us.py
+++ b/locations/spiders/noodles_and_company_us.py
@@ -7,4 +7,4 @@ class NoodlesAndCompanyUSSpider(SitemapSpider, StructuredDataSpider):
     name = "noodles_and_company_us"
     item_attributes = {"brand": "Noodles and Company", "brand_wikidata": "Q7049673"}
     sitemap_urls = ["https://locations.noodles.com/sitemap.xml"]
-    sitemap_rules = [(r"https://locations\.noodles\.com/\w\w/[-\w]+/[-\w]+\.html$", "parse_sd")]
+    sitemap_rules = [(r"https:\/\/locations\.noodles\.com\/[^/]+/[^/]+/(?!delivery)[a-z0-9-]+$", "parse_sd")]


### PR DESCRIPTION
`Fixes : updated sitemap_rule to fix spider`

{'atp/brand/Noodles and Company': 464,
 'atp/brand_wikidata/Q7049673': 464,
 'atp/category/amenity/restaurant': 464,
 'atp/cdn/cloudflare/response_count': 466,
 'atp/cdn/cloudflare/response_status_count/200': 466,
 'atp/field/branch/missing': 464,
 'atp/field/email/missing': 464,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 464,
 'atp/field/operator_wikidata/missing': 464,
 'atp/item_scraped_host_count/locations.noodles.com': 464,
 'atp/nsi/perfect_match': 464,
 'downloader/request_bytes': 179835,
 'downloader/request_count': 466,
 'downloader/request_method_count/GET': 466,
 'downloader/response_bytes': 9177859,
 'downloader/response_count': 466,
 'downloader/response_status_count/200': 466,
 'elapsed_time_seconds': 566.405148,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 27, 6, 46, 30, 16864, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 82359352,
 'httpcompression/response_count': 466,
 'item_scraped_count': 464,
 'items_per_minute': None,
 'log_count/DEBUG': 941,
 'log_count/INFO': 18,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 466,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 465,
 'scheduler/dequeued/memory': 465,
 'scheduler/enqueued': 465,
 'scheduler/enqueued/memory': 465,
 'start_time': datetime.datetime(2024, 12, 27, 6, 37, 3, 611716, tzinfo=datetime.timezone.utc)}