### PR TITLE
[Auchan LU] Fix Spider

### DIFF
--- a/locations/spiders/auchan_lu.py
+++ b/locations/spiders/auchan_lu.py
@@ -10,12 +10,13 @@ class AuchanLUSpider(scrapy.Spider):
 
     def start_requests(self):
         yield JsonRequest(
-            url="https://api.auchan.com/corp/cms/v4/lu/template/stores",
-            headers={"X-Gravitee-Api-Key": "f303247f-d0d9-4036-9232-6b9cca51ca6d"},
+            url="https://api.ari.auchan.com/ari/digit/portal-cms/lu/template/stores?context=push-stores-list",
+            headers={"X-Gravitee-Api-Key": "226ec165-1e26-45c8-a5ed-25a2cd3c5329"},
         )
 
     def parse(self, response, **kwargs):
         for store in response.json():
             store.update(store.pop("address"))
             item = DictParser.parse(store)
+            item["website"] = "https://www.auchan.lu/fr/retail/"+store["pageName"]
             yield item

--- a/locations/spiders/auchan_lu.py
+++ b/locations/spiders/auchan_lu.py
@@ -18,5 +18,5 @@ class AuchanLUSpider(scrapy.Spider):
         for store in response.json():
             store.update(store.pop("address"))
             item = DictParser.parse(store)
-            item["website"] = "https://www.auchan.lu/fr/retail/"+store["pageName"]
+            item["website"] = "https://www.auchan.lu/fr/retail/" + store["pageName"]
             yield item

--- a/locations/spiders/auchan_lu.py
+++ b/locations/spiders/auchan_lu.py
@@ -3,10 +3,13 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 
+AUCHAN_DRIVE = {"brand": "Auchan Drive", "brand_wikidata": "Q2870659"}
+MY_AUCHAN = {"brand": "My Auchan", "brand_wikidata": "Q115800307"}
+AUCHAN = {"brand": "Auchan", "brand_wikidata": "Q758603"}
+
 
 class AuchanLUSpider(scrapy.Spider):
     name = "auchan_lu"
-    item_attributes = {"brand": "Auchan", "brand_wikidata": "Q758603"}
 
     def start_requests(self):
         yield JsonRequest(
@@ -24,5 +27,15 @@ class AuchanLUSpider(scrapy.Spider):
             )
             item["extras"]["website:en"] = "https://www.auchan.lu/en/retail/{}".format(store["pageName"])
             item["extras"]["website:de"] = "https://www.auchan.lu/de/retail/{}".format(store["pageName"])
+
+            if store["type"] == "1":
+                item.update(AUCHAN_DRIVE)
+                item["branch"] = item.pop("name").removeprefix("Auchan Drive ")
+            elif store["type"] in ["3", "4"]:
+                item.update(AUCHAN)
+                item["branch"] = item.pop("name").removeprefix("Auchan ")
+            elif store["type"] == "5":
+                item.update(MY_AUCHAN)
+                item["branch"] = item.pop("name").removeprefix("MyAuchan ").removeprefix("My Auchan ")
 
             yield item

--- a/locations/spiders/auchan_lu.py
+++ b/locations/spiders/auchan_lu.py
@@ -18,5 +18,11 @@ class AuchanLUSpider(scrapy.Spider):
         for store in response.json():
             store.update(store.pop("address"))
             item = DictParser.parse(store)
-            item["website"] = "https://www.auchan.lu/fr/retail/" + store["pageName"]
+
+            item["website"] = item["extras"]["website:fr"] = "https://www.auchan.lu/fr/retail/{}".format(
+                store["pageName"]
+            )
+            item["extras"]["website:en"] = "https://www.auchan.lu/en/retail/{}".format(store["pageName"])
+            item["extras"]["website:de"] = "https://www.auchan.lu/de/retail/{}".format(store["pageName"])
+
             yield item


### PR DESCRIPTION
`Fixes : updated start_urls to fix spider`

{'atp/brand/Auchan': 29,
 'atp/brand_wikidata/Q758603': 29,
 'atp/category/shop/supermarket': 29,
 'atp/field/branch/missing': 29,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 29,
 'atp/field/image/missing': 29,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 29,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/phone/missing': 29,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 29,
 'atp/field/twitter/missing': 29,
 'atp/item_scraped_host_count/api.ari.auchan.com': 29,
 'atp/nsi/cc_match': 29,
 'downloader/request_bytes': 745,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 10394,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.857329,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 31, 8, 34, 47, 174172, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 29,
 'items_per_minute': None,
 'log_count/DEBUG': 42,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 31, 8, 34, 44, 316843, tzinfo=datetime.timezone.utc)}