### PR TITLE
New spider: TD Bank (3648 locations)

### DIFF
--- a/locations/spiders/td_bank.py
+++ b/locations/spiders/td_bank.py
@@ -1,0 +1,61 @@
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import OpeningHours
+from locations.items import set_closed
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class TdBankSpider(JSONBlobSpider):
+    name = "td_bank"
+    item_attributes = {
+        "brand": "TD Bank",
+        "brand_wikidata": "Q7669891",
+    }
+    start_urls = ["https://www.tdbank.com/net/get12.ashx?longitude=-94&latitude=48&json=y&searchradius=25000&searchunit=mi&numresults=10000"]
+    locations_key = ["markers", "marker"]
+
+    def post_process_item(self, item, response, location):
+        item.pop("name", None)
+        item["country"] = location["coun"].upper()
+        item["extras"]["fax"] = location.get("faxno")
+        item["extras"]["start_date"] = location.get("opendate")
+
+        apply_yes_no(Extras.DRIVE_THROUGH, item, location["driveup"] == "Y", location["driveup"] != "N")
+        apply_yes_no(Extras.WHEELCHAIR, item, location["wheelchair"] == "Y", location["wheelchair"] != "N")
+
+        if location["type"] == "1":
+            apply_category(Categories.ATM, item)
+        else:
+            apply_category(Categories.BANK, item)
+            apply_yes_no(Extras.ATM, item, location["type"] == "3")
+        if location["coun"] == "ca":
+            item["brand"] = "TD"
+            item["brand_wikidata"] = "Q1080670"
+        if item.get("isshutdown") == "Y":
+            set_closed(item)
+
+        if branch_n := location["branchN"]:
+            item["website"] = f"https://locations.td.com/{branch_n}"
+
+        if currencies := location["currencies"]:
+            for currency in currencies.split(", "):
+                apply_yes_no(f"currency:{currency.upper()}", item, True)
+        if languages := location["languages"]:
+            for language in languages.split("|"):
+                apply_yes_no(f"language:{language}", item, True)
+
+        if (location["driveup"] == "Y") and (driveuphours := location.get("driveuphours")):
+            item["extras"]["opening_hours:drive_through"] = self.parse_hours(driveuphours).as_opening_hours()
+        if hours := location.get("hours"):
+            item["opening_hours"] = self.parse_hours(hours)
+
+        yield item
+
+    def parse_hours(self, hours):
+        oh = OpeningHours()
+        for day, times in hours.items():
+            if times == "CLOSED":
+                oh.set_closed(day)
+            else:
+                opening, closing = times.split(" - ")
+                oh.add_range(day, opening, closing, time_format="%I:%M %p")
+        return oh

--- a/locations/spiders/td_bank.py
+++ b/locations/spiders/td_bank.py
@@ -10,7 +10,9 @@ class TdBankSpider(JSONBlobSpider):
         "brand": "TD Bank",
         "brand_wikidata": "Q7669891",
     }
-    start_urls = ["https://www.tdbank.com/net/get12.ashx?longitude=-94&latitude=48&json=y&searchradius=25000&searchunit=mi&numresults=10000"]
+    start_urls = [
+        "https://www.tdbank.com/net/get12.ashx?longitude=-94&latitude=48&json=y&searchradius=25000&searchunit=mi&numresults=10000"
+    ]
     locations_key = ["markers", "marker"]
 
     def post_process_item(self, item, response, location):


### PR DESCRIPTION
```py
{'atp/brand/TD': 1983,
 'atp/brand/TD Bank': 1665,
 'atp/brand_wikidata/Q1080670': 1983,
 'atp/brand_wikidata/Q7669891': 1665,
 'atp/category/amenity/atm': 1461,
 'atp/category/amenity/bank': 2187,
 'atp/clean_strings/addr_full': 1,
 'atp/country/CA': 1983,
 'atp/country/US': 1665,
 'atp/field/branch/missing': 3648,
 'atp/field/city/missing': 3648,
 'atp/field/email/missing': 3648,
 'atp/field/image/missing': 3648,
 'atp/field/name/missing': 1461,
 'atp/field/opening_hours/missing': 1461,
 'atp/field/operator/missing': 2187,
 'atp/field/operator_wikidata/missing': 2187,
 'atp/field/phone/missing': 1471,
 'atp/field/postcode/missing': 3648,
 'atp/field/state/from_reverse_geocoding': 3648,
 'atp/field/state/missing': 25,
 'atp/field/street_address/missing': 3648,
 'atp/field/twitter/missing': 3648,
 'atp/field/website/missing': 2537,
 'atp/item_scraped_host_count/www.tdbank.com': 3684,
 'atp/nsi/cc_match': 3648,
 'atp/operator/TD': 909,
 'atp/operator/TD Bank': 552,
 'atp/operator_wikidata/Q1080670': 909,
 'atp/operator_wikidata/Q7669891': 552,
 'downloader/request_bytes': 716,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 372671,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 9.50473,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 5, 23, 10, 17, 956292, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5860062,
 'httpcompression/response_count': 2,
 'item_dropped_count': 36,
 'item_dropped_reasons_count/DropItem': 36,
 'item_scraped_count': 3648,
 'items_per_minute': None,
 'log_count/DEBUG': 3697,
 'log_count/INFO': 10,
 'memusage/max': 255979520,
 'memusage/startup': 255979520,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 5, 23, 10, 8, 451562, tzinfo=datetime.timezone.utc)}
```