### PR TITLE
[Napa Auto Care] Add  Spider (16k auto care centers)

### DIFF
--- a/locations/spiders/napa_auto_care.py
+++ b/locations/spiders/napa_auto_care.py
@@ -1,0 +1,36 @@
+import re
+import urllib
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class NapaAutoCareSpider(SitemapSpider):
+    name = "napa_auto_care"
+    item_attributes = {"brand": "NAPA AutoCare Center", "brand_wikidata": "Q6970842"}
+    sitemap_urls = ["https://www.napaonline.com/autocare_sitemap.xml"]
+    sitemap_rules = [(r"/en/autocare/\?facilityId=", "parse")]
+    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if match := re.search(r"https://maps\.googleapis\.com/maps/api/staticmap\?center=(.+?)\"", response.text):
+            location_info = urllib.parse.unquote(match.group(1))
+            item = Feature()
+            item["ref"] = response.url.split("facilityId=")[1].strip("/")
+            item["website"] = response.url
+            item["addr_full"] = clean_address(location_info.split("Phone:")[0]).replace("+", " ")
+            if phone := re.search(r"phoneNumber=\"(.+?)\"/>", location_info):
+                item["phone"] = phone.group(1)
+            if coordinates := re.search(r"\|label:\d\|(-?\d+\.\d+),(-?\d+\.\d+)&", location_info):
+                item["lat"], item["lon"] = coordinates.groups()
+            apply_category(Categories.SHOP_CAR_REPAIR, item)
+            yield item


### PR DESCRIPTION
According to Napa's [website](https://www.napaonline.com/en/discover-napa), there are 18k auto care centers. 
![image](https://github.com/user-attachments/assets/0730cc46-8d92-47d2-9825-bdc62ac35dad)

Based on `sitemap` used expected count after complete spider run will be  around `16k`.
Summary generated for 2k POIs.
```python
{'atp/brand/NAPA AutoCare Center': 2016,
 'atp/brand_wikidata/Q6970842': 2016,
 'atp/category/shop/car_repair': 2016,
 'atp/country/CA': 3,
 'atp/country/KY': 1,
 'atp/country/US': 2012,
 'atp/field/branch/missing': 2016,
 'atp/field/city/missing': 2016,
 'atp/field/country/from_reverse_geocoding': 2016,
 'atp/field/email/missing': 2016,
 'atp/field/image/missing': 2016,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 2016,
 'atp/field/operator/missing': 2016,
 'atp/field/operator_wikidata/missing': 2016,
 'atp/field/phone/invalid': 29,
 'atp/field/postcode/missing': 2016,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 2016,
 'atp/field/twitter/missing': 2016,
 'atp/item_scraped_host_count/www.napaonline.com': 2016,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2015,
 'atp/nsi/match_failed': 1,
 'downloader/exception_count': 6,
 'downloader/exception_type_count/playwright._impl._errors.TimeoutError': 6,
 'downloader/request_bytes': 1619097,
 'downloader/request_count': 2040,
 'downloader/request_method_count/GET': 2040,
 'downloader/response_bytes': 565215763,
 'downloader/response_count': 2034,
 'downloader/response_status_count/200': 2018,
 'downloader/response_status_count/530': 16,
 'elapsed_time_seconds': 3834.329701,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 4, 10, 17, 6, 38, 244487, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 16,
 'httperror/response_ignored_status_count/530': 16,
 'item_scraped_count': 2016,
 'items_per_minute': None,
 'log_count/DEBUG': 397820,
 'log_count/ERROR': 6,
 'log_count/INFO': 92,
 'log_count/WARNING': 6,
 'memusage/max': 525856768,
 'memusage/startup': 199462912,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2040,
 'playwright/page_count/closed': 2040,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 195917,
 'playwright/request_count/aborted': 193739,
 'playwright/request_count/method/GET': 195917,
 'playwright/request_count/navigation': 2056,
 'playwright/request_count/resource_type/document': 2056,
 'playwright/request_count/resource_type/image': 104994,
 'playwright/request_count/resource_type/script': 34321,
 'playwright/request_count/resource_type/stylesheet': 54546,
 'playwright/response_count': 2056,
 'playwright/response_count/method/GET': 2056,
 'playwright/response_count/resource_type/document': 2056,
 'request_depth_max': 1,
 'response_received_count': 2034,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2039,
 'scheduler/dequeued/memory': 2039,
 'scheduler/enqueued': 16309,
 'scheduler/enqueued/memory': 16309,
 'start_time': datetime.datetime(2025, 4, 10, 16, 2, 43, 914786, tzinfo=datetime.timezone.utc)}
```