### PR TITLE
[Starbucks US] Clean name

### DIFF
--- a/locations/spiders/starbucks_us.py
+++ b/locations/spiders/starbucks_us.py
@@ -4,7 +4,7 @@ from math import sqrt
 
 from scrapy import Request, Spider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
@@ -17,7 +17,7 @@ STARBUCKS_SHARED_ATTRIBUTES = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
 
 class StarbucksUSSpider(Spider):
     name = "starbucks_us"
-    item_attributes = STARBUCKS_SHARED_ATTRIBUTES | {"extras": Categories.COFFEE_SHOP.value}
+    item_attributes = STARBUCKS_SHARED_ATTRIBUTES
     allowed_domains = ["www.starbucks.com"]
     searchable_point_files = ["us_centroids_50mile_radius.csv"]
     country_filter = ["US"]
@@ -52,7 +52,6 @@ class StarbucksUSSpider(Spider):
             store_lon = store.get("coordinates", {}).get("longitude")
 
             properties = {
-                "name": store["name"],
                 "branch": store["name"],
                 "street_address": clean_address(
                     [
@@ -73,6 +72,7 @@ class StarbucksUSSpider(Spider):
                 "extras": {"number": store["storeNumber"], "ownership_type": store["ownershipTypeCode"]},
             }
             item = Feature(**properties)
+            apply_category(Categories.COFFEE_SHOP, item)
             self.parse_hours(item, store)
             yield item
 


### PR DESCRIPTION
I'm not expecting this to run, since it didn't in the last few weeklies, but I did a partial run locally:

```python
{'atp/brand/Starbucks': 80,
 'atp/brand_wikidata/Q37158': 80,
 'atp/category/amenity/cafe': 80,
 'atp/field/email/missing': 80,
 'atp/field/image/missing': 80,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 80,
 'atp/field/operator_wikidata/missing': 80,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 80,
 'atp/item_scraped_host_count/www.starbucks.com': 156,
 'atp/nsi/cc_match': 80,
 'downloader/request_bytes': 125046,
 'downloader/request_count': 283,
 'downloader/request_method_count/GET': 283,
 'downloader/response_bytes': 519978,
 'downloader/response_count': 283,
 'downloader/response_status_count/200': 283,
 'elapsed_time_seconds': 260.181315,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2025, 1, 1, 10, 45, 34, 597306, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 215,
 'httpcache/hit': 68,
 'httpcache/miss': 215,
 'httpcache/store': 215,
 'item_dropped_count': 76,
 'item_dropped_reasons_count/DropItem': 76,
 'item_scraped_count': 80,
 'items_per_minute': None,
 'log_count/INFO': 15,
 'log_count/WARNING': 2,
 'memusage/max': 411586560,
 'memusage/startup': 259465216,
 'request_depth_max': 3,
 'response_received_count': 283,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 282,
 'scheduler/dequeued/memory': 282,
 'scheduler/enqueued': 290,
 'scheduler/enqueued/memory': 290,
 'start_time': datetime.datetime(2025, 1, 1, 10, 41, 14, 415991, tzinfo=datetime.timezone.utc)}
```