### PR TITLE
Increase max-zoom during run_all_spiders again, again

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -89,7 +89,7 @@ uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPI
 
 tippecanoe --cluster-distance=25 \
            --drop-rate=g \
-           --maximum-zoom=15 \
+           --maximum-zoom=16 \
            --maximum-tile-bytes=1000000 \
            --cluster-maxzoom=g \
            --layer="alltheplaces" \


### PR DESCRIPTION
Continuation from #12833

The gravestones are causing individual tiles to get very busy and fail the build.