### PR TITLE
[Gbfs] Fix Spider

### DIFF
--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -353,7 +353,7 @@ class GbfsSpider(CSVFeedSpider):
 
     def parse_row(self, response, row):
         url = row["Auto-Discovery URL"]
-        if auth := row["Authentication Info"]:
+        if auth := row["Authentication Info URL"]:
             if auth.startswith("http"):
                 return
             else:
@@ -369,7 +369,7 @@ class GbfsSpider(CSVFeedSpider):
         for feed in DictParser.get_nested_key(data, "feeds") or []:
             if feed["name"] == "station_information":
                 url = feed["url"]
-                if auth := kwargs["Authentication Info"]:
+                if auth := kwargs["Authentication Info URL"]:
                     if auth not in url:
                         url = "{}?{}".format(url, auth)
                 yield JsonRequest(url=url, cb_kwargs=kwargs, callback=self.parse_stations)


### PR DESCRIPTION
**_Fixes : updated keys to fix spider_**

```python
{'atp/brand/AAR Bike': 120,
 'atp/brand/AB mit Lara': 13,
 'atp/brand/AQTA': 10,
 'atp/brand/ARVAL': 1,
 'atp/brand/AW-bike': 17,
 'atp/brand/Accès Vélo': 14,
 'atp/brand/Altervelo Libre-service': 31,
 'atp/brand/Ambici': 215,
 'atp/brand/Arizona': 119,
 'atp/brand/Arriva Nitra Slovakia': 16,
 'atp/brand/Aventura BCycle': 5,
 'atp/brand/BARshare Barnim All': 20,
 'atp/brand/BARshare Barnim Cars': 20,
 'atp/brand/BBK Klimabizi': 4,
 'atp/brand/BIKER Białystok Poland': 64,
 'atp/brand/BIKETOWN': 250,
 'atp/brand/BL bike': 5,
 'atp/brand/Bay Wheels': 568,
 'atp/brand/BelfastBikes': 59,
 'atp/brand/Bentonville BCycle': 22,
 'atp/brand/Bergen City Bike': 108,
 'atp/brand/Bergisches e-Bike': 56,
 'atp/brand/Beryl - BCP': 467,
 'atp/brand/Beryl - Brighton': 109,
 'atp/brand/Beryl - Cornwall': 106,
 'atp/brand/Beryl - Greater Manchester': 284,
 'atp/brand/Beryl - Hackney Cargo Bike': 4,
 'atp/brand/Beryl - Hereford': 74,
 'atp/brand/Beryl - Hertsmere': 27,
 'atp/brand/Beryl - Isle of Wight': 88,
 'atp/brand/Beryl - Leeds': 82,
 'atp/brand/Beryl - Norwich': 192,
 'atp/brand/Beryl - Plymouth': 134,
 'atp/brand/Beryl - Portsmouth': 104,
 'atp/brand/Beryl - Southampton': 105,
 'atp/brand/Beryl - Watford': 95,
 'atp/brand/Beryl - West Midlands': 424,
 'atp/brand/Beryl - Westminster Cargo Bike': 4,
 'atp/brand/Beryl - Wool': 7,
 'atp/brand/BiciMAD': 1233,
 'atp/brand/BiciMislata Mislata': 20,
 'atp/brand/BiciPalma': 84,
 'atp/brand/Bicicoruña': 53,
 'atp/brand/BicikeLJ': 86,
 'atp/brand/Bicing': 516,
 'atp/brand/Bike Brasilia': 69,
 'atp/brand/Bike Chattanooga': 43,
 'atp/brand/Bike Estácio': 50,
 'atp/brand/Bike Itaú - Pernambuco': 90,
 'atp/brand/Bike Itaú - Rio': 408,
 'atp/brand/Bike Itaú - Salvador': 56,
 'atp/brand/Bike Itaú - Sampa': 241,
 'atp/brand/Bike Itaú - Santiago': 190,
 'atp/brand/Bike Nordelta': 21,
 'atp/brand/Bike Porto Alegre': 90,
 'atp/brand/Bike Share Toronto': 877,
 'atp/brand/BikeKIA': 36,
 'atp/brand/BikeLNK': 21,
 'atp/brand/Bikeshare Kona': 23,
 'atp/brand/Biki': 1055,
 'atp/brand/Bilbaobizi (Bilbao)': 46,
 'atp/brand/Bird': 3884,
 'atp/brand/Bird Ottawa': 580,
 'atp/brand/Bizi': 108,
 'atp/brand/Bizkaibizi Spain': 84,
 'atp/brand/Blue Bikes': 529,
 'atp/brand/Blue-bike': 199,
 'atp/brand/Boaz Bikes': 1,
 'atp/brand/Bogotá': 292,
 'atp/brand/Bolt Alytus': 20,
 'atp/brand/Bolt Antwerp': 77,
 'atp/brand/Bolt Bremen': 11,
 'atp/brand/Bolt Brussels': 2320,
 'atp/brand/Bolt Bydgoszcz': 24,
 'atp/brand/Bolt Charleroi': 75,
 'atp/brand/Bolt Covilhã': 65,
 'atp/brand/Bolt Dinant': 23,
 'atp/brand/Bolt Dusseldorf': 234,
 'atp/brand/Bolt Elblag': 18,
 'atp/brand/Bolt Enschede': 231,
 'atp/brand/Bolt Esposende': 48,
 'atp/brand/Bolt Ghent': 1802,
 'atp/brand/Bolt Groningen': 683,
 'atp/brand/Bolt Helsinki': 300,
 'atp/brand/Bolt Inowrocław': 4,
 'atp/brand/Bolt Karlsruhe': 28,
 'atp/brand/Bolt Konin': 1,
 'atp/brand/Bolt Liège': 840,
 'atp/brand/Bolt Mikołajki': 16,
 'atp/brand/Bolt Namur': 153,
 'atp/brand/Bolt Nicosia': 302,
 'atp/brand/Bolt Nijmegen': 55,
 'atp/brand/Bolt Oviedo': 164,
 'atp/brand/Bolt Ponta Delgada': 63,
 'atp/brand/Bolt Portlaoise': 48,
 'atp/brand/Bolt Stuttgart': 28,
 'atp/brand/Bolt Władysławowo': 230,
 'atp/brand/Bolt Ypres': 39,
 'atp/brand/Bonn nextbike': 78,
 'atp/brand/Boulder BCycle': 55,
 'atp/brand/Broward B-cycle': 19,
 'atp/brand/Bublr Bikes': 110,
 'atp/brand/Buzau VeloCity': 49,
 'atp/brand/Bysykkel': 6,
 'atp/brand/C-Vélo': 58,
 'atp/brand/CaliVélo': 53,
 'atp/brand/Call a Bike': 1386,
 'atp/brand/CapCotentin': 19,
 'atp/brand/CapMetro': 73,
 'atp/brand/Capital Bikeshare': 792,
 'atp/brand/Car-ship': 20,
 'atp/brand/CarSharing Renningen': 30,
 'atp/brand/Careem BIKE': 277,
 'atp/brand/Chełmski Rower': 17,
 'atp/brand/Choletbus 2 Roues': 12,
 'atp/brand/Cincy Red Bike': 70,
 'atp/brand/Citi Bike': 2233,
 'atp/brand/Citiz AUPA': 8,
 'atp/brand/Citiz Alpes Loire': 372,
 'atp/brand/Citiz Angers': 23,
 'atp/brand/Citiz BFC': 54,
 'atp/brand/Citiz Développement': 48,
 'atp/brand/Citiz Gironde': 106,
 'atp/brand/Citiz Grand Est': 248,
 'atp/brand/Citiz Grand Poitiers': 21,
 'atp/brand/Citiz LPA': 218,
 'atp/brand/Citiz La Rochelle': 24,
 'atp/brand/Citiz Lille Arras': 74,
 'atp/brand/Citiz Nantes': 50,
 'atp/brand/Citiz Occitanie': 115,
 'atp/brand/Citiz Ogalo': 6,
 'atp/brand/Citiz Provence': 100,
 'atp/brand/Citiz Rennes Métropole': 53,
 'atp/brand/Clemson BikeShare': 12,
 'atp/brand/Co-bikes': 2,
 'atp/brand/CoGo': 92,
 "atp/brand/Cycl'AM": 32,
 'atp/brand/CyclOcity': 23,
 'atp/brand/Cyclocity': 35,
 'atp/brand/Cyclolibre': 10,
 'atp/brand/Cyclovis': 27,
 'atp/brand/Cykl': 13,
 'atp/brand/Częstochowski Rower Miejski Poland': 26,
 'atp/brand/DCS Bike': 5,
 'atp/brand/Dbizi': 69,
 'atp/brand/Deer': 405,
 'atp/brand/Dej Velo City': 14,
 'atp/brand/Des Moines B-cycle': 29,
 'atp/brand/Die Grüne Flotte': 261,
 'atp/brand/Docomo Bike Share': 6109,
 'atp/brand/Donkey Republic': 7714,
 'atp/brand/Donkey Republic Westhoek': 56,
 'atp/brand/Dott': 42209,
 'atp/brand/Dott Aachen': 8,
 'atp/brand/Dott Abu Dhabi': 1295,
 'atp/brand/Dott Arezzo': 67,
 'atp/brand/Dott Asker': 389,
 'atp/brand/Dott Baden bei Wien': 46,
 'atp/brand/Dott Bari': 41,
 'atp/brand/Dott Basel': 32,
 'atp/brand/Dott Basildon': 56,
 'atp/brand/Dott Bath': 196,
 'atp/brand/Dott Berlin': 486,
 'atp/brand/Dott Bialogard': 48,
 'atp/brand/Dott Bielefeld': 28,
 'atp/brand/Dott Bochum': 7,
 'atp/brand/Dott Bonn': 3,
 'atp/brand/Dott Bourgoin Jallieu': 70,
 'atp/brand/Dott Braintree': 26,
 'atp/brand/Dott Braniewo': 15,
 'atp/brand/Dott Bratislava': 734,
 'atp/brand/Dott Bregenz': 83,
 'atp/brand/Dott Brodnica': 10,
 'atp/brand/Dott Brunswick': 40,
 'atp/brand/Dott Brühl': 78,
 'atp/brand/Dott Budapest': 931,
 'atp/brand/Dott Bytom': 2,
 'atp/brand/Dott Böblingen': 8,
 'atp/brand/Dott CASGBS': 343,
 'atp/brand/Dott Chelmsford': 65,
 'atp/brand/Dott Colchester': 80,
 'atp/brand/Dott Cologne': 57,
 'atp/brand/Dott Copenhagen': 8294,
 'atp/brand/Dott Cottbus': 3,
 'atp/brand/Dott Darmstadt': 21,
 'atp/brand/Dott Doha': 101,
 'atp/brand/Dott Dornbirn': 2,
 'atp/brand/Dott Dortmund': 5,
 'atp/brand/Dott Drammen': 39,
 'atp/brand/Dott Dubai': 341,
 'atp/brand/Dott Dubai Hills': 7,
 'atp/brand/Dott Duisburg': 1,
 'atp/brand/Dott Dunaujvaros': 23,
 'atp/brand/Dott Dusseldorf': 239,
 'atp/brand/Dott Eindhoven': 140,
 'atp/brand/Dott Elbląg': 59,
 'atp/brand/Dott Elmshorn': 1,
 'atp/brand/Dott Erlangen': 13,
 'atp/brand/Dott Eskilstuna': 62,
 'atp/brand/Dott Espoo': 35,
 'atp/brand/Dott Essen': 7,
 'atp/brand/Dott Feldkirchen bei Graz': 24,
 'atp/brand/Dott Flensburg': 30,
 'atp/brand/Dott Frankfurt': 156,
 'atp/brand/Dott Friedrichshafen': 38,
 'atp/brand/Dott Gdansk': 489,
 'atp/brand/Dott Gera': 24,
 'atp/brand/Dott Godollo': 79,
 'atp/brand/Dott Goleniow': 17,
 'atp/brand/Dott Gothenburg': 1250,
 'atp/brand/Dott Gpseo': 344,
 'atp/brand/Dott Gyor': 239,
 'atp/brand/Dott Hamburg': 6,
 'atp/brand/Dott Hameenlinna': 5,
 'atp/brand/Dott Hamm': 1,
 'atp/brand/Dott Hannover': 27,
 'atp/brand/Dott Hatvan': 20,
 'atp/brand/Dott Heidelberg': 17,
 'atp/brand/Dott Heilbronn': 32,
 'atp/brand/Dott Helsingborg': 413,
 'atp/brand/Dott Helsinki': 361,
 'atp/brand/Dott Hennef': 14,
 'atp/brand/Dott Herford': 3,
 'atp/brand/Dott Herne': 1,
 'atp/brand/Dott Hildesheim': 3,
 'atp/brand/Dott Ibiza': 27,
 'atp/brand/Dott Ingolstadt': 14,
 'atp/brand/Dott Innsbruck': 58,
 'atp/brand/Dott Jeddah': 78,
 'atp/brand/Dott Joensuu': 17,
 'atp/brand/Dott Jonkoping': 175,
 'atp/brand/Dott Jyvaskyla': 17,
 'atp/brand/Dott Kaiserslautern': 15,
 'atp/brand/Dott Karlsruhe': 33,
 'atp/brand/Dott Kassel': 29,
 'atp/brand/Dott Katowice': 61,
 'atp/brand/Dott Kiel': 21,
 'atp/brand/Dott Klagenfurt': 47,
 'atp/brand/Dott Klaukkala': 1,
 'atp/brand/Dott Konin': 38,
 'atp/brand/Dott Korneuburg': 43,
 'atp/brand/Dott Kołobrzeg': 61,
 'atp/brand/Dott Krakow': 377,
 'atp/brand/Dott Kuopio': 19,
 'atp/brand/Dott La-Manga': 20,
 'atp/brand/Dott Lahti': 27,
 'atp/brand/Dott Langenfeld': 8,
 'atp/brand/Dott Lappeenranta': 2,
 'atp/brand/Dott Leipzig': 125,
 'atp/brand/Dott Leoben': 5,
 'atp/brand/Dott Lidköping': 66,
 'atp/brand/Dott Lillestrøm': 12,
 'atp/brand/Dott Lindau': 36,
 'atp/brand/Dott Linz': 148,
 'atp/brand/Dott Liptovsky-Mikulas': 17,
 'atp/brand/Dott Lorca': 151,
 'atp/brand/Dott Lubliniec': 1,
 'atp/brand/Dott Ludwigsburg': 16,
 'atp/brand/Dott Lübeck': 1,
 'atp/brand/Dott Mainz': 2,
 'atp/brand/Dott Mannheim': 188,
 'atp/brand/Dott Meerbusch': 3,
 'atp/brand/Dott Mikołów': 32,
 'atp/brand/Dott Milton Keynes': 222,
 'atp/brand/Dott Miskolc': 238,
 'atp/brand/Dott Międzyzdroje': 24,
 'atp/brand/Dott Monchengladbach': 3,
 'atp/brand/Dott Mulheim an der Ruhr': 70,
 'atp/brand/Dott Munich': 312,
 'atp/brand/Dott Murcia': 596,
 'atp/brand/Dott Mödling': 63,
 'atp/brand/Dott Münster': 412,
 'atp/brand/Dott Nitra': 44,
 'atp/brand/Dott Nottingham': 351,
 'atp/brand/Dott Nowogard': 27,
 'atp/brand/Dott Nowy Dwór Mazowiecki': 1,
 'atp/brand/Dott Nowy-Targ': 16,
 'atp/brand/Dott Nuremberg': 270,
 'atp/brand/Dott Oleśnica': 71,
 'atp/brand/Dott Osnabrück': 2,
 'atp/brand/Dott Oświęcim': 18,
 'atp/brand/Dott Paderborn': 26,
 'atp/brand/Dott Partille': 83,
 'atp/brand/Dott Pezinok': 77,
 'atp/brand/Dott Piekary Śląskie': 1,
 'atp/brand/Dott Police': 18,
 'atp/brand/Dott Potsdam': 6,
 'atp/brand/Dott Prawobrzeże': 29,
 'atp/brand/Dott Prešov': 3,
 'atp/brand/Dott Prievidza': 3,
 'atp/brand/Dott Raisio': 8,
 'atp/brand/Dott Ras Al Khaimah': 31,
 'atp/brand/Dott Recklinghausen': 13,
 'atp/brand/Dott Regensburg': 42,
 'atp/brand/Dott Reggio Emilia': 1,
 'atp/brand/Dott Reutlingen': 3,
 'atp/brand/Dott Rewal': 21,
 'atp/brand/Dott Riyadh': 190,
 'atp/brand/Dott Romanshorn': 188,
 'atp/brand/Dott Rostock': 5,
 'atp/brand/Dott Rüsselsheim': 44,
 'atp/brand/Dott SIEMU': 112,
 'atp/brand/Dott Saarbrücken': 30,
 'atp/brand/Dott Sandefjord': 1,
 'atp/brand/Dott Sankt Augustin': 42,
 'atp/brand/Dott Seinajoki': 1,
 'atp/brand/Dott Sharjah': 26,
 'atp/brand/Dott Siófok': 38,
 'atp/brand/Dott Skawina': 36,
 'atp/brand/Dott Skovde': 232,
 'atp/brand/Dott Solingen': 6,
 'atp/brand/Dott St. Gallen': 96,
 'atp/brand/Dott Steyr': 13,
 'atp/brand/Dott Stjørdal': 34,
 'atp/brand/Dott Stuttgart': 27,
 'atp/brand/Dott Swiecie': 14,
 'atp/brand/Dott Szczecin': 94,
 'atp/brand/Dott Słupsk': 16,
 'atp/brand/Dott Tampere': 149,
 'atp/brand/Dott Tarnowskie Góry': 1,
 'atp/brand/Dott Tarragona': 110,
 'atp/brand/Dott Tenerife': 181,
 'atp/brand/Dott Tenerife-Sur': 176,
 'atp/brand/Dott Trento': 1187,
 'atp/brand/Dott Trnava': 55,
 'atp/brand/Dott Trollhättan': 18,
 'atp/brand/Dott Trondheim': 44,
 'atp/brand/Dott Trzebnica': 2,
 'atp/brand/Dott Turku': 61,
 'atp/brand/Dott Tübingen': 8,
 'atp/brand/Dott Ulm': 10,
 'atp/brand/Dott Utrecht': 1208,
 'atp/brand/Dott Vaasa': 17,
 'atp/brand/Dott Vantaa': 21,
 'atp/brand/Dott Varberg': 199,
 'atp/brand/Dott Vaxjo': 110,
 'atp/brand/Dott Velden-Am-Worthersee': 15,
 'atp/brand/Dott Värnamo': 18,
 'atp/brand/Dott Wels': 46,
 'atp/brand/Dott Wiesbaden': 40,
 'atp/brand/Dott Winterthur': 17,
 'atp/brand/Dott Wolfsburg': 22,
 'atp/brand/Dott Wrocław': 1,
 'atp/brand/Dott Zurich': 77,
 'atp/brand/Dott Überlingen': 12,
 'atp/brand/Dublinbikes': 114,
 'atp/brand/EDEKA Grünheide': 17,
 'atp/brand/Ecobici': 1076,
 'atp/brand/Eifel e-Bike': 52,
 'atp/brand/EinfachMobil': 75,
 'atp/brand/El Paso B-cycle': 19,
 'atp/brand/Explore Bike Share': 35,
 'atp/brand/Fa.Mo.Se': 25,
 'atp/brand/Flamingo Dunedin': 34,
 'atp/brand/Flamingo Palerston North': 53,
 'atp/brand/Flamingo Porirua': 20,
 'atp/brand/Flamingo Waimakariri': 6,
 'atp/brand/Flamingo Wellington': 41,
 'atp/brand/Flinkster': 85,
 'atp/brand/Frelo Freiburg': 124,
 'atp/brand/GREENbike': 60,
 'atp/brand/GRM Grodzisk Poland': 17,
 'atp/brand/Gmünd bewegt!': 3,
 'atp/brand/GoAbout': 75,
 'atp/brand/Graben - ready4green': 2,
 'atp/brand/Grad Drniš (Croatia)': 6,
 'atp/brand/Grad Ivanić-Grad (Croatia)': 5,
 'atp/brand/Grad Karlovac (Croatia)': 13,
 'atp/brand/Grad Križevci (Croatia)': 11,
 'atp/brand/Grad Metković (Croatia)': 5,
 'atp/brand/Grad Sisak (Croatia)': 5,
 'atp/brand/Grad Slavonski Brod (Croatia)': 10,
 'atp/brand/Grad Split (Croatia)': 96,
 'atp/brand/Grad Velika Gorica (Croatia)': 4,
 'atp/brand/Grad Vukovar (Croatia)': 2,
 'atp/brand/Grad Zadar (Croatia)': 8,
 'atp/brand/Grad Zaprešić (Croatia)': 7,
 'atp/brand/Grad Šibenik (Croatia)': 12,
 'atp/brand/Greenville B-cycle': 12,
 'atp/brand/HELLO CYCLING': 10872,
 'atp/brand/HIBike': 23,
 'atp/brand/HOPR Bishop Ranch': 61,
 'atp/brand/Heartland B-cycle': 82,
 'atp/brand/Heraeus Hanau': 5,
 'atp/brand/Hertz Bildeling': 26,
 'atp/brand/Hopp Washington DC': 30,
 'atp/brand/Hyre': 458,
 'atp/brand/Impulsyon': 30,
 'atp/brand/Indego': 263,
 'atp/brand/Indy - Pacers Bikeshare': 51,
 'atp/brand/JOLT': 15,
 'atp/brand/Jackson County': 1,
 'atp/brand/Jastrebarsko (Croatia)': 1,
 'atp/brand/KARBIS Turkey': 4,
 'atp/brand/KVB Rad Germany': 195,
 'atp/brand/KVV.nextbike': 111,
 "atp/brand/Karu'Vélo": 14,
 'atp/brand/Knot Strasbourg': 25,
 'atp/brand/Kolumbus Bysykkel': 219,
 'atp/brand/Koniński Rower Miejski Poland': 12,
 'atp/brand/Koszaliński Rower Miejski Poland': 20,
 'atp/brand/Kołobrzeski Rower Miejski Poland': 20,
 'atp/brand/LE vélo STAR': 57,
 'atp/brand/LIEmobil Liechtenstein': 35,
 'atp/brand/LOVELO Libre-service': 121,
 'atp/brand/La Baule': 14,
 'atp/brand/Landkreis Nordsachsen - Deutschland': 19,
 'atp/brand/LastenVelo Freiburg': 44,
 'atp/brand/Le Marcel': 27,
 'atp/brand/Le Vélo par TBM': 212,
 'atp/brand/Leipzig Sandkasten': 4,
 'atp/brand/Les Petites Reines': 15,
 'atp/brand/Levélo': 203,
 'atp/brand/Li Bia Velo': 27,
 'atp/brand/Libélo': 53,
 'atp/brand/Lime Antwerp': 1,
 'atp/brand/Lime Arlington': 1,
 'atp/brand/Lime Baltimore': 1,
 'atp/brand/Lime Brussels': 1,
 'atp/brand/Lime Calgary': 1,
 'atp/brand/Lime Chicago': 1,
 'atp/brand/Lime Cleveland': 1,
 'atp/brand/Lime Colorado Springs': 1,
 'atp/brand/Lime Detroit': 1,
 'atp/brand/Lime Edmonton': 1,
 'atp/brand/Lime Frankfurt': 1,
 'atp/brand/Lime Grand Rapids': 1,
 'atp/brand/Lime Hamburg': 1,
 'atp/brand/Lime Kelowna': 1,
 'atp/brand/Lime Louisville': 1,
 'atp/brand/Lime Marseille': 1,
 'atp/brand/Lime New York': 1,
 'atp/brand/Lime Oakland': 1,
 'atp/brand/Lime Oberhausen': 1,
 'atp/brand/Lime Opfikon': 1,
 'atp/brand/Lime Ottawa': 1,
 'atp/brand/Lime Paris': 1,
 'atp/brand/Lime Portland': 1,
 'atp/brand/Lime Reutlingen': 1,
 'atp/brand/Lime San Francisco': 1,
 'atp/brand/Lime San Jose': 1,
 'atp/brand/Lime Seattle': 1,
 'atp/brand/Lime Solingen': 1,
 'atp/brand/Lime Tel Aviv': 1,
 'atp/brand/Lime Vancouver': 69,
 'atp/brand/Lime Washington DC': 1,
 'atp/brand/Lime Zug': 1,
 'atp/brand/Lovesharing': 14,
 'atp/brand/Lundahoj': 19,
 'atp/brand/Lyft': 1935,
 'atp/brand/MBajk': 35,
 'atp/brand/MOBIbike': 522,
 'atp/brand/MOL Bubi': 219,
 'atp/brand/MV-Rad': 50,
 'atp/brand/Madison B-cycle': 100,
 'atp/brand/Mein konrad': 37,
 'atp/brand/Metro Bike Share': 219,
 'atp/brand/Metrorower': 925,
 'atp/brand/Mevo': 744,
 'atp/brand/MiBiciTuBici': 91,
 'atp/brand/Mibici Guadalajara': 367,
 'atp/brand/Milan Bikemi': 323,
 'atp/brand/Mobi Bike Share': 258,
 'atp/brand/Mogo Detroit': 82,
 'atp/brand/Moinesti': 8,
 'atp/brand/MonaBike': 54,
 'atp/brand/Movemix Bike': 104,
 'atp/brand/NEW MöBus nextbike': 48,
 'atp/brand/NS OV Fiets': 287,
 'atp/brand/Naolib': 125,
 "atp/brand/Naolib Micromob'": 16,
 'atp/brand/Nashville BCycle': 35,
 'atp/brand/Naturenergie sharing': 306,
 'atp/brand/Neuron Mobility': 1995,
 'atp/brand/Neuron Oshawa': 81,
 'atp/brand/Nextbike': 9733,
 'atp/brand/Nextbike Prishtina': 10,
 'atp/brand/Nibelungen-Bike': 36,
 'atp/brand/Nike Biketown': 24,
 'atp/brand/Nomago Bikes - GO2GO': 20,
 'atp/brand/Nomago Bikes - GO2GO Gorizia': 3,
 'atp/brand/Nomago Bikes - KOLESCE': 83,
 'atp/brand/Nomago Bikes - LJUBLJANA': 44,
 'atp/brand/Nomago Bikes - ZANAPREJ': 7,
 'atp/brand/OLi-Bike': 32,
 'atp/brand/OVO Bikes Glasgow': 114,
 'atp/brand/OberSchwabenMobil CarSharing': 11,
 'atp/brand/Ogalo Cyclette': 21,
 'atp/brand/Ontibici': 24,
 'atp/brand/Optymo Belfort': 35,
 'atp/brand/Optymo Belfort Auto libre-service': 52,
 'atp/brand/Općina Brinje (Croatia)': 2,
 'atp/brand/Općina Pitomača (Croatia)': 3,
 'atp/brand/Oslo Bysykkel': 270,
 'atp/brand/Otto': 18,
 'atp/brand/PBSC HQ': 3,
 'atp/brand/Piaseczyński Rower Miejski Poland': 7,
 'atp/brand/PickeBike Aubonne': 14,
 'atp/brand/PickeBike Basel': 60,
 'atp/brand/PickeBike Fribourg': 53,
 'atp/brand/Pogoh': 60,
 'atp/brand/Pony': 12474,
 'atp/brand/Potsdam Rad': 131,
 'atp/brand/PubliBike': 661,
 'atp/brand/Périvélo': 3,
 'atp/brand/RGV B-cycle': 7,
 'atp/brand/RSVG-Bike': 175,
 'atp/brand/RTC Bike Share': 29,
 'atp/brand/RVK': 48,
 'atp/brand/Redding Bikeshare': 22,
 'atp/brand/RegioRadStuttgart': 226,
 'atp/brand/Rhoule': 2,
 'atp/brand/Rivi Bike': 7,
 'atp/brand/Rower Miejski w Ostrowie Wielkopolskim Poland': 11,
 'atp/brand/Rowerowe Łódzkie Poland (RL)': 135,
 "atp/brand/Rubis'Velo": 38,
 'atp/brand/Ryde Fredrikstad': 45,
 'atp/brand/Ryde Sarpsborg': 31,
 'atp/brand/Ryde Trondheim': 202,
 'atp/brand/Ryde_Oslo': 1057,
 'atp/brand/SAP Walldorf': 18,
 'atp/brand/SBU Wolf Ride Bike Share': 14,
 'atp/brand/San Antonio B-cycle': 16,
 'atp/brand/Santa Barbara BCycle': 87,
 'atp/brand/Santa Cruz BCycle': 98,
 'atp/brand/Santander Cycles - Brunel': 9,
 'atp/brand/Santander Cycles - Milton Keynes': 48,
 'atp/brand/Santander Cycles - Swansea': 6,
 'atp/brand/Semo Vélo': 31,
 'atp/brand/Senica bajk': 25,
 'atp/brand/Sevici': 257,
 'atp/brand/Share Birrer': 19,
 'atp/brand/Shared Mobility': 7725,
 'atp/brand/Sibiu BikeCity': 57,
 'atp/brand/Sitycleta (Las Palmas)': 72,
 'atp/brand/Slatina Velo City': 5,
 'atp/brand/StadtRad Greifswald': 21,
 'atp/brand/Stadtmobil Karlsruhe': 520,
 'atp/brand/Stadtmobil Rhein-Neckar': 457,
 'atp/brand/Stadtmobil Stuttgart': 318,
 'atp/brand/Stadtrad Innsbruck Austria': 52,
 'atp/brand/Stadtwerk Tauberfranken': 12,
 'atp/brand/Styr & Ställ (Sweden, Göteborg)': 135,
 'atp/brand/TLP Mobilites': 13,
 'atp/brand/TUeBICI': 38,
 'atp/brand/Tarnowski Rower Miejski Poland': 18,
 'atp/brand/TeilAuto Biberach': 9,
 'atp/brand/TeilAuto Neckar-Alb': 142,
 'atp/brand/TeilAuto Schwäbisch Hall': 11,
 'atp/brand/Tempovelo': 16,
 'atp/brand/Ti Vélo': 14,
 'atp/brand/Topoloveni Bike': 4,
 'atp/brand/Trondheim Bysykkel': 66,
 'atp/brand/Tugo': 40,
 'atp/brand/Tychowski Rower Miejski Poland': 2,
 'atp/brand/Târgu-Mures': 5,
 'atp/brand/UBC': 108,
 'atp/brand/UsedomRad Germany': 97,
 "atp/brand/V'lille": 261,
 'atp/brand/VAG_Rad': 107,
 'atp/brand/VETURILO Poland': 336,
 'atp/brand/VOI Antwerp': 425,
 'atp/brand/VRNnextbike': 427,
 'atp/brand/VVT REGIORAD Tirol': 22,
 'atp/brand/Valenbisi': 276,
 'atp/brand/Valentine Bike Share': 1,
 'atp/brand/Valladolid': 100,
 "atp/brand/Vel'OH!": 147,
 'atp/brand/Velam': 29,
 "atp/brand/Velect'in": 9,
 'atp/brand/Velo Antwerpen': 316,
 'atp/brand/Velo Sântana': 8,
 'atp/brand/Velospot': 1014,
 'atp/brand/Vernou Vélo': 1,
 'atp/brand/Verona Bike': 40,
 'atp/brand/Vertuose': 39,
 'atp/brand/Villo': 348,
 'atp/brand/Vilvolt': 77,
 'atp/brand/Vivélo': 8,
 'atp/brand/Voi': 1970,
 'atp/brand/Voi Arendal': 90,
 'atp/brand/Voi Bergen': 263,
 'atp/brand/Voi Kristiansand': 105,
 'atp/brand/Voi Le Havre': 400,
 'atp/brand/Voi Lillestrom': 21,
 'atp/brand/Voi Oslo': 1805,
 'atp/brand/Voi Stavanger': 176,
 'atp/brand/Voi Trondheim': 152,
 'atp/brand/VélO2': 45,
 "atp/brand/VélOstan'lib": 38,
 'atp/brand/VélYcéo': 5,
 'atp/brand/Vélhop - Strasbourg': 35,
 "atp/brand/Vélib' Metropole": 1472,
 'atp/brand/Vélibéo': 19,
 'atp/brand/Vélivert': 99,
 'atp/brand/Vélo Tanlib': 38,
 "atp/brand/Vélo d'Aqui": 6,
 "atp/brand/Vélo'Baie": 4,
 "atp/brand/Vélo'Cité": 18,
 "atp/brand/Vélo'v": 434,
 'atp/brand/VéloCité': 56,
 'atp/brand/VéloZef': 29,
 "atp/brand/Vélomagg'": 55,
 'atp/brand/Vélopop': 28,
 'atp/brand/VélÔToulouse': 383,
 'atp/brand/WE-cycle': 49,
 'atp/brand/WESTcargo powered by nextbike': 4,
 'atp/brand/WRM nextbike Poland': 235,
 'atp/brand/WienMobil Rad': 254,
 'atp/brand/WinsenRad': 21,
 'atp/brand/Wolsztyński Rower Miejski': 3,
 'atp/brand/Zebullo': 63,
 'atp/brand/Zenica': 15,
 'atp/brand/biciArteixo': 8,
 'atp/brand/carvelo eCargo-Bike Sharing': 328,
 'atp/brand/city bike Linz': 50,
 'atp/brand/eMobi (Croatia)': 27,
 'atp/brand/edrive carsharing': 73,
 'atp/brand/fLotte Brandenburg': 48,
 'atp/brand/kotobike': 164,
 'atp/brand/meinRad': 185,
 'atp/brand/meinSiggi': 64,
 'atp/brand/metropolradruhr Germany': 506,
 'atp/brand/mobic': 156,
 'atp/brand/sprintRAD': 96,
 'atp/brand/westBike': 20,
 'atp/brand/wupsiRad Leverkusen': 116,
 'atp/brand/zeo Carsharing': 63,
 'atp/brand/àVélo': 165,
 'atp/brand/Łódzki Rower Publiczny': 166,
 'atp/brand/Żyrardowski Rower Miejski Poland': 7,
 'atp/brand_wikidata/Q1034635': 792,
 'atp/brand_wikidata/Q1060525': 1386,
 'atp/brand_wikidata/Q107463014': 42209,
 'atp/brand_wikidata/Q1120762': 1472,
 'atp/brand_wikidata/Q123507620': 925,
 'atp/brand_wikidata/Q16971391': 568,
 'atp/brand_wikidata/Q17018523': 877,
 'atp/brand_wikidata/Q17077936': 1935,
 'atp/brand_wikidata/Q17402113': 1233,
 'atp/brand_wikidata/Q1833385': 516,
 'atp/brand_wikidata/Q2351279': 9733,
 'atp/brand_wikidata/Q2974438': 2233,
 'atp/brand_wikidata/Q3555363': 661,
 'atp/brand_wikidata/Q386': 922,
 'atp/brand_wikidata/Q55533296': 6109,
 'atp/brand_wikidata/Q56314221': 1014,
 'atp/brand_wikidata/Q5817067': 1076,
 'atp/brand_wikidata/Q60860236': 744,
 'atp/brand_wikidata/Q61650427': 1594,
 'atp/brand_wikidata/Q63753939': 7714,
 'atp/brand_wikidata/Q91231927': 10872,
 'atp/category/amenity/bicycle_rental': 174041,
 'atp/category/amenity/kick-scooter_rental': 9408,
 'atp/category/missing': 7725,
 'atp/cdn/cloudflare/response_count': 143,
 'atp/cdn/cloudflare/response_status_count/200': 143,
 'atp/clean_strings/name': 2399,
 'atp/clean_strings/postcode': 47,
 'atp/clean_strings/street_address': 3843,
 'atp/country/AE': 1977,
 'atp/country/AR': 511,
 'atp/country/AT': 1255,
 'atp/country/BA': 58,
 'atp/country/BE': 17054,
 'atp/country/BG': 5,
 'atp/country/BR': 1011,
 'atp/country/CA': 4800,
 'atp/country/CH': 11844,
 'atp/country/CL': 190,
 'atp/country/CO': 292,
 'atp/country/CY': 586,
 'atp/country/CZ': 3128,
 'atp/country/DE': 18205,
 'atp/country/DK': 11303,
 'atp/country/ES': 4726,
 'atp/country/FI': 1559,
 'atp/country/FR': 39126,
 'atp/country/GB': 4934,
 'atp/country/HR': 275,
 'atp/country/HU': 1884,
 'atp/country/IE': 162,
 'atp/country/IL': 1287,
 'atp/country/IS': 1,
 'atp/country/IT': 17832,
 'atp/country/JP': 17168,
 'atp/country/LI': 42,
 'atp/country/LT': 55,
 'atp/country/LU': 147,
 'atp/country/LV': 42,
 'atp/country/MC': 54,
 'atp/country/MX': 1044,
 'atp/country/NL': 4145,
 'atp/country/NO': 5637,
 'atp/country/NZ': 169,
 'atp/country/PL': 5092,
 'atp/country/PT': 331,
 'atp/country/QA': 101,
 'atp/country/RO': 151,
 'atp/country/SA': 268,
 'atp/country/SE': 2559,
 'atp/country/SI': 278,
 'atp/country/SK': 1010,
 'atp/country/TR': 127,
 'atp/country/UA': 70,
 'atp/country/US': 8669,
 'atp/country/XK': 10,
 'atp/field/branch/missing': 191174,
 'atp/field/brand_wikidata/missing': 96589,
 'atp/field/city/missing': 191086,
 'atp/field/email/missing': 191174,
 'atp/field/image/missing': 191174,
 'atp/field/lat/invalid': 2,
 'atp/field/lat/missing': 167,
 'atp/field/lon/invalid': 2,
 'atp/field/lon/missing': 167,
 'atp/field/name/missing': 152,
 'atp/field/opening_hours/missing': 191174,
 'atp/field/operator/missing': 166041,
 'atp/field/operator_wikidata/missing': 168215,
 'atp/field/phone/missing': 180284,
 'atp/field/postcode/missing': 182533,
 'atp/field/state/from_reverse_geocoding': 13314,
 'atp/field/state/missing': 177862,
 'atp/field/street_address/missing': 156951,
 'atp/field/twitter/missing': 191174,
 'atp/field/website/missing': 5,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/abmitlara.de': 13,
 'atp/item_scraped_host_count/acoruna.publicbikesystem.net': 53,
 'atp/item_scraped_host_count/api-public.odpt.org': 16981,
 'atp/item_scraped_host_count/api.cyclocity.fr': 2483,
 'atp/item_scraped_host_count/api.delijn.be': 199,
 'atp/item_scraped_host_count/api.entur.io': 5004,
 'atp/item_scraped_host_count/api.gbfs.v3.0.ecovelo.mobi': 622,
 'atp/item_scraped_host_count/api.knotcity.io': 25,
 'atp/item_scraped_host_count/api.mobidata-bw.de': 6611,
 'atp/item_scraped_host_count/api.publibike.ch': 661,
 'atp/item_scraped_host_count/api.saint-etienne-metropole.fr': 99,
 'atp/item_scraped_host_count/api.voiapp.io': 2126,
 'atp/item_scraped_host_count/app.kotobike.jp': 164,
 'atp/item_scraped_host_count/app.linkalock.com': 120,
 'atp/item_scraped_host_count/aspen.publicbikesystem.net': 49,
 'atp/item_scraped_host_count/austin.publicbikesystem.net': 73,
 'atp/item_scraped_host_count/auto-birrer.ch': 19,
 'atp/item_scraped_host_count/backend.citiz.fr': 1520,
 'atp/item_scraped_host_count/barcelona.publicbikesystem.net': 516,
 'atp/item_scraped_host_count/bdx.mecatran.com': 212,
 'atp/item_scraped_host_count/beryl-gbfs-production.web.app': 2306,
 'atp/item_scraped_host_count/bogota.publicbikesystem.net': 292,
 'atp/item_scraped_host_count/brasilia.publicbikesystem.net': 69,
 'atp/item_scraped_host_count/buenosaires.publicbikesystem.net': 399,
 'atp/item_scraped_host_count/chattanooga.publicbikesystem.net': 43,
 'atp/item_scraped_host_count/clermontferrand.publicbikesystem.net': 58,
 'atp/item_scraped_host_count/curitiba.publicbikesystem.net': 50,
 'atp/item_scraped_host_count/data.lime.bike': 100,
 'atp/item_scraped_host_count/data.optymo.fr': 87,
 'atp/item_scraped_host_count/data.rideflamingo.com': 154,
 'atp/item_scraped_host_count/dej.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/detroit.publicbikesystem.net': 82,
 'atp/item_scraped_host_count/dubai.publicbikesystem.net': 277,
 'atp/item_scraped_host_count/eu.ftp.opendatasoft.com': 57,
 'atp/item_scraped_host_count/gbfs.api.ridedott.com': 70585,
 'atp/item_scraped_host_count/gbfs.bcycle.com': 1480,
 'atp/item_scraped_host_count/gbfs.bici.madrid': 624,
 'atp/item_scraped_host_count/gbfs.getapony.com': 12474,
 'atp/item_scraped_host_count/gbfs.goabout.com': 75,
 'atp/item_scraped_host_count/gbfs.hopr.city': 288,
 'atp/item_scraped_host_count/gbfs.lyft.com': 6399,
 'atp/item_scraped_host_count/gbfs.mex.lyftbikes.com': 677,
 'atp/item_scraped_host_count/gbfs.nextbike.net': 17718,
 'atp/item_scraped_host_count/gbfs.omega.fifteen.eu': 203,
 'atp/item_scraped_host_count/gbfs.openov.nl': 287,
 'atp/item_scraped_host_count/gbfs.partners.fifteen.eu': 170,
 'atp/item_scraped_host_count/gbfs.smartbike.com': 316,
 'atp/item_scraped_host_count/gbfs.urbansharing.com': 1336,
 'atp/item_scraped_host_count/gbfs.velobixi.com': 922,
 'atp/item_scraped_host_count/gbsf.movatic.co': 1,
 'atp/item_scraped_host_count/guadalajara.publicbikesystem.net': 367,
 'atp/item_scraped_host_count/honolulu.publicbikesystem.net': 133,
 'atp/item_scraped_host_count/kona.publicbikesystem.net': 46,
 'atp/item_scraped_host_count/madrid.publicbikesystem.net': 609,
 'atp/item_scraped_host_count/mds.bird.co': 4464,
 'atp/item_scraped_host_count/mds.bolt.eu': 7876,
 'atp/item_scraped_host_count/mds.neuron-mobility.com': 2076,
 'atp/item_scraped_host_count/media.ilevia.fr': 261,
 'atp/item_scraped_host_count/moinesti.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/monaco.publicbikesystem.net': 54,
 'atp/item_scraped_host_count/montpellier-fr.fifteen.site': 55,
 'atp/item_scraped_host_count/nike.publicbikesystem.net': 24,
 'atp/item_scraped_host_count/nordelta.publicbikesystem.net': 21,
 'atp/item_scraped_host_count/opendata.bbnavi.de': 88,
 'atp/item_scraped_host_count/pbsn.publicbikesystem.net': 3,
 'atp/item_scraped_host_count/pittsburgh.publicbikesystem.net': 60,
 'atp/item_scraped_host_count/portoalegre.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/prod-api.joltscooters.co.nz': 15,
 'atp/item_scraped_host_count/quebec.publicbikesystem.net': 165,
 'atp/item_scraped_host_count/recife.publicbikesystem.net': 90,
 'atp/item_scraped_host_count/riodejaneiro.publicbikesystem.net': 408,
 'atp/item_scraped_host_count/riviera.publicbikesystem.net': 7,
 'atp/item_scraped_host_count/saguenay.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/salvador.publicbikesystem.net': 56,
 'atp/item_scraped_host_count/sansebastian.publicbikesystem.net': 69,
 'atp/item_scraped_host_count/santana.publicbikesystem.net': 8,
 'atp/item_scraped_host_count/santiago.publicbikesystem.net': 190,
 'atp/item_scraped_host_count/saopaulo.publicbikesystem.net': 241,
 'atp/item_scraped_host_count/sibiu.publicbikesystem.net': 57,
 'atp/item_scraped_host_count/stables.donkey.bike': 7770,
 'atp/item_scraped_host_count/stonybrook.publicbikesystem.net': 14,
 'atp/item_scraped_host_count/targumures.publicbikesystem.net': 5,
 'atp/item_scraped_host_count/toronto.publicbikesystem.net': 877,
 'atp/item_scraped_host_count/tucson.publicbikesystem.net': 40,
 'atp/item_scraped_host_count/valence.publicbikesystem.net': 53,
 'atp/item_scraped_host_count/valladolid.publicbikesystem.net': 100,
 'atp/item_scraped_host_count/vancouver-gbfs.smoove.pro': 258,
 'atp/item_scraped_host_count/velib-metropole-opendata.smovengo.cloud': 1472,
 'atp/item_scraped_host_count/www.cykl.nl': 13,
 'atp/item_scraped_host_count/www.mibicitubici.gob.ar': 91,
 'atp/item_scraped_host_count/www.sharedmobility.ch': 7725,
 'atp/item_scraped_host_count/zaragoza.publicbikesystem.net': 108,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 44725,
 'atp/nsi/cc_match': 1425,
 'atp/nsi/match_failed': 24727,
 'atp/nsi/perfect_match': 23708,
 'atp/operator/5M2-BKT': 1076,
 'atp/operator/CityBike Global': 744,
 'atp/operator/Deutsche Bahn Connect': 1386,
 'atp/operator/Donkey Republic': 362,
 'atp/operator/Empresa Municipal de Transportes de Madrid': 1233,
 'atp/operator/Lyft': 3593,
 'atp/operator/Nextbike': 48,
 'atp/operator/Nextbike GZM': 925,
 'atp/operator/OpenStreet': 10872,
 'atp/operator/Pedalem Barcelona': 516,
 'atp/operator/PubliBike': 1675,
 'atp/operator/Smovengo': 1472,
 'atp/operator/Toronto Parking Authority': 877,
 'atp/operator/nextbike Cy Ltd': 284,
 'atp/operator/ТОВ Некстбайк Україна': 70,
 'atp/operator_wikidata/Q1094755': 1233,
 'atp/operator_wikidata/Q1152100': 1386,
 'atp/operator_wikidata/Q123614695': 516,
 'atp/operator_wikidata/Q127573015': 925,
 'atp/operator_wikidata/Q17077936': 3593,
 'atp/operator_wikidata/Q2351279': 48,
 'atp/operator_wikidata/Q3555363': 1675,
 'atp/operator_wikidata/Q43593262': 10872,
 'atp/operator_wikidata/Q47008427': 1472,
 'atp/operator_wikidata/Q63753939': 362,
 'atp/operator_wikidata/Q7826466': 877,
 'downloader/exception_count': 29,
 'downloader/exception_type_count/twisted.internet.error.DNSLookupError': 24,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 5,
 'downloader/request_bytes': 1049016,
 'downloader/request_count': 2315,
 'downloader/request_method_count/GET': 2315,
 'downloader/response_bytes': 16119353,
 'downloader/response_count': 2286,
 'downloader/response_status_count/200': 2214,
 'downloader/response_status_count/302': 2,
 'downloader/response_status_count/307': 1,
 'downloader/response_status_count/400': 8,
 'downloader/response_status_count/404': 40,
 'downloader/response_status_count/429': 1,
 'downloader/response_status_count/502': 16,
 'downloader/response_status_count/503': 4,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 2384.71832,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 16, 7, 0, 51, 831407, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 60926997,
 'httpcompression/response_count': 1356,
 'httperror/response_ignored_count': 54,
 'httperror/response_ignored_status_count/400': 8,
 'httperror/response_ignored_status_count/404': 40,
 'httperror/response_ignored_status_count/502': 6,
 'item_scraped_count': 191174,
 'items_per_minute': None,
 'log_count/DEBUG': 193495,
 'log_count/ERROR': 18,
 'log_count/INFO': 102,
 'request_depth_max': 2,
 'response_received_count': 2268,
 'responses_per_minute': None,
 'retry/count': 38,
 'retry/max_reached': 12,
 'retry/reason_count/429 Unknown Status': 1,
 'retry/reason_count/502 Bad Gateway': 10,
 'retry/reason_count/503 Service Unavailable': 4,
 'retry/reason_count/twisted.internet.error.DNSLookupError': 19,
 'retry/reason_count/twisted.internet.error.TimeoutError': 4,
 'scheduler/dequeued': 2315,
 'scheduler/dequeued/memory': 2315,
 'scheduler/enqueued': 2315,
 'scheduler/enqueued/memory': 2315,
 'start_time': datetime.datetime(2025, 4, 16, 6, 21, 7, 113087, tzinfo=datetime.timezone.utc)}

```