### PR TITLE
New spider: CAT Scale (2259 locations)

### DIFF
--- a/locations/spiders/cat_scale_ca_us.py
+++ b/locations/spiders/cat_scale_ca_us.py
@@ -1,0 +1,30 @@
+from scrapy.spiders import CSVFeedSpider
+
+from locations.items import Feature
+
+
+class CatScaleCAUSSpider(CSVFeedSpider):
+    name = "cat_scale_ca_us"
+    allowed_domains = ["catscale.com"]
+    start_urls = ["https://catscale.com/exl.php"]
+
+    item_attributes = {
+        "brand": "CAT Scale",
+        "brand_wikidata": "Q111631907",
+    }
+
+    def parse_row(self, response, row):
+        item = Feature()
+        item["ref"] = row["CATScaleNumber"]
+        item["state"] = row["State"]
+        item["city"] = row["InterstateCity"]
+        item["located_in"] = row["TruckstopName"]
+        item["street_address"] = row["InterstateAddress"]
+        item["postcode"] = row["InterstatePostalCode"]
+        item["country"] = "US" if row["InterstatePostalCode"].isdigit() else "CA"
+        item["phone"] = row["PhoneNumber"]
+        item["extras"]["fax"] = row["FaxNumber"]
+        item["lat"] = row["Latitude"]
+        item["lon"] = row["Longitude"]
+        item["extras"]["located_in:website"] = row["URL"]
+        return item


### PR DESCRIPTION
```py
{'atp/brand/CAT Scale': 2259,
 'atp/brand_wikidata/Q111631907': 2259,
 'atp/category/amenity/weighbridge': 2259,
 'atp/clean_strings/city': 27,
 'atp/clean_strings/lat': 4,
 'atp/clean_strings/located_in': 44,
 'atp/clean_strings/lon': 10,
 'atp/clean_strings/phone': 39,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street_address': 15,
 'atp/country/CA': 51,
 'atp/country/US': 2208,
 'atp/field/branch/missing': 2259,
 'atp/field/email/missing': 2259,
 'atp/field/image/missing': 2259,
 'atp/field/opening_hours/missing': 2259,
 'atp/field/operator/missing': 2259,
 'atp/field/operator_wikidata/missing': 2259,
 'atp/field/phone/invalid': 15,
 'atp/field/phone/missing': 23,
 'atp/field/state/from_reverse_geocoding': 5,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2259,
 'atp/field/website/missing': 2259,
 'atp/item_scraped_host_count/catscale.com': 2259,
 'atp/nsi/perfect_match': 2259,
 'downloader/request_bytes': 603,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 378009,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.010376,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 28, 19, 25, 36, 90885, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2259,
 'items_per_minute': None,
 'log_count/DEBUG': 2272,
 'log_count/INFO': 10,
 'memusage/max': 255123456,
 'memusage/startup': 255123456,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 2, 28, 19, 25, 33, 80509, tzinfo=datetime.timezone.utc)}
```