### PR TITLE
New spider: Pet Food Express (69 locations)

### DIFF
--- a/locations/spiders/pet_food_express_us.py
+++ b/locations/spiders/pet_food_express_us.py
@@ -1,0 +1,22 @@
+from scrapy import Request
+
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class PetFoodExpressUSSpider(JSONBlobSpider):
+    name = "pet_food_express_us"
+    item_attributes = {
+        "brand": "Pet Food Express",
+        "brand_wikidata": "Q7171541",
+    }
+
+    def start_requests(self):
+        yield Request(
+            "https://apis.petfood.express/bigcommerce/store/map/",
+            headers={"x-api-key": "5a69a1c9bb55458d8d831768ae2ab349"},
+        )
+
+    def post_process_item(self, item, response, location):
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Pet Food Express': 69,
 'atp/brand_wikidata/Q7171541': 69,
 'atp/category/shop/pet': 69,
 'atp/clean_strings/street_address': 3,
 'atp/country/US': 69,
 'atp/field/country/from_spider_name': 69,
 'atp/field/email/missing': 69,
 'atp/field/image/missing': 69,
 'atp/field/opening_hours/missing': 69,
 'atp/field/operator/missing': 69,
 'atp/field/operator_wikidata/missing': 69,
 'atp/field/state/from_reverse_geocoding': 69,
 'atp/field/twitter/missing': 69,
 'atp/field/website/missing': 69,
 'atp/item_scraped_host_count/apis.petfood.express': 69,
 'atp/nsi/perfect_match': 69,
 'downloader/request_bytes': 679,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7757,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.207255,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 3, 19, 55, 28, 264231, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25538,
 'httpcompression/response_count': 1,
 'item_scraped_count': 69,
 'items_per_minute': None,
 'log_count/DEBUG': 83,
 'log_count/INFO': 10,
 'memusage/max': 255377408,
 'memusage/startup': 255377408,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 3, 19, 55, 26, 56976, tzinfo=datetime.timezone.utc)}
```