### PR TITLE
[Bauhaus CH] Fix Spider

### DIFF
--- a/locations/spiders/bauhaus_ch.py
+++ b/locations/spiders/bauhaus_ch.py
@@ -1,59 +1,19 @@
 from typing import Iterable
 
-from scrapy.http import Request, Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-
-from locations.categories import Categories, apply_category
-from locations.google_url import url_to_coords
-from locations.hours import CLOSED_DE, DAYS_DE, OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.storefinders.woosmap import WoosmapSpider
 
 BAUHAUS_SHARED_ATTRIBUTES = {"brand": "Bauhaus", "brand_wikidata": "Q672043"}
 
 
-class BauhausCHSpider(CrawlSpider):
+class BauhausCHSpider(WoosmapSpider):
     name = "bauhaus_ch"
     item_attributes = BAUHAUS_SHARED_ATTRIBUTES
-    allowed_domains = ["www.bauhaus.ch", "goo.gl", "www.google.ch"]
-    start_urls = ["https://www.bauhaus.ch/de/fachcentren"]
-    rules = [Rule(LinkExtractor(allow=r"^https:\/\/www\.bauhaus\.ch\/de\/fachcentren\/fachcenter-[\w\-]+$"), "parse")]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,  # Don't check robots.txt for www.google.ch
-        "DUPEFILTER_CLASS": "scrapy.dupefilters.BaseDupeFilter",  # Some stores have the same coordinates (source problem)
-        # but it's better to extract duplicate coordinates via
-        # the expanded www.google.ch URL than to ignore a store.
-    }
+    key = "woos-23dea7a7-1819-3653-a927-b29706843612"
+    origin = "https://www.bauhaus.ch"
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        properties = {
-            "ref": response.url.split("/fachcenter-", 1)[1],
-            "branch": response.xpath("//main/section[1]/h1/text()").get().removeprefix("Fachcenter "),
-            "addr_full": merge_address_lines(
-                response.xpath("//main/section[3]//table/tbody/tr[1]/td[2]/text()").getall()
-            ),
-            "phone": response.xpath("//main/section[3]//table/tbody/tr[2]/td[2]//text()").get(),
-            "email": response.xpath("//main/section[3]//table/tbody/tr[3]/td[2]//text()").get(),
-            "website": response.url,
-            "opening_hours": OpeningHours(),
-        }
-
-        hours_string = " ".join(response.xpath("//main/section[2]//table//text()").getall())
-        properties["opening_hours"].add_ranges_from_string(hours_string, days=DAYS_DE, closed=CLOSED_DE)
-
-        apply_category(Categories.SHOP_DOITYOURSELF, properties)
-
-        short_google_maps_url = response.xpath(
-            '//main/section[3]//a[contains(@href, "https://goo.gl/maps/")]/@href'
-        ).get()
-        item = Feature(**properties)
-        item["extras"] = {}
-        item["extras"]["@source_uri"] = item["website"]
-        yield Request(url=short_google_maps_url, meta={"item": item}, callback=self.add_coordinates)
-
-    # Follow shortened URL to find full Google Maps URL containing coordinates
-    def add_coordinates(self, response: Response) -> Iterable[Feature]:
-        item = response.meta["item"]
-        item["lat"], item["lon"] = url_to_coords(response.url)
+    def parse_item(self, item: Feature, feature: dict) -> Iterable[Feature]:
+        print(feature)
+        item["branch"] = item.pop("name")
+        item["website"] = "https://www.bauhaus.ch/de/s/service/fachcentren/fachcenter-{}".format(item["branch"].lower())
         yield item

--- a/locations/spiders/bauhaus_ch.py
+++ b/locations/spiders/bauhaus_ch.py
@@ -13,7 +13,6 @@ class BauhausCHSpider(WoosmapSpider):
     origin = "https://www.bauhaus.ch"
 
     def parse_item(self, item: Feature, feature: dict) -> Iterable[Feature]:
-        print(feature)
         item["branch"] = item.pop("name")
         item["website"] = "https://www.bauhaus.ch/de/s/service/fachcentren/fachcenter-{}".format(item["branch"].lower())
         yield item


### PR DESCRIPTION
`Fixes : code refactored to fix spider`

{'atp/brand/Bauhaus': 5,
 'atp/brand_wikidata/Q672043': 5,
 'atp/category/shop/doityourself': 5,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/CH': 5,
 'atp/field/image/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/field/state/missing': 5,
 'atp/field/twitter/missing': 5,
 'atp/item_scraped_host_count/api.woosmap.com': 5,
 'atp/nsi/cc_match': 5,
 'downloader/request_bytes': 727,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 2777,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.141286,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 6, 4, 27, 53, 639574, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11394,
 'httpcompression/response_count': 1,
 'item_scraped_count': 5,
 'items_per_minute': None,
 'log_count/DEBUG': 18,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 6, 4, 27, 50, 498288, tzinfo=datetime.timezone.utc)}
