### PR TITLE
Add Rosetta APR "storefinder" for Australian electricity features

### DIFF
--- a/locations/archive_utils.py
+++ b/locations/archive_utils.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from zipfile import ZipFile
 
+
 def unzip_file_from_archive(compressed_data: bytes, file_path: str, password: str | None = None) -> bytes:
     """
     Extract and return a specified file from a ZIP archive.

--- a/locations/archive_utils.py
+++ b/locations/archive_utils.py
@@ -1,0 +1,14 @@
+from io import BytesIO
+from zipfile import ZipFile
+
+def unzip_file_from_archive(compressed_data: bytes, file_path: str, password: str | None = None) -> bytes:
+    """
+    Extract and return a specified file from a ZIP archive.
+    :param compressed_data: source archive as a bytes array
+    :param file_path: path and name of the file within the archive to extract
+    :param password: optional password required to extract from the archive
+    :return: extracted file as a bytes array
+    """
+    with ZipFile(BytesIO(compressed_data)) as archive:
+        with archive.open(file_path, mode="r", pwd=password) as file:
+            return file.read()

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -317,8 +317,15 @@ class Categories(Enum):
 
     ANTENNA = {"man_made": "antenna"}
     MONITORING_STATION = {"man_made": "monitoring_station"}
+    SUBSTATION = {"power": "substation"}
+    SUBSTATION_GENERATION = {"power": "substation", "substation": "generation"}
+    SUBSTATION_MINOR_DISTRIBUTION = {"power": "substation", "substation": "minor_distribution"}
+    SUBSTATION_INDUSTRIAL = {"power": "substation", "substation": "industrial"}
+    SUBSTATION_TRACTION = {"power": "substation", "substation": "traction"}
+    SUBSTATION_TRANSMISSION = {"power": "substation", "substation": "transmission"}
+    SUBSTATION_ZONE = {"power": "substation", "substation": "distribution"}
     SURVEILLANCE_CAMERA = {"man_made": "surveillance", "surveillance:type": "camera"}
-
+    TRANSFORMER = {"power": "transformer"}
 
 def apply_category(category, item: Feature):
     """
