### PR TITLE
[Radisson Hotels] Switch to API to fix the broken spider

### DIFF
--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -34,7 +34,7 @@ class RadissonHotelsSpider(scrapy.Spider):
 
     def start_requests(self) -> Iterable[Request]:
         yield JsonRequest(
-            url="https://www.radissonhotels.com/zimba-api/hotels?limit=1000", headers={"accept-language": "en-us"}
+            url="https://www.radissonhotels.com/zimba-api/hotels?limit=2000", headers={"accept-language": "en-us"}
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
@@ -47,6 +47,7 @@ class RadissonHotelsSpider(scrapy.Spider):
                 if page.get("code") == "overview":
                     item["website"] = response.urljoin(page["url"])
                     break
+            item["image"] = hotel.get("image", {}).get("url")
 
             if brand_info := self.brand_mapping.get(hotel.get("brand")):
                 item["brand"], item["brand_wikidata"] = brand_info

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -23,8 +23,8 @@ class RadissonHotelsSpider(scrapy.Spider):
         "rad": ["Radisson", "Q1751979"],
         # I did not find the sub-brand wikidata so I put None.
         "prz": ["Prizeotel", None],
-        "rdi": ["Radisson Individuals", None],
         "ri": ["Radisson Individuals", None],
+        "pis": ["Park Inn & Suites by Radisson", None],
     }
     custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -43,6 +43,10 @@ class RadissonHotelsSpider(scrapy.Spider):
             item = DictParser.parse(hotel)
             item["ref"] = hotel.get("code")
             item["street_address"] = item.pop("addr_full")
+            for page in hotel.get("pages", []):
+                if page.get("code") == "overview":
+                    item["website"] = response.urljoin(page["url"])
+
             if brand_info := self.brand_mapping.get(hotel.get("brand")):
                 item["brand"], item["brand_wikidata"] = brand_info
             else:

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -46,6 +46,7 @@ class RadissonHotelsSpider(scrapy.Spider):
             for page in hotel.get("pages", []):
                 if page.get("code") == "overview":
                     item["website"] = response.urljoin(page["url"])
