### PR TITLE
[Pizza Hut FR] Fix Spider

### DIFF
--- a/locations/spiders/pizza_hut_fr.py
+++ b/locations/spiders/pizza_hut_fr.py
@@ -3,6 +3,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class PizzaHutFRSpider(SitemapSpider, StructuredDataSpider):
@@ -11,10 +12,9 @@ class PizzaHutFRSpider(SitemapSpider, StructuredDataSpider):
     PIZZA_HUT_DELIVERY = {"brand": "Pizza Hut Delivery", "brand_wikidata": "Q107293079"}
     sitemap_urls = ["https://www.pizzahut.fr/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.pizzahut\.fr\/huts\/[-\w]+\/([-.\w]+)\/$", "parse_sd")]
+    custom_settings = {"USER_AGENT":BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["street_address"] = merge_address_lines(item["street_address"])
-
         if item["website"].startswith("https://www.pizzahut.fr/huts/"):
             item.update(self.PIZZA_HUT_DELIVERY)
             apply_category(Categories.FAST_FOOD, item)

--- a/locations/spiders/pizza_hut_fr.py
+++ b/locations/spiders/pizza_hut_fr.py
@@ -1,7 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -12,7 +11,7 @@ class PizzaHutFRSpider(SitemapSpider, StructuredDataSpider):
     PIZZA_HUT_DELIVERY = {"brand": "Pizza Hut Delivery", "brand_wikidata": "Q107293079"}
     sitemap_urls = ["https://www.pizzahut.fr/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.pizzahut\.fr\/huts\/[-\w]+\/([-.\w]+)\/$", "parse_sd")]
-    custom_settings = {"USER_AGENT":BROWSER_DEFAULT}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if item["website"].startswith("https://www.pizzahut.fr/huts/"):


### PR DESCRIPTION
`Fixes : added user_agent to fix spider`

{'atp/brand/Pizza Hut Delivery': 117,
 'atp/brand_wikidata/Q107293079': 117,
 'atp/category/amenity/fast_food': 117,
 'atp/country/FR': 117,
 'atp/field/branch/missing': 117,
 'atp/field/email/missing': 117,
 'atp/field/image/dropped': 117,
 'atp/field/image/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/twitter/missing': 117,
 'atp/item_scraped_host_count/www.pizzahut.fr': 117,
 'atp/nsi/perfect_match': 117,
 'downloader/request_bytes': 127090,
 'downloader/request_count': 120,
 'downloader/request_method_count/GET': 120,
 'downloader/response_bytes': 1492646,
 'downloader/response_count': 120,
 'downloader/response_status_count/200': 120,
 'elapsed_time_seconds': 148.377338,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 27, 10, 29, 56, 397647, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5559336,
 'httpcompression/response_count': 120,
 'item_scraped_count': 117,
 'items_per_minute': None,
 'log_count/DEBUG': 248,
 'log_count/INFO': 11,
 'request_depth_max': 1,
 'response_received_count': 120,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 119,
 'scheduler/dequeued/memory': 119,
 'scheduler/enqueued': 119,
 'scheduler/enqueued/memory': 119,
 'start_time': datetime.datetime(2025, 1, 27, 10, 27, 28, 20309, tzinfo=datetime.timezone.utc)}