### PR TITLE
Insomnia Cookies: Rewrite to fix spider

### DIFF
--- a/locations/spiders/insomnia_cookies.py
+++ b/locations/spiders/insomnia_cookies.py
@@ -1,52 +1,142 @@
-import csv
-import json
+from scrapy import Spider
+from scrapy.http import JsonRequest
 
-import scrapy
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import OpeningHours
+from locations.pipelines.state_clean_up import STATES
 
-from locations.items import Feature
-from locations.searchable_points import open_searchable_points
+COUNTRIES_QUERY = """query COUNTRIES($countryId: ID) {
+  countries(countryId: $countryId) {
+    all {
+      id
+      name
+      url
+      api_url
+      iso3166_code
+    }
+  }
+}"""
+
+LOCATION_SEARCH_QUERY = """query locations($address: String!) {
+  locationSearch(data: {address: $address}) {
+    externalId
+  }
+}"""
+
+STORE_SEARCH_QUERY = """query stores($externalId: String) {
+  storeSearch(data: {externalId: $externalId}) {
+    stores {
+      id
+      countryId
+      name
+      slug
+      address
+      mailingAddress
+      city
+      state
+      zip
+      phone
+      storefrontImage
+      lat
+      lng
+      hours {
+        type
+        days {
+          day
+          hour
+        }
+      }
+    }
+  }
+}"""
 
 
-class InsomniaCookiesSpider(scrapy.Spider):
+class InsomniaCookiesSpider(Spider):
     name = "insomnia_cookies"
     item_attributes = {"brand": "Insomnia Cookies", "brand_wikidata": "Q16997024"}
-    allowed_domains = ["insomniacookies.com"]
+
+    # Too many requests in too short a time puts your IP into a long (>4hr)
+    # timeout. A 15 second delay between requests seems to work.
+    custom_settings = {"DOWNLOAD_DELAY": 15}
 
     def start_requests(self):
-        with open_searchable_points("us_centroids_25mile_radius.csv") as points:
-            reader = csv.DictReader(points)
-            for line in reader:
-                graphql_query = {
-                    "operationName": "stores",
-                    "query": "query stores($lat: Float, $lng: Float, $externalId: String, $orderTypeId: ID) {\n  storeSearch(data: {lat: $lat, lng: $lng, externalId: $externalId, orderTypeId: $orderTypeId}) {\n    lat\n    lng\n    address {\n      address1\n      city\n      state\n      postcode\n      lat\n      lng\n      __typename\n    }\n    stores {\n      id\n      name\n      address\n      distanceToStore\n      phone\n      storefrontImage\n      lat\n      lng\n      inDeliveryRange\n     status\n      note\n      storeType\n      isPickupOpen\n      isDeliveryOpen\n      hours {\n        type\n        days {\n          day\n          hour\n          __typename\n        }\n        __typename\n      }\n      blurb\n      promotionalText\n      __typename\n    }\n    __typename\n  }\n}\n",
-                    "variables": {
-                        "externalId": None,
-                        "lat": float(line["latitude"]),
-                        "lng": float(line["longitude"]),
-                    },
-                }
+        # First get a list of countries with their names, websites, and API
+        # endpoints.
+        yield JsonRequest(
+            "https://api.insomniacookies.com/graphql",
+            data={"query": COUNTRIES_QUERY},
+            callback=self.parse_countries,
+        )
 
