### PR TITLE
Switch ref:google tag to ref:google:place_id

### DIFF
--- a/locations/spiders/betts_au.py
+++ b/locations/spiders/betts_au.py
@@ -20,5 +20,5 @@ class BettsAUSpider(Spider):
         for row in rows:
             item = DictParser.parse(row)
             item["branch"] = item.pop("name").removeprefix("Betts ")
-            item["extras"]["ref:google"] = row["place_id"]
+            item["extras"]["ref:google:place_id"] = row["place_id"]
             yield item

--- a/locations/spiders/carbon_health_us.py
+++ b/locations/spiders/carbon_health_us.py
@@ -32,7 +32,7 @@ class CarbonHealthUSSpider(Spider):
             item["name"] = self.item_attributes["brand"]
 
             item["image"] = f"https://images.carbonhealth.com/{location['coverImageId']}/2x.jpg"
-            item["extras"]["ref:google"] = location.get("googlePlaceId")
+            item["extras"]["ref:google:place_id"] = location.get("googlePlaceId")
             item["website"] = f"https://carbonhealth.com/locations/{location['slug']}"
 
             address = location["address"]

--- a/locations/spiders/cum_books_za.py
+++ b/locations/spiders/cum_books_za.py
@@ -26,7 +26,7 @@ class CumBooksZASpider(Spider):
                 "lon": location["coords"]["lng"],
                 "street_address": location["address1"],
                 "addr_full": clean_address([location["address1"], location["address2"]]),
-                "extras": {"ref:google": location.get("placeId")},
+                "extras": {"ref:google:place_id": location.get("placeId")},
             }
 
             yield Feature(**properties)

--- a/locations/spiders/ernstings_family.py
+++ b/locations/spiders/ernstings_family.py
@@ -25,7 +25,7 @@ class ErnstingsFamilySpider(Spider):
                 location["phone"] = location.pop("primaryPhone")
                 item = DictParser.parse(location)
                 item["opening_hours"] = self.format_opening_hours(location["regularHours"]["periods"])
-                item["extras"]["ref:google"] = location["placeid"]
+                item["extras"]["ref:google:place_id"] = location["placeid"]
 
                 yield item
 

--- a/locations/spiders/ikea.py
+++ b/locations/spiders/ikea.py
@@ -111,7 +111,7 @@ class IkeaSpider(scrapy.Spider):
 
             item["extras"]["store_type"] = store["buClassification"]["code"]
             item["extras"]["start_date"] = store["openCloseDates"]["openingDate"].replace("T00:00:00Z", "")
-            item["extras"]["ref:google"] = store.get("placeId")
+            item["extras"]["ref:google:place_id"] = store.get("placeId")
 
             apply_category(Categories.SHOP_FURNITURE, item)
             yield item

--- a/locations/spiders/ismash_gb.py
+++ b/locations/spiders/ismash_gb.py
@@ -19,7 +19,7 @@ class IsmashGBSpider(Spider):
             item["addr_full"] = location["address"]
             item["email"] = location["contact_email"]
             item["phone"] = location["contact_phone"]
-            item["extras"]["ref:google"] = location["googleID"]
+            item["extras"]["ref:google:place_id"] = location["googleID"]
             item["ref"] = location["id"]
             item["lat"] = location["latitude"]
             item["lon"] = location["longitude"]

--- a/locations/spiders/kfc_fr.py
+++ b/locations/spiders/kfc_fr.py
@@ -20,7 +20,7 @@ class KfcFRSpider(Spider):
             item = DictParser.parse(location)
             item["branch"] = item.pop("name").removeprefix("KFC ")
             item["website"] = "https://www.kfc.fr/nos-restaurants/{}".format(location["url"])
-            item["extras"]["ref:google"] = location["placeId"]
+            item["extras"]["ref:google:place_id"] = location["placeId"]
 
             apply_yes_no(Extras.DELIVERY, item, "delivery" in location["dispositions"])
             apply_yes_no(Extras.TAKEAWAY, item, "pickup" in location["dispositions"])

