### PR TITLE
New spider: Western Dental (245 locations)

### DIFF
--- a/locations/spiders/western_dental_us.py
+++ b/locations/spiders/western_dental_us.py
@@ -1,0 +1,26 @@
+import chompjs
+
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class WesternDentalUSSpider(JSONBlobSpider):
+    name = "western_dental_us"
+    item_attributes = {
+        "brand": "Western Dental",
+        "brand_wikidata": "Q64211989",
+    }
+    start_urls = ["https://www.westerndental.com/en-us/find-a-location"]
+
+    def extract_json(self, response):
+        return chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "var locationsInit = ")]/text()').get()
+        )
+
+    def post_process_item(self, item, response, location):
+        item["branch"] = location["StoreNickname"].title()
+        item["street_address"] = item.pop("addr_full")
+        item["website"] = response.urljoin(location["DocumentUrlPath"])
+        item["postcode"] = str(item["postcode"])
+        apply_category(Categories.DENTIST, item)
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Western Dental': 245,
 'atp/brand_wikidata/Q64211989': 245,
 'atp/category/amenity/dentist': 245,
 'atp/category/multiple': 245,
 'atp/clean_strings/phone': 2,
 'atp/clean_strings/street_address': 4,
 'atp/country/US': 245,
 'atp/field/country/from_spider_name': 245,
 'atp/field/email/missing': 245,
 'atp/field/image/missing': 245,
 'atp/field/opening_hours/missing': 245,
 'atp/field/operator/missing': 245,
 'atp/field/operator_wikidata/missing': 245,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 245,
 'atp/item_scraped_host_count/www.westerndental.com': 246,
 'atp/nsi/match_failed': 245,
 'downloader/request_bytes': 770,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 52498,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.052043,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 1, 1, 16, 48, 520040, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 321319,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 245,
 'items_per_minute': None,
 'log_count/DEBUG': 259,
 'log_count/INFO': 10,
 'memusage/max': 255324160,
 'memusage/startup': 255324160,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 1, 1, 16, 45, 467997, tzinfo=datetime.timezone.utc)}
```