### PR TITLE
[total_energies] TotalErg to IP Gruppo API and Total Access to TotalEnergies

### DIFF
--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -44,7 +44,7 @@ BRANDS_MAPPING = {
     "Slovnaft": ("Slovnaft", "Q1587563"),
     "TOTAL": ("Total", "Q154037"),
     "LOTOS": ("Lotos", "Q1256909"),
-    "TOTAL ACCESS": ("Total Access", "Q154037"),
+    "TOTAL ACCESS": ("TotalEnergies", "Q154037"),
     "ex-OMV": ("MOL", "Q549181"),
 }
 

--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -25,10 +25,10 @@ class TotalEnergiesSpider(WoosmapSpider):
         "aral": {"brand": "Aral", "brand_wikidata": "Q565734"},
         "bp": {"brand": "BP", "brand_wikidata": "Q152057"},
         #   1454 "unb" - unbranded/independend
-        "totalerg": {"brand": "TotalErg", "brand_wikidata": "Q3995933"},
+        "totalerg": {"brand": "IP", "brand_wikidata": "Q3788748"},
         "ela": {"brand": "Elan", "brand_wikidata": "Q57980752"},
         "mol": {"brand": "MOL", "brand_wikidata": "Q549181"},
-        "tac": {"brand": "Total Access", "brand_wikidata": "Q154037"},
+        "tac": {"brand": "TotalEnergies", "brand_wikidata": "Q154037"},
         "avi": {"brand": "Avia", "brand_wikidata": "Q300147"},
         "as24": {"brand": "AS 24", "brand_wikidata": "Q2819394"},
         "ess": {"brand": "Esso", "brand_wikidata": "Q867662"},


### PR DESCRIPTION
Total Erg was sold to IP Gruppo API, thus will be rebranding.
And Total Access has been rebranded as part of larger rebranding to TotalEnergies. I plan on deleting from NSI as well.