### PR TITLE
Add Hobby Lobby spider (1040 locations)

### DIFF
--- a/locations/spiders/hobby_lobby.py
+++ b/locations/spiders/hobby_lobby.py
@@ -1,0 +1,44 @@
+from urllib.parse import urlparse
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class HobbyLobbySpider(SitemapSpider, StructuredDataSpider):
+    name = "hobby_lobby"
+    allowed_domains = ["hobbylobby.com"]
+    item_attributes = {
+        "brand": "Hobby Lobby",
+        "brand_wikidata": "Q5874938",
+    }
+    sitemap_urls = ["https://www.hobbylobby.com/sitemap-Store.xml"]
+    sitemap_rules = [
+        (r"/stores/search/(\d+)$", "parse_sd"),
+    ]
+    time_format = "%H:%M %p"
+    custom_settings = {
+        # Site has no rate limiting
+        "DOWNLOAD_DELAY": 0.1,
+    }
+    # There are only social links for branch, not location
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def pre_process_data(self, ld_data, **kwargs):
+        ld_data.pop("name", None)
+        # Broken image link
+        ld_data.pop("image", None)
+
+        # ID/ref should be store number, not main website URL
+        url = urlparse(ld_data["url"])
+        ref = url.path.split("/")[-1]
+        ld_data["@id"] = ref
+        # Store URLs have the wrong domain
+        url = url._replace(scheme="https", netloc="www.hobbylobby.com")
+        ld_data["url"] = url.geturl()
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_CRAFT, item)
+        yield item

--- a/locations/spiders/hobby_lobby_us.py
+++ b/locations/spiders/hobby_lobby_us.py
@@ -6,9 +6,9 @@ from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class HobbyLobbySpider(SitemapSpider, StructuredDataSpider):
-    name = "hobby_lobby"
-    allowed_domains = ["hobbylobby.com"]
+class HobbyLobbyUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "hobby_lobby_us"
+    allowed_domains = ["www.hobbylobby.com"]
     item_attributes = {
         "brand": "Hobby Lobby",
         "brand_wikidata": "Q5874938",
@@ -17,11 +17,7 @@ class HobbyLobbySpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"/stores/search/(\d+)$", "parse_sd"),
     ]
-    time_format = "%H:%M %p"
-    custom_settings = {
-        # Site has no rate limiting
-        "DOWNLOAD_DELAY": 0.1,
-    }
+    time_format = "%I:%M %p"
     # There are only social links for branch, not location
     search_for_twitter = False
     search_for_facebook = False


### PR DESCRIPTION
This has a bug that I can't figure out. 
The `ld_data` has
```py
'openingHoursSpecification': [..., {'dayOfWeek': 'Monday', 'opens': '09:00 AM', 'closes': '08:00 PM', '@type': 'OpeningHoursSpecification'}, ...]
```
but if I set
```py
time_format = "%H:%M %p"
```
the closing time is parsed as `08:00`. The "PM" is ignored. Is this a bug with `StructuredDataSpider` or `OpeningHours`?

Also, this is my second spider I've written. Could I request general feedback?