### PR TITLE
[Coccinelle FR] Fix spider

### DIFF
--- a/locations/spiders/coccinelle_fr.py
+++ b/locations/spiders/coccinelle_fr.py
@@ -4,12 +4,14 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
 BRANDS = {
     "coccimarket": {"brand": "CocciMarket", "brand_wikidata": "Q90020480"},
     "coccimarket city": {"brand": "CocciMarket City", "brand_wikidata": "Q90020481"},
+    "coccimarket easy": {"brand": "CocciMarket Easy", "brand_wikidata": ""},
     "coccinelle express": {"brand": "Coccinelle Express", "brand_wikidata": "Q90020479"},
     "coccinelle supermarche": {"brand": "Coccinelle Supermarché", "brand_wikidata": "Q90020459"},
 }
@@ -51,4 +53,6 @@ class CoccinelleFRSpider(SitemapSpider):
             item.update(brand_info)
         else:
             self.logger.error("Unexpected type: {}".format(brand_key))
+        if brand_key == "coccimarket easy":
+            apply_category(Categories.SHOP_CONVENIENCE, item)
         yield item

--- a/locations/spiders/coccinelle_fr.py
+++ b/locations/spiders/coccinelle_fr.py
@@ -33,6 +33,7 @@ class CoccinelleFRSpider(SitemapSpider):
         item["lat"] = location.get("lat")
         item["lon"] = location.get("lng")
         item["ref"] = response.xpath("//@data-shop").get()
+        item["branch"] = response.xpath('//meta[@property="og:title"]/@content').get("").split("|")[0].strip().title()
         item["website"] = response.url
         item["street_address"] = merge_address_lines(
             [
@@ -40,7 +41,7 @@ class CoccinelleFRSpider(SitemapSpider):
                 response.xpath('//*[contains(@class,"addr-2")]/text()').get(""),
             ]
         )
