### PR TITLE
Fix San Francisco spider geometries

### DIFF
--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -67,7 +67,7 @@ def item_to_properties(item: Item) -> dict[str, Any]:
     return props
 
 
-def item_to_geometry(item: Item) -> (dict|None):
+def item_to_geometry(item: Item) -> dict | None:
     """
     Convert the item to a GeoJSON geometry object. If the item has lat and lon fields,
     but no geometry field, then a Point geometry will be created. Otherwise the

--- a/locations/exporters/geojson.py
+++ b/locations/exporters/geojson.py
@@ -67,7 +67,7 @@ def item_to_properties(item: Item) -> dict[str, Any]:
     return props
 
 
-def item_to_geometry(item: Item) -> dict:
+def item_to_geometry(item: Item) -> (dict|None):
     """
     Convert the item to a GeoJSON geometry object. If the item has lat and lon fields,
     but no geometry field, then a Point geometry will be created. Otherwise the
@@ -80,6 +80,7 @@ def item_to_geometry(item: Item) -> dict:
     lat = item.get("lat")
     lon = item.get("lon")
     geometry = item.get("geometry")
+
     if lat and lon and not geometry:
         try:
             geometry = {
@@ -88,6 +89,14 @@ def item_to_geometry(item: Item) -> dict:
             }
         except ValueError:
             logging.warning("Couldn't convert lat (%s) and lon (%s) to float", lat, lon)
+
+    # Check for empty or missing coordinates list in geometry
+    if geometry and isinstance(geometry, dict):
+        coordinates = geometry.get("coordinates")
+        if not coordinates:
+            logging.warning("Invalid geometry coordinates: %s", geometry)
+            return None
+
     return geometry
 
 

--- a/locations/spiders/infrastructure/san_francisco_mta_bicycle_parking_us.py
+++ b/locations/spiders/infrastructure/san_francisco_mta_bicycle_parking_us.py
@@ -23,12 +23,21 @@ class SanFranciscoMtaBicycleParkingUSSpider(ArcGISFeatureServerSpider):
         item["ref"] = str(feature["OBJECTID"])
         item.pop("street", None)
         item["street_address"] = item.pop("addr_full", None)
+
         apply_category(Categories.BICYCLE_PARKING, item)
+
         if capacity := feature.get("SPACES"):
             item["extras"]["capacity"] = capacity
+
         if feature.get("RACKS"):
             item["extras"]["bicycle_parking"] = "rack"
+
         if installation_year := feature.get("INSTALL_YR"):
             if installation_month := feature.get("INSTALL_MO"):
                 item["extras"]["start_date"] = "{}-{}".format(installation_year, str(installation_month).zfill(2))
+
+        # Clear out the occasional empty coordinates array in geometry
+        if item.geometry and item.geometry.get("coordinates") == []:
+            item.geometry = None
+
         yield item

--- a/locations/spiders/infrastructure/san_francisco_mta_bicycle_parking_us.py
+++ b/locations/spiders/infrastructure/san_francisco_mta_bicycle_parking_us.py
@@ -37,7 +37,8 @@ class SanFranciscoMtaBicycleParkingUSSpider(ArcGISFeatureServerSpider):
                 item["extras"]["start_date"] = "{}-{}".format(installation_year, str(installation_month).zfill(2))
 
         # Clear out the occasional empty coordinates array in geometry
-        if item.geometry and item.geometry.get("coordinates") == []:
-            item.geometry = None
+        geom = item.get("geometry")
+        if geom and geom.get("coordinates") == []:
+            item["geometry"] = None
 
         yield item

--- a/locations/storefinders/arcgis_feature_server.py
+++ b/locations/storefinders/arcgis_feature_server.py
@@ -150,6 +150,12 @@ class ArcGISFeatureServerSpider(Spider):
             feature.update(properties)
             self.pre_process_data(feature)
             item = DictParser.parse(feature)
