### PR TITLE
[tuev_nord_de] Add spider (402 locations)

### DIFF
--- a/locations/spiders/tuev_nord_de.py
+++ b/locations/spiders/tuev_nord_de.py
@@ -1,0 +1,24 @@
+import json
+
+import scrapy
+
+from locations.dict_parser import DictParser
+
+
+class TuevNordDESpider(scrapy.Spider):
+
+    name = "tuev_nord_de"
+    item_attributes = {"brand": "TÜV Nord", "brand_wikidata": "Q2463547"}
+    baseurl = ""
+    start_urls = ["https://www.tuev-nord.de/de/privatkunden/tuev-stationen/"]
+
+    def parse(self, response, **kwargs):
+        data_locations = json.loads(response.xpath("//div/@data-locations").get())
+        for location in data_locations:
+            location["street_address"] = location.pop("address")
+            location["zipcode"] = location.pop("plz")
+            location["name"] = location.pop("station")
+            location["ref"] = location["name"]
+            location["website"] = response.urljoin(location.pop("link"))
+            item = DictParser.parse(location)
+            yield item


### PR DESCRIPTION
In Germany [TÜV Nord](https://www.tuev-nord.de/) is one of the licensed companies that perform the legally mandated regular automobile inspections. This scraper adds their inspection stations.

```
2025-01-25 00:08:19 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/TÜV Nord': 402,
 'atp/brand_wikidata/Q2463547': 402,
 'atp/category/amenity/vehicle_inspection': 402,
 'atp/country/DE': 402,
 'atp/field/branch/missing': 402,
 'atp/field/country/from_spider_name': 402,
 'atp/field/email/missing': 402,
 'atp/field/image/missing': 402,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 402,
 'atp/field/operator/missing': 402,
 'atp/field/operator_wikidata/missing': 402,
 'atp/field/phone/missing': 402,
 'atp/field/state/missing': 402,
 'atp/field/twitter/missing': 402,
 'atp/item_scraped_host_count/www.tuev-nord.de': 402,
 'atp/nsi/perfect_match': 402,
```