### PR TITLE
New spider: Blink (7893 charging stations + 26415 charge points)

### DIFF
--- a/locations/spiders/blink.py
+++ b/locations/spiders/blink.py
@@ -1,0 +1,106 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+SOCKET_TYPES = {
+    "CCS1": "type1_combo",
+    "CCS2": "type2_combo",
+    "CHAdeMO": "chademo",
+    "GBT": "gb_ac",
+    "J1772": "type1",
+    "MENNEKES": "type2",
+    "NACS": "tesla_supercharger",
+}
+
+
+class BlinkSpider(Spider):
+    name = "blink"
+    item_attributes = {
+        "brand": "Blink",
+        "brand_wikidata": "Q62065645",
+        "operator": "Blink",
+        "operator_wikidata": "Q62065645",
+    }
+
+    # First request the map, but it only returns lat/lon/ID for each station
+    def start_requests(self):
+        yield JsonRequest(
+            "https://apigw.blinknetwork.com/nmap/v3/locations/map/pins",
+            data={
+                "latitude": 0,
+                "longitude": 0,
+                "radius": 25000,
+            },
+            callback=self.parse_pins,
+        )
+
+    # For each station, request details, and pass through lat/lon
+    def parse_pins(self, response):
+        for pin in response.json():
+            yield JsonRequest(
+                f"https://apigw.blinknetwork.com/v3/locations/map/{pin['locationId']}",
+                callback=self.parse_station,
+                cb_kwargs={"lat": pin["latitude"], "lon": pin["longitude"]},
+            )
+
+    def parse_station(self, response, lat, lon):
+        location = response.json()
+        item = DictParser.parse(location)
+
+        item["lat"] = lat
+        item["lon"] = lon
+        item["branch"] = item.pop("name")
+        apply_category(Categories.CHARGING_STATION, item)
+
+        oh = OpeningHours()
+        for line in location["locationSchedule"]["locationScheduleInfoDTO"]:
+            if line["isOpen"]:
+                oh.add_range(line["weekDay"], line["startTime"], line["endTime"])
+            else:
+                oh.set_closed(line["weekDay"])
+        item["opening_hours"] = oh
+
+        yield item
+
+        # Additionally request details about the chargers
+        yield JsonRequest(
+            f"https://apigw.blinknetwork.com/v3/locations/{location['locationId']}",
+            callback=self.parse_points,
+            cb_kwargs={"parent": item},
+        )
+
+    def parse_points(self, response, parent):
+        for level in response.json():
+            for charger in level["chargers"]:
+                item = Feature(
+                    city=parent.get("city"),
+                    country=parent.get("country"),
+                    geometry=parent.get("geometry"),
+                    opening_hours=parent.get("opening_hours"),
+                    postcode=parent.get("postcode"),
+                    state=parent.get("state"),
+                    street_address=parent.get("street_address"),
+                )
+                apply_category({"man_made": "charge_point"}, item)
+                item["name"] = charger["portName"]
+                # For OSM tagging, "ref" is probably better, but ref needs to be globally unique in ATP
+                item["extras"]["ref:serial"] = charger["serialNumber"]
+                item["ref"] = charger["portId"]
+
+                socket_type = SOCKET_TYPES.get(charger["connectorType"])
+                if socket_type is None:
+                    self.crawler.stats.inc_value(f"atp/{self.name}/unknown_socket/{charger['connectorType']}")
+                else:
+                    apply_yes_no(f"socket:{socket_type}", item, True)
+                    item["extras"][f"socket:{socket_type}:output"] = str(round(charger["maxPower"] / 1000, 1))
+                    item["extras"][f"socket:{socket_type}:voltage"] = str(charger["maxVoltage"])
+                    item["extras"][f"socket:{socket_type}:current"] = str(charger["maxCurrent"])
+
+                if charger["isRestricted"]:
+                    item["extras"]["access"] = "private"
+
+                yield item


### PR DESCRIPTION
Makes one request to get a list of all station locations, then two requests for each station: first to get station information, then to get information about the chargers at each station. It seems annoying to me to have to make so many requests, but it's far from the only spider that makes around 1 request per location, so whatever. If the maintainers request, I can reduce the level of detail and reduce the number of requests: either remove the second request per station and don't collect information about chargers, or remove both requests per station and only get coordinates.

```py
{'atp/blink/unknown_socket/GBT': 8,
 'atp/brand/Blink': 34308,
 'atp/brand_wikidata/Q62065645': 34308,
 'atp/category/amenity/charging_station': 7893,
 'atp/category/man_made/charge_point': 26415,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/street_address': 1,
 'atp/country/AE': 2,
 'atp/country/CA': 117,
 'atp/country/CL': 3,
 'atp/country/CO': 3,
 'atp/country/CR': 44,
 'atp/country/GR': 1107,
 'atp/country/GU': 3,
 'atp/country/HN': 23,
 'atp/country/IL': 95,
 'atp/country/MX': 81,
 'atp/country/PR': 89,
 'atp/country/SV': 53,
 'atp/country/TC': 13,
 'atp/country/US': 32675,
 'atp/field/branch/missing': 26415,
 'atp/field/city/missing': 75,
 'atp/field/email/missing': 34308,
 'atp/field/image/missing': 34308,
 'atp/field/lat/missing': 34,
 'atp/field/lon/missing': 34,
 'atp/field/name/missing': 525,
 'atp/field/phone/missing': 34308,
 'atp/field/postcode/missing': 177,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 1029,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 34308,
 'atp/field/website/missing': 34308,
 'atp/geometry/null_island': 9,
 'atp/item_scraped_host_count/apigw.blinknetwork.com': 34308,
 'atp/nsi/cc_match': 32675,
 'atp/nsi/match_failed': 1633,
 'atp/operator/Blink': 34308,
 'atp/operator_wikidata/Q62065645': 34308,
 'downloader/request_bytes': 7523203,
 'downloader/request_count': 16724,
 'downloader/request_method_count/GET': 16723,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 23774720,
 'downloader/response_count': 16724,
 'downloader/response_status_count/200': 15787,
 'downloader/response_status_count/404': 937,
 'elapsed_time_seconds': 20360.400371,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 8, 3, 16, 55, 356957, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 936,
 'httperror/response_ignored_status_count/404': 936,
 'item_scraped_count': 34308,
 'items_per_minute': None,
 'log_count/INFO': 1285,
 'memusage/max': 487055360,
 'memusage/startup': 255692800,
 'request_depth_max': 2,
 'response_received_count': 16724,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 16723,
 'scheduler/dequeued/memory': 16723,
 'scheduler/enqueued': 16723,
 'scheduler/enqueued/memory': 16723,
 'start_time': datetime.datetime(2025, 3, 7, 21, 37, 34, 956586, tzinfo=datetime.timezone.utc)}
```