### PR TITLE
[Cricket Wireless] Fix Spider

### DIFF
--- a/locations/spiders/cricket_wireless.py
+++ b/locations/spiders/cricket_wireless.py
@@ -1,16 +1,29 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
+
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CricketWirelessSpider(CrawlSpider,StructuredDataSpider):
+class CricketWirelessSpider(CrawlSpider, StructuredDataSpider):
     name = "cricket_wireless"
     item_attributes = {"brand": "Cricket Wireless", "brand_wikidata": "Q5184987"}
     start_urls = ["https://www.cricketwireless.com/stores/index.html"]
     rules = [
-        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]')),
-        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]')),
-        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link flex items-center gap-1 w-fit text-brand-blue a4-Link")]',deny_domains=["www.google.com"]),callback="parse"),
+        Rule(
+            LinkExtractor(
+                restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]'
+            )
+        ),
+        Rule(
+            LinkExtractor(
+                restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]'
+            )
+        ),
+        Rule(
+            LinkExtractor(
+                restrict_xpaths='//a[contains(@class, "Link flex items-center gap-1 w-fit text-brand-blue a4-Link")]',
+                deny_domains=["www.google.com"],
+            ),
+            callback="parse",
+        ),
     ]
-
-

--- a/locations/spiders/cricket_wireless.py
+++ b/locations/spiders/cricket_wireless.py
@@ -1,7 +1,16 @@
-from locations.storefinders.momentfeed import MomentFeedSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CricketWirelessSpider(MomentFeedSpider):
+class CricketWirelessSpider(CrawlSpider,StructuredDataSpider):
     name = "cricket_wireless"
     item_attributes = {"brand": "Cricket Wireless", "brand_wikidata": "Q5184987"}
-    api_key = "IVNLPNUOBXFPALWE"
+    start_urls = ["https://www.cricketwireless.com/stores/index.html"]
+    rules = [
+        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]')),
+        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]')),
+        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link flex items-center gap-1 w-fit text-brand-blue a4-Link")]',deny_domains=["www.google.com"]),callback="parse"),
+    ]
+
+


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/Cricket Wireless': 3340,
 'atp/brand_wikidata/Q5184987': 3340,
 'atp/category/shop/mobile_phone': 3340,
 'atp/country/US': 3340,
 'atp/field/branch/missing': 3340,
 'atp/field/email/missing': 3340,
 'atp/field/opening_hours/missing': 15,
 'atp/field/operator/missing': 3340,
 'atp/field/operator_wikidata/missing': 3340,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 3340,
 'atp/item_scraped_host_count/www.cricketwireless.com': 3340,
 'atp/nsi/perfect_match': 3340,
 'downloader/request_bytes': 8727004,
 'downloader/request_count': 5815,
 'downloader/request_method_count/GET': 5815,
 'downloader/response_bytes': 183211383,
 'downloader/response_count': 5815,
 'downloader/response_status_count/200': 5815,
 'elapsed_time_seconds': 7141.127307,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 9, 12, 19, 27, 804802, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 629763456,
 'httpcompression/response_count': 5815,
 'item_scraped_count': 3340,
 'items_per_minute': None,
 'log_count/DEBUG': 9166,
 'log_count/INFO': 128,
 'request_depth_max': 3,
 'response_received_count': 5815,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5814,
 'scheduler/dequeued/memory': 5814,
 'scheduler/enqueued': 5814,
 'scheduler/enqueued/memory': 5814,
 'start_time': datetime.datetime(2025, 1, 9, 10, 20, 26, 677495, tzinfo=datetime.timezone.utc)}