### PR TITLE
[Mol] Fix spider

### DIFF
--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -166,6 +166,7 @@ class MolSpider(scrapy.Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for poi in response.json():
             poi.update(poi.pop("gpsPosition"))
+            poi.pop("county", None)  # sometimes contains country info
             item = DictParser.parse(poi)
             item["ref"] = poi.get("code")
             item["street_address"] = item.pop("addr_full", None)

--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -165,6 +165,7 @@ class MolSpider(scrapy.Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for poi in response.json():
+            poi.update(poi.pop("gpsPosition"))
             item = DictParser.parse(poi)
             item["ref"] = poi.get("code")
             item["street_address"] = item.pop("addr_full", None)

--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -224,6 +224,6 @@ class MolSpider(scrapy.Spider):
                         oh.add_days_range(NAMED_DAY_RANGES_EN.get("Weekdays"), time_open, time_close)
                     else:
                         oh.add_range(day, time_open, time_close)
-            item["opening_hours"] = oh.as_opening_hours()
+            item["opening_hours"] = oh
         except Exception as e:
             self.logger.warning(f"Failed to parse hours: {hours}, {e}")

--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -40,14 +40,16 @@ BRANDS_MAPPING = {
     "INA": ("INA", "Q1662137"),
     "MOL": ("MOL", "Q549181"),
     "MOL (AGIP)": ("MOL", "Q549181"),
-    "MOL Ceska Republika": ("MOL", "Q549181"),
+    "MOL CESKA REPUBLIKA": ("MOL", "Q549181"),
     "MOLPLUGEE": ("MOL", "Q549181"),
-    "PapOil": ("PapOil", None),
-    "Slovnaft": ("Slovnaft", "Q1587563"),
+    "PAPOIL": ("PapOil", None),
+    "SLOVNAFT": ("Slovnaft", "Q1587563"),
     "TOTAL": ("Total", "Q154037"),
     "LOTOS": ("Lotos", "Q1256909"),
     "TOTAL ACCESS": ("TotalEnergies", "Q154037"),
-    "ex-OMV": ("MOL", "Q549181"),
+    "EX-OMV": ("MOL", "Q549181"),
+    "TIFON": ("Tifon", None),
+    "ENERGOPETROL": ("Energopetrol", "Q120433"),
 }
 
 FUEL_MAPPING = {
@@ -191,7 +193,8 @@ class MolSpider(scrapy.Spider):
                 self.crawler.stats.inc_value(f"atp/mol/{attribute_name}/failed/{name}")
 
     def parse_brand(self, item, poi) -> Any:
-        if brand_details := BRANDS_MAPPING.get(poi.get("brand")):
+        brand_key = poi["brand"].upper() if poi.get("brand") else ""
+        if brand_details := BRANDS_MAPPING.get(brand_key):
             brand, brand_wikidata = brand_details
             item["brand"] = brand
             item["brand_wikidata"] = brand_wikidata

--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -53,28 +53,35 @@ BRANDS_MAPPING = {
 }
 
 FUEL_MAPPING = {
-    "AdBlue": Fuel.ADBLUE,
-    "CNG (Comprimed natural gas, in tank)": None,
-    "EVO 100 Plus (GASOLINE PREMIUM)": Fuel.OCTANE_100,
+    "ADBLUE": Fuel.ADBLUE,
+    "BLUE DIESEL": Fuel.DIESEL,
+    "CNG": Fuel.CNG,
+    "DIESEL": Fuel.DIESEL,
+    "DYNAMIC DIESEL": Fuel.DIESEL,
+    "EVO 100 PLUS (GASOLINE PREMIUM)": Fuel.OCTANE_100,
+    "EVO 100 PLUS": Fuel.OCTANE_100,
+    "EVO 100": Fuel.OCTANE_100,
     "EVO 95": Fuel.OCTANE_95,
     "EVO 95 PLUS": Fuel.OCTANE_95,
-    "EUROSUPER 100 Class Plus": Fuel.OCTANE_100,
+    "EVO 98 PLUS": Fuel.OCTANE_98,
+    "EUROSUPER 100 CLASS PLUS": Fuel.OCTANE_100,
     "EUROSUPER 95": Fuel.OCTANE_95,
-    "EUROSUPER 95 Class Plus": Fuel.OCTANE_95,
-    "EVO Diesel": Fuel.DIESEL,
+    "EUROSUPER 95 CLASS PLUS": Fuel.OCTANE_95,
+    "EVO DIESEL": Fuel.DIESEL,
     "EURODIESEL": Fuel.DIESEL,
-    "EURODIESEL Class Plus": Fuel.DIESEL,
+    "EURODIESEL CLASS PLUS": Fuel.DIESEL,
     "EVO DIESEL PLUS WINTER DIESEL": Fuel.COLD_WEATHER_DIESEL,
-    "EVO Diesel Plus (DIESEL PREMIUM)": Fuel.DIESEL,
-    "LPG ": Fuel.LPG,
-    "MOL Racing Fuel": "fuel:octane_102",
-    "Maingrade 95": Fuel.OCTANE_95,
-    "Premium Gasoline": Fuel.OCTANE_95,
-    "Premium Diesel": Fuel.DIESEL,
-    "Maingrade Diesel": Fuel.DIESEL,
-    "Maingrade 95 Plus": Fuel.OCTANE_95,
+    "EVO DIESEL PLUS (DIESEL PREMIUM)": Fuel.DIESEL,
+    "EVO DIESEL PLUS": Fuel.DIESEL,
+    "LPG": Fuel.LPG,
+    "MOL RACING FUEL": "fuel:octane_102",
+    "MAINGRADE 95": Fuel.OCTANE_95,
+    "PREMIUM GASOLINE": Fuel.OCTANE_95,
+    "PREMIUM DIESEL": Fuel.DIESEL,
+    "MAINGRADE DIESEL": Fuel.DIESEL,
+    "MAINGRADE 95 PLUS": Fuel.OCTANE_95,
     "RACING 102": "fuel:octane_102",
-    "XXL Diesel": Fuel.DIESEL,
+    "XXL DIESEL": Fuel.DIESEL,
 }
 
 SERVICES_MAPPING = {
@@ -187,6 +194,8 @@ class MolSpider(scrapy.Spider):
     def parse_attribute(self, item, data: dict, attribute_name: str, mapping: dict) -> Any:
         for attribute in data.get(attribute_name, {}).get("values", []):
             name = attribute.get("name")
+            if attribute_name == "fuelsAndAdditives":
+                name = name.upper() if name else ""
             if tag := mapping.get(name):
                 apply_yes_no(tag, item, True)
             else:

--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -166,6 +166,8 @@ class MolSpider(scrapy.Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for poi in response.json():
             poi.update(poi.pop("gpsPosition"))
+            if not poi.get("latitude") and not poi.get("address"):  # not enough location data
+                continue
             poi.pop("county", None)  # sometimes contains country info
             item = DictParser.parse(poi)
             item["ref"] = poi.get("code")


### PR DESCRIPTION
Replaced non functional API and refactored code accordingly to fix the broken spider.

```
{'atp/brand/Energopetrol': 54,
 'atp/brand/INA': 513,
 'atp/brand/Lotos': 129,
 'atp/brand/MOL': 1576,
 'atp/brand/PapOil': 11,
 'atp/brand/Slovnaft': 283,
 'atp/brand/Tifon': 52,
 'atp/brand/Total': 3259,
 'atp/brand/TotalEnergies': 683,
 'atp/brand_wikidata/Q120433': 54,
 'atp/brand_wikidata/Q1256909': 129,
 'atp/brand_wikidata/Q154037': 3942,
 'atp/brand_wikidata/Q1587563': 283,
 'atp/brand_wikidata/Q1662137': 513,
 'atp/brand_wikidata/Q549181': 1576,
 'atp/category/amenity/fuel': 7091,
 'atp/country/AT': 12,
 'atp/country/BA': 107,
 'atp/country/BE': 517,
 'atp/country/CZ': 311,
 'atp/country/DE': 835,
 'atp/country/FR': 2232,
 'atp/country/HR': 477,
 'atp/country/HU': 498,
 'atp/country/LU': 41,
 'atp/country/ME': 12,
 'atp/country/NL': 316,
 'atp/country/PL': 931,
 'atp/country/RO': 263,
 'atp/country/RS': 81,
 'atp/country/SI': 175,
 'atp/country/SK': 283,
 'atp/field/branch/missing': 7091,
 'atp/field/brand/missing': 531,
 'atp/field/brand_wikidata/missing': 594,
 'atp/field/city/missing': 3683,
 'atp/field/email/missing': 7091,
 'atp/field/image/missing': 7091,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 4465,
 'atp/field/operator/missing': 7091,
 'atp/field/operator_wikidata/missing': 7091,
 'atp/field/phone/invalid': 109,
 'atp/field/phone/missing': 799,
 'atp/field/postcode/missing': 528,
 'atp/field/state/missing': 7091,
 'atp/field/street_address/missing': 18,
 'atp/field/twitter/missing': 7091,
 'atp/field/website/missing': 7091,
 'atp/geometry/null_island': 3,
 'atp/item_scraped_host_count/tankstellenfinder.molaustria.at': 7110,
```