### PR TITLE
[Honda AU] Fix Spider

### DIFF
--- a/locations/spiders/honda_au.py
+++ b/locations/spiders/honda_au.py
@@ -17,7 +17,6 @@ class HondaAUSpider(Spider):
     start_urls = ["https://www.honda.com.au/api/locateDealer/Dealerships/get"]
     require_proxy = True
 
-
     def start_requests(self):
         for url in self.start_urls:
             yield JsonRequest(url=url)

--- a/locations/spiders/honda_au.py
+++ b/locations/spiders/honda_au.py
@@ -15,6 +15,8 @@ class HondaAUSpider(Spider):
     item_attributes = {"brand": "Honda", "brand_wikidata": "Q9584"}
     allowed_domains = ["www.honda.com.au"]
     start_urls = ["https://www.honda.com.au/api/locateDealer/Dealerships/get"]
+    require_proxy = True
+
 
     def start_requests(self):
         for url in self.start_urls:


### PR DESCRIPTION
`Fixes : added flag require_proxy`

{'atp/brand/Honda': 248,
 'atp/brand_wikidata/Q9584': 248,
 'atp/category/shop/car': 76,
 'atp/category/shop/car_parts': 86,
 'atp/category/shop/car_repair': 86,
 'atp/field/country/from_spider_name': 248,
 'atp/field/email/missing': 50,
 'atp/field/image/missing': 248,
 'atp/field/name/missing': 86,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 248,
 'atp/field/operator_wikidata/missing': 248,
 'atp/field/twitter/missing': 248,
 'atp/item_scraped_host_count/www.honda.com.au': 248,
 'atp/nsi/cc_match': 162,
 'atp/nsi/match_failed': 86,
 'downloader/request_bytes': 1053,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 273034,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.215578,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 6, 7, 57, 45, 661617, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1170043,
 'httpcompression/response_count': 2,
 'item_scraped_count': 248,
 'items_per_minute': None,
 'log_count/DEBUG': 261,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 6, 7, 57, 40, 446039, tzinfo=datetime.timezone.utc)}