### PR TITLE
[Burger King SG] Fix spider

### DIFF
--- a/locations/spiders/burger_king_sg.py
+++ b/locations/spiders/burger_king_sg.py
@@ -26,7 +26,6 @@ class BurgerKingSGSpider(Spider):
             item["ref"] = location.xpath("@data-restaurant-id").get()
             item["lat"], item["lon"] = url_to_coords(location.xpath('.//a[@class="markerArea"]/@href').get())
             item["branch"] = location.xpath('.//dt[@class="mainAddress"]/text()').get().removeprefix("BK ")
-            item["phone"] = location.xpath('.//span[@class="phone"]/text()').get().replace("Phone:", "")
             item["website"] = f"{self.website_root}/Locator/Details/" + item["ref"]
             yield Request(url=item["website"], callback=self.parse_location, meta={"item": item})
         if response.xpath('//a[contains(@class, "bk-btn-next")]').get() is not None:


### PR DESCRIPTION
`phone` details is not available at all  for any of the POIs. Done code clean up to fix the error.

```python
{'atp/brand/Burger King': 68,
 'atp/brand_wikidata/Q177054': 68,
 'atp/category/amenity/fast_food': 68,
 'atp/country/SG': 68,
 'atp/field/city/missing': 68,
 'atp/field/country/from_spider_name': 68,
 'atp/field/email/missing': 68,
 'atp/field/image/missing': 68,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 68,
 'atp/field/operator_wikidata/missing': 68,
 'atp/field/phone/missing': 68,
 'atp/field/postcode/missing': 68,
 'atp/field/state/missing': 68,
 'atp/field/street_address/missing': 68,
 'atp/field/twitter/missing': 68,
 'atp/item_scraped_host_count/www.burgerking.com.sg': 68,
 'atp/nsi/cc_match': 68,
 'downloader/request_bytes': 32109,
 'downloader/request_count': 86,
 'downloader/request_method_count/GET': 86,
 'downloader/response_bytes': 4927051,
 'downloader/response_count': 86,
 'downloader/response_status_count/200': 85,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 104.929261,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 11, 5, 54, 3, 526361, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 68,
 'items_per_minute': None,
 'log_count/DEBUG': 172,
 'log_count/INFO': 10,
 'request_depth_max': 17,
 'response_received_count': 86,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 85,
 'scheduler/dequeued/memory': 85,
 'scheduler/enqueued': 85,
 'scheduler/enqueued/memory': 85,
 'start_time': datetime.datetime(2025, 2, 11, 5, 52, 18, 597100, tzinfo=datetime.timezone.utc)}
```