### PR TITLE
[Avia PL] Added fuel details

### DIFF
--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -4,10 +4,9 @@ import scrapy
 from scrapy import Request, Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, Fuel, FuelCards, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
-from locations.categories import Access, Categories, Extras, Fuel, FuelCards, apply_category, apply_yes_no
-
 
 FUELS_AND_SERVICES_MAPPING = {
     # Fuels
@@ -17,7 +16,7 @@ FUELS_AND_SERVICES_MAPPING = {
     "gas_98": Fuel.OCTANE_98,
     "gas_95": Fuel.OCTANE_95,
     "lpg": Fuel.LPG,
-    "hvo" : Fuel.BIODIESEL,
+    "hvo": Fuel.BIODIESEL,
     # Fuel cards
     "eurowag": FuelCards.EUROWAG,
     "dkv": FuelCards.DKV,
@@ -25,6 +24,7 @@ FUELS_AND_SERVICES_MAPPING = {
     "avia": FuelCards.AVIA,
     "e100": FuelCards.E100,
 }
+
 
 class AviaPLSpider(Spider):
     name = "avia_pl"
@@ -49,8 +49,8 @@ class AviaPLSpider(Spider):
                 item["lon"] = ".".join([item["lon"][0:2], item["lon"][2:].replace(".", "")])
             apply_category(Categories.FUEL_STATION, item)
             for key in ["cards", "fuels"]:
-                for tag,value in station["features"][key].items():
-                    if not isinstance(value,bool):
+                for tag, value in station["features"][key].items():
+                    if not isinstance(value, bool):
                         continue
-                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag],item,True if value == True else False)
+                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag], item, True if value == True else False)
             yield item

--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -4,10 +4,27 @@ import scrapy
 from scrapy import Request, Spider
 from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.spiders.avia_de import AVIA_SHARED_ATTRIBUTES
+from locations.categories import Access, Categories, Extras, Fuel, FuelCards, apply_category, apply_yes_no
 
+
+FUELS_AND_SERVICES_MAPPING = {
+    # Fuels
+    "adblue": Fuel.ADBLUE,
+    "diesel": Fuel.DIESEL,
+    "diesel_gold": Fuel.DIESEL,
+    "gas_98": Fuel.OCTANE_98,
+    "gas_95": Fuel.OCTANE_95,
+    "lpg": Fuel.LPG,
+    "hvo" : Fuel.BIODIESEL,
+    # Fuel cards
+    "eurowag": FuelCards.EUROWAG,
+    "dkv": FuelCards.DKV,
+    "uta": FuelCards.UTA,
+    "avia": FuelCards.AVIA,
+    "e100": FuelCards.E100,
+}
 
 class AviaPLSpider(Spider):
     name = "avia_pl"
@@ -31,5 +48,9 @@ class AviaPLSpider(Spider):
             if item["lon"][-2] == ".":
                 item["lon"] = ".".join([item["lon"][0:2], item["lon"][2:].replace(".", "")])
             apply_category(Categories.FUEL_STATION, item)
-
+            for key in ["cards", "fuels"]:
+                for tag,value in station["features"][key].items():
+                    if not isinstance(value,bool):
+                        continue
+                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag],item,True if value == True else False)
             yield item

--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -52,5 +52,5 @@ class AviaPLSpider(Spider):
                 for tag, value in station["features"][key].items():
                     if not isinstance(value, bool):
                         continue
-                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag], item, True if value == True else False)
+                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag], item, True if value else False)
             yield item


### PR DESCRIPTION
_**Fixes : added fuel details**_

```python
{'atp/brand/Avia': 138,
 'atp/brand_wikidata/Q300147': 138,
 'atp/category/amenity/fuel': 138,
 'atp/country/PL': 138,
 'atp/field/branch/missing': 138,
 'atp/field/country/from_spider_name': 138,
 'atp/field/email/missing': 138,
 'atp/field/image/missing': 138,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 138,
 'atp/field/operator_wikidata/missing': 138,
 'atp/field/phone/missing': 6,
 'atp/field/state/missing': 138,
 'atp/field/street_address/missing': 138,
 'atp/field/twitter/missing': 138,
 'atp/field/website/missing': 138,
 'atp/item_scraped_host_count/api.mapa.aviapolska.pl': 138,
 'atp/nsi/cc_match': 138,
 'downloader/request_bytes': 981,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 147997,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.449813,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 20, 10, 12, 49, 725395, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 121,
 'httpcompression/response_count': 1,
 'item_scraped_count': 138,
 'items_per_minute': None,
 'log_count/DEBUG': 151,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 20, 10, 12, 45, 275582, tzinfo=datetime.timezone.utc)}
```