### PR TITLE
[omv] fix Avanti wikidata

### DIFF
--- a/locations/spiders/omv.py
+++ b/locations/spiders/omv.py
@@ -16,7 +16,7 @@ BRANDS_AND_COUNTRIES = {
         "brand_wikidata": "Q168238",
     },
     "PETROM": {"countries": ["ROU", "MDA"], "brand": "Petrom", "brand_wikidata": "Q1755034"},
-    "AVANTI": {"countries": ["AUT"], "brand": "Avanti", "brand_wikidata": "Q168238"},
+    "AVANTI": {"countries": ["AUT"], "brand": "Avanti", "brand_wikidata": "Q124350461"},
     "HOFER": {"countries": ["AUT"], "brand": "Hofer Diskont", "brand_wikidata": "Q107803455"},
 }
 


### PR DESCRIPTION
Ether a mistake or NSI was updated since creation of the spider: https://nsi.guide/index.html?t=brands&k=amenity&v=fuel&tt=avanti. This PR fixes it.