### PR TITLE
fuel:electric -> fuel:electricity

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -465,7 +465,7 @@ class Fuel(Enum):
     HEATING_OIL = "fuel:heating_oil"
     KEROSENE = "fuel:kerosene"
 
-    ELECTRIC = "fuel:electric"  # Electric vehicle charger
+    ELECTRIC = "fuel:electricity"  # Electric vehicle charger
 
 
 class Extras(Enum):

--- a/locations/spiders/rosneft_ru.py
+++ b/locations/spiders/rosneft_ru.py
@@ -37,7 +37,7 @@ class RosneftRUSpider(scrapy.Spider):
         "wash": Extras.CAR_WASH,
         "tire": "service:vehicle:tyres",
         "hotel": None,
-        "electro": "fuel:electric",
+        "electro": "fuel:electricity",
         "cash": PaymentMethods.CASH,
         "finmarket": None,
     }


### PR DESCRIPTION
it is used more widely in OSM https://overpass-turbo.eu/s/1WXD https://overpass-turbo.eu/s/1WXF

it is used in docs, see https://github.com/alltheplaces/alltheplaces/blob/0403f55d4f5773d83a2cde2925287b0f09d37084/docs/EXTRA_ATTRIBUTES.md?plain=1#L38

`fuel:electricity` is also more common in ATP itself

```
rg "fuel:electric\"" | wc -l
1165
rg "fuel:electricity" | wc -l
4484
```

though neither is listed at https://wiki.openstreetmap.org/wiki/Key:fuel:* (I started https://wiki.openstreetmap.org/wiki/Talk:Key:fuel:*#fuel%3Aelectricity )