### PR TITLE
[Carls JR US] Fix Spider

### DIFF
--- a/locations/spiders/carls_jr_us.py
+++ b/locations/spiders/carls_jr_us.py
@@ -9,8 +9,8 @@ from locations.structured_data_spider import StructuredDataSpider
 class CarlsJrUSSpider(SitemapSpider, StructuredDataSpider):
     name = "carls_jr_us"
     item_attributes = {"brand": "Carl's Jr.", "brand_wikidata": "Q1043486"}
-    sitemap_urls = ["https://locations.carlsjr.com/robots.txt"]
-    sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+/$", "parse")]
+    sitemap_urls = ["https://locations.carlsjr.com/sitemap.xml"]
+    sitemap_rules = [(r"com/\w\w/[^/]+/[^/]+/$", "parse_sd")]
     wanted_types = ["LocalBusiness"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):


### PR DESCRIPTION
**_Fixes : updated sitemap_urls to fix spider_**

```python
{"atp/brand/Carl's Jr.": 1031,
 'atp/brand_wikidata/Q1043486': 1031,
 'atp/category/amenity/fast_food': 1031,
 'atp/cdn/cloudflare/response_count': 1033,
 'atp/cdn/cloudflare/response_status_count/200': 1033,
 'atp/country/US': 1031,
 'atp/field/branch/missing': 1031,
 'atp/field/email/missing': 1031,
 'atp/field/image/dropped': 1031,
 'atp/field/image/missing': 1031,
 'atp/field/opening_hours/missing': 1031,
 'atp/field/operator/missing': 1031,
 'atp/field/operator_wikidata/missing': 1031,
 'atp/item_scraped_host_count/locations.carlsjr.com': 1031,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1031,
 'downloader/request_bytes': 397802,
 'downloader/request_count': 1033,
 'downloader/request_method_count/GET': 1033,
 'downloader/response_bytes': 29405709,
 'downloader/response_count': 1033,
 'downloader/response_status_count/200': 1033,
 'elapsed_time_seconds': 1260.887634,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 28, 5, 20, 4, 890746, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 163278237,
 'httpcompression/response_count': 1033,
 'item_scraped_count': 1031,
 'items_per_minute': None,
 'log_count/DEBUG': 2075,
 'log_count/INFO': 30,
 'request_depth_max': 1,
 'response_received_count': 1033,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1032,
 'scheduler/dequeued/memory': 1032,
 'scheduler/enqueued': 1032,
 'scheduler/enqueued/memory': 1032,
 'start_time': datetime.datetime(2025, 3, 28, 4, 59, 4, 3112, tzinfo=datetime.timezone.utc)}
```