### PR TITLE
[Mr Bricolage BE] Fix spider

### DIFF
--- a/locations/spiders/mr_bricolage_be.py
+++ b/locations/spiders/mr_bricolage_be.py
@@ -23,6 +23,7 @@ class MrBricolageBESpider(JSONBlobSpider):
         )["stores"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Mr.Bricolage ")
         item["website"] = feature.get("urlStore")
         item["facebook"] = feature.get("fb_url")
         item["opening_hours"] = OpeningHours()

--- a/locations/spiders/mr_bricolage_be.py
+++ b/locations/spiders/mr_bricolage_be.py
@@ -1,102 +1,24 @@
-import scrapy
+from typing import Iterable
 
-from locations.hours import DAYS_FR, OpeningHours
+import chompjs
+from scrapy.http import Response
+
 from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class MrBricolageBESpider(scrapy.Spider):
+class MrBricolageBESpider(JSONBlobSpider):
     name = "mr_bricolage_be"
     item_attributes = {"brand": "Mr. Bricolage", "brand_wikidata": "Q3141657"}
-    start_urls = ["https://www.mr-bricolage.be/magasins?ajax=1&all=1"]
+    start_urls = ["https://www.mr-bricolage.be/magasins"]
 
-    def parse(self, response):
-        stores = response.xpath("/markers/marker")
-        for store in stores:
-            # There is a StoreNo but there is no more info.
-            # ref = store.xpath("./StoreNo/text()").get()
-            ref = store.xpath("./@id_store").get()
-            name = store.xpath("./@name").get()
-            phone = store.xpath("./@phone").get()
-            city = store.xpath("./VisitCity/text()").get()
-            lon = float(store.xpath("./@lng").get())
-            lat = float(store.xpath("./@lat").get())
-            website = "https://www.mr-bricolage.be" + store.xpath("./@link").get()
+    def extract_json(self, response: Response) -> list:
+        return chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "var extendStore")]')
+            .re_first(r"var extendStore[=\s]+({.+})\s*;")
+            .replace("formated", "formatted")
+        )["stores"]
 
-            properties = {
-                "ref": ref,
-                "name": name,
-                "phone": phone,
-                "city": city,
-                "lon": lon,
-                "lat": lat,
-                "website": website,
-            }
-
-            if website:
-                yield scrapy.http.Request(
-                    url=website,
-                    method="GET",
-                    callback=self.add_website_info,
-                    cb_kwargs={"properties": properties},
-                )
-            else:
-                yield Feature(**properties)
-
-    def add_website_info(self, response, properties):
-        properties = self.get_address_info(response, properties)
-
-        if opening_hours := self.parse_hours(response):
-            properties["opening_hours"] = opening_hours
-
-        yield Feature(**properties)
-
-    def get_address_info(self, response, properties):
-        addr_part = (
-            response.xpath('//*[@class="advanced-cms-wrapper "]')
-            .xpath('//*[@class="col-md-4"]//*[@class="rte"]/p[2]/text()')
-            .getall()
-        )
-
-        if len(addr_part) == 2:
-            street_address, postcode_city = self.clean_text(addr_part[0]), self.clean_text(addr_part[1])
-        elif len(addr_part) == 1:
-            street_address = self.clean_text(addr_part[0])
-            postcode_city = self.clean_text(
-                (
-                    response.xpath('//*[@class="advanced-cms-wrapper "]')
-                    .xpath('//*[@class="col-md-4"]//*[@class="rte"]/p[2]/text()')
-                    .getall()
-                )[0]
-            )
-
-        addr_full = clean_address([street_address, postcode_city])
-        properties["addr_full"] = addr_full
-        properties["street_address"] = street_address
-        return properties
-
-    def parse_hours(self, store):
-        open_hours_path = store.xpath('//*[@class="advanced-cms-wrapper "]').xpath("//table/tbody")
-        opening_hours = OpeningHours()
-
-        for i in range(1, 8):
-            if (day_path := open_hours_path.xpath(f"//tr[{i}]/td/text()").getall()) is not None:
-                # Add Week days
-                if len(day_path) == 2:
-                    day, hours = self.clean_text(day_path[0]), self.clean_text(day_path[1])
-                else:
-                    day = self.clean_text(day_path[0])
-                    hours = open_hours_path.xpath(f"//tr[{i}]/td[2]/span/text()").get()
-                if hours != "Fermé":
-                    open_hours, close_hours = hours.split(" ")[0], hours.split(" ")[2]
-                    opening_hours.add_range(
-                        day=DAYS_FR[day],
-                        open_time=open_hours,
-                        close_time=close_hours,
-                        time_format="%H:%M",
-                    )
-
-        return opening_hours.as_opening_hours()
-
-    def clean_text(self, text):
-        return text.replace(",", "").replace("\xa0", " ")
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["website"] = feature.get("urlStore")
+        yield item

--- a/locations/spiders/mr_bricolage_be.py
+++ b/locations/spiders/mr_bricolage_be.py
@@ -24,6 +24,7 @@ class MrBricolageBESpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["website"] = feature.get("urlStore")
+        item["facebook"] = feature.get("fb_url")
         item["opening_hours"] = OpeningHours()
         for index, rule in enumerate(json.loads(feature.get("hours", "[]"))):
             for shift in rule:


### PR DESCRIPTION
Utilized `JSON Blob` to fix the broken spider.

```
{'atp/brand/Mr. Bricolage': 44,
 'atp/brand_wikidata/Q3141657': 44,
 'atp/category/shop/doityourself': 44,
 'atp/country/BE': 44,
 'atp/field/country/from_website_url': 44,
 'atp/field/email/missing': 44,
 'atp/field/image/missing': 44,
 'atp/field/operator/missing': 44,
 'atp/field/operator_wikidata/missing': 44,
 'atp/field/state/missing': 44,
 'atp/field/twitter/missing': 44,
 'atp/item_scraped_host_count/www.mr-bricolage.be': 44,
 'atp/nsi/cc_match': 44,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 928,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 79053,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 17.794674,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 4, 11, 53, 54, 403766, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 824523,
 'httpcompression/response_count': 1,
 'item_scraped_count': 44,
 'items_per_minute': None,
 'log_count/DEBUG': 58,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 4, 11, 53, 36, 609092, tzinfo=datetime.timezone.utc)}
```