### PR TITLE
New spider: Les Schwab Tire Center (543 locations)

### DIFF
--- a/locations/spiders/les_schwab_us.py
+++ b/locations/spiders/les_schwab_us.py
@@ -1,0 +1,37 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+# The shop webpages do have structured data, but they do not have coordinates,
+# so we need to use a different method.
+class LesSchwabUSSpider(SitemapSpider):
+    name = "les_schwab_us"
+    item_attributes = {
+        "brand": "Les Schwab Tire Center",
+        "brand_wikidata": "Q6529977",
+    }
+    sitemap_urls = ["https://www.lesschwab.com/sitemap-custom-stores.xml"]
+    sitemap_rules = [
+        (r"^https://www.lesschwab.com/stores/[a-z]{2}$", "parse"),
+    ]
+
+    def parse(self, response):
+        for location in json.loads(response.xpath("//@data-locations").get()):
+            item = DictParser.parse(location)
+            item["name"], item["branch"] = item["name"].split(" - ")
+            el = response.xpath(f"//div[@data-store-map-id={location['id']}]")
+            item["website"] = response.urljoin(el.css(".js-store-detail-url::attr(href)").get())
+            _, _, item["street_address"] = el.css(".storeDetails__streetName::text").get().partition(".")
+            _, _, item["addr_full"] = merge_address_lines(el.xpath(".//address//text()").getall()).partition(".")
+
+            oh = OpeningHours()
+            for line in el.xpath(".//h6/../div//text()").getall():
+                oh.add_ranges_from_string(line)
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{'atp/brand/Les Schwab Tire Center': 543,
 'atp/brand_wikidata/Q6529977': 543,
 'atp/category/shop/tyres': 543,
 'atp/cdn/cloudflare/response_count': 12,
 'atp/cdn/cloudflare/response_status_count/200': 12,
 'atp/clean_strings/addr_full': 543,
 'atp/clean_strings/street_address': 543,
 'atp/country/US': 543,
 'atp/field/city/missing': 543,
 'atp/field/country/from_spider_name': 543,
 'atp/field/email/missing': 543,
 'atp/field/image/missing': 543,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 543,
 'atp/field/operator_wikidata/missing': 543,
 'atp/field/postcode/missing': 543,
 'atp/field/state/from_reverse_geocoding': 543,
 'atp/field/twitter/missing': 543,
 'atp/item_scraped_host_count/www.lesschwab.com': 543,
 'atp/nsi/perfect_match': 543,
 'downloader/request_bytes': 8261,
 'downloader/request_count': 12,
 'downloader/request_method_count/GET': 12,
 'downloader/response_bytes': 520312,
 'downloader/response_count': 12,
 'downloader/response_status_count/200': 12,
 'elapsed_time_seconds': 14.371828,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 2, 28, 20, 12, 17, 869761, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5633296,
 'httpcompression/response_count': 12,
 'item_scraped_count': 543,
 'items_per_minute': None,
 'log_count/DEBUG': 566,
 'log_count/INFO': 10,
 'memusage/max': 254943232,
 'memusage/startup': 254943232,
 'request_depth_max': 1,
 'response_received_count': 12,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 11,
 'scheduler/dequeued/memory': 11,
 'scheduler/enqueued': 11,
 'scheduler/enqueued/memory': 11,
 'start_time': datetime.datetime(2025, 2, 28, 20, 12, 3, 497933, tzinfo=datetime.timezone.utc)}
```