### PR TITLE
[Dino PL] Fix Spider

### DIFF
--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -16,6 +16,8 @@ class DinoPLSpider(Spider):
     allowed_domains = ["marketdino.pl"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = ["https://marketdino.pl/external/map/index.html"]
+    no_refs = True
+
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # Search for the desired JavaScript file
@@ -44,14 +46,11 @@ class DinoPLSpider(Spider):
             aesgcm.decrypt(bytes.fromhex(response.meta["iv"]), bytes.fromhex(response.text), None).decode("utf-8")
         )
         for location in geojson["features"]:
-            if location["properties"]["status"] != "MARKET OTWARTY":  # "MARKET OPEN"
-                continue
             item = DictParser.parse(location["properties"])
-            item.pop("name", None)
             item["geometry"] = location["geometry"]
             item["opening_hours"] = OpeningHours()
-            if week_hours := location["properties"].get("weekHours"):
+            if week_hours := location["properties"]["weekHours"]:
                 item["opening_hours"].add_days_range(["Mo", "Tu", "We", "Th", "Fr", "Sa"], *week_hours.split("-", 1))
-            if sun_hours := location["properties"].get("sundayHours"):
+            if sun_hours := location["properties"]["sundayHours"]:
                 item["opening_hours"].add_range("Su", *sun_hours.split("-", 1))
             yield item

--- a/locations/spiders/dino_pl.py
+++ b/locations/spiders/dino_pl.py
@@ -18,7 +18,6 @@ class DinoPLSpider(Spider):
     start_urls = ["https://marketdino.pl/external/map/index.html"]
     no_refs = True
 
-
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # Search for the desired JavaScript file
         yield response.follow(


### PR DESCRIPTION
`Fixes : updated parse_encrypted_geojson to fix spider`


{'atp/brand/Dino': 2689,
 'atp/brand_wikidata/Q11694239': 2689,
 'atp/category/shop/supermarket': 2689,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/country/PL': 2689,
 'atp/field/branch/missing': 2689,
 'atp/field/city/missing': 2689,
 'atp/field/country/from_spider_name': 2689,
 'atp/field/email/missing': 2689,
 'atp/field/image/missing': 2689,
 'atp/field/operator/missing': 2689,
 'atp/field/operator_wikidata/missing': 2689,
 'atp/field/phone/missing': 2689,
 'atp/field/postcode/missing': 2689,
 'atp/field/state/missing': 2689,
 'atp/field/street_address/missing': 2689,
 'atp/field/twitter/missing': 2689,
 'atp/field/website/missing': 2689,
 'atp/item_scraped_host_count/api.marketdino.pl': 2689,
 'atp/nsi/perfect_match': 2689,
 'downloader/request_bytes': 1217,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 1718965,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 11.837001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 27, 13, 52, 12, 88836, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3137112,
 'httpcompression/response_count': 3,
 'item_scraped_count': 2689,
 'items_per_minute': None,
 'log_count/DEBUG': 2703,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 3,
 'responses_per_minute': None,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 1, 27, 13, 52, 0, 251835, tzinfo=datetime.timezone.utc)}