### PR TITLE
[check properties pipeline] change country_regex to use geonames

### DIFF
--- a/locations/pipelines/check_item_properties.py
+++ b/locations/pipelines/check_item_properties.py
@@ -1,7 +1,7 @@
 import math
 import re
 
-import pycountry
+from geonamescache import GeonamesCache
 from scrapy import Spider
 
 from locations.hours import OpeningHours
@@ -25,6 +25,7 @@ def check_field(item, spider: Spider, param, allowed_types, match_regex=None):
 
 
 class CheckItemPropertiesPipeline:
+    gc = GeonamesCache()
     # From https://github.com/django/django/blob/master/django/core/validators.py
     url_regex = re.compile(
         r"^(?:http)s?://"  # http:// or https://
@@ -35,7 +36,7 @@ class CheckItemPropertiesPipeline:
         r"(?:/?|[/?]\S+)$",
         re.IGNORECASE,
     )
-    country_regex = re.compile("(^(?:" + r"|".join([country.alpha_2 for country in pycountry.countries]) + ")$)")
+    country_regex = re.compile("(^(?:" + r"|".join([country for country in gc.get_countries().keys()]) + ")$)")
     email_regex = re.compile(r"(^[-\w_.+]+@[-\w]+\.[-\w.]+$)")
     twitter_regex = re.compile(r"^@?([-\w_]+)$")
     wikidata_regex = re.compile(

--- a/tests/test_pipeline_check_item_properties.py
+++ b/tests/test_pipeline_check_item_properties.py
@@ -2,7 +2,7 @@ from scrapy import Spider
 from scrapy.utils.test import get_crawler
 
 from locations.items import Feature
-from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline, check_field
+from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline
 
 
 def get_spider() -> Spider:
@@ -17,24 +17,24 @@ def test_country_field_check():
     # Official country code
     item = Feature(country="ZA")
     spider = get_spider()
-    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    pipeline.process_item(item, spider)
     assert not spider.crawler.stats.get_value("atp/field/country/invalid")
 
     # So called "User-assigned" country code
     # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements
     item = Feature(country="XK")
     spider = get_spider()
-    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    pipeline.process_item(item, spider)
     assert not spider.crawler.stats.get_value("atp/field/country/invalid")
 
     # Country name is not a valid country code
     item = Feature(country="South Africa")
     spider = get_spider()
-    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    pipeline.process_item(item, spider)
     assert spider.crawler.stats.get_value("atp/field/country/invalid")
 
     # Invalid code
     item = Feature(country="00")
     spider = get_spider()
-    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    pipeline.process_item(item, spider)
     assert spider.crawler.stats.get_value("atp/field/country/invalid")

--- a/tests/test_pipeline_check_item_properties.py
+++ b/tests/test_pipeline_check_item_properties.py
@@ -1,0 +1,40 @@
+from scrapy import Spider
+from scrapy.utils.test import get_crawler
+
+from locations.items import Feature
+from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline, check_field
+
+
+def get_spider() -> Spider:
+    spider = Spider(name="test")
+    spider.crawler = get_crawler()
+    return spider
+
+
+def test_country_field_check():
+    pipeline = CheckItemPropertiesPipeline()
+
+    # Official country code
+    item = Feature(country="ZA")
+    spider = get_spider()
+    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    assert not spider.crawler.stats.get_value("atp/field/country/invalid")
+
+    # So called "User-assigned" country code
+    # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements
+    item = Feature(country="XK")
+    spider = get_spider()
+    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    assert not spider.crawler.stats.get_value("atp/field/country/invalid")
+
+    # Country name is not a valid country code
+    item = Feature(country="South Africa")
+    spider = get_spider()
+    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    assert spider.crawler.stats.get_value("atp/field/country/invalid")
+
+    # Invalid code
+    item = Feature(country="00")
+    spider = get_spider()
+    check_field(item, spider, "country", (str,), pipeline.country_regex)
+    assert spider.crawler.stats.get_value("atp/field/country/invalid")


### PR DESCRIPTION
Rel to https://github.com/alltheplaces/alltheplaces/pull/11946#issue-2782670540, it makes sense that check properties pipeline should do a country code check based on the same library as in country code cleanup pipeline. Otherwise Kosovo (XK) will be reported as invalid country code.