### PR TITLE
[mcondalds] add mccafe pois (2694 locations)

### DIFF
--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -1,6 +1,6 @@
 import scrapy
 
-from locations.categories import Categories, Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
 from locations.hours import DAYS_FULL, OpeningHours
@@ -112,6 +112,15 @@ class McdonaldsSpider(scrapy.Spider):
 
             if hours := self.store_hours(properties.get("restauranthours")):
                 item["opening_hours"] = hours
+
+
+            if "MCCAFE" in filter_type:
+                mccafe = item.deepcopy()
+                mccafe["ref"] = "{}-mccafe".format(item["ref"])
+                mccafe["brand"] = "McCafé"
+                mccafe["brand_wikidata"] = "Q3114287"
+                apply_category(Categories.CAFE, mccafe)
+                yield mccafe
 
             yield item
 

--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -113,7 +113,6 @@ class McdonaldsSpider(scrapy.Spider):
             if hours := self.store_hours(properties.get("restauranthours")):
                 item["opening_hours"] = hours
 
-
             if "MCCAFE" in filter_type:
                 mccafe = item.deepcopy()
                 mccafe["ref"] = "{}-mccafe".format(item["ref"])


### PR DESCRIPTION
for available countries added mccafe brand pois

```{'atp/brand/McCafé': 2694,
 "atp/brand/McDonald's": 15792,
 'atp/brand_wikidata/Q3114287': 2694,
 'atp/brand_wikidata/Q38076': 15792,
 'atp/category/amenity/cafe': 2694,
 'atp/category/amenity/fast_food': 15792,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/email': 17,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/phone': 977,
 'atp/clean_strings/postcode': 9,
 'atp/country/AE': 91,
 'atp/country/BH': 18,
 'atp/country/CA': 2187,
 'atp/country/CH': 277,
 'atp/country/DE': 2123,
 'atp/country/DK': 120,
 'atp/country/FI': 86,
 'atp/country/GB': 1472,
 'atp/country/HU': 180,
 'atp/country/IE': 91,
 'atp/country/KW': 53,
 'atp/country/NL': 474,
 'atp/country/NO': 22,
 'atp/country/OM': 25,
 'atp/country/QA': 106,
 'atp/country/SA': 103,
 'atp/country/SE': 89,
 'atp/country/TW': 737,
 'atp/country/UA': 112,
 'atp/country/US': 10120,
 'atp/field/branch/missing': 18486,
 'atp/field/city/missing': 721,
 'atp/field/email/invalid': 135,
 'atp/field/email/missing': 17306,
 'atp/field/image/missing': 18486,
 'atp/field/opening_hours/missing': 57,
 'atp/field/operator/missing': 18486,
 'atp/field/operator_wikidata/missing': 18486,
 'atp/field/phone/invalid': 81,
 'atp/field/phone/missing': 138,
 'atp/field/postcode/missing': 650,
 'atp/field/state/from_reverse_geocoding': 2187,
 'atp/field/state/missing': 4030,
 'atp/field/twitter/missing': 18486,
 'atp/item_scraped_host_count/www.mcdonalds.com': 263225,
 'atp/nsi/cc_match': 15792,
 'atp/nsi/perfect_match': 2694,
 'downloader/request_bytes': 7956968,
 'downloader/request_count': 5137,
 'downloader/request_method_count/GET': 5137,
 'downloader/response_bytes': 55629303,
 'downloader/response_count': 5137,
 'downloader/response_status_count/200': 5137,
 'elapsed_time_seconds': 6264.071874,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 21, 19, 33, 50, 248072, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 535742266,
 'httpcompression/response_count': 5137,
 'item_dropped_count': 244739,
 'item_dropped_reasons_count/DropItem': 244739,
 'item_scraped_count': 18486,
 'log_count/ERROR': 70,
 'log_count/INFO': 113,
 'log_count/WARNING': 136,
 'memusage/max': 496660480,
 'memusage/startup': 188760064,
 'response_received_count': 5137,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5136,
 'scheduler/dequeued/memory': 5136,
 'scheduler/enqueued': 5136,
 'scheduler/enqueued/memory': 5136,
 'spider_exceptions/KeyError': 70,
 'start_time': datetime.datetime(2025, 3, 21, 17, 49, 26, 176198, tzinfo=datetime.timezone.utc)}
```