### PR TITLE
[Avera US] Fix spider

### DIFF
--- a/locations/spiders/avera_us.py
+++ b/locations/spiders/avera_us.py
@@ -24,3 +24,4 @@ class AveraUSSpider(SitemapSpider, StructuredDataSpider):
         "ROBOTSTXT_OBEY": False,
     }
     requires_proxy = "US"
+    time_format = "%H:%M:%S"

--- a/locations/spiders/avera_us.py
+++ b/locations/spiders/avera_us.py
@@ -1,33 +1,26 @@
-from scrapy import Spider
+from scrapy.settings.default_settings import DEFAULT_REQUEST_HEADERS
+from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
-from locations.pipelines.address_clean_up import clean_address
+from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AveraUSSpider(Spider):
+class AveraUSSpider(SitemapSpider, StructuredDataSpider):
     name = "avera_us"
     item_attributes = {
         "brand": "Avera",
         "brand_wikidata": "Q4828238",
     }
-    allowed_domains = ["www.avera.org"]
-    start_urls = ["https://www.avera.org/api/locations/all"]
+    sitemap_urls = ["https://www.avera.org/sitemap.xml"]
+    sitemap_rules = [(r"https://www.avera.org/locations/profile/[-\w]+", "parse_sd")]
     user_agent = BROWSER_DEFAULT
-    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 60}
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": DEFAULT_REQUEST_HEADERS
+        | {
+            "Connection": "keep-alive",
+            "Sec-Fetch-Site": "same-origin",
+            "sec-ch-dpr": "",
+        },
+        "ROBOTSTXT_OBEY": False,
+    }
     requires_proxy = "US"
-
-    def parse(self, response):
-        for location in response.json():
-            item = DictParser.parse(location)
-            item["ref"] = location["LocationId"]
-            item["street_address"] = clean_address(
-                [location["Address"].get("AddressLine1"), location["Address"].get("AddressLine2")]
-            )
-            if "Main" in location["PhoneNumbers"]:
-                item["phone"] = location["PhoneNumbers"]["Main"].get("WholeNumber")
-            item["opening_hours"] = OpeningHours()
-            for day in location["OfficeHours"]:
-                item["opening_hours"].add_range(day["DayOfTheWeek"], day["OpenTime"], day["CloseTime"], "%H:%M:%S")
-            yield item


### PR DESCRIPTION
`API` earlier used, is now blocked, hence code refactored using `sitemap` and `SD` to fix the spider. Additional `headers` are required to get rid of blockage.

```
{'atp/brand/Avera': 441,
 'atp/brand_wikidata/Q4828238': 441,
 'atp/category/amenity/hospital': 441,
 'atp/category/multiple': 441,
 'atp/field/branch/missing': 441,
 'atp/field/country/from_spider_name': 441,
 'atp/field/email/missing': 436,
 'atp/field/image/invalid': 10,
 'atp/field/lat/missing': 11,
 'atp/field/lon/missing': 11,
 'atp/field/opening_hours/missing': 129,
 'atp/field/phone/missing': 13,
 'atp/field/postcode/missing': 1,
 'atp/item_scraped_host_count/www.avera.org': 443,
 'atp/nsi/perfect_match': 441,
 'atp/operator/Avera Health': 441,
 'atp/operator_wikidata/Q4828238': 441,
 'downloader/request_bytes': 235638,
 'downloader/request_count': 444,
 'downloader/request_method_count/GET': 444,
 'downloader/response_bytes': 6553181,
 'downloader/response_count': 444,
 'downloader/response_status_count/200': 444,
 'elapsed_time_seconds': 5.000068,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 3, 12, 59, 6, 135979, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 444,
 'httpcompression/response_bytes': 20036871,
 'httpcompression/response_count': 444,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 441,
 'log_count/DEBUG': 899,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 444,
 'scheduler/dequeued': 444,
 'scheduler/dequeued/memory': 444,
 'scheduler/enqueued': 444,
 'scheduler/enqueued/memory': 444,
 'start_time': datetime.datetime(2025, 1, 3, 12, 59, 1, 135911, tzinfo=datetime.timezone.utc)}
```