### PR TITLE
Increase max-zoom during run_all_spiders

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -88,7 +88,7 @@ scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPIDER_RUN
 
 tippecanoe --cluster-distance=25 \
            --drop-rate=g \
-           --maximum-zoom=13 \
+           --maximum-zoom=14 \
            --cluster-maxzoom=g \
            --layer="alltheplaces" \
            --read-parallel \


### PR DESCRIPTION
The build over this past weekend failed because tippecanoe couldn't fit everything in a single tile (downtown Melbourne: 13/7394/5026). This bumps up the max zoom so that it has a better chance of doing that.