### PR TITLE
[Coinstar] Flag coinstar spider as requires proxy

### DIFF
--- a/locations/spiders/coinstar.py
+++ b/locations/spiders/coinstar.py
@@ -13,6 +13,7 @@ class CoinstarSpider(Spider):
     item_attributes = {"brand": "Coinstar", "brand_wikidata": "Q5141641"}
     start_urls = ["https://www.coinstar.com/findakiosk"]
     max_results = 1000
+    requires_proxy = True
 
     def parse(self, response):
         s = response.xpath("//script[contains(text(), 'csApiToken')]/text()").get()


### PR DESCRIPTION
**_The spider works fine from IN, so flag as requires proxy_** 

```python
{'atp/brand/Coinstar': 24968,
 'atp/brand_wikidata/Q5141641': 24968,
 'atp/category/amenity/payment_terminal': 24968,
 'atp/cdn/cloudflare/response_count': 505,
 'atp/cdn/cloudflare/response_status_count/200': 505,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/postcode': 23194,
 'atp/clean_strings/street_address': 8,
 'atp/country/CA': 572,
 'atp/country/DE': 2499,
 'atp/country/ES': 683,
 'atp/country/FR': 1279,
 'atp/country/GB': 1977,
 'atp/country/IE': 105,
 'atp/country/IT': 335,
 'atp/country/US': 17518,
 'atp/field/branch/missing': 24968,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 24968,
 'atp/field/image/missing': 24968,
 'atp/field/opening_hours/missing': 24968,
 'atp/field/operator/missing': 24968,
 'atp/field/operator_wikidata/missing': 24968,
 'atp/field/phone/missing': 24968,
 'atp/field/postcode/missing': 139,
 'atp/field/state/missing': 1312,
 'atp/field/twitter/missing': 24968,
 'atp/item_scraped_host_count/finder.coinstarapi.com': 31001,
 'atp/nsi/perfect_match': 24968,
 'downloader/request_bytes': 246595,
 'downloader/request_count': 505,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 504,
 'downloader/response_bytes': 6361550,
 'downloader/response_count': 505,
 'downloader/response_status_count/200': 505,
 'elapsed_time_seconds': 623.205588,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 13, 9, 48, 3, 497244, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 198681594,
 'httpcompression/response_count': 505,
 'item_dropped_count': 6033,
 'item_dropped_reasons_count/DropItem': 6033,
 'item_scraped_count': 24968,
 'items_per_minute': None,
 'log_count/DEBUG': 31517,
 'log_count/INFO': 19,
 'request_depth_max': 1,
 'response_received_count': 505,
 'responses_per_minute': None,
 'scheduler/dequeued': 505,
 'scheduler/dequeued/memory': 505,
 'scheduler/enqueued': 505,
 'scheduler/enqueued/memory': 505,
 'start_time': datetime.datetime(2025, 3, 13, 9, 37, 40, 291656, tzinfo=datetime.timezone.utc)}
```