### PR TITLE
[BestWestern] Fix Spider

### DIFF
--- a/locations/spiders/best_western.py
+++ b/locations/spiders/best_western.py
@@ -5,8 +5,6 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class BestWesternSpider(scrapy.spiders.SitemapSpider):
@@ -23,14 +21,7 @@ class BestWesternSpider(scrapy.spiders.SitemapSpider):
     allowed_domains = ["bestwestern.com"]
     sitemap_urls = ["https://www.bestwestern.com/etc/seo/bestwestern/hotels.xml"]
     sitemap_rules = [(r"/en_US/book/[-\w]+/[-\w]+/propertyCode\.\d+\.html$", "parse_hotel")]
-    is_playwright_spider = True
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 300 * 1000,
-        "USER_AGENT": BROWSER_DEFAULT,
-        "CONCURRENT_REQUESTS": 1,
-        "DOWNLOAD_DELAY": 3,
-        "ROBOTSTXT_OBEY": False,
-    }
+    download_delay = 3
     requires_proxy = True
 
     def parse_hotel(self, response):

--- a/locations/spiders/best_western.py
+++ b/locations/spiders/best_western.py
@@ -31,6 +31,7 @@ class BestWesternSpider(scrapy.spiders.SitemapSpider):
         "DOWNLOAD_DELAY": 3,
         "ROBOTSTXT_OBEY": False,
     }
+    requires_proxy = True
 
     def parse_hotel(self, response):
         hotel_details = response.xpath('//div[@id="hotel-details-info"]/@data-hoteldetails').get()

--- a/locations/spiders/best_western.py
+++ b/locations/spiders/best_western.py
@@ -25,6 +25,7 @@ class BestWesternSpider(scrapy.spiders.SitemapSpider):
     sitemap_rules = [(r"/en_US/book/[-\w]+/[-\w]+/propertyCode\.\d+\.html$", "parse_hotel")]
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 300 * 1000,
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
         "DOWNLOAD_DELAY": 3,

--- a/locations/spiders/best_western.py
+++ b/locations/spiders/best_western.py
@@ -5,6 +5,7 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -22,7 +23,8 @@ class BestWesternSpider(scrapy.spiders.SitemapSpider):
     allowed_domains = ["bestwestern.com"]
     sitemap_urls = ["https://www.bestwestern.com/etc/seo/bestwestern/hotels.xml"]
     sitemap_rules = [(r"/en_US/book/[-\w]+/[-\w]+/propertyCode\.\d+\.html$", "parse_hotel")]
-    custom_settings = {
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
         "DOWNLOAD_DELAY": 3,


### PR DESCRIPTION
Used `playwright` to access the `sitemap`. Still captcha page comes up during the run, increasing `download_delay` may incease the items scraped.

```
{'atp/brand/Aiden by Best Western': 2,
 'atp/brand/Best Western': 106,
 'atp/brand/Best Western Plus': 36,
 'atp/brand/Best Western Premier': 13,
 'atp/brand/Sure Hotel': 1,
 'atp/brand/Surestay': 4,
 'atp/brand/Surestay Plus': 3,
 'atp/brand_wikidata/Q830334': 165,
 'atp/category/tourism/hotel': 165,
 'atp/field/branch/missing': 165,
 'atp/field/email/missing': 165,
 'atp/field/opening_hours/missing': 165,
 'atp/field/operator/missing': 165,
 'atp/field/operator_wikidata/missing': 165,
 'atp/field/phone/invalid': 6,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 159,
 'atp/field/twitter/missing': 165,
 'atp/item_scraped_host_count/www.bestwestern.com': 165,
 'atp/nsi/match_failed': 165,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/playwright._impl._errors.Error': 1,
 'downloader/request_bytes': 2150119,
 'downloader/request_count': 3777,
 'downloader/request_method_count/GET': 3777,
 'downloader/response_bytes': 124776398,
 'downloader/response_count': 3776,
 'downloader/response_status_count/200': 201,
 'downloader/response_status_count/403': 3575,
 'elapsed_time_seconds': 14766.584442,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 1, 12, 28, 43, 252027, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 3575,
 'httperror/response_ignored_status_count/403': 3575,
 'item_scraped_count': 165,
 'log_count/DEBUG': 70618,
 'log_count/ERROR': 1,
 'log_count/INFO': 3836,
 'log_count/WARNING': 1,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 3777,
 'playwright/page_count/closed': 3777,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 31443,
 'playwright/request_count/aborted': 27664,
 'playwright/request_count/method/GET': 31443,
 'playwright/request_count/navigation': 3779,
 'playwright/request_count/resource_type/document': 3779,
 'playwright/request_count/resource_type/font': 19076,
 'playwright/request_count/resource_type/image': 3009,
 'playwright/request_count/resource_type/script': 5178,
 'playwright/request_count/resource_type/stylesheet': 401,
 'playwright/response_count': 3778,
 'playwright/response_count/method/GET': 3778,
 'playwright/response_count/resource_type/document': 3778,
 'request_depth_max': 1,
 'response_received_count': 3776,
 'scheduler/dequeued': 3777,
 'scheduler/dequeued/memory': 3777,
 'scheduler/enqueued': 3777,
 'scheduler/enqueued/memory': 3777,
 'start_time': datetime.datetime(2025, 1, 1, 8, 22, 36, 667585, tzinfo=datetime.timezone.utc)}
```