### PR TITLE
[Busy Beaver US] Fix Spider

### DIFF
--- a/locations/spiders/busy_beaver_us.py
+++ b/locations/spiders/busy_beaver_us.py
@@ -1,14 +1,23 @@
-from locations.categories import Categories
-from locations.hours import DAYS_EN
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 
 
-class BusyBeaverUSSpider(WPStoreLocatorSpider):
+class BusyBeaverUSSpider(scrapy.Spider):
     name = "busy_beaver_us"
     item_attributes = {
         "brand": "Busy Beaver",
         "brand_wikidata": "Q108394482",
-        "extras": Categories.SHOP_DOITYOURSELF.value,
     }
-    allowed_domains = ["busybeaver.com"]
-    days = DAYS_EN
+    start_urls = ["https://cdn.builder.io/api/v3/content/store-locator?apiKey=5b1557836a7c4ddcadf9328da7855dc8"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["results"][0]["data"]["stores"]:
+            item = DictParser.parse(store)
+            item["ref"] = store["posId"]
+            apply_category(Categories.SHOP_DOITYOURSELF, item)
+            yield item


### PR DESCRIPTION
_**Fixes : code refactored to fix spider**_

```python
{'atp/brand/Busy Beaver': 19,
 'atp/brand_wikidata/Q108394482': 19,
 'atp/category/shop/doityourself': 19,
 'atp/cdn/cloudfront/response_count': 1,
 'atp/cdn/cloudfront/response_status_count/200': 1,
 'atp/country/US': 19,
 'atp/field/branch/missing': 19,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 19,
 'atp/field/opening_hours/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/field/website/missing': 19,
 'atp/item_scraped_host_count/cdn.builder.io': 19,
 'atp/nsi/brand_missing': 19,
 'downloader/request_bytes': 668,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4248,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.624744,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 21, 7, 46, 25, 160253, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14297,
 'httpcompression/response_count': 1,
 'item_scraped_count': 19,
 'items_per_minute': None,
 'log_count/DEBUG': 32,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 21, 7, 46, 21, 535509, tzinfo=datetime.timezone.utc)}
```