### PR TITLE
[Mego LV] Fix spider

### DIFF
--- a/locations/spiders/mego_lv.py
+++ b/locations/spiders/mego_lv.py
@@ -11,6 +11,7 @@ class MegoLVSpider(JSONBlobSpider):
     name = "mego_lv"
     start_urls = ["https://mego.lv/wp-admin/admin-ajax.php?action=store_filter"]
     item_attributes = {"brand_wikidata": "Q16363314"}
+    download_timeout = 120
 
     def extract_json(self, response: Response) -> list[dict]:
         stores = []

--- a/locations/spiders/mego_lv.py
+++ b/locations/spiders/mego_lv.py
@@ -1,5 +1,9 @@
+from typing import Iterable
+
 from scrapy.http import Response
 
+from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -17,3 +21,10 @@ class MegoLVSpider(JSONBlobSpider):
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("mapLocation", {}))
         feature["name"] = "Mego"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if hours := feature.get("information"):
+            hours = hours.replace("Darba dienās", "Weekdays").replace("Sest.", "Sat.").replace("Sv.", "Sun.")
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Mego': 90,
 'atp/brand_wikidata/Q16363314': 90,
 'atp/category/shop/supermarket': 90,
 'atp/country/LV': 90,
 'atp/field/branch/missing': 90,
 'atp/field/country/from_spider_name': 90,
 'atp/field/email/missing': 90,
 'atp/field/image/missing': 90,
 'atp/field/operator/missing': 90,
 'atp/field/operator_wikidata/missing': 90,
 'atp/field/phone/missing': 90,
 'atp/field/state/missing': 68,
 'atp/field/street_address/missing': 90,
 'atp/field/twitter/missing': 90,
 'atp/field/website/missing': 90,
 'atp/item_scraped_host_count/mego.lv': 90,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 90,
 'downloader/request_bytes': 629,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 227140,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 12.450951,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 8, 14, 21, 33, 945247, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 90,
 'items_per_minute': None,
 'log_count/DEBUG': 103,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 8, 14, 21, 21, 494296, tzinfo=datetime.timezone.utc)}
```