### PR TITLE
[Migros CH] Fix Spider

### DIFF
--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -1,7 +1,6 @@
 import json
 import re
 
-import chompjs
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -38,7 +37,12 @@ class MigrosCHSpider(SitemapSpider):
 
     def parse(self, response):
 
-        data = json.loads(re.search(r'({.*})\]n',response.xpath('//*[contains(text(),"initialActiveStore")]/text()').get().replace('\\',"")).group(1))
+        data = json.loads(
+            re.search(
+                r"({.*})\]n",
+                response.xpath('//*[contains(text(),"initialActiveStore")]/text()').get().replace("\\", ""),
+            ).group(1)
+        )
         store = data["initialActiveStore"]
         loc = store["location"]
         for market in store["markets"]:

--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -1,5 +1,7 @@
 import json
+import re
 
+import chompjs
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -35,13 +37,12 @@ class MigrosCHSpider(SitemapSpider):
     sitemap_rules = [(r"https://filialen\.migros\.ch/de/", "parse")]
 
     def parse(self, response):
-        data_js = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
-        data = json.loads(data_js)
-        page_props = data["props"]["pageProps"]
-        store = page_props["initialActiveStore"]
+
+        data = json.loads(re.search(r'({.*})\]n',response.xpath('//*[contains(text(),"initialActiveStore")]/text()').get().replace('\\',"")).group(1))
+        store = data["initialActiveStore"]
         loc = store["location"]
         for market in store["markets"]:
-            if market["slug"] != page_props["initialSlug"]:
+            if market["slug"] != data["initialSlug"]:
                 continue
             brand_key = market["type"].split("_")[0]
             if brand_key not in self.brands:


### PR DESCRIPTION
`Fixes : updated parse method to fix spider`

{'atp/brand/Alnatura': 25,
 'atp/brand/Do It + Garden': 42,
 'atp/brand/Florissimo': 285,
 'atp/brand/Micasa': 39,
 'atp/brand/Migrolino': 317,
 'atp/brand/Migros': 666,
 'atp/brand/Migros Café': 5,
 'atp/brand/Migros Change': 14,
 'atp/brand/Migros Partner': 45,
 'atp/brand/Migros Restaurant': 140,
 'atp/brand/Migros Take Away': 90,
 'atp/brand/OBI': 7,
 'atp/brand/Outlet Migros': 28,
 'atp/brand/PickMup Box': 186,
 'atp/brand/SportXX': 49,
 'atp/brand/VOI': 76,
 'atp/brand_wikidata/Q108866119': 42,
 'atp/brand_wikidata/Q110277616': 76,
 'atp/brand_wikidata/Q111803848': 140,
 'atp/brand_wikidata/Q111826610': 90,
 'atp/brand_wikidata/Q115659418': 285,
 'atp/brand_wikidata/Q115659564': 28,
 'atp/brand_wikidata/Q115659823': 14,
 'atp/brand_wikidata/Q115661152': 666,
 'atp/brand_wikidata/Q115661379': 5,
 'atp/brand_wikidata/Q115661515': 45,
 'atp/brand_wikidata/Q115679275': 186,
 'atp/brand_wikidata/Q1926676': 39,
 'atp/brand_wikidata/Q19309319': 49,
 'atp/brand_wikidata/Q300518': 7,
 'atp/brand_wikidata/Q56745088': 317,
 'atp/brand_wikidata/Q876811': 25,
 'atp/category/amenity/bureau_de_change': 14,
 'atp/category/amenity/cafe': 5,
 'atp/category/amenity/fast_food': 90,
 'atp/category/amenity/product_pickup': 186,
 'atp/category/amenity/recycling': 666,
 'atp/category/amenity/restaurant': 140,
 'atp/category/multiple': 666,
 'atp/category/shop/convenience': 317,
 'atp/category/shop/doityourself': 49,
 'atp/category/shop/florist': 285,
 'atp/category/shop/furniture': 39,
 'atp/category/shop/sports': 49,
 'atp/category/shop/supermarket': 174,
 'atp/closed_poi': 39,
 'atp/country/CH': 2002,
 'atp/country/FR': 5,
 'atp/country/LI': 7,
 'atp/field/branch/missing': 2014,
 'atp/field/email/missing': 118,
 'atp/field/image/missing': 2014,
 'atp/field/opening_hours/invalid': 5,
 'atp/field/operator/missing': 1348,
 'atp/field/operator_wikidata/missing': 1348,
 'atp/field/phone/invalid': 9,
 'atp/field/phone/missing': 15,
 'atp/field/state/missing': 2014,
 'atp/field/twitter/missing': 2014,
 'atp/item_scraped_host_count/filialen.migros.ch': 2014,
 'atp/nsi/brand_missing': 644,
 'atp/nsi/perfect_match': 1370,
 'atp/operator/Migros': 666,
 'atp/operator_wikidata/Q115661152': 666,
 'downloader/request_bytes': 778930,
 'downloader/request_count': 2028,
 'downloader/request_method_count/GET': 2028,
 'downloader/response_bytes': 29198951,
 'downloader/response_count': 2028,
 'downloader/response_status_count/200': 2028,
 'elapsed_time_seconds': 1341.859179,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 23, 10, 42, 19, 634606, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 117859090,
 'httpcompression/response_count': 2017,
 'item_scraped_count': 2014,
 'items_per_minute': None,
 'log_count/DEBUG': 4054,
 'log_count/ERROR': 1,
 'log_count/INFO': 31,
 'request_depth_max': 2,
 'response_received_count': 2028,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2027,
 'scheduler/dequeued/memory': 2027,
 'scheduler/enqueued': 2027,
 'scheduler/enqueued/memory': 2027,
 'start_time': datetime.datetime(2025, 1, 23, 10, 19, 57, 775427, tzinfo=datetime.timezone.utc)}