### PR TITLE
[Burger King KR] Fix Spider

### DIFF
--- a/locations/spiders/burger_king_kr.py
+++ b/locations/spiders/burger_king_kr.py
@@ -63,7 +63,8 @@ class BurgerKingKRSpider(JSONBlobSpider):
 
         item["opening_hours"] = OpeningHours()
         for days_key, days_val in [("storTimeDays", DAYS_WEEKDAY), ("storTimeWeekend", DAYS_WEEKEND)]:
-            item["opening_hours"].add_days_range(days_val, *location[days_key].split("~"))
+            if location[days_key]:
+                item["opening_hours"].add_days_range(days_val, *location[days_key].split("~"))
 
         item["website"] = "https://www.burgerking.co.kr/store/{}".format(item["ref"])
 


### PR DESCRIPTION
**_Fixes : added if condition to avoid null values_**

```python
{'atp/brand/버거킹': 513,
 'atp/brand_wikidata/Q177054': 513,
 'atp/category/amenity/fast_food': 513,
 'atp/clean_strings/addr_full': 511,
 'atp/clean_strings/phone': 4,
 'atp/country/KR': 513,
 'atp/field/city/missing': 513,
 'atp/field/country/from_spider_name': 513,
 'atp/field/email/missing': 513,
 'atp/field/image/missing': 513,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 513,
 'atp/field/operator_wikidata/missing': 513,
 'atp/field/postcode/missing': 513,
 'atp/field/state/missing': 513,
 'atp/field/street_address/missing': 513,
 'atp/field/twitter/missing': 513,
 'atp/item_scraped_host_count/www.burgerking.co.kr': 513,
 'atp/nsi/cc_match': 513,
 'downloader/request_bytes': 1252,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1171469,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.934772,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 3, 8, 9, 31, 426131, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 513,
 'items_per_minute': None,
 'log_count/DEBUG': 526,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 3, 8, 9, 24, 491359, tzinfo=datetime.timezone.utc)}
```
