### PR TITLE
[Sprouts Farmers Market] Fix Spider

### DIFF
--- a/locations/spiders/sprouts_farmers_market.py
+++ b/locations/spiders/sprouts_farmers_market.py
@@ -1,37 +1,33 @@
 import re
+from typing import Any
 
-from scrapy.spiders import SitemapSpider
+from requests import Response
+from scrapy.spiders import CrawlSpider, Rule
 
+from locations.google_url import extract_google_position
 from locations.hours import OpeningHours, day_range, sanitise_day
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
+from scrapy.linkextractors import LinkExtractor
 
 
-class SproutsFarmersMarketSpider(SitemapSpider, StructuredDataSpider):
+class SproutsFarmersMarketSpider(CrawlSpider):
     name = "sprouts_farmers_market"
-    allowed_domains = ["www.sprouts.com"]
     item_attributes = {"brand": "Sprouts Farmers Market", "brand_wikidata": "Q7581369"}
-    sitemap_urls = ["https://www.sprouts.com/store-sitemap.xml"]
-    sitemap_rules = [(r"^https:\/\/www.sprouts.com\/store\/\w\w\/*\/*\/", "parse_sd")]
+    start_urls = ["https://www.sprouts.com/stores/"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"https://www.sprouts.com/stores/[^/]+/"),
+        ),
+        Rule(LinkExtractor(allow=r"https://www.sprouts.com/store/[^/]+/[^/]+/[^/]+/"), callback="parse"),
+    ]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = response.url
-        item["opening_hours"] = ld_data["openingHours"].replace(",", ";")
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["branch"] = response.xpath('//*[@class="cell store-details"]/h1/text()').get()
+        item["street_address"] = response.xpath('//*[@class="store-address"]/a/text()[1]').get()
+        item["addr_full"] = response.xpath('//*[@class="store-address"]/a').xpath("normalize-space()").get()
+        item["ref"] = item["website"] = response.url
+        extract_google_position(item, response)
         yield item
-
-    def pre_process_data(self, ld_data, **kwargs):
-        oh = OpeningHours()
-        for days, open_time, open_time_ampm, close_time, close_time_ampm in re.findall(
-            r"(\w+-\w+) (\d+:\d+)\s?(AM|am|PM|pm) (\d+:\d+)\s?(AM|am|PM|pm)",
-            ld_data["openingHours"],
-        ):
-            start_day, end_day = days.split("-")
-            start_day = sanitise_day(start_day)
-            end_day = sanitise_day(end_day)
-            for day in day_range(start_day, end_day):
-                oh.add_range(
-                    day,
-                    open_time + open_time_ampm,
-                    close_time + close_time_ampm,
-                    time_format="%I:%M%p",
-                )
-        ld_data["openingHours"] = oh.as_opening_hours()

--- a/locations/spiders/sprouts_farmers_market.py
+++ b/locations/spiders/sprouts_farmers_market.py
@@ -1,15 +1,11 @@
-import re
 from typing import Any
 
 from requests import Response
+from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.google_url import extract_google_position
-from locations.hours import OpeningHours, day_range, sanitise_day
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
-from locations.structured_data_spider import StructuredDataSpider
-from scrapy.linkextractors import LinkExtractor
 
 
 class SproutsFarmersMarketSpider(CrawlSpider):


### PR DESCRIPTION
**_Fixes : code refactored to use crawl spider to fix spider_**

```python
{'atp/brand/Sprouts Farmers Market': 452,
 'atp/brand_wikidata/Q7581369': 452,
 'atp/category/shop/supermarket': 452,
 'atp/cdn/cloudflare/response_count': 478,
 'atp/cdn/cloudflare/response_status_count/200': 478,
 'atp/clean_strings/street_address': 450,
 'atp/country/US': 452,
 'atp/field/city/missing': 452,
 'atp/field/country/from_reverse_geocoding': 452,
 'atp/field/email/missing': 452,
 'atp/field/image/missing': 452,
 'atp/field/opening_hours/missing': 452,
 'atp/field/operator/missing': 452,
 'atp/field/operator_wikidata/missing': 452,
 'atp/field/phone/missing': 452,
 'atp/field/postcode/missing': 452,
 'atp/field/twitter/missing': 452,
 'atp/item_scraped_host_count/www.sprouts.com': 452,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 452,
 'downloader/request_bytes': 198480,
 'downloader/request_count': 478,
 'downloader/request_method_count/GET': 478,
 'downloader/response_bytes': 13513106,
 'downloader/response_count': 478,
 'downloader/response_status_count/200': 478,
 'dupefilter/filtered': 56,
 'elapsed_time_seconds': 62.173747,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 7, 5, 33, 8, 718598, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 92952627,
 'httpcompression/response_count': 478,
 'item_scraped_count': 452,
 'items_per_minute': None,
 'log_count/DEBUG': 949,
 'log_count/INFO': 10,
 'request_depth_max': 2,
 'response_received_count': 478,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 477,
 'scheduler/dequeued/memory': 477,
 'scheduler/enqueued': 477,
 'scheduler/enqueued/memory': 477,
 'start_time': datetime.datetime(2025, 4, 7, 5, 32, 6, 544851, tzinfo=datetime.timezone.utc)}
```