### PR TITLE
[Change Group] Fix  Spider

### DIFF
--- a/locations/spiders/change_group.py
+++ b/locations/spiders/change_group.py
@@ -13,7 +13,11 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class ChangeGroupSpider(Spider):
     name = "change_group"
     item_attributes = {"brand": "Change Group", "brand_wikidata": "Q5071758"}
-    start_urls = ["https://uk.changegroup.com/slatwall/?slatAction=changeGroup:main.globalBranchData"]
+    """
+        The following Javascript file has the actual API details, being used.
+        https://uk.changegroup.com/.resources/ProsegurWebCorpModule/resources/changegroup/branch-locator/main.js
+    """
+    start_urls = ["https://uksw.changegroup.com/slatwall/?slatAction=changeGroup:main.globalBranchData"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.text.encode("utf-8")


### PR DESCRIPTION
API url updated to fix the spider.

```
{'atp/brand/Change Group': 185,
 'atp/brand_wikidata/Q5071758': 185,
 'atp/category/amenity/bureau_de_change': 185,
 'atp/country/AT': 2,
 'atp/country/AU': 27,
 'atp/country/CY': 5,
 'atp/country/DE': 8,
 'atp/country/DK': 7,
 'atp/country/ES': 21,
 'atp/country/FI': 7,
 'atp/country/FR': 23,
 'atp/country/GB': 53,
 'atp/country/IS': 3,
 'atp/country/NZ': 2,
 'atp/country/SE': 27,
 'atp/field/branch/missing': 185,
 'atp/field/email/missing': 185,
 'atp/field/image/missing': 185,
 'atp/field/lat/missing': 10,
 'atp/field/lon/missing': 10,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 185,
 'atp/field/operator_wikidata/missing': 185,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 76,
 'atp/field/state/missing': 151,
 'atp/field/twitter/missing': 185,
 'atp/field/website/missing': 185,
 'atp/item_scraped_host_count/uksw.changegroup.com': 185,
 'atp/nsi/brand_missing': 185,
 'downloader/request_bytes': 666,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 205449,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.580136,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 1, 31, 9, 18, 58, 771130, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 178,
 'httpcompression/response_count': 1,
 'item_scraped_count': 185,
 'items_per_minute': None,
 'log_count/DEBUG': 198,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 1, 31, 9, 18, 55, 190994, tzinfo=datetime.timezone.utc)}
```