### PR TITLE
[Aarons ] Switch to API to fix spider

### DIFF
--- a/locations/spiders/aarons.py
+++ b/locations/spiders/aarons.py
@@ -1,40 +1,18 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class AaronsSpider(SitemapSpider, StructuredDataSpider):
+class AaronsSpider(CrawlSpider, StructuredDataSpider):
     name = "aarons"
-    sitemap_urls = ["https://locations.aarons.com/robots.txt"]
-    sitemap_rules = [(r"\.com/\w\w/\w\w/[^/]+/[^/]+$", "parse")]
     item_attributes = {"brand": "Aaron's", "brand_wikidata": "Q10397787", "extras": Categories.SHOP_FURNITURE.value}
+    start_urls = ["https://www.aarons.com/locations/us", "https://www.aarons.com/locations/ca"]
+    rules = [
+        Rule(LinkExtractor(allow=r"/[a-z]{2}/[a-z]{2}/?$")),
+        Rule(LinkExtractor(allow=r"/[a-z]{2}/[a-z]{2}/[-\w]+/[-\w]+"), callback="parse_sd"),
+    ]
     drop_attributes = {"name", "image"}
     wanted_types = ["Store"]
     search_for_twitter = False
-
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            if any(
-                entry["loc"].endswith(s)
-                for s in [
-                    "/ashley-furniture",
-                    "/bedroom-furniture",
-                    "/computers",
-                    "/gaming",
-                    "/ge",
-                    "/hp",
-                    "/lg",
-                    "/living-room-furniture",
-                    "/mattresses",
-                    "/refrigerators",
-                    "/samsung",
-                    "/service-area",
-                    "/sony",
-                    "/televisions",
-                    "/washer-dryer",
-                    "/woodhaven",
-                ]
-            ):
-                continue
-            yield entry

--- a/locations/spiders/aarons.py
+++ b/locations/spiders/aarons.py
@@ -30,6 +30,12 @@ class AaronsSpider(Spider):
                 [address.get("line1"), address.get("line2"), address.get("line3")]
             )
             item["website"] = response.urljoin(location.get("url"))
+            item["phone"] = "; ".join(
+                filter(
+                    None,
+                    [location.get("mainPhone", {}).get("number"), location.get("alternatePhone", {}).get("number")],
+                )
+            )
             yield item
         new_offset = kwargs["offset"] + kwargs["limit"]
         if new_offset < response.json()["response"]["count"]:

--- a/locations/spiders/aarons.py
+++ b/locations/spiders/aarons.py
@@ -1,7 +1,9 @@
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -16,3 +18,8 @@ class AaronsSpider(CrawlSpider, StructuredDataSpider):
     drop_attributes = {"name", "image"}
     wanted_types = ["Store"]
     search_for_twitter = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if not item.get("street_address"):
+            return
+        yield item


### PR DESCRIPTION
`Sitemap` no longer has location urls, hence switched to `CrawlSpider`.

```python
{"atp/brand/Aaron's": 961,
 'atp/brand_wikidata/Q10397787': 961,
 'atp/category/shop/furniture': 961,
 'atp/country/CA': 18,
 'atp/country/US': 943,
 'atp/field/branch/missing': 961,
 'atp/field/email/missing': 961,
 'atp/field/image/missing': 961,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 961,
 'atp/field/operator_wikidata/missing': 961,
 'atp/field/twitter/missing': 961,
 'atp/item_scraped_host_count/www.aarons.com': 961,
 'atp/nsi/perfect_match': 961,
 'downloader/request_bytes': 423308,
 'downloader/request_count': 1100,
 'downloader/request_method_count/GET': 1100,
 'downloader/response_bytes': 56094521,
 'downloader/response_count': 1100,
 'downloader/response_status_count/200': 1097,
 'downloader/response_status_count/404': 3,
 'elapsed_time_seconds': 49.605318,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 14, 8, 26, 58, 548827, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1100,
 'httpcompression/response_bytes': 352848993,
 'httpcompression/response_count': 1100,
 'item_scraped_count': 961,
 'items_per_minute': None,
 'log_count/DEBUG': 2073,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 1100,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1099,
 'scheduler/dequeued/memory': 1099,
 'scheduler/enqueued': 1099,
 'scheduler/enqueued/memory': 1099,
 'start_time': datetime.datetime(2025, 3, 14, 8, 26, 8, 943509, tzinfo=datetime.timezone.utc)}
```