### PR TITLE
[Burger King KR] Fix spider

### DIFF
--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -17,42 +17,37 @@ class BurgerKingKRSpider(JSONBlobSpider):
     locations_key = ["body", "storInfo"]
 
     def start_requests(self) -> Iterable[JsonRequest | Request]:
-        headers = {
-            "accept": "*/*",
-            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-        }
-        data = {
-            "message": json.dumps(
-                {
-                    "header": {
-                        "result": True,
-                        "error_code": "",
-                        "error_text": "",
-                        "info_text": "",
-                        "message_version": "",
-                        "login_session_id": "",
-                        "trcode": "BKR0343",
-                        "cd_call_chnn": "01",
-                    },
-                    "body": {
-                        "dataCount": "2000",
-                        "membershipYn": "",
-                        "orderType": "01",
-                        "page": "1",
-                        "searchKeyword": "",
-                        "serviceCode": [],
-                        "sort": "02",
-                        "yCoordinates": "37.5726506",
-                        "xCoordinates": "126.9810922",
-                        "isAllYn": "Y",
-                    },
-                }
-            )
-        }
         yield FormRequest(
             url="https://www.burgerking.co.kr/burgerking/BKR0343.json",
-            headers=headers,
-            formdata=data,
+            headers={"accept": "*/*"},
+            formdata={
+                "message": json.dumps(
+                    {
+                        "header": {
+                            "result": True,
+                            "error_code": "",
+                            "error_text": "",
+                            "info_text": "",
+                            "message_version": "",
+                            "login_session_id": "",
+                            "trcode": "BKR0343",
+                            "cd_call_chnn": "01",
+                        },
+                        "body": {
+                            "dataCount": "2000",
+                            "membershipYn": "",
+                            "orderType": "01",
+                            "page": "1",
+                            "searchKeyword": "",
+                            "serviceCode": [],
+                            "sort": "02",
+                            "yCoordinates": "37.5726506",
+                            "xCoordinates": "126.9810922",
+                            "isAllYn": "Y",
+                        },
+                    }
+                )
+            },
         )
 
     def post_process_item(self, item, response, location):

--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -5,6 +5,7 @@ from scrapy import FormRequest, Request
 from scrapy.http import JsonRequest
 
 from locations.categories import Extras, apply_yes_no
+from locations.hours import DAYS_WEEKDAY, DAYS_WEEKEND, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
@@ -64,4 +65,8 @@ class BurgerKingKRSpider(JSONBlobSpider):
             services = [service["storeServiceName"] for service in services]
             apply_yes_no(Extras.DRIVE_THROUGH, item, "드라이브스루" in services, False)
             apply_yes_no(Extras.DELIVERY, item, "딜리버리" in services, False)
+
+        item["opening_hours"] = OpeningHours()
+        for days_key, days_val in [("storTimeDays", DAYS_WEEKDAY), ("storTimeWeekend", DAYS_WEEKEND)]:
+            item["opening_hours"].add_days_range(days_val, *location[days_key].split("~"))
         yield item

--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -7,13 +7,12 @@ from scrapy.http import JsonRequest
 from locations.categories import Extras, apply_yes_no
 from locations.hours import DAYS_WEEKDAY, DAYS_WEEKEND, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
-from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
 
 class BurgerKingKRSpider(JSONBlobSpider):
     download_timeout = 60
     name = "burger_king_kr"
-    item_attributes = BURGER_KING_SHARED_ATTRIBUTES
+    item_attributes = {"brand_wikidata": "Q177054"}
     locations_key = ["body", "storInfo"]
 
     def start_requests(self) -> Iterable[JsonRequest | Request]:

--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -61,6 +61,7 @@ class BurgerKingKRSpider(JSONBlobSpider):
         item["lon"] = location["storCoordX"]
         item["branch"] = location["storNm"]
         item["addr_full"] = location["storAddr"]
+        item["phone"] = location["storTelNo"]
         if services := location.get("storeServiceCodeList"):
             services = [service["storeServiceName"] for service in services]
             apply_yes_no(Extras.DRIVE_THROUGH, item, "드라이브스루" in services, False)

--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -1,7 +1,11 @@
+import json
+from typing import Iterable
+
+from scrapy import FormRequest, Request
+from scrapy.http import JsonRequest
+
 from locations.categories import Extras, apply_yes_no
-from locations.hours import DAYS, DAYS_KR, DELIMITERS_KR, NAMED_DAY_RANGES_KR, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 
 
@@ -9,26 +13,55 @@ class BurgerKingKRSpider(JSONBlobSpider):
     download_timeout = 60
     name = "burger_king_kr"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    start_urls = ["https://burgerking.co.kr/store/selectStore.json"]
