### PR TITLE
[Matalan GB] Fix spider

### DIFF
--- a/locations/spiders/matalan_gb.py
+++ b/locations/spiders/matalan_gb.py
@@ -1,22 +1,17 @@
 import json
 
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class MatalanGBSpider(CrawlSpider, StructuredDataSpider):
+class MatalanGBSpider(SitemapSpider, StructuredDataSpider):
     name = "matalan_gb"
     item_attributes = {"brand": "Matalan", "brand_wikidata": "Q12061509"}
     allowed_domains = ["www.matalan.co.uk"]
-    start_urls = ["https://www.matalan.co.uk/stores/uk"]
-    rules = [
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[^/]+$")),
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/stores/uk/[^/]+/[^/]+$"), "parse_sd", follow=True),
-        Rule(LinkExtractor(allow=r"^https://www.matalan.co.uk/store/[^/]+/[^/]+$"), "parse_sd"),
-    ]
+    sitemap_urls = ["https://www.matalan.co.uk/robots.txt"]
+    sitemap_rules = [(r"/stores/uk/[^/]+/[^/]+/[^/]+$", "parse_sd")]
     time_format = "%H:%M:%S"
 
     def post_process_item(self, item, response, ld_data, **kwargs):


### PR DESCRIPTION
```python
{'atp/brand/Matalan': 236,
 'atp/brand_wikidata/Q12061509': 236,
 'atp/category/shop/clothes': 236,
 'atp/closed_poi': 10,
 'atp/country/GB': 236,
 'atp/field/email/missing': 236,
 'atp/field/image/missing': 236,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 236,
 'atp/field/operator_wikidata/missing': 236,
 'atp/field/phone/missing': 236,
 'atp/item_scraped_host_count/www.matalan.co.uk': 236,
 'atp/nsi/perfect_match': 236,
 'downloader/request_bytes': 211975,
 'downloader/request_count': 249,
 'downloader/request_method_count/GET': 249,
 'downloader/response_bytes': 66532011,
 'downloader/response_count': 249,
 'downloader/response_status_count/200': 249,
 'elapsed_time_seconds': 287.912603,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 26, 11, 6, 49, 824719, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 236,
 'httpcache/hit': 13,
 'httpcache/miss': 236,
 'httpcache/store': 236,
 'httpcompression/response_bytes': 293974468,
 'httpcompression/response_count': 249,
 'item_scraped_count': 236,
 'items_per_minute': None,
 'log_count/DEBUG': 497,
 'log_count/INFO': 13,
 'log_count/WARNING': 8,
 'memusage/max': 508743680,
 'memusage/startup': 193851392,
 'request_depth_max': 3,
 'response_received_count': 249,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 248,
 'scheduler/dequeued/memory': 248,
 'scheduler/enqueued': 248,
 'scheduler/enqueued/memory': 248,
 'start_time': datetime.datetime(2025, 2, 26, 11, 2, 1, 912116, tzinfo=datetime.timezone.utc)}
```