+
+            # Esri's GeoJSON output is not always valid, so check for known problems
+            geom = item.get("geometry")
+            if geom and geom.get("coordinates") == []:
+                item["geometry"] = None
+
             yield from self.post_process_item(item, response, feature)
 
         if "&resultRecordCount=" in response.url:

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -1,0 +1,38 @@
+from locations.exporters.geojson import item_to_geometry
+from locations.items import Feature
+
+
+def test_item_to_properties():
+    assert False
+
+
+def test_item_to_geometry():
+    # Feature with lat and lon set and geometry not set should create a Point geometry
+    item = Feature()
+    item["lat"] = 1
+    item["lon"] = 2
+    item["geometry"] = None
+    geometry = item_to_geometry(item)
+    assert geometry == {"type": "Point", "coordinates": [2.0, 1.0]}
+
+    # Feature with lat and lon set and geometry set should use the geometry
+    item = Feature()
+    item["geometry"] = {"type": "Polygon", "coordinates": [[1, 2], [3, 4]]}
+    geometry = item_to_geometry(item)
+    assert geometry == {"type": "Polygon", "coordinates": [[1, 2], [3, 4]]}
+
+    # Feature with lat and lon not set and geometry not set should return None
+    item = Feature()
+    item["lat"] = None
+    item["lon"] = None
+    item["geometry"] = None
+    geometry = item_to_geometry(item)
+    assert geometry is None
+
+    # Feature with point geometry that is empty (invalid geo) should return None
+    item = Feature()
+    item["lat"] = None
+    item["lon"] = None
+    item["geometry"] = {"type": "Point", "coordinates": []}
+    geometry = item_to_geometry(item)
+    assert geometry is None

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -1,9 +1,59 @@
-from locations.exporters.geojson import item_to_geometry
+from locations.exporters.geojson import item_to_geometry, item_to_properties
 from locations.items import Feature
 
 
 def test_item_to_properties():
-    assert False
+    # Test with a feature that has some properties
+    item = Feature()
+    item["name"] = "Test Name"
+    # We have manual mapping for some specific properties
+    item["addr_full"] = "123 Test St"
+    item["street"] = "Test St"
+    item["housenumber"] = "123"
+    item["postcode"] = "12345"
+    item["city"] = "Test City"
+    item["state"] = "Test State"
+    item["country"] = "Test Country"
+    item["twitter"] = "test_twitter"
+    item["facebook"] = "test_facebook"
+    item["brand_wikidata"] = "Q123456"
+    item["located_in_wikidata"] = "Q654321"
+    # Ref should get converted to string
+    item["ref"] = 123
+    # This should get added alongside the other properties. Empty and null values should be ignored
+    item["extras"] = {"key1": "value1", "key2": "value2", "key3": None, "key4": ""}
+    properties = item_to_properties(item)
+    assert properties == {
+        "name": "Test Name",
+        "addr:full": "123 Test St",
+        "addr:street": "Test St",
+        "addr:housenumber": "123",
+        "addr:postcode": "12345",
+        "addr:city": "Test City",
+        "addr:state": "Test State",
+        "addr:country": "Test Country",
+        "contact:twitter": "test_twitter",
+        "contact:facebook": "test_facebook",
+        "brand:wikidata": "Q123456",
+        "located_in:wikidata": "Q654321",
+        "key1": "value1",
+        "key2": "value2",
+        "ref": "123",
+    }
+
+    # Test that empty or null values are ignored
+    item = Feature()
+    item["name"] = None
+    item["addr_full"] = ""
+    item["street"] = "Test St"
+    assert item_to_properties(item) == {
+        "addr:street": "Test St",
+    }
+
+    # Test with an empty feature
+    item = Feature()
+    properties = item_to_properties(item)
+    assert properties == {}
 
 
 def test_item_to_geometry():


### PR DESCRIPTION
The build failed this weekend because tippecanoe couldn't handle a feature with an invalid geometry like this (empty coordinates):

```json
{
  "type":"Feature",
  "id":9214,
  "geometry":{"type":"Point","coordinates":[]},
  "properties":{}
}
```

It sucks that ESRI generates invalid GeoJSON like this, so we should protect against it as much as possible.