### PR TITLE
[IKEA] Collect more location types

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -57,6 +57,7 @@ class Categories(Enum):
 
     LEISURE_DOG_PARK = {"leisure": "dog_park"}
     LEISURE_FITNESS_STATION = {"leisure": "fitness_station"}
+    LEISURE_INDOOR_PLAY = {"leisure": "indoor_play"}
     LEISURE_NATURE_RESERVE = {"leisure": "nature_reserve"}
     LEISURE_PARK = {"leisure": "park"}
     LEISURE_PITCH = {"leisure": "pitch"}


### PR DESCRIPTION
```python
{'atp/brand/IKEA': 1588,
 'atp/brand_wikidata/Q54078': 1588,
 'atp/category/amenity/cafe': 85,
 'atp/category/amenity/fast_food': 649,
 'atp/category/leisure/indoor_play': 274,
 'atp/category/shop/convenience': 134,
 'atp/category/shop/furniture': 446,
 'atp/clean_strings/street_address': 3,
 'atp/country/AE': 11,
 'atp/country/AT': 32,
 'atp/country/AU': 47,
 'atp/country/BE': 8,
 'atp/country/BH': 5,
 'atp/country/CA': 60,
 'atp/country/CH': 40,
 'atp/country/CL': 2,
 'atp/country/CN': 71,
 'atp/country/CZ': 14,
 'atp/country/DE': 211,
 'atp/country/DK': 27,
 'atp/country/EG': 6,
 'atp/country/ES': 114,
 'atp/country/FI': 25,
 'atp/country/FR': 92,
 'atp/country/GB': 97,
 'atp/country/HR': 6,
 'atp/country/HU': 18,
 'atp/country/IE': 5,
 'atp/country/IL': 5,
 'atp/country/IN': 13,
 'atp/country/IT': 111,
 'atp/country/JO': 4,
 'atp/country/JP': 37,
 'atp/country/KR': 18,
 'atp/country/KW': 10,
 'atp/country/MA': 8,
 'atp/country/MX': 8,
 'atp/country/MY': 15,
 'atp/country/NL': 13,
 'atp/country/NO': 37,
 'atp/country/PH': 5,
 'atp/country/PL': 61,
 'atp/country/PT': 22,
 'atp/country/QA': 5,
 'atp/country/RO': 13,
 'atp/country/RS': 4,
 'atp/country/SA': 17,
 'atp/country/SE': 80,
 'atp/country/SG': 13,
 'atp/country/SI': 6,
 'atp/country/SK': 6,
 'atp/country/TH': 4,
 'atp/country/UA': 1,
 'atp/country/US': 181,
 'atp/field/email/missing': 1588,
 'atp/field/image/missing': 1588,
 'atp/field/name/missing': 8,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 1588,
 'atp/field/operator_wikidata/missing': 1588,
 'atp/field/phone/missing': 1588,
 'atp/field/state/from_reverse_geocoding': 60,
 'atp/field/state/missing': 1347,
 'atp/field/twitter/missing': 1588,
 'atp/item_scraped_host_count/www.ikea.cn': 71,
 'atp/item_scraped_host_count/www.ikea.com': 1517,
 'atp/nsi/cc_match': 877,
 'atp/nsi/match_failed': 711,
 'downloader/request_bytes': 57262,
 'downloader/request_count': 48,
 'downloader/request_method_count/GET': 48,
 'downloader/response_bytes': 220012,
 'downloader/response_count': 48,
 'downloader/response_status_count/200': 48,
 'elapsed_time_seconds': 1.735516,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 6, 12, 43, 29, 701019, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 48,
 'httpcompression/response_bytes': 1143626,
 'httpcompression/response_count': 47,
 'item_scraped_count': 1588,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 266878976,
 'memusage/startup': 266878976,
 'response_received_count': 48,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 46,
 'scheduler/dequeued/memory': 46,
 'scheduler/enqueued': 46,
 'scheduler/enqueued/memory': 46,
 'start_time': datetime.datetime(2025, 3, 6, 12, 43, 27, 965503, tzinfo=datetime.timezone.utc)}
```