### PR TITLE
[Carls Jr NZ] Fix  Spider

### DIFF
--- a/locations/spiders/carls_jr_nz.py
+++ b/locations/spiders/carls_jr_nz.py
@@ -16,7 +16,7 @@ class CarlsJrNZSpider(Spider):
     no_refs = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath("//@data-block-json").getall():
+        for location in response.xpath("//@data-context").getall():
             store = json.loads(location)["location"]
             item = Feature()
             item["name"] = store.get("addressTitle")


### PR DESCRIPTION
```
{"atp/brand/Carl's Jr.": 18,
 'atp/brand_wikidata/Q1043486': 18,
 'atp/category/amenity/fast_food': 18,
 'atp/country/NZ': 18,
 'atp/field/branch/missing': 18,
 'atp/field/city/missing': 18,
 'atp/field/country/from_website_url': 18,
 'atp/field/email/missing': 18,
 'atp/field/image/missing': 18,
 'atp/field/opening_hours/missing': 18,
 'atp/field/operator/missing': 18,
 'atp/field/operator_wikidata/missing': 18,
 'atp/field/phone/missing': 18,
 'atp/field/postcode/missing': 18,
 'atp/field/state/missing': 18,
 'atp/field/street_address/missing': 18,
 'atp/field/twitter/missing': 18,
 'atp/item_scraped_host_count/www.carlsjr.co.nz': 18,
 'atp/nsi/perfect_match': 18,
 'downloader/request_bytes': 680,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29241,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.846727,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 31, 6, 14, 37, 936567, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 167478,
 'httpcompression/response_count': 2,
 'item_scraped_count': 18,
 'items_per_minute': None,
 'log_count/DEBUG': 31,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 31, 6, 14, 33, 89840, tzinfo=datetime.timezone.utc)}
```