### PR TITLE
[Omv] Fix spider

### DIFF
--- a/locations/spiders/omv.py
+++ b/locations/spiders/omv.py
@@ -174,7 +174,7 @@ class OmvSpider(scrapy.Spider):
                         from_time = time_from.split("=")[1]
                         to_time = time_to.split("=")[1]
                         oh.add_range(DAYS[int(day_of_week) - 1], from_time, to_time)
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
         except Exception as e:
             self.logger.error(f"Error parsing hours: {opening_hours}, {e}")
 

--- a/locations/spiders/omv.py
+++ b/locations/spiders/omv.py
@@ -163,17 +163,16 @@ class OmvSpider(scrapy.Spider):
         oh = OpeningHours()
         try:
             if opening_hours:
-                for day in opening_hours.split("#"):
-                    ranges = day.split(",")
-                    day_of_week = ranges[0].split("=")[1]
-                    time_ranges = ranges[1:]
-                    if "closed=TRUE" in time_ranges[0]:
-                        continue
+                for rule_str in opening_hours.split("#"):
+                    rule = {}
+                    for prop in rule_str.split(","):
+                        k, v = prop.split("=")
+                        rule[k] = v
+
+                    if rule.get("closed") == "TRUE":
+                        oh.set_closed(DAYS[int(rule["dayOfWeek"]) - 1])
                     else:
-                        time_from, time_to = time_ranges[1:]
-                        from_time = time_from.split("=")[1]
-                        to_time = time_to.split("=")[1]
-                        oh.add_range(DAYS[int(day_of_week) - 1], from_time, to_time)
+                        oh.add_range(DAYS[int(rule["dayOfWeek"]) - 1], rule["from"], rule["to"])
                 item["opening_hours"] = oh
         except Exception as e:
             self.logger.error(f"Error parsing hours: {opening_hours}, {e}")


### PR DESCRIPTION
Fixed fetching of  essential parameters to make the API calls successful.

