### PR TITLE
[Tgi Fridays GR] Fix Spider

### DIFF
--- a/locations/spiders/tgi_fridays_gr.py
+++ b/locations/spiders/tgi_fridays_gr.py
@@ -1,12 +1,25 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any
 
-from locations.structured_data_spider import StructuredDataSpider
+import scrapy
+from scrapy.http import Response
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
 
 
-class TgiFridaysGRSpider(SitemapSpider, StructuredDataSpider):
+class TgiFridaysGRSpider(scrapy.Spider):
     name = "tgi_fridays_gr"
     item_attributes = {"brand": "TGI Fridays", "brand_wikidata": "Q1524184"}
-    sitemap_urls = [
-        "https://www.fridays.gr/page-sitemap.xml",
-    ]
-    sitemap_rules = [("/en/restaurants/", "parse_sd")]
+    start_urls = ["https://www.fridays.gr/en/restaurants/"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for restaurant in response.xpath('//*[@id = "map-category-locations"]//li'):
+            item = Feature()
+            item["name"] = restaurant.xpath(".//h4/text()").get()
+            item["addr_full"] = restaurant.xpath(".//p/text()").get()
+            item["phone"] = restaurant.xpath('.//*[contains(@href,"tel:")]//text()').get()
+            item["email"] = restaurant.xpath('.//*[contains(@href,"mailto:")]/text()').get()
+            item["ref"] = restaurant.xpath(".//@data-id").get()
+            item["website"] = "https://www.fridays.gr/"
+            extract_google_position(item, restaurant)
+            yield item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/TGI Fridays': 9,
 'atp/brand_wikidata/Q1524184': 9,
 'atp/category/amenity/restaurant': 9,
 'atp/field/branch/missing': 9,
 'atp/field/city/missing': 9,
 'atp/field/country/from_spider_name': 9,
 'atp/field/image/missing': 9,
 'atp/field/opening_hours/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 9,
 'atp/field/state/missing': 9,
 'atp/field/street_address/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/item_scraped_host_count/www.fridays.gr': 9,
 'atp/nsi/perfect_match': 9,
 'downloader/request_bytes': 666,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 55522,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.471977,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 7, 7, 38, 55, 347297, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 344126,
 'httpcompression/response_count': 2,
 'item_scraped_count': 9,
 'items_per_minute': None,
 'log_count/DEBUG': 22,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 7, 7, 38, 50, 875320, tzinfo=datetime.timezone.utc)}

