### PR TITLE
[Next] Use stable url for country selection

### DIFF
--- a/locations/spiders/next.py
+++ b/locations/spiders/next.py
@@ -15,7 +15,7 @@ class NextSpider(Spider):
     VICTORIAS_SECRET = {"brand": "Victoria's Secret", "brand_wikidata": "Q332477"}
     PINK = {"brand": "Pink", "brand_wikidata": "Q20716793"}
     item_attributes = NEXT
-    start_urls = ["http://stores.next.co.uk/"]
+    start_urls = ["https://www.next.co.uk/countryselect"]
 
     @staticmethod
     def get_time(time: str) -> str:
@@ -41,10 +41,10 @@ class NextSpider(Spider):
         return o
 
     def parse(self, response, **kwargs):
-        for country in response.xpath('//select[@id="country-store"]/option/@value').getall():
+        for country in response.xpath('//*[contains(@class, "country-name")]/text()').getall():
             yield FormRequest(
                 url="https://stores.next.co.uk/index/stores",
-                formdata={"country": country},
+                formdata={"country": country.strip()},
                 callback=self.parse_country,
             )
 

--- a/locations/spiders/next.py
+++ b/locations/spiders/next.py
@@ -74,7 +74,7 @@ class NextSpider(Spider):
             item = DictParser.parse(location)
 
             item["ref"] = location["location_id"]
-            item["name"] = location["branch_name"]
+            item["branch"] = item.pop("name")
             item["website"] = response.url
 
             item["opening_hours"] = self.store_hours(location)


### PR DESCRIPTION
https://stores.next.co.uk/ is unstable and sometimes redirects to https://www.next.co.uk/storelocator
Updated `start_url` to make country selection stable using https://www.next.co.uk/countryselect

```
{'atp/brand/Next': 826,
 'atp/brand/Next Home': 52,
 "atp/brand/Victoria's Secret": 1,
 'atp/brand_wikidata/Q116897680': 52,
 'atp/brand_wikidata/Q246655': 826,
 'atp/brand_wikidata/Q332477': 1,
 'atp/category/shop/clothes': 827,
 'atp/category/shop/furniture': 52,
 'atp/field/branch/missing': 879,
 'atp/field/city/missing': 5,
 'atp/field/email/missing': 879,
 'atp/field/image/missing': 879,
 'atp/field/opening_hours/missing': 177,
 'atp/field/operator/missing': 879,
 'atp/field/operator_wikidata/missing': 879,
 'atp/field/phone/invalid': 47,
 'atp/field/phone/missing': 23,
 'atp/field/postcode/missing': 167,
 'atp/field/state/missing': 687,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 879,
 'atp/item_scraped_host_count/stores.next.co.uk': 879,
 'atp/nsi/perfect_match': 879,
 'downloader/request_bytes': 1940013,
 'downloader/request_count': 1013,
 'downloader/request_method_count/GET': 883,
 'downloader/request_method_count/POST': 130,
 'downloader/response_bytes': 4564583,
 'downloader/response_count': 1013,
 'downloader/response_status_count/200': 1011,
 'downloader/response_status_count/500': 1,
 'downloader/response_status_count/504': 1,
 'dupefilter/filtered': 12,
 'elapsed_time_seconds': 1245.466343,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 2, 11, 27, 36, 786391, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18940082,
 'httpcompression/response_count': 1010,
 'item_scraped_count': 879,
 'log_count/DEBUG': 3967,
 'log_count/INFO': 30,
 'request_depth_max': 2,
 'response_received_count': 1011,
 'retry/count': 2,
 'retry/reason_count/500 Internal Server Error': 1,
 'retry/reason_count/504 Gateway Time-out': 1,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 1011,
 'scheduler/dequeued/memory': 1011,
 'scheduler/enqueued': 1011,
 'scheduler/enqueued/memory': 1011,
 'start_time': datetime.datetime(2025, 1, 2, 11, 6, 51, 320048, tzinfo=datetime.timezone.utc)}
```