### PR TITLE
[Allpoint] Add Spider (35440 locations)

### DIFF
--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -1,0 +1,41 @@
+import json
+from typing import Any, Iterable
+
+import scrapy
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class AllpointSpider(Spider):
+    name = "allpoint"
+    item_attributes = {"brand": "Allpoint", "brand_wikidata": "Q4733264"}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    download_timeout = 50
+
+    def make_request(self, page: int) -> Request:
+        return JsonRequest(
+            url="https://clsws.locatorsearch.net/Rest/LocatorSearchAPI.svc/GetLocations",
+            data={
+                "NetworkId": 10029,
+                "Latitude": 0,
+                "Longitude": 0,
+                "Miles": 500000,
+                "SearchByOptions": "ATMSF, ATMDP",
+                "PageIndex": page,
+            },
+            cb_kwargs={"current_page": page},
+        )
+
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(1)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if response.json()["data"]["ATMInfo"]:
+            for atm in response.json()["data"]["ATMInfo"]:
+                item = DictParser.parse(atm)
+                yield item
+            yield self.make_request(kwargs["current_page"] + 1)

--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -1,13 +1,10 @@
-import json
 from typing import Any, Iterable
 
-import scrapy
 from scrapy import Request
 from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class AllpointSpider(Spider):

--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -13,7 +13,6 @@ from locations.user_agents import BROWSER_DEFAULT
 class AllpointSpider(Spider):
     name = "allpoint"
     item_attributes = {"brand": "Allpoint", "brand_wikidata": "Q4733264"}
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
     download_timeout = 50
 
     def make_request(self, page: int) -> Request:


### PR DESCRIPTION
```python
{'atp/brand/Allpoint': 35440,
 'atp/brand_wikidata/Q4733264': 35440,
 'atp/category/amenity/atm': 35440,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/street': 3,
 'atp/country/AU': 263,
 'atp/country/CA': 352,
 'atp/country/GB': 8722,
 'atp/country/MX': 325,
 'atp/country/US': 25778,
 'atp/field/branch/missing': 35440,
 'atp/field/email/missing': 35440,
 'atp/field/image/missing': 35440,
 'atp/field/name/missing': 35440,
 'atp/field/opening_hours/missing': 35440,
 'atp/field/operator/missing': 35440,
 'atp/field/operator_wikidata/missing': 35440,
 'atp/field/phone/missing': 35440,
 'atp/field/street_address/missing': 35440,
 'atp/item_scraped_host_count/clsws.locatorsearch.net': 55644,
 'atp/nsi/perfect_match': 35440,
 'downloader/request_bytes': 470990,
 'downloader/request_count': 558,
 'downloader/request_method_count/POST': 558,
 'downloader/response_bytes': 72514842,
 'downloader/response_status_count/200': 558,
 'elapsed_time_seconds': 349.086317,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 12, 9, 24, 50, 50554, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 35440,
 'items_per_minute': None,
 'log_count/DEBUG': 56229,
 'log_count/INFO': 14,
 'request_depth_max': 557,
 'response_received_count': 558,
 'responses_per_minute': None,
 'scheduler/dequeued': 558,
 'scheduler/dequeued/memory': 558,
 'scheduler/enqueued': 558,
 'scheduler/enqueued/memory': 558,
 'start_time': datetime.datetime(2025, 3, 12, 9, 19, 0, 964237, tzinfo=datetime.timezone.utc)}
```