### PR TITLE
[Trung Nguyen Coffee VN] Fix Spider

### DIFF
--- a/locations/spiders/trung_nguyen_coffee_vn.py
+++ b/locations/spiders/trung_nguyen_coffee_vn.py
@@ -1,4 +1,5 @@
 from locations.storefinders.super_store_finder import SuperStoreFinderSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class TrungNguyenCoffeeVNSpider(SuperStoreFinderSpider):
@@ -10,3 +11,4 @@ class TrungNguyenCoffeeVNSpider(SuperStoreFinderSpider):
     allowed_domains = [
         "trungnguyenlegend.com",
     ]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
`Fixes : added user_agent to fix spider`


{'atp/brand/Trung Nguyên': 660,
 'atp/brand_wikidata/Q3541154': 660,
 'atp/category/amenity/cafe': 660,
 'atp/field/branch/missing': 660,
 'atp/field/city/missing': 660,
 'atp/field/country/from_spider_name': 660,
 'atp/field/email/missing': 660,
 'atp/field/image/missing': 660,
 'atp/field/opening_hours/missing': 660,
 'atp/field/operator/missing': 660,
 'atp/field/operator_wikidata/missing': 660,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 53,
 'atp/field/postcode/missing': 660,
 'atp/field/state/missing': 660,
 'atp/field/street_address/missing': 660,
 'atp/field/twitter/missing': 660,
 'atp/field/website/missing': 660,
 'atp/item_scraped_host_count/trungnguyenlegend.com': 660,
 'atp/nsi/perfect_match': 660,
 'downloader/request_bytes': 575,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 54559,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.140661,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 6, 6, 18, 30, 292808, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 638897,
 'httpcompression/response_count': 2,
 'item_scraped_count': 660,
 'items_per_minute': None,
 'log_count/DEBUG': 673,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 6, 6, 18, 25, 152147, tzinfo=datetime.timezone.utc)}