### PR TITLE
Fix name/Wikidata item of Melbourne City Council features

### DIFF
--- a/locations/spiders/melbourne_city_council_barbecues_au.py
+++ b/locations/spiders/melbourne_city_council_barbecues_au.py
@@ -7,9 +7,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbourneBarbecuesAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_barbecues_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilBarbecuesAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_barbecues_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_barbeque&datadefinition=__dd__ar_barbeque&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_dog_parks_au.py
+++ b/locations/spiders/melbourne_city_council_dog_parks_au.py
@@ -9,7 +9,7 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class MelbourneCityCouncilDogParksAUSpider(JSONBlobSpider):
     name = "melbourne_city_council_dog_parks_au"
-    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763", "nsi_id": "N/A"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_dogoffleash&datadefinition=__dd__ar_dogoffleash&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_dog_parks_au.py
+++ b/locations/spiders/melbourne_city_council_dog_parks_au.py
@@ -7,9 +7,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbourneDogParksAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_dog_parks_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilDogParksAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_dog_parks_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_dogoffleash&datadefinition=__dd__ar_dogoffleash&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_drinking_fountains_au.py
+++ b/locations/spiders/melbourne_city_council_drinking_fountains_au.py
@@ -7,9 +7,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbourneDrinkingFountainsAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_drinking_fountains_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilDrinkingFountainsAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_drinking_fountains_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_drinkingfountain&datadefinition=__dd__ar_drinkingfountain&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_playgrounds_au.py
+++ b/locations/spiders/melbourne_city_council_playgrounds_au.py
@@ -9,7 +9,7 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class MelbourneCityCouncilPlaygroundsAUSpider(JSONBlobSpider):
     name = "melbourne_city_council_playgrounds_au"
-    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763", "nsi_id": "N/A"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_playground&datadefinition=__dd__ar_playground&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_playgrounds_au.py
+++ b/locations/spiders/melbourne_city_council_playgrounds_au.py
@@ -7,9 +7,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbournePlaygroundsAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_playgrounds_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilPlaygroundsAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_playgrounds_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_playground&datadefinition=__dd__ar_playground&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_sharps_waste_baskets_au.py
+++ b/locations/spiders/melbourne_city_council_sharps_waste_baskets_au.py
@@ -7,9 +7,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbourneSyringeBinsAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_syringe_bins_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilSharpsWasteBasketsAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_sharps_waste_baskets_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_syringebin&datadefinition=__dd__syringebin&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"

--- a/locations/spiders/melbourne_city_council_toilets_au.py
+++ b/locations/spiders/melbourne_city_council_toilets_au.py
@@ -9,9 +9,9 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class CityOfMelbourneToiletsAUSpider(JSONBlobSpider):
-    name = "city_of_melbourne_toilets_au"
-    item_attributes = {"operator": "City of Melbourne", "operator_wikidata": "Q1919098"}
+class MelbourneCityCouncilToiletsAUSpider(JSONBlobSpider):
+    name = "melbourne_city_council_toilets_au"
+    item_attributes = {"operator": "Melbourne City Council", "operator_wikidata": "Q56477763"}
     allowed_domains = ["maps.melbourne.vic.gov.au"]
     start_urls = [
         "https://maps.melbourne.vic.gov.au/weave/services/v1/feature/getFeatures?shape=POLYGON((278984.5214999998%205773194.2749,278984.5214999998%205853194.1042,361023.5938999998%205853194.1042,361023.5938999998%205773194.2749,278984.5214999998%205773194.2749))&entityId=lyr_publictoilet&datadefinition=__dd__ar_public_toilet&outCrs=EPSG:4326&inCrs=EPSG:7855&operation=intersects&returnCentroid=true&returnFirst=false"


### PR DESCRIPTION
Use Melbourne City Council (the government organisation/council operating features) and not City of Melbourne (the administrative region which Melbourne City Council is responsible for).