### PR TITLE
[Burlington US] Update sitmap url to fix  spider

### DIFF
--- a/locations/spiders/burlington_us.py
+++ b/locations/spiders/burlington_us.py
@@ -5,7 +5,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class BurlingtonUSSpider(SitemapSpider, StructuredDataSpider):
     name = "burlington_us"
-    sitemap_urls = ["https://stores.burlington.com/robots.txt"]
+    sitemap_urls = ["https://stores.burlington.com/sitemap.xml"]
     sitemap_rules = [(r"^https://stores\.burlington\.com/.*/.*/.*/$", "parse")]
     item_attributes = {
         "brand": "Burlington",


### PR DESCRIPTION
```python
{'atp/brand/Burlington': 1112,
 'atp/brand_wikidata/Q4999220': 1112,
 'atp/category/shop/department_store': 1112,
 'atp/cdn/cloudflare/response_count': 1114,
 'atp/cdn/cloudflare/response_status_count/200': 1114,
 'atp/country/US': 1112,
 'atp/field/branch/missing': 1112,
 'atp/field/email/missing': 1112,
 'atp/field/image/missing': 1112,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1112,
 'atp/field/operator_wikidata/missing': 1112,
 'atp/field/twitter/missing': 1112,
 'atp/item_scraped_host_count/stores.burlington.com': 1112,
 'atp/nsi/perfect_match': 1112,
 'downloader/request_bytes': 413600,
 'downloader/request_count': 1114,
 'downloader/request_method_count/GET': 1114,
 'downloader/response_bytes': 42955985,
 'downloader/response_count': 1114,
 'downloader/response_status_count/200': 1114,
 'elapsed_time_seconds': 1371.447856,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 14, 5, 43, 52, 229527, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1114,
 'httpcache/miss': 1114,
 'httpcache/store': 1114,
 'httpcompression/response_bytes': 212177553,
 'httpcompression/response_count': 1114,
 'item_scraped_count': 1112,
 'items_per_minute': None,
 'log_count/DEBUG': 2238,
 'log_count/INFO': 32,
 'request_depth_max': 1,
 'response_received_count': 1114,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1113,
 'scheduler/dequeued/memory': 1113,
 'scheduler/enqueued': 1113,
 'scheduler/enqueued/memory': 1113,
 'start_time': datetime.datetime(2025, 3, 14, 5, 21, 0, 781671, tzinfo=datetime.timezone.utc)}
```