### PR TITLE
Sally Beauty US/CA: Switch to structured-data

### DIFF
--- a/locations/spiders/sally_beauty.py
+++ b/locations/spiders/sally_beauty.py
@@ -1,84 +1,26 @@
-from urllib.parse import urlencode
+import re
 
-import scrapy
-from scrapy.selector import Selector
+from scrapy.spiders import SitemapSpider
 
-from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
-from locations.searchable_points import open_searchable_points
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class SallyBeautySpider(scrapy.Spider):
+class SallyBeautySpider(SitemapSpider, StructuredDataSpider):
     name = "sally_beauty"
-    item_attributes = {"brand": "Sally Beauty", "brand_wikidata": "Q7405065"}
-    allowed_domains = ["sallybeauty.com"]
+    item_attributes = {
+        "brand": "Sally Beauty",
+        "brand_wikidata": "Q7405065",
+    }
+    sitemap_urls = ["https://stores.sallybeauty.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"https://stores.sallybeauty.com/[a-z]{2}/[a-z]+/beauty-supply-[\w-]+.html", "parse"),
+    ]
+    drop_attributes = {"name", "facebook"}
+    search_for_twitter = False
 
-    def start_requests(self):
-        base_url = "https://www.sallybeauty.com/on/demandware.store/Sites-SA-Site/default/Stores-FindStores?"
-
-        point_files = [
-            "us_centroids_100mile_radius.csv",
-            "ca_centroids_100mile_radius.csv",
-        ]
-
-        params = {
-            "showmap": "true",
-            "radius": "100",
-        }
-
-        for point_file in point_files:
-            with open_searchable_points(point_file) as points:
-                next(points)
-                for point in points:
-                    _, lat, lon = point.strip().split(",")
-                    params.update({"lat": lat, "long": lon})
-                    yield scrapy.Request(url=base_url + urlencode(params))
-
-    def parse_hours(self, hours):
-        hrs = Selector(text=hours)
-        days = hrs.xpath('//div[@class="store-hours-day"]/text()').extract()
-        hours = hrs.xpath('//div[@class="store-hours-day"]/span/text()').extract()
-
-        opening_hours = OpeningHours()
-
-        for d, h in zip(days, hours):
-            try:
-                day = d.strip(": ")
-                open_time, close_time = h.split(" - ")
-                open_time = open_time.lstrip("0")
-                opening_hours.add_range(
-                    day=day[:2],
-                    open_time=open_time,
-                    close_time=close_time,
-                    time_format="%I:%M %p",
-                )
-            except:
-                continue
-
-        return opening_hours.as_opening_hours()
-
-    def parse(self, response):
-        jdata = response.json()
-
-        for row in jdata.get("stores", []):
-            properties = {
-                "ref": row["ID"],
-                "name": row["name"],
-                "addr_full": clean_address([row.get("address1"), row.get("address2")]),
-                "city": row["city"],
-                "postcode": row["postalCode"],
-                "lat": row["latitude"],
-                "lon": row["longitude"],
-                "phone": row["phone"],
-                "state": row["stateCode"],
-            }
-
-            store_hours = row.get("storeHours")
-            if store_hours:
-                hours = self.parse_hours(store_hours)
-
-                if hours:
-                    properties["opening_hours"] = hours
-
-            yield Feature(**properties)
+    def parse(self, response, **kwargs):
+        # Try to correct syntax errors
+        for el in response.xpath('//script[@type="application/ld+json"]'):
+            match = re.search(r',\s*"mainEntityOfPage"', el.root.text)
+            el.root.text = el.root.text[: match.start()] + "}]"
+        yield from self.parse_sd(response)

--- a/locations/spiders/sally_beauty_ca.py
+++ b/locations/spiders/sally_beauty_ca.py
@@ -1,0 +1,30 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SallyBeautyCASpider(CrawlSpider, StructuredDataSpider):
+    name = "sally_beauty_ca"
+    item_attributes = {
+        "brand": "Sally Beauty",
+        "brand_wikidata": "Q7405065",
+    }
+    allowed_domains = ["stores.sallybeauty.ca"]
+    start_urls = ["https://stores.sallybeauty.ca/"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"^https://stores.sallybeauty.ca/[a-z]{2}/$"),
+            follow=True,
+        ),
+        Rule(
+            LinkExtractor(allow=r"^https://stores.sallybeauty.ca/[a-z]{2}/[a-z]+/$"),
+            follow=True,
+        ),
+        Rule(
+            LinkExtractor(allow=r"^https://stores.sallybeauty.ca/[a-z]{2}/[a-z]+/beauty-supply-[\w-]+.html$"),
+            callback="parse_sd",
+        ),
+    ]
+    drop_attributes = {"name", "facebook", "image"}
+    search_for_twitter = False

