### PR TITLE
New spider: dd's Discounts (358 locations)

### DIFF
--- a/locations/spiders/dds_discounts_us.py
+++ b/locations/spiders/dds_discounts_us.py
@@ -1,0 +1,24 @@
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.storefinders.where2getit import Where2GetItSpider
+
+
+class DdsDiscountsUSSpider(Where2GetItSpider):
+    name = "dds_discounts_us"
+    item_attributes = {
+        "brand_wikidata": "Q83743863",
+        "brand": "dd's Discounts",
+    }
+    api_brand_name = "ddsdiscounts"
+    api_key = "4E0CC702-70E5-11E8-923C-16F58D89CD5A"
+
+    def parse_item(self, item, location):
+        item["branch"] = location["name1"]
+        item["state"] = location["state"] or location["province"]
+
+        oh = OpeningHours()
+        for day in DAYS_FULL:
+            if hours := location.get(day.lower()):
+                oh.add_range(day, *hours.split(" - "), time_format="%I:%M %p")
+        item["opening_hours"] = oh
+
+        yield item


### PR DESCRIPTION
```py
{"atp/brand/dd's Discounts": 358,
 'atp/brand_wikidata/Q83743863': 358,
 'atp/category/shop/department_store': 358,
 'atp/country/US': 358,
 'atp/field/email/missing': 358,
 'atp/field/image/missing': 358,
 'atp/field/operator/missing': 358,
 'atp/field/operator_wikidata/missing': 358,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 358,
 'atp/field/website/missing': 358,
 'atp/item_scraped_host_count/hosted.where2getit.com': 358,
 'atp/nsi/perfect_match': 358,
 'downloader/request_bytes': 466,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 34396,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.02455,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 1, 0, 53, 14, 401204, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 419050,
 'httpcompression/response_count': 1,
 'item_scraped_count': 358,
 'items_per_minute': None,
 'log_count/DEBUG': 370,
 'log_count/INFO': 10,
 'memusage/max': 254816256,
 'memusage/startup': 254816256,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 1, 0, 53, 13, 376654, tzinfo=datetime.timezone.utc)}
```