### PR TITLE
[Nutrition Warehouse AU] Fix spider

### DIFF
--- a/locations/spiders/nutrition_warehouse_au.py
+++ b/locations/spiders/nutrition_warehouse_au.py
@@ -25,5 +25,6 @@ class NutritionWarehouseAUSpider(Spider):
             item["ref"] = store.get("g_id")
             item["branch"] = item.pop("name").removeprefix("Nutrition Warehouse ")
             item["name"] = self.item_attributes["brand"]
+            item["addr_full"] = store.get("complete_address")
             apply_category(Categories.SHOP_NUTRITION_SUPPLEMENTS, item)
             yield item

--- a/locations/spiders/nutrition_warehouse_au.py
+++ b/locations/spiders/nutrition_warehouse_au.py
@@ -1,15 +1,27 @@
-from locations.categories import apply_category
-from locations.storefinders.stockinstore import StockInStoreSpider
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 
 
-class NutritionWarehouseAUSpider(StockInStoreSpider):
+class NutritionWarehouseAUSpider(Spider):
     name = "nutrition_warehouse_au"
     item_attributes = {"brand": "Nutrition Warehouse", "brand_wikidata": "Q117747424"}
-    api_site_id = "10098"
-    api_widget_id = "105"
-    api_widget_type = "storelocator"
-    api_origin = "https://www.nutritionwarehouse.com.au"
 
-    def parse_item(self, item, location):
-        apply_category({"shop": "nutrition_supplements"}, item)
-        yield item
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://brauz-api-netlify-v2.netlify.app/api/thirdparty/store/find-stores-with-items-availability",
+            data={
+                "group_number": "NUTRITIONWAREHOUSE",
+            },
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["data"]:
+            item = DictParser.parse(store)
+            item["ref"] = store.get("g_id")
+            apply_category(Categories.SHOP_NUTRITION_SUPPLEMENTS, item)
+            yield item

--- a/locations/spiders/nutrition_warehouse_au.py
+++ b/locations/spiders/nutrition_warehouse_au.py
@@ -23,5 +23,7 @@ class NutritionWarehouseAUSpider(Spider):
         for store in response.json()["data"]:
             item = DictParser.parse(store)
             item["ref"] = store.get("g_id")
+            item["branch"] = item.pop("name").removeprefix("Nutrition Warehouse ")
+            item["name"] = self.item_attributes["brand"]
             apply_category(Categories.SHOP_NUTRITION_SUPPLEMENTS, item)
             yield item


### PR DESCRIPTION
`Stockinstore` API is no longer working, used new API to fix the spider and code refactored accordingly.

```
{'atp/brand/Nutrition Warehouse': 117,
 'atp/brand_wikidata/Q117747424': 117,
 'atp/category/shop/nutrition_supplements': 117,
 'atp/field/image/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/street_address/missing': 117,
 'atp/field/twitter/missing': 117,
 'atp/field/website/missing': 117,
 'atp/item_scraped_host_count/brauz-api-netlify-v2.netlify.app': 117,
 'atp/nsi/brand_missing': 117,
 'downloader/request_bytes': 746,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 17645,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.031318,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 30, 14, 22, 32, 225206, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 272316,
 'httpcompression/response_count': 2,
 'item_scraped_count': 117,
 'log_count/DEBUG': 136,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 30, 14, 22, 29, 193888, tzinfo=datetime.timezone.utc)}
```