### PR TITLE
[Loves]

### DIFF
--- a/locations/spiders/loves.py
+++ b/locations/spiders/loves.py
@@ -1,55 +1,30 @@
 from typing import Any
 
 import scrapy
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class LovesSpider(scrapy.Spider):
     name = "loves"
     SPEEDCO = {"brand": "Speedco", "brand_wikidata": "Q112455073"}
     item_attributes = {"brand": "Love's", "brand_wikidata": "Q1872496"}
-    allowed_domains = ["www.loves.com"]
-    page = 0
-
-    def start_requests(self):
-        yield JsonRequest(
-            f"https://www.loves.com/api/sitecore/StoreSearch/SearchStoresWithDetail?pageNumber={self.page}&top=50&lat=0&lng=0"
-        )
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.loves.com/api/fetch_all_stores?requestingSite=Loves"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        stores = response.json()
-        if not stores:
-            return
-        for store in stores:
-            item = Feature(
-                branch=store["PreferredName"],
-                ref=store["SiteId"],
-                street_address=store["Address"],
-                city=store["City"],
-                state=store["State"],
-                postcode=store["Zip"],
-                phone=store["MainPhone"],
-                email=store["MainEmail"],
-                lat=float(store["Latitude"]),
-                lon=float(store["Longitude"]),
-            )
+        for store in response.json()["stores"]:
+            if store["isHotel"] is True:
+                continue  # ChoiceHotelsSpider
+            item = DictParser.parse(store)
+            item["ref"] = store.get("number")
+            item["website"] = "https://www.loves.com/locations/{}".format(store["number"])
 
-            item["website"] = "https://www.loves.com/locations/{}".format(store["SiteName"].split(" ")[-1])
-
-            if store["IsLoveStore"] is True:
-                apply_category({"highway": "services"}, item)
-            elif store["IsSpeedCo"] is True:
+            if "speedco" in store["mapPinUrl"].lower():
                 item.update(self.SPEEDCO)
                 apply_category(Categories.SHOP_TRUCK_REPAIR, item)
-            elif store["IsHotel"] is True:
-                apply_category(Categories.HOTEL, item)
-                continue  # ChoiceHotelsSpider
-
+            else:
+                apply_category({"highway": "services"}, item)
             yield item
-
-        self.page += 1
-        next_page = f"https://www.loves.com/api/sitecore/StoreSearch/SearchStoresWithDetail?pageNumber={self.page}&top=50&lat=0&lng=0"
-        yield response.follow(next_page, callback=self.parse)

--- a/locations/spiders/loves.py
+++ b/locations/spiders/loves.py
@@ -25,6 +25,8 @@ class LovesSpider(scrapy.Spider):
             if "speedco" in store["mapPinUrl"].lower():
                 item.update(self.SPEEDCO)
                 apply_category(Categories.SHOP_TRUCK_REPAIR, item)
+            elif "countrystore" in store["mapPinUrl"].lower():
+                apply_category(Categories.FUEL_STATION, item)
             else:
                 apply_category({"highway": "services"}, item)
             yield item

--- a/locations/spiders/loves_us.py
+++ b/locations/spiders/loves_us.py
@@ -7,8 +7,8 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
-class LovesSpider(scrapy.Spider):
-    name = "loves"
+class LovesUSSpider(scrapy.Spider):
+    name = "loves_us"
     SPEEDCO = {"brand": "Speedco", "brand_wikidata": "Q112455073"}
     item_attributes = {"brand": "Love's", "brand_wikidata": "Q1872496"}
     custom_settings = {"ROBOTSTXT_OBEY": False}


### PR DESCRIPTION
Replaced non-functional API by new one to fix and accordingly refactor the spider. Also fixed the category by identifying fuel stations by `Love's` known as `Love's Country Store`. Kindly refer to [wikipedia](https://en.wikipedia.org/wiki/Love%27s)'s screenshot attached below:
![image](https://github.com/user-attachments/assets/1130ed69-bb68-4ff5-b1ee-ca932f9ba7b1)

```
{"atp/brand/Love's": 654,
 'atp/brand/Speedco': 53,
 'atp/brand_wikidata/Q112455073': 53,
 'atp/brand_wikidata/Q1872496': 654,
 'atp/category/amenity/fuel': 63,
 'atp/category/highway/services': 591,
 'atp/category/shop/truck_repair': 53,
 'atp/country/US': 707,
 'atp/field/branch/missing': 707,
 'atp/field/country/from_spider_name': 707,
 'atp/field/email/missing': 707,
 'atp/field/image/missing': 707,
 'atp/field/opening_hours/missing': 707,
 'atp/field/operator/missing': 707,
 'atp/field/operator_wikidata/missing': 707,
 'atp/field/twitter/missing': 707,
 'atp/item_scraped_host_count/www.loves.com': 707,
 'atp/nsi/cc_match': 654,
 'atp/nsi/perfect_match': 53,
 'downloader/request_bytes': 335,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 55840,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.001727,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 17, 12, 46, 44, 94338, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 484431,
 'httpcompression/response_count': 1,
 'item_scraped_count': 707,
 'items_per_minute': None,
 'log_count/DEBUG': 719,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 17, 12, 46, 40, 92611, tzinfo=datetime.timezone.utc)}
```