### PR TITLE
[JD Wetherspoon] Fix Spider

### DIFF
--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -1,3 +1,4 @@
+import html
 from typing import Any
 
 import chompjs
@@ -15,7 +16,8 @@ class JDWetherspoonSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in chompjs.parse_js_object(response.xpath('//*[contains(text(),"pubsData")]/text()').get()):
             item = DictParser.parse(location)
-            item["ref"] = item["website"]
+            item["name"] = html.unescape(item["name"])
             item["image"] = location["featured_image"]
+            item["ref"] = item["website"]
 
             yield item

--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -15,11 +15,9 @@ class JDWetherspoonSpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in chompjs.parse_js_object(
-            response.xpath('//script[@id="filter-google-maps-js-after"]/text()').get()
+            response.xpath('//*[contains(text(),"pubsData")]/text()').get()
         ):
             item = DictParser.parse(location)
-            item["name"] = html.unescape(item["name"])
-            item["image"] = location["featured_image"]
             item["ref"] = item["website"]
 
             yield item

--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -16,5 +16,6 @@ class JDWetherspoonSpider(Spider):
         for location in chompjs.parse_js_object(response.xpath('//*[contains(text(),"pubsData")]/text()').get()):
             item = DictParser.parse(location)
             item["ref"] = item["website"]
+            item["image"] = location["featured_image"]
 
             yield item

--- a/locations/spiders/j_d_wetherspoon.py
+++ b/locations/spiders/j_d_wetherspoon.py
@@ -1,4 +1,3 @@
-import html
 from typing import Any
 
 import chompjs
@@ -14,9 +13,7 @@ class JDWetherspoonSpider(Spider):
     start_urls = ["https://www.jdwetherspoon.com/pub-search/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in chompjs.parse_js_object(
-            response.xpath('//*[contains(text(),"pubsData")]/text()').get()
-        ):
+        for location in chompjs.parse_js_object(response.xpath('//*[contains(text(),"pubsData")]/text()').get()):
             item = DictParser.parse(location)
             item["ref"] = item["website"]
 


### PR DESCRIPTION
`Fixes : updated xpath to fix spider`

{'atp/brand/Wetherspoon': 799,
 'atp/brand_wikidata/Q6109362': 799,
 'atp/category/amenity/pub': 799,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/GB': 793,
 'atp/country/IE': 6,
 'atp/field/branch/missing': 799,
 'atp/field/city/missing': 799,
 'atp/field/country/from_reverse_geocoding': 799,
 'atp/field/email/missing': 799,
 'atp/field/image/missing': 799,
 'atp/field/opening_hours/missing': 799,
 'atp/field/operator/missing': 799,
 'atp/field/operator_wikidata/missing': 799,
 'atp/field/phone/missing': 799,
 'atp/field/street_address/missing': 799,
 'atp/field/twitter/missing': 799,
 'atp/item_scraped_host_count/www.jdwetherspoon.com': 799,
 'atp/nsi/perfect_match': 799,
 'downloader/request_bytes': 792,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 74686,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.346883,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 24, 10, 7, 48, 942379, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 526176,
 'httpcompression/response_count': 2,
 'item_scraped_count': 799,
 'items_per_minute': None,
 'log_count/DEBUG': 812,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 24, 10, 7, 42, 595496, tzinfo=datetime.timezone.utc)}