### PR TITLE
[Mitsubishi DK SE] Update Mitsubishi DK Spider to add SE locations

### DIFF
--- a/locations/spiders/mitsubishi_dk_se.py
+++ b/locations/spiders/mitsubishi_dk_se.py
@@ -17,6 +17,8 @@ class MitsubishiDKSESpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("street", None)
+        if website := feature.get("website"):
+            item["website"] = "https://" + website if website.startswith("www.") else website
 
         categories = (feature.get("categories") or "").split(",")
         if "1" in categories or "19" in categories:

--- a/locations/spiders/mitsubishi_dk_se.py
+++ b/locations/spiders/mitsubishi_dk_se.py
@@ -18,10 +18,10 @@ class MitsubishiDKSESpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("street", None)
 
-        categories = feature.get("categories") or ""
-        if "1" in categories:
+        categories = (feature.get("categories") or "").split(",")
+        if "1" in categories or "19" in categories:
             apply_category(Categories.SHOP_CAR, item)
-            apply_yes_no(Extras.CAR_REPAIR, item, "2" in categories)
-        elif "2" in categories:
+            apply_yes_no(Extras.CAR_REPAIR, item, "2" in categories or "18" in categories)
+        elif "2" in categories or "18" in categories:
             apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item

--- a/locations/spiders/mitsubishi_dk_se.py
+++ b/locations/spiders/mitsubishi_dk_se.py
@@ -7,10 +7,13 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class MitsubishiDKSpider(JSONBlobSpider):
-    name = "mitsubishi_dk"
+class MitsubishiDKSESpider(JSONBlobSpider):
+    name = "mitsubishi_dk_se"
     item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
-    start_urls = ["https://mitsubishi-motors.dk/wp-admin/admin-ajax.php?action=asl_load_stores"]
+    start_urls = [
+        f"https://mitsubishi-motors.{country_code}/wp-admin/admin-ajax.php?action=asl_load_stores"
+        for country_code in ["dk", "se"]
+    ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("street", None)


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 92,
 'atp/brand_wikidata/Q36033': 92,
 'atp/category/shop/car': 52,
 'atp/category/shop/car_repair': 40,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 1,
 'atp/country/DK': 28,
 'atp/country/FO': 1,
 'atp/country/GL': 1,
 'atp/country/SE': 62,
 'atp/field/branch/missing': 92,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 92,
 'atp/field/opening_hours/missing': 92,
 'atp/field/operator/missing': 92,
 'atp/field/operator_wikidata/missing': 92,
 'atp/field/state/missing': 92,
 'atp/field/twitter/missing': 92,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/mitsubishi-motors.dk': 30,
 'atp/item_scraped_host_count/mitsubishi-motors.se': 62,
 'atp/nsi/cc_match': 92,
 'downloader/request_bytes': 1631,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 12227,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 4,
 'downloader/response_status_count/307': 1,
 'elapsed_time_seconds': 5.840579,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 21, 12, 22, 17, 587954, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 76237,
 'httpcompression/response_count': 4,
 'item_scraped_count': 92,
 'items_per_minute': None,
 'log_count/DEBUG': 108,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 3, 21, 12, 22, 11, 747375, tzinfo=datetime.timezone.utc)}
```