### PR TITLE
Increase max-zoom during run_all_spiders again

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -89,7 +89,7 @@ uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPI
 
 tippecanoe --cluster-distance=25 \
            --drop-rate=g \
-           --maximum-zoom=14 \
+           --maximum-zoom=15 \
            --cluster-maxzoom=g \
            --layer="alltheplaces" \
            --read-parallel \


### PR DESCRIPTION
Trees and grave stones make it so tile 14/4592/6013 couldn't be produced in the latest build.

This allows the pmtiles generator to go down to zoom 15.