### PR TITLE
Keke's Breakfast Cafe: Rewrite to use API

### DIFF
--- a/locations/spiders/keke.py
+++ b/locations/spiders/keke.py
@@ -1,37 +1,67 @@
+import base64
 import json
-import re
 
-from scrapy.spiders import SitemapSpider
+from scrapy import Request, Spider
+from scrapy.selector import Selector
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
-class KekeSpider(SitemapSpider, StructuredDataSpider):
+class KekeSpider(Spider):
     name = "keke"
     item_attributes = {"brand": "Keke's Breakfast Cafe", "brand_wikidata": "Q115930150"}
-    allowed_domains = ["kekes.com"]
-    sitemap_urls = ["https://www.kekes.com/sitemap.xml"]
-    sitemap_rules = [("/kekes-", "parse_sd")]
-    wanted_types = ["LocalBusiness"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.kekes.com/_api/v1/access-tokens"]
 
-    def post_process_item(self, item, response, ld_data):
-        if response.xpath('//div[@class="sqs-block-content"]/p[1]/text()').get() == "COMING SOON!":
-            return
-        data = json.loads(response.xpath("//@data-block-json").get()).get("location", {})
-        item["name"] = response.xpath('//div[@class="sqs-block-content"]//h1/text()').get()
-        if address := response.xpath(
-            '//a[contains(@href, "maps/place/") or contains(@href, "/g.page/") or contains(@href, "/maps?q")]/text()'
-        ).extract():
-            item["housenumber"] = (re.findall(r"^\d+", address[0].strip())[:1] or (None,))[0]
-            item["street_address"] = address[0].strip()
-            item["city"] = address[-1].split(",")[0]
-            item["state"] = address[-1].split(",")[1].split()[0]
-            item["postcode"] = address[-1].split(",")[1].split()[1]
-        item["country"] = data.get("addressCountry")
-        item["email"] = response.xpath('//a[contains(@href, "mailto")]/text()').get()
-        item["phone"] = response.xpath('//a[contains(@href, "tel")]/text()').get()
-        item["lat"] = data.get("mapLat")
-        item["lon"] = data.get("mapLng")
+    def parse(self, response):
+        query = {
+            "dataCollectionId": "Locations",
+            "query": {"paging": {"limit": 1000}},
+            "environment": "LIVE",
+            "appId": "8c1ec64c-b621-4d3a-9cad-af08be8eba54",
+        }
+        encoded_query = base64.b64encode(json.dumps(query).encode()).decode()
+        sv_session = response.json()["svSession"]
+        yield Request(
+            f"https://www.kekes.com/_api/cloud-data/v2/items/query?.r={encoded_query}",
+            headers={"Cookie": f"svSession={sv_session}"},
+            callback=self.parse_query_response,
+        )
 
-        yield item
+    def parse_query_response(self, response):
+        for data_item in response.json()["dataItems"]:
+            location = data_item["data"]
+            if location["comingSoonYN"]:
+                continue
+
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["ref"] = location["_id"]
+            item["addr_full"] = location["address"].get("formatted")
+            item["street_address"] = location["address"]["streetAddress"].get("formattedAddressLine")
+            item["extras"]["addr:unit"] = location["address"]["streetAddress"].get("apt")
+            item["street"] = location["address"]["streetAddress"].get("name")
+            item["housenumber"] = location["address"]["streetAddress"].get("number")
+            item["state"] = location["address"].get("subdivision")
+            item["lat"] = location["markerLat"]
+            item["lon"] = location["markerLng"]
+            item["extras"]["website:orders"] = location.get("ezChowUrl")
+            item["website"] = response.urljoin(location["link-locations-1-title"])
+            item["phone"] = Selector(text=location["phoneNumber"]).xpath("//text()").get()
+
+            apply_yes_no("drink:alcohol", item, location.get("alcoholYN", False))
+            apply_yes_no(Extras.DELIVERY, item, location.get("deliveryYN", False))
+            apply_yes_no(Extras.INDOOR_SEATING, item, location.get("dineInYN", False))
+            apply_yes_no(Extras.OUTDOOR_SEATING, item, location.get("outdoorSeatingYN", False))
+            apply_yes_no(Extras.TAKEAWAY, item, location.get("pickupYN", False))
+
+            oh = OpeningHours()
+            oh.add_ranges_from_string(f"Daily {location['hours']}")
+            item["opening_hours"] = oh
+
+            if location.get("cateringYN"):
+                apply_category(Categories.CRAFT_CATERER, item)
+            apply_category(Categories.RESTAURANT, item)
+
+            yield item


### PR DESCRIPTION
Not sure if this will be any more or less stable than the sitemap, but it's fewer requests and it does work.

```py
{"atp/brand/Keke's Breakfast Cafe": 70,
 'atp/brand_wikidata/Q115930150': 70,
 'atp/category/amenity/restaurant': 70,
 'atp/category/multiple': 61,
 'atp/country/US': 70,
 'atp/field/email/missing': 70,
 'atp/field/image/missing': 70,
 'atp/field/operator/missing': 70,
 'atp/field/operator_wikidata/missing': 70,
 'atp/field/phone/invalid': 1,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 70,
 'atp/item_scraped_host_count/www.kekes.com': 70,
 'atp/nsi/perfect_match': 70,
 'downloader/request_bytes': 1552,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 42301,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.278993,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 10, 21, 46, 16, 581820, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 490228,
 'httpcompression/response_count': 3,
 'item_scraped_count': 70,
 'items_per_minute': None,
 'log_count/DEBUG': 84,
 'log_count/INFO': 10,
 'memusage/max': 251056128,
 'memusage/startup': 251056128,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 2, 10, 21, 46, 13, 302827, tzinfo=datetime.timezone.utc)}
```