### PR TITLE
[Docs] Fix broken links and other various doc fixes

### DIFF
--- a/docs/API_SPIDER.md
+++ b/docs/API_SPIDER.md
@@ -14,7 +14,7 @@ While exploring the storefinder you wish to spider, look for indicators or commo
 
 Examples:
 - [univeral_store_au](../locations/spiders/universal_store_au.py) - Based on a [closeby](../locations/storefinders/closeby.py) storefinder.
-- [see_candies](../locations/spiders/see_candies.py) - Based on a [rioseo](../locations/storefinders/rio_seo.py) storefinder, overriding the default behaviours
+- [sees_candies](../locations/spiders/sees_candies.py) - Based on a [rioseo](../locations/storefinders/rio_seo.py) storefinder, overriding the default behaviours
 
 ### Investigating an API
 
@@ -65,5 +65,5 @@ We provide a certain amount of library support for driving such APIs with data. 
 All the above is best illustrated with some further examples:
 
 * [spar_gb.py](../locations/spiders/spar_gb.py) (drive query API by postcode)
-* [petsathome_gb.py](../locations/spiders/pets_at_home_gb.py) (query GB at 20km point resolution)
-* [thebodyshop.py](../locations/spiders/the_body_shop.py) (use sitemap to generate API parameters)
+* [pets_at_home_gb.py](../locations/spiders/pets_at_home_gb.py) (query GB at 20km point resolution)
+* [the_body_shop.py](../locations/spiders/the_body_shop.py) (use sitemap to generate API parameters)

--- a/docs/OPEN_GRAPH_PROTOCOL.md
+++ b/docs/OPEN_GRAPH_PROTOCOL.md
@@ -1,6 +1,6 @@
 ## Open Graph Protocol
 
-Similar to [Structured Data](./docs/STRUCTURED_DATA.md]; [Open Graph Protocol](https://ogp.me) is a way for sites to assert facts in the `<meta>` tags of their websites.
+Similar to [Structured Data](./STRUCTURED_DATA.md); [Open Graph Protocol](https://ogp.me) is a way for sites to assert facts in the `<meta>` tags of their websites.
 
 While this can be any RDFa/Schema.org/similar terminology, it is commonly used with open graph specific vocabularies.
 

--- a/docs/SITEMAP.md
+++ b/docs/SITEMAP.md
@@ -12,8 +12,8 @@ The sitemap is such an important concept that the [scrapy framework](https://scr
 
 Within our project there are a several examples showing slightly different use of `SitemapSpider` support:
 
-* [`jackinthebox.py`](../locations/spiders/jack_in_the_box.py)
-* [`moeys.py`](../locations/spiders/moes_southwest_grill.py)
+* [`jack_in_the_box.py`](../locations/spiders/jack_in_the_box.py)
+* [`moes_southwest_grill.py`](../locations/spiders/moes_southwest_grill.py)
 * [`shopko.py`](../locations/spiders/shopko.py)
 
 Note that spiders with have good sitemap links nearly always have good machine-readable [structured data](./STRUCTURED_DATA.md) for their POI details. In these cases you will see frequent use of our [`StructuredDataSpider`](../locations/structured_data_spider.py) assistant class.

--- a/docs/SPIDER_NAMING.md
+++ b/docs/SPIDER_NAMING.md
@@ -19,7 +19,7 @@ class GreatNameSpider(scrapy.Spider):
     name = "great_name"
 ```
 
-The camel case approach illustrated for the class name
+The pascal case approach illustrated for the class name
 is further recommended. If you know the company / brand
 that you are spidering only has locations in one country then it
 is helpful to suffix your name with the

--- a/docs/STRUCTURED_DATA.md
+++ b/docs/STRUCTURED_DATA.md
@@ -4,7 +4,7 @@ The web is full of information. A lot you can see, it is rendered by your browse
 
 More information can be found at [schema.org](https://schema.org/). Various online resources are available such as the [schema validation tool](https://validator.schema.org/) to help you extract structured data on an ad-hoc basis from a URL. For example, the web page for this [smashburger location](https://smashburger.com/locations/us/co/lafayette/2755-dagny-way/) decodes to [yield this structured data](https://validator.schema.org/#url=https%3A%2F%2Fsmashburger.com%2Flocations%2Fus%2Fco%2Flafayette%2F2755-dagny-way%2F).
 
-See also [open graph protocol](docs/OPEN_GRAPH_PROTOCOL.md)
+See also [open graph protocol](./OPEN_GRAPH_PROTOCOL.md)
 
 ### StructuredDataSpider
 
@@ -16,7 +16,7 @@ The `parse_sd` method will look for default `wanted_types` in the page. The spid
 
 This is best illustrated by reference to some example spiders in the project:
 
-* [jackinthebox.py](../locations/spiders/jack_in_the_box.py) (as simple as it gets!)
+* [jack_in_the_box.py](../locations/spiders/jack_in_the_box.py) (as simple as it gets!)
 * [petco.py](../locations/spiders/petco.py) (totally declarative, sitemap filter for store pages)
 * [wickes_gb.py](../locations/spiders/wickes_gb.py) (post-process example)
 * [subway.py](../locations/spiders/subway.py) (pre-process example)


### PR DESCRIPTION
* Fix broken links to other doc files

* Fix incorrect mention of camel case, was actually talking about pascal case

* Change references to files to match their filenames (e.g. jackinthebox.py -> jack_in_the_box.py, true filename)

* Fix broken link to See's Candies spider (see_candies.py doesn't exist, found sees_candies.py)