### PR TITLE
[CleanStringsPipeline] Add pipeline to unescape strings

### DIFF
--- a/locations/pipelines/clean_strings.py
+++ b/locations/pipelines/clean_strings.py
@@ -10,9 +10,12 @@ def clean_string(val: str) -> str:
 
 
 class CleanStringsPipeline:
+    skipped_keys = {"ref", "website"}
 
     def process_item(self, item: Feature, spider: Spider):
         for key, value in item.items():
+            if key in self.skipped_keys:
+                continue
             if not isinstance(value, str):
                 continue
 

--- a/locations/pipelines/clean_strings.py
+++ b/locations/pipelines/clean_strings.py
@@ -13,9 +13,12 @@ class CleanStringsPipeline:
 
     def process_item(self, item: Feature, spider: Spider):
         for key, value in item.items():
-            if isinstance(value, str):
-                cleaned_value = clean_string(value)
-                if cleaned_value != value:
-                    item[key] = cleaned_value
-                    spider.crawler.stats.inc_value("atp/clean_strings/{}".format(key))
+            if not isinstance(value, str):
+                continue
+
+            cleaned_value = clean_string(value)
+            if cleaned_value != value:
+                item[key] = cleaned_value
+                spider.crawler.stats.inc_value("atp/clean_strings/{}".format(key))
+
         return item

--- a/locations/pipelines/clean_strings.py
+++ b/locations/pipelines/clean_strings.py
@@ -1,0 +1,21 @@
+import html
+
+from scrapy import Spider
+
+from locations.items import Feature
+
+
+def clean_string(val: str) -> str:
+    return html.unescape(val).strip()
+
+
+class CleanStringsPipeline:
+
+    def process_item(self, item: Feature, spider: Spider):
+        for key, value in item.items():
+            if isinstance(value, str):
+                cleaned_value = clean_string(value)
+                if cleaned_value != value:
+                    item[key] = clean_string(value)
+                    spider.crawler.stats.inc_value("atp/clean_strings/{}".format(key))
+        return item

--- a/locations/pipelines/clean_strings.py
+++ b/locations/pipelines/clean_strings.py
@@ -16,6 +16,6 @@ class CleanStringsPipeline:
             if isinstance(value, str):
                 cleaned_value = clean_string(value)
                 if cleaned_value != value:
-                    item[key] = clean_string(value)
+                    item[key] = cleaned_value
                     spider.crawler.stats.inc_value("atp/clean_strings/{}".format(key))
         return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -12,6 +12,7 @@ import os
 import scrapy
 
 import locations
+from locations.pipelines.clean_strings import CleanStringsPipeline
 
 BOT_NAME = "locations"
 
