### PR TITLE
New spider: Marco's Pizza (1241 locations)

### DIFF
--- a/locations/spiders/marcos.py
+++ b/locations/spiders/marcos.py
@@ -1,0 +1,61 @@
+import json
+import time
+
+import chompjs
+from scrapy import Request, Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
+
+
+def minutes_to_time(minutes: int):
+    return time.gmtime(minutes * 60)
+
+
+class MarcosSpider(Spider):
+    name = "marcos"
+    item_attributes = {
+        "brand": "Marco's Pizza",
+        "brand_wikidata": "Q6757382",
+    }
+    # First get country info
+    start_urls = [
+        "https://momspublicstorage.blob.core.windows.net/content/moms/online/brand-data/online-brand-data-LPHP3Y.json"
+    ]
+
+    def parse(self, response):
+        countries = {country["CountryID"]: country for country in response.json()["CONTs"]}
+        # Then fetch locations
+        yield Request(
+            "https://order.marcos.com/brand/?sk=LPHP3Y/locations",
+            callback=self.parse_locations,
+            cb_kwargs={"countries": countries},
+        )
+
+    def parse_locations(self, response, countries):
+        locations = json.loads(
+            chompjs.parse_js_object(response.xpath('//script[contains(text(), "let Temp = ")]/text()').get())[
+                "BrandLocations"
+            ]
+        )
+        for location in locations:
+            item = DictParser.parse(location)
+            item["country"] = countries[location["countryId"]]["IsoCode"]
+            item["ref"] = location["storeKey"]
+            item["phone"] = (
+                None
+                if item["phone"] == "1111111111"
+                else countries[location["countryId"]]["CountryCode"] + item["phone"]
+            )
+            item["extras"]["website:orders"] = f"{location['OnlineOrderingURL']}?id={location['storeKey']}"
+
+            oh = OpeningHours()
+            for day in location["Hours"]:
+                oh.add_range(
+                    DAYS_FROM_SUNDAY[day["WeekDayNo"]],
+                    minutes_to_time(day["OpenDayMinute"]),
+                    minutes_to_time(day["CloseDayMinute"]),
+                )
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
```py
{"atp/brand/Marco's Pizza": 1241,
 'atp/brand_wikidata/Q6757382': 1241,
 'atp/category/amenity/fast_food': 1241,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/street_address': 9,
 'atp/country/BH': 6,
 'atp/country/PR': 53,
 'atp/country/US': 1182,
 'atp/field/branch/missing': 1241,
 'atp/field/email/missing': 1241,
 'atp/field/image/missing': 1241,
 'atp/field/operator/missing': 1241,
 'atp/field/operator_wikidata/missing': 1241,
 'atp/field/phone/missing': 4,
 'atp/field/state/from_reverse_geocoding': 6,
 'atp/field/state/missing': 8,
 'atp/field/twitter/missing': 1241,
 'atp/field/website/missing': 1241,
 'atp/item_scraped_host_count/order.marcos.com': 1241,
 'atp/nsi/perfect_match': 1241,
 'downloader/request_bytes': 1459,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 269851,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/400': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.413486,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 13, 19, 3, 48, 374274, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1356067,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1241,
 'items_per_minute': None,
 'log_count/DEBUG': 1258,
 'log_count/INFO': 10,
 'memusage/max': 256147456,
 'memusage/startup': 256147456,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/400': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 3, 13, 19, 3, 43, 960788, tzinfo=datetime.timezone.utc)}
```