### PR TITLE
[bpb_xk] add spider (66 locations)

### DIFF
--- a/locations/spiders/bpb_xk.py
+++ b/locations/spiders/bpb_xk.py
@@ -1,0 +1,32 @@
+import json
+import re
+
+from scrapy import Selector
+
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class BpbXkSpider(JSONBlobSpider):
+    name = "bpb_xk"
+    item_attributes = {
+        "brand": "Banka Për Biznes",
+        "brand_wikidata": "Q16349919",
+    }
+    start_urls = ["https://www.bpbbank.com/front/dist/js/main.js"]
+
+    def extract_json(self, response):
+        return json.loads(re.search(r"var locations = jQuery.parseJSON\(\'(.*)\'\);", response.text).group(1))
+
+    def post_process_item(self, item, response, location):
+        item.pop("name")  # title is address, not name
+        item.pop("city")  # is not accurate
+        item["ref"] = f"{location.get('title','').replace(' ', '-')}-{location['type']}"
+        item["addr_full"] = location["title"]
+        item["phone"] = Selector(text=location["text"]).xpath("//p/text()").re_first(r"Tel: (.*)")
+        if location["type"] == 1:
+            apply_category(Categories.BANK, item)
+        else:
+            apply_category(Categories.ATM, item)
+        # TODO: hours
+        yield item

--- a/locations/spiders/bpb_xk.py
+++ b/locations/spiders/bpb_xk.py
@@ -7,7 +7,7 @@ from locations.categories import Categories, apply_category
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class BpbXkSpider(JSONBlobSpider):
+class BpbXKSpider(JSONBlobSpider):
     name = "bpb_xk"
     item_attributes = {
         "brand": "Banka Për Biznes",

--- a/locations/spiders/bpb_xk.py
+++ b/locations/spiders/bpb_xk.py
@@ -21,7 +21,7 @@ class BpbXKSpider(JSONBlobSpider):
     def post_process_item(self, item, response, location):
         item.pop("name")  # title is address, not name
         item.pop("city")  # is not accurate
-        item["ref"] = f"{location.get('title','').replace(' ', '-')}-{location['type']}"
+        item["ref"] = f"{location.get('title', '').replace(' ', '-')}-{location['type']}"
         item["addr_full"] = location["title"]
         item["phone"] = Selector(text=location["text"]).xpath("//p/text()").re_first(r"Tel: (.*)")
         if location["type"] == 1:


### PR DESCRIPTION
I committed this spider with `--no-verify` flag, there are two small things to fix:

- [XK](https://www.wikidata.org/wiki/Q1246) is treated as invalid country code in `CheckItemPropertiesPipeline`
-  spider name validation fires with `Spider name 'bpb_xk' should use class name 'BpbXkSpider' instead of 'BpbXKSpider'`

Stats:

```json
{
  "atp/brand/Banka Për Biznes": 66,
  "atp/brand_wikidata/Q16349919": 66,
  "atp/category/amenity/atm": 39,
  "atp/category/amenity/bank": 27,
  "atp/country/XK": 66,
  "atp/field/branch/missing": 66,
  "atp/field/city/missing": 66,
  "atp/field/country/from_spider_name": 66,
  "atp/field/country/invalid": 66,
  "atp/field/email/missing": 66,
  "atp/field/image/missing": 66,
  "atp/field/lat/missing": 1,
  "atp/field/lon/missing": 1,
  "atp/field/name/missing": 66,
  "atp/field/opening_hours/missing": 66,
  "atp/field/operator/missing": 66,
  "atp/field/operator_wikidata/missing": 66,
  "atp/field/phone/missing": 3,
  "atp/field/postcode/missing": 66,
  "atp/field/state/missing": 66,
  "atp/field/street_address/missing": 66,
  "atp/field/twitter/missing": 66,
  "atp/field/website/missing": 66,
  "atp/item_scraped_host_count/www.bpbbank.com": 72,
  "atp/nsi/brand_missing": 66,
  "downloader/request_bytes": 623,
  "downloader/request_count": 2,
  "downloader/request_method_count/GET": 2,
  "downloader/response_bytes": 13393,
  "downloader/response_count": 2,
  "downloader/response_status_count/200": 2,
  "elapsed_time_seconds": 0.581553,
  "feedexport/success_count/FileFeedStorage": 1,
  "finish_reason": "finished",
  "finish_time": "2025-01-12T19:55:35.479253+00:00",
  "httpcache/hit": 2,
  "httpcompression/response_bytes": 47122,
  "httpcompression/response_count": 2,
  "item_dropped_count": 6,
  "item_dropped_reasons_count/DropItem": 6,
  "item_scraped_count": 66,
  "log_count/ERROR": 66,
  "log_count/INFO": 10,
  "log_count/WARNING": 1,
  "memusage/max": 230752256,
  "memusage/startup": 230752256,
  "response_received_count": 2,
  "robotstxt/request_count": 1,
  "robotstxt/response_count": 1,
  "robotstxt/response_status_count/200": 1,
  "scheduler/dequeued": 1,
  "scheduler/dequeued/memory": 1,
  "scheduler/enqueued": 1,
  "scheduler/enqueued/memory": 1,
  "start_time": "2025-01-12T19:55:34.897700+00:00"
}
```