### PR TITLE
[Boost Mobile US] Fix spider

### DIFF
--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
@@ -11,3 +12,9 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://www.boostmobile.com/locations/sitemap-business-main-pages.xml"]
     sitemap_rules = [(r"/locations/bd/boost-mobile-[a-z]{2}-[-\w]", "parse_sd")]
+    custom_settings = {
+        "USER_AGENT": BROWSER_DEFAULT,
+        "CONCURRENT_REQUESTS": 1,
+        "DOWNLOAD_DELAY": 5,
+        "ROBOTSTXT_OBEY": False,
+    }

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -21,6 +21,9 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
         "ROBOTSTXT_OBEY": False,
     }
 
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data["openingHours"] = ld_data.pop("openingHoursSpecification", [])
+
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["addr_full"] = item.pop("street_address")
         item["street_address"] = item.pop("name").removeprefix("Boost ")

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -1,65 +1,13 @@
-from typing import Iterable
-from urllib.parse import urljoin
+from scrapy.spiders import SitemapSpider
 
-from scrapy import Request, Spider
-from scrapy.http import Response
-
-from locations.dict_parser import DictParser
-from locations.geo import country_iseadgg_centroids
-from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class BoostMobileUSSpider(Spider):
+class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
     name = "boost_mobile_us"
     item_attributes = {
         "brand": "Boost Mobile",
         "brand_wikidata": "Q4943790",
     }
-
-    def start_requests(self) -> Iterable[Request]:
-        for lat, lon in country_iseadgg_centroids(["US"], 79):
-            yield Request(
-                "https://www.boostmobile.com/locations/api/get-nearby-business/?lat={}&lon={}&showall=false".format(
-                    lat, lon
-                )
-            )
-
-    def parse(self, response: Response) -> Iterable[Feature | Request]:
-        features = response.json()["business_list"]["object_list"]
-
-        if len(features) > 0:
-            self.crawler.stats.inc_value("atp/geo_search/hits")
-        else:
-            self.crawler.stats.inc_value("atp/geo_search/misses")
-        self.crawler.stats.max_value("atp/geo_search/max_features_returned", len(features))
-
-        for feature in features:
-            if feature["business_type_text"] == "National Retailer":
-                # Exclude Boost Mobile inside Walmart and 7-Eleven.
-                # TODO: we might want to include these in the future with located_in tags.
-                continue
-            item = DictParser.parse(feature)
-            item["name"] = None
-            item["ref"] = feature["dl2_click_id"]
-            item["city"] = feature["locale"]["name"]
-            item["state"] = feature["locale"]["region"]["state"]
-            item["addr_full"] = clean_address(feature["address_text_lines"])
-            item["website"] = urljoin("https://www.boostmobile.com/", feature["business_link"])
-            item["postcode"] = feature["address_postcode"]
-            item["phone"] = feature["contact_context"]["business_phone_raw"]
-            item["opening_hours"] = self.parse_opening_hours(feature)
-            yield item
-
-        if next_page := response.json()["business_list"]["next_page_number"]:
-            yield Request(response.url + f"&page={next_page}")
-
-    def parse_opening_hours(self, feature: dict) -> OpeningHours:
-        oh = OpeningHours()
-        if hours := feature.get("all_opening_hours", {}).get("schemaHrs"):
-            for h in hours:
-                day, open_close = h.split(" ")
-                open, close = open_close.split("-")
-                oh.add_range(day, open, close)
-        return oh
+    sitemap_urls = ["https://www.boostmobile.com/locations/sitemap-business-main-pages.xml"]
+    sitemap_rules = [(r"/locations/bd/boost-mobile-[a-z]{2}-[-\w]", "parse_sd")]

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -28,4 +28,6 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
         item["addr_full"] = item.pop("street_address")
         item["street_address"] = item.pop("name").removeprefix("Boost ")
         item["image"] = None
+        if "Temporarily Closed" in response.xpath('//*[contains(@class, "location-details")]').get(""):
+            item["opening_hours"] = "off"
         yield item

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -18,3 +20,7 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
         "DOWNLOAD_DELAY": 5,
         "ROBOTSTXT_OBEY": False,
     }
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["addr_full"] = item.pop("street_address")
+        yield item

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -23,4 +23,5 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["addr_full"] = item.pop("street_address")
+        item["street_address"] = item.pop("name").removeprefix("Boost ")
         yield item

--- a/locations/spiders/boost_mobile_us.py
+++ b/locations/spiders/boost_mobile_us.py
@@ -27,4 +27,5 @@ class BoostMobileUSSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["addr_full"] = item.pop("street_address")
         item["street_address"] = item.pop("name").removeprefix("Boost ")
+        item["image"] = None
         yield item


### PR DESCRIPTION
The previously used `API` is only working for the website, but outside browser, even using all headers etc it says `The requested URL was rejected. Please consult with your administrator.`, hence code refactored using `Sitemap` and  `SD` to fix the spider.

Scraped count is reasonable, because [Boost owned stores count is around 4000](https://www.fierce-network.com/wireless/boost-mobile-expands-distribution-walgreens).

![image](https://github.com/user-attachments/assets/a3ca866b-f5c6-4df2-85e4-4f5752d772a6)


```python
{'atp/brand/Boost Mobile': 3521,
 'atp/brand_wikidata/Q4943790': 3521,
 'atp/category/shop/mobile_phone': 3521,
 'atp/country/US': 3521,
 'atp/field/branch/missing': 3521,
 'atp/field/email/missing': 3479,
 'atp/field/image/missing': 3521,
 'atp/field/opening_hours/invalid': 95,
 'atp/field/operator/missing': 3521,
 'atp/field/operator_wikidata/missing': 3521,
 'atp/field/twitter/missing': 3521,
 'atp/item_scraped_host_count/www.boostmobile.com': 3521,
 'atp/nsi/perfect_match': 3521,
 'downloader/request_bytes': 2802576,
 'downloader/request_count': 3522,
 'downloader/request_method_count/GET': 3522,
 'downloader/response_bytes': 134931009,
 'downloader/response_count': 3522,
 'downloader/response_status_count/200': 3522,
 'elapsed_time_seconds': 99.475756,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 12, 14, 59, 37, 671894, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 3522,
 'httpcompression/response_bytes': 1155908866,
 'httpcompression/response_count': 3522,
 'item_scraped_count': 3521,
 'items_per_minute': None,
 'log_count/DEBUG': 7055,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 3522,
 'responses_per_minute': None,
 'scheduler/dequeued': 3522,
 'scheduler/dequeued/memory': 3522,
 'scheduler/enqueued': 3522,
 'scheduler/enqueued/memory': 3522,
 'start_time': datetime.datetime(2025, 2, 12, 14, 57, 58, 196138, tzinfo=datetime.timezone.utc)}
```