### PR TITLE
[Anaconda AU] Fix spider

### DIFF
--- a/locations/spiders/anaconda_au.py
+++ b/locations/spiders/anaconda_au.py
@@ -18,7 +18,9 @@ class AnacondaAUSpider(SitemapSpider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         properties = {
             "ref": response.xpath('//div[contains(@id, "maps_canvas")]/@data-storeid').extract_first(),
-            "name": response.xpath('//div[contains(@id, "maps_canvas")]/@data-storename').extract_first(),
+            "branch": response.xpath('//div[contains(@id, "maps_canvas")]/@data-storename')
+            .extract_first()
+            .removeprefix("Anaconda "),
             "lat": response.xpath('//div[contains(@id, "maps_canvas")]/@data-latitude').extract_first(),
             "lon": response.xpath('//div[contains(@id, "maps_canvas")]/@data-longitude').extract_first(),
             "addr_full": " ".join(

--- a/locations/spiders/anaconda_au.py
+++ b/locations/spiders/anaconda_au.py
@@ -1,38 +1,21 @@
 from typing import Any
 
-import scrapy
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import extract_phone
 
 
-class AnacondaAUSpider(scrapy.Spider):
+class AnacondaAUSpider(SitemapSpider):
     name = "anaconda_au"
     item_attributes = {"brand": "Anaconda", "brand_wikidata": "Q105981238"}
-    start_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml"]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "REDIRECT_ENABLED": True}
-    handle_httpstatus_list = [302]
+    sitemap_urls = ["https://www.anacondastores.com/sitemap/store/store-sitemap.xml"]
+    sitemap_rules = [(r"/store/[-\w]+/[-\w]+/[-\w]+$", "parse")]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
-        yield scrapy.Request(url=token_request_url, callback=self.parse_token_request)
-
-    def parse_token_request(self, response):
-        token_request_url = str(response.headers.getlist("Location")[0].decode("utf-8"))
-        yield scrapy.Request(url=token_request_url, callback=self.parse_token)
-
-    def parse_token(self, response):
-        url = str(response.headers.getlist("Location")[0].decode("utf-8"))
-        token = str(response.headers.getlist("Set-Cookie")[0].decode("utf-8"))
-        yield scrapy.Request(url=url, headers={"cookie": token}, callback=self.parse_store_urls)
-
-    def parse_store_urls(self, response, **kwargs):
-        for link in response.xpath("//urlset//url//loc/text()").getall():
-            yield scrapy.Request(url=link, callback=self.parse_store)
-
-    def parse_store(self, response):
         properties = {
             "ref": response.xpath('//div[contains(@id, "maps_canvas")]/@data-storeid').extract_first(),
             "name": response.xpath('//div[contains(@id, "maps_canvas")]/@data-storename').extract_first(),


### PR DESCRIPTION
Sitemap's behavior is not stable, saying based on [last fix](https://github.com/alltheplaces/alltheplaces/pull/11689). Now it's accessible straight away, so using it again. If it breaks again then we'll think of alternate approach.

```
{'atp/brand/Anaconda': 88,
 'atp/brand_wikidata/Q105981238': 88,
 'atp/category/shop/outdoor': 88,
 'atp/country/AU': 88,
 'atp/field/city/missing': 88,
 'atp/field/email/missing': 88,
 'atp/field/image/missing': 88,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 88,
 'atp/field/operator_wikidata/missing': 88,
 'atp/field/postcode/missing': 88,
 'atp/field/state/missing': 88,
 'atp/field/street_address/missing': 88,
 'atp/field/twitter/missing': 88,
 'atp/item_scraped_host_count/www.anacondastores.com': 88,
 'atp/nsi/perfect_match': 88,
 'downloader/request_bytes': 65598,
 'downloader/request_count': 90,
 'downloader/request_method_count/GET': 90,
 'downloader/response_bytes': 4172006,
 'downloader/response_count': 90,
 'downloader/response_status_count/200': 89,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.822963,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 30, 7, 51, 32, 44284, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 90,
 'httpcompression/response_bytes': 22020141,
 'httpcompression/response_count': 90,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 88,
 'items_per_minute': None,
 'log_count/DEBUG': 190,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 90,
 'responses_per_minute': None,
 'scheduler/dequeued': 90,
 'scheduler/dequeued/memory': 90,
 'scheduler/enqueued': 90,
 'scheduler/enqueued/memory': 90,
 'start_time': datetime.datetime(2025, 1, 30, 7, 51, 28, 221321, tzinfo=datetime.timezone.utc)}
```