### PR TITLE
[Fastned] Fix Spider

### DIFF
--- a/locations/spiders/fastned.py
+++ b/locations/spiders/fastned.py
@@ -14,8 +14,6 @@ class FastnedSpider(Spider):
             item = DictParser.parse(location)
 
             apply_category(Categories.CHARGING_STATION, item)
-            item["operator"] = self.item_attributes["brand"]
-            item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
 
             # TODO: connector data available in location["connectors"]
             item["street_address"] = item.pop("addr_full", None)


### PR DESCRIPTION
```python
{'atp/category/amenity/charging_station': 345,
 'atp/country/BE': 36,
 'atp/country/CH': 10,
 'atp/country/DE': 42,
 'atp/country/DK': 3,
 'atp/country/FR': 44,
 'atp/country/GB': 30,
 'atp/country/NL': 180,
 'atp/field/branch/missing': 345,
 'atp/field/brand/missing': 345,
 'atp/field/brand_wikidata/missing': 345,
 'atp/field/email/missing': 345,
 'atp/field/image/missing': 345,
 'atp/field/opening_hours/missing': 345,
 'atp/field/phone/missing': 345,
 'atp/field/postcode/missing': 345,
 'atp/field/state/missing': 345,
 'atp/field/twitter/missing': 345,
 'atp/field/website/missing': 345,
 'atp/item_scraped_host_count/route.fastned.nl': 345,
 'atp/nsi/cc_match': 288,
 'atp/nsi/match_failed': 57,
 'atp/operator/Fastned': 345,
 'atp/operator_wikidata/Q19935749': 345,
 'downloader/request_bytes': 618,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16213,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.58802,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 14, 9, 51, 39, 627959, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 121954,
 'httpcompression/response_count': 1,
 'item_scraped_count': 345,
 'items_per_minute': None,
 'log_count/DEBUG': 358,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 14, 9, 51, 32, 39939, tzinfo=datetime.timezone.utc)}
```