### PR TITLE
[shurgard] add locations in Germany

### DIFF
--- a/locations/spiders/shurgard.py
+++ b/locations/spiders/shurgard.py
@@ -7,5 +7,5 @@ class ShurgardSpider(SitemapSpider, StructuredDataSpider):
     name = "shurgard"
     item_attributes = {"brand": "Shurgard", "brand_wikidata": "Q3482670"}
     sitemap_urls = ["https://www.shurgard.com/sitemap.xml"]
-    sitemap_rules = [(r"/en-(?:\w\w/self-storage-[-\w]+|be/self-storage)/[-\w]+/[-\w]+$", "parse_sd")]
+    sitemap_rules = [(r"/en-(?:\w\w/self-storage-[-\w]+|[bd]e/self-storage)/[-\w]+/[-\w]+$", "parse_sd")]
     wanted_types = ["SelfStorage"]


### PR DESCRIPTION
German locations also use the `/self-storage/` URL format.

```
2025-01-09 22:46:30 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Shurgard': 220,
 'atp/brand_wikidata/Q3482670': 220,
 'atp/category/shop/storage_rental': 220,
 'atp/field/branch/missing': 220,
 'atp/field/city/missing': 143,
 'atp/field/country/from_reverse_geocoding': 220,
 'atp/field/email/missing': 220,
 'atp/field/image/missing': 220,
 'atp/field/opening_hours/missing': 220,
 'atp/field/operator/missing': 220,
 'atp/field/operator_wikidata/missing': 220,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 69,
 'atp/field/street_address/missing': 69,
 'atp/item_scraped_host_count/www.shurgard.com': 220,
 'atp/nsi/perfect_match': 220,
```