### PR TITLE
[Mcdonalds AU] Increase download timeout to fix the spider

### DIFF
--- a/locations/spiders/mcdonalds_au.py
+++ b/locations/spiders/mcdonalds_au.py
@@ -15,7 +15,7 @@ class McdonaldsAUSpider(Spider):
     item_attributes = McdonaldsSpider.item_attributes
     allowed_domains = ["mcdonalds.com.au"]
     start_urls = ["https://mcdonalds.com.au/data/store"]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
+    custom_settings = {"DOWNLOAD_TIMEOUT": 180}
 
     @staticmethod
     def parse_hours(rules: list) -> OpeningHours:


### PR DESCRIPTION
```python
{"atp/brand/McDonald's": 1049,
 'atp/brand_wikidata/Q38076': 1049,
 'atp/category/amenity/fast_food': 1049,
 'atp/country/AU': 1049,
 'atp/field/branch/missing': 1049,
 'atp/field/country/from_spider_name': 1049,
 'atp/field/email/missing': 1049,
 'atp/field/image/missing': 1049,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 1049,
 'atp/field/operator_wikidata/missing': 1049,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 7,
 'atp/field/twitter/missing': 1049,
 'atp/field/website/missing': 1049,
 'atp/item_scraped_host_count/mcdonalds.com.au': 1049,
 'atp/mcdonalds_au/facilities/fail/24 Hours': 713,
 'atp/mcdonalds_au/facilities/fail/Birthday Parties': 335,
 'atp/mcdonalds_au/facilities/fail/McCafé': 922,
 'atp/mcdonalds_au/facilities/fail/Playland': 812,
 'atp/nsi/cc_match': 1049,
 'downloader/request_bytes': 614,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5233912,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 179.343708,
 'finish_reason': 'finished',

```