### PR TITLE
[Shake Shack] Fix spider

### DIFF
--- a/locations/spiders/shake_shack.py
+++ b/locations/spiders/shake_shack.py
@@ -1,6 +1,9 @@
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -15,3 +18,9 @@ class ShakeShackSpider(CrawlSpider, StructuredDataSpider):
             callback="parse_sd",
         ),
     ]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if isinstance(item.get("city"), list):
+            item["street_address"] = merge_address_lines([item.get("street_address"), item["city"][0]])
+            item["city"] = item["city"][-1]
+        yield item

--- a/locations/spiders/shake_shack.py
+++ b/locations/spiders/shake_shack.py
@@ -1,42 +1,17 @@
-import scrapy
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ShakeShackSpider(scrapy.spiders.SitemapSpider):
+class ShakeShackSpider(CrawlSpider, StructuredDataSpider):
     name = "shake_shack"
     download_delay = 2.0
     item_attributes = {"brand": "Shake Shack", "brand_wikidata": "Q1058722"}
-    allowed_domains = ["shakeshack.com"]
-    sitemap_urls = [
-        "https://shakeshack.com/sitemap.xml",
+    start_urls = ["https://shakeshack.com/locations"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"/location/[-\w]+$"),
+            callback="parse_sd",
+        ),
     ]
-    sitemap_rules = [(r"/location/", "parse")]
-
-    def parse(self, response):
-        addr_container = response.css(".field--name-field-address-line-1").xpath("..")
-        addr_text = addr_container.xpath("./div/text()|./text()").extract()
-        # Site contains addresses from various countries completely unstructured,
-        # as well as ad-hoc textual locations.
-        addr_full = "; ".join(filter(None, (s.strip() for s in addr_text)))
-
-        hours_text = response.xpath('//h3[text()="Hours"]/..//div/text()').extract()
-        hours_text = list(filter(None, (s.strip() for s in hours_text)))
-        oh = OpeningHours()
-        for hours in hours_text:
-            day, interval = hours.split(": ")
-            open_time, close_time = interval.split(" \u2013 ")
-            oh.add_range(day[:2], open_time, close_time, "%I:%M%p")
-
-        properties = {
-            "ref": response.url.split("/")[-1],
-            "website": response.url,
-            "lat": response.xpath("//@data-lat").get(),
-            "lon": response.xpath("//@data-lng").get(),
-            "name": response.xpath('//meta[@property="og:title"]/@content').get(),
-            "opening_hours": oh.as_opening_hours(),
-            "phone": response.css(".field--name-field-phone-number ::text").get(),
-            "addr_full": addr_full,
-        }
-        yield Feature(**properties)


### PR DESCRIPTION
Sitemap is no longer available, switched to `CrawlSpider` and utilized `Structured Data` to fix the spider.
```

{'atp/brand/Shake Shack': 544,
 'atp/brand_wikidata/Q1058722': 544,
 'atp/category/amenity/fast_food': 544,
 'atp/cdn/cloudflare/response_count': 546,
 'atp/cdn/cloudflare/response_status_count/200': 546,
 'atp/field/branch/missing': 544,
 'atp/field/city/missing': 13,
 'atp/field/email/missing': 544,
 'atp/field/image/missing': 544,
 'atp/field/lat/missing': 46,
 'atp/field/lon/missing': 46,
 'atp/field/opening_hours/missing': 544,
 'atp/field/operator/missing': 544,
 'atp/field/operator_wikidata/missing': 544,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 151,
 'atp/field/postcode/missing': 136,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/state/missing': 166,
 'atp/field/state/wrong_type': 1,
 'atp/field/street_address/missing': 3,
 'atp/item_scraped_host_count/shakeshack.com': 544,
 'atp/nsi/perfect_match': 544,
 'downloader/request_bytes': 290839,
 'downloader/request_count': 546,
 'downloader/request_method_count/GET': 546,
 'downloader/response_bytes': 16421300,
 'downloader/response_count': 546,
 'downloader/response_status_count/200': 546,
 'elapsed_time_seconds': 1326.000042,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 2, 14, 52, 32, 422604, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 53101454,
 'httpcompression/response_count': 546,
 'item_scraped_count': 544,
 'log_count/DEBUG': 1101,
 'log_count/ERROR': 1,
 'log_count/INFO': 32,
 'request_depth_max': 1,
 'response_received_count': 546,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 545,
 'scheduler/dequeued/memory': 545,
 'scheduler/enqueued': 545,
 'scheduler/enqueued/memory': 545,
 'start_time': datetime.datetime(2025, 1, 2, 14, 30, 26, 422562, tzinfo=datetime.timezone.utc)}
```