### PR TITLE
[Healius AU] Fix spider

### DIFF
--- a/locations/spiders/healius_au.py
+++ b/locations/spiders/healius_au.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+from urllib.parse import urljoin
 
 from scrapy.http import Response
 
@@ -16,37 +17,44 @@ class HealiusAUSpider(JSONBlobSpider):
             "brand": "Abbott Pathology",
             "brand_wikidata": "Q126165721",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.abbottpathology.com.au",
         },
         "DOREVITCH": {
             "brand": "Dorevitch Pathology",
             "brand_wikidata": "Q126165490",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.dorevitch.com.au",
         },
         "LAVERTY": {
             "brand": "Laverty Pathology",
             "brand_wikidata": "Q105256033",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.laverty.com.au",
         },
         "LUMUS": {
             "brand": "Lumus Imaging",
             "brand_wikidata": "Q130311754",
             # Note: Proposed OSM tag per https://wiki.openstreetmap.org/wiki/Proposal:Medical_Imaging
             "category": Categories.MEDICAL_IMAGING,
+            "website": "https://www.lumusimaging.com.au",
         },
         "QML": {
             "brand": "QML Pathology",
             "brand_wikidata": "Q126165557",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.qml.com.au",
         },
         "TML": {
             "brand": "TML Pathology",
             "brand_wikidata": "Q126165745",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.tmlpath.com.au",
         },
         "WDP": {
             "brand": "Western Diagnostic Pathology",
             "brand_wikidata": "Q126165699",
             "category": Categories.SAMPLE_COLLECTION,
+            "website": "https://www.wdp.com.au",
         },
     }
     allowed_domains = ["api.apps.healius.com.au"]
@@ -60,6 +68,7 @@ class HealiusAUSpider(JSONBlobSpider):
             if brand_code in self.brands.keys():
                 item["brand"] = self.brands[brand_code]["brand"]
                 item["brand_wikidata"] = self.brands[brand_code]["brand_wikidata"]
+                item["website"] = urljoin(self.brands[brand_code]["website"], f'/locations/{feature["url"]}')
                 apply_category(self.brands[brand_code]["category"], item)
             else:
                 raise ValueError("Unknown brand code: {}".format(brand_code))

--- a/locations/spiders/healius_au.py
+++ b/locations/spiders/healius_au.py
@@ -63,17 +63,17 @@ class HealiusAUSpider(JSONBlobSpider):
     ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name", None)
         if brand_code := feature.get("logo"):
             brand_code = brand_code.upper()
             if brand_code in self.brands.keys():
-                item["brand"] = self.brands[brand_code]["brand"]
+                item["name"] = item["brand"] = self.brands[brand_code]["brand"]
                 item["brand_wikidata"] = self.brands[brand_code]["brand_wikidata"]
                 item["website"] = urljoin(self.brands[brand_code]["website"], f'/locations/{feature["url"]}')
                 apply_category(self.brands[brand_code]["category"], item)
             else:
                 raise ValueError("Unknown brand code: {}".format(brand_code))
 
-        item["branch"] = item.pop("name", None)
         item["street_address"] = item["addr_full"]
         item["addr_full"] = clean_address([feature.get("address"), feature.get("address2")])
         item["opening_hours"] = self.parse_opening_hours(feature)

