### PR TITLE
New spider: Baja Fresh (75 locations)

### DIFF
--- a/locations/spiders/baja_fresh_us.py
+++ b/locations/spiders/baja_fresh_us.py
@@ -1,0 +1,25 @@
+import json
+
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class BajaFreshUSSpider(JSONBlobSpider):
+    name = "baja_fresh_us"
+    item_attributes = {
+        "brand": "Baja Fresh",
+        "brand_wikidata": "Q2880019",
+    }
+    start_urls = ["https://www.bajafresh.com/locator/index.php?brand=25&mode=desktop&pagesize=7000&q=55114"]
+
+    def extract_json(self, response):
+        for location_js in response.xpath("//div[starts-with(@id, 'store_')]/script/text()").getall():
+            first_bracket = location_js.find(" = {")
+            last_bracket = location_js.find("}", first_bracket)
+            yield json.loads(location_js[first_bracket + 3 : last_bracket + 1])
+
+    def post_process_item(self, item, response, location):
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = item.pop("name")
+        item["extras"]["website:orders"] = location["OrderOnline"]
+        item["website"] = response.urljoin(f"/stores/{location['SEOPath']}/{location['StoreId']}")
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Baja Fresh': 75,
 'atp/brand_wikidata/Q2880019': 75,
 'atp/category/amenity/fast_food': 75,
 'atp/clean_strings/street_address': 32,
 'atp/country/US': 75,
 'atp/field/email/missing': 75,
 'atp/field/image/missing': 75,
 'atp/field/opening_hours/missing': 75,
 'atp/field/operator/missing': 75,
 'atp/field/operator_wikidata/missing': 75,
 'atp/field/phone/missing': 5,
 'atp/field/twitter/missing': 75,
 'atp/item_scraped_host_count/www.bajafresh.com': 75,
 'atp/nsi/perfect_match': 75,
 'downloader/request_bytes': 667,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 40927,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.722402,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 3, 21, 9, 21, 987538, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 339204,
 'httpcompression/response_count': 1,
 'item_scraped_count': 75,
 'items_per_minute': None,
 'log_count/DEBUG': 88,
 'log_count/INFO': 10,
 'memusage/max': 255422464,
 'memusage/startup': 255422464,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 3, 21, 9, 19, 265136, tzinfo=datetime.timezone.utc)}
```