### PR TITLE
[Zumiez] Fix Spider

### DIFF
--- a/locations/spiders/zumiez.py
+++ b/locations/spiders/zumiez.py
@@ -13,6 +13,7 @@ class ZumiezSpider(JSONBlobSpider):
     name = "zumiez"
     item_attributes = {"brand": "Zumiez", "brand_wikidata": "Q8075252"}
     start_urls = ["https://www.zumiez.com/graphql?hash=505530338"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def extract_json(self, response: Response) -> dict | list[dict]:
         return response.json()["data"]["getStores"]

--- a/locations/spiders/zumiez.py
+++ b/locations/spiders/zumiez.py
@@ -19,6 +19,7 @@ class ZumiezSpider(JSONBlobSpider):
         return response.json()["data"]["getStores"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
         if feature.get("has_store_page"):
             item["website"] = f"https://www.zumiez.com/stores/{feature.get('identifier')}"
         try:


### PR DESCRIPTION
**_Fixes : Flag robotstxt as False to fix spider_**

```python
{'atp/brand/Zumiez': 615,
 'atp/brand_wikidata/Q8075252': 615,
 'atp/category/shop/clothes': 615,
 'atp/country/CA': 46,
 'atp/country/MX': 1,
 'atp/country/PR': 5,
 'atp/country/US': 563,
 'atp/field/branch/missing': 615,
 'atp/field/country/from_reverse_geocoding': 615,
 'atp/field/email/missing': 615,
 'atp/field/image/missing': 615,
 'atp/field/operator/missing': 615,
 'atp/field/operator_wikidata/missing': 615,
 'atp/field/phone/invalid': 1,
 'atp/field/street_address/missing': 615,
 'atp/field/twitter/missing': 615,
 'atp/item_scraped_host_count/www.zumiez.com': 615,
 'atp/nsi/perfect_match': 615,
 'downloader/request_bytes': 317,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 122799,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.631418,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 26, 6, 22, 9, 880569, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2040105,
 'httpcompression/response_count': 1,
 'item_scraped_count': 615,
 'items_per_minute': None,
 'log_count/DEBUG': 627,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 26, 6, 22, 6, 249151, tzinfo=datetime.timezone.utc)}
```