### PR TITLE
[Banner Health] Fix Spider

### DIFF
--- a/locations/spiders/banner_health.py
+++ b/locations/spiders/banner_health.py
@@ -1,75 +1,25 @@
 import json
-import re
-import time
+from typing import Any
 
-from scrapy.spiders import SitemapSpider
+import scrapy
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class BannerHealthSpider(SitemapSpider):
+class BannerHealthSpider(StructuredDataSpider):
     name = "banner_health"
     item_attributes = {"operator": "Banner Health", "operator_wikidata": "Q4856918"}
     allowed_domains = ["bannerhealth.com"]
-    sitemap_urls = ["https://www.bannerhealth.com/sitemap-BH.xml"]
-    sitemap_rules = [(r"https://www.bannerhealth.com/locations/[-\w]+", "parse_location")]
+    start_urls = ["https://www.bannerhealth.com/api/sitecore/location/LocationSearch"]
+    wanted_types = ["Hospital"]
 
-    def parse_location(self, response):
-        other = response.xpath("/html/body/div[1]/div[2]/div/div[2]/div").get()
-        if not (data := response.xpath('//div[@data-js="map_canvas"]/@data-map-config').get()):
-            data = response.xpath('//div[@data-js="map_canvas-v2"]/@data-map-config').get()
-        if data and not other:
-            if not (
-                cty_ste_pde := response.xpath(
-                    '//div[contains(@class,"text-card-location-image-content")]/p[1]/text()[3]'
-                ).get()
-            ):
-                cty_ste_pde = response.xpath(
-                    '//div[contains(@class,"text-card-location-image-content")]/p[1]/text()[2]'
-                ).get()
-            if not cty_ste_pde:
-                cty_ste_pde = response.xpath("//address/text()[3]").get()
-            if not cty_ste_pde:
-                cty_ste_pde = response.xpath("//address/text()[2]").get()
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in (json.loads(response.json()))["LocationModelList"]:
+            yield scrapy.Request(url="https://www.bannerhealth.com" + location["LocationURL"], callback=self.parse_sd)
 
-            days = response.xpath('//div[@class="card-hours-row"]')
-            oh = OpeningHours()
-            for day in days:
-                hours = day.xpath("./div[2]/text()").get().replace("\n", "").strip()
-                if not hours == "Closed":
-                    for hour in hours.split(","):
-                        open_time = re.split(".to|to", hour)[0].replace(".", "").strip()
-                        close_time = re.split(".to|to", hour)[1].replace(".", "").strip()
-                        oh.add_range(
-                            day=day.xpath("./div[1]/text()").get().replace("\n", "").strip(),
-                            open_time=time.strftime(
-                                "%H:%M", time.strptime(open_time, "%I:%M %p" if ":" in open_time else "%I %p")
-                            ),
-                            close_time=time.strftime(
-                                "%H:%M", time.strptime(close_time, "%I:%M %p" if ":" in close_time else "%I %p")
-                            ),
-                        )
-
-            data = json.loads(data)
-            cty_ste_pde = cty_ste_pde.strip().strip("\n").replace("\xa0", "")
-            postcode = re.findall("[0-9]{5}-[0-9]{4}|[0-9]{5}", cty_ste_pde)[0]
-            state = (re.findall("[A-Z]{2}", cty_ste_pde)[0:1] or (None,))[0]
-            city = cty_ste_pde.replace(str(state), "").replace(postcode, "").replace(",", "").strip()
-
-            properties = {
-                "ref": response.url,
-                "postcode": postcode,
-                "state": state,
-                "city": city,
-                "lat": data.get("markerList")[0].get("Latitude"),
-                "lon": data.get("markerList")[0].get("Longitude"),
-                "name": data.get("markerList")[0].get("Locations")[0].get("Name"),
-                "street_address": data.get("markerList")[0].get("Locations")[0].get("Address").replace("<br/>", ""),
-                "phone": data.get("markerList")[0].get("Locations")[0].get("PhoneNumber"),
-                "opening_hours": oh.as_opening_hours(),
-            }
-
-            apply_category(Categories.CLINIC, properties)
-            yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        apply_category(Categories.CLINIC, item)
+        yield item

--- a/locations/spiders/banner_health.py
+++ b/locations/spiders/banner_health.py
@@ -15,7 +15,7 @@ class BannerHealthSpider(StructuredDataSpider):
     allowed_domains = ["bannerhealth.com"]
     start_urls = ["https://www.bannerhealth.com/api/sitecore/location/LocationSearch"]
     wanted_types = ["Hospital"]
-    custom_settings = {"ROBOTSTXT_OBEY":False}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in (json.loads(response.json()))["LocationModelList"]:

--- a/locations/spiders/banner_health.py
+++ b/locations/spiders/banner_health.py
@@ -15,6 +15,7 @@ class BannerHealthSpider(StructuredDataSpider):
     allowed_domains = ["bannerhealth.com"]
     start_urls = ["https://www.bannerhealth.com/api/sitecore/location/LocationSearch"]
     wanted_types = ["Hospital"]
+    custom_settings = {"ROBOTSTXT_OBEY":False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in (json.loads(response.json()))["LocationModelList"]:


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/category/amenity/clinic': 577,
 'atp/category/multiple': 577,
 'atp/cdn/cloudflare/response_count': 578,
 'atp/cdn/cloudflare/response_status_count/200': 578,
 'atp/clean_strings/name': 34,
 'atp/clean_strings/street_address': 3,
 'atp/country/US': 577,
 'atp/field/branch/missing': 577,
 'atp/field/brand/missing': 577,
 'atp/field/brand_wikidata/missing': 577,
 'atp/field/email/missing': 577,
 'atp/item_scraped_host_count/www.bannerhealth.com': 577,
 'atp/nsi/cc_match': 577,
 'atp/operator/Banner Health': 577,
 'atp/operator_wikidata/Q4856918': 577,
 'downloader/exception_count': 8,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 8,
 'downloader/request_bytes': 441320,
 'downloader/request_count': 586,
 'downloader/request_method_count/GET': 586,
 'downloader/response_bytes': 9632500,
 'downloader/response_count': 578,
 'downloader/response_status_count/200': 578,
 'elapsed_time_seconds': 724.973985,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 5, 11, 10, 4, 21168, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 44698842,
 'httpcompression/response_count': 578,
 'item_scraped_count': 577,
 'items_per_minute': None,
 'log_count/DEBUG': 1174,
 'log_count/INFO': 21,
 'request_depth_max': 1,
 'response_received_count': 578,
 'responses_per_minute': None,
 'retry/count': 8,
 'retry/reason_count/twisted.internet.error.TimeoutError': 8,
 'scheduler/dequeued': 586,
 'scheduler/dequeued/memory': 586,
 'scheduler/enqueued': 586,
 'scheduler/enqueued/memory': 586,
 'start_time': datetime.datetime(2025, 3, 5, 10, 57, 59, 47183, tzinfo=datetime.timezone.utc)}
```