### PR TITLE
[Fcbanking] Fix spider

### DIFF
--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -18,4 +18,5 @@ class FcbankingSpider(SitemapSpider, StructuredDataSpider):
         location = json.loads(response.xpath("//@data-location").get(""))
         item["lat"] = location.get("latLng", {}).get("latitude")
         item["lon"] = location.get("latLng", {}).get("longitude")
+        item["name"], item["branch"] = item["name"].removesuffix(" Office").split(" - ", 1)
         yield item

--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -3,6 +3,7 @@ import json
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -19,4 +20,5 @@ class FcbankingSpider(SitemapSpider, StructuredDataSpider):
         item["lat"] = location.get("latLng", {}).get("latitude")
         item["lon"] = location.get("latLng", {}).get("longitude")
         item["name"], item["branch"] = item["name"].removesuffix(" Office").split(" - ", 1)
+        apply_category(Categories.BANK, item)
         yield item

--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -3,7 +3,7 @@ import json
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -21,4 +21,12 @@ class FcbankingSpider(SitemapSpider, StructuredDataSpider):
         item["lon"] = location.get("latLng", {}).get("longitude")
         item["name"], item["branch"] = item["name"].removesuffix(" Office").split(" - ", 1)
         apply_category(Categories.BANK, item)
+        apply_yes_no(
+            Extras.ATM,
+            item,
+            any(
+                location.get(atm_key)
+                for atm_key in ["hasDriveUpATM", "hasWalkUpATM", "hasOffPremiseWalkUpATM", "hasOffPremiseDriveUpATM"]
+            ),
+        )
         yield item

--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -1,37 +1,11 @@
-import json
-import re
-import urllib.parse
-
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FcbankingSpider(SitemapSpider):
+class FcbankingSpider(SitemapSpider, StructuredDataSpider):
     name = "fcbanking"
     item_attributes = {"brand": "First Commonwealth Bank", "brand_wikidata": "Q5452773"}
-    allowed_domains = ["www.fcbanking.com"]
     sitemap_urls = ["https://www.fcbanking.com/robots.txt"]
-    sitemap_follow = ["branch-locations"]
-    sitemap_rules = [(r"branch-locations/.", "parse")]
-
-    def parse(self, response):
-        map_script = response.xpath('//script/text()[contains(., "setLat")]').get()
-        map_script = map_script.replace("\r", "\n")
-        lat = re.search(r'setLat\("(.*)"\)', map_script)[1]
-        lon = re.search(r'setLon\("(.*)"\)', map_script)[1]
-
-        ldjson = response.xpath('//script[@type="application/ld+json"]/text()').get()
-        ldjson = ldjson.replace("\r", "\n")
-        data = json.loads(re.sub(r"^//.*$", "", ldjson, flags=re.M))
-        item = LinkedDataParser.parse_ld(data)
-        item["lat"] = lat
-        item["lon"] = lon
-        item["website"] = response.url
-        path = urllib.parse.urlsplit(response.url).path
-        item["ref"] = path.removeprefix("/branch-locations")
-        hours_fixed = [re.sub(r"([ap])\.m\.?", r"\1m", row).replace("\u2013", "-") for row in data["openingHours"]]
-        item["opening_hours"] = LinkedDataParser.parse_opening_hours({"openingHours": hours_fixed}, "%I:%M %p")
-        apply_category(Categories.BANK, item)
-        yield item
+    sitemap_rules = [(r"/branch-locations/[-\w]+/[-\w]+/[-\w]+/[-\w]+", "parse_sd")]
+    wanted_types = ["BankOrCreditUnion"]  # Capture only url specific linked data

--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -1,5 +1,9 @@
+import json
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,3 +13,9 @@ class FcbankingSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.fcbanking.com/robots.txt"]
     sitemap_rules = [(r"/branch-locations/[-\w]+/[-\w]+/[-\w]+/[-\w]+", "parse_sd")]
     wanted_types = ["BankOrCreditUnion"]  # Capture only url specific linked data
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        location = json.loads(response.xpath("//@data-location").get(""))
+        item["lat"] = location.get("latLng", {}).get("latitude")
+        item["lon"] = location.get("latLng", {}).get("longitude")
+        yield item

--- a/locations/spiders/fcbanking.py
+++ b/locations/spiders/fcbanking.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
@@ -14,6 +15,12 @@ class FcbankingSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.fcbanking.com/robots.txt"]
     sitemap_rules = [(r"/branch-locations/[-\w]+/[-\w]+/[-\w]+/[-\w]+", "parse_sd")]
     wanted_types = ["BankOrCreditUnion"]  # Capture only url specific linked data
+    time_format = "%I:%M %p"
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data["openingHours"] = [
+            re.sub(r"([ap])\.m\.?", r"\1m", row).replace("\u2013", "-") for row in ld_data.get("openingHours", [])
+        ]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         location = json.loads(response.xpath("//@data-location").get(""))


### PR DESCRIPTION
Utilized `Structured Data` to fix the spider, also identified `ATM`s.

```python
{'atp/brand/First Commonwealth Bank': 125,
 'atp/brand_wikidata/Q5452773': 125,
 'atp/category/amenity/bank': 125,
 'atp/country/US': 125,
 'atp/field/country/from_reverse_geocoding': 125,
 'atp/field/email/missing': 1,
 'atp/field/image/dropped': 125,
 'atp/field/image/missing': 125,
 'atp/field/operator/missing': 125,
 'atp/field/operator_wikidata/missing': 125,
 'atp/item_scraped_host_count/www.fcbanking.com': 125,
 'atp/nsi/cc_match': 125,
 'downloader/request_bytes': 138590,
 'downloader/request_count': 128,
 'downloader/request_method_count/GET': 128,
 'downloader/response_bytes': 18799071,
 'downloader/response_count': 128,
 'downloader/response_status_count/200': 128,
 'elapsed_time_seconds': 8.132148,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 5, 10, 21, 39, 413544, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 128,
 'httpcompression/response_bytes': 84120027,
 'httpcompression/response_count': 127,
 'item_scraped_count': 125,
 'items_per_minute': None,
 'log_count/DEBUG': 265,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 128,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 127,
 'scheduler/dequeued/memory': 127,
 'scheduler/enqueued': 127,
 'scheduler/enqueued/memory': 127,
 'start_time': datetime.datetime(2025, 2, 5, 10, 21, 31, 281396, tzinfo=datetime.timezone.utc)}
```