### PR TITLE
[SourceLondonGB] Fix Spider

### DIFF
--- a/locations/spiders/source_london_gb.py
+++ b/locations/spiders/source_london_gb.py
@@ -1,4 +1,8 @@
-from scrapy import Spider
+from typing import Iterable
+
+import scrapy
+from scrapy import Spider, Request
+from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -7,10 +11,14 @@ from locations.dict_parser import DictParser
 class SourceLondonGBSpider(Spider):
     name = "source_london_gb"
     item_attributes = {"brand": "Source London", "brand_wikidata": "Q7565133"}
-    start_urls = ["https://www.sourcelondon.net/api/infra/location"]
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://www.sourcelondon.net/api/infra/location", headers={"X-API-VERSION": "2"}, callback=self.parse
+        )
 
     def parse(self, response, **kwargs):
-        for location in response.json():
+        for location in response.json()["internalLocations"]:
             item = DictParser.parse(location)
             apply_category(Categories.CHARGING_STATION, item)
             yield item

--- a/locations/spiders/source_london_gb.py
+++ b/locations/spiders/source_london_gb.py
@@ -1,7 +1,6 @@
 from typing import Iterable
 
-import scrapy
-from scrapy import Spider, Request
+from scrapy import Request, Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category


### PR DESCRIPTION
`Fixes : added start request to fix spider`


{'atp/brand/Source London': 1149,
 'atp/brand_wikidata/Q7565133': 1149,
 'atp/category/amenity/charging_station': 1149,
 'atp/field/branch/missing': 1149,
 'atp/field/country/from_spider_name': 1149,
 'atp/field/email/missing': 1149,
 'atp/field/image/missing': 1149,
 'atp/field/opening_hours/missing': 1149,
 'atp/field/phone/missing': 1149,
 'atp/field/state/missing': 1149,
 'atp/field/street_address/missing': 1149,
 'atp/field/twitter/missing': 1149,
 'atp/field/website/missing': 1149,
 'atp/item_scraped_host_count/www.sourcelondon.net': 1149,
 'atp/nsi/cc_match': 1149,
 'atp/operator/Source London': 1149,
 'atp/operator_wikidata/Q7565133': 1149,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4555021,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.515482,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 30, 10, 12, 37, 789552, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1149,
 'items_per_minute': None,
 'log_count/DEBUG': 1162,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 30, 10, 12, 30, 274070, tzinfo=datetime.timezone.utc)}