### PR TITLE
[Pizza Hut VN] Fix spider

### DIFF
--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -1,10 +1,12 @@
+import base64
+import hashlib
+import hmac
 import re
 import time
 import uuid
 from typing import Any
 
 import scrapy
-from scrapy import Request
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
@@ -16,32 +18,32 @@ from locations.pipelines.address_clean_up import clean_address
 class PizzaHutVNSpider(scrapy.Spider):
     name = "pizza_hut_vn"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
-    start_urls = ["https://pizzahut.vn/_next/static/chunks/700-ac6d47c5279a8d47.js"]
+    start_urls = ["https://pizzahut.vn/_next/static/chunks/3070-0d2156c9136abbb1.js"]
+    api_url = "https://rwapi.pizzahut.vn/api/store/GetAllStoreList"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        next_action_token = re.search(r"([a-f0-9]{40})", response.text).group(1)
         timestamp = int(time.time() * 1000)
         device_uid = uuid.uuid4()
-        yield Request(
-            url="https://pizzahut.vn/store-location?area=north",
-            method="POST",
-            body=f'[{{"url":"/store/GetAllStoreList","method":"get","bodyData":"","timeStamp":"{timestamp}","deviceUID":"{device_uid}"}}]',
-            headers={
-                "next-action": next_action_token,
-            },
-            callback=self.parse_token,
-            meta=dict(timestamp=timestamp, device_uid=device_uid),
-        )
 
-    def parse_token(self, response: Response, **kwargs: Any) -> Any:
-        access_token = re.search(r"1[:\s]+\"(.+)\"", response.text).group(1)
+        app_code, secret_key, access_key = re.findall(
+            r"[a-z][\s=]+\(0,[\n\s]*[a-z]\.[a-z]\)\(\"([a-z0-9]+)\"\)", response.text
+        )[:3]
+
+        query_string = f"TimeStamp={timestamp}&DeviceUID={device_uid}&AppCode={app_code}&AccessKey={access_key}&Method=GET&url={self.api_url}&Body="
+
+        key = base64.b64decode(secret_key)
+        message = query_string.encode("utf-8")
+        signature = hmac.new(key, message, hashlib.sha512)
+
+        access_token = base64.b64encode(signature.digest()).decode("utf-8")
+
         yield JsonRequest(
-            url="https://rwapi.pizzahut.vn/api/store/GetAllStoreList",
+            url=self.api_url,
             headers={
                 "Authorization": f"Bearer {access_token}",
-                "deviceuid": str(response.meta["device_uid"]),
+                "deviceuid": str(device_uid),
                 "project_id": "WEB",
-                "timestamp": str(response.meta["timestamp"]),
+                "timestamp": str(timestamp),
             },
             callback=self.parse_stores,
         )

--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -13,6 +13,7 @@ from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class PizzaHutVNSpider(scrapy.Spider):
@@ -20,6 +21,7 @@ class PizzaHutVNSpider(scrapy.Spider):
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
     start_urls = ["https://pizzahut.vn/_next/static/chunks/3070-0d2156c9136abbb1.js"]
     api_url = "https://rwapi.pizzahut.vn/api/store/GetAllStoreList"
+    user_agent = BROWSER_DEFAULT
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         timestamp = int(time.time() * 1000)


### PR DESCRIPTION
Updated API bearer token generation method to fix the spider.

```python
{'atp/brand/Pizza Hut': 119,
 'atp/brand_wikidata/Q191615': 119,
 'atp/category/amenity/restaurant': 119,
 'atp/clean_strings/addr_full': 8,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/lat': 1,
 'atp/clean_strings/lon': 118,
 'atp/country/VN': 119,
 'atp/field/city/missing': 119,
 'atp/field/country/from_spider_name': 119,
 'atp/field/email/missing': 119,
 'atp/field/image/missing': 119,
 'atp/field/operator/missing': 119,
 'atp/field/operator_wikidata/missing': 119,
 'atp/field/phone/missing': 119,
 'atp/field/postcode/missing': 119,
 'atp/field/state/missing': 119,
 'atp/field/street_address/missing': 119,
 'atp/field/twitter/missing': 119,
 'atp/field/website/missing': 119,
 'atp/item_scraped_host_count/rwapi.pizzahut.vn': 119,
 'atp/nsi/cc_match': 119,
 'downloader/request_bytes': 2226,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 100430,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 4.417003,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 13, 11, 48, 4, 503559, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 166589,
 'httpcompression/response_count': 2,
 'item_scraped_count': 119,
 'items_per_minute': None,
 'log_count/DEBUG': 135,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 3, 13, 11, 48, 0, 86556, tzinfo=datetime.timezone.utc)}
```