### PR TITLE
[Allpoint] Fix low scraped count

### DIFF
--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -33,5 +33,6 @@ class AllpointSpider(Spider):
         if response.json()["data"]["ATMInfo"]:
             for atm in response.json()["data"]["ATMInfo"]:
                 item = DictParser.parse(atm)
+                item["street_address"] = item.pop("street", None)
                 yield item
             yield self.make_request(kwargs["current_page"] + 1)

--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -17,9 +17,9 @@ class AllpointSpider(Spider):
             url="https://clsws.locatorsearch.net/Rest/LocatorSearchAPI.svc/GetLocations",
             data={
                 "NetworkId": 10029,
-                "Latitude": 0,
-                "Longitude": 0,
-                "Miles": 500000,
+                "Latitude": 33.15004936,
+                "Longitude": -96.83464,
+                "Miles": 50000,
                 "SearchByOptions": "ATMSF, ATMDP",
                 "PageIndex": page,
             },


### PR DESCRIPTION
```
{'atp/brand/Allpoint': 37806,
 'atp/brand_wikidata/Q4733264': 37806,
 'atp/category/amenity/atm': 37806,
 'atp/clean_strings/city': 10,
 'atp/clean_strings/street_address': 1,
 'atp/country/AU': 130,
 'atp/country/CA': 377,
 'atp/country/GB': 8129,
 'atp/country/MX': 367,
 'atp/country/US': 28803,
 'atp/field/branch/missing': 37806,
 'atp/field/email/missing': 37806,
 'atp/field/image/missing': 37806,
 'atp/field/name/missing': 37806,
 'atp/field/opening_hours/missing': 37806,
 'atp/field/operator/missing': 37806,
 'atp/field/operator_wikidata/missing': 37806,
 'atp/field/phone/missing': 37806,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 37806,
 'atp/field/website/missing': 37806,
 'atp/item_scraped_host_count/clsws.locatorsearch.net': 59848,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 37806,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 545757,
 'downloader/request_count': 602,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 601,
 'downloader/response_bytes': 79036557,
 'downloader/response_count': 601,
 'downloader/response_status_count/200': 600,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 16683.370348,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 3, 18, 42, 7, 852940, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 22042,
 'item_dropped_reasons_count/DropItem': 22042,
 'item_scraped_count': 37806,
 'items_per_minute': None,
 'log_count/DEBUG': 60468,
 'log_count/INFO': 287,
 'request_depth_max': 599,
 'response_received_count': 601,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 601,
 'scheduler/dequeued/memory': 601,
 'scheduler/enqueued': 601,
 'scheduler/enqueued/memory': 601,
 'start_time': datetime.datetime(2025, 4, 3, 14, 4, 4, 482592, tzinfo=datetime.timezone.utc)}
```