### PR TITLE
[Cookout] Fix spider to get all locations 

### DIFF
--- a/locations/spiders/cookout.py
+++ b/locations/spiders/cookout.py
@@ -1,5 +1,3 @@
-import re
-
 import scrapy
 
 from locations.items import Feature
@@ -11,59 +9,6 @@ class CookoutSpider(scrapy.Spider):
     start_urls = [
         "https://cookout.com/wp-admin/admin-ajax.php?action=store_search&lat=40.71278&lng=-74.00597&max_results=500&search_radius=1000"
     ]
-
-    def store_hours(self, store_hours):
-        m = re.findall(r"<tr><td>(\w*)<\/td><td><time>([0-9: APM-]*)</time></td></tr>", store_hours)
-
-        day_groups = []
-        this_day_group = dict()
-        for day, hours_together in m:
-            day = day[:2]
-            h = re.findall("([0-9]{1,2}):([0-9]{1,2}) ([APM]{2})", hours_together)
-            (from_h, from_m, from_ap), (to_h, to_m, to_ap) = h
-
-            from_h = int(from_h)
-            if from_ap == "PM":
-                from_h += 12
-
-            to_h = int(to_h)
-            if to_h == "PM":
-                to_h += 12
-
-            hours = "{:02}:{}-{:02}:{}".format(
-                from_h,
-                from_m,
-                to_h,
-                to_m,
-            )
-
-            if not this_day_group:
-                this_day_group = {"from_day": day, "to_day": day, "hours": hours}
-            elif this_day_group["hours"] != hours:
-                day_groups.append(this_day_group)
-                this_day_group = {"from_day": day, "to_day": day, "hours": hours}
-            elif this_day_group["hours"] == hours:
-                this_day_group["to_day"] = day
-
-        day_groups.append(this_day_group)
-
-        opening_hours = ""
-        if len(day_groups) == 1 and day_groups[0]["hours"] in (
-            "00:00-23:59",
-            "00:00-00:00",
-        ):
-            opening_hours = "24/7"
-        else:
-            for day_group in day_groups:
-                if day_group["from_day"] == day_group["to_day"]:
-                    opening_hours += "{from_day} {hours}; ".format(**day_group)
-                elif day_group["from_day"] == "Su" and day_group["to_day"] == "Sa":
-                    opening_hours += "{hours}; ".format(**day_group)
-                else:
-                    opening_hours += "{from_day}-{to_day} {hours}; ".format(**day_group)
-            opening_hours = opening_hours[:-2]
-
-        return opening_hours
 
     def parse(self, response):
         data = response.json()
@@ -86,11 +31,4 @@ class CookoutSpider(scrapy.Spider):
             if phone:
                 properties["phone"] = phone
 
-            hours = store.get("hours", "")
-            if hours:
-                properties["opening_hours"] = self.store_hours(hours)
-
             yield Feature(**properties)
-
-        else:
-            self.logger.info("No results")

--- a/locations/spiders/cookout.py
+++ b/locations/spiders/cookout.py
@@ -1,34 +1,16 @@
-import logging
-import os
 import re
 
 import scrapy
 
 from locations.items import Feature
-from locations.searchable_points import open_searchable_points
-
-STATES = ["NC", "AL", "GA", "KY", "MD", "MS", "SC", "TN", "VA", "WV"]
 
 
 class CookoutSpider(scrapy.Spider):
     name = "cookout"
     item_attributes = {"brand": "Cook Out", "brand_wikidata": "Q5166992"}
-    allowed_domains = ["cookout.com"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-
-    def start_requests(self):
-        base_url = "https://cookout.com/wp-admin/admin-ajax.php?action=store_search&lat={lat}&lng={lng}&max_results=300&search_radius=500"
-
-        logging.info(os.path.dirname(os.path.realpath(__file__)))
-        logging.info(os.getcwd())
-
-        with open_searchable_points("us_centroids_100mile_radius_state.csv") as points:
-            next(points)
-            for point in points:
-                _, lat, lon, state = point.strip().split(",")
-                if state in STATES:
-                    url = base_url.format(lat=lat, lng=lon)
-                    yield scrapy.Request(url=url, callback=self.parse)
+    start_urls = [
+        "https://cookout.com/wp-admin/admin-ajax.php?action=store_search&lat=40.71278&lng=-74.00597&max_results=500&search_radius=1000"
+    ]
 
     def store_hours(self, store_hours):
         m = re.findall(r"<tr><td>(\w*)<\/td><td><time>([0-9: APM-]*)</time></td></tr>", store_hours)

--- a/locations/spiders/cookout.py
+++ b/locations/spiders/cookout.py
@@ -15,6 +15,8 @@ class CookoutSpider(scrapy.Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
+            if store.get("coming_soon"):
+                continue
             item = DictParser.parse(store)
             item["street_address"] = item.pop("addr_full")
             item["branch"] = store.get("store")

--- a/locations/spiders/cookout.py
+++ b/locations/spiders/cookout.py
@@ -17,4 +17,5 @@ class CookoutSpider(scrapy.Spider):
         for store in response.json():
             item = DictParser.parse(store)
             item["street_address"] = item.pop("addr_full")
+            item["branch"] = store.get("store")
             yield item

--- a/locations/spiders/cookout_us.py
+++ b/locations/spiders/cookout_us.py
@@ -20,4 +20,5 @@ class CookoutUSSpider(scrapy.Spider):
             item = DictParser.parse(store)
             item["street_address"] = item.pop("addr_full")
             item["branch"] = store.get("store")
+            item["website"] = "https://cookout.com/locations/"
             yield item

--- a/locations/spiders/cookout_us.py
+++ b/locations/spiders/cookout_us.py
@@ -6,8 +6,8 @@ from scrapy.http import Response
 from locations.dict_parser import DictParser
 
 
-class CookoutSpider(scrapy.Spider):
-    name = "cookout"
+class CookoutUSSpider(scrapy.Spider):
+    name = "cookout_us"
     item_attributes = {"brand": "Cook Out", "brand_wikidata": "Q5166992"}
     start_urls = [
         "https://cookout.com/wp-admin/admin-ajax.php?action=store_search&lat=40.71278&lng=-74.00597&max_results=500&search_radius=1000"


### PR DESCRIPTION
Updated `start_url` to get max count of POIs, also code simplified, removed `opening_hours` code as it was resulting in `key_error`, also `hours` data is not reliable because it doesn't match with google maps info.

```
{'atp/brand/Cook Out': 339,
 'atp/brand_wikidata/Q5166992': 339,
 'atp/category/amenity/fast_food': 339,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/field/email/missing': 339,
 'atp/field/image/missing': 339,
 'atp/field/opening_hours/missing': 339,
 'atp/field/operator/missing': 339,
 'atp/field/operator_wikidata/missing': 339,
 'atp/field/phone/missing': 336,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 339,
 'atp/item_scraped_host_count/cookout.com': 339,
 'atp/nsi/perfect_match': 339,
 'downloader/request_bytes': 699,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 20590,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.968757,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 27, 10, 43, 11, 138530, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 218899,
 'httpcompression/response_count': 2,
 'item_scraped_count': 339,
 'log_count/DEBUG': 352,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 27, 10, 43, 7, 169773, tzinfo=datetime.timezone.utc)}
```