### PR TITLE
run_pr_spiders: increase timeout from 60s to 120s for running spiders

### DIFF
--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -131,7 +131,7 @@ do
     STATSFILE="${SPIDER_RUN_DIR}/stats.json"
     FAILURE_REASON="success"
 
-    timeout -k 5s 90s \
+    timeout -k 5s 120s \
     scrapy runspider \
         -o "file://${OUTFILE}:geojson" \
         -o "file://${PARQUETFILE}:parquet" \

--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -131,7 +131,7 @@ do
     STATSFILE="${SPIDER_RUN_DIR}/stats.json"
     FAILURE_REASON="success"
 
-    timeout -k 5s 120s \
+    timeout -k 5s 150s \
     scrapy runspider \
         -o "file://${OUTFILE}:geojson" \
         -o "file://${PARQUETFILE}:parquet" \

--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -137,7 +137,7 @@ do
         -o "file://${PARQUETFILE}:parquet" \
         --loglevel=INFO \
         --logfile="${LOGFILE}" \
-        -s CLOSESPIDER_TIMEOUT=60 \
+        -s CLOSESPIDER_TIMEOUT=120 \
         -s CLOSESPIDER_ERRORCOUNT=1 \
         -s LOGSTATS_FILE="${STATSFILE}" \
         $spider


### PR DESCRIPTION
https://github.com/alltheplaces/alltheplaces/pull/12483 is an example of a PR where a large file is slow to download (over 60s) and an increased timeout is desirable to allow the CI process a chance to complete.