### PR TITLE
settings: refactor and remove circular dependency with geojson exporter

### DIFF
--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -1,11 +1,11 @@
-import base64
-import datetime
-import hashlib
-import io
-import json
-import logging
-import uuid
-from typing import Any, Generator, Type
+from base64 import urlsafe_b64encode
+from datetime import datetime
+from hashlib import sha1
+from io import StringIO
+from json import dump
+from logging import warning
+from uuid import uuid1
+from typing import Any
 
 from scrapy import Item, Spider
 from scrapy.exporters import JsonItemExporter
@@ -13,7 +13,7 @@ from scrapy.utils.misc import walk_modules
 from scrapy.utils.python import to_bytes
 from scrapy.utils.spider import iter_spider_classes
 
-from locations.settings import SPIDER_MODULES
+from locations.items import Feature
 
 mapping = (
     ("addr_full", "addr:full"),
@@ -53,8 +53,10 @@ def item_to_properties(item: Item) -> dict[str, Any]:
     # Add in the extra bits
     if extras := item.get("extras"):
         for key, value in extras.items():
-            if value is not None and value != "":
-                # Only export populated values
+            if value is not None and value != "" and key != "@spider" and key != "@spider_classes":
+                # Only export populated values and ignore certain attributes
+                # which are output in the GeoJSON header as
+                # non-feature-specific attributes.
                 props[key] = value
 
     # Bring in the optional stuff
@@ -86,11 +88,11 @@ def item_to_geometry(item: Item) -> dict:
                 "coordinates": [float(item["lon"]), float(item["lat"])],
             }
         except ValueError:
-            logging.warning("Couldn't convert lat (%s) and lon (%s) to float", lat, lon)
+            warning("Couldn't convert lat (%s) and lon (%s) to float", lat, lon)
     return geometry
 
 
