### PR TITLE
[Captain D] Fix spider

### DIFF
--- a/locations/spiders/captain_d.py
+++ b/locations/spiders/captain_d.py
@@ -8,3 +8,4 @@ class CaptainDSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Captain D's", "brand_wikidata": "Q5036616"}
     sitemap_urls = ["https://locations.captainds.com/robots.txt"]
     sitemap_rules = [(r"https://locations.captainds.com/ll/US/\w{2}/[-\w]+/[-\w]+", "parse_sd")]
+    json_parser = "chompjs"

--- a/locations/spiders/captain_d.py
+++ b/locations/spiders/captain_d.py
@@ -7,7 +7,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.items import Feature
+from locations.items import Feature, set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -44,4 +44,6 @@ class CaptainDSpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["branch"] = item.pop("name").title()
+        if all(rule.get("opens") == "" for rule in ld_data.get("openingHoursSpecification", [])):
+            set_closed(item)
         yield item

--- a/locations/spiders/captain_d.py
+++ b/locations/spiders/captain_d.py
@@ -1,11 +1,27 @@
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Any
+from urllib.parse import urljoin
+
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CaptainDSpider(SitemapSpider, StructuredDataSpider):
+# Sitemap is there, but it doesn't provide all locations
+class CaptainDSpider(CrawlSpider, StructuredDataSpider):
     name = "captain_d"
     item_attributes = {"brand": "Captain D's", "brand_wikidata": "Q5036616"}
-    sitemap_urls = ["https://locations.captainds.com/robots.txt"]
-    sitemap_rules = [(r"https://locations.captainds.com/ll/US/\w{2}/[-\w]+/[-\w]+", "parse_sd")]
+    start_urls = ["https://locations.captainds.com/site-map/US/"]
+    rules = [
+        Rule(LinkExtractor(allow=r"/site-map/us/\w{2}/$")),
+        Rule(LinkExtractor(allow=r"/site-map/us/\w{2}/[-\w]+/$"), callback="parse_locations"),
+    ]
     json_parser = "chompjs"
+
+    # Ultimate POI page urls are not directly available to the CrawlSpider
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
+        for slug in re.findall(r"\"localpage_url_id\"[:\s]+\"(.+?)\"", response.text):
+            yield Request(url=urljoin(response.url.replace("site-map", "ll"), f"{slug}/"), callback=self.parse_sd)

--- a/locations/spiders/captain_d.py
+++ b/locations/spiders/captain_d.py
@@ -1,7 +1,10 @@
-from locations.storefinders.momentfeed import MomentFeedSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CaptainDSpider(MomentFeedSpider):
+class CaptainDSpider(SitemapSpider, StructuredDataSpider):
     name = "captain_d"
     item_attributes = {"brand": "Captain D's", "brand_wikidata": "Q5036616"}
-    api_key = "AJXCZOENNNXKHAKZ"
+    sitemap_urls = ["https://locations.captainds.com/robots.txt"]
+    sitemap_rules = [(r"https://locations.captainds.com/ll/US/\w{2}/[-\w]+/[-\w]+", "parse_sd")]

--- a/locations/spiders/captain_d.py
+++ b/locations/spiders/captain_d.py
@@ -7,6 +7,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -40,3 +41,7 @@ class CaptainDSpider(CrawlSpider, StructuredDataSpider):
                     ld_data["openingHoursSpecification"][monday_index]["closes"] = ld_data["openingHoursSpecification"][
                         tuesday_index
                     ]["closes"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").title()
+        yield item


### PR DESCRIPTION
Tried with [Sitemap](https://locations.captainds.com/robots.txt) but POIs count scraped `443` , switched to `CrawlSpider` to match the expected count, and we get `520` POIs. `opening_hours` fixed for missing data.

```
{"atp/brand/Captain D's": 520,
 'atp/brand_wikidata/Q5036616': 520,
 'atp/category/amenity/fast_food': 520,
 'atp/country/US': 520,
 'atp/field/email/missing': 520,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 520,
 'atp/field/operator_wikidata/missing': 520,
 'atp/item_scraped_host_count/locations.captainds.com': 520,
 'atp/nsi/perfect_match': 520,
 'downloader/request_bytes': 487025,
 'downloader/request_count': 971,
 'downloader/request_method_count/GET': 971,
 'downloader/response_bytes': 26266884,
 'downloader/response_count': 971,
 'downloader/response_status_count/200': 968,
 'downloader/response_status_count/301': 3,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 10.086741,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 20, 9, 56, 7, 738249, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 971,
 'httpcompression/response_bytes': 169628342,
 'httpcompression/response_count': 968,
 'item_scraped_count': 520,
 'items_per_minute': None,
 'log_count/DEBUG': 1504,
 'log_count/INFO': 9,
 'request_depth_max': 3,
 'response_received_count': 968,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 970,
 'scheduler/dequeued/memory': 970,
 'scheduler/enqueued': 970,
 'scheduler/enqueued/memory': 970,
 'start_time': datetime.datetime(2025, 1, 20, 9, 55, 57, 651508, tzinfo=datetime.timezone.utc)}
```