### PR TITLE
[Pizza Hut FR] Fix branding

### DIFF
--- a/locations/spiders/pizza_hut_fr.py
+++ b/locations/spiders/pizza_hut_fr.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -8,19 +9,16 @@ from locations.user_agents import BROWSER_DEFAULT
 class PizzaHutFRSpider(SitemapSpider, StructuredDataSpider):
     name = "pizza_hut_fr"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
-    PIZZA_HUT_DELIVERY = {"brand": "Pizza Hut Delivery", "brand_wikidata": "Q107293079"}
     sitemap_urls = ["https://www.pizzahut.fr/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.pizzahut\.fr\/huts\/[-\w]+\/([-.\w]+)\/$", "parse_sd")]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    user_agent = BROWSER_DEFAULT
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        if item["website"].startswith("https://www.pizzahut.fr/huts/"):
-            item.update(self.PIZZA_HUT_DELIVERY)
-            apply_category(Categories.FAST_FOOD, item)
-        else:
-            apply_category(Categories.RESTAURANT, item)
-
         if not item["opening_hours"]:
-            return
+            set_closed(item)
+
+        item["branch"] = item.pop("name").removeprefix("Pizza Hut ")
+
+        apply_category(Categories.RESTAURANT, item)
 
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Pizza Hut': 118,
 'atp/brand_wikidata/Q191615': 118,
 'atp/category/amenity/restaurant': 118,
 'atp/closed_poi': 1,
 'atp/country/FR': 118,
 'atp/field/email/missing': 118,
 'atp/field/image/dropped': 118,
 'atp/field/image/missing': 118,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 118,
 'atp/field/operator_wikidata/missing': 118,
 'atp/field/twitter/missing': 118,
 'atp/item_scraped_host_count/www.pizzahut.fr': 118,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 118,
 'downloader/request_bytes': 38738,
 'downloader/request_count': 120,
 'downloader/request_method_count/GET': 120,
 'downloader/response_bytes': 1438756,
 'downloader/response_count': 120,
 'downloader/response_status_count/200': 120,
 'elapsed_time_seconds': 1.189478,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 11, 10, 54, 0, 649698, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 120,
 'httpcompression/response_bytes': 5554309,
 'httpcompression/response_count': 120,
 'item_scraped_count': 118,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 274505728,
 'memusage/startup': 274505728,
 'request_depth_max': 1,
 'response_received_count': 120,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 119,
 'scheduler/dequeued/memory': 119,
 'scheduler/enqueued': 119,
 'scheduler/enqueued/memory': 119,
 'start_time': datetime.datetime(2025, 4, 11, 10, 53, 59, 460220, tzinfo=datetime.timezone.utc)}
```