### PR TITLE
[Marathon Petroleum US] Fix Spider

### DIFF
--- a/locations/spiders/marathon_petroleum_us.py
+++ b/locations/spiders/marathon_petroleum_us.py
@@ -12,11 +12,9 @@ class MarathonPetroleumUSSpider(Spider):
         "ARCO": {"brand": "Arco", "brand_wikidata": "Q304769"},
         "MARATHON": {"brand": "Marathon", "brand_wikidata": "Q458363"},
     }
-    allowed_domains = ["devmarathon.dialogs8.com"]
     start_urls = [
-        "https://devmarathon.dialogs8.com/ajax_stations_search.html?reason=get-station-info&reason=get-station-info"
+        "https://www.marathonarcorewards.com/ajax_trip_planner_search.html?reason=get-station-info&reason=get-station-info"
     ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         for url in self.start_urls:


### PR DESCRIPTION
`Fixes : updated start_urls to fix spider`

{'atp/brand/Arco': 1224,
 'atp/brand/Marathon': 6081,
 'atp/brand_wikidata/Q304769': 1224,
 'atp/brand_wikidata/Q458363': 6081,
 'atp/category/amenity/fuel': 7305,
 'atp/country/US': 7305,
 'atp/field/branch/missing': 7305,
 'atp/field/country/from_spider_name': 7305,
 'atp/field/email/missing': 7305,
 'atp/field/image/missing': 7305,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 7305,
 'atp/field/operator/missing': 7305,
 'atp/field/operator_wikidata/missing': 7305,
 'atp/field/phone/invalid': 17,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 7305,
 'atp/field/website/missing': 7305,
 'atp/item_scraped_host_count/www.marathonarcorewards.com': 7305,
 'downloader/request_bytes': 937,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 687054,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 22.575534,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 22, 8, 34, 51, 241784, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3911394,
 'httpcompression/response_count': 2,
 'item_scraped_count': 7305,
 'items_per_minute': None,
 'log_count/DEBUG': 7318,
 'log_count/INFO': 9,
 'log_count/WARNING': 705,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 22, 8, 34, 28, 666250, tzinfo=datetime.timezone.utc)}