### PR TITLE
[HSBC TW] Fix spider

### DIFF
--- a/locations/spiders/hsbc_tw.py
+++ b/locations/spiders/hsbc_tw.py
@@ -20,9 +20,14 @@ class HsbcTWSpider(StructuredDataSpider):
 
     def parse(self, response: Response, **kwargs):
         for branch in response.xpath(r'//*[@class="desktop"]//td[2]').xpath("normalize-space()").getall():
-            url = "https://www.hsbc.com.tw/en-tw/branch-list/" + branch.lower().replace(
-                "taoyuan branch", "tahsin branch"
-            ).replace(" (bilingual branch)", "").replace(" ", "-")
+            url = (
+                "https://www.hsbc.com.tw/en-tw/branch-list/"
+                + branch.lower()
+                .replace("taoyuan branch", "tahsin branch")
+                .replace(" (bilingual branch)", "")
+                .replace(" ", "-")
+                + "/"
+            )
             yield scrapy.Request(url=url, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data, **kwargs):


### PR DESCRIPTION
```python
{'atp/brand/HSBC': 25,
 'atp/brand_wikidata/Q5635861': 25,
 'atp/category/amenity/bank': 25,
 'atp/clean_strings/branch': 1,
 'atp/country/TW': 25,
 'atp/field/email/missing': 25,
 'atp/field/image/dropped': 25,
 'atp/field/image/missing': 25,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/phone/missing': 25,
 'atp/field/state/missing': 25,
 'atp/field/twitter/missing': 25,
 'atp/item_scraped_host_count/www.hsbc.com.tw': 25,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 25,
 'downloader/request_bytes': 16920,
 'downloader/request_count': 28,
 'downloader/request_method_count/GET': 28,
 'downloader/response_bytes': 643031,
 'downloader/response_count': 28,
 'downloader/response_status_count/200': 27,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 33.4107,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 8, 11, 31, 8, 979606, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3675115,
 'httpcompression/response_count': 27,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 25,
 'items_per_minute': None,
 'log_count/DEBUG': 64,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 28,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 27,
 'scheduler/dequeued/memory': 27,
 'scheduler/enqueued': 27,
 'scheduler/enqueued/memory': 27,
 'start_time': datetime.datetime(2025, 4, 8, 11, 30, 35, 568906, tzinfo=datetime.timezone.utc)}
```