### PR TITLE
[Magasin Vert FR] Fix spider

### DIFF
--- a/locations/spiders/magasin_vert_fr.py
+++ b/locations/spiders/magasin_vert_fr.py
@@ -30,4 +30,5 @@ class MagasinVertFRSpider(JSONBlobSpider):
             item.update(brand_info)
             item["branch"] = item.pop("name").removeprefix(item["brand"]).strip()
             item["name"] = item["brand"]
+        item["website"] = feature.get("cms_page_url")
         yield item

--- a/locations/spiders/magasin_vert_fr.py
+++ b/locations/spiders/magasin_vert_fr.py
@@ -1,3 +1,8 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -6,7 +11,10 @@ class MagasinVertFRSpider(JSONBlobSpider):
     allowed_domains = [
         "www.monmagasinvert.fr",
     ]
-    item_attributes = {"brand": "Magasin Vert", "brand_wikidata": "Q16661975"}
+    BRANDS = {
+        "mv": {"brand": "Magasin Vert", "brand_wikidata": "Q16661975"},
+        "pv": {"brand": "Point Vert", "brand_wikidata": "Q16661975"},
+    }
     start_urls = [
         "https://www.monmagasinvert.fr/rest/mon_magasin_vert_lot1/V1/inventory/in-store-pickup/pickup-locations/?searchRequest[scopeCode]=mon_magasin_vert_lot1"
     ]
@@ -15,3 +23,9 @@ class MagasinVertFRSpider(JSONBlobSpider):
 
     def pre_process_data(self, feature: dict) -> None:
         feature["ref"] = feature.get("pickup_location_code")
+        feature.update(feature.pop("extension_attributes", {}))
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if brand_info := self.BRANDS.get(feature.get("store_type")):
+            item.update(brand_info)
+        yield item

--- a/locations/spiders/magasin_vert_fr.py
+++ b/locations/spiders/magasin_vert_fr.py
@@ -28,4 +28,6 @@ class MagasinVertFRSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         if brand_info := self.BRANDS.get(feature.get("store_type")):
             item.update(brand_info)
+            item["branch"] = item.pop("name").removeprefix(item["brand"]).strip()
+            item["name"] = item["brand"]
         yield item

--- a/locations/spiders/magasin_vert_fr.py
+++ b/locations/spiders/magasin_vert_fr.py
@@ -1,9 +1,17 @@
-from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class MagasinVertFRSpider(AmastyStoreLocatorSpider):
+class MagasinVertFRSpider(JSONBlobSpider):
     name = "magasin_vert_fr"
     allowed_domains = [
         "www.monmagasinvert.fr",
     ]
     item_attributes = {"brand": "Magasin Vert", "brand_wikidata": "Q16661975"}
+    start_urls = [
+        "https://www.monmagasinvert.fr/rest/mon_magasin_vert_lot1/V1/inventory/in-store-pickup/pickup-locations/?searchRequest[scopeCode]=mon_magasin_vert_lot1"
+    ]
+    locations_key = "items"
+    needs_json_request = True
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature["ref"] = feature.get("pickup_location_code")


### PR DESCRIPTION
Code refactored using new API to fix broken spider because of non-functional API.
```python
{'atp/brand/Magasin Vert': 35,
 'atp/brand/Point Vert': 81,
 'atp/brand_wikidata/Q16661975': 116,
 'atp/category/shop/garden_centre': 116,
 'atp/country/FR': 116,
 'atp/field/country/from_spider_name': 116,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 116,
 'atp/field/operator/missing': 116,
 'atp/field/operator_wikidata/missing': 116,
 'atp/field/state/missing': 116,
 'atp/field/street_address/missing': 116,
 'atp/field/twitter/missing': 116,
 'atp/item_scraped_host_count/www.monmagasinvert.fr': 116,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 116,
 'downloader/request_bytes': 753,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 150371,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.02922,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 9, 6, 14, 42, 604732, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 246,
 'httpcompression/response_count': 1,
 'item_scraped_count': 116,
 'items_per_minute': None,
 'log_count/DEBUG': 129,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 9, 6, 14, 36, 575512, tzinfo=datetime.timezone.utc)}
```