### PR TITLE
[Dicks Sporting Goods] Flag dicks_sporting_goods spider as requires proxy

### DIFF
--- a/locations/spiders/dicks_sporting_goods.py
+++ b/locations/spiders/dicks_sporting_goods.py
@@ -13,6 +13,7 @@ class DicksSportingGoodsSpider(SitemapSpider):
     sitemap_urls = ["https://stores.dickssportinggoods.com/robots.txt"]
     sitemap_rules = [(r"com/\w\w/[^/]+/(\d+)/", "parse_store")]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     def parse_hours(self, response):
         days = response.xpath('//meta[@property="business:hours:day"]/@content').extract()


### PR DESCRIPTION
**_The spider works fine from IN, so flag as requires proxy_**

```python
{"atp/brand/Dick's Sporting Goods": 717,
 'atp/brand_wikidata/Q5272601': 717,
 'atp/category/shop/sports': 717,
 'atp/cdn/cloudflare/response_count': 774,
 'atp/cdn/cloudflare/response_status_count/200': 774,
 'atp/clean_strings/branch': 696,
 'atp/clean_strings/street_address': 587,
 'atp/country/US': 717,
 'atp/field/branch/missing': 717,
 'atp/field/email/missing': 717,
 'atp/field/image/missing': 717,
 'atp/field/operator/missing': 717,
 'atp/field/operator_wikidata/missing': 717,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 717,
 'atp/item_scraped_host_count/stores.dickssportinggoods.com': 717,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 717,
 'downloader/request_bytes': 301368,
 'downloader/request_count': 774,
 'downloader/request_method_count/GET': 774,
 'downloader/response_bytes': 18786059,
 'downloader/response_count': 774,
 'downloader/response_status_count/200': 774,
 'elapsed_time_seconds': 946.240838,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 3, 28, 10, 39, 54, 285824, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 116936729,
 'httpcompression/response_count': 774,
 'item_scraped_count': 717,
 'items_per_minute': None,
 'log_count/DEBUG': 1502,
 'log_count/ERROR': 54,
 'log_count/INFO': 24,
 'request_depth_max': 3,
 'response_received_count': 774,
 'responses_per_minute': None,
 'scheduler/dequeued': 774,
 'scheduler/dequeued/memory': 774,
 'scheduler/enqueued': 774,
 'scheduler/enqueued/memory': 774,
 'spider_exceptions/ValueError': 54,
 'start_time': datetime.datetime(2025, 3, 28, 10, 24, 8, 44986, tzinfo=datetime.timezone.utc)}
```