### PR TITLE
[discover.swiss] Add spider for 3843 hotels and 54 serviced apartments

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -616,6 +616,7 @@ class PaymentMethods(Enum):
     PAYPAY = "payment:paypay"
     POWERCARD = "payment:powercard"
     POSTEPAY = "payment:postepay"
+    POSTFINANCE_CARD = "payment:postfinance_card"
     QUICPAY = "payment:quicpay"
     RAKUTEN_PAY = "payment:rakuten_pay"
     SAMSUNG_PAY = "payment:samsung_pay"
@@ -640,9 +641,12 @@ payment_method_aliases = {
     "China UnionPay": PaymentMethods.UNIONPAY,
     "Discover": PaymentMethods.DISCOVER_CARD,
     "Diners": PaymentMethods.DINERS_CLUB,
+    "JCB Card": PaymentMethods.JCB,
     "Maestro (Ausland)": PaymentMethods.MAESTRO,
     "MasterCard": PaymentMethods.MASTER_CARD,
+    "PostFinance Card": PaymentMethods.POSTFINANCE_CARD,
     "PowerCard": PaymentMethods.POWERCARD,
+    "UnionPay": PaymentMethods.UNIONPAY,
 }
 
 

--- a/locations/spiders/discover_swiss.py
+++ b/locations/spiders/discover_swiss.py
@@ -10,6 +10,23 @@ from locations.items import Feature
 class DiscoverSwissSpider(scrapy.Spider):
     name = "discover_swiss"
     allowed_domains = ["api.discover.swiss"]
+    dataset_attributes = {
+        # This dataset includes some data from other sources, like hotel
+        # chains. But a lot of their content is unique, such as small hotels
+        # that aren’t part of a chain.
+        "aggregate": "yes",
+        # Mandatory attribution as per CC-BY 4.0, waived for OpenStreetMap
+        # via standard template. Negotiations took place in January 2025
+        # between Hotellerie Suisse (who runs the discover.swiss platform)
+        # and the Swiss OpenStreetMap association.
+        # https://osmfoundation.org/wiki/Licence/Waiver_and_Permission_Templates
+        "attribution": "mandatory",
+        "attribution:name": "discover.swiss",
+        "attribution:wikidata": "Q131983936",
+        "use:openstreetmap": "yes",
+        "license": "CC-BY 4.0",
+        "license:wikidata": "Q20007257",
+    }
     headers = {
         "Ocp-Apim-Subscription-Key": "defe4e15094b4d388ecf3b37bbe88a85",
         "Accept-Language": "de",

--- a/locations/spiders/discover_swiss.py
+++ b/locations/spiders/discover_swiss.py
@@ -1,0 +1,97 @@
+import urllib.parse
+
+import scrapy
+
+from locations.categories import Categories, PaymentMethods, apply_category, map_payment
+from locations.items import Feature
+
+
+# Hotels (including hostels and serviced apartments) in Switzerland
+class DiscoverSwissSpider(scrapy.Spider):
+    name = "discover_swiss"
+    allowed_domains = ["api.discover.swiss"]
+    headers = {
+        "Ocp-Apim-Subscription-Key": "defe4e15094b4d388ecf3b37bbe88a85",
+        "Accept-Language": "de",
+    }
+    url = "https://api.discover.swiss/info/v2/lodgingbusinesses/?project=dsod-content&top=-1"
+
+    def start_requests(self):
+        yield scrapy.Request(self.url, headers=self.headers)
+
+    def parse(self, response):
+        data = response.json()
+        token = data.get("nextPageToken")
+        if token and data.get("hasNextPage"):
+            token_quoted = urllib.parse.quote(token, safe="")
+            next_url = self.url + "&continuationToken=" + token_quoted
+            yield scrapy.Request(next_url, headers=self.headers)
+        for item in data.get("data", []):
+            category = self.parse_category(item)
+            ref = self.parse_ref(item)
+            geo = item.get("geo")
+            if item.get("removed") or not all([category, ref, geo]):
+                continue
+            address = item.get("address", {})
+            extras = {
+                "beds": item.get("numberOfBeds"),
+                "ele": geo.get("elevation"),
+                "rooms": self.parse_rooms(item),
+                "stars": self.parse_stars(item),
+            }
+            feature = Feature(
+                ref=ref,
+                lat=geo["latitude"],
+                lon=geo["longitude"],
+                name=item["name"],
+                street_address=address.get("streetAddress") or None,
+                postcode=address.get("postalCode") or None,
+                city=address.get("addressLocality") or None,
+                country=address.get("addressCountry") or "CH",
+                image=item.get("image", {}).get("contentUrl"),
+                phone=item.get("telephone") or None,
+                email=address.get("email") or None,
+                website=item.get("url") or None,
+                extras={k: str(v) for (k, v) in extras.items() if v},
+            )
+            apply_category(category, feature)
+            self.parse_payment(item, feature)
+            yield feature
+
+    def parse_category(self, item):
+        t = item.get("type")
+        if t == "schema.org/LodgingBusiness":
+            subtype = item.get("starRating", {}).get("additionalType")
+            return {
+                "ServicedApartments": Categories.TOURISM_APARTMENT,
+                "swissLodge": Categories.TOURISM_HOSTEL,
+            }.get(subtype, Categories.HOTEL)
+        return None
+
+    def parse_payment(self, item, feature):
+        for p in item.get("paymentAccepted", "").split(","):
+            # "Postcard" seems too Switzerland-specific to be added
+            # to categories.py.
+            p = {"Postcard": "PostFinance Card"}.get(p, p)
+            map_payment(feature, p, PaymentMethods)
+
+    def parse_ref(self, item):
+        for prop in item.get("additionalProperty", []):
+            if prop.get("propertyId") == "hsId":
+                if value := prop.get("value"):
+                    return str(value)
+        return None
+
+    def parse_rooms(self, item):
+        for c in item.get("numberOfRooms", []):
+            if c.get("propertyId") == "total":
+                return c.get("value")
+        return None
+
+    def parse_stars(self, item):
+        if s := item.get("starRating"):
+            stars = str(s.get("ratingValue", "")).rstrip(".0")
+            if s.get("superior"):
+                stars = stars + "S"
+            return stars
+        return None

--- a/locations/spiders/discover_swiss.py
+++ b/locations/spiders/discover_swiss.py
@@ -20,7 +20,7 @@ class DiscoverSwissSpider(scrapy.Spider):
         # between Hotellerie Suisse (who runs the discover.swiss platform)
         # and the Swiss OpenStreetMap association.
         # https://osmfoundation.org/wiki/Licence/Waiver_and_Permission_Templates
-        "attribution": "mandatory",
+        "attribution": "required",
         "attribution:name": "discover.swiss",
         "attribution:wikidata": "Q131983936",
         "use:openstreetmap": "yes",


### PR DESCRIPTION
disover.swiss is the IT backend platform of the Swiss hotels association.