@@ -357,6 +364,7 @@ def apply_category(category, item: Feature):
 
 
 top_level_tags = [
+    "aeroway",
     "amenity",
     "club",
     "craft",
@@ -368,13 +376,13 @@ top_level_tags = [
     "leisure",
     "man_made",
     "office",
+    "power",
     "public_transport",
     "shop",
+    "telecom",
     "tourism",
-    "aeroway",
     "railway",
     "waterway",
-    "telecom",
 ]
 
 

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -327,6 +327,7 @@ class Categories(Enum):
     SURVEILLANCE_CAMERA = {"man_made": "surveillance", "surveillance:type": "camera"}
     TRANSFORMER = {"power": "transformer"}
 
+
 def apply_category(category, item: Feature):
     """
     Apply categories to a Feature, where categories can be supplied as a

--- a/locations/crypto_utils.py
+++ b/locations/crypto_utils.py
@@ -1,0 +1,20 @@
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.padding import PKCS7
+
+
+def decrypt_aes256cbc_pkcs7(ciphertext: bytes, key: str, iv: str) -> bytes:
+    """
+    Decrypt data that is encrypted with cipher AES256 used in CBC mode with
+    PKCS7 padding.
+    :param ciphertext: encrypted data as a bytes array
+    :param key: hex encoded key matching regular expression ^[0-9a-f]{64}$
+    :param iv: hex encoded initialization vector matching regular expression
+               ^[0-9a-f]{32}$
+    :return: decrypted data (plaintext) as a bytes array
+    """
+    cipher = Cipher(algorithms.AES256(key=bytes.fromhex(key)), modes.CBC(initialization_vector=bytes.fromhex(iv)))
+    decryptor = cipher.decryptor()
+    padded_plaintext = decryptor.update(ciphertext) + decryptor.finalize()
+    unpadder = PKCS7(block_size=128).unpadder()
+    unpadded_plaintext = unpadder.update(padded_plaintext) + unpadder.finalize()
+    return unpadded_plaintext

--- a/locations/pipelines/geojson_multipoint_simplification.py
+++ b/locations/pipelines/geojson_multipoint_simplification.py
@@ -1,0 +1,31 @@
+from scrapy import Spider
+
+from locations.items import Feature
+
+
+class GeoJSONMultiPointSimplificationPipeline:
+
+    def process_item(self, item: Feature, spider: Spider):
+        """
+        If MultiPoint geometry only contains a single coordinate, the geometry
+        can be changed from MultiPoint to Point. Point is simpler for ATP
+        users and tools to work with and has broader support than MultiPoint.
+        """
+        if not item.get("geometry"):
+            return item
+        if not item["geometry"].get("type"):
+            return item
+        if item["geometry"]["type"] != "MultiPoint":
+            return item
+        if not item["geometry"].get("coordinates"):
+            return item
+        if not isinstance(item["geometry"]["coordinates"], list):
+            return item
+        if len(item["geometry"]["coordinates"]) != 1:
+            return item
+        new_geometry = {
+            "type": "Point",
+            "coordinates": item["geometry"]["coordinates"][0],
+        }
+        item["geometry"] = new_geometry
+        return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -115,7 +115,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.closed.ClosePipeline": 650,
     "locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": 700,
     "locations.pipelines.check_item_properties.CheckItemPropertiesPipeline": 750,
-    "locations.pipelines.geojson_multipoint_simplication.GeoJSONMultiPointSimplificationPipeline": 760,
+    "locations.pipelines.geojson_multipoint_simplification.GeoJSONMultiPointSimplificationPipeline": 760,
     "locations.pipelines.count_categories.CountCategoriesPipeline": 800,
     "locations.pipelines.count_brands.CountBrandsPipeline": 810,
     "locations.pipelines.count_operators.CountOperatorsPipeline": 820,

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -115,6 +115,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.closed.ClosePipeline": 650,
     "locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": 700,
     "locations.pipelines.check_item_properties.CheckItemPropertiesPipeline": 750,
+    "locations.pipelines.geojson_multipoint_simplication.GeoJSONMultiPointSimplificationPipeline": 760,
     "locations.pipelines.count_categories.CountCategoriesPipeline": 800,
     "locations.pipelines.count_brands.CountBrandsPipeline": 810,
     "locations.pipelines.count_operators.CountOperatorsPipeline": 820,

--- a/locations/spiders/ausgrid_au.py
+++ b/locations/spiders/ausgrid_au.py
@@ -1,0 +1,225 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class AusgridAUSpider(RosettaAPRSpider):
+    name = "ausgrid_au"
+    item_attributes = {"operator": "Ausgrid", "operator_wikidata": "Q4822750"}
+    start_urls = ["https://dtapr.ausgrid.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="./layers/Zone_Substations_Ausgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Transmission_Sub_Station_Ausgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transmission_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Supply_Point_Station_Ausgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_bulk_supply_points",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Switch_Station_Ausgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_switching_stations",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_ref_and_name(self, description: str) -> (str | None, str | None, str | None):
+        """
+        Extract a substation identifier, name and short name from the title of
+        a substation provided in source data. The difference between a name
+        and short name is the short name omits any voltage differentiator in
+        the title and some punctuation and suffixes are removed.
+
+        Examples:
+          1. "ZN12345 ST. MOONVILLE 220kV STS" -> ("ZN12345", "ST. MOONVILLE 220kV STS", "ST MOONVILLE")
+          2. "ZN12345 ST. MOONVILLE STS" -> ("ZN12345", "ST. MOONVILLE STS", "ST MOONVILLE")
+          3. "ZN12345 ST. MOONVILLE" -> ("ZN12345", "ST. MOONVILLE", "ST MOONVILLE")
+          3. "ZN12345" -> ("ZN12345", None, None)
+        """
+        ref = None
+        name = None
+        short_name = None
+        if m := re.fullmatch(r"^([A-Z]{2}\d+) (.+)$", description):
+            ref = m.group(1)
+            name = m.group(2)
+        elif m := re.fullmatch(r"^([A-Z]{2}\d+)$", description):
+            ref = m.group(1)
+            name = None
+        else:
+            self.logger.error(
+                'Could not detect assigned substation identifier from: "{}". Description/title used as an identifier instead.'.format(
+                    description
+                )
+            )
+            ref = description
+            name = description
+        if name:
+            name_words = re.split(r"\W+", name.replace(".", ""))
+            for name_word in name_words:
+                if name_word in ["STS"]:
+                    break
+                if re.search(r"\d+", name_word):
+                    break
+                if not short_name:
+                    short_name = name_word
+                else:
+                    short_name = f"{short_name} {name_word}"
+        return (ref, name, short_name)
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            ref, name, short_name = self.parse_ref_and_name(feature["Name"])
+            properties = {
+                "ref": ref,
+                "name": name,
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./ausgrid_data/Technical_Specifiction_Summer_ZS.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "total_capacity_mva",
+                "firm_capacity_mva",
+                "load_transfer_capacity_mva",
+                "peak_load_exceeded_hours",
+                "embedded_generation_solar_mw",
+                "embedded_generation_other_mw",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            ref, name, short_name = self.parse_ref_and_name("{} {}".format(properties["ref"], properties["name"]))
+            if short_name and short_name in features_dict.keys():
+                if voltages_str := features_dict[short_name]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if total_capacity_mva := features_dict[short_name]["total_capacity_mva"]:
+                    properties["extras"]["rating"] = f"{total_capacity_mva} MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_transmission_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            ref, name, short_name = self.parse_ref_and_name(feature["Name"])
+            properties = {
+                "ref": ref,
+                "name": name,
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./ausgrid_data/Technical_Specifiction_Summer_TX.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_transmission_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "total_capacity_mva",
+                "firm_capacity_mva",
+                "load_transfer_capacity_mva",
+                "peak_load_exceeded_hours",
+                "embedded_generation_solar_mw",
+                "embedded_generation_other_mw",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_transmission_substation_attribs(
+        self, features: list[dict], existing_features: list[dict]
+    ) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            ref, name, short_name = self.parse_ref_and_name("{} {}".format(properties["ref"], properties["name"]))
+            if short_name and short_name in features_dict.keys():
+                if voltages_str := features_dict[short_name]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if total_capacity_mva := features_dict[short_name]["total_capacity_mva"]:
+                    properties["extras"]["rating"] = f"{total_capacity_mva} MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_bulk_supply_points(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            ref, name, short_name = self.parse_ref_and_name(feature["Name"])
+            properties = {
+                "ref": ref,
+                "name": name,
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            properties["extras"]["voltage"] = feature["Voltage"].replace("kV", "000").replace(" ", "")
+            items.append(Feature(**properties))
+        return items
+
+    def parse_switching_stations(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            ref, name, short_name = self.parse_ref_and_name(feature["Name"])
+            properties = {
+                "ref": ref,
+                "name": name,
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            properties["extras"]["voltage"] = feature["Voltage"].replace("kV", "000").replace(" ", "")
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/ausnet_dapr_au.py
+++ b/locations/spiders/ausnet_dapr_au.py
@@ -1,0 +1,118 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class AusnetDaprAUSpider(RosettaAPRSpider):
+    name = "ausnet_dapr_au"
+    item_attributes = {"operator": "AusNet", "operator_wikidata": "Q7392701"}
+    start_urls = ["https://dapr.ausnetservices.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="./layers/Ausnet_Victorian_Zone_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Ausnet_Victorian_Transmission_Terminal_Stations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transmission_substations",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["asset_code"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            voltages = ";".join(
+                map(
+                    lambda x: str(int(float(x) * 1000)),
+                    filter(None, [feature.get("sub_high_bus_voltage"), feature.get("sub_low_bus_voltage")]),
+                )
+            )
+            properties["extras"]["voltage"] = voltages
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./ausnet_data/Ausnet_Zone_Substations_Technical_Specifications.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "transformers_count",
+                "installed_capacity_mva",
+                "nminus1_summer_capacity_mva",
+                "nminus1_winter_capacity_mva",
+                "load_transfers_2023",
+                "embedded_generation_mw",
+                "n_capacity_mva",
+                "nminus1_capacity_mva",
+                "nminus2_capacity_mva",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            short_name = properties["name"].removesuffix(" ZSS")
+            if short_name in features_dict.keys():
+                if installed_capacity_mva := features_dict[short_name]["installed_capacity_mva"]:
+                    properties["extras"]["rating"] = f"{installed_capacity_mva} MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_transmission_substations(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            if m := re.fullmatch(r"^([^\(]+) \(([^\)]+)\)$", feature["Name"]):
+                full_name = m.group(1)
+                abbrev_name = m.group(2)
+            else:
+                full_name = feature["Name"]
+                abbrev_name = None
+
+            if abbrev_name:
+                ref = abbrev_name
+            elif feature.get("FID"):
+                ref = feature["FID"]
+            else:
+                self.logger.error(
+                    "Could not detect assigned substation identifier. Unstable OBJECTID used as an identifier instead."
+                )
+                ref = feature["OBJECTID"]
+
+            properties = {
+                "ref": ref,
+                "name": full_name,
+                "geometry": feature["geometry"],
+                "state": feature.get("STATE"),
+            }
+            if feature.get("SUBURB"):
+                properties["city"] = feature["SUBURB"]
+            elif feature.get("SITESUBURB"):
+                properties["city"] = feature["SITESUBURB"]
+
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+
+            if abbrev_name:
+                properties["extras"]["short_name"] = abbrev_name
+
+            if feature.get("VOLTAGE"):
+                properties["extras"]["voltage"] = str(int(float(feature["VOLTAGE"]) * 1000))
+            elif feature.get("CAPACITY_kV"):
+                properties["extras"]["voltage"] = str(int(float(feature["CAPACITY_kV"]) * 1000))
+
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/ausnet_gridview_au.py
+++ b/locations/spiders/ausnet_gridview_au.py
@@ -1,0 +1,75 @@
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class AusnetGridviewAUSpider(RosettaAPRSpider):
+    name = "ausnet_gridview_au"
+    item_attributes = {"operator": "AusNet", "operator_wikidata": "Q7392701"}
+    start_urls = ["https://gridview.ausnetservices.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/ausnet_gridview_layers_serve_2024/Ausnet_Victorian_Distribution_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transformers_geojson",
+        ),
+    ]
+    # Note: data centre IP addresses appear to be blocked. requires_proxy="AU"
+    # would usually be a workaround however Zyte API limits HTTP response
+    # bodies to 10MB which is not large enough to download the data files.
+    #
+    # Reference:
+    # https://docs.zyte.com/zyte-api/faq.html#is-there-a-response-size-limit
+
+    def parse_transformers_geojson(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./ausnet_data/distribution_substation_data.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_transformers_csv",
+            column_headings=["id", "name", "capacity_kva"],
+        )
+        return (items, next_data_file)
+
+    def parse_transformers_csv(
+        self, features: list[dict], existing_features: list[dict]
+    ) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        features_dict = {x["id"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.TRANSFORMER, properties)
+            if properties["ref"] in features_dict.keys():
+                properties["name"] = features_dict[properties["ref"]]["name"].strip()
+                if capacity_kva := features_dict[properties["ref"]]["capacity_kva"].strip():
+                    properties["extras"]["rating"] = f"{capacity_kva} kVA"
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="https://gridview.ausnetservices.com.au/ausnet_data/distribution_substation_mapping.zip",
+            file_type="csv",
+            encrypted=False,
+            callback_function_name="parse_transformers_zip",
+            archive_format="zip",
+            archive_filename="distribution_substation_mapping.csv",
+        )
+        return (items, next_data_file)
+
+    def parse_transformers_zip(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["SUBSTATION"]: x for x in features}
+        for properties in existing_features:
+            if properties["ref"] in features_dict.keys():
+                new_name = features_dict[properties["ref"]]["NAME"].strip()
+                if properties.get("name") and properties["name"] != new_name:
+                    properties["extras"]["alt_name"] = new_name
+                else:
+                    properties["name"] = new_name
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/endeavour_energy_au.py
+++ b/locations/spiders/endeavour_energy_au.py
@@ -1,0 +1,156 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class EndeavourEnergyAUSpider(RosettaAPRSpider):
+    name = "endeavour_energy_au"
+    item_attributes = {"operator": "Endeavour Energy", "operator_wikidata": "Q5375986"}
+    start_urls = ["https://dapr.endeavourenergy.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="./layers/Zone-Substations_Endeavour.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Transmission_Sub_Station_Endeavour.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transmission_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Supply_Point_Station_Endeavour.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_bulk_supply_points",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            if feature["Name"].upper().endswith("(PROPOSED)"):
+                continue
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./endeavour_data/Zone_Substation_Data_Technical_Endeavour.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "transformers",
+                "installed_capacity_mva",
+                "secure_capacity_mva",
+                "peak_load_exceeded_hours",
+                "embedded_generation_mw",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            if properties["ref"] in features_dict.keys():
+                if voltages_str := features_dict[properties["ref"]]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if installed_capacity_mva := features_dict[properties["ref"]]["installed_capacity_mva"]:
+                    properties["extras"]["rating"] = str(installed_capacity_mva) + " MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_transmission_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["Name"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./endeavour_data/Transmission_Sub_Station_Technical_Endeavour.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_transmission_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "transformers",
+                "installed_capacity_mva",
+                "secure_capacity_mva",
+                "peak_load_exceeded_hours",
+                "embedded_generation_mw",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_transmission_substation_attribs(
+        self, features: list[dict], existing_features: list[dict]
+    ) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            if properties["ref"] in features_dict.keys():
+                if voltages_str := features_dict[properties["ref"]]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if installed_capacity_mva := features_dict[properties["ref"]]["installed_capacity_mva"]:
+                    properties["extras"]["rating"] = str(installed_capacity_mva) + " MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_bulk_supply_points(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/essential_energy_au.py
+++ b/locations/spiders/essential_energy_au.py
@@ -1,0 +1,136 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class EssentialEnergyAUSpider(RosettaAPRSpider):
+    name = "essential_energy_au"
+    item_attributes = {"operator": "Essential Energy", "operator_wikidata": "Q17003842"}
+    start_urls = ["https://dapr.essentialenergy.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="./layers/Zone_Substations_Essential.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Supply_Point_Station_Essential.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_bulk_supply_points",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            if feature.get("asset_code"):
+                ref = feature["asset_code"]
+            elif feature.get("sbuiltenv_transmissionsubstatio"):
+                ref = str(feature["sbuiltenv_transmissionsubstatio"])
+            else:
+                ref = feature["asset_name"]
+            properties = {
+                "ref": ref,
+                "name": feature["asset_name"],
+                "city": feature["suburb"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./essential_data/Zone_Substation_Data_Technical_Essential.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "transformer_1_capacity_mva",
+                "transformer_2_capacity_mva",
+                "transformer_3_capacity_mva",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            if properties["name"] in features_dict.keys():
+                if voltages_str := features_dict[properties["name"]]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                transformer_capacities = []
+                # Transformer capacities are provided as two or three values
+                # e.g. "10/15" or "10/15/20". It is not known what each of
+                # these numbers are, but it is assumed to be similar to the
+                # following types of capacity measurement methods:
+                # 1. ONAN: Oil Natural Air Natural
+                # 2. ONAF: Oil Natural Air Forced
+                # 3. CMR: Continuous Maximum Rating
+                # 4. CER: Continuous Emergency Rating
+                # This code keeps things simple and just picks the biggest
+                # number supplied for each transformer.
+                if transformer_1_capacity_mva_str := features_dict[properties["name"]]["transformer_1_capacity_mva"]:
+                    transformer_1_capacities = sorted(
+                        list(
+                            set(map(lambda x: float(x), re.findall(r"(\d+(?:\.\d+)?)", transformer_1_capacity_mva_str)))
+                        ),
+                        reverse=True,
+                    )
+                    if len(transformer_1_capacities) >= 1:
+                        transformer_capacities.append(transformer_1_capacities[0])
+                if transformer_2_capacity_mva_str := features_dict[properties["name"]]["transformer_2_capacity_mva"]:
+                    transformer_2_capacities = sorted(
+                        list(
+                            set(map(lambda x: float(x), re.findall(r"(\d+(?:\.\d+)?)", transformer_2_capacity_mva_str)))
+                        ),
+                        reverse=True,
+                    )
+                    if len(transformer_2_capacities) >= 1:
+                        transformer_capacities.append(transformer_2_capacities[0])
+                if transformer_3_capacity_mva_str := features_dict[properties["name"]]["transformer_3_capacity_mva"]:
+                    transformer_3_capacities = sorted(
+                        list(
+                            set(map(lambda x: float(x), re.findall(r"(\d+(?:\.\d+)?)", transformer_3_capacity_mva_str)))
+                        ),
+                        reverse=True,
+                    )
+                    if len(transformer_3_capacities) >= 1:
+                        transformer_capacities.append(transformer_3_capacities[0])
+                if len(transformer_capacities) > 1:
+                    total_capacity_mva = str(sum(transformer_capacities)) + " MVA"
+                    properties["extras"]["rating"] = total_capacity_mva
+            items.append(Feature(**properties))
+        return items
+
+    def parse_bulk_supply_points(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["asset_name"],
+                "name": feature["asset_name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/evoenergy_au.py
+++ b/locations/spiders/evoenergy_au.py
@@ -1,0 +1,92 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class EvoenergyAUSpider(RosettaAPRSpider):
+    name = "evoenergy_au"
+    item_attributes = {"operator": "Evoenergy", "operator_wikidata": "Q111081969"}
+    start_urls = ["https://apr.evoenergy.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/evoenergy_layers_serve_2024/Evoenergy_Zone_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/evoenergy_layers_serve_2024/Evoenergy_Switching_Stations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_switching_stations",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./evoenergy_data/Evoenergy_Zone_Substations_Technical_Specifications.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "comissioned_date",
+                "voltages",
+                "total_capacity",
+                "firm_capacity",
+                "transformers_count",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            new_ref = properties["ref"].removesuffix(" Zone Substation")
+            if new_ref in features_dict.keys():
+                if voltages_str := features_dict[new_ref]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if total_capacity := features_dict[new_ref]["total_capacity"]:
+                    properties["extras"]["rating"] = total_capacity
+            items.append(Feature(**properties))
+        return items
+
+    def parse_switching_stations(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/powercor_au.py
+++ b/locations/spiders/powercor_au.py
@@ -1,0 +1,121 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class PowercorAUSpider(RosettaAPRSpider):
+    name = "powercor_au"
+    item_attributes = {"operator": "Powercor", "operator_wikidata": "Q7236677"}
+    start_urls = ["https://dapr.powercor.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/citipower_powercor_layers_serve/CitiPower_Powercor_Zone_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/citipower_powercor_layers_serve/CitiPower_Powercor_Distribution_Substations_July_2024.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transformers",
+        ),
+    ]
+    # Note: data centre IP addresses appear to be blocked. requires_proxy="AU"
+    # would usually be a workaround however Zyte API limits HTTP response
+    # bodies to 10MB which is not large enough to download the data files.
+    #
+    # Reference:
+    # https://docs.zyte.com/zyte-api/faq.html#is-there-a-response-size-limit
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": str(feature["id"]),
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./powercor_data/powercor_tech_spec_zs_summer.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "total_capacity_mva",
+                "unknown1",
+                "unknown2",
+                "unknown3",
+                "unknown4",
+                "unknown5",
+                "unknown6",
+                "unknown7",
+                "unknown8",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["name"].removesuffix(" Zone Substation") + " ZS": x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            if properties["name"] in features_dict.keys():
+                if voltages_str := features_dict[properties["name"]]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if total_capacity_mva := features_dict[properties["name"]]["total_capacity_mva"]:
+                    properties["extras"]["rating"] = str(total_capacity_mva) + " MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_transformers(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": str(feature["GIS_ID"]),
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="https://dapr.citipower.com.au/serve.php?file=./powercor_data/CitiPower_Powercor_Distribution_Substations_July_2024.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_transformer_attribs",
+        )
+        return (items, next_data_file)
+
+    def parse_transformer_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {x["GIS_ID"]: x for x in features}
+        for properties in existing_features:
+            apply_category(Categories.TRANSFORMER, properties)
+            if properties["ref"] in features_dict.keys():
+                properties["name"] = features_dict[properties["ref"]]["SUB_NAME"]
+                if voltage := features_dict[properties["ref"]]["VOLTAGE"]:
+                    if voltage != "unknown":
+                        properties["extras"]["voltage:primary"] = voltage.replace("kV", "000").replace(" ", "")
+                if rating := features_dict[properties["ref"]]["INSTALLED_"]:
+                    if rating != "unknown":
+                        properties["extras"]["rating"] = rating.replace(".0", "").replace(" ", "") + " kVA"
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/transgrid_au.py
+++ b/locations/spiders/transgrid_au.py
@@ -1,0 +1,116 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class TransgridAUSpider(RosettaAPRSpider):
+    name = "transgrid_au"
+    item_attributes = {"operator": "TransGrid", "operator_wikidata": "Q7833620"}
+    start_urls = ["https://tapr.transgrid.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="./layers/Transmission_Sub_Station_Transgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transmission_substations",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Bulk_Supply_Points_Transgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_bulk_supply_points",
+        ),
+        RosettaAPRDataFile(
+            url="./layers/Generation_Transgrid.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_generator_substations",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_transmission_substations(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"].replace("\\/", "/"),
+                "name": feature["Name"].replace("\\/", "/"),
+                "geometry": feature["geometry"],
+                "city": feature["SITESUBURB"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            voltages = list(
+                map(
+                    lambda x: str(x),
+                    sorted(
+                        list(
+                            set(
+                                map(
+                                    lambda x: int(float(x) * 1000),
+                                    re.findall(r"(\d{2,}(?:\.\d+)?)", properties["name"]),
+                                )
+                            )
+                        ),
+                        reverse=True,
+                    ),
+                )
+            )
+            if len(voltages) >= 1:
+                properties["extras"]["voltage"] = ";".join(voltages)
+            elif feature.get("CAPACITY_kV"):
+                properties["extras"]["voltage"] = str(int(float(feature["CAPACITY_kV"]) * 1000))
+            items.append(Feature(**properties))
+        return items
+
+    def parse_bulk_supply_points(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+                "city": feature["SITESUBURB"],
+            }
+            apply_category(Categories.SUBSTATION_TRANSMISSION, properties)
+            voltages = list(
+                map(
+                    lambda x: str(x),
+                    sorted(
+                        list(
+                            set(
+                                map(
+                                    lambda x: int(float(x) * 1000),
+                                    re.findall(r"(\d{2,}(?:\.\d+)?)", properties["name"]),
+                                )
+                            )
+                        ),
+                        reverse=True,
+                    ),
+                )
+            )
+            properties["extras"]["voltage"] = ";".join(voltages)
+            items.append(Feature(**properties))
+        return items
+
+    def parse_generator_substations(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.SUBSTATION_GENERATION, properties)
+            capacity_mva = sum(
+                list(
+                    map(
+                        lambda x: int(float(x)),
+                        re.findall(r"(\d+(?:\.\d+)?)", re.sub(r"\([^\)]*\)", "", str(feature["Nameplate Rating"]))),
+                    )
+                )
+            )
+            properties["extras"]["rating"] = f"{capacity_mva} MVA"
+            items.append(Feature(**properties))
+        return items

--- a/locations/spiders/united_energy_au.py
+++ b/locations/spiders/united_energy_au.py
@@ -1,0 +1,98 @@
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.rosetta_apr import RosettaAPRDataFile, RosettaAPRSpider
+
+
+class UnitedEnergyAUSpider(RosettaAPRSpider):
+    name = "united_energy_au"
+    item_attributes = {"operator": "United Energy", "operator_wikidata": "Q48790747"}
+    start_urls = ["https://dapr.unitedenergy.com.au/"]
+    data_files = [
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/united_energy_layers_serve2/United_Energy_Zone_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_zone_substations",
+        ),
+        RosettaAPRDataFile(
+            url="https://content.rosettaanalytics.com.au/united_energy_layers_serve2/United_Energy_Distribution_Substations.geojson",
+            file_type="geojson",
+            encrypted=True,
+            callback_function_name="parse_transformers",
+        ),
+    ]
+    requires_proxy = "AU"
+
+    def parse_zone_substations(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile):
+        items = []
+        for feature in features:
+            properties = {
+                "ref": feature["Name"].upper().split(" ZONE SUBSTATION", 1)[0].split(" TERMINAL STATION", 1)[0],
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            items.append(properties)
+        next_data_file = RosettaAPRDataFile(
+            url="./ue_data/ue_tech_spec_zs.csv",
+            file_type="csv",
+            encrypted=True,
+            callback_function_name="parse_zone_substation_attribs",
+            column_headings=[
+                "name",
+                "voltages",
+                "capacity_mva",
+                "unknown1",
+                "unknown2",
+                "unknown3",
+                "unknown4",
+                "unknown5",
+            ],
+        )
+        return (items, next_data_file)
+
+    def parse_zone_substation_attribs(self, features: list[dict], existing_features: list[dict]) -> list[Feature]:
+        items = []
+        features_dict = {
+            x["name"].upper().split(" ZONE SUBSTATION", 1)[0].split(" TERMINAL STATION", 1)[0]: x for x in features
+        }
+        for properties in existing_features:
+            apply_category(Categories.SUBSTATION_ZONE, properties)
+            if properties["ref"] in features_dict.keys():
+                properties["name"] = features_dict[properties["ref"]]["name"]
+                if voltages_str := features_dict[properties["ref"]]["voltages"]:
+                    voltages = list(
+                        map(
+                            lambda x: str(x),
+                            sorted(
+                                list(
+                                    set(
+                                        map(
+                                            lambda x: int(float(x) * 1000), re.findall(r"(\d+(?:\.\d+)?)", voltages_str)
+                                        )
+                                    )
+                                ),
+                                reverse=True,
+                            ),
+                        )
+                    )
+                    properties["extras"]["voltage"] = ";".join(voltages)
+                if capacity_mva := features_dict[properties["ref"]]["capacity_mva"]:
+                    properties["extras"]["rating"] = f"{capacity_mva} MVA"
+            items.append(Feature(**properties))
+        return items
+
+    def parse_transformers(self, features: list[dict]) -> list[Feature]:
+        items = []
+        for feature in features:
+            properties = {
+                "ref": str(feature["ID"]),
+                "name": feature["Name"],
+                "geometry": feature["geometry"],
+            }
+            apply_category(Categories.TRANSFORMER, properties)
+            if capacity_kva := feature.get("MDIC_KVA"):
+                properties["extras"]["rating"] = f"{capacity_kva} kVA"
+            items.append(Feature(**properties))
+        return items

--- a/locations/storefinders/rosetta_apr.py
+++ b/locations/storefinders/rosetta_apr.py
@@ -176,7 +176,8 @@ class RosettaAPRSpider(Spider):
             column_headings=response.meta["data_file"].column_headings,
         )
 
-        callback_function = getattr(self, response.meta["data_file"].callback_function_name)
+        callback_function_name = response.meta["data_file"].callback_function_name
+        callback_function = getattr(self, callback_function_name)
         type_hints = get_type_hints(callback_function)
         if (
             "features" in type_hints.keys()

--- a/locations/storefinders/rosetta_apr.py
+++ b/locations/storefinders/rosetta_apr.py
@@ -1,0 +1,224 @@
+import csv
+from base64 import b64decode
+from itertools import pairwise
+from json import loads
+import re
+from typing import Iterable, NamedTuple, get_type_hints
+from urllib.parse import urljoin
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.archive_utils import unzip_file_from_archive
+from locations.crypto_utils import decrypt_aes256cbc_pkcs7
+from locations.items import Feature
+
+
+class RosettaAPRDataFile(NamedTuple):
+    """
+    A named tuple for a data file retrieved through the Rosetta APR spider.
+    The following attributes exist:
+      - `url`: a string containing the relative path/file name which is
+        provided in URLs of `{start_urls[0]}/serve.php?file={file_name}`.
+        Values of `file_name` can be observed in network requests in a browser
+        when layers are enabled and disabled. Alternatively, data files can
+        sometimes be hosted on external domains. If `url` is a full URL
+        starting with `https://` or `http://`, this full URL is used for
+        downloading the data file.
+      - `file_type`: a string with the value of `"geojson"` or `"csv"`. Other
+        file types may be supported in the future. Data files are normalised
+        to a type of `list[dict]`. See also `archive_format` for data files
+        that are compressed archives. If the data file is a compressed ZIP
+        archive containing a single GeoJSON file, `archive_format="zip"` and
+        `file_type="geojson"` both need to be specified.
+      - `encrypted`: boolean value for whether the data file is encrypted. If
+        `True`, the data file is automatically decrypted prior to the callback
+        function being called. Decryption parameters are obtained
+        from the `key` and `iv` attributes of the spider if provided, or are
+        otherwise automatically detected from parsing `self.start_urls[0]`.
+      - `callback_function_name`: a string with a value being the name of a
+        function implemented by the spider which is called for each data file.
+        Must have one of the following definitions:
+          1. `def callback_function(self, features: list[dict]) -> list[Feature]
+          2. `def callback_function(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile)
+          3. `def callback_function(self, features: list[dict], existing_features: list[dict]) -> list[Feature]
+          4. `def callback_function(self, features: list[dict], existing_features: list[dict]) -> (list[dict], RosettaAPRDataFile)
+        Definition (1) is the simplest and is used whenever all the fields of
+        data required to describe a feature are included in a single data file
+        which has been downloaded. There is no need to download additional
+        data files to supplement/merge fields of data across two or more data
+        files.
+        Definition (2) is used when downloading the first data file, knowing
+        that additional data files need to be subsequently downloaded and
+        parsed to supplement/merge fields of data across two or more data
+        files.
+        Definition (3) is used for parsing an additional data file and
+        supplementing/merging data fields across two or more data files. In
+        this definition, there is no need to download a third (or any
+        additional) data file.
+        Definition (4) is used for parsing an additional data file and
+        supplementing/merging data fields across two or more data files. In
+        this definition, there is a need to download a third, or fourth, or
+        any additional number of data files. The callback function for the
+        last data file to be downloaded in succession should be definition
+        (3).
+      - `archive_format`: a string with the value of `"zip"`, or the default
+        `None` value if the data file is not a compressed archive.
+      - `archive_filename`: a string which is the name of a filename within
+        a compressed archive. This `archive_filename` attribute is ignored if
+        `archive_format` is the default value of `None`.
+      - `column_headings`: a list of column headings to use if `file_type` is
+        `"csv"`. This attribute is ignored for other values of `file_type`. An
+        example is `column_headings = ["ID", "NAME", "LAT", "LON"]`. If this
+        `column_headings` attribute is left undefined (default of `None`) then
+        the first row of the CSV file will be used as headings.
+    """
+    url: str
+    file_type: str
+    encrypted: bool
+    callback_function_name: str
+    archive_format: str | None = None
+    archive_filename: str | None = None
+    column_headings: list[str] | None = None
+
+
+class RosettaAPRSpider(Spider):
+    """
+    Rosetta Analytics APR Portal is used by Australian electricity network
+    operators for providing public data on the electricity network and assets
+    within. A list of users is provided at:
+      https://rosettaanalytics.com.au/apr-portal/
+
+    To use this spider, specify `start_urls[0]` as the APR Portal website for
+    an electricity network operator. This `start_urls[0]` will probably be one
+    of the URLs listed at https://rosettaanalytics.com.au/apr-portal/
+
+    Also specify one or more data files in the `data_files` list. These data
+    files will be downloaded from the selected APR Portal and then can be
+    individually parsed. Each item in the `data_files` list is expected to be
+    a named tuple of type `RosettaAPRDataFile`.
+
+    By default, decryption parameters for encrypted data files are
+    automatically extracted from parsing of `self.start_urls[0]`. Should this
+    automatic extraction not work, decryption parameters can be specified
+    manually with `key` and `iv` attributes. These attributes are expected to
+    be strings in hexadecimal notation and are passed into a AES256-CBC
+    function. `key` is expected to have a length of 64, and `iv` a length of
+    32.
+
+    There is no guarantee provided for the order in which data files are
+    downloaded and the callback function called.
+    """
+    data_files: list[RosettaAPRDataFile] = []
+    key: str | None = None
+    iv: str | None = None
+
+    def start_requests(self) -> Iterable[Request]:
+        if (not self.key or not self.iv) and True in [x[2] for x in self.data_files]:
+            yield Request(url=self.start_urls[0], callback=self.parse_decryption_params)
+        else:
+            yield from self.request_data_files()
+
+    def parse_decryption_params(self, response: Response) -> Iterable[Request]:
+        js_blob_candidates = response.xpath('//script[contains(text(), "var _0x")]/text()').getall()
+        for js_blob_candidate in js_blob_candidates:
+            if m := re.search(r"^\s*var _0x[0-9a-f]{4}\s*=\s*\[", js_blob_candidate, flags=re.MULTILINE):
+                obfuscated_js_array = js_blob_candidate[m.start(0):].split("[", 1)[1].split("];", 1)[0]
+                obfuscated_js_array = list(map(lambda x: bytes.fromhex(x.strip('"').replace("\\x", " ")).decode("utf-8", errors="backslashreplace"), obfuscated_js_array.split(",")))
+                for pair in pairwise(obfuscated_js_array):
+                    if re.fullmatch(r"[0-9a-f]{64}", pair[0]) and re.fullmatch("[0-9a-f]{32}", pair[1]):
+                        self.key = pair[0]
+                        self.iv = pair[1]
+                        break
+                if self.key and self.iv:
+                    break
+        if not self.key or not self.iv:
+            raise Exception("Could not automatically locate required AES256-CBC key and IV values for decrypting data files.")
+            return
+        yield from self.request_data_files()
+
+    def request_data_files(self) -> Iterable[Request]:
+        for data_file in self.data_files:
+            yield from self.request_data_file(data_file=data_file)
+
+    def request_data_file(self, data_file: RosettaAPRDataFile, meta: dict = {}) -> Iterable[Request]:
+        new_meta = meta.copy()
+        new_meta.update({"data_file": data_file})
+        if data_file.url.startswith("https://") or data_file.url.startswith("http://"):
+            # Data file hosted externally.
+            yield Request(url=data_file.url, meta=new_meta, callback=self.parse_data_file)
+        else:
+            # Data file served directly from the same domain.
+            yield Request(url=urljoin(self.start_urls[0], f"/serve.php?file={data_file[0]}"), meta=new_meta, callback=self.parse_data_file)
+
+    def parse_data_file(self, response: Response) -> Iterable[Feature | Request]:
+        features = self.decode_data_file(raw_data_file=response.body, file_type=response.meta["data_file"].file_type, encrypted=response.meta["data_file"].encrypted, archive_format=response.meta["data_file"].archive_format, archive_filename=response.meta["data_file"].archive_filename, column_headings=response.meta["data_file"].column_headings)
+
+        callback_function = getattr(self, response.meta["data_file"].callback_function_name)
+        type_hints = get_type_hints(callback_function)
+        if "features" in type_hints.keys() and str(type_hints["features"]) == "list[dict]" and "return" in type_hints.keys():
+            if "existing_features" in type_hints.keys() and str(type_hints["existing_features"]) == "list[dict]":
+                if str(type_hints["return"]) == "list[locations.items.Feature]":
+                    # Handles callback functions of definition:
+                    # def callback_function(self, features: list[dict], existing_features: list[dict]) -> list[Feature]
+                    items = callback_function(features, response.meta["existing_features"])
+                    for item in items:
+                        yield item
+                elif str(type_hints["return"]) == "(list[dict], <class 'locations.storefinders.rosetta_apr.RosettaAPRDataFile'>)":
+                    # Handles callback functions of definition:
+                    # def callback_function(self, features: list[dict], existing_features: list[dict]) -> (list[dict], RosettaAPRDataFile)
+                    items, data_file = callback_function(features, response.meta["existing_features"])
+                    yield from self.request_data_file(data_file=data_file, meta={"existing_features": items})
+                else:
+                    raise Exception("Invalid callback function signature for callback function \"{}\".".format(callback_function_name))
+            else:
+                if str(type_hints["return"]) == "list[locations.items.Feature]":
+                    # Handles callback functions of definition:
+                    # def callback_function(self, features: list[dict]) -> list[Feature]
+                    items = callback_function(features)
+                    for item in items:
+                        yield item
+                elif str(type_hints["return"]) == "(list[dict], <class 'locations.storefinders.rosetta_apr.RosettaAPRDataFile'>)":
+                    # Handles callback functions of definition:
+                    # def callback_function(self, features: list[dict]) -> (list[dict], RosettaAPRDataFile)
+                    items, data_file = callback_function(features)
+                    yield from self.request_data_file(data_file=data_file, meta={"existing_features": items})
+                else:
+                    raise Exception("Invalid callback function signature for callback function \"{}\".".format(callback_function_name))
+        else:
+            raise Exception("Invalid callback function signature for callback function \"{}\".".format(callback_function_name))
+
+    def decode_data_file(self, raw_data_file: bytes, file_type: str, encrypted: bool, archive_format: str | None = None, archive_filename: str | None = None, column_headings: list[str] | None = None) -> list[dict]:
+        if encrypted:
+            ciphertext = b64decode(raw_data_file.decode("utf-8"))
+            unpadded_plaintext = decrypt_aes256cbc_pkcs7(ciphertext=ciphertext, key=self.key, iv=self.iv)
+            if archive_format == "zip":
+                data_file_bytes = unzip_file_from_archive(compressed_data=unpadded_plaintext, file_path=archive_filename)
+            else:
+                data_file_bytes = unpadded_plaintext
+        elif archive_format == "zip":
+            data_file_bytes = unzip_file_from_archive(compressed_data=raw_data_file, file_path=archive_filename)
+        elif archive_format:
+            raise Exception("Unknown archive format for data file: {}.".format(archive_format))
+            return
+        else:
+            data_file_bytes = raw_data_file
+
+        features = []
+        match file_type:
+            case "csv":
+                data_file_str = data_file_bytes.decode("utf-8")
+                sniffed_dialect = csv.Sniffer().sniff(data_file_str[:1024])
+                reader = csv.DictReader(data_file_str.splitlines(), fieldnames=column_headings, dialect=sniffed_dialect)
+                for row in reader:
+                    features.append(row)
+            case "geojson":
+                data_file_str = data_file_bytes.decode("utf-8")
+                features = loads(data_file_str)["features"]
+                for feature in features:
+                    feature.update(feature["properties"])
+                    del feature["properties"]
+            case _:
+                raise Exception("Unknown file type for data file: {}.".format(file_type))
+
+        return features

--- a/tests/test_pipeline_geojson_multipoint_simplification.py
+++ b/tests/test_pipeline_geojson_multipoint_simplification.py
@@ -1,0 +1,43 @@
+from scrapy.utils.test import get_crawler
+
+from scrapy import Spider
+
+from locations.items import Feature
+from locations.pipelines.geojson_multipoint_simplification import GeoJSONMultiPointSimplificationPipeline
+
+
+def get_objects():
+    spider = Spider(name="test_spider")
+    spider.crawler = get_crawler()
+    return Feature(), GeoJSONMultiPointSimplificationPipeline(), spider
+
+
+def test_single_coordinate_multipoint():
+    item, pipeline, spider = get_objects()
+    item["geometry"] = {"type": "MultiPoint", "coordinates": [[12.34, 56.78]]}
+    pipeline.process_item(item, spider)
+    assert item["geometry"]["type"] == "Point"
+    assert item["geometry"]["coordinates"][0] == 12.34
+    assert item["geometry"]["coordinates"][1] == 56.78
+
+def test_multi_coordinate_multipoint():
+    item, pipeline, spider = get_objects()
+    item["geometry"] = {"type": "MultiPoint", "coordinates": [[12.34, 56.78], [-12.34, -56.78]]}
+    pipeline.process_item(item, spider)
+    assert item["geometry"]["type"] == "MultiPoint"
+    assert len(item["geometry"]["coordinates"]) == 2
+    assert item["geometry"]["coordinates"][0][0] == 12.34
+    assert item["geometry"]["coordinates"][0][1] == 56.78
+    assert item["geometry"]["coordinates"][1][0] == -12.34
+    assert item["geometry"]["coordinates"][1][1] == -56.78
+
+def test_undefined_geometry():
+    item, pipeline, spider = get_objects()
+    pipeline.process_item(item, spider)
+    assert item.get("geometry") == None
+
+def test_blank_geometry():
+    item, pipeline, spider = get_objects()
+    item["geometry"] = None
+    pipeline.process_item(item, spider)
+    assert item.get("geometry") == None

--- a/tests/test_pipeline_geojson_multipoint_simplification.py
+++ b/tests/test_pipeline_geojson_multipoint_simplification.py
@@ -35,11 +35,11 @@ def test_multi_coordinate_multipoint():
 def test_undefined_geometry():
     item, pipeline, spider = get_objects()
     pipeline.process_item(item, spider)
-    assert item.get("geometry") == None
+    assert item.get("geometry") is None
 
 
 def test_blank_geometry():
     item, pipeline, spider = get_objects()
     item["geometry"] = None
     pipeline.process_item(item, spider)
-    assert item.get("geometry") == None
+    assert item.get("geometry") is None

--- a/tests/test_pipeline_geojson_multipoint_simplification.py
+++ b/tests/test_pipeline_geojson_multipoint_simplification.py
@@ -1,6 +1,5 @@
-from scrapy.utils.test import get_crawler
-
 from scrapy import Spider
+from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
 from locations.pipelines.geojson_multipoint_simplification import GeoJSONMultiPointSimplificationPipeline
@@ -20,6 +19,7 @@ def test_single_coordinate_multipoint():
     assert item["geometry"]["coordinates"][0] == 12.34
     assert item["geometry"]["coordinates"][1] == 56.78
 
+
 def test_multi_coordinate_multipoint():
     item, pipeline, spider = get_objects()
     item["geometry"] = {"type": "MultiPoint", "coordinates": [[12.34, 56.78], [-12.34, -56.78]]}
@@ -31,10 +31,12 @@ def test_multi_coordinate_multipoint():
     assert item["geometry"]["coordinates"][1][0] == -12.34
     assert item["geometry"]["coordinates"][1][1] == -56.78
 
+
 def test_undefined_geometry():
     item, pipeline, spider = get_objects()
     pipeline.process_item(item, spider)
     assert item.get("geometry") == None
+
 
 def test_blank_geometry():
     item, pipeline, spider = get_objects()


### PR DESCRIPTION
Rosetta APR is used by most Australian energy grid operators for displaying maps of electricity grid assets such as substations and lines. Rosetta APR and this type of data is generally made publicly available.

Depending on the energy grid operator, different types of files may be served by the Rosetta APR platform such as geojson files (for features with coordinates) and csv or zipped csv spreadsheet files for detailed data on features such as capacities of substations or transformers. This storefinder provides a means to make second and subsequent requests for additional data files to allow extracted features to be supplemented with more detailed data such as capacity ratings of transformers.