### PR TITLE
[PKO Bank PL] Fix non running spider

### DIFF
--- a/locations/spiders/pko_bank_polski_pl.py
+++ b/locations/spiders/pko_bank_polski_pl.py
@@ -1,4 +1,3 @@
-
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category

--- a/locations/spiders/pko_bank_polski_pl.py
+++ b/locations/spiders/pko_bank_polski_pl.py
@@ -1,12 +1,8 @@
-import logging
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.geo import point_locations
-from locations.hours import DAYS_PL, DELIMITERS_PL, OpeningHours
 
 
 class PkoBankPolskiPLSpider(Spider):

--- a/locations/spiders/pko_bank_polski_pl.py
+++ b/locations/spiders/pko_bank_polski_pl.py
@@ -12,32 +12,15 @@ from locations.hours import DAYS_PL, DELIMITERS_PL, OpeningHours
 class PkoBankPolskiPLSpider(Spider):
     name = "pko_bank_polski_pl"
     item_attributes = {"brand": "PKO BP", "brand_wikidata": "Q578832"}
-
-    def start_requests(self):
-        for lat, lon in point_locations("eu_centroids_20km_radius_country.csv", "PL"):
-            start_lat = int(float(lat) * 10 - 0.5)
-            start_lon = int(float(lon) * 10 - 0.5)
-            bounds = ",".join([str(c) for c in [start_lat, start_lon, start_lat + 1, start_lon + 1]])
-            yield JsonRequest(
-                url=f"https://www.pkobp.pl/poi/?type=facility,atm&search=&bounds={bounds}",
-            )
+    start_urls = ["https://www.pkobp.pl/api/modules/poi-map?top-left=54.776,14.064&bottom-right=48.934,24.932"]
 
     def parse(self, response):
-        for location in response.json()["result"]:
+        for location in response.json():
             item = DictParser.parse(location)
-            if location["type"] == "atm":
+            item["ref"] = location["unique_id"]
+            if location["label"] == "atm_pko":
                 apply_category(Categories.ATM, item)
-            elif location["type"] == "facility":
+                yield item
+            elif location["label"] == "facility":
                 apply_category(Categories.BANK, item)
-            else:
-                logging.error(f"Unexpected type: {location['type']}")
-            if "opening_hours" in location:
-                if location["opening_hours"] == "Codziennie przez całą dobę":
-                    item["opening_hours"] = "24/7"
-                else:
-                    item["opening_hours"] = OpeningHours()
-                    for line in location["opening_hours"].split("<br />"):
-                        item["opening_hours"].add_ranges_from_string(
-                            ranges_string=line, days=DAYS_PL, delimiters=DELIMITERS_PL
-                        )
-            yield item
+                yield item


### PR DESCRIPTION
```python
{'atp/brand/PKO BP': 3145,
 'atp/brand_wikidata/Q578832': 3145,
 'atp/category/amenity/atm': 2696,
 'atp/category/amenity/bank': 449,
 'atp/country/PL': 3145,
 'atp/field/branch/missing': 3145,
 'atp/field/country/from_spider_name': 3145,
 'atp/field/email/missing': 3145,
 'atp/field/image/missing': 3145,
 'atp/field/name/missing': 2696,
 'atp/field/opening_hours/missing': 3145,
 'atp/field/operator/missing': 449,
 'atp/field/operator_wikidata/missing': 449,
 'atp/field/phone/invalid': 70,
 'atp/field/phone/missing': 2696,
 'atp/field/state/missing': 3145,
 'atp/field/street_address/missing': 3145,
 'atp/field/twitter/missing': 3145,
 'atp/field/website/missing': 3145,
 'atp/item_scraped_host_count/www.pkobp.pl': 3932,
 'atp/nsi/cc_match': 3145,
 'atp/operator/PKO BP': 2696,
 'atp/operator_wikidata/Q578832': 2696,
 'downloader/request_bytes': 792,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4692412,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 15.934875,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 19, 10, 39, 29, 583204, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 753,
 'httpcompression/response_count': 1,
 'item_dropped_count': 787,
 'item_dropped_reasons_count/DropItem': 787,
 'item_scraped_count': 3145,
 'items_per_minute': None,
 'log_count/DEBUG': 3945,
 'log_count/INFO': 9,
 'memusage/max': 179798016,
 'memusage/startup': 179798016,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 19, 10, 39, 13, 648329, tzinfo=datetime.timezone.utc)}
```