--- a/locations/spiders/healius_au.py
+++ b/locations/spiders/healius_au.py
@@ -51,7 +51,7 @@ class HealiusAUSpider(JSONBlobSpider):
     }
     allowed_domains = ["api.apps.healius.com.au"]
     start_urls = [
-        "https://api.apps.healius.com.au/entity/location/location/filtered?fields=ID,ADDRESS,ADDRESS2,BROCHURE,CC_ID,CLOSURES,DAYS,EMAIL,FACILITIES,FAX,GALLERY_IMAGES,HERO_IMAGE,IS_ADF_SITE,IS_ADF_SITE,LOGO,MODALITIES,MODALITIES,NAME,NEXT_OPEN,OPEN_DAYS,OPEN_EARLY_DAYS,OPEN_LATE_DAYS,PHONE,POSITION,SERVICE_TYPE,SPECIAL_TESTS,STATE,STATUS,TODAY_SHIFTS,NOTICE_EXTERNAL,NOTICE_EXTERNAL_TITLE&serviceType=ALL&includeAdfSites=true"
+        "https://api.apps.healius.com.au/entity/location/location/filtered?fields=ID,ADDRESS,ADDRESS2,BROCHURE,CC_ID,CLOSURES,DAYS,EMAIL,FACILITIES,FAX,GALLERY_IMAGES,HERO_IMAGE,IS_ADF_SITE,LOGO,MODALITIES,NAME,NEXT_OPEN,OPEN_DAYS,OPEN_EARLY_DAYS,OPEN_LATE_DAYS,PHONE,POSITION,SERVICE_TYPE,SPECIAL_TESTS,STATE,STATUS,TODAY_SHIFTS,NOTICE_EXTERNAL,URL&serviceType=ALL"
     ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:

--- a/locations/spiders/healius_au.py
+++ b/locations/spiders/healius_au.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.categories import Categories, Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -15,38 +15,38 @@ class HealiusAUSpider(JSONBlobSpider):
         "ABBOTT": {
             "brand": "Abbott Pathology",
             "brand_wikidata": "Q126165721",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
         "DOREVITCH": {
             "brand": "Dorevitch Pathology",
             "brand_wikidata": "Q126165490",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
         "LAVERTY": {
             "brand": "Laverty Pathology",
             "brand_wikidata": "Q105256033",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
         "LUMUS": {
             "brand": "Lumus Imaging",
             "brand_wikidata": "Q130311754",
             # Note: Proposed OSM tag per https://wiki.openstreetmap.org/wiki/Proposal:Medical_Imaging
-            "extras": Categories.MEDICAL_IMAGING.value,
+            "category": Categories.MEDICAL_IMAGING,
         },
         "QML": {
             "brand": "QML Pathology",
             "brand_wikidata": "Q126165557",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
         "TML": {
             "brand": "TML Pathology",
             "brand_wikidata": "Q126165745",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
         "WDP": {
             "brand": "Western Diagnostic Pathology",
             "brand_wikidata": "Q126165699",
-            "extras": Categories.SAMPLE_COLLECTION.value,
+            "category": Categories.SAMPLE_COLLECTION,
         },
     }
     allowed_domains = ["api.apps.healius.com.au"]
@@ -60,7 +60,7 @@ class HealiusAUSpider(JSONBlobSpider):
             if brand_code in self.brands.keys():
                 item["brand"] = self.brands[brand_code]["brand"]
                 item["brand_wikidata"] = self.brands[brand_code]["brand_wikidata"]
-                item["extras"] = self.brands[brand_code]["extras"]
+                apply_category(self.brands[brand_code]["category"], item)
             else:
                 raise ValueError("Unknown brand code: {}".format(brand_code))
 


### PR DESCRIPTION
```
{'atp/brand/Abbott Pathology': 25,
 'atp/brand/Dorevitch Pathology': 467,
 'atp/brand/Laverty Pathology': 568,
 'atp/brand/Lumus Imaging': 130,
 'atp/brand/QML Pathology': 495,
 'atp/brand/TML Pathology': 19,
 'atp/brand/Western Diagnostic Pathology': 207,
 'atp/brand_wikidata/Q105256033': 568,
 'atp/brand_wikidata/Q126165490': 467,
 'atp/brand_wikidata/Q126165557': 495,
 'atp/brand_wikidata/Q126165699': 207,
 'atp/brand_wikidata/Q126165721': 25,
 'atp/brand_wikidata/Q126165745': 19,
 'atp/brand_wikidata/Q130311754': 130,
 'atp/category/healthcare/medical_imaging': 130,
 'atp/category/healthcare/sample_collection': 1781,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/AU': 1911,
 'atp/field/city/missing': 1911,
 'atp/field/country/from_spider_name': 1911,
 'atp/field/email/invalid': 3,
 'atp/field/email/missing': 101,
 'atp/field/image/missing': 1911,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 1911,
 'atp/field/operator_wikidata/missing': 1911,
 'atp/field/phone/invalid': 12,
 'atp/field/phone/missing': 58,
 'atp/field/postcode/missing': 1911,
 'atp/field/twitter/missing': 1911,
 'atp/item_scraped_host_count/api.apps.healius.com.au': 1911,
 'atp/nsi/brand_missing': 1343,
 'atp/nsi/perfect_match': 568,
 'downloader/request_bytes': 942,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 521144,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 27.880242,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 6, 14, 6, 18, 669191, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8568729,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1911,
 'items_per_minute': None,
 'log_count/DEBUG': 1925,
 'log_count/INFO': 9,
 'log_count/WARNING': 3,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 6, 14, 5, 50, 788949, tzinfo=datetime.timezone.utc)}
```