+                    break
 
             if brand_info := self.brand_mapping.get(hotel.get("brand")):
                 item["brand"], item["brand_wikidata"] = brand_info

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -34,7 +34,7 @@ class RadissonHotelsSpider(scrapy.Spider):
 
     def start_requests(self) -> Iterable[Request]:
         yield JsonRequest(
-            url="https://www.radissonhotels.com/zimba-api/hotels?limit=2000", headers={"accept-language": "en-us"}
+            url="https://www.radissonhotels.com/zimba-api/hotels?limit=1000", headers={"accept-language": "en-us"}
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
```python
{'atp/brand/Art’otel': 7,
 'atp/brand/Country Inn & Suites by Radisson': 12,
 'atp/brand/Park Inn & Suites by Radisson': 2,
 'atp/brand/Park Inn by Radisson': 92,
 'atp/brand/Park Plaza Hotels & Resorts': 35,
 'atp/brand/Prizeotel': 15,
 'atp/brand/Radisson': 124,
 'atp/brand/Radisson Blu': 335,
 'atp/brand/Radisson Collection': 40,
 'atp/brand/Radisson Individuals': 73,
 'atp/brand/Radisson RED': 27,
 'atp/brand_wikidata/Q14516231': 7,
 'atp/brand_wikidata/Q1751979': 124,
 'atp/brand_wikidata/Q2052550': 35,
 'atp/brand_wikidata/Q28233721': 27,
 'atp/brand_wikidata/Q5177332': 12,
 'atp/brand_wikidata/Q60711675': 92,
 'atp/brand_wikidata/Q60716706': 40,
 'atp/brand_wikidata/Q7281341': 335,
 'atp/category/tourism/hotel': 762,
 'atp/clean_strings/email': 26,
 'atp/clean_strings/phone': 30,
 'atp/clean_strings/postcode': 30,
 'atp/clean_strings/street_address': 18,
 'atp/country/AE': 16,
 'atp/country/AL': 1,
 'atp/country/AM': 2,
 'atp/country/AT': 9,
 'atp/country/AU': 2,
 'atp/country/AZ': 1,
 'atp/country/BD': 2,
 'atp/country/BE': 15,
 'atp/country/BG': 2,
 'atp/country/BH': 1,
 'atp/country/BN': 1,
 'atp/country/CG': 1,
 'atp/country/CH': 9,
 'atp/country/CI': 1,
 'atp/country/CN': 25,
 'atp/country/CY': 2,
 'atp/country/CZ': 1,
 'atp/country/DE': 53,
 'atp/country/DK': 6,
 'atp/country/EE': 5,
 'atp/country/EG': 5,
 'atp/country/ES': 8,
 'atp/country/ET': 1,
 'atp/country/FI': 9,
 'atp/country/FJ': 1,
 'atp/country/FR': 21,
 'atp/country/GA': 2,
 'atp/country/GB': 62,
 'atp/country/GE': 6,
 'atp/country/GH': 1,
 'atp/country/GN': 1,
 'atp/country/GR': 5,
 'atp/country/HR': 7,
 'atp/country/HU': 7,
 'atp/country/ID': 3,
 'atp/country/IE': 10,
 'atp/country/IN': 130,
 'atp/country/IQ': 2,
 'atp/country/IS': 2,
 'atp/country/IT': 15,
 'atp/country/JO': 1,
 'atp/country/KE': 3,
 'atp/country/KW': 2,
 'atp/country/KZ': 3,
 'atp/country/LB': 2,
 'atp/country/LK': 4,
 'atp/country/LT': 4,
 'atp/country/LU': 1,
 'atp/country/LV': 7,
 'atp/country/LY': 1,
 'atp/country/MA': 9,
 'atp/country/MD': 1,
 'atp/country/MG': 3,
 'atp/country/ML': 2,
 'atp/country/MT': 2,
 'atp/country/MU': 3,
 'atp/country/MV': 1,
 'atp/country/MY': 1,
 'atp/country/MZ': 1,
 'atp/country/NE': 1,
 'atp/country/NG': 4,
 'atp/country/NL': 10,
 'atp/country/NO': 22,
 'atp/country/NP': 1,
 'atp/country/OM': 6,
 'atp/country/PG': 1,
 'atp/country/PH': 6,
 'atp/country/PK': 1,
 'atp/country/PL': 18,
 'atp/country/PT': 1,
 'atp/country/QA': 1,
 'atp/country/RE': 1,
 'atp/country/RO': 5,
 'atp/country/RS': 4,
 'atp/country/RU': 40,
 'atp/country/RW': 2,
 'atp/country/SA': 33,
 'atp/country/SE': 10,
 'atp/country/SI': 1,
 'atp/country/SK': 2,
 'atp/country/SL': 1,
 'atp/country/SN': 2,
 'atp/country/SS': 1,
 'atp/country/TD': 1,
 'atp/country/TH': 10,
 'atp/country/TN': 5,
 'atp/country/TR': 39,
 'atp/country/UA': 5,
 'atp/country/UZ': 2,
 'atp/country/VN': 7,
 'atp/country/ZA': 13,
 'atp/country/ZM': 2,
 'atp/field/branch/missing': 762,
 'atp/field/brand_wikidata/missing': 90,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 3,
 'atp/field/opening_hours/missing': 762,
 'atp/field/operator/missing': 762,
 'atp/field/operator_wikidata/missing': 762,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 6,
 'atp/field/postcode/missing': 46,
 'atp/field/state/missing': 762,
 'atp/field/twitter/missing': 762,
 'atp/item_scraped_host_count/www.radissonhotels.com': 762,
 'atp/nsi/perfect_match': 672,
 'downloader/request_bytes': 302,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 265164,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.264399,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 7, 13, 24, 15, 396294, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1776712,
 'httpcompression/response_count': 1,
 'item_scraped_count': 762,
 'items_per_minute': None,
 'log_count/DEBUG': 774,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 7, 13, 24, 11, 131895, tzinfo=datetime.timezone.utc)}
```