### PR TITLE
[Mitsubishi PR] Add Spider (20 locations)

### DIFF
--- a/locations/spiders/mitsubishi_pr.py
+++ b/locations/spiders/mitsubishi_pr.py
@@ -1,5 +1,3 @@
-import json
-import re
 from typing import Any
 
 import chompjs
@@ -8,7 +6,6 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
 

--- a/locations/spiders/mitsubishi_pr.py
+++ b/locations/spiders/mitsubishi_pr.py
@@ -1,0 +1,37 @@
+import json
+import re
+from typing import Any
+
+import chompjs
+import scrapy
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class MitsubishiPRSpider(scrapy.Spider):
+    name = "mitsubishi_pr"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://www.mitsubishimotors.pr/concesionarios"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = list(
+            chompjs.parse_js_objects(response.xpath('//*[contains(text(),"__PRELOADED_STATE__")]/text()').get())
+        )
+        for key in raw_data[1]["ROOT_QUERY"][
+            'searchDealer({"criteria":{"filters":null,"language":"es","latitude":18.222271,"longitude":-66.430417,"market":"pr","radius":2000,"service":"all"},"path":"/pr/es/concesionarios"})'
+        ]:
+            address_data = raw_data[1][f'${key["id"]}.address']
+            item = DictParser.parse(address_data)
+            item["ref"] = key["id"]
+            item["postcode"] = address_data["postalArea"]
+            item["addr_full"] = merge_address_lines(
+                [address_data["addressLine1"], address_data["addressLine2"], address_data["addressLine3"]]
+            )
+            item["phone"] = raw_data[1][f'${key["id"]}.phone']["phoneNumber"]
+            item["branch"] = raw_data[1][key["id"]]["name"]
+            apply_category(Categories.SHOP_CAR, item)
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 20,
 'atp/brand_wikidata/Q36033': 20,
 'atp/category/shop/car': 20,
 'atp/country/PR': 20,
 'atp/field/city/missing': 20,
 'atp/field/country/from_spider_name': 20,
 'atp/field/email/missing': 20,
 'atp/field/image/missing': 20,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 20,
 'atp/field/operator_wikidata/missing': 20,
 'atp/field/state/missing': 20,
 'atp/field/twitter/missing': 20,
 'atp/field/website/missing': 20,
 'atp/item_scraped_host_count/www.mitsubishimotors.pr': 20,
 'atp/nsi/cc_match': 20,
 'downloader/request_bytes': 318,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 32980,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.843557,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 19, 9, 43, 40, 288828, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 283350,
 'httpcompression/response_count': 1,
 'item_scraped_count': 20,
 'items_per_minute': None,
 'log_count/DEBUG': 32,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 19, 9, 43, 38, 445271, tzinfo=datetime.timezone.utc)}
```