### PR TITLE
[Giant Eagle US] Fix spider

### DIFF
--- a/locations/spiders/giant_eagle_us.py
+++ b/locations/spiders/giant_eagle_us.py
@@ -4,7 +4,7 @@ from typing import Any, Iterable
 from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.geo import postal_regions
 from locations.hours import OpeningHours
@@ -169,7 +169,12 @@ class GiantEagleUSSpider(Spider):
                 item.update(self.MARKET_DISTRICT)
             else:
                 item.update(self.GIANT_EAGLE)
+
             apply_category(Categories.SHOP_SUPERMARKET, item)
+
+            if services := location_info["availableServices"]:
+                apply_yes_no(Extras.DELIVERY, item, services.get("delivery"))
+                apply_yes_no(Extras.TAKEAWAY, item, services.get("pickup"))
 
             yield item
 


### PR DESCRIPTION
Replaced non functional API by `GraphQL` one and code refactored accordingly to fix the spider. POIs count saturates with the current `zipcode` based search requests.

```
{'atp/brand/GetGo': 14,
 'atp/brand/Giant Eagle': 191,
 'atp/brand/Giant Eagle Pharmacy': 197,
 'atp/brand/Market District': 22,
 'atp/brand_wikidata/Q1522721': 191,
 'atp/brand_wikidata/Q5553766': 14,
 'atp/brand_wikidata/Q98550869': 22,
 'atp/category/amenity/pharmacy': 197,
 'atp/category/multiple': 197,
 'atp/category/shop/convenience': 14,
 'atp/category/shop/supermarket': 213,
 'atp/field/branch/missing': 424,
 'atp/field/brand_wikidata/missing': 197,
 'atp/field/country/from_spider_name': 424,
 'atp/field/email/missing': 424,
 'atp/field/image/missing': 424,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 424,
 'atp/field/operator_wikidata/missing': 424,
 'atp/field/phone/missing': 16,
 'atp/field/twitter/missing': 424,
 'atp/item_scraped_host_count/core.shop.gianteagle.com': 2045,
 'atp/nsi/brand_missing': 22,
 'atp/nsi/cc_match': 14,
 'atp/nsi/perfect_match': 191,
 'downloader/request_bytes': 6069262,
 'downloader/request_count': 1380,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1379,
 'downloader/response_bytes': 1656887,
 'downloader/response_count': 1380,
 'downloader/response_status_count/200': 1380,
 'elapsed_time_seconds': 13.781548,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 7, 15, 9, 52, 247009, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1380,
 'httpcompression/response_bytes': 6163119,
 'httpcompression/response_count': 1379,
 'item_dropped_count': 1621,
 'item_dropped_reasons_count/DropItem': 1621,
 'item_scraped_count': 424,
 'log_count/DEBUG': 3437,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'request_depth_max': 3,
 'response_received_count': 1380,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1379,
 'scheduler/dequeued/memory': 1379,
 'scheduler/enqueued': 1379,
 'scheduler/enqueued/memory': 1379,
 'start_time': datetime.datetime(2025, 1, 7, 15, 9, 38, 465461, tzinfo=datetime.timezone.utc)}
```