### PR TITLE
[Sola Salon Studios] Update API URL to fix the spider

### DIFF
--- a/locations/spiders/sola_salon_studios.py
+++ b/locations/spiders/sola_salon_studios.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 from chompjs import parse_js_object
 from scrapy import Request, Spider
-from scrapy.http import JsonRequest
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import clean_address
@@ -10,20 +12,16 @@ class SolaSalonStudiosSpider(Spider):
     name = "sola_salon_studios"
     item_attributes = {"brand": "Sola Salons", "brand_wikidata": "Q64337426"}
     allowed_domains = ["platform.solasalonstudios.com", "www.solasalonstudios.com"]
-    start_urls = ["https://platform.solasalonstudios.com/v1/get-web-locations-list"]
+    start_urls = ["https://platform.solasalonstudios.com/v1/get-web-locations-list?country=all&sola-demo=false"]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
-
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for state in response.json()["data"]:
             for location in state["locations"]:
                 item = DictParser.parse(location)
                 item["website"] = "https://www.solasalonstudios.com/locations/" + location["url_name"]
                 yield Request(url=item["website"], meta={"item": item}, callback=self.add_address_details)
 
-    def add_address_details(self, response):
+    def add_address_details(self, response: Response) -> Any:
         location_js = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
         location = parse_js_object(location_js)["props"]["pageProps"]["locationSEODetails"]["data"]
         item = response.meta["item"]


### PR DESCRIPTION
```python
{'atp/brand/Sola Salons': 747,
 'atp/brand_wikidata/Q64337426': 747,
 'atp/category/shop/beauty': 747,
 'atp/cdn/cloudflare/response_count': 748,
 'atp/cdn/cloudflare/response_status_count/200': 748,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/postcode': 69,
 'atp/country/CA': 5,
 'atp/country/US': 742,
 'atp/field/branch/missing': 747,
 'atp/field/email/missing': 747,
 'atp/field/image/missing': 747,
 'atp/field/opening_hours/missing': 747,
 'atp/field/operator/missing': 747,
 'atp/field/operator_wikidata/missing': 747,
 'atp/field/twitter/missing': 747,
 'atp/item_scraped_host_count/www.solasalonstudios.com': 747,
 'atp/nsi/perfect_match': 747,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 323138,
 'downloader/request_count': 752,
 'downloader/request_method_count/GET': 752,
 'downloader/response_bytes': 26744562,
 'downloader/response_count': 751,
 'downloader/response_status_count/200': 749,
 'downloader/response_status_count/308': 1,
 'downloader/response_status_count/403': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 920.755178,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 4, 12, 27, 40, 735681, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 751,
 'httpcache/miss': 752,
 'httpcache/store': 751,
 'httpcompression/response_bytes': 196496047,
 'httpcompression/response_count': 748,
 'item_scraped_count': 747,
 'items_per_minute': None,
 'log_count/DEBUG': 1513,
 'log_count/INFO': 25,
 'request_depth_max': 1,
 'response_received_count': 750,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 750,
 'scheduler/dequeued/memory': 750,
 'scheduler/enqueued': 750,
 'scheduler/enqueued/memory': 750,
 'start_time': datetime.datetime(2025, 3, 4, 12, 12, 19, 980503, tzinfo=datetime.timezone.utc)}
```