### PR TITLE
[KFC TH][KFC CA][KFC ZA] Fix Spider

### DIFF
--- a/locations/spiders/kfc_au.py
+++ b/locations/spiders/kfc_au.py
@@ -6,6 +6,7 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import clean_address
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class KfcAUSpider(scrapy.Spider):
@@ -15,6 +16,7 @@ class KfcAUSpider(scrapy.Spider):
     tenant_id = "afd3813afa364270bfd33f0a8d77252d"
     web_root = "https://www.kfc.com.au/restaurants/"
     requires_proxy = True  # Requires AU proxy, possibly residential IPs only.
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def start_requests(self):
         yield JsonRequest(

--- a/locations/spiders/kfc_th.py
+++ b/locations/spiders/kfc_th.py
@@ -6,5 +6,5 @@ class KfcTHSpider(KfcAUSpider):
 
     region_code = "apac"
     tenant_id = "59dhhptudcn7hk1ogssvsb4cujvbcnh6o"
-    web_root = "https://www.kfc.co.th/restaurants/"
+    web_root = None
     requires_proxy = False


### PR DESCRIPTION
**_Fixes: added user_agent to kfc_au spider to fix dependent spiders i.e. kfc_th,kfc_ca,kfc_za _**
**_kfc_th_**:
```python
{'atp/brand/KFC': 1200,
 'atp/brand_wikidata/Q524757': 1200,
 'atp/category/amenity/fast_food': 1200,
 'atp/clean_strings/city': 17,
 'atp/clean_strings/state': 3,
 'atp/country/TH': 1200,
 'atp/field/image/missing': 1200,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 1200,
 'atp/field/operator_wikidata/missing': 1200,
 'atp/field/phone/invalid': 1111,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 1200,
 'atp/field/website/missing': 1200,
 'atp/item_scraped_host_count/orderserv-kfc-apac-olo-api.yum.com': 1200,
 'atp/nsi/cc_match': 1200,
 'downloader/request_bytes': 1071101,
 'downloader/request_count': 1207,
 'downloader/request_method_count/GET': 1207,
 'downloader/response_bytes': 2926928,
 'downloader/response_count': 1207,
 'downloader/response_status_count/200': 1201,
 'downloader/response_status_count/400': 6,
 'dupefilter/filtered': 8,
 'elapsed_time_seconds': 54.063033,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 26, 5, 4, 47, 866726, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14477083,
 'httpcompression/response_count': 1201,
 'httperror/response_ignored_count': 6,
 'httperror/response_ignored_status_count/400': 6,
 'item_scraped_count': 1200,
 'items_per_minute': None,
 'log_count/DEBUG': 2420,
 'log_count/INFO': 15,
 'request_depth_max': 1,
 'response_received_count': 1207,
 'responses_per_minute': None,
 'scheduler/dequeued': 1207,
 'scheduler/dequeued/memory': 1207,
 'scheduler/enqueued': 1207,
 'scheduler/enqueued/memory': 1207,
 'start_time': datetime.datetime(2025, 3, 26, 5, 3, 53, 803693, tzinfo=datetime.timezone.utc)}
```
**_kfc_ca:_**
```python
{'atp/brand/KFC': 656,
 'atp/brand_wikidata/Q524757': 656,
 'atp/category/amenity/fast_food': 656,
 'atp/country/CA': 656,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 656,
 'atp/field/opening_hours/missing': 36,
 'atp/field/operator/missing': 656,
 'atp/field/operator_wikidata/missing': 656,
 'atp/field/phone/missing': 3,
 'atp/field/state/from_reverse_geocoding': 50,
 'atp/field/twitter/missing': 656,
 'atp/field/website/missing': 656,
 'atp/item_scraped_host_count/orderserv-kfc-na-olo-api.yum.com': 656,
 'atp/nsi/cc_match': 656,
 'downloader/request_bytes': 618747,
 'downloader/request_count': 700,
 'downloader/request_method_count/GET': 700,
 'downloader/response_bytes': 2330431,
 'downloader/response_count': 700,
 'downloader/response_status_count/200': 657,
 'downloader/response_status_count/400': 36,
 'downloader/response_status_count/403': 7,
 'dupefilter/filtered': 30,
 'elapsed_time_seconds': 868.719697,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 25, 12, 46, 24, 205427, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17108761,
 'httpcompression/response_count': 657,
 'httperror/response_ignored_count': 43,
 'httperror/response_ignored_status_count/400': 36,
 'httperror/response_ignored_status_count/403': 7,
 'item_scraped_count': 656,
 'items_per_minute': None,
 'log_count/DEBUG': 1368,
 'log_count/INFO': 66,
 'request_depth_max': 1,
 'response_received_count': 700,
 'responses_per_minute': None,
 'scheduler/dequeued': 700,
 'scheduler/dequeued/memory': 700,
 'scheduler/enqueued': 700,
 'scheduler/enqueued/memory': 700,
 'start_time': datetime.datetime(2025, 3, 25, 12, 31, 55, 485730, tzinfo=datetime.timezone.utc)}
```
**_kfc_za:_**
```python
{'atp/brand/KFC': 1117,
 'atp/brand_wikidata/Q524757': 1117,
 'atp/category/amenity/fast_food': 1117,
 'atp/clean_strings/branch': 4,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/state': 3,
 'atp/country/ZA': 1117,
 'atp/field/country/from_spider_name': 333,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 1117,
 'atp/field/opening_hours/missing': 9,
 'atp/field/operator/missing': 1117,
 'atp/field/operator_wikidata/missing': 1117,
 'atp/field/phone/invalid': 7,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 1117,
 'atp/field/website/invalid': 3,
 'atp/item_scraped_host_count/orderserv-kfc-eu-olo-api.yum.com': 1152,
 'atp/nsi/cc_match': 1117,
 'downloader/request_bytes': 1014478,
 'downloader/request_count': 1156,
 'downloader/request_method_count/GET': 1156,
 'downloader/response_bytes': 2604233,
 'downloader/response_count': 1156,
 'downloader/response_status_count/200': 1153,
 'downloader/response_status_count/400': 3,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 1418.659088,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 25, 13, 0, 11, 449670, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12507189,
 'httpcompression/response_count': 1153,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/400': 3,
 'item_scraped_count': 1117,
 'items_per_minute': None,
 'log_count/DEBUG': 2460,
 'log_count/ERROR': 35,
 'log_count/INFO': 35,
 'log_count/WARNING': 4,
 'request_depth_max': 1,
 'response_received_count': 1156,
 'responses_per_minute': None,
 'scheduler/dequeued': 1156,
 'scheduler/dequeued/memory': 1156,
 'scheduler/enqueued': 1156,
 'scheduler/enqueued/memory': 1156,
 'start_time': datetime.datetime(2025, 3, 25, 12, 36, 32, 790582, tzinfo=datetime.timezone.utc)}
```