### PR TITLE
[q_park] Changed deals to a list 

### DIFF
--- a/locations/spiders/q_park.py
+++ b/locations/spiders/q_park.py
@@ -1,0 +1,124 @@
+import json
+import re
+from typing import Iterable
+
+from scrapy import Request, Spider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
+
+COUNTRIES = {
+    "be": {"lang": "nl-be", "poi": "bezienswaardigheden", "uri_path": "parkeren"},
+    "de": {"lang": "en-gb", "poi": "poi", "uri_path": "cities"},
+    "dk": {"lang": "en-gb", "poi": "poi", "uri_path": "parking"},
+    "fr": {"lang": "en-gb", "poi": "poi", "uri_path": "cities"},
+    "ie": {"lang": "en-gb", "poi": "poi", "uri_path": "cities"},
+    "nl": {"lang": "en-gb", "poi": "poi", "uri_path": "parking"},
+    "co.uk": {"lang": "en-gb", "poi": "poi", "uri_path": "cities"},
+}
+DEALS_KEYWORDS = [
+    "goedkoop-parkeren-",
+    "gunstig-parken",
+    "guenstig-parken",
+    "deals",
+    "dublin-city-offers",
+    "cheap-parking-",
+    "tilbud-paa-parkering-",
+    "cork-city-offers",
+]
+
+
+class QParkSpider(Spider):
+    name = "q_park"
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+
+    def start_requests(self) -> Iterable[Request]:
+        for country, info in COUNTRIES.items():
+            yield Request(
+                url=f"https://www.q-park.{country}/{info['lang']}/{info['uri_path']}/",
+                cb_kwargs={"country_info": info},
+                callback=self.parse_country,
+            )
+
+    def parse_country(self, response, country_info):
+        cities = response.xpath(
+            f"""//a[@class='no-link'][contains(@href, '/{country_info["lang"]}/{country_info["uri_path"]}/')]/@href"""
+        ).getall()
+        for city in cities:
+            yield Request(
+                url=response.urljoin(city),
+                cb_kwargs={"city": city, "country_info": country_info},
+                callback=self.parse_city,
+            )
+
+    def parse_city(self, response, city, country_info):
+        hrefs = response.xpath("//a[@class='no-link']/@href").getall()
+        hrefs = set(hrefs)
+
+        for href in hrefs:
+            href_is_deal = False
+            for keyword in DEALS_KEYWORDS:
+                if keyword in href:
+                    href_is_deal = True
+            if href_is_deal:
+                continue
+            if f"/{country_info['poi']}/" not in href:
+                yield Request(
+                    url=response.urljoin(href),
+                    callback=self.parse_facility,
+                )
+
+    def parse_facility(self, response):
+        ld_jsons = response.xpath("//script[@type='application/ld+json']/text()").getall()
+        for ld_json in ld_jsons:
+            facility_info = json.loads(ld_json)
+            if facility_info.get("@type") == "ParkingFacility":
+                continue
+        item = DictParser.parse(facility_info)
+        item["phone"] = facility_info.get("address", {}).get("telephone")
+        item["website"] = response.url
+        item["ref"] = response.url.split("/")[-2]
+
+        try:
+            google_urls = response.xpath("//a[contains(@href, 'google.com/maps')]/@href").getall()
+            for url in google_urls:
+                if "destination=" in url and "destination_place_id=" not in url:
+                    item["lat"] = url.split("destination=")[1].split(",")[0]
+                    item["lon"] = url.split("destination=")[1].split(",")[1]
+
+            if not item.get("lat") and not item.get("lon"):
+                google_api_urls = response.xpath(
+                    "//div[@class='img-bg'][contains(@data-background-image, 'googleapis')]/@data-background-image"
+                ).getall()
+                for url in google_api_urls:
+                    if "map-marker-blue.png" in url:
+                        item["lat"] = url.split("map-marker-blue.png")[1].split(",")[0]
+                        item["lon"] = url.split("map-marker-blue.png")[1].split(",")[1]
+                        if "%7C" in item["lat"]:
+                            item["lat"] = item["lat"].split("%7C")[1]
+                        if "&signature=" in item["lon"]:
+                            item["lon"] = item["lon"].split("&signature=")[0]
+                        self.crawler.stats.inc_value("zzz/googleapi")
+        except Exception:
+            self.crawler.stats.inc_value("q_park/failed_to_get_lat_lon")
+
+        match = re.search(r"const customGtmEventsToPush = (\[.*?\]);", response.text, re.DOTALL)
+        try:
+            match_json = json.loads(match.group(1).strip())
+            for element in match_json:
+                if "productDetail" in element:
+                    item["extras"]["capacity"] = element["productDetail"].get("totalSpots")
+                    item["extras"]["capacity:disabled"] = element["productDetail"].get("disabledSpots")
+                    item["extras"]["capacity:charging"] = element["productDetail"].get("chargingPoints", "no")
+                    item["extras"]["maxheight"] = element["productDetail"].get("entryHeight")
+                    if item["extras"]["maxheight"]:
+                        item["extras"]["maxheight"] = item["extras"]["maxheight"] + " meters"
+        except Exception:
+            self.crawler.stats.inc_value("q_park/failed_to_get_capacity")
+
+        apply_category(Categories.PARKING, item)
+        item["operator"] = "Q-Park"
+        item["operator_wikidata"] = "Q1127798"
+
+        yield item


