### PR TITLE
[Food City Southeast US] Extract address parts directly. Fix delivery tag.

### DIFF
--- a/locations/spiders/food_city_southeast_us.py
+++ b/locations/spiders/food_city_southeast_us.py
@@ -44,7 +44,9 @@ class FoodCitySoutheastUSSpider(Spider):
             item["state"] = store_listing.xpath(f"..//input[@id='State{ref}']/@value").get()
             item["postcode"] = store_listing.xpath(f"..//input[@id='Zip{ref}']/@value").get()
 
-            item["phone"] = store_listing.xpath(".//div[@class='location']//a[@class='tel']/@href").get().removeprefix("tel:")
+            item["phone"] = (
+                store_listing.xpath(".//div[@class='location']//a[@class='tel']/@href").get().removeprefix("tel:")
+            )
             for location_hours in store_listing.xpath(".//*[@class='hours']"):
                 h2 = location_hours.xpath("./h2/text()").get()
                 if h2 == "Store Hours":
@@ -55,7 +57,9 @@ class FoodCitySoutheastUSSpider(Spider):
                     item["extras"]["opening_hours:pharmacy"] = self.parse_opening_hours(
                         location_hours.xpath("./p/text()").getall()
                     ).as_opening_hours()
-            apply_yes_no(Extras.DELIVERY, item, bool(store_listing.xpath(".//img[contains(@src, '/home-delivery.png')]")))
+            apply_yes_no(
+                Extras.DELIVERY, item, bool(store_listing.xpath(".//img[contains(@src, '/home-delivery.png')]"))
+            )
             yield item
 
         if len(listings) == self.page_size:

--- a/locations/spiders/food_city_southeast_us.py
+++ b/locations/spiders/food_city_southeast_us.py
@@ -6,7 +6,6 @@ from scrapy.http import Response
 from locations.categories import Extras, apply_yes_no
 from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
 
 
 class FoodCitySoutheastUSSpider(Spider):
@@ -35,21 +34,28 @@ class FoodCitySoutheastUSSpider(Spider):
             if lat == "0":
                 continue  # skip duplicate store data without coordinates
             item = Feature()
+            ref = store_listing.xpath("@data-id").get()
             item["lat"], item["lon"] = lat, lon
-            item["ref"] = store_listing.xpath("@data-id").get()
-            item["website"] = f"https://www.foodcity.com/stores/store-details/{item['ref']}"
-            item["addr_full"] = clean_address(store_listing.xpath(".//*[@class='location']/p/text()").getall()).split(
-                "miles"
-            )[-1]
-            item["phone"] = store_listing.xpath(".//a[contains(@href,'tel')]/@href").get()
+            item["ref"] = ref
+            item["website"] = f"https://www.foodcity.com/stores/store-details/{ref}"
+            # These hidden input tags are siblings to store_listing
+            item["street_address"] = store_listing.xpath(f"..//input[@id='Address{ref}']/@value").get()
+            item["city"] = store_listing.xpath(f"..//input[@id='City{ref}']/@value").get()
+            item["state"] = store_listing.xpath(f"..//input[@id='State{ref}']/@value").get()
+            item["postcode"] = store_listing.xpath(f"..//input[@id='Zip{ref}']/@value").get()
+
+            item["phone"] = store_listing.xpath(".//div[@class='location']//a[@class='tel']/@href").get().removeprefix("tel:")
             for location_hours in store_listing.xpath(".//*[@class='hours']"):
-                if "Store Hours" in location_hours.get():
-                    item["opening_hours"] = self.parse_opening_hours(location_hours.xpath("./p/text()").getall())
-                if "Pharmacy Hours" in location_hours.get():
+                h2 = location_hours.xpath("./h2/text()").get()
+                if h2 == "Store Hours":
+                    item["opening_hours"] = self.parse_opening_hours(
+                        location_hours.xpath("./p/text()").getall()
+                    ).as_opening_hours()
+                if h2 == "Pharmacy Hours":
                     item["extras"]["opening_hours:pharmacy"] = self.parse_opening_hours(
                         location_hours.xpath("./p/text()").getall()
                     ).as_opening_hours()
-            apply_yes_no(Extras.DELIVERY, item, bool(store_listing.xpath(".//img[@src='/images/home-delivery.png']")))
+            apply_yes_no(Extras.DELIVERY, item, bool(store_listing.xpath(".//img[contains(@src, '/home-delivery.png')]")))
             yield item
 
         if len(listings) == self.page_size:


### PR DESCRIPTION
`extras.delivery` was not being parsed correctly.
Address parts can be pulled from sibling hidden inputs with `id="Address123"` etc.
```py
{'atp/brand/Food City': 153,
 'atp/brand_wikidata/Q16981107': 153,
 'atp/category/shop/supermarket': 153,
 'atp/field/branch/missing': 153,
 'atp/field/country/from_spider_name': 153,
 'atp/field/email/missing': 153,
 'atp/field/image/missing': 153,
 'atp/field/operator/missing': 153,
 'atp/field/operator_wikidata/missing': 153,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/missing': 153,
 'atp/item_scraped_host_count/www.foodcity.com': 153,
 'atp/nsi/perfect_match': 153,
 'downloader/request_bytes': 19743,
 'downloader/request_count': 17,
 'downloader/request_method_count/GET': 17,
 'downloader/response_bytes': 161849,
 'downloader/response_count': 17,
 'downloader/response_status_count/200': 17,
 'elapsed_time_seconds': 19.401713,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 4, 9, 12, 44, 771211, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 651270,
 'httpcompression/response_count': 17,
 'item_scraped_count': 153,
 'items_per_minute': None,
 'log_count/DEBUG': 181,
 'log_count/INFO': 10,
 'memusage/max': 260575232,
 'memusage/startup': 260575232,
 'request_depth_max': 15,
 'response_received_count': 17,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 16,
 'scheduler/dequeued/memory': 16,
 'scheduler/enqueued': 16,
 'scheduler/enqueued/memory': 16,
 'start_time': datetime.datetime(2025, 1, 4, 9, 12, 25, 369498, tzinfo=datetime.timezone.utc)}
```