### PR TITLE
Allow larger tiles in the global run

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -90,6 +90,7 @@ uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPI
 tippecanoe --cluster-distance=25 \
            --drop-rate=g \
            --maximum-zoom=15 \
+           --maximum-tile-bytes=1000000 \
            --cluster-maxzoom=g \
            --layer="alltheplaces" \
            --read-parallel \


### PR DESCRIPTION
We're still running into problems with the all spiders run, so this gives more room to the very dense tiles.