### PR TITLE
[Cenex] Fix Spider

### DIFF
--- a/locations/spiders/cenex.py
+++ b/locations/spiders/cenex.py
@@ -2,7 +2,6 @@ import scrapy
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class CenexSpider(scrapy.Spider):

--- a/locations/spiders/cenex.py
+++ b/locations/spiders/cenex.py
@@ -8,75 +8,55 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class CenexSpider(scrapy.Spider):
     name = "cenex"
     item_attributes = {"brand": "Cenex", "brand_wikidata": "Q62127191"}
-    allowed_domains = ["www.cenex.com"]
 
     def start_requests(self):
         yield scrapy.http.JsonRequest(
             "https://www.cenex.com/getlocationsearch",
             method="POST",
             data={
-                "SearchRequest": {
-                    "Metadata": {"MapId": "", "Categories": []},
-                    "Query": {
-                        "SearchLat": 0,
-                        "SearchLong": 0,
-                        "LocationTypes": [1, 16, 15],
-                        "Amenities": [],
-                        "Organizations": ["28e93e82-edfa-418e-90aa-7ded057a0c68"],
-                        "NELat": 90,
-                        "NELong": 180,
-                        "SWLat": -90,
-                        "SWLong": -180,
-                    },
-                },
-                "MapItemId": "40381d43-1c05-43e0-8477-78737b9974df",
-                "AllOrganizationIds": [
-                    "b4ed9d2c-cc3b-4ce0-b642-79d75eac11fa",
-                    "cb27078e-9b6a-4f4d-ac81-eb1d163a5ff6",
-                    "68be9e56-ff49-4724-baf0-90fc833fb459",
-                    "28e93e82-edfa-418e-90aa-7ded057a0c68",
-                ],
-                "ServiceUrl": "https://locatorservice.chsinc.ds/api/search",
+                "SearchLat": 0,
+                "SearchLong": 0,
+                "LocationTypes": [1, 16, 15],
+                "Amenities": [],
+                "Organizations": ["28e93e82-edfa-418e-90aa-7ded057a0c68"],
+                "NELat": 90,
+                "NELong": 180,
+                "SWLat": -90,
+                "SWLong": -180,
             },
         )
 
     def parse(self, response):
-        result = response.json()
-
-        for store in result["SearchResponse"]["Locations"]:
+        for store in response.json()["Locations"]:
             amenities = [a["Name"] for a in store["Amenities"]]
             item = Feature(
                 lon=store["Long"],
                 lat=store["Lat"],
-                ref=store["LocationId"],
+                ref=store["Id"],
                 name=store["Name"],
-                street_address=merge_address_lines([store["Address1"], store["Address2"]]),
-                city=store["City"],
-                state=store["State"],
-                postcode=store["Zip"],
+                addr_full=store["Address"],
                 country="US",
                 phone=store["Phone"],
-                website=store["WebsiteUrl"],
-                opening_hours="24/7" if "24-Hour Fueling" in amenities else None,
+                opening_hours="24/7" if "24-hour fueling" in amenities else None,
             )
 
             apply_category(Categories.FUEL_STATION, item)
             apply_yes_no(Extras.ATM, item, "ATM" in amenities)
             apply_yes_no(Extras.COMPRESSED_AIR, item, "Air" in amenities)
             apply_yes_no(Fuel.BIODIESEL, item, "Biodiesel" in amenities)
-            apply_yes_no(Extras.CAR_WASH, item, "Car Wash" in amenities)
+            apply_yes_no(Extras.CAR_WASH, item, "Car wash" in amenities)
             # "Cenex® Lubricants"
-            apply_yes_no(Fuel.DIESEL, item, "Cenex® Premium Diesel Fuel" in amenities)
-            apply_yes_no("shop=yes", item, "Convenience Store" in amenities)
+            apply_yes_no(Fuel.DIESEL, item, "Cenex® premium diesel fuel" in amenities)
+            apply_yes_no("shop=yes", item, "Convenience store" in amenities)
             # "DEF Available"
-            apply_yes_no(Fuel.DIESEL, item, "Diesel Fuel" in amenities)
-            apply_yes_no(Fuel.E85, item, "Flex Fuels" in amenities)
+            apply_yes_no(Fuel.DIESEL, item, "Diesel fuel" in amenities)
+            apply_yes_no(Fuel.E85, item, "Flex fuels" in amenities)
             # "Made Fresh Foods"
             # "No Inside Services"
-            apply_yes_no(Fuel.PROPANE, item, "Propane Cylinder Filling or Exchange" in amenities)
+            apply_yes_no(Fuel.PROPANE, item, "Propane cylinder filling or exchange" in amenities)
             apply_yes_no("food=yes", item, "Restaurant" in amenities)
-            apply_yes_no("hgv", item, "Truck Stop" in amenities)
-            apply_yes_no(Fuel.HGV_DIESEL, item, "Truck Stop" in amenities)
+            apply_yes_no("hgv", item, "Truck stop" in amenities)
+            apply_yes_no(Fuel.HGV_DIESEL, item, "Truck stop" in amenities)
             apply_yes_no(Extras.WIFI, item, "Wi-Fi" in amenities)
 
             yield item


### PR DESCRIPTION
**_Fixes : updated start_requests to fix spider_**

```python
{'atp/brand/Cenex': 1223,
 'atp/brand_wikidata/Q62127191': 1223,
 'atp/category/amenity/fuel': 1223,
 'atp/clean_strings/name': 39,
 'atp/country/US': 1223,
 'atp/field/branch/missing': 1223,
 'atp/field/city/missing': 1223,
 'atp/field/email/missing': 1223,
 'atp/field/image/missing': 1223,
 'atp/field/opening_hours/missing': 308,
 'atp/field/operator/missing': 1223,
 'atp/field/operator_wikidata/missing': 1223,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 1223,
 'atp/field/state/from_reverse_geocoding': 1223,
 'atp/field/state/missing': 4,
 'atp/field/street_address/missing': 1223,
 'atp/field/twitter/missing': 1223,
 'atp/field/website/missing': 1223,
 'atp/item_scraped_host_count/www.cenex.com': 1223,
 'atp/nsi/cc_match': 1223,
 'downloader/request_bytes': 1000,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 99539,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.218521,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 3, 11, 41, 40, 788651, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 399985,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1223,
 'items_per_minute': None,
 'log_count/DEBUG': 1236,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 3, 11, 41, 34, 570130, tzinfo=datetime.timezone.utc)}
```