### PR TITLE
pipelines/check_item_properties: improve country code matching, stats

### DIFF
--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -1,7 +1,7 @@
 import math
-import pycountry
 import re
 
+import pycountry
 from scrapy import Spider
 
 from locations.hours import OpeningHours

--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -1,4 +1,5 @@
 import math
+import pycountry
 import re
 
 from scrapy import Spider
@@ -34,7 +35,7 @@ class CheckItemPropertiesPipeline:
         r"(?:/?|[/?]\S+)$",
         re.IGNORECASE,
     )
-    country_regex = re.compile(r"(^[A-Z]{2}$)")
+    country_regex = re.compile("(^(?:" + r"|".join([country.alpha_2 for country in pycountry.countries]) + ")$)")
     email_regex = re.compile(r"(^[-\w_.+]+@[-\w]+\.[-\w.]+$)")
     twitter_regex = re.compile(r"^@?([-\w_]+)$")
     wikidata_regex = re.compile(
@@ -87,6 +88,9 @@ class CheckItemPropertiesPipeline:
         if not (item.get("geometry") or get_lat_lon(item)):
             spider.crawler.stats.inc_value("atp/field/lat/missing")
             spider.crawler.stats.inc_value("atp/field/lon/missing")
+
+        if country_code := item.get("country"):
+            spider.crawler.stats.inc_value(f"atp/country/{country_code}")
 
         if twitter := item.get("twitter"):
             if not isinstance(twitter, str):


### PR DESCRIPTION
* Ensure country codes for items are valid (assigned) ISO 3166-1 alpha-2 codes and not unassigned codes such as "ZZ".

* Collect statistics on the number of items extracted per country code. This is helpful to debug multinational spiders to determine if features of all expected countries are being extracted. It is also helpful to alert to spiders named e.g. "_gb" for the UK, but also including features in territories such as "IM" (Isle of Man), and thus the spider should be renamed.