-def item_to_geojson_feature(item: Item) -> dict:
+def item_to_geojson_feature(item: Feature) -> dict:
     feature = {
         "id": compute_hash(item),
         "type": "Feature",
@@ -101,72 +103,92 @@ def item_to_geojson_feature(item: Item) -> dict:
     return feature
 
 
-def compute_hash(item: Item) -> str:
-    ref = str(item.get("ref") or uuid.uuid1()).encode("utf8")
-    sha1 = hashlib.sha1(ref)
+def compute_hash(item: Feature) -> str:
+    item_ref = str(item.get("ref"))
+    item_spider_class = item.get("extras", {}).get("@spider_classes", [None])[0]
+    item_spider_name = None
+    if item_spider_class:
+        item_spider_name = getattr(item_spider_class, "name", None)
 
-    if spider_name := item.get("extras", {}).get("@spider"):
-        sha1.update(spider_name.encode("utf8"))
+    if item_ref and item_spider_name:
+        sha1_hash = sha1(item_ref.encode("utf8"))
+        sha1_hash.update(item_spider_name.encode("utf8"))
+        return urlsafe_b64encode(sha1_hash.digest()).decode("utf8")
 
-    return base64.urlsafe_b64encode(sha1.digest()).decode("utf8")
-
-
-def find_spider_class(spider_name: str):
-    if not spider_name:
-        return None
-    for spider_class in iter_spider_classes_in_all_modules():
-        if spider_name == spider_class.name:
-            return spider_class
-    return None
-
-
-def iter_spider_classes_in_all_modules() -> Generator[Type[Spider], Any, None]:
-    for mod in SPIDER_MODULES:
-        for module in walk_modules(mod):
-            for spider_class in iter_spider_classes(module):
-                yield spider_class
+    # If a spider has no_refs = True, generate a GeoJSON feature identifier
+    # as a random UUID that will change each time a crawl and export is
+    # completed.
+    return uuid1().encode("utf8")
 
 
-def get_dataset_attributes(spider_name) -> {}:
-    spider_class = find_spider_class(spider_name)
-    dataset_attributes = getattr(spider_class, "dataset_attributes", {})
-    settings = getattr(spider_class, "custom_settings", {}) or {}
-    if not settings.get("ROBOTSTXT_OBEY", True):
-        # See https://github.com/alltheplaces/alltheplaces/issues/4537
-        dataset_attributes["spider:robots_txt"] = "ignored"
-    dataset_attributes["@spider"] = spider_name
-    dataset_attributes["spider:collection_time"] = datetime.datetime.now().isoformat()
+def get_dataset_attributes(spider_classes: list[type]) -> dict:
+    """
+    Apply dataset attributes from base classes and the class of the spider in
+    reverse method resolution order, overwriting any previous value. This is
+    best illustrated by an example:
 
-    return dataset_attributes
+    class ExampleSpider(ParentSpiderClassA, ParentSpiderClassB):
+        dataset_attributes = {"attribute_a": "E", "attribute_b": "X"}
 
+    class ParentSpiderClassA():
+        dataset_attributes = {"attribute_a": "A", "attribute_c": "Y"}
+
+    class ParentSpiderClassB():
+        dataset_attributes = {"attribute_a": "B", "attribute_c": "Z"}
+
+    For this example, this function will return the following dictionary:
+        dataset_attributes = {
+            "attribute_a": "E",
+            "attribute_b": "X",
+            "attribute_c": "Y",
+        }
+    """
+    combined_dataset_attributes = {}
+    for spider_class in reversed(spider_classes):
+        dataset_attributes = getattr(spider_class, "dataset_attributes", {}) or {}
+        settings = getattr(spider_class, "custom_settings", {}) or {}
+        if not settings.get("ROBOTSTXT_OBEY", True):
+            # See https://github.com/alltheplaces/alltheplaces/issues/4537
+            dataset_attributes["spider:robots_txt"] = "ignored"
+        combined_dataset_attributes.update(dataset_attributes)
+    if len(spider_classes) > 0:
+        if spider_name := getattr(spider_classes[0], "name", None):
+            combined_dataset_attributes["@spider"] = spider_name
+    combined_dataset_attributes["spider:collection_time"] = datetime.now().isoformat()
+    return combined_dataset_attributes
 
 class GeoJsonExporter(JsonItemExporter):
     def __init__(self, file, **kwargs):
         super().__init__(file, **kwargs)
-        self.spider_name = None
+        self.exporter_spider_class: type = None
 
     def start_exporting(self):
         pass
 
-    def export_item(self, item):
-        spider_name = item.get("extras", {}).get("@spider")
+    def export_item(self, item: Feature):
+        item_spider_classes = item.get("extras", {}).get("@spider_classes", [])
+        item_spider_class = None
+        if len(item_spider_classes) > 0:
+            item_spider_class = item_spider_classes[0]
 
         if self.first_item:
-            self.spider_name = spider_name
-            self.write_geojson_header()
+            # Remember the spider class which generated the first item this
+            # exporter first encounters. If this exporter then encounters an
+            # item generated by a different spider class, stop exporting and
+            # generate a fatal exception. It is preferred to cancel the export
+            # than to omit a GeoJSON file with the wrong headers confused
+            # between two or more spiders.
+            self.exporter_spider_class = item_spider_class
+            self.write_geojson_header(item_spider_classes)
 
-        if spider_name != self.spider_name:
-            # It really should not happen that a single exporter instance
-            # handles output from different spiders. If it does happen,
-            # we rather crash than emit GeoJSON with the wrong dataset
-            # properties, which may include legally relevant license tags.
+        if item_spider_class != self.exporter_spider_class:
             raise ValueError(
-                f"harvest from multiple spiders ({spider_name, self.spider_name}) cannot be written to same GeoJSON file"
+                f"Items generated from multiple spiders ({item_spider_class, self.exporter_spider_class}) cannot be written to same GeoJSON file."
             )
 
         super().export_item(item)
 
-    def _get_serialized_fields(self, item, default_value=None, include_empty=None):
+    def _get_serialized_fields(self, item: Feature, default_value=None, include_empty=None):
         feature = [
             ("type", "Feature"),
             ("id", compute_hash(item)),
@@ -176,11 +198,11 @@ class GeoJsonExporter(JsonItemExporter):
 
         return feature
 
-    def write_geojson_header(self):
-        header = io.StringIO()
+    def write_geojson_header(self, spider_classes: list[type]) -> None:
+        header = StringIO()
         header.write('{"type":"FeatureCollection","dataset_attributes":')
-        json.dump(
-            get_dataset_attributes(self.spider_name), header, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        dump(
+            get_dataset_attributes(spider_classes), header, ensure_ascii=False, separators=(",", ":"), sort_keys=True
         )
         header.write(',"features":[\n')
         self.file.write(to_bytes(header.getvalue(), self.encoding))

--- a/locations/exporters/ld_geojson.py
+++ b/locations/exporters/ld_geojson.py
@@ -12,7 +12,11 @@ class LineDelimitedGeoJsonExporter(JsonLinesItemExporter):
     def export_item(self, item):
         if self.first_item:
             self.first_item = False
-            self.dataset_attributes = get_dataset_attributes(item["extras"].get("@spider"))
+            spider_classes = item.get("extras", {}).get("@spider_classes", [])
+            dataset_attributes = get_dataset_attributes(spider_classes)
+            if "@spider_classes" in dataset_attributes.keys():
+                del dataset_attributes["@spider_classes"]
+            self.dataset_attributes = dataset_attributes
         super().export_item(item)
 
     def _get_serialized_fields(self, item, default_value=None, include_empty=None):

--- a/locations/pipelines/apply_source_spider_attributes.py
+++ b/locations/pipelines/apply_source_spider_attributes.py
@@ -1,0 +1,13 @@
+from scrapy.utils.trackref import object_ref
+
+from inspect import getmro
+
+class ApplySourceSpiderAttributesPipeline:
+    def process_item(self, item, spider):
+        existing_extras = item.get("extras", {})
+        existing_extras["@spider"] = spider.name
+        spider_classes = getmro(type(spider))
+        spider_classes = tuple(filter(lambda x: x != object_ref and x != object, spider_classes))
+        existing_extras["@spider_classes"] = spider_classes
+        item["extras"] = existing_extras
+        return item

--- a/locations/pipelines/apply_spider_name.py
+++ b/locations/pipelines/apply_spider_name.py
@@ -1,7 +1,0 @@
-class ApplySpiderNamePipeline:
-    def process_item(self, item, spider):
-        existing_extras = item.get("extras", {})
-        existing_extras["@spider"] = spider.name
-        item["extras"] = existing_extras
-
-        return item

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -7,14 +7,49 @@
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 
-import os
+from os import environ
 
-import scrapy
+from scrapy import __version__ as scrapy_version
 
-import locations
+from scrapy_playwright.handler import ScrapyPlaywrightDownloadHandler
+from scrapy_zyte_api import ScrapyZyteAPIDownloadHandler, ScrapyZyteAPIRequestFingerprinter
+
+from locations import __version__ as atp_bot_version
+from locations.exporters.geojson import GeoJsonExporter
+from locations.exporters.geoparquet import GeoparquetExporter
+from locations.exporters.ld_geojson import LineDelimitedGeoJsonExporter
+from locations.exporters.osm import OSMExporter
+from locations.extensions import LogStatsExtension
+from locations.logformatter import DebugDuplicateLogFormatter
+from locations.middlewares.cdnstats import CDNStatsMiddleware
+from locations.middlewares.playwright_middleware import PlaywrightMiddleware
+from locations.middlewares.track_sources import TrackSourcesMiddleware
+from locations.middlewares.zyte_api_by_country import ZyteApiByCountryMiddleware
+from locations.pipelines.address_clean_up import AddressCleanUpPipeline
+from locations.pipelines.apply_nsi_categories import ApplyNSICategoriesPipeline
+from locations.pipelines.apply_source_spider_attributes import ApplySourceSpiderAttributesPipeline
+from locations.pipelines.apply_spider_level_attributes import ApplySpiderLevelAttributesPipeline
+from locations.pipelines.assert_url_scheme import AssertURLSchemePipeline
+from locations.pipelines.check_item_properties import CheckItemPropertiesPipeline
 from locations.pipelines.clean_strings import CleanStringsPipeline
+from locations.pipelines.closed import ClosePipeline
+from locations.pipelines.count_brands import CountBrandsPipeline
+from locations.pipelines.count_operators import CountOperatorsPipeline
+from locations.pipelines.count_categories import CountCategoriesPipeline
+from locations.pipelines.country_code_clean_up import CountryCodeCleanUpPipeline
+from locations.pipelines.drop_attributes import DropAttributesPipeline
+from locations.pipelines.drop_logo import DropLogoPipeline
+from locations.pipelines.duplicates import DuplicatesPipeline
+from locations.pipelines.email_clean_up import EmailCleanUpPipeline
+from locations.pipelines.extract_gb_postcode import ExtractGBPostcodePipeline
+from locations.pipelines.geojson_geometry_reprojection import GeoJSONGeometryReprojectionPipeline
+from locations.pipelines.geojson_multipoint_simplification import GeoJSONMultiPointSimplificationPipeline
+from locations.pipelines.phone_clean_up import PhoneCleanUpPipeline
+from locations.pipelines.state_clean_up import StateCodeCleanUpPipeline
+
 
 BOT_NAME = "locations"
+BOT_VERSION = atp_bot_version
 
 SPIDER_MODULES = ["locations.spiders"]
 NEWSPIDER_MODULE = "locations.spiders"
@@ -22,20 +57,20 @@ COMMANDS_MODULE = "locations.commands"
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) {BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; framework {scrapy.__version__})"
+USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) {BOT_NAME}/{BOT_VERSION} (+https://github.com/alltheplaces/alltheplaces; framework {scrapy_version})"
 
 ROBOTSTXT_USER_AGENT = BOT_NAME
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 
-FEED_URI = os.environ.get("FEED_URI")
-FEED_FORMAT = os.environ.get("FEED_FORMAT")
+FEED_URI = environ.get("FEED_URI")
+FEED_FORMAT = environ.get("FEED_FORMAT")
 FEED_EXPORTERS = {
-    "geojson": "locations.exporters.geojson.GeoJsonExporter",
-    "parquet": "locations.exporters.geoparquet.GeoparquetExporter",
-    "ndgeojson": "locations.exporters.ld_geojson.LineDelimitedGeoJsonExporter",
-    "osm": "locations.exporters.osm.OSMExporter",
+    "geojson": GeoJsonExporter,
+    "parquet": GeoparquetExporter,
+    "ndgeojson": LineDelimitedGeoJsonExporter,
+    "osm": OSMExporter,
 }
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
@@ -67,26 +102,26 @@ TELNETCONSOLE_ENABLED = False
 # Enable or disable spider middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 SPIDER_MIDDLEWARES = {
-    "locations.middlewares.track_sources.TrackSourcesMiddleware": 500,
+    TrackSourcesMiddleware: 500,
 }
 
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {}
 
-if os.environ.get("ZYTE_API_KEY"):
+if environ.get("ZYTE_API_KEY"):
     DOWNLOAD_HANDLERS = {
-        "http": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
-        "https": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
+        "http": ScrapyZyteAPIDownloadHandler,
+        "https": ScrapyZyteAPIDownloadHandler,
     }
     DOWNLOADER_MIDDLEWARES = {
-        "locations.middlewares.zyte_api_by_country.ZyteApiByCountryMiddleware": 500,
-        "scrapy_zyte_api.ScrapyZyteAPIDownloaderMiddleware": 1000,
+        ZyteApiByCountryMiddleware: 500,
+        ScrapyZyteAPIDownloaderMiddleware: 1000,
     }
-    REQUEST_FINGERPRINTER_CLASS = "scrapy_zyte_api.ScrapyZyteAPIRequestFingerprinter"
+    REQUEST_FINGERPRINTER_CLASS = ScrapyZyteAPIRequestFingerprinter
     TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 
-DOWNLOADER_MIDDLEWARES["locations.middlewares.cdnstats.CDNStatsMiddleware"] = 500
+DOWNLOADER_MIDDLEWARES[CDNStatsMiddleware] = 500
 
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
@@ -95,36 +130,36 @@ DOWNLOADER_MIDDLEWARES["locations.middlewares.cdnstats.CDNStatsMiddleware"] = 50
 # }
 
 EXTENSIONS = {
-    "locations.extensions.LogStatsExtension": 101,
+    LogStatsExtension: 101,
 }
 
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    "locations.pipelines.duplicates.DuplicatesPipeline": 200,
-    "locations.pipelines.drop_attributes.DropAttributesPipeline": 250,
-    "locations.pipelines.apply_spider_level_attributes.ApplySpiderLevelAttributesPipeline": 300,
-    "locations.pipelines.apply_spider_name.ApplySpiderNamePipeline": 350,
+    DuplicatesPipeline: 200,
+    DropAttributesPipeline: 250,
+    ApplySpiderLevelAttributesPipeline: 300,
+    ApplySourceSpiderAttributesPipeline: 350,
     CleanStringsPipeline: 354,
-    "locations.pipelines.country_code_clean_up.CountryCodeCleanUpPipeline": 355,
-    "locations.pipelines.state_clean_up.StateCodeCleanUpPipeline": 356,
-    "locations.pipelines.address_clean_up.AddressCleanUpPipeline": 357,
-    "locations.pipelines.phone_clean_up.PhoneCleanUpPipeline": 360,
-    "locations.pipelines.email_clean_up.EmailCleanUpPipeline": 370,
-    "locations.pipelines.geojson_geometry_reprojection.GeoJSONGeometryReprojectionPipeline": 380,
-    "locations.pipelines.extract_gb_postcode.ExtractGBPostcodePipeline": 400,
-    "locations.pipelines.assert_url_scheme.AssertURLSchemePipeline": 500,
-    "locations.pipelines.drop_logo.DropLogoPipeline": 550,
-    "locations.pipelines.closed.ClosePipeline": 650,
-    "locations.pipelines.apply_nsi_categories.ApplyNSICategoriesPipeline": 700,
-    "locations.pipelines.check_item_properties.CheckItemPropertiesPipeline": 750,
-    "locations.pipelines.geojson_multipoint_simplification.GeoJSONMultiPointSimplificationPipeline": 760,
-    "locations.pipelines.count_categories.CountCategoriesPipeline": 800,
-    "locations.pipelines.count_brands.CountBrandsPipeline": 810,
-    "locations.pipelines.count_operators.CountOperatorsPipeline": 820,
+    CountryCodeCleanUpPipeline: 355,
+    StateCodeCleanUpPipeline: 356,
+    AddressCleanUpPipeline: 357,
+    PhoneCleanUpPipeline: 360,
+    EmailCleanUpPipeline: 370,
+    GeoJSONGeometryReprojectionPipeline: 380,
+    ExtractGBPostcodePipeline: 400,
+    AssertURLSchemePipeline: 500,
+    DropLogoPipeline: 550,
+    ClosePipeline: 650,
+    ApplyNSICategoriesPipeline: 700,
+    CheckItemPropertiesPipeline: 750,
+    GeoJSONMultiPointSimplificationPipeline: 760,
+    CountCategoriesPipeline: 800,
+    CountBrandsPipeline: 810,
+    CountOperatorsPipeline: 820,
 }
 
