### PR TITLE
[Pioneer CA] Fix Spider

### DIFF
--- a/locations/spiders/pioneer_ca.py
+++ b/locations/spiders/pioneer_ca.py
@@ -1,29 +1,33 @@
+from typing import Any
+
+import scrapy
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
-from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
-class PioneerCASpider(SitemapSpider, StructuredDataSpider):
+class PioneerCASpider(scrapy.Spider):
     name = "pioneer_ca"
     item_attributes = {"brand": "Pioneer", "brand_wikidata": "Q7196684"}
-    sitemap_urls = ["https://www.pioneer.ca/sitemap-stores.xml"]
-    sitemap_rules = [(r"/en/find-station/[^/]+/[^/]+/$", "parse")]
-    wanted_types = ["GasStation"]
+    start_urls = [
+        "https://journie.ca/pioneer/api/locations/nearest?country=CA&pageSize=1000&lat=43.653226&lon=-79.3831843&range=100000000&brand=Pioneer"
+    ]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["name"] = None
-
-        services = response.xpath('//h4[@class="station__icons-list-icon-title"]/text()').getall()
-        apply_yes_no(Extras.ATM, item, "ATM" in services)
-        apply_yes_no(Fuel.DIESEL, item, "Diesel" in services)
-        apply_yes_no(Extras.SELF_CHECKOUT, item, "Pay at pump" in services)
-
-        if "Open 24h" in services:
-            item["opening_hours"] = "24/7"
-
-        apply_category(Categories.FUEL_STATION, item)
-
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            item = DictParser.parse(location)
+            item["street_address"] = location["siteAddressLine1"]
+            item["city"] = location["siteCity"]
+            item["state"] = location["siteStateProvince"]
+            item["postcode"] = location["sitePostalCode"]
+            item["website"] = "https://journie.ca/pioneer/on-en/locations/" + location["siteNumber"]
+            apply_category(Categories.FUEL_STATION, item)
+            item["opening_hours"] = OpeningHours()
+            for day_time in location["siteRegularHours"]:
+                day = day_time["dayOfWeek"]
+                open_time = day_time["openTime"]
+                close_time = day_time["closeTime"]
+                item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+            yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Pioneer': 207,
 'atp/brand_wikidata/Q7196684': 207,
 'atp/category/amenity/fuel': 207,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/CA': 207,
 'atp/field/branch/missing': 207,
 'atp/field/email/missing': 207,
 'atp/field/image/missing': 207,
 'atp/field/operator/missing': 207,
 'atp/field/operator_wikidata/missing': 207,
 'atp/field/phone/missing': 207,
 'atp/field/twitter/missing': 207,
 'atp/item_scraped_host_count/journie.ca': 207,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 207,
 'downloader/request_bytes': 894,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17464,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.254714,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 9, 12, 1, 21, 683675, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 351109,
 'httpcompression/response_count': 1,
 'item_scraped_count': 207,
 'items_per_minute': None,
 'log_count/DEBUG': 220,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 9, 12, 1, 16, 428961, tzinfo=datetime.timezone.utc)}
```