### PR TITLE
[Panda Express] Fix spider using API, with max available POIs count

### DIFF
--- a/locations/spiders/panda_express.py
+++ b/locations/spiders/panda_express.py
@@ -36,4 +36,5 @@ class PandaExpressSpider(Spider):
     def parse_locations(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["restaurants"]:
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
             yield item

--- a/locations/spiders/panda_express.py
+++ b/locations/spiders/panda_express.py
@@ -41,4 +41,10 @@ class PandaExpressSpider(Spider):
             item["street_address"] = merge_address_lines(
                 [location.get("streetaddress"), location.get("streetaddress2")]
             )
+            item["ref"] = location.get("extref")
+            item["website"] = (
+                "https://www.pandaexpress.com/locations/{}/{}/{}".format(item["state"], item["city"], item["ref"])
+                .lower()
+                .replace(" ", "-")
+            )
             yield item

--- a/locations/spiders/panda_express.py
+++ b/locations/spiders/panda_express.py
@@ -5,6 +5,7 @@ from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -37,4 +38,7 @@ class PandaExpressSpider(Spider):
         for location in response.json()["restaurants"]:
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
+            item["street_address"] = merge_address_lines(
+                [location.get("streetaddress"), location.get("streetaddress2")]
+            )
             yield item

--- a/locations/spiders/panda_express.py
+++ b/locations/spiders/panda_express.py
@@ -1,14 +1,39 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any, Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy import FormRequest, Request
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class PandaExpressSpider(SitemapSpider, StructuredDataSpider):
+class PandaExpressSpider(Spider):
     name = "panda_express"
     item_attributes = {"brand": "Panda Express", "brand_wikidata": "Q1358690"}
-    allowed_domains = ["pandaexpress.com"]
-    sitemap_urls = ["https://www.pandaexpress.com/sitemap.xml"]
-    sitemap_rules = [(r"/locations/\w{2}/[-\w]+/\d+", "parse_sd")]
-    time_format = "%I:%M %p"
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT, "DOWNLOAD_DELAY": 0.5}
+    custom_settings = {
+        "USER_AGENT": BROWSER_DEFAULT,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    def start_requests(self) -> Iterable[Request]:
+        # Fetch cookies to avoid DataDome captcha blockage
+        yield FormRequest(
+            url="https://api-js.datadome.co/js/",
+            headers={
+                "referer": "https://www.pandaexpress.com/",
+            },
+            formdata={"ddk": "988C29D6706800A8C3451C0AB0E93A"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            url="https://nomnom-prod-api.pandaexpress.com/restaurants",
+            cookies={"cookie": response.json()["cookie"]},
+            callback=self.parse_locations,
+        )
+
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["restaurants"]:
+            item = DictParser.parse(location)
+            yield item


### PR DESCRIPTION
`DataDome` captcha will come when we send multiple requests and `IP` will get blocked, so not going to fetch `opening_hours` from individual location pages. `SitemapSpider` or `CrawlSpider` approach doesn't look feasible.

```python
{'atp/brand/Panda Express': 2338,
 'atp/brand_wikidata/Q1358690': 2338,
 'atp/category/amenity/fast_food': 2338,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/country/CA': 9,
 'atp/country/US': 2329,
 'atp/field/email/missing': 2338,
 'atp/field/image/missing': 2338,
 'atp/field/opening_hours/missing': 2338,
 'atp/field/operator/missing': 2338,
 'atp/field/operator_wikidata/missing': 2338,
 'atp/field/phone/invalid': 3,
 'atp/field/twitter/missing': 2338,
 'atp/item_scraped_host_count/nomnom-prod-api.pandaexpress.com': 2338,
 'atp/nsi/perfect_match': 2338,
 'downloader/request_bytes': 868,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 325837,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.83578,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 25, 7, 47, 44, 877946, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7943563,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2338,
 'items_per_minute': None,
 'log_count/DEBUG': 2367,
 'log_count/INFO': 9,
 'memusage/max': 190722048,
 'memusage/startup': 190722048,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 2, 25, 7, 47, 36, 42166, tzinfo=datetime.timezone.utc)}
```