### PR TITLE
[Obi RU] Fix spider

### DIFF
--- a/locations/spiders/obi_ru.py
+++ b/locations/spiders/obi_ru.py
@@ -62,6 +62,7 @@ class ObiRUSpider(scrapy.Spider):
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").removeprefix("ОБИ ")
             item["phone"] = item["phone"].split("доб")[0] if item.get("phone") else None
+            item["extras"]["fax"] = store.get("fax")
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(
                 store.get("schedule"), DAYS_RU, NAMED_DAY_RANGES_RU, NAMED_TIMES_RU

--- a/locations/spiders/obi_ru.py
+++ b/locations/spiders/obi_ru.py
@@ -61,6 +61,7 @@ class ObiRUSpider(scrapy.Spider):
             item["ref"] = store.get("source_code")
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name").removeprefix("ОБИ ")
+            item["phone"] = item["phone"].split("доб")[0] if item.get("phone") else None
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(
                 store.get("schedule"), DAYS_RU, NAMED_DAY_RANGES_RU, NAMED_TIMES_RU

--- a/locations/spiders/obi_ru.py
+++ b/locations/spiders/obi_ru.py
@@ -53,7 +53,7 @@ class ObiRUSpider(scrapy.Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # HTML response contains JSON data
         for store in chompjs.parse_js_object(response.text)["data"]["offlineStores"]:
-            if "Тест" in store["name"] or "Default" in store["name"]:
+            if any(keyword in store["name"] for keyword in ["Тест", "Default"]):
                 continue  # Exclude test POIs
             if "не работает" in store["schedule"]:  # not operating
                 continue

--- a/locations/spiders/obi_ru.py
+++ b/locations/spiders/obi_ru.py
@@ -60,6 +60,7 @@ class ObiRUSpider(scrapy.Spider):
             item = DictParser.parse(store)
             item["ref"] = store.get("source_code")
             item["street_address"] = item.pop("street")
+            item["branch"] = item.pop("name").removeprefix("ОБИ ")
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(
                 store.get("schedule"), DAYS_RU, NAMED_DAY_RANGES_RU, NAMED_TIMES_RU


### PR DESCRIPTION
`GraphQL` query is used to fix the spider replacing non functional API url.

```
{'atp/brand/OBI': 29,
 'atp/brand_wikidata/Q300518': 29,
 'atp/category/shop/doityourself': 29,
 'atp/field/country/from_spider_name': 29,
 'atp/field/image/missing': 29,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/twitter/missing': 29,
 'atp/field/website/missing': 29,
 'atp/item_scraped_host_count/obi.ru': 29,
 'atp/nsi/perfect_match': 29,
 'downloader/request_bytes': 1469,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 31412,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 16.401311,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2024, 12, 31, 12, 58, 12, 614422, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 29,
 'log_count/DEBUG': 70,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/method/POST': 1,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': `2,`
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2024, 12, 31, 12, 57, 56, 213111, tzinfo=datetime.timezone.utc)}
```