### PR TITLE
[Mitsubishi BR] Add Spider (138 locations)

### DIFF
--- a/locations/spiders/mitsubishi_br.py
+++ b/locations/spiders/mitsubishi_br.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class MitsubishiBRSpider(scrapy.Spider):
+    name = "mitsubishi_br"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://api.mitsubishimotors.com.br/search/api/dealer/v1.0/nearest?page=0&size=1000"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for dealer in response.json().get("results", []):
+            item = DictParser.parse(dealer)
+            item["branch"] = item.pop("name", None)
+            website = dealer.get("website")
+            if website and not website.startswith("https"):
+                item["website"] = "https://" + website
+            if dealer.get("newCars"):
+                apply_category(Categories.SHOP_CAR, item)
+            elif not dealer.get("newCars") and dealer.get("kitCarParts"):
+                apply_category(Categories.SHOP_CAR_PARTS, item)
+            yield item

--- a/locations/spiders/mitsubishi_br.py
+++ b/locations/spiders/mitsubishi_br.py
@@ -15,10 +15,10 @@ class MitsubishiBRSpider(scrapy.Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for dealer in response.json().get("results", []):
             item = DictParser.parse(dealer)
-            item["branch"] = item.pop("name", None)
+            item["branch"] = item.pop("name")
             website = dealer.get("website")
             if website and not website.startswith("https"):
-                item["website"] = "https://" + website
+                item["website"] = "https://" + website.strip()
             if dealer.get("newCars"):
                 apply_category(Categories.SHOP_CAR, item)
             elif not dealer.get("newCars") and dealer.get("kitCarParts"):


### PR DESCRIPTION
```python
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 4,
 'atp/clean_strings/city': 17,
 'atp/clean_strings/state': 5,
 'atp/country/BR': 138,
 'atp/field/country/from_spider_name': 138,
 'atp/field/email/missing': 138,
 'atp/field/image/missing': 138,
 'atp/field/name/missing': 5,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 138,
 'atp/field/operator_wikidata/missing': 138,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 6,
 'atp/field/street_address/missing': 138,
 'atp/field/twitter/missing': 138,
 'atp/field/website/missing': 84,
 'atp/item_scraped_host_count/api.mitsubishimotors.com.br': 138,
 'atp/nsi/cc_match': 133,
 'atp/nsi/match_failed': 5,
 'downloader/request_bytes': 355,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 87878,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.499869,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 24, 5, 34, 19, 734985, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 138,
 'items_per_minute': None,
 'log_count/DEBUG': 150,
 'log_count/INFO': 10,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 24, 5, 34, 16, 235116, tzinfo=datetime.timezone.utc)}
```