### PR TITLE
[Floorworld AU] Fix Spider

### DIFF
--- a/locations/spiders/floorworld_au.py
+++ b/locations/spiders/floorworld_au.py
@@ -1,5 +1,5 @@
 import chompjs
-from scrapy import Selector, Spider
+from scrapy import Spider
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -14,8 +14,9 @@ class FloorworldAUSpider(Spider):
     def parse(self, response):
         locations = chompjs.parse_js_object(
             response.xpath('(//div[contains(@class, "goto-next")]/following::script)/text()').get()
-        )["objects"]
+        )
         for location in locations:
+            print(location)
             item = DictParser.parse(location)
             item["ref"] = location["hs_path"]
             if item.get("addr_full"):
@@ -25,9 +26,4 @@ class FloorworldAUSpider(Spider):
             item["website"] = "https://www.floorworld.com.au/store-details/" + location["hs_path"]
             if location.get("store_facebook_url"):
                 item["facebook"] = location["store_facebook_url"].split("?utm_campaign=", 1)[0]
-            item["opening_hours"] = OpeningHours()
-            hours_string = " ".join(Selector(text=location["opening_hours"]).xpath("//p/text()").getall()).replace(
-                "12 noon", "12:00 pm"
-            )
-            item["opening_hours"].add_ranges_from_string(hours_string)
             yield item

--- a/locations/spiders/floorworld_au.py
+++ b/locations/spiders/floorworld_au.py
@@ -15,7 +15,6 @@ class FloorworldAUSpider(Spider):
             response.xpath('(//div[contains(@class, "goto-next")]/following::script)/text()').get()
         )
         for location in locations:
-            print(location)
             item = DictParser.parse(location)
             item["ref"] = location["hs_path"]
             if item.get("addr_full"):

--- a/locations/spiders/floorworld_au.py
+++ b/locations/spiders/floorworld_au.py
@@ -2,7 +2,6 @@ import chompjs
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 
 
 class FloorworldAUSpider(Spider):


### PR DESCRIPTION
**_Fixes : updated parse method to fix spider_**

```python
{'atp/brand/Floorworld': 52,
 'atp/brand_wikidata/Q117156913': 52,
 'atp/category/shop/flooring': 52,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/city': 7,
 'atp/clean_strings/name': 12,
 'atp/clean_strings/phone': 6,
 'atp/country/AU': 52,
 'atp/field/branch/missing': 52,
 'atp/field/city/missing': 4,
 'atp/field/country/from_spider_name': 52,
 'atp/field/image/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/field/phone/invalid': 17,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 52,
 'atp/item_scraped_host_count/www.floorworld.com.au': 52,
 'atp/nsi/perfect_match': 52,
 'downloader/request_bytes': 314,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 50845,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.350327,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 6, 4, 38, 54, 635860, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 700191,
 'httpcompression/response_count': 1,
 'item_scraped_count': 52,
 'items_per_minute': None,
 'log_count/DEBUG': 64,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 6, 4, 38, 52, 285533, tzinfo=datetime.timezone.utc)}
```