@@ -104,6 +105,7 @@ ITEM_PIPELINES = {
     "locations.pipelines.drop_attributes.DropAttributesPipeline": 250,
     "locations.pipelines.apply_spider_level_attributes.ApplySpiderLevelAttributesPipeline": 300,
     "locations.pipelines.apply_spider_name.ApplySpiderNamePipeline": 350,
+    CleanStringsPipeline: 354,
     "locations.pipelines.country_code_clean_up.CountryCodeCleanUpPipeline": 355,
     "locations.pipelines.state_clean_up.StateCodeCleanUpPipeline": 356,
     "locations.pipelines.address_clean_up.AddressCleanUpPipeline": 357,

--- a/tests/test_pipeline_clean_strings.py
+++ b/tests/test_pipeline_clean_strings.py
@@ -1,0 +1,64 @@
+from scrapy import Spider
+from scrapy.utils.test import get_crawler
+
+from locations.items import Feature
+from locations.pipelines.clean_strings import CleanStringsPipeline, clean_string
+
+
+def get_spider() -> Spider:
+    spider = Spider(name="test")
+    spider.crawler = get_crawler()
+    return spider
+
+
+def test_clean_strings_pipeline():
+    pipeline = CleanStringsPipeline()
+
+    item = Feature(name="test", addr_full="test str 123", phone="1234567890", website="https://example.com")
+    spider = get_spider()
+    pipeline.process_item(item, spider)
+    assert item["name"] == "test"
+    assert item["addr_full"] == "test str 123"
+    assert item["phone"] == "1234567890"
+    assert not spider.crawler.stats.get_value("atp/clean_strings/name")
+    assert not spider.crawler.stats.get_value("atp/clean_strings/addr_full")
+    assert not spider.crawler.stats.get_value("atp/clean_strings/phone")
+
+    item = Feature(
+        name="&nbsp;test &amp; test  ",
+        addr_full="  &nbsp;test str 123&nbsp;  ",
+        phone="  &nbsp;1234567890&nbsp;  ",
+        website="https://example.com?query=title%20EQ%20'%3CMytitle%3E'",
+    )
+    spider = get_spider()
+    pipeline.process_item(item, spider)
+    assert item["name"] == "test & test"
+    assert item["addr_full"] == "test str 123"
+    assert item["phone"] == "1234567890"
+    assert item["website"] == "https://example.com?query=title%20EQ%20'%3CMytitle%3E'"  # URL should not be unescaped
+    assert spider.crawler.stats.get_value("atp/clean_strings/name")
+    assert spider.crawler.stats.get_value("atp/clean_strings/addr_full")
+    assert spider.crawler.stats.get_value("atp/clean_strings/phone")
+
+
+def test_clean_strings_function():
+    cases = [
+        ("", ""),
+        ("     ", ""),
+        ("&amp; &lt; &gt;", "& < >"),
+        ("   Hello World   ", "Hello World"),
+        ("CleanString", "CleanString"),
+        ("Hello&nbsp;World", "Hello World"),
+        ("&quot;Quoted Text&quot;", '"Quoted Text"'),
+        ("   &nbsp;Test&nbsp;String&nbsp;   ", "Test String"),
+        ("   &lt;div&gt;Content&lt;/div&gt;   ", "<div>Content</div>"),
+        ("Classic Digital Studio & Mp Onl;Ine", "Classic Digital Studio & Mp Onl;Ine"),
+        ("Piccola Societa&apos;cooperativa", "Piccola Societa'cooperativa"),
+        ("McDonald&#39;s Sacav&#233;m", "McDonald's Sacavém"),
+        ("Wind &amp; Tide Bookshop", "Wind & Tide Bookshop"),
+        ("RIBEIRÃO DAS NEVES &#8211; MENEZES", "RIBEIRÃO DAS NEVES – MENEZES"),
+        ("IMAGE &AMP VISION", "IMAGE & VISION"),
+        ("Antoine At Cut &Amp; Style", "Antoine At Cut &Amp; Style"),  # html.unescape is not able to handle &Amp;
+    ]
+    for input, expected in cases:
+        assert clean_string(input) == expected

--- a/tests/test_pipeline_clean_strings.py
+++ b/tests/test_pipeline_clean_strings.py
@@ -50,7 +50,7 @@ def test_clean_strings_function():
         ("CleanString", "CleanString"),
         ("Hello&nbsp;World", "Hello World"),
         ("&quot;Quoted Text&quot;", '"Quoted Text"'),
-        ("   &nbsp;Test&nbsp;String&nbsp;   ", "Test String"),
+        ("   &nbsp;Test&nbsp;String&nbsp;   ", "Test\xa0String"),
         ("   &lt;div&gt;Content&lt;/div&gt;   ", "<div>Content</div>"),
         ("Classic Digital Studio & Mp Onl;Ine", "Classic Digital Studio & Mp Onl;Ine"),
         ("Piccola Societa&apos;cooperativa", "Piccola Societa'cooperativa"),


### PR DESCRIPTION
I've thought about this before, and was a little nervous that `html.unescape` could be destructive to none escaped strings. I don't think this is the case.

Tests still need to be written.