### PR TITLE
New spider: Madison Reed (93 locations)

### DIFF
--- a/locations/spiders/madison_reed_us.py
+++ b/locations/spiders/madison_reed_us.py
@@ -1,0 +1,40 @@
+from http.cookies import SimpleCookie
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class MadisonReedUSSpider(Spider):
+    name = "madison_reed_us"
+    item_attributes = {
+        "brand": "Madison Reed",
+        "brand_wikidata": "Q60770929",
+    }
+
+    # Need to get a token before making any API requests
+    start_urls = ["https://www.madison-reed.com/store-locator"]
+
+    def parse(self, response):
+        # Parse token from response headers
+        cookie = SimpleCookie()
+        for line in response.headers.getlist("Set-Cookie"):
+            cookie.load(line.decode())
+        yield JsonRequest(
+            "https://www.madison-reed.com/api/colorbar/getActiveWholesalesLocationsList",
+            data={"lat": 0, "lon": 0, "maxDistance": 24901},
+            headers={"x-csrf-stp": cookie["csrf_stp"].value},
+            callback=self.parse_locations,
+        )
+
+    def parse_locations(self, response):
+        for location in response.json():
+            if location["type"] != "MR":
+                continue
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name").removesuffix(" Hair Color Bar")
+            item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
+            item["ref"] = location["code"]
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Madison Reed': 93,
 'atp/brand_wikidata/Q60770929': 93,
 'atp/category/shop/beauty': 93,
 'atp/country/US': 93,
 'atp/field/country/from_spider_name': 93,
 'atp/field/email/missing': 93,
 'atp/field/image/missing': 93,
 'atp/field/opening_hours/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/phone/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/field/website/missing': 93,
 'atp/item_scraped_host_count/www.madison-reed.com': 93,
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 2049,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 189717,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.146956,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 30, 1, 16, 46, 137713, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 831867,
 'httpcompression/response_count': 2,
 'item_scraped_count': 93,
 'items_per_minute': None,
 'log_count/DEBUG': 107,
 'log_count/INFO': 10,
 'memusage/max': 254128128,
 'memusage/startup': 254128128,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 1, 30, 1, 16, 41, 990757, tzinfo=datetime.timezone.utc)}
```