### PR TITLE
follow OpenStreetMap opening_hours over midnight

### DIFF
--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -67,7 +67,6 @@ When we can, the format for opening hours follows [OpenStreetMap's `opening_hour
 * Consistent with OpenStreetMap's syntax, days are omitted from the opening hours string when the entry is closed on that day.
 * In some cases only some days of week can be parsed. The unparsable days are omitted from the opening hours while not actually be closed. It is impossible to distinguish between a parsing error and the store being closed, as described in [this issue](https://github.com/alltheplaces/alltheplaces/issues/6943).
 * Opening hours provided by a source and recorded in All the Places may be special for the week due to presence of public holidays within the week at the time of parsing. As a result, the day may be omitted from opening hours output. Also for this reason, some days may have unusually short or unusually long opening hours. Data captured from previous All the Places builds can be checked to find the most common (regular) opening hours for a location.
-* Opening hours format does not match OSM syntax exactly [when time ranges extend across midnight](https://github.com/alltheplaces/alltheplaces/discussions/4959).
 * `Mo-Su closed` typically indicates POI closed temporarily for reasons of maintenance and refurbishment. POIs that are permanently closed but listed by source data are returned with the `end_date` field (see `end_date` specification for details).
 
 ## Categories

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -981,7 +981,7 @@ class OpeningHours:
                     next_day = DAYS[(index + 1) % len(DAYS)]
                     day_hours_midnight_split[next_day].add((OpeningHours.time_struct_instance(0, 0), h[1]))
                     if next_day in self.days_closed:
-                        del self.days_closed[next_day]
+                        self.days_closed.remove(next_day)
                 else:
                     day_hours_midnight_split[day].add(h)
         for day in DAYS:

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -953,7 +953,8 @@ class OpeningHours:
 
     @staticmethod
     def time_struct_instance(hour, minutes):
-        return time.struct_time((1900, 1, 1, hour, minutes, 0, 0, 1, -1))
+        time_format="%H:%M"
+        return time.strptime(f"{hour}:{minutes}", time_format)
 
     def as_opening_hours(self) -> str:
         day_groups = []

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -951,11 +951,6 @@ class OpeningHours:
         self.days_closed.discard(day)
         self.day_hours[day].add((open_time, close_time))
 
-    @staticmethod
-    def time_struct_instance(hour, minutes):
-        time_format="%H:%M"
-        return time.strptime(f"{hour}:{minutes}", time_format)
-
     def as_opening_hours(self) -> str:
         day_groups = []
         this_day_group = None
@@ -973,14 +968,17 @@ class OpeningHours:
         # so we need only check whether time goes over midnight and split it
         # in two regular ranges
         day_hours_midnight_split = defaultdict(set)
+        time_format="%H:%M"
+        midnight_end = time.strptime(f"23:59", time_format)
+        midnight_start = time.strptime(f"00:00", time_format)
         for index, day in enumerate(DAYS):
             for h in self.day_hours[day]:
                 if h[0].tm_hour * 60 + h[0].tm_min > h[1].tm_hour * 60 + h[1].tm_min:
                     # start hour is greater than end hour, indicating that it is
                     # an over-midnight range
-                    day_hours_midnight_split[day].add((h[0], OpeningHours.time_struct_instance(23, 59)))
+                    day_hours_midnight_split[day].add((h[0], midnight_end))
                     next_day = DAYS[(index + 1) % len(DAYS)]
-                    day_hours_midnight_split[next_day].add((OpeningHours.time_struct_instance(0, 0), h[1]))
+                    day_hours_midnight_split[next_day].add((midnight_start, h[1]))
                     if next_day in self.days_closed:
                         self.days_closed.remove(next_day)
                 else:

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -968,7 +968,7 @@ class OpeningHours:
         # Mo-Sa 10:00-02:00; Su 00:00-02:00,09:00-02:00
         # in turn means that object is open also during early Sunday hours
         #
-        # All the Places is using a small section of entire opening_hous syntax
+        # All the Places is using a small section of entire opening_hours syntax
         # so we need only check whether time goes over midnight and split it
         # in two regular ranges
         day_hours_midnight_split = defaultdict(set)

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -980,15 +980,33 @@ class OpeningHours:
 
         opening_hours = ""
 
+        # usually ; works fine as a separator between different days
+        # but it has an annoying quirk, in OpenStreetMap opening_hours syntax
+        # it overrides previous definitions
+        # so for example
+        # Mo-Sa 10:00-02:00; Su 09:00-02:00
+        # means that object is closed on midnight between Saturday and Sunday
+        # Mo-Sa 10:00-02:00, Su 09:00-02:00
+        # in turn means that object is open also during early Sunday hours
+        #
+        # All the Places is using a small section of entire opening_hous syntax
+        # so we need only check whether any time goes over midnight,
+        # in all other cases ; can be used safely
+        separator = ";"
+        for day in DAYS:
+            for h in self.day_hours[day]:
+                if h[1].tm_hour * 60 + h[1].tm_min < h[0].tm_hour * 60 + h[0].tm_min:
+                    separator = ","
+
         for day_group in day_groups:
             if not day_group["hours"]:
                 continue
             elif day_group["from_day"] == day_group["to_day"]:
-                opening_hours += "{from_day} {hours}; ".format(**day_group)
+                opening_hours += "{from_day} {hours}".format(**day_group) + separator + " "
             elif day_group["from_day"] == "Su" and day_group["to_day"] == "Sa":
-                opening_hours += "{hours}; ".format(**day_group)
+                opening_hours += "{hours}".format(**day_group) + separator + " "
             else:
-                opening_hours += "{from_day}-{to_day} {hours}; ".format(**day_group)
+                opening_hours += "{from_day}-{to_day} {hours}".format(**day_group) + separator + " "
         opening_hours = opening_hours[:-2]
 
         return opening_hours

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -968,7 +968,7 @@ class OpeningHours:
         # so we need only check whether time goes over midnight and split it
         # in two regular ranges
         day_hours_midnight_split = defaultdict(set)
-        time_format="%H:%M"
+        time_format = "%H:%M"
         midnight_end = time.strptime(f"23:59", time_format)
         midnight_start = time.strptime(f"00:00", time_format)
         for index, day in enumerate(DAYS):

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -969,8 +969,8 @@ class OpeningHours:
         # in two regular ranges
         day_hours_midnight_split = defaultdict(set)
         time_format = "%H:%M"
-        midnight_end = time.strptime(f"23:59", time_format)
-        midnight_start = time.strptime(f"00:00", time_format)
+        midnight_end = time.strptime("23:59", time_format)
+        midnight_start = time.strptime("00:00", time_format)
         for index, day in enumerate(DAYS):
             for h in self.day_hours[day]:
                 if h[0].tm_hour * 60 + h[0].tm_min > h[1].tm_hour * 60 + h[1].tm_min:

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -132,13 +132,17 @@ def test_simple_over_midnight():
     o.add_range("Mo", "07:00", "02:00")
     assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
 
-def test_hours_over_midnight_overide_closed_days():
+def test_hours_over_midnight_overide_closed_days_on_next_day():
     o = OpeningHours()
     o.add_range("Mo", "07:00", "02:00")
     o.set_closed("Tu")
     assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
-    o.set_closed(DAYS)
-    assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00; We-Su closed"
+
+def test_hours_over_midnight_removed_when_start_day_set_to_closed():
+    o = OpeningHours()
+    o.add_range("Mo", "07:00", "02:00")
+    o.set_closed("Mo")
+    assert o.as_opening_hours() == "Mo closed"
 
 def test_over_midnight():
     o = OpeningHours()

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -128,6 +128,19 @@ def test_multiple_times():
     assert o3.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
 
 
+def test_over_midnight():
+    o = OpeningHours()
+    o.add_range("Mo", "07:00", "02:00")
+    o.add_range("Tu", "07:00", "02:00")
+    o.add_range("We", "07:00", "02:00")
+    o.add_range("Th", "07:00", "02:00")
+    o.add_range("Fr", "07:00", "02:00")
+    o.add_range("Sa", "07:00", "02:00")
+    o.add_range("Su", "05:00", "03:00")
+
+    assert o.as_opening_hours() == "Mo-Sa 07:00-02:00, Su 05:00-03:00"
+
+
 def test_sanitise_days():
     assert sanitise_day("Mo") == "Mo"
     assert sanitise_day("Mon") == "Mo"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -127,6 +127,18 @@ def test_multiple_times():
     o3.add_range("Tu", "09:00", "12:00")
     assert o3.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
 
+def test_simple_over_midnight():
+    o = OpeningHours()
+    o.add_range("Mo", "07:00", "02:00")
+    assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
+
+def test_hours_over_midnight_overide_closed_days():
+    o = OpeningHours()
+    o.add_range("Mo", "07:00", "02:00")
+    o.set_closed("Tu")
+    assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
+    o.set_closed(DAYS)
+    assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00; We-Su closed"
 
 def test_over_midnight():
     o = OpeningHours()
@@ -138,7 +150,7 @@ def test_over_midnight():
     o.add_range("Sa", "07:00", "02:00")
     o.add_range("Su", "05:00", "03:00")
 
-    assert o.as_opening_hours() == "Mo-Sa 07:00-02:00, Su 05:00-03:00"
+    assert o.as_opening_hours() == "Mo 00:00-03:00,07:00-24:00; Tu-Sa 00:00-02:00,07:00-24:00; Su 00:00-02:00,05:00-24:00"
 
 
 def test_sanitise_days():

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -127,10 +127,12 @@ def test_multiple_times():
     o3.add_range("Tu", "09:00", "12:00")
     assert o3.as_opening_hours() == "Tu 09:00-12:00,15:00-17:00"
 
+
 def test_simple_over_midnight():
     o = OpeningHours()
     o.add_range("Mo", "07:00", "02:00")
     assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
+
 
 def test_hours_over_midnight_overide_closed_days_on_next_day():
     o = OpeningHours()
@@ -138,11 +140,13 @@ def test_hours_over_midnight_overide_closed_days_on_next_day():
     o.set_closed("Tu")
     assert o.as_opening_hours() == "Mo 07:00-24:00; Tu 00:00-02:00"
 
+
 def test_hours_over_midnight_removed_when_start_day_set_to_closed():
     o = OpeningHours()
     o.add_range("Mo", "07:00", "02:00")
     o.set_closed("Mo")
     assert o.as_opening_hours() == "Mo closed"
+
 
 def test_over_midnight():
     o = OpeningHours()
@@ -154,7 +158,9 @@ def test_over_midnight():
     o.add_range("Sa", "07:00", "02:00")
     o.add_range("Su", "05:00", "03:00")
 
-    assert o.as_opening_hours() == "Mo 00:00-03:00,07:00-24:00; Tu-Sa 00:00-02:00,07:00-24:00; Su 00:00-02:00,05:00-24:00"
+    assert (
+        o.as_opening_hours() == "Mo 00:00-03:00,07:00-24:00; Tu-Sa 00:00-02:00,07:00-24:00; Su 00:00-02:00,05:00-24:00"
+    )
 
 
 def test_sanitise_days():


### PR DESCRIPTION
see https://github.com/alltheplaces/alltheplaces/discussions/4959 this way opening hours now are not having a change from OSM syntax previously ATP was using ; in meaning of ,
this mattered only for opening hours extending past midnight and only there ATP was changed to use ,

far more complicated processing can be used to avoid using , in rare cases of over midnight opening hours where ; can be used anyway - but instead much simpler one was used

Disclaimer: that falls under work that was funded by EU via NGI 0 via nl.net grant (I can also process it on my side, but others would not benefit from it - so I hope that it is fine to send it here)

see also https://openingh.ypid.de/evaluation_tool/?EXP=Mo-Sa%2010%3A00-02%3A00%2C%20Su%2009%3A00-02%3A00&lat=48.7769&lon=9.1844&mode=0 and https://openingh.ypid.de/evaluation_tool/?EXP=Mo-Sa%2010%3A00-02%3A00%3B%20Su%2009%3A00-02%3A00&lat=48.7769&lon=9.1844&mode=0 for why ; vs , may matter