### PR TITLE
[Pizza Hut VN ] Generate access token to fix spider

### DIFF
--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -1,5 +1,11 @@
+import re
+import time
+import uuid
+from typing import Any
+
 import scrapy
-from scrapy.http import JsonRequest
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
@@ -10,21 +16,37 @@ from locations.pipelines.address_clean_up import clean_address
 class PizzaHutVNSpider(scrapy.Spider):
     name = "pizza_hut_vn"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
+    start_urls = ["https://pizzahut.vn/_next/static/chunks/700-ac6d47c5279a8d47.js"]
 
-    def start_requests(self):
-        # Token is generated using a timestamp and other parameters, but the timestamp-token pair remains consistent.
-        # Skipping complex JavaScript token generation implementation.
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        next_action_token = re.search(r"([a-f0-9]{40})", response.text).group(1)
+        timestamp = int(time.time() * 1000)
+        device_uid = uuid.uuid4()
+        yield Request(
+            url="https://pizzahut.vn/store-location?area=north",
+            method="POST",
+            body=f'[{{"url":"/store/GetAllStoreList","method":"get","bodyData":"","timeStamp":"{timestamp}","deviceUID":"{device_uid}"}}]',
+            headers={
+                "next-action": next_action_token,
+            },
+            callback=self.parse_token,
+            meta=dict(timestamp=timestamp, device_uid=device_uid),
+        )
+
+    def parse_token(self, response: Response, **kwargs: Any) -> Any:
+        access_token = re.search(r"1[:\s]+\"(.+)\"", response.text).group(1)
         yield JsonRequest(
             url="https://rwapi.pizzahut.vn/api/store/GetAllStoreList",
             headers={
-                "Authorization": "Bearer 5EGv68487qV+zXxlX73CFsL8L8PPBmzKEoI9AzHvrvVm95T4KpV/Ggu9zyruZvkHLFwc69R+tqoOnP5epRXRWQ==",
-                "deviceuid": "47dcdf29-8d34-4beb-ac1f-8b91537cea35",
+                "Authorization": f"Bearer {access_token}",
+                "deviceuid": str(response.meta["device_uid"]),
                 "project_id": "WEB",
-                "timestamp": "1739260740720",
+                "timestamp": str(response.meta["timestamp"]),
             },
+            callback=self.parse_stores,
         )
 
-    def parse(self, response, **kwargs):
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["PZH_StoreList"]["StoreList"]:
             item = Feature()
             item["ref"] = store.get("store_code")


### PR DESCRIPTION
```python
{'atp/brand/Pizza Hut': 121,
 'atp/brand_wikidata/Q191615': 121,
 'atp/category/amenity/restaurant': 121,
 'atp/country/VN': 121,
 'atp/field/city/missing': 121,
 'atp/field/country/from_spider_name': 121,
 'atp/field/email/missing': 121,
 'atp/field/image/missing': 121,
 'atp/field/operator/missing': 121,
 'atp/field/operator_wikidata/missing': 121,
 'atp/field/phone/missing': 121,
 'atp/field/postcode/missing': 121,
 'atp/field/state/missing': 121,
 'atp/field/street_address/missing': 121,
 'atp/field/twitter/missing': 121,
 'atp/field/website/missing': 121,
 'atp/item_scraped_host_count/rwapi.pizzahut.vn': 121,
 'atp/nsi/cc_match': 121,
 'downloader/request_bytes': 2986,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 4,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 101966,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 6.369037,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 17, 11, 43, 30, 657967, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 166084,
 'httpcompression/response_count': 3,
 'item_scraped_count': 121,
 'items_per_minute': None,
 'log_count/DEBUG': 138,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 5,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 2, 17, 11, 43, 24, 288930, tzinfo=datetime.timezone.utc)}
```