### PR TITLE
[Southern Coop] Fix spider

### DIFF
--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -1,19 +1,20 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
+
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.spiders.central_england_cooperative import COOP_FOOD, set_operator
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.uberall import UberallSpider
 
 SOUTHERN_COOP = {"brand": "The Southern Co-operative", "brand_wikidata": "Q7569773"}
 
 
-class SouthernCoopSpider(SitemapSpider, StructuredDataSpider):
+class SouthernCoopSpider(UberallSpider):
     name = "southern_coop"
-    sitemap_urls = ["https://stores.southern.coop/robots.txt"]
-    sitemap_rules = [(r"\.coop\/[-\w]+\/[-\w]+\/[-\w]+\.html$", "parse_sd")]
-    drop_attributes = {"image"}
+    key = "uvMckoaRcAUKR0LkkH03SVNyf7A4Lk"
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
         set_operator(SOUTHERN_COOP, item)
         item.update(COOP_FOOD)
         apply_category(Categories.SHOP_CONVENIENCE, item)

--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -19,4 +19,9 @@ class SouthernCoopSpider(UberallSpider):
         item.update(COOP_FOOD)
         apply_category(Categories.SHOP_CONVENIENCE, item)
 
+        item[
+            "website"
+        ] = f'https://southern.coop/store-locator/l/-/{location["city"]}/{location["streetAndNumber"]}/{location["id"]}'.lower().replace(
+            " ", "-"
+        )
         yield item

--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -22,7 +22,8 @@ class SouthernCoopSpider(UberallSpider):
         else:
             item.update(COOP_FOOD)
         apply_category(Categories.SHOP_CONVENIENCE, item)
-
+        item["branch"] = item.pop("name").removeprefix("Co-op Food").removeprefix(f'{item["brand"]}').strip()
+        item["name"] = item["brand"]
         item[
             "website"
         ] = f'https://southern.coop/store-locator/l/-/{location["city"]}/{location["streetAndNumber"]}/{location["id"]}'.lower().replace(

--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -8,6 +8,7 @@ from locations.spiders.central_england_cooperative import COOP_FOOD, set_operato
 from locations.storefinders.uberall import UberallSpider
 
 SOUTHERN_COOP = {"brand": "The Southern Co-operative", "brand_wikidata": "Q7569773"}
+WELCOME = {"brand": "Welcome", "brand_wikidata": "Q123004215"}
 
 
 class SouthernCoopSpider(UberallSpider):
@@ -16,7 +17,10 @@ class SouthernCoopSpider(UberallSpider):
 
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
         set_operator(SOUTHERN_COOP, item)
-        item.update(COOP_FOOD)
+        if "Welcome" in item["name"]:
+            item.update(WELCOME)
+        else:
+            item.update(COOP_FOOD)
         apply_category(Categories.SHOP_CONVENIENCE, item)
 
         item[

--- a/locations/spiders/southern_coop.py
+++ b/locations/spiders/southern_coop.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.items import Feature, set_closed
 from locations.spiders.central_england_cooperative import COOP_FOOD, set_operator
 from locations.storefinders.uberall import UberallSpider
 
@@ -16,6 +16,8 @@ class SouthernCoopSpider(UberallSpider):
     key = "uvMckoaRcAUKR0LkkH03SVNyf7A4Lk"
 
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        if "closed" in item["name"].lower():
+            set_closed(item)
         set_operator(SOUTHERN_COOP, item)
         if "Welcome" in item["name"]:
             item.update(WELCOME)


### PR DESCRIPTION
`StructuredData` no longer present in the location pages, hence utilized `Uberall` API to fix the spider.

```python
{'atp/brand/The Co-operative Food': 194,
 'atp/brand/Welcome': 74,
 'atp/brand_wikidata/Q107617274': 194,
 'atp/brand_wikidata/Q123004215': 74,
 'atp/category/shop/convenience': 268,
 'atp/closed_poi': 2,
 'atp/country/GB': 268,
 'atp/field/branch/missing': 1,
 'atp/field/email/missing': 268,
 'atp/field/image/missing': 219,
 'atp/field/opening_hours/invalid': 2,
 'atp/field/phone/missing': 5,
 'atp/field/twitter/missing': 268,
 'atp/item_scraped_host_count/uberall.com': 268,
 'atp/nsi/match_failed': 194,
 'atp/nsi/perfect_match': 74,
 'atp/operator/The Southern Co-operative': 268,
 'atp/operator_wikidata/Q7569773': 268,
 'downloader/request_bytes': 670,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 33767,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.454559,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 20, 8, 14, 35, 471909, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 356942,
 'httpcompression/response_count': 2,
 'item_scraped_count': 268,
 'items_per_minute': None,
 'log_count/DEBUG': 281,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 20, 8, 14, 32, 17350, tzinfo=datetime.timezone.utc)}
```