### PR TITLE
[e_leclerc] fix starting space in brand name

### DIFF
--- a/locations/spiders/e_leclerc.py
+++ b/locations/spiders/e_leclerc.py
@@ -20,7 +20,7 @@ class ELeclercSpider(WoosmapSpider):
         "E.Leclerc Express": ({"brand": "E.Leclerc Express"}, Categories.SHOP_SUPERMARKET),
         "Voyages": ({"brand": "E.Leclerc"}, Categories.SHOP_TRAVEL_AGENCY),
         "Espace Culturel": ({"brand": "E.Leclerc Espace Culturel"}, Categories.SHOP_ELECTRONICS),
-        "Parapharmacie": ({"brand": " E.Leclerc Parapharmacie"}, Categories.PHARMACY),
+        "Parapharmacie": ({"brand": "E.Leclerc Parapharmacie"}, Categories.PHARMACY),
         "Location": ({"brand": "E.Leclerc Location"}, Categories.CAR_RENTAL),
         "Brico": ({"brand": "E.Leclerc Brico"}, Categories.SHOP_DOITYOURSELF),
         "Click and Collect": None,


### PR DESCRIPTION
I kind of want structural solution for such typos in the code. [test_item_attributes](https://github.com/alltheplaces/alltheplaces/blob/master/tests/test_item_attributes.py) can probably be updated to spot starting and trailing spaces in item_attributes... but it does not save when typo is in other parts of spider code.