--- a/locations/spiders/sally_beauty_us.py
+++ b/locations/spiders/sally_beauty_us.py
@@ -5,8 +5,8 @@ from scrapy.spiders import SitemapSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class SallyBeautySpider(SitemapSpider, StructuredDataSpider):
-    name = "sally_beauty"
+class SallyBeautyUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "sally_beauty_us"
     item_attributes = {
         "brand": "Sally Beauty",
         "brand_wikidata": "Q7405065",


### PR DESCRIPTION
The API used previously still works, so a minimal fix would just be to remove or update `allowed_domains`. But as far as I can tell the API is limited to 30 results per query, so capturing all locations would require ~7k requests, more than the ~2k required for a sitemap crawler. And it has rate limiting.

```py
{'atp/brand/Sally Beauty': 2284,
 'atp/brand_wikidata/Q7405065': 2284,
 'atp/category/shop/hairdresser_supply': 2284,
 'atp/country/MX': 2,
 'atp/country/PR': 36,
 'atp/country/US': 2246,
 'atp/field/branch/missing': 2284,
 'atp/field/country/from_reverse_geocoding': 2284,
 'atp/field/email/missing': 2284,
 'atp/field/image/dropped': 2284,
 'atp/field/image/missing': 2284,
 'atp/field/operator/missing': 2284,
 'atp/field/operator_wikidata/missing': 2284,
 'atp/field/phone/invalid': 2,
 'atp/field/twitter/missing': 2284,
 'atp/item_scraped_host_count/stores.sallybeauty.com': 2284,
 'atp/nsi/perfect_match': 2284,
 'downloader/request_bytes': 923508,
 'downloader/request_count': 2286,
 'downloader/request_method_count/GET': 2286,
 'downloader/response_bytes': 84856480,
 'downloader/response_count': 2286,
 'downloader/response_status_count/200': 2286,
 'elapsed_time_seconds': 2808.332919,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 18, 20, 9, 58, 261169, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 838417824,
 'httpcompression/response_count': 2286,
 'item_scraped_count': 2284,
 'items_per_minute': None,
 'log_count/DEBUG': 4587,
 'log_count/INFO': 56,
 'memusage/max': 926941184,
 'memusage/startup': 251592704,
 'request_depth_max': 1,
 'response_received_count': 2286,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2285,
 'scheduler/dequeued/memory': 2285,
 'scheduler/enqueued': 2285,
 'scheduler/enqueued/memory': 2285,
 'start_time': datetime.datetime(2025, 2, 18, 19, 23, 9, 928250, tzinfo=datetime.timezone.utc)}
```
```py
{'atp/brand/Sally Beauty': 105,
 'atp/brand_wikidata/Q7405065': 105,
 'atp/category/shop/hairdresser_supply': 105,
 'atp/country/CA': 105,
 'atp/field/branch/missing': 105,
 'atp/field/country/from_spider_name': 105,
 'atp/field/email/missing': 105,
 'atp/field/image/missing': 105,
 'atp/field/operator/missing': 105,
 'atp/field/operator_wikidata/missing': 105,
 'atp/field/twitter/missing': 105,
 'atp/item_scraped_host_count/stores.sallybeauty.ca': 105,
 'atp/nsi/perfect_match': 105,
 'downloader/request_bytes': 76220,
 'downloader/request_count': 200,
 'downloader/request_method_count/GET': 200,
 'downloader/response_bytes': 6352348,
 'downloader/response_count': 200,
 'downloader/response_status_count/200': 200,
 'dupefilter/filtered': 177,
 'elapsed_time_seconds': 242.962827,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 18, 22, 20, 53, 526600, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 57344941,
 'httpcompression/response_count': 200,
 'item_scraped_count': 105,
 'items_per_minute': None,
 'log_count/DEBUG': 317,
 'log_count/INFO': 14,
 'memusage/max': 452202496,
 'memusage/startup': 252973056,
 'request_depth_max': 3,
 'response_received_count': 200,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 199,
 'scheduler/dequeued/memory': 199,
 'scheduler/enqueued': 199,
 'scheduler/enqueued/memory': 199,
 'start_time': datetime.datetime(2025, 2, 18, 22, 16, 50, 563773, tzinfo=datetime.timezone.utc)}
```