### PR TITLE
[Evereve US] Fix Spider

### DIFF
--- a/locations/spiders/evereve_us.py
+++ b/locations/spiders/evereve_us.py
@@ -1,10 +1,9 @@
-import ast
 import json
 from typing import Iterable
 
 import scrapy
 from scrapy import Request
-from scrapy.http import Response, JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.items import Feature
@@ -15,7 +14,9 @@ class EvereveUSSpider(scrapy.Spider):
     item_attributes = {"brand": "Evereve", "brand_wikidata": "Q69891997"}
 
     def start_requests(self) -> Iterable[Request]:
-        yield JsonRequest(url = "https://evereve-prod.labs.wesupply.xyz/searchForStores",method="POST",callback=self.parse)
+        yield JsonRequest(
+            url="https://evereve-prod.labs.wesupply.xyz/searchForStores", method="POST", callback=self.parse
+        )
 
     def parse(self, response: Response) -> Iterable[Feature]:
         for store in json.loads(response.json())["MetaData"].values():
@@ -23,4 +24,3 @@ class EvereveUSSpider(scrapy.Spider):
             item = DictParser.parse(store)
             item["ref"] = store["PlaceId"]
             yield item
-

--- a/locations/spiders/evereve_us.py
+++ b/locations/spiders/evereve_us.py
@@ -1,35 +1,26 @@
+import ast
+import json
 from typing import Iterable
 
-import chompjs
 import scrapy
-from scrapy.http import Response
+from scrapy import Request
+from scrapy.http import Response, JsonRequest
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 from locations.items import Feature
 
 
 class EvereveUSSpider(scrapy.Spider):
     name = "evereve_us"
     item_attributes = {"brand": "Evereve", "brand_wikidata": "Q69891997"}
-    start_urls = ["https://evereve.com/apps/wesupply/store-locator"]
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(url = "https://evereve-prod.labs.wesupply.xyz/searchForStores",method="POST",callback=self.parse)
 
     def parse(self, response: Response) -> Iterable[Feature]:
-        for store in chompjs.parse_js_object(
-            response.xpath('//*[contains(text(),"wesupply_shop_locations")]/text()').get()
-        ):
+        for store in json.loads(response.json())["MetaData"].values():
+            store.update(store["Geometry"].pop("location"))
             item = DictParser.parse(store)
-            item["website"] = "".join(
-                ["https://evereve.com/apps/wesupply/store-locator/", "/".join(store["storeIdentifier"].values())]
-            )
-            item["opening_hours"] = OpeningHours()
-            for day, time in store["hours"].items():
-                if time == "":
-                    continue
-                if ":" not in time:
-                    time = time.replace("a-", "am - ").replace("am", ":00 AM").replace("pm", ":00 PM")
-                open_time, close_time = time.split("-")
-                item["opening_hours"].add_range(
-                    day=day, open_time=open_time.strip(), close_time=close_time.strip(), time_format="%I:%M %p"
-                )
+            item["ref"] = store["PlaceId"]
             yield item
+


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/Evereve': 119,
 'atp/brand_wikidata/Q69891997': 119,
 'atp/category/shop/clothes': 119,
 'atp/country/US': 119,
 'atp/field/branch/missing': 119,
 'atp/field/city/missing': 119,
 'atp/field/country/from_spider_name': 119,
 'atp/field/email/missing': 119,
 'atp/field/image/missing': 119,
 'atp/field/opening_hours/missing': 119,
 'atp/field/operator/missing': 119,
 'atp/field/operator_wikidata/missing': 119,
 'atp/field/phone/missing': 119,
 'atp/field/postcode/missing': 119,
 'atp/field/state/from_reverse_geocoding': 119,
 'atp/field/street_address/missing': 119,
 'atp/field/twitter/missing': 119,
 'atp/field/website/missing': 119,
 'atp/item_scraped_host_count/evereve-prod.labs.wesupply.xyz': 120,
 'atp/nsi/perfect_match': 119,
 'downloader/request_bytes': 773,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 18381,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.107089,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 5, 8, 51, 40, 139658, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 62803,
 'httpcompression/response_count': 1,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 119,
 'items_per_minute': None,
 'log_count/DEBUG': 133,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 5, 8, 51, 36, 32569, tzinfo=datetime.timezone.utc)}