### PR TITLE
New spider: Regions Bank (1454 locations)

### DIFF
--- a/locations/spiders/regions_bank_us.py
+++ b/locations/spiders/regions_bank_us.py
@@ -1,0 +1,50 @@
+import chompjs
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class RegionsBankUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "regions_bank_us"
+    item_attributes = {
+        "brand": "Regions Bank",
+        "brand_wikidata": "Q917131",
+    }
+    sitemap_urls = ["https://www.regions.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"^https://www.regions.com/locator/[a-z]{2}/[\w-]+/[\w-]+$", "parse"),
+    ]
+    search_for_facebook = False
+    search_for_twitter = False
+    search_for_amenity_features = False
+
+    def pre_process_data(self, ld_data):
+        if opening_hours_specification := ld_data.get("openingHoursSpecification"):
+            if rules := opening_hours_specification.get("dayOfWeek"):
+                ld_data["openingHoursSpecification"] = rules
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        search_results = chompjs.parse_js_object(
+            response.xpath("//script[contains(text(), 'window.searchResults')]/text()").get()
+        )
+        item["lat"] = search_results[0]["lat"]
+        item["lon"] = search_results[0]["lng"]
+
+        if ld_data["@type"] == "BankOrCreditUnion":
+            apply_category(Categories.BANK, item)
+        elif ld_data["@type"] == "AutomatedTeller":
+            apply_category(Categories.ATM, item)
+
+        _, _, item["branch"] = item.pop("name").partition(" - ")
+
+        apply_yes_no(
+            Extras.ATM, item, any(place["@type"] == "AutomatedTeller" for place in ld_data.get("containsPlace", []))
+        )
+        apply_yes_no(Extras.DRIVE_THROUGH, item, ld_data.get("hasDriveThroughService") == "True")
+
+        for language in ld_data.get("knowsLanguage", []):
+            if lang_name := language.get("alternateName"):
+                apply_yes_no(f"language:{lang_name}", item, True)
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Regions Bank': 1454,
 'atp/brand_wikidata/Q917131': 1454,
 'atp/category/amenity/atm': 197,
 'atp/category/amenity/bank': 1257,
 'atp/country/US': 1454,
 'atp/field/email/missing': 1454,
 'atp/field/image/dropped': 197,
 'atp/field/image/missing': 197,
 'atp/field/name/missing': 197,
 'atp/field/operator/missing': 1257,
 'atp/field/operator_wikidata/missing': 1257,
 'atp/field/phone/missing': 197,
 'atp/field/twitter/missing': 1454,
 'atp/item_scraped_host_count/www.regions.com': 1454,
 'atp/nsi/cc_match': 1454,
 'atp/operator/Regions Bank': 197,
 'atp/operator_wikidata/Q917131': 197,
 'downloader/request_bytes': 733798,
 'downloader/request_count': 1456,
 'downloader/request_method_count/GET': 1456,
 'downloader/response_bytes': 27522749,
 'downloader/response_count': 1456,
 'downloader/response_status_count/200': 1456,
 'elapsed_time_seconds': 1779.093079,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 6, 22, 18, 42, 741577, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 190289034,
 'httpcompression/response_count': 1456,
 'item_scraped_count': 1454,
 'items_per_minute': None,
 'log_count/DEBUG': 2921,
 'log_count/INFO': 39,
 'memusage/max': 458305536,
 'memusage/startup': 255447040,
 'request_depth_max': 1,
 'response_received_count': 1456,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1455,
 'scheduler/dequeued/memory': 1455,
 'scheduler/enqueued': 1455,
 'scheduler/enqueued/memory': 1455,
 'start_time': datetime.datetime(2025, 3, 6, 21, 49, 3, 648498, tzinfo=datetime.timezone.utc)}
```