### PR TITLE
New spider: Ninety Nine Restaurant & Pub (93 locations)

### DIFF
--- a/locations/spiders/ninety_nine_restaurant_us.py
+++ b/locations/spiders/ninety_nine_restaurant_us.py
@@ -1,0 +1,12 @@
+from locations.storefinders.nomnom import NomNomSpider
+
+
+class NinetyNineRestaurantUSSpider(NomNomSpider):
+    name = "ninety_nine_restaurant_us"
+    start_urls = ["https://order.99restaurants.com/api/restaurants"]
+    item_attributes = {
+        "brand": "Ninety Nine Restaurant & Pub",
+        "brand_wikidata": "Q64358371",
+    }
+    use_calendar = False  # only shows the current day
+    drop_attributes = {"website"}

--- a/locations/storefinders/nomnom.py
+++ b/locations/storefinders/nomnom.py
@@ -71,16 +71,17 @@ class NomNomSpider(Spider):
             apply_yes_no(Extras.TAKEAWAY, item, location["canpickup"] or location["supportscurbside"])
             apply_yes_no(Extras.DRIVE_THROUGH, item, location["supportsdrivethru"])
 
-            calendars = location["calendars"]
-            if isinstance(calendars, dict):
-                calendars = calendars["calendar"]
-            if calendars is None:
-                calendars = []
-            for calendar in calendars:
-                if calendar["type"] == "business":
-                    item["opening_hours"] = self.parse_opening_hours(calendar)
-                elif key := self.CALENDAR_KEYS.get(calendar["type"]):
-                    item["extras"][key] = self.parse_opening_hours(calendar).as_opening_hours()
+            if self.use_calendar:
+                calendars = location["calendars"]
+                if isinstance(calendars, dict):
+                    calendars = calendars["calendar"]
+                if calendars is None:
+                    calendars = []
+                for calendar in calendars:
+                    if calendar["type"] == "business":
+                        item["opening_hours"] = self.parse_opening_hours(calendar)
+                    elif key := self.CALENDAR_KEYS.get(calendar["type"]):
+                        item["extras"][key] = self.parse_opening_hours(calendar).as_opening_hours()
 
             yield from self.post_process_item(item, response, location)
 


### PR DESCRIPTION
```py
{'atp/brand/Ninety Nine Restaurant & Pub': 93,
 'atp/brand_wikidata/Q64358371': 93,
 'atp/category/amenity/restaurant': 93,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/street_address': 1,
 'atp/country/US': 93,
 'atp/field/email/missing': 93,
 'atp/field/image/missing': 93,
 'atp/field/opening_hours/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/field/website/missing': 93,
 'atp/item_scraped_host_count/order.99restaurants.com': 93,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 633,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12783,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.838683,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 9, 22, 24, 18, 808162, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 370756,
 'httpcompression/response_count': 1,
 'item_scraped_count': 93,
 'items_per_minute': None,
 'log_count/DEBUG': 106,
 'log_count/INFO': 9,
 'memusage/max': 197885952,
 'memusage/startup': 197885952,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 9, 22, 24, 15, 969479, tzinfo=datetime.timezone.utc)}
```