### PR TITLE
harden close_time parsing

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -950,6 +950,11 @@ class OpeningHours:
             open_time = time.strptime(open_time, time_format)
         if not isinstance(close_time, time.struct_time):
             close_time = time.strptime(close_time, time_format)
+            if close_time.tm_hour == 0 and close_time.tm_min == 0:
+                # weird format not caught by checks above
+                # may be 0:00 or even more divergent if time_format
+                # parameter was used with some exotic value
+                close_time = time.strptime("23:59", "%H:%M")
 
         self.days_closed.discard(day)
         self.day_hours[day].add((open_time, close_time))

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -942,9 +942,9 @@ class OpeningHours:
         if isinstance(close_time, str):
             if close_time.lower() in closed:
                 return
-            if close_time == "24:00" or close_time == "00:00":
+            if close_time in ("24:00", "00:00", "0:00"):
                 close_time = "23:59"
-            if close_time == "24:00:00" or close_time == "00:00:00":
+            if close_time in ("24:00:00", "00:00:00"):
                 close_time = "23:59:00"
         if not isinstance(open_time, time.struct_time):
             open_time = time.strptime(open_time, time_format)

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -163,6 +163,38 @@ def test_over_midnight():
     )
 
 
+def test_till_midnight():
+    o = OpeningHours()
+    o.add_range("Mo", "11:00", "23:00")
+    o.add_range("Tu", "11:00", "23:00")
+    o.add_range("We", "11:00", "23:00")
+    o.add_range("Th", "11:00", "23:00")
+    o.add_range("Fr", "11:00", "24:00")
+    o.add_range("Sa", "11:00", "24:00")
+    o.add_range("Su", "11:00", "23:00")
+
+    assert o.as_opening_hours() == "Mo-Th 11:00-23:00; Fr-Sa 11:00-24:00; Su 11:00-23:00"
+
+
+def test_till_midnight_formatted_as_zero_hour():
+    o = OpeningHours()
+    o.add_range("Mo", "11:00", "0:00")
+
+    assert o.as_opening_hours() == "Mo 11:00-24:00"
+
+
+def test_till_midnight_formatted_in_other_unusual_formats():
+    o = OpeningHours()
+    o.add_range("Mo", "11:00:00", "00:00:00", time_format="%H:%M:%S")
+
+    assert o.as_opening_hours() == "Mo 11:00-24:00"
+
+    o = OpeningHours()
+    o.add_range("Mo", "11:00:00", "0:00:00", time_format="%H:%M:%S")
+
+    assert o.as_opening_hours() == "Mo 11:00-24:00"
+
+
 def test_sanitise_days():
     assert sanitise_day("Mo") == "Mo"
     assert sanitise_day("Mon") == "Mo"

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -183,6 +183,13 @@ def test_till_midnight_formatted_as_zero_hour():
     assert o.as_opening_hours() == "Mo 11:00-24:00"
 
 
+def test_till_midnight_formatted_as_twenty_four_hour():
+    o = OpeningHours()
+    o.add_range("Mo", "11:00", "24:00")
+
+    assert o.as_opening_hours() == "Mo 11:00-24:00"
+
+
 def test_till_midnight_formatted_in_other_unusual_formats():
     o = OpeningHours()
     o.add_range("Mo", "11:00:00", "00:00:00", time_format="%H:%M:%S")
@@ -191,6 +198,11 @@ def test_till_midnight_formatted_in_other_unusual_formats():
 
     o = OpeningHours()
     o.add_range("Mo", "11:00:00", "0:00:00", time_format="%H:%M:%S")
+
+    assert o.as_opening_hours() == "Mo 11:00-24:00"
+
+    o = OpeningHours()
+    o.add_range("Mo", "11:00:00", "24:00:00", time_format="%H:%M:%S")
 
     assert o.as_opening_hours() == "Mo 11:00-24:00"
 


### PR DESCRIPTION
adds a regression test and fixes problem reported in https://github.com/alltheplaces/alltheplaces/pull/12568#discussion_r1987046526

this problem existed in past (`10:00-0:00` and `10:00-00:00` was resulting in a different output) but become more noticeable with #11989

I am quite unhappy about this fix as it leaves close_time ending at 24:00 (specified in unusual formats) with the same bug

but problem here is that using `time.strptime` on `24:00` makes it explode (at least with `"%H:%M"`) so you cannot parse and then check what is going on

but I have no better ideas right now