-                yield scrapy.Request(
-                    method="POST",
-                    headers={
-                        "content-type": "application/json",
-                        "referer": "https://insomniacookies.com/",
+    def parse_countries(self, response):
+        # The store search query searches for stores within a location, using an
+        # "externalId" (from Google), so we need to get some of those. Too large
+        # areas, like entire countries, return 0 results, so we need the largest
+        # subdivision that does return results. In my testing, provinces/states
+        # work for CA and US, but countries don't work for UK.
+        countries = response.json()["data"]["countries"]["all"]
+        for country in countries:
+            if country["iso3166_code"] in STATES:
+                subdivisions = STATES[country["iso3166_code"]].values()
+            else:
+                # Too many requests also trigger the timeout, so only query the
+                # most populous cities. Of the 34 largest cities in UK, the
+                # smallest with any locations is Nottingham, population 323632.
+                subdivisions = city_locations(country["iso3166_code"], 323632)
+            for subdivision in subdivisions:
+                yield JsonRequest(
+                    country["api_url"] + "/graphql",
+                    data={
+                        "variables": {"address": f"{subdivision['name']}, {country['name']}"},
+                        "query": LOCATION_SEARCH_QUERY,
                     },
-                    url="https://api.insomniacookies.com/graphql",
-                    body=json.dumps(graphql_query),
+                    headers={
+                        "selected-country": country["id"],
+                    },
+                    callback=self.parse_location,
+                    cb_kwargs={"countries": countries},
                 )
 
-    def parse(self, response):
-        data = json.loads(response.text)
+    def parse_location(self, response, countries):
+        # Choose the first search result.
+        external_id = response.json()["data"]["locationSearch"][0]["externalId"]
+        yield JsonRequest(
+            response.url,
+            data={
+                "variables": {"externalId": external_id},
+                "query": STORE_SEARCH_QUERY,
+            },
+            headers={
+                "selected-country": response.request.headers["selected-country"],
+            },
+            callback=self.parse_stores,
+            cb_kwargs={"countries": countries},
+        )
 
-        for store in data.get("data", {}).get("storeSearch", {}).get("stores", []):
-            properties = {
-                "ref": store.get("id"),
-                "lat": store.get("lat"),
-                "lon": store.get("lng"),
-                "name": store.get("name"),
-                "addr_full": store.get("address"),
-                "phone": store.get("phone"),
-            }
+    def parse_stores(self, response, countries):
+        for store in response.json()["data"]["storeSearch"]["stores"]:
+            item = DictParser.parse(store)
+            item["ref"] = f'{store["countryId"]}:{item["ref"]}'
+            item["branch"] = item.pop("name")
+            item["street_address"] = store["mailingAddress"]
+            item["image"] = store["storefrontImage"]
 
-            yield Feature(**properties)
+            store_countries = [c for c in countries if c["id"] == store["countryId"]]
+            if len(store_countries) == 0:
+                self.logger.warn(f"Can't find country ID {store['countryId']!r}")
+            else:
+                country = store_countries[0]
+                item["country"] = country["iso3166_code"]
+                item["extras"]["website:menu"] = f"{country['url']}/menu/{store['slug']}"
+
+            for hours in store["hours"]:
+                oh = OpeningHours()
+                for day in hours["days"]:
+                    oh.add_ranges_from_string(f"{day['day']} {day['hour']}")
+                if hours["type"] == "Retail Hours":
+                    item["opening_hours"] = oh
+                elif hours["type"] == "Delivery Hours":
+                    item["extras"]["opening_hours:delivery"] = oh.as_opening_hours()
+
+            yield item


### PR DESCRIPTION
This spider stood out to me in the [build report](https://alltheplaces-data.openaddresses.io/runs/2025-01-25-13-31-58/stats/_results.json) for how long it took and how many errors it generated. I tried my best to come up with something that worked with the site's highly aggressive rate limiting. It still takes a while (45min), but not as long as before (5hr30min); and it still isn't comprehensive (315 items), but still more complete than before (93 items).

```py
{'atp/brand/Insomnia Cookies': 315,
 'atp/brand_wikidata/Q16997024': 315,
 'atp/category/shop/pastry': 315,
 'atp/country/CA': 2,
 'atp/country/GB': 5,
 'atp/country/US': 308,
 'atp/field/email/missing': 315,
 'atp/field/image/invalid': 29,
 'atp/field/operator/missing': 315,
 'atp/field/operator_wikidata/missing': 315,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 5,
 'atp/field/twitter/missing': 315,
 'atp/field/website/missing': 315,
 'atp/item_scraped_host_count/api.insomniacookies.com': 340,
 'atp/item_scraped_host_count/uk-api.insomniacookies.com': 5,
 'atp/nsi/perfect_match': 315,
 'downloader/request_bytes': 195057,
 'downloader/request_count': 181,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 179,
 'downloader/response_bytes': 588901,
 'downloader/response_count': 181,
 'downloader/response_status_count/200': 181,
 'elapsed_time_seconds': 2666.203609,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 12, 1, 19, 33, 459932, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1216,
 'httpcompression/response_count': 2,
 'item_dropped_count': 30,
 'item_dropped_reasons_count/DropItem': 30,
 'item_scraped_count': 315,
 'items_per_minute': None,
 'log_count/DEBUG': 537,
 'log_count/INFO': 54,
 'log_count/WARNING': 29,
 'memusage/max': 405311488,
 'memusage/startup': 254140416,
 'request_depth_max': 2,
 'response_received_count': 181,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 179,
 'scheduler/dequeued/memory': 179,
 'scheduler/enqueued': 179,
 'scheduler/enqueued/memory': 179,
 'start_time': datetime.datetime(2025, 2, 12, 0, 35, 7, 256323, tzinfo=datetime.timezone.utc)}
```