-    locations_key = ["body", "storeList"]
+    locations_key = ["body", "storInfo"]
+
+    def start_requests(self) -> Iterable[JsonRequest | Request]:
+        headers = {
+            "accept": "*/*",
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+        }
+        data = {
+            "message": json.dumps(
+                {
+                    "header": {
+                        "result": True,
+                        "error_code": "",
+                        "error_text": "",
+                        "info_text": "",
+                        "message_version": "",
+                        "login_session_id": "",
+                        "trcode": "BKR0343",
+                        "cd_call_chnn": "01",
+                    },
+                    "body": {
+                        "dataCount": "2000",
+                        "membershipYn": "",
+                        "orderType": "01",
+                        "page": "1",
+                        "searchKeyword": "",
+                        "serviceCode": [],
+                        "sort": "02",
+                        "yCoordinates": "37.5726506",
+                        "xCoordinates": "126.9810922",
+                        "isAllYn": "Y",
+                    },
+                }
+            )
+        }
+        yield FormRequest(
+            url="https://www.burgerking.co.kr/burgerking/BKR0343.json",
+            headers=headers,
+            formdata=data,
+        )
 
     def post_process_item(self, item, response, location):
-        item["ref"] = location["STOR_CD"]
-        item["lat"] = location["STOR_COORD_Y"]
-        item["lon"] = location["STOR_COORD_X"]
-        item["branch"] = location["STOR_NM"]
-        item["street_address"] = location["ADDR_1"]
-        item["addr_full"] = clean_address([location["ADDR_1"], location["ADDR_2"]])
-        apply_yes_no(Extras.DRIVE_THROUGH, item, location["DIRVE_TH"] == "1", False)
-        apply_yes_no(Extras.DELIVERY, item, location["DLVYN"] == "1", False)
-
-        item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_ranges_from_string(
-            location["STORE_TIME"], days=DAYS_KR, named_day_ranges=NAMED_DAY_RANGES_KR, delimiters=DELIMITERS_KR
-        )
-        if location["DLVYN"] == "1":
-            oh = OpeningHours()
-            oh.add_days_range(DAYS, location["DLV_START_TIME"], location["DLV_FNSH_TIME"], time_format="%H%M")
-            item["extras"]["opening_hours:delivery"] = oh.as_opening_hours()
-
+        item["ref"] = location["storCd"]
+        item["lat"] = location["storCoordY"]
+        item["lon"] = location["storCoordX"]
+        item["branch"] = location["storNm"]
+        item["addr_full"] = location["storAddr"]
+        if services := location.get("storeServiceCodeList"):
+            services = [service["storeServiceName"] for service in services]
+            apply_yes_no(Extras.DRIVE_THROUGH, item, "드라이브스루" in services, False)
+            apply_yes_no(Extras.DELIVERY, item, "딜리버리" in services, False)
         yield item

--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -64,4 +64,7 @@ class BurgerKingKRSpider(JSONBlobSpider):
         item["opening_hours"] = OpeningHours()
         for days_key, days_val in [("storTimeDays", DAYS_WEEKDAY), ("storTimeWeekend", DAYS_WEEKEND)]:
             item["opening_hours"].add_days_range(days_val, *location[days_key].split("~"))
+
+        item["website"] = "https://www.burgerking.co.kr/store/{}".format(item["ref"])
+
         yield item


### PR DESCRIPTION
Previously used API no longer working, new API used and code refactored accordingly to fix the spider.

```
{'atp/brand/Burger King': 514,
 'atp/brand_wikidata/Q177054': 514,
 'atp/category/amenity/fast_food': 514,
 'atp/country/KR': 514,
 'atp/field/city/missing': 514,
 'atp/field/country/from_spider_name': 514,
 'atp/field/email/missing': 514,
 'atp/field/image/missing': 514,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 514,
 'atp/field/operator_wikidata/missing': 514,
 'atp/field/postcode/missing': 514,
 'atp/field/state/missing': 514,
 'atp/field/street_address/missing': 514,
 'atp/field/twitter/missing': 514,
 'atp/field/website/missing': 514,
 'atp/item_scraped_host_count/www.burgerking.co.kr': 514,
 'atp/nsi/cc_match': 514,
 'downloader/request_bytes': 1267,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1105736,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.708435,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 22, 10, 7, 54, 820950, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2006,
 'httpcompression/response_count': 1,
 'item_scraped_count': 514,
 'items_per_minute': None,
 'log_count/DEBUG': 528,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 22, 10, 7, 49, 112515, tzinfo=datetime.timezone.utc)}
```