### PR TITLE
[styleboxx_de] Add spider (47 locations)

### DIFF
--- a/locations/spiders/styleboxx_de.py
+++ b/locations/spiders/styleboxx_de.py
@@ -1,0 +1,7 @@
+from locations.storefinders.klier_hair_group import KlierHairGroupSpider
+
+
+class StyleboxxDESpider(KlierHairGroupSpider):
+    name = "styleboxx_de"
+    start_urls = ["https://www.styleboxx-klier.de/salons/"]
+    item_attributes = {"brand": "Styleboxx", "brand_wikidata": "Q121888237"}


### PR DESCRIPTION
[Klier Hair Group](https://klierhairgroup.de/) is the biggest hairdresser chain in Germany with several brands. [Styleboxx](https://www.styleboxx-klier.de/) is one of them. When I submitted #11426, Styleboxx had a different website than the other brands. In the meantime they switched to the same structure, so they are easy to add using the common spider class.

```
2025-01-21 20:53:29 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Styleboxx': 47,
 'atp/brand_wikidata/Q121888237': 47,
 'atp/category/shop/hairdresser': 47,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/DE': 47,
 'atp/field/branch/missing': 47,
 'atp/field/country/from_spider_name': 47,
 'atp/field/email/missing': 47,
 'atp/field/image/missing': 47,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 47,
 'atp/field/operator_wikidata/missing': 47,
 'atp/field/state/missing': 47,
 'atp/field/twitter/missing': 47,
 'atp/item_scraped_host_count/www.styleboxx-klier.de': 47,
 'atp/nsi/perfect_match': 47,
```