### PR TITLE
[DFS GB] Use API

### DIFF
--- a/locations/spiders/dfs_gb.py
+++ b/locations/spiders/dfs_gb.py
@@ -1,25 +1,45 @@
-import json
 from typing import Any
 
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.spiders import Spider
 
+from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class DfsGBSpider(SitemapSpider):
+class DfsGBSpider(Spider):
     name = "dfs_gb"
     item_attributes = {"brand": "DFS", "brand_wikidata": "Q5204927"}
-    # There is also https://www.dfs.ie/sitemap.xml, both list all stores!
-    sitemap_urls = ["https://www.dfs.co.uk/sitemap.xml"]
-    sitemap_rules = [("/store-directory/", "parse")]
+    start_urls = ["https://www.dfs.co.uk/wcs/resources/store/10202/stores?langId=-1"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = json.loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
-        store = DictParser.get_nested_key(data, "store")
-        store.update(store["yextDisplayCoordinate"])
-        item = DictParser.parse(store)
-        item["phone"] = None
-        item["ref"] = item["website"] = response.url
-        item["branch"] = item.pop("name").removeprefix("DFS ")
-        yield item
+        for location in response.json()["stores"]:
+            item = DictParser.parse(location)
+            item["phone"] = None
+            item["branch"] = item.pop("name").removeprefix("DFS ")
+            item["street_address"] = merge_address_lines([location["address"]["line1"], location["address"]["line2"]])
+            item["lat"] = location["yextRoutableCoordinate"]["latitude"]
+            item["lon"] = location["yextRoutableCoordinate"]["longitude"]
+            item["opening_hours"] = self.parse_opening_hours(location["hours"])
+            item["website"] = "https://www.dfs.co.uk/store-directory/{}".format(location["seoToken"])
+            item["image"] = "https://images.dfs.co.uk/i/dfs/{}".format(
+                location["storeImageName"].replace("?$store_ss$", "")
+            )
+
+            apply_yes_no(Extras.WHEELCHAIR, item, "Wheelchair Access" in location["services"])
+
+            yield item
+
+    def parse_opening_hours(self, rules: dict) -> OpeningHours:
+        oh = OpeningHours()
+        for day, rule in rules.items():
+            if rule["closed"] is True:
+                oh.set_closed(day)
+            else:
+                for times in rule["openIntervals"]:
+                    oh.add_range(day, times["start"], times["end"])
+
+        return oh


### PR DESCRIPTION
Crawling the site isn't as reliable as it should be: https://www.alltheplaces.xyz/spiders.html?search=dfs_gb

```python
{'atp/brand/DFS': 116,
 'atp/brand_wikidata/Q5204927': 116,
 'atp/category/shop/furniture': 116,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/field/email/missing': 116,
 'atp/field/operator/missing': 116,
 'atp/field/operator_wikidata/missing': 116,
 'atp/field/phone/missing': 116,
 'atp/field/state/missing': 66,
 'atp/field/twitter/missing': 116,
 'atp/item_scraped_host_count/www.dfs.co.uk': 116,
 'atp/nsi/perfect_match': 116,
 'downloader/request_bytes': 336,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 14273,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.604966,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 1, 14, 13, 13, 491505, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 218330,
 'httpcompression/response_count': 1,
 'item_scraped_count': 116,
 'items_per_minute': None,
 'log_count/DEBUG': 128,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 206475264,
 'memusage/startup': 206475264,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 1, 14, 13, 12, 886539, tzinfo=datetime.timezone.utc)}
```