### PR TITLE
New spider: Jaguar Land Rover (3512 locations)

### DIFF
--- a/locations/spiders/jaguar_land_rover.py
+++ b/locations/spiders/jaguar_land_rover.py
@@ -1,0 +1,217 @@
+from urllib.parse import quote
+
+from scrapy import Request, Spider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
+from locations.pipelines.state_clean_up import STATES
+
+# Set of language and country as required for the "requestMarketLocale"
+# parameter, then the actual ISO country code(s) required for
+# country_iseadgg_centroids. These were gathered from the "market selector"
+# pages at https://www.jaguar.com/retailer-locator/index.html and
+# https://www.landrover.com/national-dealer-locator.html
+COUNTRIES = {
+    ("en", "au", "AU"),
+    ("en", "bn", "BN"),
+    ("en", "kh", "KH"),
+    ("zh", "cn", "CN"),
+    ("en", "hk", "HK"),
+    ("en", "in", "IN"),
+    ("en", "id", "ID"),
+    ("jp", "jp", "JP"),
+    ("ru", "kz", "KZ"),
+    ("ko", "kr", "KR"),
+    ("en", "la", "LA"),
+    ("en", "my", "MY"),
+    ("en", "mn", "MN"),
+    ("en", "mm", "MM"),
+    ("en", "nc", "NC"),
+    ("fr", "fr", "FR"),
+    ("en", "nz", "NZ"),
+    ("en", "pk", "PK"),
+    ("en", "ph", "PH"),
+    ("en", "sg", "SG"),
+    ("en", "lk", "LK"),
+    ("zh", "tw", "TW"),
+    ("en", "th", "TH"),
+    ("en", "vn", "VN"),
+    ("en", "al", "AL"),
+    ("en", "am", "AM"),
+    ("de", "at", "AT"),
+    ("en", "az", "AZ"),
+    ("fr", "be", "BE"),
+    ("hr", "ba", "BA"),
+    ("bg", "bg", "BG"),
+    ("hr", "hr", "HR"),
+    ("en", "cy", "CY"),
+    ("tr", "cyl", "CY"),
+    ("cs", "cz", "CZ"),
+    ("da", "dk", "DK"),
+    ("et", "ee", "EE"),
+    ("fi", "fi", "FI"),
+    ("fr", "fr", "FR"),
+    ("en", "ge", "GE"),
+    ("de", "de", "DE"),
+    ("en", "gi", "GI"),
+    ("el", "gr", "GR"),
+    ("hu", "hu", "HU"),
+    ("is", "is", "IS"),
+    ("en", "ie", "IE"),
+    ("it", "it", "IT"),
+    ("en", "xk", "XK"),
+    ("lv", "lv", "LV"),
+    ("lt", "lt", "LT"),
+    ("fr", "lu", "LU"),
+    ("en", "mt", "MT"),
+    ("ro", "md", "MD"),
+    ("en", "me", "ME"),
+    ("nl", "nl", "NL"),
+    ("mk", "mk", "MK"),
+    ("no", "no", "NO"),
+    ("pl", "pl", "PL"),
+    ("pt", "pt", "PT"),
+    ("ro", "ro", "RO"),
+    ("ru", "ru", "RU"),
+    ("en", "rs", "RS"),
+    ("sk", "sk", "SK"),
+    ("sl", "si", "SI"),
+    ("es", "es", "ES"),
+    ("sv", "se", "SE"),
+    ("fr", "ch", "CH"),
+    ("tr", "tr", "TR"),
+    ("uk", "ua", "UA"),
+    ("en", "uk", "GB"),
+    ("en", "gb", "GB"),
+    ("fr", "dz", "DZ"),
+    ("en", "ao", "AO"),
+    ("en", "bh", "BH"),
+    ("en", "eg", "EG"),
+    ("en", "gh", "GH"),
+    ("en", "iq", "IQ"),
+    ("he", "il", "IL"),
+    ("en", "ci", "CI"),
+    ("en", "jo", "JO"),
+    ("en", "ke", "KE"),
+    ("en", "kw", "KW"),
+    ("en", "lb", "LB"),
+    ("en", "mu", "MU"),
+    ("en", "ma", "MA"),
+    ("en", "mz", "MZ"),
+    ("en", "ng", "NG"),
+    ("en", "om", "OM"),
+    ("en", "ps", "PS"),
+    ("en", "qa", "QA"),
+    ("en", "sa", "SA"),
+    ("en", "sn", "SN"),
+    ("en", "za", "ZA"),
+    ("en", "tz", "TZ"),
+    ("fr", "tn", "TN"),
+    ("en", "ae", "AE"),
+    ("en", "ye", "YE"),
+    ("en", "zm", "ZM"),
+    ("en", "zw", "ZW"),
+    ("en", "us", "US"),
+    # ("en", "ca", "CA"),  # doesn't work with coordinate queries, see start_requests
+    ("es", "cr", "CR"),
+    ("es", "do", "DO"),
+    ("es", "gt", "GT"),
+    ("en", "jm", "JM"),
+    ("es", "mx", "MX"),
+    ("es", "pa", "PA"),
+    ("en", "pr", "PR"),
+    ("en", "tt", "TT"),
+    ("es", "ar", "AR"),
+    ("pt", "br", "BR"),
+    ("es", "cl", "CL"),
+    ("es", "co", "CO"),
+    ("es", "ec", "EC"),
+    ("es", "py", "PY"),
+    ("es", "pe", "PE"),
+    ("es", "uy", "UY"),
+}
+
+
+class JaguarLandRoverSpider(Spider):
+    name = "jaguar_land_rover"
+
+    def start_requests(self):
+        for brand, brand_wikidata in {("Jaguar", "Q21170490"), ("Land Rover", "Q26777551")}:
+            for language, country_jlr, country_iso in COUNTRIES:
+                for lat, lng in country_iseadgg_centroids(country_iso, 458):
+                    yield Request(
+                        f"https://retailerlocator.jaguarlandrover.com/dealers?"
+                        f"lat={lat}&"
+                        f"lng={lng}&"
+                        f"requestMarketLocale={language}_{country_jlr}&"
+                        f"brand={quote(brand)}&"
+                        f"radius=460&"
+                        f"unitOfMeasure=Kilometers&"
+                        f"country={country_jlr}",
+                        cb_kwargs={"brand": brand, "brand_wikidata": brand_wikidata, "country": country_jlr},
+                    )
+            # The Canada site specifically doesn't work with the lat/lng
+            # query above.
+            for state in STATES["CA"]:
+                yield Request(
+                    f"https://retailerlocator.jaguarlandrover.com/dealers?"
+                    f"region={state}&"
+                    f"requestMarketLocale=en_ca&"
+                    f"brand={quote(brand)}&"
+                    f"radius=460&"
+                    f"unitOfMeasure=Kilometers&"
+                    f"country=ca",
+                    cb_kwargs={"brand": brand, "brand_wikidata": brand_wikidata, "country": "ca"},
+                )
+
+    def add_contact(self, item, services, contact):
+        all_contacts = set(filter(None, (service[contact] for service in services)))
+        # If all of the (email/fax/phone) for each department is the same, only add that.
+        if len(all_contacts) == 1:
+            if contact in ("email", "phone"):
+                item[contact] = all_contacts.pop()
+            else:
+                item["extras"][contact] = all_contacts.pop()
+        # Otherwise, add each department separately.
+        else:
+            for service in services:
+                item["extras"][service["type"] + ":" + contact] = service[contact]
+
+    def parse(self, response, brand, brand_wikidata, country):
+        js = response.json()
+        if error_type := js.get("errorType"):
+            if error_type == "com.connect_group.dealerlocator_lambda.response.NoResultsFound":
+                # No results found. Not really an error. Ignore.
+                return
+            else:
+                self.logger.error(js.get("errorMessage", error_type))
+
+        for location in js.get("dealers", []):
+            item = DictParser.parse(location)
+            item["website"] = location["homePage"]
+
+            # Only add brand tagging if it's a branded location.
+            if location["authorisedRepairer"] or location["dealer"] or location["special"]:
+                item["brand"] = brand
+                item["brand_wikidata"] = brand_wikidata
+
+            # "ciCode" seems to be the property most resembling an identifier,
+            # but codes are reused between countries, and unfortunately some
+            # locations list dealership and repairs separately.
+            item["ref"] = country + ":" + location["ciCode"]
+
+            self.add_contact(item, location["services"], "email")
+            self.add_contact(item, location["services"], "fax")
+            self.add_contact(item, location["services"], "phone")
+
+            # Decide on a category. If it's a dealer, use that, then say if it
+            # also offers repairs. Otherwise it's a car repair.
+            if location["dealer"] or location["approvedPreOwned"]:
+                apply_category(Categories.SHOP_CAR, item)
+                apply_yes_no(Extras.CAR_REPAIR, item, location["authorisedRepairer"] or location["bodyshop"])
+            elif location["authorisedRepairer"] or location["bodyshop"]:
+                apply_category(Categories.SHOP_CAR_REPAIR, item)
+            apply_yes_no(Extras.USED_CAR_SALES, item, location["approvedPreOwned"])
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Jaguar': 1351,
 'atp/brand/Land Rover': 1142,
 'atp/brand_wikidata/Q21170490': 1351,
 'atp/brand_wikidata/Q26777551': 1142,
 'atp/category/missing': 8,
 'atp/category/shop/car': 1920,
 'atp/category/shop/car_repair': 1584,
 'atp/country/AE': 11,
 'atp/country/AL': 1,
 'atp/country/AM': 4,
 'atp/country/AO': 2,
 'atp/country/AR': 3,
 'atp/country/AT': 33,
 'atp/country/AU': 135,
 'atp/country/AZ': 2,
 'atp/country/BA': 1,
 'atp/country/BE': 56,
 'atp/country/BG': 6,
 'atp/country/BH': 2,
 'atp/country/BN': 2,
 'atp/country/BR': 41,
 'atp/country/CA': 95,
 'atp/country/CH': 31,
 'atp/country/CI': 2,
 'atp/country/CL': 2,
 'atp/country/CN': 516,
 'atp/country/CO': 2,
 'atp/country/CR': 3,
 'atp/country/CY': 4,
 'atp/country/CZ': 18,
 'atp/country/DE': 181,
 'atp/country/DK': 7,
 'atp/country/DO': 2,
 'atp/country/DZ': 1,
 'atp/country/EC': 1,
 'atp/country/EE': 2,
 'atp/country/EG': 8,
 'atp/country/ES': 209,
 'atp/country/FI': 5,
 'atp/country/FR': 146,
 'atp/country/GB': 339,
 'atp/country/GE': 2,
 'atp/country/GH': 1,
 'atp/country/GI': 3,
 'atp/country/GR': 6,
 'atp/country/GT': 3,
 'atp/country/HK': 9,
 'atp/country/HR': 1,
 'atp/country/HU': 3,
 'atp/country/ID': 2,
 'atp/country/IE': 13,
 'atp/country/IL': 10,
 'atp/country/IN': 53,
 'atp/country/IQ': 2,
 'atp/country/IS': 3,
 'atp/country/IT': 257,
 'atp/country/JM': 1,
 'atp/country/JO': 2,
 'atp/country/JP': 71,
 'atp/country/KE': 2,
 'atp/country/KH': 4,
 'atp/country/KR': 50,
 'atp/country/KW': 1,
 'atp/country/KZ': 6,
 'atp/country/LA': 4,
 'atp/country/LB': 2,
 'atp/country/LK': 3,
 'atp/country/LT': 2,
 'atp/country/LU': 8,
 'atp/country/LV': 2,
 'atp/country/MA': 12,
 'atp/country/MD': 2,
 'atp/country/ME': 1,
 'atp/country/MK': 2,
 'atp/country/MM': 2,
 'atp/country/MN': 2,
 'atp/country/MT': 2,
 'atp/country/MU': 2,
 'atp/country/MX': 13,
 'atp/country/MY': 2,
 'atp/country/MZ': 2,
 'atp/country/NC': 2,
 'atp/country/NG': 5,
 'atp/country/NL': 44,
 'atp/country/NO': 14,
 'atp/country/NZ': 20,
 'atp/country/OM': 4,
 'atp/country/PA': 1,
 'atp/country/PE': 1,
 'atp/country/PH': 3,
 'atp/country/PK': 1,
 'atp/country/PL': 14,
 'atp/country/PS': 2,
 'atp/country/PT': 30,
 'atp/country/PY': 2,
 'atp/country/QA': 9,
 'atp/country/RO': 14,
 'atp/country/RS': 2,
 'atp/country/SA': 7,
 'atp/country/SE': 10,
 'atp/country/SG': 3,
 'atp/country/SI': 3,
 'atp/country/SK': 20,
 'atp/country/SN': 2,
 'atp/country/TH': 2,
 'atp/country/TN': 1,
 'atp/country/TR': 12,
 'atp/country/TT': 1,
 'atp/country/TW': 13,
 'atp/country/UA': 11,
 'atp/country/US': 687,
 'atp/country/UY': 3,
 'atp/country/VN': 8,
 'atp/country/XK': 1,
 'atp/country/YE': 1,
 'atp/country/ZA': 114,
 'atp/country/ZM': 2,
 'atp/country/ZW': 2,
 'atp/field/branch/missing': 3512,
 'atp/field/brand/missing': 1019,
 'atp/field/brand_wikidata/missing': 1019,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1489,
 'atp/field/image/missing': 3512,
 'atp/field/opening_hours/missing': 3512,
 'atp/field/operator/missing': 3512,
 'atp/field/operator_wikidata/missing': 3512,
 'atp/field/phone/invalid': 224,
 'atp/field/phone/missing': 933,
 'atp/field/postcode/missing': 236,
 'atp/field/state/missing': 1002,
 'atp/field/twitter/missing': 3512,
 'atp/field/website/invalid': 3,
 'atp/field/website/missing': 1158,
 'atp/item_scraped_host_count/retailerlocator.jaguarlandrover.com': 5371,
 'atp/nsi/cc_match': 2493,
 'downloader/request_bytes': 582876,
 'downloader/request_count': 1321,
 'downloader/request_method_count/GET': 1321,
 'downloader/response_bytes': 2439507,
 'downloader/response_count': 1321,
 'downloader/response_status_count/200': 1320,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 1616.084907,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 25, 23, 38, 10, 978487, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14999376,
 'httpcompression/response_count': 1320,
 'item_dropped_count': 1859,
 'item_dropped_reasons_count/DropItem': 1859,
 'item_scraped_count': 3512,
 'items_per_minute': None,
 'log_count/INFO': 36,
 'log_count/WARNING': 3,
 'memusage/max': 401092608,
 'memusage/startup': 255164416,
 'response_received_count': 1321,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1320,
 'scheduler/dequeued/memory': 1320,
 'scheduler/enqueued': 1320,
 'scheduler/enqueued/memory': 1320,
 'start_time': datetime.datetime(2025, 2, 25, 23, 11, 14, 893580, tzinfo=datetime.timezone.utc)}
```

The code is a lot less complicated than it looks, I swear :sweat_smile: 