### PR TITLE
[Starbucks AE] Add spider

### DIFF
--- a/locations/spiders/starbucks_ae.py
+++ b/locations/spiders/starbucks_ae.py
@@ -1,0 +1,25 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.items import Feature
+from locations.spiders.starbucks_us import STARBUCKS_SHARED_ATTRIBUTES
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class StarbucksAESpider(SitemapSpider, StructuredDataSpider):
+    name = "starbucks_ae"
+    item_attributes = STARBUCKS_SHARED_ATTRIBUTES
+    sitemap_urls = ["https://locations.starbucks.ae/robots.txt"]
+    sitemap_rules = [(r"ae/directory/[^/]+/[^/]+$", "parse")]
+    wanted_types = ["Restaurant"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["image"] = None
+        item["branch"] = item.pop("name").removeprefix("Starbucks ")
+
+        item["website"] = item["extras"]["website:ar"] = response.urljoin(
+            response.xpath('//a[@class="Header-langOption"][text()="Arabic"]/@href').get()
+        )
+        item["extras"]["website:en"] = response.url
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Starbucks': 325,
 'atp/brand_wikidata/Q37158': 325,
 'atp/category/amenity/cafe': 325,
 'atp/cdn/cloudflare/response_count': 328,
 'atp/cdn/cloudflare/response_status_count/200': 328,
 'atp/country/AE': 325,
 'atp/field/city/missing': 325,
 'atp/field/country/from_spider_name': 325,
 'atp/field/email/missing': 325,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 325,
 'atp/field/operator_wikidata/missing': 325,
 'atp/field/phone/missing': 11,
 'atp/field/postcode/missing': 325,
 'atp/field/state/missing': 325,
 'atp/field/twitter/missing': 325,
 'atp/item_scraped_host_count/locations.starbucks.ae': 325,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 325,
 'downloader/request_bytes': 191654,
 'downloader/request_count': 328,
 'downloader/request_method_count/GET': 328,
 'downloader/response_bytes': 7188469,
 'downloader/response_count': 328,
 'downloader/response_status_count/200': 328,
 'elapsed_time_seconds': 3.809428,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 10, 14, 54, 29, 271544, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 328,
 'httpcompression/response_bytes': 59635996,
 'httpcompression/response_count': 328,
 'item_scraped_count': 325,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 280948736,
 'memusage/startup': 280948736,
 'request_depth_max': 2,
 'response_received_count': 328,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 327,
 'scheduler/dequeued/memory': 327,
 'scheduler/enqueued': 327,
 'scheduler/enqueued/memory': 327,
 'start_time': datetime.datetime(2025, 4, 10, 14, 54, 25, 462116, tzinfo=datetime.timezone.utc)}
```