### PR TITLE
New spider: One Medical (213 locations)

### DIFF
--- a/locations/spiders/one_medical_us.py
+++ b/locations/spiders/one_medical_us.py
@@ -1,0 +1,37 @@
+import json
+
+import scrapy
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class OneMedicalUSSpider(scrapy.Spider):
+    name = "one_medical_us"
+    start_urls = ["https://www.onemedical.com/api/service_areas/"]
+    item_attributes = {
+        "operator": "1Life Healthcare",
+        "operator_wikidata": "Q85727717",
+    }
+
+    def parse(self, response):
+        for service_area in response.json():
+            yield scrapy.Request(
+                f"https://www.onemedical.com/api/locations/?code={service_area['code']}", callback=self.parse_locations
+            )
+
+    def parse_locations(self, response):
+        service_area = json.loads(response.json())
+        for location in service_area["offices"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["website"] = f"https://www.onemedical.com/locations/{service_area['code']}/{location['slug']}"
+            item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
+            item["image"] = location["image_url"]
+
+            oh = OpeningHours()
+            oh.add_ranges_from_string(location["hours"])
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/category/amenity/clinic': 213,
 'atp/category/multiple': 213,
 'atp/country/US': 213,
 'atp/field/brand/missing': 213,
 'atp/field/brand_wikidata/missing': 213,
 'atp/field/country/from_spider_name': 213,
 'atp/field/email/missing': 213,
 'atp/field/opening_hours/missing': 10,
 'atp/field/phone/missing': 213,
 'atp/field/twitter/missing': 213,
 'atp/item_scraped_host_count/www.onemedical.com': 213,
 'atp/nsi/perfect_match': 213,
 'atp/operator/1Life Healthcare': 213,
 'atp/operator_wikidata/Q85727717': 213,
 'downloader/request_bytes': 15842,
 'downloader/request_count': 36,
 'downloader/request_method_count/GET': 36,
 'downloader/response_bytes': 72092,
 'downloader/response_count': 36,
 'downloader/response_status_count/200': 36,
 'elapsed_time_seconds': 41.825671,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 30, 1, 40, 46, 968179, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 182905,
 'httpcompression/response_count': 27,
 'item_scraped_count': 213,
 'items_per_minute': None,
 'log_count/DEBUG': 260,
 'log_count/INFO': 10,
 'memusage/max': 253800448,
 'memusage/startup': 253800448,
 'request_depth_max': 1,
 'response_received_count': 36,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 35,
 'scheduler/dequeued/memory': 35,
 'scheduler/enqueued': 35,
 'scheduler/enqueued/memory': 35,
 'start_time': datetime.datetime(2025, 1, 30, 1, 40, 5, 142508, tzinfo=datetime.timezone.utc)}
```