### PR TITLE
[mcdonalds_at] Add McCafe locations and Opening Hours

### DIFF
--- a/locations/spiders/mcdonalds_at.py
+++ b/locations/spiders/mcdonalds_at.py
@@ -1,5 +1,7 @@
 import scrapy
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import CLOSED_DE, DAYS_DE, OpeningHours
 from locations.items import Feature
 from locations.spiders.mcdonalds import McdonaldsSpider
 
@@ -16,4 +18,31 @@ class McdonaldsATSpider(scrapy.spiders.SitemapSpider):
         item["website"] = item["ref"] = response.url
         item["lat"] = response.xpath('//*[@class="marker"]/@data-lat').get()
         item["lon"] = response.xpath('//*[@class="marker"]/@data-lng').get()
+
+        oh = OpeningHours()
+
+        selector = scrapy.Selector(text=response.xpath('//div[@id="restaurants"]').get())
+
+        for p in selector.xpath('.//p[string-length(text()) > 0]'):
+            if day := p.xpath('./span/text()').get():
+                day = day.title()
+                if day := DAYS_DE.get(day):
+                    open, close = (p.xpath('text()[1]').get()).split(' - ')
+                    oh.add_range(day, open, close, closed=CLOSED_DE) 
+        item["opening_hours"] = oh
+
+        services = response.xpath('//*[@class="wso-tax-img"]/img/@alt').getall()
+
+        apply_yes_no(Extras.DELIVERY, item, "McDelivery Icon" in services)
+        apply_yes_no(Extras.DRIVE_THROUGH, item, "McDrive Icon" in services)
+        apply_yes_no(Extras.WIFI, item, "Wlan Icon" in services)
+
+        if "McCafe Icon" in services:
+            mccafe = item.deepcopy()
+            mccafe["ref"] = "{}-mccafe".format(item["ref"])
+            mccafe["brand"] = "McCafé"
+            mccafe["brand_wikidata"] = "Q3114287"
+            apply_category(Categories.CAFE, mccafe)
+            yield mccafe
+ 
         yield item

--- a/locations/spiders/mcdonalds_at.py
+++ b/locations/spiders/mcdonalds_at.py
@@ -23,12 +23,12 @@ class McdonaldsATSpider(scrapy.spiders.SitemapSpider):
 
         selector = scrapy.Selector(text=response.xpath('//div[@id="restaurants"]').get())
 
-        for p in selector.xpath('.//p[string-length(text()) > 0]'):
-            if day := p.xpath('./span/text()').get():
+        for p in selector.xpath(".//p[string-length(text()) > 0]"):
+            if day := p.xpath("./span/text()").get():
                 day = day.title()
                 if day := DAYS_DE.get(day):
-                    open, close = (p.xpath('text()[1]').get()).split(' - ')
-                    oh.add_range(day, open, close, closed=CLOSED_DE) 
+                    open, close = (p.xpath("text()[1]").get()).split(" - ")
+                    oh.add_range(day, open, close, closed=CLOSED_DE)
         item["opening_hours"] = oh
 
         services = response.xpath('//*[@class="wso-tax-img"]/img/@alt').getall()
@@ -44,5 +44,5 @@ class McdonaldsATSpider(scrapy.spiders.SitemapSpider):
             mccafe["brand_wikidata"] = "Q3114287"
             apply_category(Categories.CAFE, mccafe)
             yield mccafe
- 
+
         yield item


### PR DESCRIPTION
```
{'atp/brand/McCafé': 198,
 "atp/brand/McDonald's": 205,
 'atp/brand_wikidata/Q3114287': 198,
 'atp/brand_wikidata/Q38076': 205,
 'atp/category/amenity/cafe': 198,
 'atp/category/amenity/fast_food': 205,
 'atp/country/AT': 403,
 'atp/field/branch/missing': 403,
 'atp/field/city/missing': 403,
 'atp/field/country/from_spider_name': 403,
 'atp/field/email/missing': 403,
 'atp/field/image/missing': 403,
 'atp/field/operator/missing': 403,
 'atp/field/operator_wikidata/missing': 403,
 'atp/field/phone/missing': 403,
 'atp/field/postcode/missing': 403,
 'atp/field/state/missing': 403,
 'atp/field/street_address/missing': 403,
 'atp/field/twitter/missing': 403,
 'atp/item_scraped_host_count/www.mcdonalds.at': 403,
 'atp/nsi/cc_match': 205,
 'atp/nsi/perfect_match': 198,
 'downloader/request_bytes': 118681,
 'downloader/request_count': 208,
 'downloader/request_method_count/GET': 208,
 'downloader/response_bytes': 37917157,
 'downloader/response_count': 208,
 'downloader/response_status_count/200': 208,
 'elapsed_time_seconds': 131.036148,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 17, 17, 19, 11, 533513, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 250417564,
 'httpcompression/response_count': 208,
 'item_scraped_count': 403,
 'log_count/DEBUG': 622,
 'log_count/ERROR': 1,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'memusage/max': 444329984,
 'memusage/startup': 187039744,
 'request_depth_max': 1,
 'response_received_count': 208,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 207,
 'scheduler/dequeued/memory': 207,
 'scheduler/enqueued': 207,
 'scheduler/enqueued/memory': 207,
 'spider_exceptions/ValueError': 1,
 'start_time': datetime.datetime(2025, 3, 17, 17, 17, 0, 497365, tzinfo=datetime.timezone.utc)}
```