### PR TITLE
Fix the Dockerfile command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY . .
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
 
-CMD ["/home/ubuntu/ci/run_all_spiders.sh"]
+CMD ["./ci/run_all_spiders.sh"]


### PR DESCRIPTION
The path doesn't exist anymore now that we're not in the Ubuntu image.

This caused the build to fail the last couple tries.