### PR TITLE
[Murphy USA] Improve branding

### DIFF
--- a/locations/spiders/murphy_usa_us.py
+++ b/locations/spiders/murphy_usa_us.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -5,10 +7,14 @@ from locations.categories import Categories, Extras, Fuel, apply_category, apply
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 
+BRANDS = {
+    "Murphy Express": {"name": "Murphy Express", "brand": "Murphy Express", "brand_wikidata": "Q19604459"},
+    "Murphy USA": {"name": "Murphy USA", "brand": "Murphy USA", "brand_wikidata": "Q19604459"},
+}
+
 
 class MurphyUsaUSSpider(Spider):
     name = "murphy_usa_us"
-    item_attributes = {"brand": "Murphy USA", "brand_wikidata": "Q19604459"}
     allowed_domains = ["service.murphydriverewards.com"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
     requires_proxy = True
@@ -22,10 +28,18 @@ class MurphyUsaUSSpider(Spider):
             yield JsonRequest(f"https://service.murphydriverewards.com/api/store/detail/{store_id}")
 
     def parse(self, response):
+        if "data" not in response.json():
+            return
         location = response.json()["data"]
         item = DictParser.parse(location)
         item["ref"] = location["storeNumber"]
         item["street_address"] = item.pop("addr_full")
+
+        if brand := BRANDS.get(location["chainName"]):
+            item.update(brand)
+        else:
+            self.logger.error("Unexpected brand: {}".format(location["chainName"]))
+
         item["opening_hours"] = OpeningHours()
         for day in DAYS_FULL:
             day_name = day.lower()
@@ -33,14 +47,21 @@ class MurphyUsaUSSpider(Spider):
                 item["opening_hours"].add_range(
                     day, location.get(f"{day_name}Open"), location.get(f"{day_name}Close"), "%I:%M%p"
                 )
-        apply_yes_no(Extras.TOILETS, item, location.get("hasPublicRestroom"), False)
-        apply_yes_no(Fuel.DIESEL, item, location.get("sellDiesel"), False)
-        apply_yes_no(Extras.ATM, item, location.get("hasAtm"), False)
-        apply_yes_no(Extras.CAR_WASH, item, location.get("hasCarWash"), False)
-        apply_yes_no(Fuel.PROPANE, item, location.get("sellsPropane"), False)
+
+        if start_date := location["openDate"]:
+            item["extras"]["start_date"] = datetime.strptime(start_date, "%m/%d/%Y").strftime("%Y-%m-%d")
+
+        apply_yes_no(Extras.TOILETS, item, location.get("hasPublicRestroom"), "hasPublicRestroom" in location)
+        apply_yes_no(Fuel.DIESEL, item, location.get("sellDiesel"), "sellDiesel" in location)
+        apply_yes_no(Extras.ATM, item, location.get("hasAtm"), "hasAtm" in location)
+        apply_yes_no(Extras.CAR_WASH, item, location.get("hasCarWash"), "hasCarWash" in location)
+        apply_yes_no(Fuel.PROPANE, item, location.get("sellsPropane"), "sellsPropane" in location)
+
         fuel_types = [gas_price["fuelType"] for gas_price in location["gasPrices"]]
-        apply_yes_no(Fuel.OCTANE_87, item, "Regular" in fuel_types, False)
-        apply_yes_no(Fuel.OCTANE_89, item, "Midgrade" in fuel_types, False)
-        apply_yes_no(Fuel.OCTANE_91, item, "Premium" in fuel_types, False)
+        apply_yes_no(Fuel.OCTANE_87, item, "Regular" in fuel_types)
+        apply_yes_no(Fuel.OCTANE_89, item, "Midgrade" in fuel_types)
+        apply_yes_no(Fuel.OCTANE_91, item, "Premium" in fuel_types)
+
         apply_category(Categories.FUEL_STATION, item)
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Murphy Express': 420,
 'atp/brand/Murphy USA': 1172,
 'atp/brand_wikidata/Q19604459': 1592,
 'atp/category/amenity/fuel': 1592,
 'atp/country/US': 1592,
 'atp/field/branch/missing': 1592,
 'atp/field/email/missing': 1592,
 'atp/field/image/missing': 1592,
 'atp/field/operator/missing': 1592,
 'atp/field/operator_wikidata/missing': 1592,
 'atp/field/twitter/missing': 1592,
 'atp/field/website/missing': 1592,
 'atp/item_scraped_host_count/service.murphydriverewards.com': 1592,
 'atp/nsi/match_failed': 1592,
 'downloader/request_bytes': 1059045,
 'downloader/request_count': 1594,
 'downloader/request_method_count/GET': 1594,
 'downloader/response_bytes': 2869632,
 'downloader/response_count': 1594,
 'downloader/response_status_count/200': 1594,
 'elapsed_time_seconds': 5.853244,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 12, 22, 27, 27, 935928, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1594,
 'httpcompression/response_bytes': 4563304,
 'httpcompression/response_count': 1594,
 'item_scraped_count': 1592,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 281001984,
 'memusage/startup': 281001984,
 'request_depth_max': 1,
 'response_received_count': 1594,
 'responses_per_minute': None,
 'scheduler/dequeued': 1594,
 'scheduler/dequeued/memory': 1594,
 'scheduler/enqueued': 1594,
 'scheduler/enqueued/memory': 1594,
 'start_time': datetime.datetime(2025, 3, 12, 22, 27, 22, 82684, tzinfo=datetime.timezone.utc)}
```