### PR TITLE
[Starbucks ZA] Fix Spider

### DIFF
--- a/locations/spiders/starbucks_za.py
+++ b/locations/spiders/starbucks_za.py
@@ -10,16 +10,10 @@ class StarbucksZASpider(JSONBlobSpider):
     name = "starbucks_za"
     item_attributes = STARBUCKS_SHARED_ATTRIBUTES | {"extras": Categories.COFFEE_SHOP.value}
     locations_key = "data"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         for lat, lon in country_iseadgg_centroids("ZA", 158):
-            yield JsonRequest(
-                url=f"https://www.starbucks.co.za/api/v2/stores/?filter%5Bcoordinates%5D%5Blatitude%5D={lat}&filter%5Bcoordinates%5D%5Blongitude%5D={lon}&filter%5Bradius%5D=158"
-            )
-        extra_locations = [
-            (-34, 18.45),  # Cape Town
-        ]
-        for lat, lon in extra_locations:
             yield JsonRequest(
                 url=f"https://www.starbucks.co.za/api/v2/stores/?filter%5Bcoordinates%5D%5Blatitude%5D={lat}&filter%5Bcoordinates%5D%5Blongitude%5D={lon}&filter%5Bradius%5D=158"
             )


### PR DESCRIPTION
**_Fixes : flag robots.txt as False to fix spider_**

```python
{'atp/brand/Starbucks': 72,
 'atp/brand_wikidata/Q37158': 72,
 'atp/category/amenity/cafe': 72,
 'atp/cdn/cloudflare/response_count': 35,
 'atp/cdn/cloudflare/response_status_count/200': 35,
 'atp/country/ZA': 72,
 'atp/field/email/missing': 72,
 'atp/field/image/missing': 72,
 'atp/field/opening_hours/missing': 72,
 'atp/field/operator/missing': 72,
 'atp/field/operator_wikidata/missing': 72,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 4,
 'atp/field/state/missing': 72,
 'atp/field/street_address/missing': 72,
 'atp/field/twitter/missing': 72,
 'atp/item_scraped_host_count/www.starbucks.co.za': 231,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 72,
 'downloader/request_bytes': 16988,
 'downloader/request_count': 35,
 'downloader/request_method_count/GET': 35,
 'downloader/response_bytes': 181381,
 'downloader/response_count': 35,
 'downloader/response_status_count/200': 35,
 'elapsed_time_seconds': 41.077857,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 1, 5, 20, 23, 745463, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 441567,
 'httpcompression/response_count': 35,
 'item_dropped_count': 159,
 'item_dropped_reasons_count/DropItem': 159,
 'item_scraped_count': 72,
 'items_per_minute': None,
 'log_count/DEBUG': 277,
 'log_count/INFO': 9,
 'response_received_count': 35,
 'responses_per_minute': None,
 'scheduler/dequeued': 35,
 'scheduler/dequeued/memory': 35,
 'scheduler/enqueued': 35,
 'scheduler/enqueued/memory': 35,
 'start_time': datetime.datetime(2025, 4, 1, 5, 19, 42, 667606, tzinfo=datetime.timezone.utc)}
```