### PR TITLE
[mitsubishi_tw] add spider (222 locations)

### DIFF
--- a/locations/spiders/mitsubishi_tw.py
+++ b/locations/spiders/mitsubishi_tw.py
@@ -1,0 +1,30 @@
+from scrapy.http import FormRequest
+
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class MitsubishiTWSpider(JSONBlobSpider):
+    name = "mitsubishi_tw"
+    allowed_domains = ["www.mitsubishi-motors.com.tw"]
+    item_attributes = {
+        "brand": "Mitsubishi",
+        "brand_wikidata": "Q36033",
+    }
+
+    def start_requests(self):
+        for node_type in ["1", "2"]:
+            yield FormRequest(
+                url="https://www.mitsubishi-motors.com.tw/do/locationsdo.php",
+                formdata={"surl": f"https://api.5230.com.tw/cmcAPI/index.php/getNodeList/index/nodeType/{node_type}"},
+                meta={"type": node_type},
+            )
+
+    def post_process_item(self, item, response, feature):
+        item["ref"] = feature.get("sr_cd")
+        item["name"] = feature.get("fullname")
+        if response.meta["type"] == "1":
+            apply_category(Categories.SHOP_CAR, item)
+        elif response.meta["type"] == "2":
+            apply_category(Categories.SHOP_CAR_REPAIR, item)
+        yield item


### PR DESCRIPTION
This site stores car shops and repairs as separate locations even if address is the same (refs are different though). I'm not convinced enough to write some custom code that will merge these items.

```json
{
 "atp/brand/Mitsubishi": 222,
 "atp/brand_wikidata/Q36033": 222,
 "atp/category/shop/car": 103,
 "atp/category/shop/car_repair": 119,
 "atp/clean_strings/addr_full": 2,
 "atp/country/TW": 222,
 "atp/field/branch/missing": 222,
 "atp/field/city/missing": 222,
 "atp/field/country/from_spider_name": 222,
 "atp/field/email/missing": 222,
 "atp/field/image/missing": 222,
 "atp/field/opening_hours/missing": 222,
 "atp/field/operator/missing": 222,
 "atp/field/operator_wikidata/missing": 222,
 "atp/field/phone/invalid": 1,
 "atp/field/postcode/missing": 222,
 "atp/field/state/missing": 222,
 "atp/field/street_address/missing": 222,
 "atp/field/twitter/missing": 222,
 "atp/field/website/missing": 222,
 "atp/item_scraped_host_count/www.mitsubishi-motors.com.tw": 222,
 "atp/nsi/cc_match": 222,
 "downloader/request_bytes": 2082,
 "downloader/request_count": 4,
 "downloader/request_method_count/GET": 2,
 "downloader/request_method_count/POST": 2,
 "downloader/response_bytes": 335273,
 "downloader/response_count": 4,
 "downloader/response_status_count/200": 3,
 "downloader/response_status_count/302": 1,
 "elapsed_time_seconds": 0.645631,
 "feedexport/success_count/FileFeedStorage": 1,
 "finish_reason": "finished",
 "finish_time": "2025-03-12T10:24:43.717158+00:00",
 "httpcache/hit": 4,
 "item_scraped_count": 222,
 "log_count/INFO": 10,
 "log_count/WARNING": 1,
 "memusage/max": 227819520,
 "memusage/startup": 227819520,
 "response_received_count": 3,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2025-03-12T10:24:43.071527+00:00"
}
```