### PR TITLE
New spider: Bright Now! Dental (180 locations)

### DIFF
--- a/locations/spiders/bright_now_dental_us.py
+++ b/locations/spiders/bright_now_dental_us.py
@@ -1,0 +1,21 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BrightNowDentalUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "bright_now_dental_us"
+    item_attributes = {
+        "brand": "Bright Now! Dental",
+        "brand_wikidata": "Q108286875",
+    }
+    sitemap_urls = ["https://www.brightnow.com/wp-content/uploads/custom-sitemaps/1/locations-sitemap.xml"]
+    sitemap_rules = [
+        (r"^https://www\.brightnow\.com/dental-office/[\w-]+/\d+/$", "parse"),
+    ]
+    search_for_facebook = False
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Bright Now! Dental - ")
+        item["ref"] = response.url.split("/")[-2]
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Bright Now! Dental': 180,
 'atp/brand_wikidata/Q108286875': 180,
 'atp/category/amenity/dentist': 180,
 'atp/category/multiple': 180,
 'atp/country/US': 180,
 'atp/field/email/missing': 180,
 'atp/field/image/invalid': 1,
 'atp/field/operator/missing': 180,
 'atp/field/operator_wikidata/missing': 180,
 'atp/field/twitter/missing': 180,
 'atp/item_scraped_host_count/www.brightnow.com': 180,
 'atp/nsi/perfect_match': 180,
 'downloader/request_bytes': 86135,
 'downloader/request_count': 184,
 'downloader/request_method_count/GET': 184,
 'downloader/response_bytes': 4151172,
 'downloader/response_count': 184,
 'downloader/response_status_count/200': 184,
 'elapsed_time_seconds': 226.486599,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 5, 0, 9, 58, 629716, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 19997715,
 'httpcompression/response_count': 184,
 'item_scraped_count': 180,
 'items_per_minute': None,
 'log_count/DEBUG': 375,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'memusage/max': 407216128,
 'memusage/startup': 253763584,
 'request_depth_max': 1,
 'response_received_count': 184,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 183,
 'scheduler/dequeued/memory': 183,
 'scheduler/enqueued': 183,
 'scheduler/enqueued/memory': 183,
 'start_time': datetime.datetime(2025, 2, 5, 0, 6, 12, 143117, tzinfo=datetime.timezone.utc)}
```