### PR TITLE
Mattress Warehouse: Remove brand data from POI

### DIFF
--- a/locations/spiders/mattress_warehouse_us.py
+++ b/locations/spiders/mattress_warehouse_us.py
@@ -19,4 +19,12 @@ class MattressWarehouseUSSpider(YextSpider):
 
         item["branch"] = item.pop("name").removeprefix("Mattress Warehouse ").removeprefix("of ").removeprefix("- ")
 
+        # Remove brand data from POI
+        if item.get("email") == "info@mattresswarehouse.com":
+            del item["email"]
+        if item.get("twitter") == "MWarehouseLLC":
+            del item["twitter"]
+        if item["extras"]["contact:instagram"] == "mattresswarehousellc":
+            del item["extras"]["contact:instagram"]
+
         yield item


### PR DESCRIPTION
In response to https://github.com/alltheplaces/alltheplaces/issues/10951, this removes the brand's email, instagram, and twitter from `mattress_warehouse_us`.
As mentioned in https://github.com/alltheplaces/alltheplaces/issues/11212, it might be better to add a pipeline to remove redundant brand data for all spiders, instead of making PRs for each spider.