### PR TITLE
[KBP Foods US] Fix Spider

### DIFF
--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -21,9 +21,8 @@ brands_map = {
     "KT": [KFC_SHARED_ATTRIBUTES, TACO_BELL_SHARED_ATTRIBUTES],
     "KW": [KFC_SHARED_ATTRIBUTES, WalmartUSSpider.item_attributes],
     "Sonic": [SonicDriveinSpider.item_attributes],
-    "Arbys": [
-        ArbysUSSpider.item_attributes,
-    ],
+    "Arbys": [ArbysUSSpider.item_attributes],
+    "TB": [TACO_BELL_SHARED_ATTRIBUTES],
 }
 
 

--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -1,19 +1,17 @@
-from datetime import datetime
 from typing import Any
 
-from scrapy import Selector, Spider
-from scrapy.http import JsonRequest, Response
+from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.items import Feature
 from locations.spiders.arbys_us import ArbysUSSpider
 from locations.spiders.aw_restaurants import AwRestaurantsSpider
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.spiders.ljsilvers import LjsilversSpider
 from locations.spiders.sonic_drivein import SonicDriveinSpider
-from locations.spiders.walmart_us import WalmartUSSpider
 from locations.spiders.taco_bell_us import TACO_BELL_SHARED_ATTRIBUTES
