### PR TITLE
[Mitsubishi DK] Add spider (30 locations)

### DIFF
--- a/locations/spiders/mitsubishi_dk.py
+++ b/locations/spiders/mitsubishi_dk.py
@@ -1,0 +1,16 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class MitsubishiDKSpider(JSONBlobSpider):
+    name = "mitsubishi_dk"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://mitsubishi-motors.dk/wp-admin/admin-ajax.php?action=asl_load_stores"]
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("street", None)
+        yield item

--- a/locations/spiders/mitsubishi_dk.py
+++ b/locations/spiders/mitsubishi_dk.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -13,4 +14,11 @@ class MitsubishiDKSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("street", None)
+
+        categories = feature.get("categories") or ""
+        if "1" in categories:
+            apply_category(Categories.SHOP_CAR, item)
+            apply_yes_no(Extras.CAR_REPAIR, item, "2" in categories)
+        elif "2" in categories:
+            apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 30,
 'atp/brand_wikidata/Q36033': 30,
 'atp/category/shop/car': 24,
 'atp/category/shop/car_repair': 6,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/street_address': 1,
 'atp/country/DK': 28,
 'atp/country/FO': 1,
 'atp/country/GL': 1,
 'atp/field/branch/missing': 30,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 30,
 'atp/field/opening_hours/missing': 30,
 'atp/field/operator/missing': 30,
 'atp/field/operator_wikidata/missing': 30,
 'atp/field/state/missing': 30,
 'atp/field/twitter/missing': 30,
 'atp/item_scraped_host_count/mitsubishi-motors.dk': 30,
 'atp/nsi/cc_match': 30,
 'downloader/request_bytes': 658,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5048,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.16855,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 20, 11, 25, 40, 649444, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 30078,
 'httpcompression/response_count': 2,
 'item_scraped_count': 30,
 'items_per_minute': None,
 'log_count/DEBUG': 43,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 20, 11, 25, 37, 480894, tzinfo=datetime.timezone.utc)}
```