### PR TITLE
Add missing country code for Georgia, British Virgin Islands

### DIFF
--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -47,6 +47,7 @@ COUNTRYCODE_COMPONENTS = {
     "FR",
     "GA",
     "GB",
+    "GE",
     "GG",
     "GH",
     "GR",

--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -129,6 +129,7 @@ COUNTRYCODE_COMPONENTS = {
     "UY",
     "UZ",
     "VE",
+    "VG",
     "VN",
     "XK",
     "ZA",


### PR DESCRIPTION
https://countrycode.org/georgia (chains like https://willmart.ge/)
https://countrycode.org/britishvirginislands (chains like https://riteway.vg)