### PR TITLE
[HSBC] Remove AR & AM countries urls where HSBC no longer operates

### DIFF
--- a/locations/spiders/hsbc.py
+++ b/locations/spiders/hsbc.py
@@ -13,8 +13,6 @@ class HsbcSpider(CrawlSpider, StructuredDataSpider):
     name = "hsbc"
     item_attributes = {"brand": "HSBC", "brand_wikidata": "Q190464", "extras": Categories.BANK.value}
     start_urls = [
-        "https://www.hsbc.com.ar/branch-list/",
-        "https://www.hsbc.am/en-am/branch-list/",
         "https://www.hsbc.com.au/branch-list/",
         # "https://www.hsbc.com.bh/branch-finder/",
         # "https://www.hsbc.com.bd/1/2/home",


### PR DESCRIPTION
HSBC has been acquired by some other groups and no longer operates in [AR](https://www.hsbc.com.ar/anuncio/despedida/) & [AM](https://www.hsbc.am/en-am/announcements/goodbye/).