--- a/locations/spiders/linde_direct_us.py
+++ b/locations/spiders/linde_direct_us.py
@@ -7,5 +7,5 @@ class LindeDirectUSSpider(RioSeoSpider):
     end_point = "https://maps.stores.lindedirect.com"
 
     def post_process_feature(self, feature, location):
-        feature["extras"]["ref:google"] = location.get("google_place_id")
+        feature["extras"]["ref:google:place_id"] = location.get("google_place_id")
         yield feature

--- a/locations/spiders/misenso_ch.py
+++ b/locations/spiders/misenso_ch.py
@@ -25,7 +25,7 @@ class MisensoCHSpider(Spider):
 
             item["website"] = item["extras"]["website:de"] = location["page_link_de"]
             item["extras"]["website:fr"] = location["page_link_fr"]
-            item["extras"]["ref:google"] = location["place_id"]
+            item["extras"]["ref:google:place_id"] = location["place_id"]
 
             item["opening_hours"] = OpeningHours()
             for day, times in location["amparex"]["opening_hours"].items():

--- a/locations/spiders/mister_minit_asia_pacific.py
+++ b/locations/spiders/mister_minit_asia_pacific.py
@@ -24,7 +24,7 @@ class MisterMinitAsiaPacificSpider(Spider):
                 "lon": location["coords"]["lng"],
                 "street_address": location["address1"],
                 "addr_full": clean_address([location["address1"], location["address2"]]),
-                "extras": {"ref:google": location.get("placeId")},
+                "extras": {"ref:google:place_id": location.get("placeId")},
             }
 
             if location["address2"].endswith("Australia"):

--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -46,7 +46,7 @@ class NatwestGBSpider(Spider):
             item["website"] = location["c_listing_URL"].replace("/personal", "")
             item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
             item["extras"]["ref:facebook"] = location.get("" "facebookPageUrl", "").split("/")[-1]
-            item["extras"]["ref:google"] = location["googlePlaceId"]
+            item["extras"]["ref:google:place_id"] = location["googlePlaceId"]
 
             if "phone" in item and item["phone"].replace(" ", "").startswith("+443"):
                 # not a phone number specific to given branch

--- a/locations/spiders/scribbler_gb.py
+++ b/locations/spiders/scribbler_gb.py
@@ -17,7 +17,7 @@ class ScribblerGBSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
         item["addr_full"] = clean_address([location["address1"], location["address2"]])
-        item["extras"]["ref:google"] = location.get("placeId")
+        item["extras"]["ref:google:place_id"] = location.get("placeId")
         item["lat"] = location["coords"]["lat"]
         item["lon"] = location["coords"]["lng"]
         yield item

--- a/locations/spiders/starbucks_reserve.py
+++ b/locations/spiders/starbucks_reserve.py
@@ -19,5 +19,5 @@ class StarbucksReserveSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
         item["addr_full"] = clean_address([location["address1"], location["address2"]])
-        item["extras"]["ref:google"] = location.get("placeId")
+        item["extras"]["ref:google:place_id"] = location.get("placeId")
         yield item

--- a/locations/spiders/veggie_grill_us.py
+++ b/locations/spiders/veggie_grill_us.py
@@ -21,7 +21,7 @@ class VeggieGrillUSSpider(Spider):
             item["branch"] = item.pop("name")
             item["website"] = response.urljoin(location["url"])
             item["image"] = location["fields"]["herobasic"]["images"][0]["image_url"]
-            item["extras"]["ref:google"] = location["google_place_id"]
+            item["extras"]["ref:google:place_id"] = location["google_place_id"]
             item["street_address"] = item.pop("street")
 
             oh = OpeningHours()


### PR DESCRIPTION
There are other types of Google IDs such as Google Maps CID which differ from Google Maps Place IDs. Split the ref:google tag into more specific tags to allow for both CIDs and Place IDs.

Note that from
https://taginfo.openstreetmap.org/keys/ref%3Agoogle#values it appears Google Maps redirect URLs are used for ref:google. These appear to be deprecated, as will the goo.gl redirector some time later in 2025. There appears to be no other existing ref tags used for extracing Google Maps CIDs or Place IDs so we're free to make something up.