### PR TITLE
[mcdonalds_pl] add mccafe pois (550 locations)

### DIFF
--- a/locations/spiders/mcdonalds_pl.py
+++ b/locations/spiders/mcdonalds_pl.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 import scrapy
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.spiders.mcdonalds import McdonaldsSpider
@@ -38,4 +38,13 @@ class McdonaldsPLSpider(scrapy.Spider):
             apply_yes_no(Extras.WIFI, item, poi.get("wifi"))
             apply_yes_no(Extras.DELIVERY, item, poi.get("mcDelivery"))
             apply_yes_no(Extras.DRIVE_THROUGH, item, poi.get("mcDrive"))
+
+            if poi.get("mcCafe"):
+                mccafe = item.deepcopy()
+                mccafe["ref"] = "{}-mccafe".format(item["ref"])
+                mccafe["brand"] = "McCafé"
+                mccafe["brand_wikidata"] = "Q3114287"
+                apply_category(Categories.CAFE, mccafe)
+                yield mccafe
+
             yield item


### PR DESCRIPTION
```
{'atp/brand/McCafé': 550,
 "atp/brand/McDonald's": 583,
 'atp/brand_wikidata/Q3114287': 550,
 'atp/brand_wikidata/Q38076': 583,
 'atp/category/amenity/cafe': 550,
 'atp/category/amenity/fast_food': 583,
 'atp/clean_strings/street_address': 27,
 'atp/country/PL': 1133,
 'atp/field/branch/missing': 1133,
 'atp/field/country/from_spider_name': 1133,
 'atp/field/email/missing': 1133,
 'atp/field/image/missing': 1133,
 'atp/field/operator/missing': 1133,
 'atp/field/operator_wikidata/missing': 1133,
 'atp/field/twitter/missing': 1133,
 'atp/item_scraped_host_count/mcdonalds.pl': 1133,
 'atp/nsi/cc_match': 583,
 'atp/nsi/perfect_match': 550,
 'downloader/request_bytes': 607,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 94076,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.057849,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 24, 19, 26, 34, 100234, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1353397,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1133,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 188444672,
 'memusage/startup': 188444672,
 'response_received_count': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 24, 19, 26, 31, 42385, tzinfo=datetime.timezone.utc)}
```