### PR TITLE
New spider: Truist Financial (3197 locations)

### DIFF
--- a/locations/spiders/truist_us.py
+++ b/locations/spiders/truist_us.py
@@ -1,0 +1,69 @@
+from urllib.parse import urlparse
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TruistUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "truist_us"
+    item_attributes = {
+        "brand": "Truist",
+        "brand_wikidata": "Q795486",
+    }
+    sitemap_urls = [
+        "https://www.truist.com/branch.index.xml",
+        "https://www.truist.com/atm.index.xml",
+    ]
+    sitemap_rules = [
+        (r"^https://www.truist.com/\w+/[a-z]{2}/[\w-]+/\d+/[\w-]+$", "parse"),
+    ]
+    wanted_types = ["FinancialService", "AutomatedTeller"]
+    search_for_twitter = False
+    drop_attributes = {"facebook"}
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        path = urlparse(response.url).path
+        if path.startswith("/branch/"):
+            apply_category(Categories.BANK, item)
+        elif path.startswith("/atm/"):
+            apply_category(Categories.ATM, item)
+
+        # Name is formatted something like:
+        # "Truist Somewhere Branch in City, XY, 00000"
+        # or
+        # "Truist Somewhere ATM in City, XY, 00000"
+        branch = item.pop("name").removeprefix("Truist ")
+        i = branch.find(" Branch")
+        if i == -1:
+            i = branch.find(" ATM")
+        if i != -1:
+            branch = branch[:i]
+        item["branch"] = branch
+
+        if ld_data["openingHours"] == "24 Hours":
+            item["opening_hours"] = "24/7"
+        else:
+            oh = OpeningHours()
+            for line in ld_data["openingHours"].split(", "):
+                # Website implies PM of ending time, but OpeningHours assumes AM, so need to make explicit
+                if line[-1].isdigit():
+                    line += "PM"
+                oh.add_ranges_from_string(line)
+            item["opening_hours"] = oh
+
+        yield item
+
+    def extract_amenity_features(self, item, response, ld_item):
+        apply_yes_no(
+            Extras.DRIVE_THROUGH,
+            item,
+            any(feature["name"] in ("Drive-up Window", "Drive Up") for feature in ld_item.get("amenityFeature", [])),
+        )
+        apply_yes_no(
+            Extras.WHEELCHAIR,
+            item,
+            any(feature["name"] == "Handicapped Accessible" for feature in ld_item.get("amenityFeature", [])),
+        )


### PR DESCRIPTION
The site does have an API, but it's limited to 100 results per query, which would end up needing more requests than locations. :disappointed: 

```py
{'atp/brand/Truist': 3197,
 'atp/brand_wikidata/Q795486': 3197,
 'atp/category/amenity/atm': 1294,
 'atp/category/amenity/bank': 1903,
 'atp/country/US': 3197,
 'atp/field/email/missing': 3197,
 'atp/field/image/dropped': 3197,
 'atp/field/image/missing': 3197,
 'atp/field/name/missing': 1294,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1903,
 'atp/field/operator_wikidata/missing': 1903,
 'atp/field/phone/invalid': 1,
 'atp/field/twitter/missing': 3197,
 'atp/item_scraped_host_count/www.truist.com': 3532,
 'atp/nsi/cc_match': 3197,
 'atp/operator/Truist': 1294,
 'atp/operator_wikidata/Q795486': 1294,
 'downloader/exception_count': 3,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 3,
 'downloader/request_bytes': 2369118,
 'downloader/request_count': 3565,
 'downloader/request_method_count/GET': 3565,
 'downloader/response_bytes': 132676271,
 'downloader/response_count': 3562,
 'downloader/response_status_count/200': 3535,
 'downloader/response_status_count/302': 17,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/500': 9,
 'dupefilter/filtered': 1589,
 'elapsed_time_seconds': 4380.676021,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 5, 2, 55, 37, 513000, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 679601088,
 'httpcompression/response_count': 3536,
 'httperror/response_ignored_count': 4,
 'httperror/response_ignored_status_count/404': 1,
 'httperror/response_ignored_status_count/500': 3,
 'item_dropped_count': 335,
 'item_dropped_reasons_count/DropItem': 335,
 'item_scraped_count': 3197,
 'items_per_minute': None,
 'log_count/ERROR': 3,
 'log_count/INFO': 87,
 'memusage/max': 490086400,
 'memusage/startup': 255954944,
 'request_depth_max': 1,
 'response_received_count': 3539,
 'responses_per_minute': None,
 'retry/count': 9,
 'retry/max_reached': 3,
 'retry/reason_count/500 Internal Server Error': 6,
 'retry/reason_count/twisted.internet.error.TimeoutError': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3564,
 'scheduler/dequeued/memory': 3564,
 'scheduler/enqueued': 3564,
 'scheduler/enqueued/memory': 3564,
 'start_time': datetime.datetime(2025, 3, 5, 1, 42, 36, 836979, tzinfo=datetime.timezone.utc)}
```