### PR TITLE
[State Farm US] Flag as requires proxy

### DIFF
--- a/locations/spiders/state_farm_us.py
+++ b/locations/spiders/state_farm_us.py
@@ -21,6 +21,7 @@ class StateFarmUSSpider(SitemapSpider, StructuredDataSpider):
             "User-Agent": BROWSER_DEFAULT,
         },
     }
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response, ld_data, **kwargs):
         mainEntity = ld_data.get("mainEntity")


### PR DESCRIPTION
`Fixes : spider works fine from IN, adding  proxy might resolve the issue.`

{'atp/brand/State Farm': 19497,
 'atp/brand_wikidata/Q2007336': 19497,
 'atp/category/office/insurance': 19497,
 'atp/country/US': 19497,
 'atp/field/branch/missing': 19497,
 'atp/field/email/missing': 19497,
 'atp/field/image/missing': 478,
 'atp/field/opening_hours/missing': 19497,
 'atp/field/operator/missing': 19497,
 'atp/field/operator_wikidata/missing': 19497,
 'atp/field/twitter/missing': 17169,
 'atp/item_scraped_host_count/www.statefarm.com': 19497,
 'atp/nsi/perfect_match': 19265,
 'downloader/request_bytes': 17981043,
 'downloader/request_count': 20199,
 'downloader/request_method_count/GET': 20199,
 'downloader/response_bytes': 373206645,
 'downloader/response_count': 20199,
 'downloader/response_status_count/200': 19266,
 'downloader/response_status_count/308': 933,
 'elapsed_time_seconds': 49325.414783,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 22, 22, 36, 44, 154748, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1186711472,
 'httpcompression/response_count': 19266,
 'item_scraped_count': 19497,
 'items_per_minute': None,
 'log_count/DEBUG': 39707,
 'log_count/INFO': 831,
 'request_depth_max': 1,
 'response_received_count': 19266,
 'responses_per_minute': None,
 'scheduler/dequeued': 20199,
 'scheduler/dequeued/memory': 20199,
 'scheduler/enqueued': 20199,
 'scheduler/enqueued/memory': 20199,
 'start_time': datetime.datetime(2025, 1, 22, 8, 54, 38, 739965, tzinfo=datetime.timezone.utc)}