### PR TITLE
Update function documentation for handling ambiguous data

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -721,13 +721,27 @@ class Access(Enum):
     MOTOR_CAR = "motorcar"
 
 
-def apply_yes_no(attribute, item: Feature, state: bool, apply_positive_only: bool = True):
+def apply_yes_no(attribute: str | Enum, item: Feature | dict, state: bool, apply_positive_only: bool = True) -> None:
     """
-    Many OSM POI attribute tags values are "yes"/"no". Provide support for setting these from spider code.
-    :param attribute: the tag to use for the attribute (str or Enum accepted)
-    :param item: the POI instance to update
-    :param state: if the attribute to set True or False
-    :param apply_positive_only: only add the tag if state is True
+    Many OSM POI attribute tags values are "yes"/"no". This function provides
+    a convenient method for adding an extras tag to a Feature or dictionary
+    with a "yes" or "no" value.
+
+    The apply_positive_only parameter should only be set to False if the
+    source data explicitly states "yes" or "no". For example, if the source
+    data has `{"drive_through": True}` or `{"drive_through": False}`. Or as
+    another example, if the source data has `{"features": ["drive_through"]}`
+    or `{"features": []}` AND the front end website displaying the data
+    provides a visual indication of a missing `"drive_through"` value in the
+    `"features"` array meaning the absence of a drive through service. If in
+    this second example the website does not display "Drive Through: not
+    available" (or similar) then do not assume anything about the availability
+    of a drive through and keep the default True value of apply_positive_only.
+
+    :param attribute: The tag to use for the attribute (str or Enum accepted).
+    :param item: The POI instance to update.
+    :param state: Whether the attribute is to be set to True or False.
+    :param apply_positive_only: Only add the tag if state is True.
     """
     if not state and apply_positive_only:
         return

--- a/locations/hours.py
+++ b/locations/hours.py
@@ -910,6 +910,18 @@ class OpeningHours:
 
         Recommended to use with an appropriate helper to pass a specific string or list, ie:
         `set_closed(DAYS_SR["Ponedeljak"])` or `set_closed(["Mo", "Tu", "We"])`
+
+        In the situation where source data does not explicitly state a feature
+        is closed on a specific day of a week, do not make an assumption of
+        closure status in the absence of other data. For example, source data
+        may be `{"open_days": ["monday", "wednesday"]}` for one feature, and
+        `{"open_days": ["monday", "tuesday", "wednesday"]}` for a different
+        feature. Do not assume that the first feature is closed on Tuesdays
+        unless there is other data explicitly stating this is the case. If the
+        front end website displaying this data treats the absence of `"Tuesday"`
+        in the `"open_days"` array as closure and visually states "Tuesdays:
+        closed" on the website, this function can then be used to set Tuesdays
+        to be closed.
         """
         for day in [days] if isinstance(days, str) else days:
             day = sanitise_day(day)


### PR DESCRIPTION
Per discussion in PR #12568.

If source data has two features:

{
  "feature_id": "1",
  "services": ["Showers", "Toilets"],
  "cards_accepted": ["MasterCard", "Visa"],
  "open_days": ["Monday", "Wednesday"],
}

{
  "feature_id": "2",
  "services": ["Showers"],
  "cards_accepted": ["Visa"],
  "open_days": ["Tuesday", "Thursday"],
}

Spiders should not assume that feature 2 lacks Toilets, refuses to accept MasterCard and is closed Monday, Wednesday and Friday-Sunday each week unless there is other data available to confirm such facts.

Spiders should not assume that feature 1 is closed on Tuesday and Thursday-Sunday each week unless there is other data available to confirm such facts.

Spiders can confirm that feature 2 lacks Toilets if the front end website displaying this data states for feature 2, "Toilets: not available". That is, the ambiguity of missing data in the array is clarified by the way in which the website has been programmed to interpret the data.