### PR TITLE
[Family Dollar US] Flag family_dollar_us spider as requires proxy

### DIFF
--- a/locations/spiders/family_dollar_us.py
+++ b/locations/spiders/family_dollar_us.py
@@ -11,6 +11,7 @@ class FamilyDollarUSSpider(YextAnswersSpider):
     api_key = "7a860787290ef5396ebe3ffe229d96c3"
     experience_key = "pages-locator-usa-only"
     feature_type = "family-dollar"
+    requires_proxy = True
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         item.pop("facebook", None)


### PR DESCRIPTION
**_The spider works fine from IN, so flag as requires proxy_**

```python
{'atp/brand/Family Dollar': 7613,
 'atp/brand_wikidata/Q5433101': 7613,
 'atp/category/shop/variety_store': 7613,
 'atp/cdn/cloudflare/response_count': 154,
 'atp/cdn/cloudflare/response_status_count/200': 153,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/US': 7613,
 'atp/field/branch/missing': 7613,
 'atp/field/email/missing': 7613,
 'atp/field/image/missing': 7613,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 7613,
 'atp/field/operator_wikidata/missing': 7613,
 'atp/field/phone/missing': 5,
 'atp/field/twitter/missing': 7613,
 'atp/field/website/missing': 2,
 'atp/item_scraped_host_count/liveapi.yext.com': 7613,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 7613,
 'downloader/request_bytes': 156754,
 'downloader/request_count': 154,
 'downloader/request_method_count/GET': 154,
 'downloader/response_bytes': 5688162,
 'downloader/response_count': 154,
 'downloader/response_status_count/200': 153,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 206.923331,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 27, 6, 5, 38, 821695, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 187487152,
 'httpcompression/response_count': 153,
 'item_scraped_count': 7613,
 'items_per_minute': None,
 'log_count/DEBUG': 7779,
 'log_count/INFO': 12,
 'request_depth_max': 152,
 'response_received_count': 154,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 153,
 'scheduler/dequeued/memory': 153,
 'scheduler/enqueued': 153,
 'scheduler/enqueued/memory': 153,
 'start_time': datetime.datetime(2025, 3, 27, 6, 2, 11, 898364, tzinfo=datetime.timezone.utc)}
```