### PR TITLE
[German American US] Add spider

### DIFF
--- a/locations/spiders/german_american_us.py
+++ b/locations/spiders/german_american_us.py
@@ -1,0 +1,24 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class GermanAmericanUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "german_american_us"
+    item_attributes = {"brand": "German American", "brand_wikidata": "Q120753420"}
+    start_urls = ["https://germanamerican.com/locations/locations-overview/"]
+    rules = [Rule(LinkExtractor(restrict_xpaths='//li[contains(@data-services, "143")]//a'), callback="parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+
+        item["branch"] = (
+            response.xpath('//span[contains(text(), "Office Name:")]/text()')
+            .get(default="")
+            .removeprefix("Office Name:")
+            .strip()
+        )
+
+        apply_category(Categories.BANK, item)
+        yield item


### PR DESCRIPTION
Can't remember writing this one or why I didn't do a PR at the time, but here it is.

```python
{'atp/brand/German American': 43,
 'atp/brand_wikidata/Q120753420': 43,
 'atp/category/amenity/bank': 43,
 'atp/country/US': 43,
 'atp/field/branch/missing': 1,
 'atp/field/email/missing': 43,
 'atp/field/image/dropped': 35,
 'atp/field/image/missing': 35,
 'atp/field/lat/missing': 8,
 'atp/field/lon/missing': 8,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 43,
 'atp/field/operator_wikidata/missing': 43,
 'atp/item_scraped_host_count/germanamerican.com': 43,
 'atp/nsi/cc_match': 43,
 'downloader/request_bytes': 94213,
 'downloader/request_count': 148,
 'downloader/request_method_count/GET': 148,
 'downloader/response_bytes': 790842,
 'downloader/response_count': 148,
 'downloader/response_status_count/200': 75,
 'downloader/response_status_count/301': 73,
 'elapsed_time_seconds': 0.821573,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 30, 11, 10, 0, 506833, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 148,
 'httpcompression/response_bytes': 2310519,
 'httpcompression/response_count': 75,
 'item_scraped_count': 43,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 273887232,
 'memusage/startup': 273887232,
 'request_depth_max': 1,
 'response_received_count': 75,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 147,
 'scheduler/dequeued/memory': 147,
 'scheduler/enqueued': 147,
 'scheduler/enqueued/memory': 147,
 'start_time': datetime.datetime(2025, 1, 30, 11, 9, 59, 685260, tzinfo=datetime.timezone.utc)}
```