### PR TITLE
[alaska_commercial_company] street_address

### DIFF
--- a/locations/spiders/alaska_commercial_company.py
+++ b/locations/spiders/alaska_commercial_company.py
@@ -18,7 +18,7 @@ class AlaskaCommercialCompanySpider(JSONBlobSpider):
         # {'pid': '143', 'title': 'Yakutat', 'details': '\n\t\t\t\t\t\t<h4>Yakutat <span>Alaska Commercial Company</span></h4>\n\t\t\t\t\t\t<p class="address"><strong>716 Ocean Cape Road<br />\n\t\t\t\t\t\t\tYakutat, Alaska<br />\n\t\t\t\t\t\t\t99689</strong>\n\t\t\t\t\t\t\t<br />Phone: 907-784-3386\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t</p>\n\t\t\t\t\t', 'lat': '59.5449510501618', 'lng': '-139.7313094139099'}
 
         page_html = Selector(text=location["details"])
-        location["address"] = str(page_html.xpath('//p[@class="address"]/strong/text()').get())
+        location["street_address"] = str(page_html.xpath('//p[@class="address"]/strong/text()').get())
         text = str(page_html.xpath("text()").get())
         if "Phone: " in text:
             location["phone"] = text.split("Phone: ")[1]


### PR DESCRIPTION
sometimes has state, but more often just street address and never full address

```
examples:
['209 Airport Road', '125 Main St.', '131 Akakeek St.', '811 3rd Avenue', '295 Main St.',
'345 Main St.', '155 Main St.', '6th and H Street', 'Box 109', 'PO Box 9', '1 Bayview Dr.',
'365 Main St.', '395 Bison St.', '175 Main St.', 'Mile 1 Teller Hwy', '100 Pausana St.',
 '231 Main St.', '741 Qalgi Ave', '100 Main St.', '377 State Street', '265 Main St.', 
'255 Main St.', '285 Main St.', '215 Main St.', '135 Ridgecrest St.', '106 Nicholoff Way',
'1300 Craig/Klawock Highway', '100 Southside Eskimo Creek', '6488 Klawock Hollis Hwy. #9',
'1st and Lower Milton', '30 Reynolds Ave.', '716 Ocean Cape Road']

counter_examples
['P.O. Box 70 70 First Street, AK', '705 Halibut Point Road, Suite B',
'101 Front Street, Toksook Bay, Alaska', '229 Pisokak St. Utqiagvik, Alaska']
```