### PR TITLE
[Alltown US] Fix Spider

### DIFF
--- a/locations/spiders/alltown_us.py
+++ b/locations/spiders/alltown_us.py
@@ -2,9 +2,9 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.uberall import UberallSpider
-from locations.categories import Categories, apply_category
 
 
 class AlltownUSSpider(UberallSpider):

--- a/locations/spiders/alltown_us.py
+++ b/locations/spiders/alltown_us.py
@@ -1,12 +1,17 @@
-from locations.categories import Categories
-from locations.hours import DAYS_EN
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
+from locations.categories import Categories, apply_category
 
 
-class AlltownUSSpider(WPStoreLocatorSpider):
+class AlltownUSSpider(UberallSpider):
     name = "alltown_us"
-    item_attributes = {"brand_wikidata": "Q119586667", "brand": "Alltown", "extras": Categories.SHOP_CONVENIENCE.value}
-    allowed_domains = [
-        "alltown.com",
-    ]
-    days = DAYS_EN
+    item_attributes = {"brand_wikidata": "Q119586667", "brand": "Alltown"}
+    key = "gNsMTlc7niXPwZnJ8s9NlD1eR5Z6b3"
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+        yield item


### PR DESCRIPTION
**_Fixes : code updated to use uberall spider_**

```python
{'atp/brand/Alltown': 80,
 'atp/brand_wikidata/Q119586667': 80,
 'atp/category/shop/convenience': 80,
 'atp/country/US': 80,
 'atp/field/branch/missing': 80,
 'atp/field/email/missing': 80,
 'atp/field/image/missing': 80,
 'atp/field/operator/missing': 80,
 'atp/field/operator_wikidata/missing': 80,
 'atp/field/twitter/missing': 80,
 'atp/field/website/missing': 80,
 'atp/item_scraped_host_count/uberall.com': 80,
 'atp/nsi/cc_match': 80,
 'downloader/request_bytes': 670,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8674,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.15122,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 20, 11, 46, 4, 105615, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 63932,
 'httpcompression/response_count': 2,
 'item_scraped_count': 80,
 'items_per_minute': None,
 'log_count/DEBUG': 93,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 20, 11, 46, 0, 954395, tzinfo=datetime.timezone.utc)}
```