### PR TITLE
[seven_eleven_th] fix spider

### DIFF
--- a/locations/spiders/seven_eleven_th.py
+++ b/locations/spiders/seven_eleven_th.py
@@ -37,7 +37,7 @@ class SevenElevenTHSpider(scrapy.Spider):
                 "distance": 10000000,
                 "limit": 10000000,
             }
-            yield JsonRequest("https://7eleven-api-prod.jenosize.tech/v1/Store/GetStoreByCurrentLocation", data=payload)
+            yield JsonRequest("https://web-api-ro.7eleven.co.th/v1/Store/GetStoreByCurrentLocation", data=payload)
 
     def parse(self, response):
         for poi in response.json().get("data", []):


### PR DESCRIPTION
Backend API url has changed on the site.

The spider will fail in our CI most probably.
Stats from partial test run:

```json
{
 "atp/brand/7-Eleven": 375,
 "atp/brand_wikidata/Q259340": 375,
 "atp/category/shop/convenience": 375,
 "atp/country/TH": 375,
 "atp/field/city/missing": 375,
 "atp/field/country/from_spider_name": 375,
 "atp/field/email/missing": 375,
 "atp/field/image/missing": 375,
 "atp/field/opening_hours/missing": 375,
 "atp/field/operator/missing": 375,
 "atp/field/operator_wikidata/missing": 375,
 "atp/field/phone/invalid": 122,
 "atp/field/street_address/missing": 375,
 "atp/field/twitter/missing": 375,
 "atp/field/website/missing": 375,
 "atp/item_scraped_host_count/web-api-ro.7eleven.co.th": 437,
 "atp/nsi/cc_match": 375,
 "downloader/request_bytes": 9584,
 "downloader/request_count": 21,
 "downloader/request_method_count/POST": 21,
 "downloader/response_bytes": 76452,
 "downloader/response_count": 21,
 "downloader/response_status_count/200": 21,
 "elapsed_time_seconds": 52.311121,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "shutdown",
 "finish_time": "2025-02-21T14:22:11.984732+00:00",
 "httpcompression/response_bytes": 512020,
 "httpcompression/response_count": 21,
 "item_dropped_count": 62,
 "item_dropped_reasons_count/DropItem": 62,
 "item_scraped_count": 375,
 "log_count/INFO": 11,
 "log_count/WARNING": 1,
 "memusage/max": 227917824,
 "memusage/startup": 227917824,
 "response_received_count": 21,
 "scheduler/dequeued": 21,
 "scheduler/dequeued/memory": 21,
 "scheduler/enqueued": 21,
 "scheduler/enqueued/memory": 21,
 "start_time": "2025-02-21T14:21:19.673611+00:00"
}
```