### PR TITLE
[Mitsubishi TR] Add  Spider (49 locations)

### DIFF
--- a/locations/spiders/mitsubishi_tr.py
+++ b/locations/spiders/mitsubishi_tr.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+import chompjs
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class MitsubishiTRSpider(Spider):
+    name = "mitsubishi_tr"
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
+    start_urls = ["https://www.mitsubishi-motors.com.tr/yetkili-satici-servis"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        locations = chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "sellers")]/text()').re_first(r"(\{\\\"sellers\\\":\[.+]})\""),
+            unicode_escape=True,
+        )
+        for location_type in ["sellers", "services"]:
+            for city_locations in locations[location_type][0]["cities"]:
+                for location in city_locations["data"]:
+                    # duplicate data present within each location_type i.e. sellers and services type, combining both data sets give us all desired locations
+                    item = DictParser.parse(location)
+                    if location_type == "sellers":
+                        apply_category(Categories.SHOP_CAR, item)
+                    else:
+                        apply_category(Categories.SHOP_CAR_REPAIR, item)
+
+                    yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 49,
 'atp/brand_wikidata/Q36033': 49,
 'atp/category/shop/car': 11,
 'atp/category/shop/car_repair': 38,
 'atp/clean_strings/addr_full': 2,
 'atp/clean_strings/lon': 2,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/phone': 3,
 'atp/country/TR': 49,
 'atp/field/branch/missing': 49,
 'atp/field/country/from_spider_name': 49,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 35,
 'atp/field/image/missing': 49,
 'atp/field/lat/missing': 8,
 'atp/field/lon/missing': 8,
 'atp/field/opening_hours/missing': 49,
 'atp/field/operator/missing': 49,
 'atp/field/operator_wikidata/missing': 49,
 'atp/field/phone/invalid': 3,
 'atp/field/postcode/missing': 49,
 'atp/field/state/missing': 49,
 'atp/field/street_address/missing': 49,
 'atp/field/twitter/missing': 49,
 'atp/field/website/missing': 49,
 'atp/item_scraped_host_count/www.mitsubishi-motors.com.tr': 141,
 'atp/nsi/cc_match': 49,
 'downloader/request_bytes': 649,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 328502,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.894173,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 25, 14, 21, 13, 691781, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 727907,
 'httpcompression/response_count': 2,
 'item_dropped_count': 92,
 'item_dropped_reasons_count/DropItem': 92,
 'item_scraped_count': 49,
 'items_per_minute': None,
 'log_count/DEBUG': 154,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 3, 25, 14, 21, 9, 797608, tzinfo=datetime.timezone.utc)}
```