### PR TITLE
[Ace Hardware] Flag ace_hardware spider as requires proxy

### DIFF
--- a/locations/spiders/ace_hardware.py
+++ b/locations/spiders/ace_hardware.py
@@ -7,3 +7,4 @@ class AceHardwareSpider(KiboSpider):
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True


### PR DESCRIPTION
**_The spider works fine from IN, so flag as requires proxy_**

```python
{'atp/brand/Ace Hardware': 4693,
 'atp/brand_wikidata/Q4672981': 4693,
 'atp/category/shop/doityourself': 4693,
 'atp/cdn/cloudflare/response_count': 6,
 'atp/cdn/cloudflare/response_status_count/200': 6,
 'atp/country/US': 4693,
 'atp/field/branch/missing': 4693,
 'atp/field/email/missing': 1132,
 'atp/field/image/missing': 4693,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 4693,
 'atp/field/operator_wikidata/missing': 4693,
 'atp/field/phone/missing': 11,
 'atp/field/twitter/missing': 4693,
 'atp/field/website/missing': 4693,
 'atp/item_scraped_host_count/www.acehardware.com': 4693,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4693,
 'downloader/request_bytes': 12908,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 988033,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'dupefilter/filtered': 3996,
 'elapsed_time_seconds': 23.415026,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 27, 5, 0, 14, 347825, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17811491,
 'httpcompression/response_count': 6,
 'item_scraped_count': 4693,
 'items_per_minute': None,
 'log_count/DEBUG': 4711,
 'log_count/INFO': 9,
 'request_depth_max': 4,
 'response_received_count': 6,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2025, 3, 27, 4, 59, 50, 932799, tzinfo=datetime.timezone.utc)}
```