### PR TITLE
[Mitsubishi CH] Add spider (105 locations)

### DIFF
--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -1,7 +1,8 @@
 import re
-from typing import Iterable
+from typing import Any
 
 import chompjs
+from scrapy import Request
 from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
@@ -28,14 +29,26 @@ class MitsubishiCHSpider(JSONBlobSpider):
         feature.update(feature.pop("marker", {}) | feature.pop("locationData", {}))
         feature["id"] = feature.get("externalId")
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Any:
         item["street_address"] = item.pop("addr_full", None)
         item["name"] = feature.get("organisation")
         item["website"] = response.urljoin(feature.get("www"))
 
-        if feature.get("hasSales"):
+        # hasSales, hasService fields are always false.Hence, we need to determine category from the POI pages.
+
+        yield Request(url=item["website"], callback=self.parse_location, cb_kwargs=dict(item=item))
+
+    def parse_location(self, response: Response, item: Feature) -> Any:
+        location_type = (
+            response.xpath('//*[@class="haendler-heading-details"]//*[@class="haendler-icon-text"]').get("").lower()
+        )
+
+        if "verkauf und service" in location_type:
             apply_category(Categories.SHOP_CAR, item)
-            apply_yes_no(Extras.CAR_REPAIR, item, feature.get("hasService"))
-        elif feature.get("hasService"):
+            apply_yes_no(Extras.CAR_REPAIR, item, True)
+        elif "verkauf" in location_type:
+            apply_category(Categories.SHOP_CAR, item)
+        elif "service" in location_type:
             apply_category(Categories.SHOP_CAR_REPAIR, item)
+
         yield item

--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -1,0 +1,34 @@
+import re
+from typing import Iterable
+
+import chompjs
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class MitsubishiCHSpider(JSONBlobSpider):
+    name = "mitsubishi_ch"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://www.mitsubishi-motors.ch/haendler/"]
+
+    def extract_json(self, response: Response) -> list[dict]:
+        return [
+            chompjs.parse_js_object(location)
+            for location in re.findall(
+                r"locations\[\d+\]\s*=\s*(.+?}\));",
+                response.xpath('//script[contains(text(), "locationData")]/text()').get(""),
+                re.DOTALL,
+            )
+        ]
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("marker", {}) | feature.pop("locationData", {}))
+        feature["id"] = feature.get("externalId")
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full", None)
+        item["name"] = feature.get("organisation")
+        item["website"] = response.urljoin(feature.get("www"))
+        yield item

--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -4,6 +4,7 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -31,4 +32,10 @@ class MitsubishiCHSpider(JSONBlobSpider):
         item["street_address"] = item.pop("addr_full", None)
         item["name"] = feature.get("organisation")
         item["website"] = response.urljoin(feature.get("www"))
+
+        if feature.get("hasSales"):
+            apply_category(Categories.SHOP_CAR, item)
+            apply_yes_no(Extras.CAR_REPAIR, item, feature.get("hasService"))
+        elif feature.get("hasService"):
+            apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 105,
 'atp/brand_wikidata/Q36033': 105,
 'atp/category/shop/car': 44,
 'atp/category/shop/car_repair': 61,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 3,
 'atp/country/CH': 105,
 'atp/field/branch/missing': 105,
 'atp/field/country/from_spider_name': 105,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 105,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 105,
 'atp/field/operator/missing': 105,
 'atp/field/operator_wikidata/missing': 105,
 'atp/field/phone/missing': 4,
 'atp/field/state/missing': 105,
 'atp/field/twitter/missing': 105,
 'atp/item_scraped_host_count/www.mitsubishi-motors.ch': 105,
 'atp/nsi/cc_match': 105,
 'downloader/request_bytes': 40635,
 'downloader/request_count': 107,
 'downloader/request_method_count/GET': 107,
 'downloader/response_bytes': 860496,
 'downloader/response_count': 107,
 'downloader/response_status_count/200': 107,
 'elapsed_time_seconds': 1.560937,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 21, 15, 0, 37, 910859, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 107,
 'httpcompression/response_bytes': 3778049,
 'httpcompression/response_count': 107,
 'item_scraped_count': 105,
 'items_per_minute': None,
 'log_count/DEBUG': 224,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 107,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 106,
 'scheduler/dequeued/memory': 106,
 'scheduler/enqueued': 106,
 'scheduler/enqueued/memory': 106,
 'start_time': datetime.datetime(2025, 3, 21, 15, 0, 36, 349922, tzinfo=datetime.timezone.utc)}
```