### PR TITLE
[Stadt Zuerich CH] Fix Attribute Error & Recover Lost POI's Spider

### DIFF
--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -65,6 +65,8 @@ class StadtZuerichCHSpider(scrapy.Spider):
     def parse(self, response):
         for f in response.json()["features"]:
             if item := self.parse_item(f):
+                if item["ref"] == "vap105184":
+                    continue
                 yield item
 
     def parse_item(self, f):

--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -11,7 +11,7 @@ from locations.materials import MATERIALS_DE
 class StadtZuerichCHSpider(scrapy.Spider):
     name = "stadt_zuerich_ch"
     allowed_domains = ["ogd.stadt-zuerich.ch"]
-    download_timeout = 15
+    download_timeout = 20
 
     dataset_attributes = {
         "attribution": "optional",

--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -11,6 +11,7 @@ from locations.materials import MATERIALS_DE
 class StadtZuerichCHSpider(scrapy.Spider):
     name = "stadt_zuerich_ch"
     allowed_domains = ["ogd.stadt-zuerich.ch"]
+    download_timeout = 15
 
     dataset_attributes = {
         "attribution": "optional",
@@ -103,7 +104,8 @@ class StadtZuerichCHSpider(scrapy.Spider):
             "wvz_brunnen": self.parse_fountain,
             "zweiradabstellplaetze_p": self.parse_bicycle_parking,
         }.get(id.split(".")[0]):
-            tags.update(parser(props))
+            if parser(props) is not None:
+                tags.update(parser(props))
 
         item = {
             "addr_full": tags.pop("addr:full", None),
@@ -209,14 +211,15 @@ class StadtZuerichCHSpider(scrapy.Spider):
             "Beide": {"amenity": "bicycle_parking", "motorcycle": "yes"},
         }.get(p["name"])
         operator, operator_wikidata = self.operators["Tiefbauamt"]
-        tags.update(
-            {
-                "capacity": str(int(p.get("anzahl_pp", 0))) or None,
-                "name": None,
-                "operator": operator,
-                "operator:wikidata": operator_wikidata,
-            }
-        )
+        if tags is not None:
+            tags.update(
+                {
+                    "capacity": str(int(p.get("anzahl_pp", 0))) or None,
+                    "name": None,
+                    "operator": operator,
+                    "operator:wikidata": operator_wikidata,
+                }
+            )
         return tags
 
     def parse_fountain(self, p):


### PR DESCRIPTION
`Fixes : fix attribute error & recover lost POI's`


{'atp/category/amenity/bench': 7267,
 'atp/category/amenity/bicycle_parking': 1927,
 'atp/category/amenity/fountain': 1287,
 'atp/category/amenity/kindergarten': 371,
 'atp/category/amenity/motorcycle_parking': 122,
 'atp/category/amenity/police': 81,
 'atp/category/amenity/recycling': 178,
 'atp/category/amenity/school': 657,
 'atp/category/amenity/toilets': 91,
 'atp/category/highway/street_lamp': 41926,
 'atp/category/leisure/park': 124,
 'atp/category/missing': 1,
 'atp/category/multiple': 1,
 'atp/country/CH': 54032,
 'atp/field/branch/missing': 54032,
 'atp/field/brand/missing': 54032,
 'atp/field/brand_wikidata/missing': 54032,
 'atp/field/email/missing': 53854,
 'atp/field/image/missing': 54032,
 'atp/field/name/missing': 52707,
 'atp/field/opening_hours/missing': 53467,
 'atp/field/operator/missing': 1288,
 'atp/field/operator_wikidata/missing': 1288,
 'atp/field/phone/invalid': 16,
 'atp/field/phone/missing': 52679,
 'atp/field/postcode/missing': 52656,
 'atp/field/state/missing': 54032,
 'atp/field/street_address/missing': 54032,
 'atp/field/twitter/missing': 54032,
 'atp/field/website/missing': 54032,
 'atp/item_scraped_host_count/www.ogd.stadt-zuerich.ch': 54032,
 'atp/nsi/cc_match': 124,
 'atp/nsi/match_failed': 49193,
 'atp/nsi/operator_missing': 3168,
 'atp/nsi/perfect_match': 259,
 'atp/operator/Elektrizitätswerk der Stadt Zürich': 41926,
 'atp/operator/Entsorgung + Recycling Zürich': 178,
 'atp/operator/Grün Stadt Zürich': 7391,
 'atp/operator/Schul- und Sportdepartement': 1,
 'atp/operator/Schulamt der Stadt Zürich': 1027,
 'atp/operator/Stadtpolizei Zürich': 81,
 'atp/operator/Tiefbauamt der Stadt Zürich': 2049,
 'atp/operator/Umwelt- und Gesundheitsschutz Zürich': 91,
 'atp/operator_wikidata/Q115267460': 2049,
 'atp/operator_wikidata/Q115271935': 91,
 'atp/operator_wikidata/Q115322776': 1027,
 'atp/operator_wikidata/Q1326645': 41926,
 'atp/operator_wikidata/Q1345452': 178,
 'atp/operator_wikidata/Q1551785': 7391,
 'atp/operator_wikidata/Q2327949': 81,
 'atp/operator_wikidata/Q33121519': 1,
 'downloader/request_bytes': 5448,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 15319639,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 12,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 55.383576,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 24, 5, 27, 56, 480620, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 54032,
 'items_per_minute': None,
 'log_count/DEBUG': 54072,
 'log_count/INFO': 9,
 'response_received_count': 13,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2025, 1, 24, 5, 27, 1, 97044, tzinfo=datetime.timezone.utc)}