### PR DESCRIPTION
I missed some deals urls to filter out. Refactored code slightly to have deals as a list.
<details><summary>Stats</summary>

```json
{
 "atp/brand/Q-Park": 1020,
 "atp/brand_wikidata/Q1127798": 1020,
 "atp/category/amenity/parking": 1020,
 "atp/field/branch/missing": 1020,
 "atp/field/city/missing": 118,
 "atp/field/country/from_website_url": 288,
 "atp/field/email/missing": 1020,
 "atp/field/image/missing": 1020,
 "atp/field/lat/missing": 13,
 "atp/field/lon/missing": 13,
 "atp/field/opening_hours/missing": 1020,
 "atp/field/phone/missing": 536,
 "atp/field/postcode/missing": 99,
 "atp/field/state/missing": 1020,
 "atp/field/street_address/missing": 98,
 "atp/field/twitter/missing": 1020,
 "atp/geometry/null_island": 13,
 "atp/item_scraped_host_count/www.q-park.be": 42,
 "atp/item_scraped_host_count/www.q-park.co.uk": 81,
 "atp/item_scraped_host_count/www.q-park.de": 114,
 "atp/item_scraped_host_count/www.q-park.dk": 310,
 "atp/item_scraped_host_count/www.q-park.fr": 268,
 "atp/item_scraped_host_count/www.q-park.ie": 24,
 "atp/item_scraped_host_count/www.q-park.nl": 209,
 "atp/nsi/cc_match": 1020,
 "atp/operator/Q-Park": 1020,
 "atp/operator_wikidata/Q1127798": 1020,
 "downloader/exception_count": 32,
 "downloader/exception_type_count/twisted.internet.error.TimeoutError": 32,
 "downloader/request_bytes": 801636,
 "downloader/request_count": 1363,
 "downloader/request_method_count/GET": 1363,
 "downloader/response_bytes": 27015515,
 "downloader/response_count": 1331,
 "downloader/response_status_count/200": 1331,
 "elapsed_time_seconds": 1419.899269,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2025-01-07T17:59:31.851958+00:00",
 "httpcompression/response_bytes": 147593858,
 "httpcompression/response_count": 1331,
 "item_dropped_count": 28,
 "item_dropped_reasons_count/DropItem": 28,
 "item_scraped_count": 1020,
 "log_count/INFO": 33,
 "log_count/WARNING": 1,
 "memusage/max": 416710656,
 "memusage/startup": 252231680,
 "request_depth_max": 2,
 "response_received_count": 1331,
 "retry/count": 32,
 "retry/reason_count/twisted.internet.error.TimeoutError": 32,
 "scheduler/dequeued": 1363,
 "scheduler/dequeued/memory": 1363,
 "scheduler/enqueued": 1363,
 "scheduler/enqueued/memory": 1363,
 "start_time": "2025-01-07T17:35:51.952689+00:00",
 "zzz/googleapi": 534
}
```