### PR TITLE
[Pizza Hut VN] Fix spider

### DIFF
--- a/locations/spiders/pizza_hut_vn.py
+++ b/locations/spiders/pizza_hut_vn.py
@@ -19,11 +19,18 @@ from locations.user_agents import BROWSER_DEFAULT
 class PizzaHutVNSpider(scrapy.Spider):
     name = "pizza_hut_vn"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
-    start_urls = ["https://pizzahut.vn/_next/static/chunks/3070-0d2156c9136abbb1.js"]
+    start_urls = ["https://pizzahut.vn/store-location?area=north"]
     api_url = "https://rwapi.pizzahut.vn/api/store/GetAllStoreList"
     user_agent = BROWSER_DEFAULT
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Search for the desired JavaScript file
+        yield response.follow(
+            url=response.xpath("//script/@src").re(r"/_next/static/chunks/3070-\w+\.js")[-1],
+            callback=self.parse_auth_token,
+        )
+
+    def parse_auth_token(self, response: Response, **kwargs: Any) -> Any:
         timestamp = int(time.time() * 1000)
         device_uid = uuid.uuid4()
 


### PR DESCRIPTION
```python
{'atp/brand/Pizza Hut': 118,
 'atp/brand_wikidata/Q191615': 118,
 'atp/category/amenity/restaurant': 118,
 'atp/clean_strings/addr_full': 8,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/lat': 1,
 'atp/clean_strings/lon': 117,
 'atp/country/VN': 118,
 'atp/field/city/missing': 118,
 'atp/field/country/from_spider_name': 118,
 'atp/field/email/missing': 118,
 'atp/field/image/missing': 118,
 'atp/field/operator/missing': 118,
 'atp/field/operator_wikidata/missing': 118,
 'atp/field/phone/missing': 118,
 'atp/field/postcode/missing': 118,
 'atp/field/state/missing': 118,
 'atp/field/street_address/missing': 118,
 'atp/field/twitter/missing': 118,
 'atp/field/website/missing': 118,
 'atp/item_scraped_host_count/rwapi.pizzahut.vn': 118,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 118,
 'downloader/request_bytes': 1779,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 132280,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 17.857606,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 14, 13, 30, 36, 99033, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 384052,
 'httpcompression/response_count': 3,
 'item_scraped_count': 118,
 'items_per_minute': None,
 'log_count/DEBUG': 135,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 5,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 4, 14, 13, 30, 18, 241427, tzinfo=datetime.timezone.utc)}

```