### PR TITLE
[ErnstYoung] Fix Spider

### DIFF
--- a/locations/spiders/ernst_young.py
+++ b/locations/spiders/ernst_young.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import urljoin
 
 import scrapy
 from scrapy.http import Response
@@ -10,9 +11,7 @@ from locations.pipelines.address_clean_up import clean_address
 class ErnstYoungSpider(scrapy.Spider):
     name = "ernst_young"
     item_attributes = {"brand": "EY", "brand_wikidata": "Q489097"}
-    start_urls = [
-        "https://www.ey.com/content/ey-unified-site/ey-com.office-locations.json?site=ey-com&locale=en_gl",
-    ]
+    start_urls = ["https://www.ey.com/content/ey-unified-site/ey-com.office-locations.json?site=ey-com&locale=en_us"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
@@ -35,7 +34,6 @@ class ErnstYoungSpider(scrapy.Spider):
         item["street_address"] = clean_address(office["officeAddress"].replace("<p>", "").replace("</p>", ""))
         if phone := office.get("phoneInformationDirect"):
             item["phone"] = phone[0]
-        if state_name := office["stateName"]:
-            item["state"] = state_name
-        item["ref"] = item["website"] = "https://www.ey.com" + office["href"]
+        item["state"] = office["stateName"]
+        item["ref"] = item["website"] = urljoin("https://www.ey.com", office["href"])
         return item

--- a/locations/spiders/ernst_young.py
+++ b/locations/spiders/ernst_young.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import scrapy
 from scrapy.http import Response
+
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 

--- a/locations/spiders/ernst_young.py
+++ b/locations/spiders/ernst_young.py
@@ -1,46 +1,40 @@
-import scrapy
+from typing import Any
 
+import scrapy
+from scrapy.http import Response
 from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 
 
 class ErnstYoungSpider(scrapy.Spider):
     name = "ernst_young"
     item_attributes = {"brand": "EY", "brand_wikidata": "Q489097"}
-    allowed_domains = []
     start_urls = [
-        "https://www.ey.com/eydff/services/officeLocations.json",
+        "https://www.ey.com/content/ey-unified-site/ey-com.office-locations.json?site=ey-com&locale=en_gl",
     ]
 
-    def parse_office(self, office):
-        properties = {
-            "name": office["name"],
-            "ref": office["href"].replace("/locations/", ""),
-            "city": office["officeCity"],
-            "postcode": office["officePostalCode"],
-            "country": office["officeCountry"],
-            "phone": office["officePhoneNumber"],
-            "lat": float(office["officeLatitude"]),
-            "lon": float(office["officeLongitude"]),
-        }
-        if office["officeAddress"]:
-            properties["street_address"] = office["officeAddress"].strip().replace("\r\n", " ")
-        return properties
-
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
-
         for country in data["countries"]:
+            for cities in country["cities"]:
+                for office in cities["offices"]:
+                    yield self.parse_office(office)
             for state in country["states"]:
-                state_abbr = state["stateAbbreviation"]
-                for city in state["cities"]:
-                    for office in city["offices"]:
-                        properties = self.parse_office(office)
-                        properties["state"] = state_abbr
-                        properties["website"] = response.urljoin(office["href"])
-                        yield Feature(**properties)
+                for cities in state["cities"]:
+                    for office in cities["offices"]:
+                        yield self.parse_office(office)
 
-            for city in country["cities"]:
-                for office in city["offices"]:
-                    properties = self.parse_office(office)
-                    properties["website"] = response.urljoin(office["href"])
-                    yield Feature(**properties)
+    def parse_office(self, office: dict) -> Feature:
+        item = Feature()
+        item["name"] = office["officeName"]
+        item["postcode"] = office["officePostalCode"]
+        item["lat"] = office["officeMapLatitude"]
+        item["lon"] = office["officeMapLongitude"]
+        item["city"] = office["cityName"]
+        item["street_address"] = clean_address(office["officeAddress"].replace("<p>", "").replace("</p>", ""))
+        if phone := office.get("phoneInformationDirect"):
+            item["phone"] = phone[0]
+        if state_name := office["stateName"]:
+            item["state"] = state_name
+        item["ref"] = item["website"] = "https://www.ey.com" + office["href"]
+        return item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/EY': 780,
 'atp/brand_wikidata/Q489097': 780,
 'atp/category/office/consulting': 780,
 'atp/country/AE': 3,
 'atp/country/AF': 1,
 'atp/country/AL': 2,
 'atp/country/AM': 1,
 'atp/country/AO': 1,
 'atp/country/AR': 6,
 'atp/country/AT': 4,
 'atp/country/AU': 11,
 'atp/country/AW': 1,
 'atp/country/AZ': 1,
 'atp/country/BA': 2,
 'atp/country/BB': 1,
 'atp/country/BD': 1,
 'atp/country/BE': 10,
 'atp/country/BG': 1,
 'atp/country/BH': 1,
 'atp/country/BM': 2,
 'atp/country/BN': 2,
 'atp/country/BO': 2,
 'atp/country/BR': 16,
 'atp/country/BS': 2,
 'atp/country/BW': 1,
 'atp/country/CA': 17,
 'atp/country/CG': 1,
 'atp/country/CH': 12,
 'atp/country/CI': 1,
 'atp/country/CL': 4,
 'atp/country/CM': 1,
 'atp/country/CN': 28,
 'atp/country/CO': 4,
 'atp/country/CR': 4,
 'atp/country/CW': 1,
 'atp/country/CY': 2,
 'atp/country/CZ': 4,
 'atp/country/DE': 26,
 'atp/country/DK': 10,
 'atp/country/DO': 1,
 'atp/country/DZ': 1,
 'atp/country/EC': 2,
 'atp/country/EE': 1,
 'atp/country/EG': 1,
 'atp/country/ES': 19,
 'atp/country/FI': 18,
 'atp/country/FJ': 1,
 'atp/country/FR': 25,
 'atp/country/GA': 1,
 'atp/country/GB': 23,
 'atp/country/GE': 1,
 'atp/country/GG': 1,
 'atp/country/GH': 1,
 'atp/country/GI': 1,
 'atp/country/GN': 1,
 'atp/country/GR': 3,
 'atp/country/GT': 3,
 'atp/country/GU': 1,
 'atp/country/GY': 1,
 'atp/country/HK': 3,
 'atp/country/HN': 2,
 'atp/country/HR': 2,
 'atp/country/HU': 3,
 'atp/country/ID': 2,
 'atp/country/IE': 5,
 'atp/country/IL': 5,
 'atp/country/IM': 1,
 'atp/country/IN': 21,
 'atp/country/IQ': 2,
 'atp/country/IT': 22,
 'atp/country/JE': 1,
 'atp/country/JM': 1,
 'atp/country/JO': 1,
 'atp/country/JP': 57,
 'atp/country/KE': 1,
 'atp/country/KG': 2,
 'atp/country/KH': 1,
 'atp/country/KR': 4,
 'atp/country/KW': 1,
 'atp/country/KY': 2,
 'atp/country/KZ': 2,
 'atp/country/LA': 1,
 'atp/country/LB': 1,
 'atp/country/LC': 1,
 'atp/country/LI': 1,
 'atp/country/LK': 4,
 'atp/country/LT': 2,
 'atp/country/LU': 1,
 'atp/country/LV': 1,
 'atp/country/MA': 1,
 'atp/country/MC': 1,
 'atp/country/MD': 1,
 'atp/country/ME': 1,
 'atp/country/MK': 1,
 'atp/country/MM': 1,
 'atp/country/MN': 1,
 'atp/country/MO': 1,
 'atp/country/MP': 1,
 'atp/country/MT': 1,
 'atp/country/MU': 1,
 'atp/country/MV': 1,
 'atp/country/MW': 1,
 'atp/country/MX': 15,
 'atp/country/MY': 9,
 'atp/country/MZ': 1,
 'atp/country/NA': 1,
 'atp/country/NC': 1,
 'atp/country/NI': 1,
 'atp/country/NL': 11,
 'atp/country/NO': 33,
 'atp/country/NZ': 4,
 'atp/country/OM': 1,
 'atp/country/PA': 2,
 'atp/country/PE': 3,
 'atp/country/PG': 1,
 'atp/country/PH': 13,
 'atp/country/PK': 3,
 'atp/country/PL': 9,
 'atp/country/PR': 1,
 'atp/country/PS': 1,
 'atp/country/PT': 1,
 'atp/country/PY': 1,
 'atp/country/QA': 1,
 'atp/country/RO': 4,
 'atp/country/RS': 2,
 'atp/country/RW': 1,
 'atp/country/SA': 4,
 'atp/country/SE': 44,
 'atp/country/SG': 5,
 'atp/country/SI': 2,
 'atp/country/SK': 3,
 'atp/country/SN': 1,
 'atp/country/SR': 1,
 'atp/country/SV': 1,
 'atp/country/SY': 1,
 'atp/country/TD': 1,
 'atp/country/TH': 1,
 'atp/country/TN': 1,
 'atp/country/TR': 6,
 'atp/country/TT': 1,
 'atp/country/TW': 6,
 'atp/country/TZ': 1,
 'atp/country/UA': 2,
 'atp/country/UG': 1,
 'atp/country/US': 96,
 'atp/country/UY': 1,
 'atp/country/UZ': 1,
 'atp/country/VE': 3,
 'atp/country/VG': 1,
 'atp/country/VN': 2,
 'atp/country/ZA': 7,
 'atp/country/ZM': 2,
 'atp/country/ZW': 2,
 'atp/field/branch/missing': 780,
 'atp/field/city/missing': 4,
 'atp/field/country/from_reverse_geocoding': 776,
 'atp/field/country/missing': 4,
 'atp/field/email/missing': 780,
 'atp/field/image/missing': 780,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 780,
 'atp/field/operator/missing': 780,
 'atp/field/operator_wikidata/missing': 780,
 'atp/field/phone/invalid': 29,
 'atp/field/phone/missing': 93,
 'atp/field/postcode/missing': 71,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/state/missing': 14,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 780,
 'atp/item_scraped_host_count/www.ey.com': 780,
 'atp/nsi/perfect_match': 780,
 'downloader/request_bytes': 669,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 106630,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.898511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 20, 12, 20, 52, 603863, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 960275,
 'httpcompression/response_count': 2,
 'item_scraped_count': 780,
 'items_per_minute': None,
 'log_count/DEBUG': 793,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 20, 12, 20, 46, 705352, tzinfo=datetime.timezone.utc)}
