### PR TITLE
[Éconofitness CA] Fix Spider

### DIFF
--- a/locations/spiders/econofitness_ca.py
+++ b/locations/spiders/econofitness_ca.py
@@ -10,6 +10,7 @@ class EconofitnessCASpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://econofitness.ca/en/results?searchmode=searchall&searchtext=&filters="]
     rules = [Rule(LinkExtractor(r"/en/gym/[-\w]+/\d+-"), callback="parse_sd")]
     wanted_types = ["ExerciseGym"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removesuffix(" 24/7")


### PR DESCRIPTION
**_Fixes : Flag robotstxt as False to fix spider_**

```python
{'atp/brand/Éconofitness': 76,
 'atp/brand_wikidata/Q123073582': 76,
 'atp/category/leisure/fitness_centre': 76,
 'atp/country/CA': 76,
 'atp/field/email/missing': 76,
 'atp/field/image/dropped': 76,
 'atp/field/image/missing': 76,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 76,
 'atp/field/operator_wikidata/missing': 76,
 'atp/field/state/from_reverse_geocoding': 76,
 'atp/field/twitter/missing': 76,
 'atp/item_scraped_host_count/econofitness.ca': 76,
 'atp/nsi/perfect_match': 76,
 'atp/structured_data/unmapped/amenity_features': 4,
 'downloader/request_bytes': 53732,
 'downloader/request_count': 78,
 'downloader/request_method_count/GET': 78,
 'downloader/response_bytes': 2414678,
 'downloader/response_count': 78,
 'downloader/response_status_count/200': 77,
 'downloader/response_status_count/301': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 102.425795,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 27, 8, 6, 34, 941380, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17984928,
 'httpcompression/response_count': 77,
 'item_scraped_count': 76,
 'items_per_minute': None,
 'log_count/DEBUG': 178,
 'log_count/INFO': 14,
 'request_depth_max': 1,
 'response_received_count': 77,
 'responses_per_minute': None,
 'scheduler/dequeued': 78,
 'scheduler/dequeued/memory': 78,
 'scheduler/enqueued': 78,
 'scheduler/enqueued/memory': 78,
 'start_time': datetime.datetime(2025, 2, 27, 8, 4, 52, 515585, tzinfo=datetime.timezone.utc)}
```