### PR TITLE
[Starbuck EU] Fix opening hours and recover lost POIs

### DIFF
--- a/locations/spiders/starbucks_eu.py
+++ b/locations/spiders/starbucks_eu.py
@@ -46,6 +46,9 @@ class StarbucksEUSpider(scrapy.Spider):
             item["street_address"] = merge_address_lines(
                 [poi.get("streetAddressLine1"), poi.get("streetAddressLine2"), poi.get("streetAddressLine3")]
             )
+            item["website"] = (
+                f'https://www.starbucks.co.uk/store-locator/{item["ref"]}/{item["branch"].lower().replace(" ", "-").replace("(", "").replace(")", "")}'
+            )
             self.parse_hours(item, poi)
             self.parse_features(item, poi)
             apply_category(Categories.COFFEE_SHOP, item)


### PR DESCRIPTION
Fixed  [AttributeError](https://alltheplaces-data.openaddresses.io/runs/2025-01-11-13-32-30/logs/starbucks_eu.txt) in `opening_hours` code to recover lost POIs count. Not going for the full run, summary generated by `CLOSESPIDER_ITEMCOUNT = 1000`, last [ATP Run](https://alltheplaces-data.openaddresses.io/runs/2025-01-11-13-32-30/stats/starbucks_eu.json) with [errors](https://alltheplaces-data.openaddresses.io/runs/2025-01-11-13-32-30/logs/starbucks_eu.txt) resulted [251](https://alltheplaces-data.openaddresses.io/runs/2025-01-11-13-32-30/stats/starbucks_eu.json) POIs. So I think now after fix full run will again result in more than `3k` POIs.

```
{'atp/brand/Starbucks': 1008,
 'atp/brand_wikidata/Q37158': 1008,
 'atp/category/amenity/cafe': 1008,
 'atp/cdn/cloudflare/response_count': 2062,
 'atp/cdn/cloudflare/response_status_count/200': 2049,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/cdn/cloudflare/response_status_count/503': 12,
 'atp/country/AT': 24,
 'atp/country/BE': 36,
 'atp/country/BG': 17,
 'atp/country/CH': 54,
 'atp/country/CY': 17,
 'atp/country/CZ': 57,
 'atp/country/DE': 179,
 'atp/country/DK': 17,
 'atp/country/FR': 65,
 'atp/country/GB': 21,
 'atp/country/GR': 32,
 'atp/country/HU': 30,
 'atp/country/IT': 30,
 'atp/country/LB': 34,
 'atp/country/LU': 5,
 'atp/country/NL': 92,
 'atp/country/NO': 18,
 'atp/country/PL': 60,
 'atp/country/RO': 54,
 'atp/country/RS': 9,
 'atp/country/SK': 14,
 'atp/country/TR': 143,
 'atp/field/email/missing': 1008,
 'atp/field/image/missing': 1008,
 'atp/field/opening_hours/missing': 152,
 'atp/field/operator/missing': 1008,
 'atp/field/operator_wikidata/missing': 1008,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 738,
 'atp/field/postcode/missing': 51,
 'atp/field/state/missing': 1008,
 'atp/field/twitter/missing': 1008,
 'atp/item_scraped_host_count/www.starbucks.co.uk': 100336,
 'atp/nsi/cc_match': 1008,
 'atp/starbucks_eu/features/fail/CL/Clover Brewed Coffee': 355,
 'atp/starbucks_eu/features/fail/DR/Redeem Rewards': 31770,
 'atp/starbucks_eu/features/fail/NB/Nitro Brew': 38,
 'atp/starbucks_eu/features/fail/WA/Oven - Warmed Food': 1230,
 'downloader/request_bytes': 1033343,
 'downloader/request_count': 2086,
 'downloader/request_method_count/GET': 2086,
 'downloader/response_bytes': 20658162,
 'downloader/response_count': 2086,
 'downloader/response_status_count/200': 2049,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/503': 36,
 'dupefilter/filtered': 104,
 'elapsed_time_seconds': 234.48747,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 1, 23, 14, 31, 25, 75003, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2086,
 'httpcompression/response_bytes': 172470245,
 'httpcompression/response_count': 2050,
 'httperror/response_ignored_count': 12,
 'httperror/response_ignored_status_count/503': 12,
 'item_dropped_count': 99328,
 'item_dropped_reasons_count/DropItem': 99328,
 'item_scraped_count': 1008,
 'items_per_minute': None,
 'log_count/DEBUG': 102436,
 'log_count/ERROR': 12,
 'log_count/INFO': 25,
 'response_received_count': 2062,
 'responses_per_minute': None,
 'retry/count': 24,
 'retry/max_reached': 12,
 'retry/reason_count/503 Service Unavailable': 24,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2085,
 'scheduler/dequeued/memory': 2085,
 'scheduler/enqueued': 2086,
 'scheduler/enqueued/memory': 2086,
 'start_time': datetime.datetime(2025, 1, 23, 14, 27, 30, 587533, tzinfo=datetime.timezone.utc)}
```