### PR TITLE
[Pizza Hut VN] Fix  Spider

### DIFF
--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -29,8 +29,8 @@ class PizzaHutVNSpider(scrapy.Spider):
             item = Feature()
             item["ref"] = store.get("store_code")
             item["lat"], item["lon"] = store.get("location", "").split(",")
-            item["name"] = store.get("name_vi")
-            item["extras"]["name:en"] = store.get("name_en")
+            item["branch"] = store.get("name_vi").removeprefix("Pizza Hut ")
+            item["extras"]["branch:en"] = store.get("name_en").removeprefix("Pizza Hut ")
             item["addr_full"] = store.get("add_vn")
             item["extras"]["addr:full:en"] = clean_address(store.get("add_en"))
             if store.get("Open_Time") and store.get("Close_Time"):

--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -12,11 +12,15 @@ class PizzaHutVNSpider(scrapy.Spider):
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
 
     def start_requests(self):
+        # Token is generated using a timestamp and other parameters, but the timestamp-token pair remains consistent.
+        # Skipping complex JavaScript token generation implementation.
         yield JsonRequest(
-            url="https://api2.pizzahut.vn/api-core/api/store/GetAllStoreList",
+            url="https://rwapi.pizzahut.vn/api/store/GetAllStoreList",
             headers={
-                "Authorization": "Bearer T7RJyFN5ZY/2S7axVLhzLUd6SSBr8kVzvTwp4KdEk9qbcmQN1Zyz0F7fWQoRz6Jz7GjLA6TiFzmvdOhwCKkOCA==",
-                "PROJECT_ID": "WEB",
+                "Authorization": "Bearer 5EGv68487qV+zXxlX73CFsL8L8PPBmzKEoI9AzHvrvVm95T4KpV/Ggu9zyruZvkHLFwc69R+tqoOnP5epRXRWQ==",
+                "deviceuid": "47dcdf29-8d34-4beb-ac1f-8b91537cea35",
+                "project_id": "WEB",
+                "timestamp": "1739260740720",
             },
         )
 


### PR DESCRIPTION
API request updated to fix the spider.

```python
{'atp/brand/Pizza Hut': 122,
 'atp/brand_wikidata/Q191615': 122,
 'atp/category/amenity/restaurant': 122,
 'atp/country/VN': 122,
 'atp/field/city/missing': 122,
 'atp/field/country/from_spider_name': 122,
 'atp/field/email/missing': 122,
 'atp/field/image/missing': 122,
 'atp/field/operator/missing': 122,
 'atp/field/operator_wikidata/missing': 122,
 'atp/field/phone/missing': 122,
 'atp/field/postcode/missing': 122,
 'atp/field/state/missing': 122,
 'atp/field/street_address/missing': 122,
 'atp/field/twitter/missing': 122,
 'atp/field/website/missing': 122,
 'atp/item_scraped_host_count/rwapi.pizzahut.vn': 122,
 'atp/nsi/cc_match': 122,
 'downloader/request_bytes': 850,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 50603,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.582257,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 11, 14, 40, 39, 697648, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 122,
 'items_per_minute': None,
 'log_count/DEBUG': 135,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 11, 14, 40, 37, 115391, tzinfo=datetime.timezone.utc)}
```