### PR TITLE
[Armaguard AU] Add Spider (1743 locations)

### DIFF
--- a/locations/spiders/armaguard_au.py
+++ b/locations/spiders/armaguard_au.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class ArmaguardAUSpider(scrapy.Spider):
+    name = "armaguard_au"
+    item_attributes = {"brand": "Armaguard", "brand_wikidata": "Q118898974"}
+    start_urls = [
+        "https://app.ehoundplatform.com/api/1.3/proximity_search?output=json&lat=-33.867139&lon=151.207114&count=5000&priority_distance=undefined&priority_filters=undefined&priority_logic=undefined&log_type=web&create_log=true&api_key=a34dcb3a0c98793&custom_logic=undefined&user_selection=undefined&ch=7203"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for atm in response.json()["record_set"]:
+            item = DictParser.parse(atm)
+            item["ref"] = atm["loc_id"]
+            item["branch"] = atm["details"]["location_name"]
+            item["opening_hours"] = OpeningHours()
+            if atm["opening_hours"]["abbr_opening_hours"] == "open 24x7":
+                item["opening_hours"] = "24/7"
+            else:
+                item["opening_hours"].add_ranges_from_string(atm["opening_hours"]["abbr_opening_hours"])
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Armaguard': 1743,
 'atp/brand_wikidata/Q118898974': 1743,
 'atp/category/amenity/atm': 1743,
 'atp/country/AU': 1743,
 'atp/field/email/missing': 1743,
 'atp/field/image/missing': 1743,
 'atp/field/name/missing': 1743,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 1743,
 'atp/field/operator_wikidata/missing': 1743,
 'atp/field/phone/missing': 1743,
 'atp/field/twitter/missing': 1743,
 'atp/field/website/missing': 1743,
 'atp/item_scraped_host_count/app.ehoundplatform.com': 1743,
 'atp/nsi/perfect_match': 1743,
 'downloader/request_bytes': 569,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 158947,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 10.687319,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 11, 8, 15, 56, 580467, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2581670,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1743,
 'items_per_minute': None,
 'log_count/DEBUG': 1755,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 11, 8, 15, 45, 893148, tzinfo=datetime.timezone.utc)}
```