### PR TITLE
[DM] Fix Spider

### DIFF
--- a/locations/spiders/dm.py
+++ b/locations/spiders/dm.py
@@ -38,7 +38,8 @@ class DmSpider(scrapy.Spider):
             else:
                 item["website"] = f'https://www.dm.{location["countryCode"].lower()}/store{location["storeUrlPath"]}'
             item["extras"]["check_date"] = location["updateTimeStamp"]
-            item["opening_hours"] = self.parse_hours(location["openingHours"])
+            if location.get("openingHours"):
+                item["opening_hours"] = self.parse_hours(location.get("openingHours"))
 
             apply_category(Categories.SHOP_CHEMIST, item)
 


### PR DESCRIPTION
**_Fixes : Fixes key error to fix spider_**

```python
{'atp/brand/dm': 3569,
 'atp/brand_wikidata/Q266572': 3569,
 'atp/category/shop/chemist': 3569,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/street_address': 3,
 'atp/country/AT': 378,
 'atp/country/BA': 93,
 'atp/country/BG': 120,
 'atp/country/CZ': 237,
 'atp/country/DE': 1648,
 'atp/country/HR': 178,
 'atp/country/HU': 256,
 'atp/country/IT': 28,
 'atp/country/MK': 26,
 'atp/country/PL': 53,
 'atp/country/RO': 158,
 'atp/country/RS': 134,
 'atp/country/SI': 101,
 'atp/country/SK': 159,
 'atp/field/branch/missing': 3569,
 'atp/field/email/missing': 3569,
 'atp/field/image/missing': 3569,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 3569,
 'atp/field/operator_wikidata/missing': 3569,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 3569,
 'atp/field/twitter/missing': 3569,
 'atp/item_scraped_host_count/store-data-service.services.dmtech.com': 4159,
 'atp/nsi/cc_match': 3569,
 'downloader/request_bytes': 362,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1754357,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 12.625192,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 6, 9, 47, 51, 362279, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 47893456,
 'httpcompression/response_count': 1,
 'item_dropped_count': 590,
 'item_dropped_reasons_count/DropItem': 590,
 'item_scraped_count': 3569,
 'items_per_minute': None,
 'log_count/DEBUG': 4171,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 6, 9, 47, 38, 737087, tzinfo=datetime.timezone.utc)}
```