### PR TITLE
[Supa Roof ZA] Fix spider

### DIFF
--- a/locations/spiders/supa_roof_za.py
+++ b/locations/spiders/supa_roof_za.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+from urllib.parse import urljoin
 
 import chompjs
 from scrapy.http import Response
@@ -27,4 +28,5 @@ class SupaRoofZASpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["website"] = f'https://shop.suparoof.co.za/storefinder/store/index/id/{item["ref"]}/'
+        item["image"] = urljoin("https://shop.suparoof.co.za/media/", feature["primary_image"])
         yield item

--- a/locations/spiders/supa_roof_za.py
+++ b/locations/spiders/supa_roof_za.py
@@ -27,6 +27,7 @@ class SupaRoofZASpider(JSONBlobSpider):
         feature["address"] = merge_address_lines([feature.pop("address_line1", ""), feature.pop("address_line2", "")])
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["website"] = f'https://shop.suparoof.co.za/storefinder/store/index/id/{item["ref"]}/'
+        item["branch"] = item.pop("name").removeprefix("Supa-Roof ")
+        item["website"] = f'https://shop.suparoof.co.za/storefinder/store/index/id/{item["ref"]}'
         item["image"] = urljoin("https://shop.suparoof.co.za/media/", feature["primary_image"])
         yield item


### PR DESCRIPTION
`start_url` updated and code refactored to use `JSON Blob` to fix the spider.

```python
{'atp/brand/Supa-Roof': 30,
 'atp/brand_wikidata/Q116474839': 30,
 'atp/category/shop/trade': 30,
 'atp/country/ZA': 30,
 'atp/field/country/from_spider_name': 30,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 30,
 'atp/field/operator_wikidata/missing': 30,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 30,
 'atp/field/state/missing': 18,
 'atp/field/street_address/missing': 30,
 'atp/field/twitter/missing': 30,
 'atp/item_scraped_host_count/shop.suparoof.co.za': 30,
 'atp/nsi/perfect_match': 30,
 'downloader/request_bytes': 621,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 77039,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.620343,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 6, 10, 46, 18, 226043, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 251432,
 'httpcompression/response_count': 2,
 'item_scraped_count': 30,
 'items_per_minute': None,
 'log_count/DEBUG': 53,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 6, 10, 46, 15, 605700, tzinfo=datetime.timezone.utc)}
```