### PR TITLE
[Porsche Holding] Fix spider

### DIFF
--- a/locations/spiders/porsche_holding.py
+++ b/locations/spiders/porsche_holding.py
@@ -40,7 +40,8 @@ class PorscheHoldingSpider(JSONBlobSpider):
     custom_settings = {
         "CONCURRENT_REQUESTS": 1,
         "CONCURRENT_REQUESTS_PER_DOMAIN": 1,
-        "DOWNLOAD_DELAY": 10,  # API throws 429 very quickly
+        "DOWNLOAD_DELAY": 10,  # API throws 429 very quickly,
+        "RETRY_TIMES": 5,
     }
 
     def start_requests(self) -> Iterable[Request]:

--- a/locations/spiders/porsche_holding.py
+++ b/locations/spiders/porsche_holding.py
@@ -1,3 +1,4 @@
+import re
 from typing import Iterable
 
 import pycountry
@@ -31,9 +32,7 @@ class PorscheHoldingSpider(JSONBlobSpider):
     }
     locations_key = "data"
     start_urls = [
-        "https://www.porsche-holding.com/en/company/locations",
-        "https://www.porsche-holding.com/en/company/locations/asia",
-        "https://www.porsche-holding.com/en/company/locations/south-america",
+        "https://www.porsche-holding.com/en/Company/locations",
     ]
 
     base_url = "https://hs.porsche-holding.com/api/v2/dealers"
@@ -49,7 +48,9 @@ class PorscheHoldingSpider(JSONBlobSpider):
             yield Request(url=url, callback=self.get_countries)
 
     def get_countries(self, response: Response):
-        country_names = response.xpath('//div[@class="porscheholding-countriesViewDropdown__item"]/a/text()').getall()
+        country_names = re.findall(
+            r"globe\.countryOption\.\w+\":\[\{\"type\":\d,\"value\":\"(.+?)\"}]", response.text.replace('\\"', '"')
+        )
         self.logger.info(f"Found country names: {country_names}")
         for country_name in country_names:
             matches = pycountry.countries.search_fuzzy(country_name)


### PR DESCRIPTION
```python
{'atp/brand/Volkswagen': 792,
 'atp/brand_wikidata/Q246': 792,
 'atp/category/shop/car': 449,
 'atp/category/shop/car_repair': 343,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AL': 2,
 'atp/country/AT': 245,
 'atp/country/BA': 11,
 'atp/country/BG': 10,
 'atp/country/CL': 35,
 'atp/country/CO': 33,
 'atp/country/CZ': 90,
 'atp/country/HR': 39,
 'atp/country/HU': 61,
 'atp/country/MK': 7,
 'atp/country/MY': 17,
 'atp/country/PT': 55,
 'atp/country/RO': 62,
 'atp/country/RS': 12,
 'atp/country/SG': 5,
 'atp/country/SI': 33,
 'atp/country/SK': 45,
 'atp/country/UA': 30,
 'atp/field/branch/missing': 792,
 'atp/field/city/missing': 1,
 'atp/field/email/invalid': 4,
 'atp/field/email/missing': 28,
 'atp/field/image/missing': 792,
 'atp/field/lat/missing': 7,
 'atp/field/lon/missing': 7,
 'atp/field/opening_hours/missing': 609,
 'atp/field/operator/missing': 792,
 'atp/field/operator_wikidata/missing': 792,
 'atp/field/phone/invalid': 34,
 'atp/field/phone/missing': 21,
 'atp/field/postcode/missing': 15,
 'atp/field/state/missing': 792,
 'atp/field/street_address/missing': 792,
 'atp/field/twitter/missing': 792,
 'atp/field/website/invalid': 5,
 'atp/field/website/missing': 57,
 'atp/item_scraped_host_count/hs.porsche-holding.com': 797,
 'atp/nsi/cc_match': 792,
 'downloader/request_bytes': 14456,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 289464,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 31,
 'downloader/response_status_count/429': 9,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 467.355061,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 4, 7, 22, 20, 489134, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2345653,
 'httpcompression/response_count': 21,
 'item_dropped_count': 5,
 'item_dropped_reasons_count/DropItem': 5,
 'item_scraped_count': 792,
 'items_per_minute': None,
 'log_count/DEBUG': 849,
 'log_count/INFO': 47,
 'log_count/WARNING': 13,
 'request_depth_max': 1,
 'response_received_count': 31,
 'responses_per_minute': None,
 'retry/count': 9,
 'retry/reason_count/429 Unknown Status': 9,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 38,
 'scheduler/dequeued/memory': 38,
 'scheduler/enqueued': 38,
 'scheduler/enqueued/memory': 38,
 'start_time': datetime.datetime(2025, 2, 4, 7, 14, 33, 134073, tzinfo=datetime.timezone.utc)}
```