### PR TITLE
[Optical Center] Fix Spider

### DIFF
--- a/locations/spiders/optical_center.py
+++ b/locations/spiders/optical_center.py
@@ -5,11 +5,12 @@ from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
 
+
 class OpticalCenterSpider(SitemapSpider, StructuredDataSpider):
     name = "optical_center"
     item_attributes = {"brand": "Optical Center", "brand_wikidata": "Q3354448"}
     sitemap_urls = ["https://optician.optical-center.co.uk/sitemap.xml"]
-    sitemap_rules = [("https://optician.optical-center.co.uk/","parse_sd")]
+    sitemap_rules = [("https://optician.optical-center.co.uk/", "parse_sd")]
     sitemap_follow = ["locationsitemap"]
     download_delay = 1
     requires_proxy = True

--- a/locations/spiders/optical_center.py
+++ b/locations/spiders/optical_center.py
@@ -1,24 +1,17 @@
 import html
 import json
 
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
 
-
-class OpticalCenterSpider(CrawlSpider, StructuredDataSpider):
+class OpticalCenterSpider(SitemapSpider, StructuredDataSpider):
     name = "optical_center"
     item_attributes = {"brand": "Optical Center", "brand_wikidata": "Q3354448"}
-    start_urls = ["https://optician.optical-center.co.uk/site-map"]
-    rules = [
-        Rule(
-            LinkExtractor(
-                restrict_xpaths='//a[@class="lf-sitemap-hierarchy__location__link__item lf-site-map__main__content__location__link__item"]'
-            ),
-            callback="parse_sd",
-        )
-    ]
+    sitemap_urls = ["https://optician.optical-center.co.uk/sitemap.xml"]
+    sitemap_rules = [("https://optician.optical-center.co.uk/","parse_sd")]
+    sitemap_follow = ["locationsitemap"]
+    download_delay = 1
     requires_proxy = True
     drop_attributes = {"image"}
 


### PR DESCRIPTION
`Fixes : code updated to use sitemap to fix spider`


{'atp/brand/Optical Center': 908,
 'atp/brand_wikidata/Q3354448': 908,
 'atp/category/shop/optician': 908,
 'atp/country/BE': 15,
 'atp/country/CA': 10,
 'atp/country/CH': 7,
 'atp/country/ES': 3,
 'atp/country/FR': 801,
 'atp/country/GB': 10,
 'atp/country/GP': 1,
 'atp/country/IL': 45,
 'atp/country/LU': 7,
 'atp/country/MQ': 4,
 'atp/country/RE': 5,
 'atp/field/branch/missing': 908,
 'atp/field/email/missing': 12,
 'atp/field/image/missing': 908,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 908,
 'atp/field/operator_wikidata/missing': 908,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 4,
 'atp/field/state/from_reverse_geocoding': 10,
 'atp/field/state/missing': 898,
 'atp/field/twitter/missing': 908,
 'atp/item_scraped_host_count/optician.optical-center.co.uk': 908,
 'atp/nsi/perfect_match': 908,
 'downloader/request_bytes': 507825,
 'downloader/request_count': 912,
 'downloader/request_method_count/GET': 912,
 'downloader/response_bytes': 38460763,
 'downloader/response_count': 912,
 'downloader/response_status_count/200': 912,
 'elapsed_time_seconds': 1111.537084,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 22, 3, 43, 14, 325903, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 375797706,
 'httpcompression/response_count': 912,
 'item_scraped_count': 908,
 'items_per_minute': None,
 'log_count/DEBUG': 1831,
 'log_count/INFO': 27,
 'request_depth_max': 2,
 'response_received_count': 912,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 911,
 'scheduler/dequeued/memory': 911,
 'scheduler/enqueued': 911,
 'scheduler/enqueued/memory': 911,
 'start_time': datetime.datetime(2025, 1, 22, 3, 24, 42, 788819, tzinfo=datetime.timezone.utc)}