### PR TITLE
[Mitsubishi Africa] Add Spider (33 locations)

### DIFF
--- a/locations/spiders/mitsubishi_africa.py
+++ b/locations/spiders/mitsubishi_africa.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+import chompjs
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class MitsubishiAfricaSpider(CrawlSpider):
+    name = "mitsubishi_africa"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = [
+        "https://www.mitsubishi-motors.ci/fr/concessions/",
+        "https://mitsubishimotors.cfaomotors-gabon.com/fr/concessions/",
+        "https://www.mitsubishi-motors.com.gh/en/concessions",
+        "https://www.mitsubishi-motors.mg/fr/concessions/",
+        "https://www.mitsubishi-motors-liberia.com/en/concessions",
+        "https://www.mitsubishi-motors.bj/fr/concession/mitsubishi-benin-cfao-motors",
+        "https://www.mitsubishimotors-centrafrique.com/fr/concession/mitsubishi-centrafrique-cfao-motors",
+        "https://mitsubishimotors.cfaomotors-mauritanie.com/fr/concessions/",
+        "https://www.mitsubishi-motors.com.ng/en/concessions/",
+        "https://www.mitsubishi-motors.tg/fr/concession/mitsubishi-togo-cfao-motors",
+    ]
+    rules = [Rule(LinkExtractor(restrict_xpaths='//*[@class="concessions"]'), callback="parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["branch"] = response.xpath('//*[@id = "dealership"]//*[@class="content-heading"]//text()').get()
+        item["street_address"] = response.xpath('//*[@class="location-info"]/div[1]/text()').get()
+        item["addr_full"] = merge_address_lines(
+            [item["street_address"], response.xpath('//*[@class="location-info"]/div[2]/text()').get()]
+        )
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        item["ref"] = item["website"] = response.url
+        lat_lon = chompjs.parse_js_object(response.xpath('//*[contains(text(),"map_markers")]/text()').get())
+        item["lat"] = lat_lon[0][1]
+        item["lon"] = lat_lon[0][2]
+        apply_category(Categories.SHOP_CAR, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 33,
 'atp/brand_wikidata/Q36033': 33,
 'atp/category/shop/car': 33,
 'atp/country/BJ': 2,
 'atp/country/CF': 1,
 'atp/country/CI': 5,
 'atp/country/GA': 2,
 'atp/country/GH': 4,
 'atp/country/LR': 1,
 'atp/country/MG': 4,
 'atp/country/MR': 3,
 'atp/country/NG': 10,
 'atp/country/TG': 1,
 'atp/field/city/missing': 33,
 'atp/field/country/from_reverse_geocoding': 7,
 'atp/field/country/from_website_url': 26,
 'atp/field/email/missing': 33,
 'atp/field/image/missing': 33,
 'atp/field/opening_hours/missing': 33,
 'atp/field/operator/missing': 33,
 'atp/field/operator_wikidata/missing': 33,
 'atp/field/phone/invalid': 5,
 'atp/field/postcode/missing': 33,
 'atp/field/state/missing': 26,
 'atp/field/twitter/missing': 33,
 'atp/item_scraped_host_count/mitsubishimotors.cfaomotors-gabon.com': 2,
 'atp/item_scraped_host_count/mitsubishimotors.cfaomotors-mauritanie.com': 3,
 'atp/item_scraped_host_count/www.mitsubishi-motors-liberia.com': 1,
 'atp/item_scraped_host_count/www.mitsubishi-motors.bj': 2,
 'atp/item_scraped_host_count/www.mitsubishi-motors.ci': 5,
 'atp/item_scraped_host_count/www.mitsubishi-motors.com.gh': 4,
 'atp/item_scraped_host_count/www.mitsubishi-motors.com.ng': 10,
 'atp/item_scraped_host_count/www.mitsubishi-motors.mg': 4,
 'atp/item_scraped_host_count/www.mitsubishi-motors.tg': 1,
 'atp/item_scraped_host_count/www.mitsubishimotors-centrafrique.com': 1,
 'atp/nsi/cc_match': 33,
 'downloader/request_bytes': 47376,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 43,
 'downloader/response_bytes': 312196,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'elapsed_time_seconds': 19.609292,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 24, 13, 20, 26, 114296, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1357163,
 'httpcompression/response_count': 43,
 'item_scraped_count': 33,
 'items_per_minute': None,
 'log_count/DEBUG': 93,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 43,
 'responses_per_minute': None,
 'scheduler/dequeued': 43,
 'scheduler/dequeued/memory': 43,
 'scheduler/enqueued': 43,
 'scheduler/enqueued/memory': 43,
 'start_time': datetime.datetime(2025, 3, 24, 13, 20, 6, 505004, tzinfo=datetime.timezone.utc)}
```