### PR TITLE
[Fedex] Refactor  Spider to fix low scraped count

### DIFF
--- a/locations/spiders/fedex.py
+++ b/locations/spiders/fedex.py
@@ -86,8 +86,16 @@ class FedexSpider(CrawlSpider):
             )
             item["extras"]["fax"] = location_info.get("fax", {}).get("number")
             item["name"] = item["name"].split("(Permit to Enter)")[0].strip().replace("Centre", "Center")
-            if "FedEx Express" in item["name"]:
-                item["brand"] = "FedEx Express"
+
+            if "FedEx Express" in item["name"]:  # e.g. FedEx Express FR, FedEx Express Poland
+                item["name"] = item["brand"] = "FedEx Express"
+
+            if location_page_name := location_info.get(
+                "c_pagesName"
+            ):  # Not consistent, can't be used for deciding category
+                if "FedEx at " in location_page_name:
+                    item["located_in"] = location_page_name.split("FedEx at ")[1]
+
             if category := self.CATEGORY_MAP.get(item["name"]):
                 apply_category(category, item)
 


### PR DESCRIPTION
Spider works fine with the previous script from `IN`, but after scraping around `3500` , server throws `429` error, tried with adding delay etc, but didn't work. Hence refactored the code using API, and got around `50k`, before it complains for too many requests. Coudn't find a working way for pagination, so it has a cap of `50` count per request. Summary generated with `cache` enabled and setting `CLOSESPIDER_ITEMCOUNT = 50000`.

```
{'atp/brand/FedEx': 50395,
 'atp/brand/FedEx Express': 12,
 'atp/brand_wikidata/Q459477': 50407,
 'atp/category/amenity/parcel_locker': 168,
 'atp/category/amenity/post_box': 21025,
 'atp/category/amenity/post_depot': 178,
 'atp/category/amenity/post_office': 1859,
 'atp/category/missing': 25405,
 'atp/category/shop/copyshop': 1772,
 'atp/cdn/cloudflare/response_count': 4221,
 'atp/cdn/cloudflare/response_status_count/200': 4220,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/AE': 11,
 'atp/country/AG': 1,
 'atp/country/AT': 91,
 'atp/country/AU': 34,
 'atp/country/BH': 2,
 'atp/country/BI': 1,
 'atp/country/BJ': 1,
 'atp/country/BM': 1,
 'atp/country/BW': 1,
 'atp/country/CA': 186,
 'atp/country/CH': 13,
 'atp/country/CK': 1,
 'atp/country/CN': 93,
 'atp/country/DE': 1,
 'atp/country/DK': 3,
 'atp/country/EG': 1,
 'atp/country/ES': 53,
 'atp/country/FR': 144,
 'atp/country/GB': 4111,
 'atp/country/HK': 11,
 'atp/country/ID': 63,
 'atp/country/IE': 2,
 'atp/country/IL': 1,
 'atp/country/IN': 7,
 'atp/country/IQ': 4,
 'atp/country/IT': 50,
 'atp/country/JM': 13,
 'atp/country/JP': 24,
 'atp/country/KG': 2,
 'atp/country/MO': 1,
 'atp/country/MW': 1,
 'atp/country/MX': 409,
 'atp/country/MY': 186,
 'atp/country/NC': 1,
 'atp/country/NL': 100,
 'atp/country/NP': 1,
 'atp/country/NZ': 5,
 'atp/country/PF': 1,
 'atp/country/PK': 7,
 'atp/country/PL': 2116,
 'atp/country/SA': 1,
 'atp/country/SE': 6,
 'atp/country/SG': 93,
 'atp/country/SI': 3,
 'atp/country/US': 42550,
 'atp/field/branch/missing': 50407,
 'atp/field/city/missing': 90,
 'atp/field/email/missing': 50407,
 'atp/field/image/missing': 50407,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 50407,
 'atp/field/operator/missing': 50407,
 'atp/field/operator_wikidata/missing': 50407,
 'atp/field/phone/missing': 28179,
 'atp/field/postcode/missing': 48,
 'atp/field/state/missing': 3179,
 'atp/field/twitter/missing': 50407,
 'atp/field/website/missing': 6983,
 'atp/item_scraped_host_count/local.fedex.com': 191747,
 'downloader/request_bytes': 2067196,
 'downloader/request_count': 4262,
 'downloader/request_method_count/GET': 4262,
 'downloader/response_bytes': 1206202772,
 'downloader/response_count': 4262,
 'downloader/response_status_count/200': 4220,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/429': 41,
 'dupefilter/filtered': 443,
 'elapsed_time_seconds': 1489.220794,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 1, 28, 15, 2, 11, 282562, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 775,
 'httpcache/hit': 3487,
 'httpcache/miss': 775,
 'httpcache/store': 775,
 'httpcompression/response_bytes': 11557072312,
 'httpcompression/response_count': 4221,
 'item_dropped_count': 141340,
 'item_dropped_reasons_count/DropItem': 141340,
 'item_scraped_count': 50407,
 'items_per_minute': None,
 'log_count/DEBUG': 196013,
 'log_count/INFO': 34,
 'request_depth_max': 2,
 'response_received_count': 4221,
 'responses_per_minute': None,
 'retry/count': 41,
 'retry/reason_count/429 Unknown Status': 41,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 4261,
 'scheduler/dequeued/memory': 4261,
 'scheduler/enqueued': 6824,
 'scheduler/enqueued/memory': 6824,
 'start_time': datetime.datetime(2025, 1, 28, 14, 37, 22, 61768, tzinfo=datetime.timezone.utc)}
```