### PR TITLE
[Toyota MX] Fix Spider

### DIFF
--- a/locations/spiders/toyota_mx.py
+++ b/locations/spiders/toyota_mx.py
@@ -1,66 +1,25 @@
-from scrapy.http import JsonRequest, Request
-
+from typing import Iterable
+from scrapy.http import Response
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_WEEKDAY, OpeningHours
+from locations.dict_parser import DictParser
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address
 from locations.spiders.toyota_au import TOYOTA_SHARED_ATTRIBUTES
 
 
 class ToyotaMXSpider(JSONBlobSpider):
     name = "toyota_mx"
     item_attributes = TOYOTA_SHARED_ATTRIBUTES
-    start_urls = ["https://www.toyota.mx/distribuidores"]
-    locations_key = "response"
+    start_urls = ["https://www.toyota.mx/graphql/execute.json/tmex/distributorByStates"]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_state)
-
-    def fetch_state(self, response):
-        states = response.xpath(
-            './/form[@data-distribuidores="https://www.toyota.mx/api/distribuidores"]/.//option/@value'
-        ).getall()
-        states = [s for s in states if s.strip() != ""]
-        for state in states:
-            yield JsonRequest(
-                f"https://www.toyota.mx/api/distribuidores?estado={state}&tipo=mapa",
-                callback=self.parse,
-                meta={"state": state},
-            )
-
-    def pre_process_data(self, location):
-        location["ref"] = location.pop("tid")
-
-    def post_process_item(self, item, response, location):
-        apply_category(Categories.SHOP_CAR, item)  # No data available on different category/extra features
-        item["state"] = response.meta["state"]
-        item["image"] = location["uri"]
-        item["addr_full"] = clean_address(location["description"]).replace("<p>", "").replace("</p>", "")
-        yield JsonRequest(
-            url=f"https://www.toyota.mx/api/geo?distribuidor={item['ref']}&tipo=distribuidor",
-            meta={"item": item},
-            callback=self.parse_dealer,
-        )
-
-    def parse_dealer(self, response):
-        item = response.meta["item"]
-        location = response.json()
-        item["email"] = location["email"].replace(",", ";")
-        item["website"] = location.get("sitio")
-
-        item["opening_hours"] = OpeningHours()
-        for key, days in {
-            "lunesviernes": "Mo-Fr",
-            "sabado": "Sa",
-            "domingo": "Su",
-        }.items():
-            if times := location.get(key):
-                item["opening_hours"].add_ranges_from_string(f'{days} {times.replace("a.m.", "").replace("p.m.", "")}')
-            else:
-                try:
-                    item["opening_hours"].set_closed(days)
-                except ValueError:
-                    item["opening_hours"].set_closed(DAYS_WEEKDAY)
-
-        yield item
+    def parse(self, response: Response) -> Iterable[Feature]:
+        for data in response.json()["data"]["stateDistributorsList"]["items"]:
+            state = data["state"]
+            for store in data["distributors"]:
+                item = DictParser.parse(store)
+                item["website"] = "https://www.toyota.mx"
+                item["ref"] = store["dealerCode"]
+                item["addr_full"] = store["address"]["plaintext"]
+                item["state"] = state
+                apply_category(Categories.SHOP_CAR, item)
+                yield item

--- a/locations/spiders/toyota_mx.py
+++ b/locations/spiders/toyota_mx.py
@@ -19,7 +19,6 @@ class ToyotaMXSpider(scrapy.Spider):
             state = data["state"]
             for store in data["distributors"]:
                 item = DictParser.parse(store)
-                item["website"] = "https://www.toyota.mx"
                 item["ref"] = store["dealerCode"]
                 item["addr_full"] = store["address"]["plaintext"]
                 item["state"] = state

--- a/locations/spiders/toyota_mx.py
+++ b/locations/spiders/toyota_mx.py
@@ -1,5 +1,7 @@
 from typing import Iterable
+
 from scrapy.http import Response
+
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.items import Feature

--- a/locations/spiders/toyota_mx.py
+++ b/locations/spiders/toyota_mx.py
@@ -1,15 +1,15 @@
 from typing import Iterable
 
+import scrapy
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.toyota_au import TOYOTA_SHARED_ATTRIBUTES
 
 
-class ToyotaMXSpider(JSONBlobSpider):
+class ToyotaMXSpider(scrapy.Spider):
     name = "toyota_mx"
     item_attributes = TOYOTA_SHARED_ATTRIBUTES
     start_urls = ["https://www.toyota.mx/graphql/execute.json/tmex/distributorByStates"]


### PR DESCRIPTION
`Fixes : code refactored to fix spider`


{'atp/brand/Toyota': 101,
 'atp/brand_wikidata/Q53268': 101,
 'atp/category/shop/car': 101,
 'atp/country/MX': 101,
 'atp/field/branch/missing': 101,
 'atp/field/city/missing': 101,
 'atp/field/country/from_spider_name': 101,
 'atp/field/email/missing': 101,
 'atp/field/image/missing': 101,
 'atp/field/opening_hours/missing': 101,
 'atp/field/operator/missing': 101,
 'atp/field/operator_wikidata/missing': 101,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 101,
 'atp/field/street_address/missing': 101,
 'atp/field/twitter/missing': 101,
 'atp/item_scraped_host_count/www.toyota.mx': 103,
 'atp/nsi/cc_match': 101,
 'downloader/request_bytes': 680,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14076,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.105479,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 17, 10, 12, 11, 579164, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 71906,
 'httpcompression/response_count': 2,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 101,
 'items_per_minute': None,
 'log_count/DEBUG': 116,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 17, 10, 12, 8, 473685, tzinfo=datetime.timezone.utc)}