### PR TITLE
[mcdonalds_pt] Added McCafe POIs

### DIFF
--- a/locations/spiders/mcdonalds_pt.py
+++ b/locations/spiders/mcdonalds_pt.py
@@ -3,7 +3,7 @@ import html
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import DAYS_PT, OpeningHours, sanitise_day
 from locations.items import Feature
 from locations.spiders.mcdonalds import McdonaldsSpider
@@ -26,6 +26,14 @@ class McdonaldsPTSpider(SitemapSpider, StructuredDataSpider):
         apply_yes_no(Extras.WIFI, item, "Wi-Fi" in services)
         apply_yes_no(Extras.BABY_CHANGING_TABLE, item, "Fraldário" in services)
         apply_yes_no(Extras.TAKEAWAY, item, "Takeaway" in services)
+
+        if "McCafé" in services:
+            mccafe = item.deepcopy()
+            mccafe["ref"] = "{}-mccafe".format(item["ref"])
+            mccafe["brand"] = "McCafé"
+            mccafe["brand_wikidata"] = "Q3114287"
+            apply_category(Categories.CAFE, mccafe)
+            yield mccafe
 
         item["opening_hours"] = self.parse_opening_hours(
             response.xpath(


### PR DESCRIPTION
```
{'atp/brand/McCafé': 107,
 "atp/brand/McDonald's": 210,
 'atp/brand_wikidata/Q3114287': 107,
 'atp/brand_wikidata/Q38076': 210,
 'atp/category/amenity/cafe': 107,
 'atp/category/amenity/fast_food': 210,
 'atp/clean_strings/city': 83,
 'atp/clean_strings/state': 53,
 'atp/clean_strings/street_address': 181,
 'atp/country/PT': 317,
 'atp/field/city/missing': 3,
 'atp/field/email/missing': 317,
 'atp/field/image/dropped': 317,
 'atp/field/image/missing': 317,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 317,
 'atp/field/operator_wikidata/missing': 317,
 'atp/field/phone/missing': 317,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 15,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 317,
 'atp/item_scraped_host_count/www.mcdonalds.pt': 317,
 'atp/nsi/cc_match': 210,
 'atp/nsi/perfect_match': 107,
 'downloader/request_bytes': 78069,
 'downloader/request_count': 214,
 'downloader/request_method_count/GET': 214,
 'downloader/response_bytes': 10702060,
 'downloader/response_count': 214,
 'downloader/response_status_count/200': 214,
 'elapsed_time_seconds': 257.03319,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 14, 20, 13, 39, 807515, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 317,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'memusage/max': 339165184,
 'memusage/startup': 188276736,
 'request_depth_max': 1,
 'response_received_count': 214,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 213,
 'scheduler/dequeued/memory': 213,
 'scheduler/enqueued': 213,
 'scheduler/enqueued/memory': 213,
 'start_time': datetime.datetime(2025, 3, 14, 20, 9, 22, 774325, tzinfo=datetime.timezone.utc)}
```