```
{'atp/brand/Avanti': 134,
 'atp/brand/Hofer Diskont': 78,
 'atp/brand/OMV': 999,
 'atp/brand/Petrom': 455,
 'atp/brand_wikidata/Q107803455': 78,
 'atp/brand_wikidata/Q168238': 1133,
 'atp/brand_wikidata/Q1755034': 455,
 'atp/category/amenity/fuel': 1666,
 'atp/country/AT': 418,
 'atp/country/BG': 93,
 'atp/country/CZ': 138,
 'atp/country/HU': 202,
 'atp/country/MD': 65,
 'atp/country/RO': 556,
 'atp/country/RS': 64,
 'atp/country/SK': 130,
 'atp/field/branch/missing': 1666,
 'atp/field/email/missing': 1666,
 'atp/field/image/missing': 1666,
 'atp/field/operator/missing': 1666,
 'atp/field/operator_wikidata/missing': 1666,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 132,
 'atp/field/state/missing': 1666,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 1666,
 'atp/field/website/missing': 1666,
 'atp/item_scraped_host_count/app.wigeogis.com': 1666,
 'atp/nsi/cc_match': 1666,
 'atp/omv/paymentDetails/failed/ARBÖ Card': 1,
 'atp/omv/paymentDetails/failed/Cadhoc': 539,
 'atp/omv/paymentDetails/failed/CadouPass': 539,
 'atp/omv/paymentDetails/failed/CheckDejeuner': 538,
 'atp/omv/paymentDetails/failed/GustoPass': 539,
 'atp/omv/paymentDetails/failed/SmartPass': 539,
 'atp/omv/paymentDetails/failed/TicketRestaurant': 539,
 'atp/omv/paymentDetails/failed/Westaco': 318,
 'atp/omv/paymentDetails/failed/jö Karte': 187,
 'atp/omv/siteFeatures/failed/Alzabox': 14,
 'atp/omv/siteFeatures/failed/Bank service': 15,
 'atp/omv/siteFeatures/failed/Car care areas': 130,
 'atp/omv/siteFeatures/failed/Coffee corner': 1,
 'atp/omv/siteFeatures/failed/Digital Vignette': 162,
 'atp/omv/siteFeatures/failed/Electric fast charging': 145,
 'atp/omv/siteFeatures/failed/Electric fast charging - 1X FLEXPOLE': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - 300 KW': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - AC 43 kw, CCS DC 50 kw': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - DC 300 KW 1 CCS': 3,
 'atp/omv/siteFeatures/failed/Electric fast charging - DC 300 KW 2 CCS': 5,
 'atp/omv/siteFeatures/failed/Electric fast charging - DC 75 KW 1 CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - FLEXPOLE 150 KW': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Ionity: CCS 350 kw': 7,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION  DC 150kW Flexpole': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 130KW; 2CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 130KW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 150 KW; 2CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 150KW; 2CCS': 11,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 150KW; 4CCS': 4,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 150kW; 2CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300 KW 4 CCS; 400 KW 9 CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300 KW; 2 CC': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300 KW; 4 CCS': 34,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300KW, 2 CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300KW; 2CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300KW; 4CCS': 10,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300kW; 2CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 300kW; 4CCS': 3,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 350KW; 3CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 400kW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION DC 75KW; 1 CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, 1 x HYC150 Alpitronic': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Alpitronic, 100kW; 2CCS': 5,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Alpitronic, 150kW; 1CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Alpitronic, 200kW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Alpitronic, 300kW; 2CCS': 3,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Ekoenergetyka Axon Easy 400KW; 2CCS': 2,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Flexpole, 150kW; 2CCS': 7,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV E-MOTION, Flexpole, 150kW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 150KW; 4 CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 150KW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV e-Motion DC 300KW; 4CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - OMV, E-MOTION DC 300KW; 2CCS': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 22kw, CCS DC 50kw; Ionity: CCS 350kw': 3,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 43 kw, CCS DC 50 kw': 9,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics: AC 43kw, CCS DC 50kw; Ionity: CCS 350kw': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics:AC 22 kw,CCS DC 50 kw; Ionity:CCS 350 kw': 1,
 'atp/omv/siteFeatures/failed/Electric fast charging - Smatrics:AC22kw,CCSDC50kw;Tesla:120kw;Ionity:350kw': 1,
 'atp/omv/siteFeatures/failed/Geis point': 14,
 'atp/omv/siteFeatures/failed/HUGO highway toll': 16,
 'atp/omv/siteFeatures/failed/High speed pump': 815,
 'atp/omv/siteFeatures/failed/Lotto Toto acceptence': 179,
 'atp/omv/siteFeatures/failed/Medipoint': 96,
 'atp/omv/siteFeatures/failed/My Auchan': 391,
 'atp/omv/siteFeatures/failed/Open 24 hours': 1156,
 'atp/omv/siteFeatures/failed/Pay at the pump': 208,
 'atp/omv/siteFeatures/failed/Postal service': 145,
 'atp/omv/siteFeatures/failed/Restaurant': 280,
 'atp/omv/siteFeatures/failed/SMILE & DRIVE': 130,
 'atp/omv/siteFeatures/failed/Sazka terminal': 120,
 'atp/omv/siteFeatures/failed/Shop': 1366,
 'atp/omv/siteFeatures/failed/Spar Express': 87,
 'atp/omv/siteFeatures/failed/Super Shop': 203,
 'atp/omv/siteFeatures/failed/Tabacco shop': 3,
 'atp/omv/siteFeatures/failed/Tankomat open 24 hours': 208,
 'atp/omv/siteFeatures/failed/Ticketportal': 343,
 'atp/omv/siteFeatures/failed/VIVA shop': 858,
 'atp/omv/siteFeatures/failed/Vignette': 1185,
 'atp/omv/siteFeatures/failed/Waste oil collection': 52,
 'downloader/request_bytes': 859763,
 'downloader/request_count': 1679,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1677,
 'downloader/response_bytes': 4780345,
 'downloader/response_count': 1679,
 'downloader/response_status_count/200': 1679,
 'elapsed_time_seconds': 220.912311,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 17, 6, 28, 3, 235638, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7450741,
 'httpcompression/response_count': 1660,
 'item_scraped_count': 1666,
 'items_per_minute': None,
 'log_count/DEBUG': 3356,
 'log_count/INFO': 12,
 'request_depth_max': 2,
 'response_received_count': 1679,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1678,
 'scheduler/dequeued/memory': 1678,
 'scheduler/enqueued': 1678,
 'scheduler/enqueued/memory': 1678,
 'start_time': datetime.datetime(2025, 1, 17, 6, 24, 22, 323327, tzinfo=datetime.timezone.utc)}
```