### PR TITLE
[National Tyres and Autocare GB] Add spider

### DIFF
--- a/locations/spiders/national_tyres_and_autocare_gb.py
+++ b/locations/spiders/national_tyres_and_autocare_gb.py
@@ -1,0 +1,24 @@
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NationalTyresAndAutocareGBSpider(CrawlSpider, StructuredDataSpider):
+    name = "national_tyres_and_autocare_gb"
+    item_attributes = {"brand": "National Tyres and Autocare", "brand_wikidata": "Q6979055"}
+    start_urls = ["https://www.national.co.uk/branches"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"branch/(\d+)/[^/]+/$", restrict_xpaths='//a[not(contains(text(), "Halfords"))]'),
+            callback="parse",
+        )
+    ]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("National Tyres and Autocare ")
+        extract_google_position(item, response)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/National Tyres and Autocare': 194,
 'atp/brand_wikidata/Q6979055': 194,
 'atp/category/shop/car_repair': 194,
 'atp/field/city/missing': 194,
 'atp/field/email/missing': 194,
 'atp/field/operator/missing': 194,
 'atp/field/operator_wikidata/missing': 194,
 'atp/field/state/missing': 194,
 'atp/item_scraped_host_count/www.national.co.uk': 194,
 'atp/nsi/perfect_match': 194,
 'downloader/request_bytes': 87182,
 'downloader/request_count': 196,
 'downloader/request_method_count/GET': 196,
 'downloader/response_bytes': 4440559,
 'downloader/response_count': 196,
 'downloader/response_status_count/200': 196,
 'elapsed_time_seconds': 239.190516,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 1, 17, 4, 50, 400389, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 196,
 'httpcache/miss': 196,
 'httpcache/store': 196,
 'httpcompression/response_bytes': 23821664,
 'httpcompression/response_count': 196,
 'item_scraped_count': 194,
 'items_per_minute': None,
 'log_count/DEBUG': 402,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'memusage/max': 361558016,
 'memusage/startup': 206405632,
 'request_depth_max': 1,
 'response_received_count': 196,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 195,
 'scheduler/dequeued/memory': 195,
 'scheduler/enqueued': 195,
 'scheduler/enqueued/memory': 195,
 'start_time': datetime.datetime(2025, 1, 1, 17, 0, 51, 209873, tzinfo=datetime.timezone.utc)}
```