### PR TITLE
[Starbucks US] Fix  Spider

### DIFF
--- a/locations/spiders/starbucks_us.py
+++ b/locations/spiders/starbucks_us.py
@@ -12,7 +12,7 @@ from locations.searchable_points import open_searchable_points
 from locations.spiders.tesco_gb import set_located_in
 
 HEADERS = {"X-Requested-With": "XMLHttpRequest"}
-STORELOCATOR = "https://www.starbucks.com/bff/locations?lat={}&lng={}"
+STORELOCATOR = "https://www.starbucks.com/apiproxy/v1/locations?lat={}&lng={}"
 STARBUCKS_SHARED_ATTRIBUTES = {"brand": "Starbucks", "brand_wikidata": "Q37158"}
 
 


### PR DESCRIPTION
`API` url updated to fix the spider.

Summary generated for small item count.

```python
{'atp/brand/Starbucks': 56,
 'atp/brand_wikidata/Q37158': 56,
 'atp/category/amenity/cafe': 56,
 'atp/country/US': 56,
 'atp/field/email/missing': 56,
 'atp/field/image/missing': 56,
 'atp/field/operator/missing': 56,
 'atp/field/operator_wikidata/missing': 56,
 'atp/field/twitter/missing': 56,
 'atp/item_scraped_host_count/www.starbucks.com': 56,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 56,
 'downloader/request_bytes': 108644,
 'downloader/request_count': 277,
 'downloader/request_method_count/GET': 277,
 'downloader/response_bytes': 301657,
 'downloader/response_count': 277,
 'downloader/response_status_count/200': 277,
 'elapsed_time_seconds': 338.406565,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 4, 17, 14, 4, 0, 841473, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 56,
 'items_per_minute': None,
 'log_count/DEBUG': 344,
 'log_count/INFO': 14,
 'request_depth_max': 2,
 'response_received_count': 277,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 276,
 'scheduler/dequeued/memory': 276,
 'scheduler/enqueued': 283,
 'scheduler/enqueued/memory': 283,
 'start_time': datetime.datetime(2025, 4, 17, 13, 58, 22, 434908, tzinfo=datetime.timezone.utc)}
```