### PR TITLE
[Česká Pošta] Clean brand and categories

### DIFF
--- a/docs/CATEGORIES.md
+++ b/docs/CATEGORIES.md
@@ -7,3 +7,11 @@ which takes a category from the `Categories` enum and the POI.
 
 The `Categories` enum can be extended with [OSM categories](https://wiki.openstreetmap.org/wiki/Map_features), this
 should be the "top level" tag, additional attributes can be added with `apply_yes_no` or directly to `extras`.
+
+### Output
+
+We follow [OSM categories](https://wiki.openstreetmap.org/wiki/Map_features), as best we can, however there are times
+when we don't know the correct category.
+For these we may use [`amenity=yes`](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dyes), you may be able to get some
+value from them by clustering them with other data eg collecting `post_office=post_partner` from `czech_post_cz`,
+however you probably don't want to put them in a product on their own.

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -12,6 +12,8 @@ from locations.items import Feature
 # of lots of string bashing. If ever NSI / ATP were to change / augment the category scheme
 # then the level of indirection provided here may also be of help!
 class Categories(Enum):
+    GENERIC_POI = {"amenity": "yes"}
+
     BICYCLE_PARKING = {"amenity": "bicycle_parking"}
     BICYCLE_RENTAL = {"amenity": "bicycle_rental"}
     CAR_RENTAL = {"amenity": "car_rental"}

--- a/locations/spiders/czech_post_cz.py
+++ b/locations/spiders/czech_post_cz.py
@@ -1,36 +1,62 @@
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from typing import Any
 
-from locations.categories import Categories, apply_category
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+
+CZECH_POST = {
+    "brand": "Česká Pošta",
+    "brand_wikidata": "Q341090",
+    "operator": "Česká pošta, s.p.",
+    "operator_wikidata": "Q341090",
+}
 
 
 class CzechPostCZSpider(Spider):
     name = "czech_post_cz"
-    item_attributes = {"brand": "Česká pošta", "brand_wikidata": "Q341090"}
     start_urls = ["https://www.postaonline.cz/en/vyhledat-pobocku"]
 
-    types = {
-        "Balíkovna": {"amenity": "post_office", "post_office": "post_partner", "parcel_pickup": "yes"},
-        "Depot": Categories.POST_DEPOT,
-        "Post office": Categories.POST_OFFICE,
-        "Postal agency": {"amenity": "post_office", "post_office": "post_partner"},  # 6 "vydejniMisto"
-        "Service point": {"amenity": "post_office", "post_office": "post_partner"},  # 43 "vydejniMisto"
-        "Technical outlet": {"amenity": "post_office", "post_office": "post_partner"},  # 252 "technickaProvozovna"
-        "post.type.external.partner-box": Categories.PARCEL_LOCKER,  # "balikovna_box"
-    }
-
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         yield JsonRequest(
             url="https://www.postaonline.cz/en/vyhledat-pobocku?p_p_id=findpostoffice_WAR_findpostportlet&p_p_lifecycle=2&p_p_resource_id=preparePostForMap",
             callback=self.parse_locations,
         )
 
-    def parse_locations(self, response, **kwargs):
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
             item = DictParser.parse(location)
 
-            if cat := self.types.get(location["type"]):
-                apply_category(cat, item)
+            item["website"] = item["extras"]["website:cs"] = (
+                "https://www.postaonline.cz/detail-pobocky/-/pobocky/detail/{}".format(item["postcode"])
+            )
+            item["extras"]["website:en"] = "https://www.postaonline.cz/en/detail-pobocky/-/pobocky/detail/{}".format(
+                item["postcode"]
+            )
+
+            if location["type"] == "Balíkovna":
+                apply_category(Categories.GENERIC_POI, item)
+                apply_yes_no("post_office=post_partner", item, True)
+                apply_yes_no(Extras.PARCEL_PICKUP, item, True)
+            elif location["type"] == "Depot":
+                item.update(CZECH_POST)
+                apply_category(Categories.POST_DEPOT, item)
+            elif location["type"] == "Post office":
+                item.update(CZECH_POST)
+                apply_category(Categories.POST_OFFICE, item)
+            elif location["type"] == "Postal agency":  # 6 "vydejniMisto"
+                apply_category(Categories.GENERIC_POI, item)
+                apply_yes_no("post_office=post_partner", item, True)
+            elif location["type"] == "Service point":  # 43 "vydejniMisto"
+                apply_category(Categories.GENERIC_POI, item)
+                apply_yes_no("post_office=post_partner", item, True)
+            elif location["type"] == "Technical outlet":  # 252 "technickaProvozovna"
+                apply_category(Categories.GENERIC_POI, item)
+                apply_yes_no("post_office=post_partner", item, True)
+            elif location["type"] == "post.type.external.partner-box":  # "balikovna_box"
+                apply_category(Categories.PARCEL_LOCKER, item)
+            else:
+                self.logger.error("Unexpected type: {}".format(location["type"]))
 
             yield item


### PR DESCRIPTION
The only interesting thing here I'm using `amenity=yes` as a "This is a POI, but we don't know the category". I think a fair US example of this is a 7-Eleven that also offers a UPS drop off, it isn't a stand alone POI, it's an attribute of 7-Eleven. That 7-Eleven probably also does FedEx and Western Union money transfers, it is 1 POI, not 4.

In this spider, the majority of the POIs are not `amenity=post_office` as the current output suggests, but a different shop (could be `shop=supermarket`, `shop=convenience`, `shop=newsagent` etc) but we don't know.

We had previously softly agreed with Matkoniecz that these types of POIs shouldn't get a category, but it didn't work. Here with errors/stats complaining ended up with bad categories being added and he ended up just excluding the spiders anyway.