### PR TITLE
urgent_care=yes vs healthcare:speciality=urgent

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -240,7 +240,7 @@ class Categories(Enum):
     CHILD_CARE = {"amenity": "childcare"}
     CINEMA = {"amenity": "cinema"}
     CLINIC = {"amenity": "clinic", "healthcare": "clinic"}
-    CLINIC_URGENT = {"amenity": "clinic", "healthcare": "clinic", "urgent_care": "yes"}
+    CLINIC_URGENT = {"amenity": "clinic", "healthcare": "clinic", "healthcare:speciality": "urgent"}
     COFFEE_SHOP = {"amenity": "cafe", "cuisine": "coffee_shop"}
     COMMUNITY_CENTRE = {"amenity": "community_centre"}
     COMPRESSED_AIR = {"amenity": "compressed_air"}


### PR DESCRIPTION
I am less and less sure here, the more I look into it after finding it with my weird tag checker run on ATP. I guess I will still create it to avoid wasting time.

https://wiki.openstreetmap.org/wiki/Key:healthcare:speciality documents `healthcare:speciality=urgent`

`urgent_care=yes` or `urgent_care` seem to have no wiki page

But  https://wiki.openstreetmap.org/wiki/Proposal:Urgent_care exists

And https://overpass-turbo.eu/s/1WXM https://overpass-turbo.eu/s/1WXO - proposal version is actually used more. Confusingly, I see both almost entirely in USA. How such thing is tagged elsewhere?

Maybe proper fix would be making wiki page for `urgent_care=yes` / `urgent_care` and mentioning it at https://wiki.openstreetmap.org/wiki/Key:healthcare:speciality ?

Is it possible to have say urgent care eye doctor? (that would make more sense to have `urgent_care=yes` rather than listing as a separate speciality)