### PR TITLE
[Picard] Sync brand with NSI

### DIFF
--- a/locations/spiders/picard_fr.py
+++ b/locations/spiders/picard_fr.py
@@ -1,19 +1,19 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PicardFRSpider(SitemapSpider):
+class PicardFRSpider(SitemapSpider, StructuredDataSpider):
     name = "picard_fr"
-    item_attributes = {"brand": "Picard Surgelés", "brand_wikidata": "Q3382454"}
-
+    item_attributes = {"brand": "Picard", "brand_wikidata": "Q3382454"}
     allowed_domains = ["magasins.picard.fr"]
     sitemap_urls = ["https://magasins.picard.fr/sitemap.xml"]
     sitemap_follow = [r"https:\/\/magasins\.picard\.fr\/locationsitemap\d+\.xml"]
     drop_attributes = {"image"}
+    wanted_types = ["LocalBusiness"]
 
-    def parse(self, response, **kwargs):
-        feature = LinkedDataParser.parse(response, "LocalBusiness")
-        feature["website"] = response.url
-        feature["ref"] = response.url
-        yield feature
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("PICARD ")
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Picard': 1189,
 'atp/brand_wikidata/Q3382454': 1189,
 'atp/category/shop/frozen_food': 1189,
 'atp/country/BE': 16,
 'atp/country/FR': 1155,
 'atp/country/GP': 2,
 'atp/country/GY': 1,
 'atp/country/LU': 2,
 'atp/country/NC': 3,
 'atp/country/RE': 10,
 'atp/field/image/missing': 1189,
 'atp/field/operator/missing': 1189,
 'atp/field/operator_wikidata/missing': 1189,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 1189,
 'atp/field/twitter/missing': 1189,
 'atp/item_scraped_host_count/magasins.picard.fr': 1189,
 'atp/nsi/perfect_match': 1189,
 'downloader/request_bytes': 620545,
 'downloader/request_count': 1200,
 'downloader/request_method_count/GET': 1200,
 'downloader/response_bytes': 21463932,
 'downloader/response_count': 1200,
 'downloader/response_status_count/200': 1194,
 'downloader/response_status_count/502': 3,
 'downloader/response_status_count/503': 3,
 'elapsed_time_seconds': 1439.270132,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 21, 15, 44, 34, 289108, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1185,
 'httpcache/hit': 15,
 'httpcache/miss': 1185,
 'httpcache/store': 1185,
 'httpcompression/response_bytes': 148792667,
 'httpcompression/response_count': 1200,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/502': 1,
 'httperror/response_ignored_status_count/503': 1,
 'item_scraped_count': 1189,
 'items_per_minute': None,
 'log_count/DEBUG': 2401,
 'log_count/ERROR': 2,
 'log_count/INFO': 35,
 'log_count/WARNING': 1,
 'memusage/max': 418467840,
 'memusage/startup': 261754880,
 'request_depth_max': 2,
 'response_received_count': 1196,
 'responses_per_minute': None,
 'retry/count': 4,
 'retry/max_reached': 2,
 'retry/reason_count/502 Bad Gateway': 2,
 'retry/reason_count/503 Service Unavailable': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1199,
 'scheduler/dequeued/memory': 1199,
 'scheduler/enqueued': 1199,
 'scheduler/enqueued/memory': 1199,
 'start_time': datetime.datetime(2025, 1, 21, 15, 20, 35, 18976, tzinfo=datetime.timezone.utc)}
```