### PR TITLE
[Panda Express] Fix Spider

### DIFF
--- a/locations/spiders/panda_express.py
+++ b/locations/spiders/panda_express.py
@@ -1,37 +1,10 @@
-from scrapy import FormRequest
-from scrapy.http import JsonRequest
+from scrapy.spiders import SitemapSpider
 
-from locations.storefinders.nomnom import NomNomSpider, slugify
-from locations.user_agents import BROWSER_DEFAULT
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PandaExpressSpider(NomNomSpider):
+class PandaExpressSpider(SitemapSpider, StructuredDataSpider):
     name = "panda_express"
     item_attributes = {"brand": "Panda Express", "brand_wikidata": "Q1358690"}
-    domain = "pandaexpress.com"
-    user_agent = BROWSER_DEFAULT
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    use_calendar = False
-
-    def start_requests(self):
-        # Fetch cookies to avoid DataDome captcha blockage
-        yield FormRequest(
-            url="https://api-js.datadome.co/js/",
-            headers={
-                "referer": "https://www.pandaexpress.com/",
-            },
-            formdata={"ddk": "988C29D6706800A8C3451C0AB0E93A"},
-            callback=self.parse_cookies,
-        )
-
-    def parse_cookies(self, response):
-        yield JsonRequest(
-            url="https://nomnom-prod-api.pandaexpress.com/restaurants",
-            cookies={"cookie": response.json()["cookie"]},
-        )
-
-    def post_process_item(self, item, response, feature):
-        item["website"] = (
-            f"https://www.pandaexpress.com/locations/{slugify(feature['state'])}/{slugify(feature['city'])}/{feature['extref']}"
-        )
-        yield item
+    sitemap_urls = ["https://www.pandaexpress.com/locations/sitemap.xml"]
+    sitemap_rules = [(r"https://www.pandaexpress.com/locations/[^/]+/[^/]+/\d+$", "parse_sd")]


### PR DESCRIPTION
**Fixes : code refactored to use sitemap to fix spider**

{'atp/brand/Panda Express': 2533,
 'atp/brand_wikidata/Q1358690': 2533,
 'atp/category/amenity/fast_food': 2533,
 'atp/cdn/cloudflare/response_count': 2535,
 'atp/cdn/cloudflare/response_status_count/200': 2535,
 'atp/country/US': 2533,
 'atp/field/branch/missing': 2533,
 'atp/field/email/missing': 2533,
 'atp/field/image/dropped': 2533,
 'atp/field/image/missing': 2533,
 'atp/field/operator/missing': 2533,
 'atp/field/operator_wikidata/missing': 2533,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 61,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 1,
 'atp/item_scraped_host_count/www.pandaexpress.com': 2533,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2533,
 'downloader/request_bytes': 1003097,
 'downloader/request_count': 2535,
 'downloader/request_method_count/GET': 2535,
 'downloader/response_bytes': 121615818,
 'downloader/response_count': 2535,
 'downloader/response_status_count/200': 2535,
 'elapsed_time_seconds': 110.68636,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 21, 9, 19, 34, 114622, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 574104814,
 'httpcompression/response_count': 2535,
 'item_scraped_count': 2533,
 'items_per_minute': None,
 'log_count/DEBUG': 5080,
 'log_count/INFO': 11,
 'request_depth_max': 1,
 'response_received_count': 2535,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2534,
 'scheduler/dequeued/memory': 2534,
 'scheduler/enqueued': 2534,
 'scheduler/enqueued/memory': 2534,
 'start_time': datetime.datetime(2025, 4, 21, 9, 17, 43, 428262, tzinfo=datetime.timezone.utc)}