### PR TITLE
[Costco CA] Fix Spider

### DIFF
--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -20,15 +20,15 @@ class CostcoCASpider(scrapy.Spider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in list(response.json()):
-            if type(store) != bool :
+        for store in response.json():
+            if isinstance(store, dict):
                 item = DictParser.parse(store)
                 item.pop("name")
                 item["ref"] = store["stlocID"]
                 item["branch"] = store["locationName"]
                 item["website"] = (
                     "https://www.costco.ca/warehouse-locations/"
-                    + "-".join([item["branch"].replace(" ","-"),item["state"],str(item["ref"])])
+                    + "-".join([item["branch"].replace(" ", "-"), item["state"], str(item["ref"])])
                     + ".html"
                 )
                 apply_category(Categories.SHOP_WHOLESALE, item)

--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -15,18 +15,21 @@ class CostcoCASpider(scrapy.Spider):
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def start_requests(self) -> Iterable[Request]:
-        yield scrapy.Request(url="https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA",
-                             callback=self.parse)
+        yield scrapy.Request(
+            url="https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA", callback=self.parse
+        )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json():
-            if store == False:
-                continue
-            item = DictParser.parse(store)
-            item.pop("name")
-            item["ref"] = store["stlocID"]
-            item["branch"] = store["locationName"]
-            item["website"] = "https://www.costco.ca/warehouse-locations/" + "-".join(
-                [item["branch"], item["state"], str(item["ref"])]) + ".html"
-            apply_category(Categories.SHOP_WHOLESALE, item)
-            yield item
+        for store in list(response.json()):
+            if type(store) != bool :
+                item = DictParser.parse(store)
+                item.pop("name")
+                item["ref"] = store["stlocID"]
+                item["branch"] = store["locationName"]
+                item["website"] = (
+                    "https://www.costco.ca/warehouse-locations/"
+                    + "-".join([item["branch"].replace(" ","-"),item["state"],str(item["ref"])])
+                    + ".html"
+                )
+                apply_category(Categories.SHOP_WHOLESALE, item)
+                yield item

--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -10,7 +10,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class CostcoCASpider(Spider):
     name = "costco_ca"
-    item_attributes = {"name": "Costco", "brand": "Costco", "brand_wikidata": "Q715583"}
+    item_attributes = {"brand": "Costco", "brand_wikidata": "Q715583"}
     start_urls = ["https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA"]
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
@@ -18,8 +18,7 @@ class CostcoCASpider(Spider):
         for store in response.json():
             if isinstance(store, dict):
                 item = DictParser.parse(store)
-                item.pop("name")
-                item["ref"] = store["stlocID"]
+                item["ref"] = item.pop("name")
                 item["branch"] = store["locationName"]
                 item["website"] = (
                     "https://www.costco.ca/warehouse-locations/"
@@ -27,4 +26,10 @@ class CostcoCASpider(Spider):
                     + ".html"
                 )
                 apply_category(Categories.SHOP_WHOLESALE, item)
+
+                if store["hasBusinessDepartment"] is True:
+                    item["name"] = "Costco Business Center"
+                else:
+                    item["name"] = "Costco"
+
                 yield item

--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -16,20 +16,21 @@ class CostcoCASpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
-            if isinstance(store, dict):
-                item = DictParser.parse(store)
-                item["ref"] = item.pop("name")
-                item["branch"] = store["locationName"]
-                item["website"] = (
-                    "https://www.costco.ca/warehouse-locations/"
-                    + "-".join([item["branch"].replace(" ", "-"), item["state"], str(item["ref"])])
-                    + ".html"
-                )
-                apply_category(Categories.SHOP_WHOLESALE, item)
+            if not isinstance(store, dict):
+                continue
+            item = DictParser.parse(store)
+            item["ref"] = item.pop("name")
+            item["branch"] = store["locationName"]
+            item["website"] = (
+                "https://www.costco.ca/warehouse-locations/"
+                + "-".join([item["branch"].replace(" ", "-"), item["state"], str(item["ref"])])
+                + ".html"
+            )
+            apply_category(Categories.SHOP_WHOLESALE, item)
 
-                if store["hasBusinessDepartment"] is True:
-                    item["name"] = "Costco Business Center"
-                else:
-                    item["name"] = "Costco"
+            if store["hasBusinessDepartment"] is True:
+                item["name"] = "Costco Business Center"
+            else:
+                item["name"] = "Costco"
 
-                yield item
+            yield item

--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -1,7 +1,6 @@
-from typing import Any, Iterable
+from typing import Any
 
-import scrapy
-from scrapy import Request
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
@@ -9,15 +8,11 @@ from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class CostcoCASpider(scrapy.Spider):
+class CostcoCASpider(Spider):
     name = "costco_ca"
     item_attributes = {"name": "Costco", "brand": "Costco", "brand_wikidata": "Q715583"}
+    start_urls = ["https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA"]
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
-
-    def start_requests(self) -> Iterable[Request]:
-        yield scrapy.Request(
-            url="https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA", callback=self.parse
-        )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

{'atp/brand/Costco': 109,
 'atp/brand_wikidata/Q715583': 109,
 'atp/category/shop/wholesale': 109,
 'atp/country/CA': 109,
 'atp/field/email/missing': 109,
 'atp/field/image/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/field/website/invalid': 49,
 'atp/item_scraped_host_count/www.costco.ca': 109,
 'atp/nsi/match_failed': 109,
 'downloader/request_bytes': 292,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 19601,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.21845,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 12, 12, 32, 50, 473525, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 85919,
 'httpcompression/response_count': 1,
 'item_scraped_count': 109,
 'items_per_minute': None,
 'log_count/DEBUG': 121,
 'log_count/INFO': 9,
 'log_count/WARNING': 49,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 12, 12, 32, 48, 255075, tzinfo=datetime.timezone.utc)}