### PR TITLE
[Burger King BE LU] Fix Spider

### DIFF
--- a/locations/spiders/burger_king_be_lu.py
+++ b/locations/spiders/burger_king_be_lu.py
@@ -2,7 +2,6 @@ from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 from locations.storefinders.uberall import UberallSpider
 
 
-
 class BurgerKingBELUSpider(UberallSpider):
     name = "burger_king_be_lu"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES

--- a/locations/spiders/burger_king_be_lu.py
+++ b/locations/spiders/burger_king_be_lu.py
@@ -1,15 +1,9 @@
-import scrapy
-
-from locations.linked_data_parser import LinkedDataParser
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
+from locations.storefinders.uberall import UberallSpider
 
 
-class BurgerKingBELUSpider(scrapy.Spider):
+
+class BurgerKingBELUSpider(UberallSpider):
     name = "burger_king_be_lu"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    start_urls = ["https://stores.burgerking.be/nl/"]
-
-    def parse(self, response, **kwargs):
-        for ld in LinkedDataParser.iter_linked_data(response):
-            if ld["@type"] == "LocalBusiness":
-                yield LinkedDataParser.parse_ld(ld)
+    key = "PsPq35VbL5KCvUbfAeLz66TgZx2FUH"


### PR DESCRIPTION
**_Fixes : code refactored to fix to use uberall spider_**

```python
{'atp/brand/Burger King': 68,
 'atp/brand_wikidata/Q177054': 68,
 'atp/category/amenity/fast_food': 68,
 'atp/country/BE': 58,
 'atp/country/LU': 10,
 'atp/field/branch/missing': 68,
 'atp/field/email/missing': 68,
 'atp/field/image/missing': 67,
 'atp/field/operator/missing': 68,
 'atp/field/operator_wikidata/missing': 68,
 'atp/field/phone/missing': 25,
 'atp/field/twitter/missing': 68,
 'atp/field/website/missing': 68,
 'atp/item_scraped_host_count/uberall.com': 68,
 'atp/nsi/cc_match': 68,
 'downloader/request_bytes': 670,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 9338,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.187936,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 10, 7, 20, 49, 15488, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 59587,
 'httpcompression/response_count': 2,
 'item_scraped_count': 68,
 'items_per_minute': None,
 'log_count/DEBUG': 81,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 10, 7, 20, 45, 827552, tzinfo=datetime.timezone.utc)}
```