### PR TITLE
[Qdoba] Fix Spider

### DIFF
--- a/locations/spiders/qdoba.py
+++ b/locations/spiders/qdoba.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -8,5 +10,9 @@ class QdobaSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Qdoba", "brand_wikidata": "Q1363885"}
     allowed_domains = ["qdoba.com"]
     sitemap_urls = ["https://locations.qdoba.com/sitemap.xml"]
-    sitemap_rules = [(r"com/\w\w/\w\w/[^/]+/[^/]+\.html", "parse")]
-    wanted_types = ["Restaurant"]
+    sitemap_rules = [(r"com/[^/]+/[^/]+/[^/]+/.*", "parse")]
+    wanted_types = ["Organization"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if ld_data.get("geo"):
+            yield item


### PR DESCRIPTION
`Fixes : updated sitemap_rules to fix spider`


{'atp/brand/Qdoba': 2373,
 'atp/brand_wikidata/Q1363885': 2373,
 'atp/category/amenity/fast_food': 2373,
 'atp/cdn/cloudflare/response_count': 2376,
 'atp/cdn/cloudflare/response_status_count/200': 2376,
 'atp/closed_check': 12,
 'atp/country/CA': 39,
 'atp/country/JP': 3,
 'atp/country/PR': 7,
 'atp/country/US': 2324,
 'atp/field/branch/missing': 2373,
 'atp/field/email/missing': 2373,
 'atp/field/image/missing': 2373,
 'atp/field/opening_hours/missing': 1594,
 'atp/field/operator/missing': 2373,
 'atp/field/operator_wikidata/missing': 2373,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 821,
 'atp/field/twitter/missing': 2373,
 'atp/item_scraped_host_count/locations.qdoba.com': 2373,
 'atp/nsi/perfect_match': 2373,
 'downloader/request_bytes': 1321701,
 'downloader/request_count': 2376,
 'downloader/request_method_count/GET': 2376,
 'downloader/response_bytes': 35945522,
 'downloader/response_count': 2376,
 'downloader/response_status_count/200': 2376,
 'elapsed_time_seconds': 2905.372854,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 22, 4, 14, 22, 269971, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 152187648,
 'httpcompression/response_count': 2376,
 'item_scraped_count': 2373,
 'items_per_minute': None,
 'log_count/DEBUG': 4760,
 'log_count/INFO': 57,
 'log_count/WARNING': 12,
 'request_depth_max': 2,
 'response_received_count': 2376,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2375,
 'scheduler/dequeued/memory': 2375,
 'scheduler/enqueued': 2375,
 'scheduler/enqueued/memory': 2375,
 'start_time': datetime.datetime(2025, 1, 22, 3, 25, 56, 897117, tzinfo=datetime.timezone.utc)}