### PR TITLE
[Smashburger] Fix Spider

### DIFF
--- a/locations/spiders/smashburger.py
+++ b/locations/spiders/smashburger.py
@@ -15,7 +15,6 @@ class SmashburgerSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w(?:/\w\w)?(?:/[^/]+)?$")),
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w/\w\w/[^/]+/[^/]+$"), callback="parse_sd"),
     ]
-    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["website"] = response.url

--- a/locations/spiders/smashburger.py
+++ b/locations/spiders/smashburger.py
@@ -15,6 +15,7 @@ class SmashburgerSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w(?:/\w\w)?(?:/[^/]+)?$")),
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w/\w\w/[^/]+/[^/]+$"), callback="parse_sd"),
     ]
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["website"] = response.url

--- a/locations/spiders/smashburger.py
+++ b/locations/spiders/smashburger.py
@@ -10,12 +10,11 @@ class SmashburgerSpider(CrawlSpider, StructuredDataSpider):
     name = "smashburger"
     item_attributes = {"brand": "Smashburger", "brand_wikidata": "Q17061332"}
     allowed_domains = ["smashburger.com"]
-    start_urls = ["https://smashburger.com/locations/index.html"]
+    start_urls = ["https://smashburger.com/locations"]
     rules = [
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w(?:/\w\w)?(?:/[^/]+)?$")),
         Rule(LinkExtractor(allow=r"^https://smashburger\.com/locations/\w\w/\w\w/[^/]+/[^/]+$"), callback="parse_sd"),
     ]
-    wanted_types = ["Restaurant"]
     requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):


### PR DESCRIPTION
**_Fixes : updated start_urls to fix spider_**

```python
{'atp/brand/Smashburger': 196,
 'atp/brand_wikidata/Q17061332': 196,
 'atp/category/amenity/fast_food': 196,
 'atp/cdn/cloudflare/response_count': 261,
 'atp/cdn/cloudflare/response_status_count/200': 258,
 'atp/cdn/cloudflare/response_status_count/404': 3,
 'atp/country/CA': 6,
 'atp/country/US': 190,
 'atp/field/branch/missing': 196,
 'atp/field/email/missing': 196,
 'atp/field/image/missing': 196,
 'atp/field/opening_hours/missing': 196,
 'atp/field/operator/missing': 196,
 'atp/field/operator_wikidata/missing': 196,
 'atp/field/twitter/missing': 196,
 'atp/item_scraped_host_count/smashburger.com': 196,
 'atp/nsi/perfect_match': 196,
 'atp/structured_data/unmapped/amenity_features': 181,
 'downloader/request_bytes': 207365,
 'downloader/request_count': 261,
 'downloader/request_method_count/GET': 261,
 'downloader/response_bytes': 7652825,
 'downloader/response_count': 261,
 'downloader/response_status_count/200': 258,
 'downloader/response_status_count/404': 3,
 'dupefilter/filtered': 114,
 'elapsed_time_seconds': 316.077399,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 28, 8, 36, 33, 916549, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 34315349,
 'httpcompression/response_count': 261,
 'item_scraped_count': 196,
 'items_per_minute': None,
 'log_count/DEBUG': 650,
 'log_count/INFO': 195,
 'request_depth_max': 3,
 'response_received_count': 261,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 260,
 'scheduler/dequeued/memory': 260,
 'scheduler/enqueued': 260,
 'scheduler/enqueued/memory': 260,
 'start_time': datetime.datetime(2025, 2, 28, 8, 31, 17, 839150, tzinfo=datetime.timezone.utc)}
```