### PR TITLE
[Sigma IT] Fix Spider

### DIFF
--- a/locations/spiders/sigma_it.py
+++ b/locations/spiders/sigma_it.py
@@ -1,26 +1,32 @@
-from typing import Iterable
+from typing import Any
 
-from scrapy import Request
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
 from locations.hours import CLOSED_IT, DAYS_IT, OpeningHours
 from locations.items import Feature
-from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
 
 
-class SigmaITSpider(AgileStoreLocatorSpider):
+class SigmaITSpider(SitemapSpider):
     name = "sigma_it"
-    item_attributes = {"brand": "Sigma", "brand_wikidata": "Q3977979", "extras": Categories.SHOP_SUPERMARKET.value}
-    allowed_domains = ["www.supersigma.com"]
+    item_attributes = {"brand": "Sigma", "brand_wikidata": "Q3977979"}
+    sitemap_urls = ["https://www.supersigma.com/store-sitemap.xml"]
+    sitemap_rules = [("/pdv/", "parse")]
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request]:
-        item["website"] = "https://www.supersigma.com/pdv/" + feature["slug"] + "/"
-        yield Request(url=item["website"], meta={"item": item}, callback=self.parse_hours)
-
-    def parse_hours(self, response: Response) -> Iterable[Feature]:
-        item = response.meta["item"]
-        item["website"] = response.url  # Capture any redirected URL
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["name"] = response.xpath("//title/text()").get()
+        item["street_address"] = response.xpath('//*[@class="fl fw fs16 "]/text()').get()
+        address2 = response.xpath('//*[@class="fl fw fs16 ml10 mt0 mb2"]').get()
+        if address2:
+            item["addr_full"] = ",".join([item["street_address"], address2])
+        item["ref"] = item["website"] = response.url
+        item["phone"] = response.xpath('//*[@class="fl fw fs16 "][2]/text()').get()
+        item["email"] = response.xpath('//*[@class="fl fw fs14 mb3 "]/text()').get()
+        extract_google_position(item, response)
+        apply_category(Categories.SHOP_SUPERMARKET, item)
         hours_string = " ".join(
             filter(
                 None, map(str.strip, response.xpath('//span[contains(@class, "bkg_orari")]/span/span//text()').getall())


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Sigma': 532,
 'atp/brand_wikidata/Q3977979': 532,
 'atp/category/shop/supermarket': 532,
 'atp/clean_strings/street_address': 2,
 'atp/country/IT': 532,
 'atp/field/branch/missing': 532,
 'atp/field/city/missing': 532,
 'atp/field/country/from_spider_name': 532,
 'atp/field/email/missing': 139,
 'atp/field/image/missing': 532,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 532,
 'atp/field/operator_wikidata/missing': 532,
 'atp/field/phone/invalid': 22,
 'atp/field/phone/missing': 36,
 'atp/field/postcode/missing': 532,
 'atp/field/state/missing': 532,
 'atp/field/twitter/missing': 532,
 'atp/item_scraped_host_count/www.supersigma.com': 532,
 'downloader/request_bytes': 206560,
 'downloader/request_count': 534,
 'downloader/request_method_count/GET': 534,
 'downloader/response_bytes': 14311631,
 'downloader/response_count': 534,
 'downloader/response_status_count/200': 534,
 'elapsed_time_seconds': 661.459658,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 4, 8, 41, 7, 106617, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 69197304,
 'httpcompression/response_count': 534,
 'item_scraped_count': 532,
 'items_per_minute': None,
 'log_count/DEBUG': 1077,
 'log_count/INFO': 20,
 'request_depth_max': 1,
 'response_received_count': 534,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 533,
 'scheduler/dequeued/memory': 533,
 'scheduler/enqueued': 533,
 'scheduler/enqueued/memory': 533,
 'start_time': datetime.datetime(2025, 3, 4, 8, 30, 5, 646959, tzinfo=datetime.timezone.utc)}
```