### PR TITLE
[Car Max US ] Fix Spider

### DIFF
--- a/locations/spiders/car_max_us.py
+++ b/locations/spiders/car_max_us.py
@@ -6,23 +6,22 @@ from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.user_agents import FIREFOX_LATEST
+from locations.user_agents import FIREFOX_LATEST, BROWSER_DEFAULT
 
 
 class CarMaxUSSpider(Spider):
     name = "car_max_us"
     item_attributes = {"brand": "CarMax", "brand_wikidata": "Q5037190"}
     start_urls = ["https://www.carmax.com/stores/api/all"]
-    user_agent = FIREFOX_LATEST
+    user_agent = BROWSER_DEFAULT
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
-            if location["activeStatus"] != "Active":
+            if location["status"] != "Active":
                 continue
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
             item["street_address"] = merge_address_lines([location["addressLine1"], location["addressLine2"]])
             item["state"] = location["stateAbbreviation"]
             item["website"] = urljoin("https://www.carmax.com/stores/", location["id"])
-
             yield item

--- a/locations/spiders/car_max_us.py
+++ b/locations/spiders/car_max_us.py
@@ -6,7 +6,7 @@ from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.user_agents import FIREFOX_LATEST, BROWSER_DEFAULT
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class CarMaxUSSpider(Spider):


### PR DESCRIPTION
**_Fixes : updated if condition to fix spider_**

```python
{'atp/brand/CarMax': 253,
 'atp/brand_wikidata/Q5037190': 253,
 'atp/category/shop/car': 253,
 'atp/country/US': 253,
 'atp/field/country/from_spider_name': 253,
 'atp/field/email/missing': 253,
 'atp/field/image/missing': 253,
 'atp/field/opening_hours/missing': 253,
 'atp/field/operator/missing': 253,
 'atp/field/operator_wikidata/missing': 253,
 'atp/field/phone/missing': 253,
 'atp/field/twitter/missing': 253,
 'atp/item_scraped_host_count/www.carmax.com': 253,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 253,
 'downloader/request_bytes': 1027,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 468576,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.954636,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 8, 2, 38, 54, 65086, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1337,
 'httpcompression/response_count': 1,
 'item_scraped_count': 253,
 'items_per_minute': None,
 'log_count/DEBUG': 266,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 8, 2, 38, 50, 110450, tzinfo=datetime.timezone.utc)}
```