### PR TITLE
[Krispy Krunchy Chicken US] Fix Spider

### DIFF
--- a/locations/spiders/krispy_krunchy_chicken_us.py
+++ b/locations/spiders/krispy_krunchy_chicken_us.py
@@ -1,29 +1,20 @@
-from typing import Any
+import re
 
-import chompjs
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class KrispyKrunchyChickenUSSpider(SitemapSpider):
+class KrispyKrunchyChickenUSSpider(SitemapSpider, StructuredDataSpider):
     name = "krispy_krunchy_chicken_us"
     item_attributes = {"brand_wikidata": "Q65087447"}
-    sitemap_urls = ["https://www.krispykrunchy.com/robots.txt"]
-    sitemap_follow = ["wpsl_stores"]
-    sitemap_rules = [(r"/locations/([^/]+)/$", "parse")]
+    sitemap_urls = ["https://locations.krispykrunchy.com/sitemap.xml"]
+    sitemap_rules = [(r"https://locations.krispykrunchy.com/[^/]+/[^/]+/", "parse_sd")]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = chompjs.parse_js_object(
-            response.xpath('//script[@id="wpsl-js-js-extra"]/text()').re_first(r"wpslMap_0 = ({.+})")
-        )
-        for location in data["locations"]:
-            item = DictParser.parse(location)
-            item["addr_full"] = None
-            item["street_address"] = merge_address_lines([location["address"], location["address2"]])
-            item["branch"] = location["store"]
-            item["website"] = response.url
-
-            yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["lat"], item["lon"] = re.search(
+            r"latitude%22%3A(-?\d+\.\d+).*longitude%22%3A(-?\d+\.\d+)", response.text
+        ).groups()
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to use structured data to fix spider_**

```python
{'atp/brand/Krispy Krunchy Chicken': 3210,
 'atp/brand_wikidata/Q65087447': 3210,
 'atp/category/amenity/fast_food': 3210,
 'atp/cdn/cloudflare/response_count': 3226,
 'atp/cdn/cloudflare/response_status_count/200': 3213,
 'atp/cdn/cloudflare/response_status_count/404': 13,
 'atp/country/US': 3210,
 'atp/field/branch/missing': 3210,
 'atp/field/email/missing': 3210,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 3210,
 'atp/field/operator_wikidata/missing': 3210,
 'atp/field/phone/missing': 4,
 'atp/field/twitter/missing': 3210,
 'atp/item_scraped_host_count/locations.krispykrunchy.com': 3210,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3210,
 'downloader/request_bytes': 1888231,
 'downloader/request_count': 3227,
 'downloader/request_method_count/GET': 3227,
 'downloader/response_bytes': 53281600,
 'downloader/response_count': 3227,
 'downloader/response_status_count/200': 3213,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 13,
 'elapsed_time_seconds': 3964.457492,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 2, 9, 17, 37, 761833, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 206462239,
 'httpcompression/response_count': 3226,
 'httperror/response_ignored_count': 13,
 'httperror/response_ignored_status_count/404': 13,
 'item_scraped_count': 3210,
 'items_per_minute': None,
 'log_count/DEBUG': 6449,
 'log_count/INFO': 88,
 'request_depth_max': 2,
 'response_received_count': 3226,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3226,
 'scheduler/dequeued/memory': 3226,
 'scheduler/enqueued': 3226,
 'scheduler/enqueued/memory': 3226,
 'start_time': datetime.datetime(2025, 4, 2, 8, 11, 33, 304341, tzinfo=datetime.timezone.utc)}
```