-LOG_FORMATTER = "locations.logformatter.DebugDuplicateLogFormatter"
+LOG_FORMATTER = DebugDuplicateLogFormatter
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
@@ -153,10 +188,10 @@ DEFAULT_PLAYWRIGHT_SETTINGS = {
     "PLAYWRIGHT_ABORT_REQUEST": lambda request: not request.resource_type == "document",
     "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
     "DOWNLOAD_HANDLERS": {
-        "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-        "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+        "http": ScrapyPlaywrightDownloadHandler,
+        "https": ScrapyPlaywrightDownloadHandler,
     },
-    "DOWNLOADER_MIDDLEWARES": {"locations.middlewares.playwright_middleware.PlaywrightMiddleware": 543},
+    "DOWNLOADER_MIDDLEWARES": {PlaywrightMiddleware: 543},
 }
 
 DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS = DEFAULT_PLAYWRIGHT_SETTINGS | {


### PR DESCRIPTION
Most of the Scrapy settings which accept class references as strings also accept the class type itself. The difference is lazy loading of extensions, pipelines and exporters (and similar) with class references as strings, versus eager loading of these classes when Scrapy is started. Almost everything of substance that settings.py was going to lazy load is eventually loaded in every ATP crawl anyway, so lazy loading provides little to no benefit. _IF_ there was an expensive pipeline in the future which took considerable time to load then it would make better sense to selectively load it using a spider's overridden SETTINGS attribute, rather than apply that pipeline to every single item from every spider.

For the few classes settings.py called out to (such as exporters) which would typically not always be loaded, these are extremely simple in nature and the performance benefit of lazy loading these simple classes will be negligable.

The benefit of eager loading from settings.py is the ability to more readily detect syntax errors in extensions, pipelines and exporters (and similar) without having to wait for a complete crawl to complete, and without having to attempt a crawl of each combination of extensions, pipelines and exporters (and similar) to ensure all are free of syntax errors.

To enact this change, extensions, pipelines and exporters (and similar) can no longer import from settings.py as this would create a circular redundancy. The GeoJSON exporter was unnecessarily importing from settings.py and this has had to be removed in favour of an alternative method that doesn't create a circular dependency.