### PR TITLE
[Mcdonalds Latin America] Fix KeyError to recover lost POIs count for the spider

### DIFF
--- a/locations/spiders/mcdonalds_latin_america.py
+++ b/locations/spiders/mcdonalds_latin_america.py
@@ -1,5 +1,7 @@
+from typing import Any, Iterable
+
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -30,11 +32,11 @@ class McdonaldsLatinAmericaSpider(Spider):
         "VE",
     ]
 
-    def start_requests(self):
+    def start_requests(self) -> Iterable[JsonRequest]:
         for country_code in self.country_codes:
             yield JsonRequest(url=self.start_urls[0], headers={"x-app-country": country_code}, dont_filter=True)
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         if not response.json().get("status"):
             return
 
@@ -58,11 +60,11 @@ class McdonaldsLatinAmericaSpider(Spider):
                         item["opening_hours"].add_range(
                             day_hours["day"].title(), time_period["start"], time_period["end"]
                         )
-
-            apply_yes_no(Extras.DRIVE_THROUGH, item, location["services"]["driveThru"], False)
-            apply_yes_no(Extras.DELIVERY, item, location["services"]["mcDelivery"], False)
-            apply_yes_no(Extras.WIFI, item, location["services"]["wifi"], False)
-            apply_yes_no(Extras.WHEELCHAIR, item, location["services"]["wheelchairAccess"], False)
+            if services := location.get("services"):
+                apply_yes_no(Extras.DRIVE_THROUGH, item, services.get("driveThru") is True, False)
+                apply_yes_no(Extras.DELIVERY, item, services.get("mcDelivery") is True, False)
+                apply_yes_no(Extras.WIFI, item, services.get("wifi") is True, False)
+                apply_yes_no(Extras.WHEELCHAIR, item, services.get("wheelchairAccess") is True, False)
 
             apply_category(Categories.FAST_FOOD, item)
 


### PR DESCRIPTION
```python
{"atp/brand/McDonald's": 3718,
 'atp/brand_wikidata/Q38076': 3718,
 'atp/category/amenity/fast_food': 3718,
 'atp/clean_strings/addr_full': 2,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/name': 17,
 'atp/clean_strings/street_address': 39,
 'atp/country/AR': 404,
 'atp/country/BR': 2240,
 'atp/country/CL': 190,
 'atp/country/CO': 67,
 'atp/country/CR': 76,
 'atp/country/EC': 32,
 'atp/country/GF': 3,
 'atp/country/GP': 9,
 'atp/country/MQ': 5,
 'atp/country/MX': 365,
 'atp/country/PA': 80,
 'atp/country/PE': 26,
 'atp/country/PR': 57,
 'atp/country/UY': 46,
 'atp/country/VE': 118,
 'atp/field/branch/missing': 3718,
 'atp/field/city/missing': 285,
 'atp/field/email/missing': 3718,
 'atp/field/image/missing': 3718,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 980,
 'atp/field/operator/missing': 3718,
 'atp/field/operator_wikidata/missing': 3718,
 'atp/field/phone/missing': 3718,
 'atp/field/postcode/missing': 3718,
 'atp/field/state/missing': 3718,
 'atp/field/street_address/missing': 464,
 'atp/field/twitter/missing': 3718,
 'atp/field/website/missing': 3718,
 'atp/item_scraped_host_count/api-middleware-mcd.mcdonaldscupones.com': 3920,
 'atp/nsi/cc_match': 3718,
 'downloader/request_bytes': 5925,
 'downloader/request_count': 16,
 'downloader/request_method_count/GET': 16,
 'downloader/response_bytes': 806529,
 'downloader/response_count': 16,
 'downloader/response_status_count/200': 15,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 21.565554,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 7, 13, 58, 12, 737001, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11943903,
 'httpcompression/response_count': 15,
 'item_dropped_count': 202,
 'item_dropped_reasons_count/DropItem': 202,
 'item_scraped_count': 3718,
 'items_per_minute': None,
 'log_count/DEBUG': 3948,
 'log_count/INFO': 9,
 'response_received_count': 16,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 15,
 'scheduler/dequeued/memory': 15,
 'scheduler/enqueued': 15,
 'scheduler/enqueued/memory': 15,
 'start_time': datetime.datetime(2025, 3, 7, 13, 57, 51, 171447, tzinfo=datetime.timezone.utc)}
```