### PR TITLE
[Shell AU] Fix Spider

### DIFF
--- a/locations/spiders/shell_au.py
+++ b/locations/spiders/shell_au.py
@@ -7,7 +7,7 @@ from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.items import Feature
 from locations.spiders.otr_au import OtrAUSpider
 from locations.spiders.shell import ShellSpider
-from locations.spiders.vets4pets_gb import set_located_in
+from locations.spiders.tesco_gb import set_located_in
 from locations.storefinders.mapdata_services import MapDataServicesSpider
 
 SHOP_BRANDS = {
@@ -43,7 +43,7 @@ class ShellAUSpider(MapDataServicesSpider):
         if feature.get("retail_shop") == "1":
             shop = item.deepcopy()
             shop["ref"] = "{}-shop".format(shop["ref"])
-            set_located_in(shop, FUEL_BRANDS[feature["forecourt_brand"]])
+            set_located_in(FUEL_BRANDS[feature["forecourt_brand"]], shop)
 
             apply_category(Categories.SHOP_CONVENIENCE, shop)
 


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/OTR': 139,
 'atp/brand/Reddy Express': 565,
 'atp/brand/Shell': 1112,
 'atp/brand_wikidata/Q110716465': 1112,
 'atp/brand_wikidata/Q116394019': 139,
 'atp/brand_wikidata/Q5144653': 565,
 'atp/category/amenity/fuel': 1112,
 'atp/category/shop/convenience': 1056,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 2,
 'atp/country/AU': 2168,
 'atp/field/branch/missing': 1354,
 'atp/field/brand/missing': 352,
 'atp/field/brand_wikidata/missing': 352,
 'atp/field/email/missing': 2168,
 'atp/field/image/missing': 2168,
 'atp/field/name/missing': 352,
 'atp/field/opening_hours/missing': 1668,
 'atp/field/operator/missing': 2168,
 'atp/field/operator_wikidata/missing': 2168,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 11,
 'atp/field/twitter/missing': 2168,
 'atp/field/website/missing': 2168,
 'atp/item_scraped_host_count/data.nowwhere.com.au': 2168,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1816,
 'downloader/request_bytes': 585,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 2471602,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 11.86076,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 15, 7, 31, 41, 461327, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2168,
 'items_per_minute': None,
 'log_count/DEBUG': 2180,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 15, 7, 31, 29, 600567, tzinfo=datetime.timezone.utc)}
```