### PR TITLE
[gbfs] Changed default category to Bicycle_rental

### DIFF
--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -434,10 +434,7 @@ class GbfsSpider(CSVFeedSpider):
                     break
             else:
                 item["brand"] = kwargs["Name"]  # Closer to OSM operator or network?
-                if "bike" in kwargs["Name"].lower() or "cycle" in kwargs["Name"].lower():
-                    apply_category(Categories.BICYCLE_RENTAL, item)
-                else:
-                    apply_category({"public_transport": "stop_position"}, item)
+                apply_category(Categories.BICYCLE_RENTAL, item)
 
             if station.get("is_virtual_station"):
                 item["extras"]["physically_present"] = "no"


### PR DESCRIPTION
I made a [PR](https://github.com/alltheplaces/alltheplaces/pull/10184) adding brands from the name of the dataset back in September. As you can see the majority (for brands I added which were not all) are bicycle rentals. The dataset titles must have changed as the stop_positions have increased since then. Now as this is a bike share feed I think we can change the default to bicycle rental. 