### PR TITLE
[Mitsubishi BY RU] Add spider (89 locations)

### DIFF
--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -1,8 +1,11 @@
+from typing import Iterable
+
 import chompjs
 from scrapy import Selector
 from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.structured_data_spider import extract_phone
 
@@ -18,7 +21,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
             -1
         ]
 
-    def post_process_item(self, item, response, feature):
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         extract_phone(item, Selector(text=feature["phone"]))
         item["website"] = (
             "https://www." + feature["www"].replace("www.", "")

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -19,5 +19,11 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, feature):
         extract_phone(item, Selector(text=feature["phone"]))
-        item["website"] = "https://www." + feature["www"].replace("www.", "") if not feature["www"].startswith("http") else feature["www"]
+        item["website"] = (
+            "https://www." + feature["www"].replace("www.", "")
+            if not feature["www"].startswith("http")
+            else feature["www"]
+        )
+        if "mitsubishi" not in item["website"]:  # Not a branded location
+            return
         yield item

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -23,11 +23,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         extract_phone(item, Selector(text=feature["phone"]))
-        item["website"] = (
-            "https://www." + feature["www"].replace("www.", "")
-            if not feature["www"].startswith("http")
-            else feature["www"]
-        )
+        item["website"] = "https://" + feature["www"] if not feature["www"].startswith("http") else feature["www"]
         if "mitsubishi" not in item["website"]:  # Not a branded location
             return
 

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -19,4 +19,5 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, feature):
         extract_phone(item, Selector(text=feature["phone"]))
+        item["website"] = "https://www." + feature["www"].replace("www.", "") if not feature["www"].startswith("http") else feature["www"]
         yield item

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -1,0 +1,22 @@
+import chompjs
+from scrapy import Selector
+from scrapy.http import Response
+
+from locations.json_blob_spider import JSONBlobSpider
+from locations.structured_data_spider import extract_phone
+
+
+class MitsubishiBYRUSpider(JSONBlobSpider):
+    name = "mitsubishi_by_ru"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://www.mitsubishi-motors.ru/for-byers/dealers/"]
+    no_refs = True
+
+    def extract_json(self, response: Response) -> list[dict]:
+        return list(chompjs.parse_js_objects(response.xpath('//script[contains(text(), "placemarks")]/text()').get()))[
+            -1
+        ]
+
+    def post_process_item(self, item, response, feature):
+        extract_phone(item, Selector(text=feature["phone"]))
+        yield item

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -2,6 +2,7 @@ import chompjs
 from scrapy import Selector
 from scrapy.http import Response
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.json_blob_spider import JSONBlobSpider
 from locations.structured_data_spider import extract_phone
 
@@ -26,4 +27,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
         )
         if "mitsubishi" not in item["website"]:  # Not a branded location
             return
+
+        apply_category(Categories.SHOP_CAR, item)
+        apply_yes_no(Extras.CAR_REPAIR, item, feature.get("service_partner") == "1")
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 89,
 'atp/brand_wikidata/Q36033': 89,
 'atp/category/shop/car': 89,
 'atp/clean_strings/addr_full': 1,
 'atp/country/BY': 4,
 'atp/country/RU': 85,
 'atp/field/branch/missing': 89,
 'atp/field/city/missing': 89,
 'atp/field/country/from_website_url': 89,
 'atp/field/email/missing': 89,
 'atp/field/image/missing': 89,
 'atp/field/opening_hours/missing': 89,
 'atp/field/operator/missing': 89,
 'atp/field/operator_wikidata/missing': 89,
 'atp/field/postcode/missing': 89,
 'atp/field/state/missing': 89,
 'atp/field/street_address/missing': 89,
 'atp/field/twitter/missing': 89,
 'atp/item_scraped_host_count/www.mitsubishi-motors.ru': 89,
 'atp/nsi/cc_match': 89,
 'downloader/request_bytes': 685,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23793,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.549296,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 19, 11, 26, 22, 866483, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 141074,
 'httpcompression/response_count': 2,
 'item_scraped_count': 89,
 'items_per_minute': None,
 'log_count/DEBUG': 102,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 19, 11, 26, 20, 317187, tzinfo=datetime.timezone.utc)}
```