### PR TITLE
[Martin's Super Markets US] Fix brand:wikidata

### DIFF
--- a/locations/spiders/martins_us.py
+++ b/locations/spiders/martins_us.py
@@ -7,6 +7,6 @@ class MartinsUSSpider(FreshopSpider):
     app_key = "martins"
     item_attributes = {
         "brand": "Martin's Super Markets",
-        "brand_wikidata": "Q7573912",
+        "brand_wikidata": "Q6774803",
         "extras": Categories.SHOP_SUPERMARKET.value,
     }

--- a/locations/spiders/martins_us.py
+++ b/locations/spiders/martins_us.py
@@ -1,12 +1,15 @@
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.storefinders.freshop import FreshopSpider
 
 
 class MartinsUSSpider(FreshopSpider):
     name = "martins_us"
+    item_attributes = {"brand": "Martin's Super Markets", "brand_wikidata": "Q6774803"}
     app_key = "martins"
-    item_attributes = {
-        "brand": "Martin's Super Markets",
-        "brand_wikidata": "Q6774803",
-        "extras": Categories.SHOP_SUPERMARKET.value,
-    }
+
+    def parse_item(self, item, location):
+        item["branch"] = item.pop("name")
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item


### PR DESCRIPTION
BTW, in NSI it is also Q6774803 - matching state after this PR ( https://github.com/osmlab/name-suggestion-index/blob/main/data/brands/shop/supermarket.json#L5053C28-L5053C36 ) - though this by itself it does not mean it is correct