### PR TITLE
Attempt to change from PAT to GitHub App installation token

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -6,7 +6,9 @@ env:
     CODEBUILD_CACHE_BUCKET: codebuild-cache.openaddresses.io
   secrets-manager:
     ZYTE_API_KEY: "alltheplaces:ZYTE_API_KEY"
-    GITHUB_TOKEN: "alltheplaces:GITHUB_TOKEN"
+    GITHUB_APP_ID: "alltheplaces:GITHUB_APP_ID"
+    GITHUB_APP_PRIVATE_KEY_BASE64: "alltheplaces:GITHUB_APP_PRIVATE_KEY_BASE64"
+    GITHUB_APP_INSTALLATION_ID: "alltheplaces:GITHUB_APP_INSTALLATION_ID"
 
 phases:
   install:

--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -41,7 +41,7 @@ get_installation_token() {
 
     jwt=$(generate_jwt "$app_id" "$private_key")
 
-    curl -v -X POST \
+    curl -s -X POST \
          -H "Authorization: Bearer ${jwt}" \
          -H "Accept: application/vnd.github.v3+json" \
          "https://api.github.com/app/installations/${installation_id}/access_tokens" \
@@ -300,12 +300,18 @@ fi
 
 if [ "${pull_request_number}" != "false" ]; then
     curl \
-        -v \
+        -s \
         -XPOST \
         -H "Authorization: token ${github_access_token}" \
         -H "Accept: application/vnd.github.v3+json" \
         -d "{\"body\":\"${PR_COMMENT_BODY}\"}" \
         "https://api.github.com/repos/alltheplaces/alltheplaces/issues/${pull_request_number}/comments"
+
+    if [ ! $? -eq 0 ]; then
+        (>&2 echo "comment post failed")
+        exit 1
+    fi
+
     echo "Added a comment to pull https://github.com/alltheplaces/alltheplaces/pull/${pull_request_number}"
 else
     echo "Not posting to GitHub because no pull event number set"

--- a/locations/spiders/dicks_sporting_goods.py
+++ b/locations/spiders/dicks_sporting_goods.py
@@ -12,6 +12,7 @@ class DicksSportingGoodsSpider(SitemapSpider):
     allowed_domains = ["dickssportinggoods.com"]
     sitemap_urls = ["https://stores.dickssportinggoods.com/robots.txt"]
     sitemap_rules = [(r"com/\w\w/[^/]+/(\d+)/", "parse_store")]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse_hours(self, response):
         days = response.xpath('//meta[@property="business:hours:day"]/@content').extract()


### PR DESCRIPTION
The Personal Access Token that I was using through @scraperbot to post comments on these PRs stopped working at some point this weekend. I tried to regenerate it but couldn't get the permissions right for whatever reason. It seems that the "right" way to do it is to use a GitHub App, so I created one of those and adjusted the script to use that flow to generate an access token instead.