### PR TITLE
New spider: Decathlon MA (18 locations)

### DIFF
--- a/locations/spiders/decathlon_ma.py
+++ b/locations/spiders/decathlon_ma.py
@@ -1,0 +1,46 @@
+from chompjs import parse_js_object
+from scrapy import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours, DAYS_FR
+from locations.pipelines.address_clean_up import clean_address
+from locations.spiders.decathlon_fr import DecathlonFRSpider
+
+
+class DecathlonMASpider(Spider):
+    name = "decathlon_ma"
+    item_attributes = DecathlonFRSpider.item_attributes
+    start_urls = ["https://www.decathlon.ma/content/154-filialen-decathlon"]
+
+    def parse(self, response):
+        js_blob = response.xpath('//script[contains(text(), ",stores=[{")]/text()').get()
+
+        js_blob_markers = (
+            js_blob.split(",store_marker=", 1)[1].split(",store_name=", 1)[0].replace('\\"', "'").replace("\\/", "/")
+        )
+        markers = parse_js_object(js_blob_markers, unicode_escape=True)
+        markers = {marker["store_number"]: marker for marker in markers}
+
+        js_blob_stores = js_blob.split(",stores=", 1)[1].split(",zoom=", 1)[0].replace('\\"', "'").replace("\\/", "/")
+        locations = parse_js_object(js_blob_stores, unicode_escape=True)
+
+        for location in locations:
+            location["hours"] = parse_js_object(location["hours"])
+            location["website"] = markers[location["store_number"]]["link"]
+            item = DictParser.parse(location)
+
+            item["ref"] = str(location["store_number"])
+            item["street_address"] = clean_address([location["address1"], location["address2"]])
+
+            item["opening_hours"] = OpeningHours()
+            for day_number, day_hours in enumerate(location["hours"]):
+                for time_range in day_hours:
+                    hours_string = time_range.replace("H", ":")
+                    item["opening_hours"].add_ranges_from_string(
+                        f"{DAYS[day_number]} {hours_string}",
+                        days=DAYS_FR,
+                        delimiters=["-", "à", "a", ","]
+                    )
+
+
+            yield item

--- a/locations/spiders/decathlon_ma.py
+++ b/locations/spiders/decathlon_ma.py
@@ -2,7 +2,7 @@ from chompjs import parse_js_object
 from scrapy import Spider
 
 from locations.dict_parser import DictParser
-from locations.hours import DAYS, OpeningHours, DAYS_FR
+from locations.hours import DAYS, DAYS_FR, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
 from locations.spiders.decathlon_fr import DecathlonFRSpider
 
@@ -37,10 +37,7 @@ class DecathlonMASpider(Spider):
                 for time_range in day_hours:
                     hours_string = time_range.replace("H", ":")
                     item["opening_hours"].add_ranges_from_string(
-                        f"{DAYS[day_number]} {hours_string}",
-                        days=DAYS_FR,
-                        delimiters=["-", "à", "a", ","]
+                        f"{DAYS[day_number]} {hours_string}", days=DAYS_FR, delimiters=["-", "à", "a", ","]
                     )
-
 
             yield item


### PR DESCRIPTION
#12121


```
{'atp/brand/Decathlon': 18,
 'atp/brand_wikidata/Q509349': 18,
 'atp/category/shop/sports': 18,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/MA': 18,
 'atp/field/branch/missing': 18,
 'atp/field/country/from_spider_name': 18,
 'atp/field/email/missing': 5,
 'atp/field/image/missing': 18,
 'atp/field/lat/missing': 1,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 18,
 'atp/field/operator_wikidata/missing': 18,
 'atp/field/state/missing': 18,
 'atp/field/twitter/missing': 18,
 'atp/field/website/missing': 2,
 'atp/item_scraped_host_count/www.decathlon.ma': 18,
 'atp/nsi/cc_match': 18,
 'downloader/request_bytes': 907,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 34519,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.071658,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 10, 10, 59, 8, 909434, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 313130,
 'httpcompression/response_count': 2,
 'item_scraped_count': 18,
 'items_per_minute': None,
 'log_count/DEBUG': 31,
 'log_count/INFO': 10,
 'memusage/max': 216907776,
 'memusage/startup': 216907776,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 10, 10, 59, 6, 837776, tzinfo=datetime.timezone.utc)}
2025-03-10 10:59:08 [scrapy.core.engine] INFO: Spider closed (finished)
```