+from locations.spiders.walmart_us import WalmartUSSpider
 
 brands_map = {
     "KA": [KFC_SHARED_ATTRIBUTES, AwRestaurantsSpider.item_attributes],

--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -11,7 +11,6 @@ from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.spiders.ljsilvers import LjsilversSpider
 from locations.spiders.sonic_drivein import SonicDriveinSpider
 from locations.spiders.taco_bell_us import TACO_BELL_SHARED_ATTRIBUTES
-from locations.spiders.walmart_us import WalmartUSSpider
 
 brands_map = {
     "KA": [KFC_SHARED_ATTRIBUTES, AwRestaurantsSpider.item_attributes],
@@ -19,7 +18,7 @@ brands_map = {
     "KFC": [KFC_SHARED_ATTRIBUTES],
     "KL": [KFC_SHARED_ATTRIBUTES, LjsilversSpider.item_attributes],
     "KT": [KFC_SHARED_ATTRIBUTES, TACO_BELL_SHARED_ATTRIBUTES],
-    "KW": [KFC_SHARED_ATTRIBUTES, WalmartUSSpider.item_attributes],
+    "KW": [KFC_SHARED_ATTRIBUTES],
     "Sonic": [SonicDriveinSpider.item_attributes],
     "Arbys": [ArbysUSSpider.item_attributes],
     "TB": [TACO_BELL_SHARED_ATTRIBUTES],

--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -31,7 +31,6 @@ class KbpFoodsUSSpider(Spider):
     name = "kbp_foods_us"
     start_urls = ["https://kbpbrands.com/api/locations"]
     item_attributes = {"operator": "KBP Foods"}
-    brands = {}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
@@ -41,7 +40,7 @@ class KbpFoodsUSSpider(Spider):
             if brands := brands_map.get(store["type"].strip()):
                 for b in brands:
                     i = item.deepcopy()
-                    i["brand"] = "{}".format(b["brand"])
+                    i["ref"] = "{}-{}".format(item["ref"], b["brand"])
                     i.update(b)
                     yield i
             else:

--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -35,6 +35,7 @@ class KbpFoodsUSSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
             item = DictParser.parse(store)
+            item["branch"] = item.pop("name")
             item["street_address"] = item.pop("addr_full")
             apply_category(Categories.FAST_FOOD, item)
             if brands := brands_map.get(store["type"].strip()):

--- a/locations/spiders/kbp_foods_us.py
+++ b/locations/spiders/kbp_foods_us.py
@@ -5,10 +5,14 @@ from scrapy import Selector, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.items import Feature
+from locations.spiders.arbys_us import ArbysUSSpider
 from locations.spiders.aw_restaurants import AwRestaurantsSpider
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.spiders.ljsilvers import LjsilversSpider
+from locations.spiders.sonic_drivein import SonicDriveinSpider
+from locations.spiders.walmart_us import WalmartUSSpider
 from locations.spiders.taco_bell_us import TACO_BELL_SHARED_ATTRIBUTES
 
 brands_map = {
@@ -16,59 +20,32 @@ brands_map = {
     "KB": [KFC_SHARED_ATTRIBUTES, TACO_BELL_SHARED_ATTRIBUTES],
     "KFC": [KFC_SHARED_ATTRIBUTES],
     "KL": [KFC_SHARED_ATTRIBUTES, LjsilversSpider.item_attributes],
+    "KT": [KFC_SHARED_ATTRIBUTES, TACO_BELL_SHARED_ATTRIBUTES],
+    "KW": [KFC_SHARED_ATTRIBUTES, WalmartUSSpider.item_attributes],
+    "Sonic": [SonicDriveinSpider.item_attributes],
+    "Arbys": [
+        ArbysUSSpider.item_attributes,
+    ],
 }
 
 
 class KbpFoodsUSSpider(Spider):
     name = "kbp_foods_us"
-    start_urls = ["https://kbp-foods.com/wp-admin/admin-ajax.php?action=get_all_locations"]
+    start_urls = ["https://kbpbrands.com/api/locations"]
     item_attributes = {"operator": "KBP Foods"}
     brands = {}
-    start_dates = {}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["locations"]:
-            self.brands[location["title"]] = location["brand"]
-            self.start_dates[location["title"]] = datetime.strptime(location["date_opened"], "%m/%d/%Y").strftime(
-                "%Y-%m-%d"
-            )
-
-            yield self.make_request(1)
-
-    def make_request(self, page: int) -> JsonRequest:
-        return JsonRequest(
-            url="https://kbp-foods.com/wp-json/facetwp/v1/refresh",
-            data={
-                "action": "facetwp_refresh",
-                "data": {"facets": {"proximity": [], "map": []}, "template": "locations", "paged": page},
-            },
-            cb_kwargs={"page": page},
-            callback=self.parse_locations,
-        )
-
-    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
-        if data := response.json()["settings"]["map"]["locations"]:
-            for store in data:
-                item = Feature()
-                html_data = Selector(text=store["content"])
-                item["ref"] = html_data.xpath("//h2/text()").get()
-                item["lat"] = store["position"]["lat"]
-                item["lon"] = store["position"]["lng"]
-                item["addr_full"] = html_data.xpath('//*[@class="fwpl-item"]/text()').get()
-                item["phone"] = html_data.xpath('//*[contains(@href, "tel:")]/text()').get()
-
-                apply_category(Categories.FAST_FOOD, item)
-
-                item["extras"]["start_date"] = self.start_dates[item["ref"]]
-
-                if brands := brands_map.get(self.brands[item["ref"]]):
-                    for b in brands:
-                        i = item.deepcopy()
-                        i["ref"] = "{}-{}".format(item["ref"], b["brand"])
-                        i.update(b)
-                        yield i
-                else:
-                    self.logger.error("Unmapped brand: {}".format(self.brands[item["ref"]]))
-                    yield item
-
-            yield self.make_request(kwargs["page"] + 1)
+        for store in response.json():
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("addr_full")
+            apply_category(Categories.FAST_FOOD, item)
+            if brands := brands_map.get(store["type"].strip()):
+                for b in brands:
+                    i = item.deepcopy()
+                    i["brand"] = "{}".format(b["brand"])
+                    i.update(b)
+                    yield i
+            else:
+                self.logger.error("Unmapped brand: {}".format(store["type"]))
+                yield item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{"atp/brand/Arby's": 118,
 'atp/brand/KFC': 832,
 'atp/brand/Sonic Drive-In': 85,
 'atp/brand_wikidata/Q524757': 832,
 'atp/brand_wikidata/Q630866': 118,
 'atp/brand_wikidata/Q7561808': 85,
 'atp/category/amenity/fast_food': 1089,
 'atp/country/US': 1089,
 'atp/field/branch/missing': 1089,
 'atp/field/brand/missing': 54,
 'atp/field/brand_wikidata/missing': 54,
 'atp/field/country/from_spider_name': 1089,
 'atp/field/email/missing': 1089,
 'atp/field/image/missing': 1089,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 1089,
 'atp/field/operator_wikidata/missing': 1089,
 'atp/field/phone/invalid': 19,
 'atp/field/phone/missing': 2,
 'atp/field/state/from_reverse_geocoding': 854,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 1089,
 'atp/field/website/missing': 1089,
 'atp/item_scraped_host_count/kbpbrands.com': 1238,
 'atp/nsi/cc_match': 832,
 'atp/nsi/perfect_match': 203,
 'atp/operator/KBP Foods': 1089,
 'downloader/request_bytes': 611,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 82591,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.569124,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 13, 12, 40, 19, 570613, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 572459,
 'httpcompression/response_count': 1,
 'item_dropped_count': 149,
 'item_dropped_reasons_count/DropItem': 149,
 'item_scraped_count': 1089,
 'items_per_minute': None,
 'log_count/DEBUG': 1251,
 'log_count/ERROR': 54,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 13, 12, 40, 13, 1489, tzinfo=datetime.timezone.utc)}