### PR TITLE
[Pizza Hut TR] Make spider stable against TimeOutError

### DIFF
--- a/locations/spiders/pizza_hut_tr.py
+++ b/locations/spiders/pizza_hut_tr.py
@@ -11,6 +11,7 @@ class PizzaHutTRSpider(scrapy.Spider):
     name = "pizza_hut_tr"
     item_attributes = PizzaHutUSSpider.PIZZA_HUT
     start_urls = ["https://www.pizzahut.com.tr/static/js/main.c39af298.chunk.js"]
+    download_timeout = 90
 
     def parse(self, response, **kwargs):
         if match := re.search(r"Username[:\s]+\"(.+?)\"[\s,]+Password[:\s]+\"(.+?)\"", response.text):


### PR DESCRIPTION
Spider some times failed because of `TimeOutError`,  increased `download_timeout`  value, to avoid this kind of failure as it already happened in one of the [run](https://alltheplaces-data.openaddresses.io/runs/2024-12-21-13-32-12/logs/pizza_hut_tr.txt) in past. 

```
{'atp/brand/Pizza Hut': 258,
 'atp/brand_wikidata/Q191615': 258,
 'atp/category/amenity/restaurant': 258,
 'atp/cdn/cloudflare/response_count': 6,
 'atp/cdn/cloudflare/response_status_count/200': 4,
 'atp/cdn/cloudflare/response_status_count/404': 2,
 'atp/country/TR': 258,
 'atp/field/branch/missing': 258,
 'atp/field/city/missing': 258,
 'atp/field/country/from_spider_name': 258,
 'atp/field/email/missing': 258,
 'atp/field/image/missing': 258,
 'atp/field/lat/missing': 38,
 'atp/field/lon/missing': 38,
 'atp/field/opening_hours/missing': 258,
 'atp/field/operator/missing': 258,
 'atp/field/operator_wikidata/missing': 258,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 224,
 'atp/field/postcode/missing': 258,
 'atp/field/state/missing': 258,
 'atp/field/street_address/missing': 258,
 'atp/field/twitter/missing': 258,
 'atp/field/website/missing': 258,
 'atp/item_scraped_host_count/api.pizzahut.com.tr': 258,
 'atp/nsi/cc_match': 258,
 'downloader/request_bytes': 3143,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 5,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 366871,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 4,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 44.22956,

```