### PR TITLE
[Aldi Sud CN] Fix Spider

### DIFF
--- a/locations/spiders/aldi_sud_cn.py
+++ b/locations/spiders/aldi_sud_cn.py
@@ -1,5 +1,3 @@
-import re
-
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category
@@ -23,10 +21,13 @@ class AldiSudCNSpider(Spider):
                     item["branch"] = store["title-en"].removeprefix("ALDI ").removesuffix(" Store")
                     item["addr_full"] = store["address-en"]
 
-                    oh = OpeningHours()
-                    start_time, end_time = re.search(r"(\d+:\d+)-(\d+:\d+)", store["hours"]).groups()
-                    oh.add_days_range(DAYS, start_time, end_time)
-                    item["opening_hours"] = oh
+                    try:
+                        oh = OpeningHours()
+                        start_time, end_time = store["hours"].split("-")
+                        oh.add_days_range(DAYS, start_time, end_time)
+                        item["opening_hours"] = oh
+                    except:
+                        self.logger.error("Error parsing opening hours: {}".format(store["hours"]))
 
                     # TODO: Transform store["locationX"] store["locationX"]
 

--- a/locations/spiders/aldi_sud_cn.py
+++ b/locations/spiders/aldi_sud_cn.py
@@ -17,9 +17,9 @@ class AldiSudCNSpider(Spider):
         districts = response.json().values()
         for district in districts:
             for store_data in district["district-data"].values():
-                for store in store_data["stores"].values():
+                for ref, store in store_data["stores"].items():
                     item = Feature()
-                    item["ref"] = store["mapLink"]
+                    item["ref"] = ref
                     item["branch"] = store["title-en"].removeprefix("ALDI ").removesuffix(" Store")
                     item["addr_full"] = store["address-en"]
                     oh = OpeningHours()

--- a/locations/spiders/aldi_sud_cn.py
+++ b/locations/spiders/aldi_sud_cn.py
@@ -22,11 +22,11 @@ class AldiSudCNSpider(Spider):
                     item["ref"] = ref
                     item["branch"] = store["title-en"].removeprefix("ALDI ").removesuffix(" Store")
                     item["addr_full"] = store["address-en"]
+
                     oh = OpeningHours()
-                    for day in DAYS:
-                        start_time, end_time = re.search(r"(\d+:\d+)-(\d+:\d+)", store["hours"]).groups()
-                        oh.add_range(day, start_time, end_time)
-                    item["opening_hours"] = oh.as_opening_hours()
+                    start_time, end_time = re.search(r"(\d+:\d+)-(\d+:\d+)", store["hours"]).groups()
+                    oh.add_days_range(DAYS, start_time, end_time)
+                    item["opening_hours"] = oh
 
                     # TODO: Transform store["locationX"] store["locationX"]
 


### PR DESCRIPTION
**_Fixes : updated parse method to fix spider_**

```python
{'atp/brand/Aldi': 70,
 'atp/brand_wikidata/Q41171672': 70,
 'atp/category/shop/supermarket': 70,
 'atp/clean_strings/branch': 1,
 'atp/country/CN': 70,
 'atp/field/city/missing': 70,
 'atp/field/email/missing': 70,
 'atp/field/image/missing': 70,
 'atp/field/lat/missing': 70,
 'atp/field/lon/missing': 70,
 'atp/field/operator/missing': 70,
 'atp/field/operator_wikidata/missing': 70,
 'atp/field/phone/missing': 70,
 'atp/field/postcode/missing': 70,
 'atp/field/state/missing': 70,
 'atp/field/street_address/missing': 70,
 'atp/field/twitter/missing': 70,
 'atp/field/website/missing': 70,
 'atp/item_scraped_host_count/aldi.cn': 70,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 70,
 'atp/tt_locate/fail': 70,
 'downloader/request_bytes': 318,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 33358,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.321876,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 15, 6, 30, 12, 163338, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 70,
 'items_per_minute': None,
 'log_count/DEBUG': 107,
 'log_count/INFO': 10,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 15, 6, 30, 8, 841462, tzinfo=datetime.timezone.utc),
 'tt_requires_proxy': True}
 
```