### PR TITLE
[Mitsubishi BE LU] Update  Mitsubishi BE Spider to distinguish LU locations

### DIFF
--- a/locations/spiders/mitsubishi_be_lu.py
+++ b/locations/spiders/mitsubishi_be_lu.py
@@ -10,11 +10,12 @@ from locations.pipelines.address_clean_up import clean_address
 from locations.spiders.mitsubishi import MitsubishiSpider
 
 
-class MitsubishiBESpider(JSONBlobSpider):
-    name = "mitsubishi_be"
+class MitsubishiBELUSpider(JSONBlobSpider):
+    name = "mitsubishi_be_lu"
     item_attributes = MitsubishiSpider.item_attributes
     start_urls = ["https://mitsubishi-motors.be/dealers.json"]
     locations_key = "dealers"
+    skip_auto_cc_spider_name = True
 
     def pre_process_data(self, feature: dict):
         for key in list(feature.keys()):


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 60,
 'atp/brand_wikidata/Q36033': 60,
 'atp/category/shop/car_repair': 60,
 'atp/country/BE': 56,
 'atp/country/LU': 4,
 'atp/field/branch/missing': 60,
 'atp/field/city/missing': 60,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/country/from_website_url': 59,
 'atp/field/image/missing': 60,
 'atp/field/operator/missing': 60,
 'atp/field/operator_wikidata/missing': 60,
 'atp/field/state/missing': 59,
 'atp/field/street_address/missing': 60,
 'atp/field/twitter/missing': 60,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/mitsubishi-motors.be': 60,
 'atp/nsi/cc_match': 60,
 'downloader/request_bytes': 624,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14121,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.457401,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 20, 12, 7, 11, 428498, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 76836,
 'httpcompression/response_count': 2,
 'item_scraped_count': 60,
 'items_per_minute': None,
 'log_count/DEBUG': 132,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 20, 12, 7, 8, 971097, tzinfo=datetime.timezone.utc)}
```