### PR TITLE
[Fust CH] Fix spider

### DIFF
--- a/locations/spiders/fust_ch.py
+++ b/locations/spiders/fust_ch.py
@@ -1,82 +1,34 @@
-import itertools
-import re
+from typing import Iterable
 
-from scrapy.spiders import SitemapSpider
+import chompjs
+from scrapy.http import Response
 
-from locations.hours import DAYS_DE, OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class FustCHSpider(SitemapSpider):
+class FustCHSpider(JSONBlobSpider):
     name = "fust_ch"
     item_attributes = {
         "brand": "Fust",
         "brand_wikidata": "Q1227164",
         "country": "CH",
     }
-    allowed_domains = ["www.fust.ch"]
-    sitemap_urls = ["https://www.fust.ch/sitemap.xml"]
-    sitemap_follow = ["/myinterfaces", "/sitemap/www.fust.ch-de-"]
-    sitemap_rules = [(r"/de/.+/filialen/", "parse")]
+    start_urls = ["https://www.fust.ch/store-finder"]
 
-    def parse(self, response):
-        # The site uses microformats, but it’s always for the headquarter,
-        # not for the branch.
-        email = self.parse_email(response)
-        if not email:
-            return
-        s = response.css(".requestFiliale")
-        branch = self.parse_branch(s)
-        lat, lon = self.parse_lat_lon(s)
-        properties = {
-            "city": branch.split()[0],
-            "branch": branch,
-            "email": email,
-            "image": self.parse_image(response),
-            "lat": lat,
-            "lon": lon,
-            "opening_hours": self.parse_opening_hours(response),
-            "phone": self.parse_phone(response),
-            "postcode": s.xpath("@data-prj-zip").get(),
-            "ref": email.split("@")[0],
-            "street_address": s.xpath("@data-prj-adress").get(),
-            "website": response.url,
-        }
-        yield Feature(**properties)
+    def extract_json(self, response: Response) -> list[dict]:
+        location_data = response.xpath('//script[contains(text(), "pointOfService")]/text()').get()
+        return [
+            chompjs.parse_js_object(location, unicode_escape=True)
+            for location in location_data.split(r"{\"pointOfService\":")[1:]
+        ]
 
-    def parse_branch(self, s):
-        return s.xpath("@data-prj-city").get().split("(")[0].strip()
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("address"))
 
-    def parse_email(self, s):
-        if match := re.search(r"s?\d+@fust.ch", s.text):
-            return match.group(0)
-
-    def parse_image(self, s):
-        url = s.css(".filialeimg").xpath("@data-src").get()
-        return s.urljoin(url.split("?")[0]) if url else None
-
-    def parse_lat_lon(self, s):
-        map_url = s.xpath("//a[@data-fancy-wrapcss]/@href").get()
-        if match := re.search(r"&ll=(\d+\.\d+),(\d+\.\d+)", map_url):
-            lat, lon = map(float, match.groups())
-            if lat != 0.0 and lon != 0.0:
-                return (lat, lon)
-        return (None, None)
-
-    def parse_opening_hours(self, s):
-        oh = OpeningHours()
-        e = s.xpath("//div[text()='Öffnungszeiten']/../table/tr/td/text()")
-        e = [x.strip() for x in e.getall() if x.strip()]
-        for day, hours in itertools.pairwise(e):
-            day = DAYS_DE.get(day)
-            match = re.match(r"^(\d{2}:\d{2})-(\d{2}:\d{2})$", hours)
-            if day and match:
-                open_time, close_time = match.groups()
-                oh.add_range(day, open_time, close_time)
-        return oh.as_opening_hours()
-
-    def parse_phone(self, response):
-        for url in response.xpath("//div[text()='Kontakt']/..//a/@href").getall():
-            url = url.strip()
-            if url.startswith("tel:+41"):
-                return url[4:]
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2")])
+        item["branch"] = item.pop("name").replace("-", " ").title().removesuffix(" Center")
+        item["website"] = response.urljoin(feature["url"].split("?")[0].replace("/store/", "/store-finder/"))
+        yield item

--- a/locations/spiders/fust_ch.py
+++ b/locations/spiders/fust_ch.py
@@ -26,6 +26,8 @@ class FustCHSpider(JSONBlobSpider):
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))
+        if contact_info := feature.get("contactDetails"):
+            feature.update(contact_info[0])
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2")])


### PR DESCRIPTION
Sitemap can still be used after updating sitemap urls but `xpaths` have been changed, also POIs data is available from the store finder page itself using a single request, hence utilized JSON Bolb to fix the spider.

```
{'atp/brand/Fust': 134,
 'atp/brand_wikidata/Q1227164': 134,
 'atp/category/shop/electronics': 134,
 'atp/country/CH': 134,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 134,
 'atp/field/operator/missing': 134,
 'atp/field/operator_wikidata/missing': 134,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 134,
 'atp/field/twitter/missing': 134,
 'atp/item_scraped_host_count/www.fust.ch': 134,
 'atp/nsi/perfect_match': 134,
 'downloader/request_bytes': 606,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 161168,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.242376,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 30, 13, 55, 12, 211454, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1757975,
 'httpcompression/response_count': 2,
 'item_scraped_count': 134,
 'items_per_minute': None,
 'log_count/DEBUG': 147,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 30, 13, 55, 8, 969078, tzinfo=datetime.timezone.utc)}
```