-        item["city"] = response.xpath('//*[contains(@class,"city")]/text()').get()
+        item["city"] = response.xpath('//*[contains(@class,"city")]/text()').get("").title()
         item["postcode"] = response.xpath('//*[contains(@class,"zipcode")]/text()').get()
         item["phone"] = response.xpath('//a[contains(@href,"tel:")]/@href').get()
         brand_key = (

--- a/locations/spiders/coccinelle_fr.py
+++ b/locations/spiders/coccinelle_fr.py
@@ -11,7 +11,7 @@ from locations.pipelines.address_clean_up import merge_address_lines
 BRANDS = {
     "coccimarket": {"brand": "CocciMarket", "brand_wikidata": "Q90020480"},
     "coccimarket city": {"brand": "CocciMarket City", "brand_wikidata": "Q90020481"},
-    "coccimarket easy": {"brand": "CocciMarket Easy", "brand_wikidata": ""},
+    "coccimarket easy": {"brand": "CocciMarket Easy", "name": "CocciMarket Easy"},
     "coccinelle express": {"brand": "Coccinelle Express", "brand_wikidata": "Q90020479"},
     "coccinelle supermarche": {"brand": "Coccinelle Supermarché", "brand_wikidata": "Q90020459"},
 }

--- a/locations/spiders/coccinelle_fr.py
+++ b/locations/spiders/coccinelle_fr.py
@@ -1,38 +1,54 @@
+import json
 from typing import Any
 
-from scrapy import Spider
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 
 BRANDS = {
-    "CocciMarket": {"brand": "CocciMarket", "brand_wikidata": "Q90020480"},
-    "CocciMarket City - Easy": {"brand": "CocciMarket City", "brand_wikidata": "Q90020481"},
-    "Coccinelle Express": {"brand": "Coccinelle Express", "brand_wikidata": "Q90020479"},
-    "Coccinelle Supermarché": {"brand": "Coccinelle Supermarché", "brand_wikidata": "Q90020459"},
+    "coccimarket": {"brand": "CocciMarket", "brand_wikidata": "Q90020480"},
+    "coccimarket city": {"brand": "CocciMarket City", "brand_wikidata": "Q90020481"},
+    "coccinelle express": {"brand": "Coccinelle Express", "brand_wikidata": "Q90020479"},
+    "coccinelle supermarche": {"brand": "Coccinelle Supermarché", "brand_wikidata": "Q90020459"},
 }
 
 
-class CoccinelleFRSpider(Spider):
+class CoccinelleFRSpider(SitemapSpider):
     name = "coccinelle_fr"
-    start_urls = ["https://www.coccinelle.fr/data/locations.xml"]
+    sitemap_urls = ["https://www.coccinelle.fr/sitemap.xml"]
+    sitemap_rules = [("/magasin/", "parse")]
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            entry["loc"] = entry["loc"].replace("http://default/", "https://www.coccinelle.fr/")
+            yield entry
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath("/markers/marker"):
-            item = Feature()
-            item["lat"] = location.xpath("@lat").get()
-            item["lon"] = location.xpath("@lng").get()
-            item["street_address"] = location.xpath("@address").get()
-            item["city"] = location.xpath("@city").get()
-            item["postcode"] = location.xpath("@postal").get()
-            item["country"] = location.xpath("@country").get()
-            item["phone"] = location.xpath("@phone").get()
-            item["email"] = location.xpath("@email").get()
-            item["ref"] = item["website"] = response.urljoin(location.xpath("@web").get())
-
-            if b := BRANDS.get(location.xpath("@category").get()):
-                item.update(b)
-            else:
-                self.logger.error("Unexpected type: {}".format(location.xpath("@category").get()))
-
-            yield item
+        location = json.loads(response.xpath('//script[contains(text(),"rndmaps")]/text()').get())["rndmaps"]
+        item = Feature()
+        item["lat"] = location.get("lat")
+        item["lon"] = location.get("lng")
+        item["ref"] = response.xpath("//@data-shop").get()
+        item["website"] = response.url
+        item["street_address"] = merge_address_lines(
+            [
+                response.xpath('//*[contains(@class,"addr-1")]/text()').get(""),
+                response.xpath('//*[contains(@class,"addr-2")]/text()').get(""),
+            ]
+        )
+        item["city"] = response.xpath('//*[contains(@class,"city")]/text()').get()
+        item["postcode"] = response.xpath('//*[contains(@class,"zipcode")]/text()').get()
+        item["phone"] = response.xpath('//a[contains(@href,"tel:")]/@href').get()
+        brand_key = (
+            response.xpath('//img[@alt="logo coccinelle"]/following-sibling::*[contains(@class,"poppins")]/text()')
+            .get("")
+            .strip()
+            .lower()
+        )
+        if brand_info := BRANDS.get(brand_key):
+            item.update(brand_info)
+        else:
+            self.logger.error("Unexpected type: {}".format(brand_key))
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/CocciMarket': 502,
 'atp/brand/CocciMarket City': 41,
 'atp/brand/CocciMarket Easy': 8,
 'atp/brand/Coccinelle Express': 168,
 'atp/brand/Coccinelle Supermarché': 81,
 'atp/brand_wikidata/Q90020459': 81,
 'atp/brand_wikidata/Q90020479': 168,
 'atp/brand_wikidata/Q90020480': 502,
 'atp/brand_wikidata/Q90020481': 41,
 'atp/category/shop/convenience': 551,
 'atp/category/shop/supermarket': 249,
 'atp/country/FR': 800,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 800,
 'atp/field/email/missing': 800,
 'atp/field/image/missing': 800,
 'atp/field/opening_hours/missing': 800,
 'atp/field/operator/missing': 800,
 'atp/field/operator_wikidata/missing': 800,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 73,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 800,
 'atp/field/twitter/missing': 800,
 'atp/item_scraped_host_count/www.coccinelle.fr': 800,
 'atp/nsi/perfect_match': 792,
 'downloader/request_bytes': 284178,
 'downloader/request_count': 802,
 'downloader/request_method_count/GET': 802,
 'downloader/response_bytes': 5856224,
 'downloader/response_count': 802,
 'downloader/response_status_count/200': 802,
 'elapsed_time_seconds': 6.5525,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 13, 14, 10, 6, 533537, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 802,
 'httpcompression/response_bytes': 20835261,
 'httpcompression/response_count': 802,
 'item_scraped_count': 800,
 'items_per_minute': None,
 'log_count/DEBUG': 1614,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 802,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 801,
 'scheduler/dequeued/memory': 801,
 'scheduler/enqueued': 801,
 'scheduler/enqueued/memory': 801,
 'start_time': datetime.datetime(2025, 2, 13, 14, 9, 59, 981037, tzinfo=datetime.timezone.utc)}
```