### PR TITLE
[Kahve Dunyasi] Fix spider

### DIFF
--- a/locations/spiders/kahve_dunyasi.py
+++ b/locations/spiders/kahve_dunyasi.py
@@ -17,6 +17,8 @@ class KahveDunyasiSpider(JSONBlobSpider):
         if not feature.get("latitute") and not feature.get("address"):
             return
         item["street_address"] = item.pop("addr_full", "")
+        item["branch"] = item.pop("name")
+
         apply_yes_no(Extras.WIFI, item, feature["hasWifi"])
         apply_yes_no(Extras.TAKEAWAY, item, feature["isAvailableForTakeAway"])
         apply_yes_no(Extras.SMOKING_AREA, item, feature["hasSmokingArea"])


### PR DESCRIPTION
`API` url updated and code refactored accordingly.

```python
{'atp/brand/Kahve Dünyası': 309,
 'atp/brand_wikidata/Q28008050': 309,
 'atp/category/amenity/cafe': 309,
 'atp/country/TR': 309,
 'atp/field/email/missing': 309,
 'atp/field/image/missing': 309,
 'atp/field/lat/invalid': 8,
 'atp/field/lat/missing': 18,
 'atp/field/lon/invalid': 8,
 'atp/field/lon/missing': 18,
 'atp/field/opening_hours/missing': 309,
 'atp/field/operator/missing': 309,
 'atp/field/operator_wikidata/missing': 309,
 'atp/field/phone/missing': 309,
 'atp/field/postcode/missing': 309,
 'atp/field/state/missing': 3,
 'atp/field/twitter/missing': 309,
 'atp/field/website/missing': 309,
 'atp/geometry/null_island': 7,
 'atp/item_scraped_host_count/api.kahvedunyasi.com': 309,
 'atp/nsi/perfect_match': 309,
 'downloader/request_bytes': 967,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 186676,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.487158,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 27, 11, 46, 46, 20873, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 309,
 'items_per_minute': None,
 'log_count/DEBUG': 322,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 27, 11, 46, 41, 533715, tzinfo=datetime.timezone.utc)}
```