### PR TITLE
[Jumbo NL] Fix spider

### DIFF
--- a/locations/spiders/jumbo_nl.py
+++ b/locations/spiders/jumbo_nl.py
@@ -118,6 +118,7 @@ class JumboNLSpider(Spider):
         for store in stores_info["stores"]:
             store.update(store["location"].pop("address"))
             item = DictParser.parse(store)
+            item["branch"] = item.pop("name").removeprefix("Jumbo ")
             item["opening_hours"] = OpeningHours()
             for day in DAYS_FULL:
                 time = store["openingHours"][day.lower()]

--- a/locations/spiders/jumbo_nl.py
+++ b/locations/spiders/jumbo_nl.py
@@ -1,52 +1,129 @@
-import html
-import re
-from typing import Any
+from typing import Any, Iterable
 
-import chompjs
-from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class JumboNLSpider(CrawlSpider):
+class JumboNLSpider(Spider):
     name = "jumbo_nl"
     item_attributes = {"brand": "Jumbo", "brand_wikidata": "Q2262314"}
-    start_urls = ["https://www.jumbo.com/winkel"]
-    allowed_domains = ["www.jumbo.com"]
-    rules = [
-        Rule(
-            LinkExtractor(
-                allow=r"/winkel/",
-                deny=["city", "foodmarkt"],
-                tags=["jum-list-item"],
-                attrs=["link"],
-            ),
-            callback="parse",
-        ),
-    ]
-
+    start_urls = ["https://www.jumbo.com/api/graphql"]
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
     }
-
     requires_proxy = True
 
+    def make_request(self, page: int, size: int = 30) -> JsonRequest:
+        return JsonRequest(
+            url="https://www.jumbo.com/api/graphql",
+            data={
+                "operationName": "GetStoreList",
+                "variables": {
+                    "input": {
+                        "latitude": "52.156108",
+                        "longitude": "5.387825",
+                        "distance": 1000,
+                        "size": size,
+                        "page": page,
+                        "locationTypes": ["PICK_UP_POINT", "SUPERMARKET", "SUPERMARKET_PICK_UP_POINT"],
+                    }
+                },
+                "query": """query GetStoreList($input: StoresByCoordinatesInput!) {
+                            storesByCoordinates(input: $input) {
+                                stores {
+                                    openingHours {
+                                        exceptions {
+                                            startsOn
+                                            endsOn
+                                        }
+                                        friday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        monday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        saturday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        sunday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        thursday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        tuesday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                        wednesday {
+                                            closesAt
+                                            opensAt
+                                        }
+                                    }
+                                    name
+                                    location {
+                                        latitude
+                                        longitude
+                                        address {
+                                            street
+                                            houseNumber
+                                            city
+                                            postalCode
+                                        }
+                                    }
+                                    facilities {
+                                        locationType
+                                    }
+                                    distance
+                                    websiteURL
+                                    storeId
+                                    commerce {
+                                        inStore {
+                                            available
+                                        }
+                                        homeDelivery {
+                                            available
+                                        }
+                                        collection {
+                                            available
+                                        }
+                                    }
+                                }
+                                totalCount
+                                totalPages
+                                page
+                            }
+                        }""",
+            },
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(0)
+
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = chompjs.parse_js_object(html.unescape(re.search(r"stores=\"(\[.*\])\"", response.text).group(1)))
-        for store in data:
-            store.update(store["location"].pop("address"))
+        stores_info = response.json()["data"]["storesByCoordinates"]
+        for store in stores_info["stores"]:
             item = DictParser.parse(store)
             item["opening_hours"] = OpeningHours()
             for day in DAYS_FULL:
                 time = store["openingHours"][day.lower()]
-                if open_time := time["open"]:
+                if open_time := time["opensAt"]:
                     open_time = open_time.replace(":00.000Z", "")
-                if close_time := time["close"]:
-                    close_time = time["close"].replace(":00.000Z", "")
+                if close_time := time["closesAt"]:
+                    close_time = close_time.replace(":00.000Z", "")
                 item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
             yield item
+
+        if stores_info["page"] < stores_info["totalPages"] - 1:  # page starts from zero
+            yield self.make_request(stores_info["page"] + 1)

--- a/locations/spiders/jumbo_nl.py
+++ b/locations/spiders/jumbo_nl.py
@@ -116,6 +116,7 @@ class JumboNLSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         stores_info = response.json()["data"]["storesByCoordinates"]
         for store in stores_info["stores"]:
+            store.update(store["location"].pop("address"))
             item = DictParser.parse(store)
             item["opening_hours"] = OpeningHours()
             for day in DAYS_FULL:


### PR DESCRIPTION
Used `GraphQL` API to fix the broken spider.

```
{'atp/brand/Jumbo': 724,
 'atp/brand_wikidata/Q2262314': 724,
 'atp/category/shop/supermarket': 724,
 'atp/country/NL': 724,
 'atp/field/country/from_spider_name': 724,
 'atp/field/email/missing': 724,
 'atp/field/image/missing': 724,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 724,
 'atp/field/operator_wikidata/missing': 724,
 'atp/field/phone/missing': 724,
 'atp/field/state/missing': 724,
 'atp/field/street_address/missing': 724,
 'atp/field/twitter/missing': 724,
 'atp/field/website/missing': 17,
 'atp/item_scraped_host_count/www.jumbo.com': 724,
 'atp/nsi/perfect_match': 724,
 'downloader/request_bytes': 124176,
 'downloader/request_count': 25,
 'downloader/request_method_count/POST': 25,
 'downloader/response_bytes': 89982,
 'downloader/response_count': 25,
 'downloader/response_status_count/200': 25,
 'elapsed_time_seconds': 29.850562,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 15, 15, 41, 40, 915640, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 717913,
 'httpcompression/response_count': 25,
 'item_scraped_count': 724,
 'items_per_minute': None,
 'log_count/DEBUG': 760,
 'log_count/INFO': 9,
 'request_depth_max': 24,
 'response_received_count': 25,
 'responses_per_minute': None,
 'scheduler/dequeued': 25,
 'scheduler/dequeued/memory': 25,
 'scheduler/enqueued': 25,
 'scheduler/enqueued/memory': 25,
 'start_time': datetime.datetime(2025, 1, 15, 15, 41, 11, 65078, tzinfo=datetime.timezone.utc)}
```