### PR TITLE
[Mitsubishi JP] Add spider (393 locations)

### DIFF
--- a/locations/spiders/mitsubishi_jp.py
+++ b/locations/spiders/mitsubishi_jp.py
@@ -1,0 +1,35 @@
+import json
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class MitsubishiJPSpider(CrawlSpider):
+    name = "mitsubishi_jp"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://map.mitsubishi-motors.co.jp/search/listHansha.do"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"search\.do\?hanshaCD=\d+&todofukenCD=\d+$"),
+        ),
+        Rule(LinkExtractor(allow=r"showKyoten\.do\?hanshaCD=\d+&kyotenCD=\d+&tenpoCD=\d+$"), callback="parse"),
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location_info = json.loads(response.xpath('//*[@id="kyotenInfoId"]/text()').get(""))[0]
+        item = Feature()
+        item["ref"] = response.url.split("tenpoCD=")[1]
+        item["website"] = response.url
+        item["name"] = location_info["kyotenName"]
+        item["lat"] = location_info["kyotenIdo"]
+        item["lon"] = location_info["kyotenKeido"]
+        # location_info["kyoten_addr"] doesn't contain postcode
+        item["addr_full"] = clean_address(
+            response.xpath('//*[contains(text(),"住所")]/following-sibling::td/span/text()').getall()
+        )
+        yield item

--- a/locations/spiders/mitsubishi_jp.py
+++ b/locations/spiders/mitsubishi_jp.py
@@ -5,6 +5,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
@@ -34,4 +35,13 @@ class MitsubishiJPSpider(CrawlSpider):
         )
         item["phone"] = response.xpath('//*[contains(@class, "mod-link-tel")]//a/@href').get()
         item["extras"]["fax"] = response.xpath('//*[contains(@class, "mod-link-fax")]/text()').get()
+
+        services = response.xpath('//*[@class="dealer__icon__txt"]/text()').getall()
+        if "新車" or "中古車" in services:
+            apply_category(Categories.SHOP_CAR, item)
+            apply_yes_no(Extras.CAR_REPAIR, item, "メンテナンス" in services)
+        elif "メンテナンス" in services:
+            apply_category(Categories.SHOP_CAR_REPAIR, item)
+        apply_yes_no(Extras.USED_CAR_SALES, item, "中古車" in services)
+        apply_yes_no(Extras.WIFI, item, "WiFi" in services)
         yield item

--- a/locations/spiders/mitsubishi_jp.py
+++ b/locations/spiders/mitsubishi_jp.py
@@ -32,4 +32,6 @@ class MitsubishiJPSpider(CrawlSpider):
         item["addr_full"] = clean_address(
             response.xpath('//*[contains(text(),"住所")]/following-sibling::td/span/text()').getall()
         )
+        item["phone"] = response.xpath('//*[contains(@class, "mod-link-tel")]//a/@href').get()
+        item["extras"]["fax"] = response.xpath('//*[contains(@class, "mod-link-fax")]/text()').get()
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 393,
 'atp/brand_wikidata/Q36033': 393,
 'atp/category/shop/car': 393,
 'atp/clean_strings/name': 1,
 'atp/country/JP': 393,
 'atp/field/branch/missing': 393,
 'atp/field/city/missing': 393,
 'atp/field/country/from_spider_name': 393,
 'atp/field/email/missing': 393,
 'atp/field/image/missing': 393,
 'atp/field/opening_hours/missing': 393,
 'atp/field/operator/missing': 393,
 'atp/field/operator_wikidata/missing': 393,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 393,
 'atp/field/state/missing': 393,
 'atp/field/street_address/missing': 393,
 'atp/field/twitter/missing': 393,
 'atp/item_scraped_host_count/map.mitsubishi-motors.co.jp': 393,
 'atp/nsi/cc_match': 393,
 'downloader/request_bytes': 252567,
 'downloader/request_count': 503,
 'downloader/request_method_count/GET': 503,
 'downloader/response_bytes': 5470895,
 'downloader/response_count': 503,
 'downloader/response_status_count/200': 502,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 27.067697,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 18, 14, 38, 22, 449734, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 503,
 'httpcompression/response_bytes': 46547359,
 'httpcompression/response_count': 502,
 'item_scraped_count': 393,
 'items_per_minute': None,
 'log_count/DEBUG': 953,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 502,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 501,
 'scheduler/dequeued/memory': 501,
 'scheduler/enqueued': 501,
 'scheduler/enqueued/memory': 501,
 'start_time': datetime.datetime(2025, 3, 18, 14, 37, 55, 382037, tzinfo=datetime.timezone.utc)}
```