### PR TITLE
[STC SE] Fix Spider

### DIFF
--- a/locations/spiders/stc_se.py
+++ b/locations/spiders/stc_se.py
@@ -6,11 +6,12 @@ import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from urllib.parse import urljoin
 
 
 class StcSESpider(scrapy.Spider):
     name = "stc_se"
-    item_attributes = {"brand": "STC", "brand_wikidata": "Q124061743"}
+    item_attributes = {"brand": "STC", "brand_wikidata": "Q115114066"}
     start_urls = ["https://www.stc.se/gym"]
 
     def parse(self, response):
@@ -18,6 +19,7 @@ class StcSESpider(scrapy.Spider):
         for club in json.loads(re.search(r"clubsData\":(\[.*\]),\"clubTypeInformation", raw_data).group(1)):
             item = DictParser.parse(club)
             item["branch"] = item.pop("name")
-            item["website"] = "https://www.stc.se/gym/" + club["slug"]
+            item["street_address"] = item.pop("street")
+            item["website"] = urljoin("https://www.stc.se/gym/", club["slug"])
             apply_category(Categories.GYM, item)
             yield item

--- a/locations/spiders/stc_se.py
+++ b/locations/spiders/stc_se.py
@@ -1,12 +1,12 @@
 import json
 import re
+from urllib.parse import urljoin
 
 import chompjs
 import scrapy
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from urllib.parse import urljoin
 
 
 class StcSESpider(scrapy.Spider):

--- a/locations/spiders/stc_se.py
+++ b/locations/spiders/stc_se.py
@@ -1,34 +1,23 @@
-import pprint
-from urllib.parse import urljoin
+import json
+import re
 
+import chompjs
 import scrapy
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 
 
 class StcSESpider(scrapy.Spider):
     name = "stc_se"
     item_attributes = {"brand": "STC", "brand_wikidata": "Q124061743"}
-    start_urls = ["https://www.stc.se/assets/clubs.json"]
+    start_urls = ["https://www.stc.se/gym"]
 
     def parse(self, response):
-        for club in response.json():
+        raw_data = chompjs.parse_js_object(response.xpath('//*[contains(text(),"clubsData")]/text()').get())[1]
+        for club in json.loads(re.search(r"clubsData\":(\[.*\]),\"clubTypeInformation", raw_data).group(1)):
             item = DictParser.parse(club)
             item["branch"] = item.pop("name")
-            item["city"] = item["city"].title()
-            item["street_address"] = item.pop("street")
-            item["website"] = urljoin("https://www.stc.se/gym/", club["slug"])
-            apply_yes_no(Extras.WIFI, item, "wifi" in club["includes"])
-
-            item["opening_hours"] = OpeningHours()
-            for rule in club["openingHours"]["default"]["data"]:
-                pprint.pp(rule)
-                if rule["hours"]["unmanned"] == "Dygnet runt":
-                    start_time, end_time = "00:00", "23:59"
-                else:
-                    start_time, end_time = rule["hours"]["unmanned"].replace(" ", "").replace(".", ":").split("-")
-                item["opening_hours"].add_range(rule["day"], start_time, end_time)
+            item["website"] = "https://www.stc.se/gym/" + club["slug"]
             apply_category(Categories.GYM, item)
             yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/STC': 257,
 'atp/brand_wikidata/Q124061743': 257,
 'atp/category/leisure/fitness_centre': 257,
 'atp/country/SE': 257,
 'atp/field/country/from_spider_name': 257,
 'atp/field/email/missing': 257,
 'atp/field/image/missing': 257,
 'atp/field/name/missing': 257,
 'atp/field/opening_hours/missing': 257,
 'atp/field/operator/missing': 257,
 'atp/field/operator_wikidata/missing': 257,
 'atp/field/phone/missing': 257,
 'atp/field/state/missing': 257,
 'atp/field/street_address/missing': 257,
 'atp/field/twitter/missing': 257,
 'atp/item_scraped_host_count/www.stc.se': 257,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 257,
 'downloader/request_bytes': 595,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 25812,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.203155,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 10, 9, 9, 49, 276715, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 169920,
 'httpcompression/response_count': 1,
 'item_scraped_count': 257,
 'items_per_minute': None,
 'log_count/DEBUG': 270,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 10, 9, 9, 46, 73560, tzinfo=datetime.timezone.utc)}
```