### PR TITLE
[H R Block] Fix spider

### DIFF
--- a/locations/spiders/h_r_block.py
+++ b/locations/spiders/h_r_block.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
@@ -13,10 +15,18 @@ class HRBlockSpider(SitemapSpider):
     custom_settings = {
         "DOWNLOADER_MIDDLEWARES": {"scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware": None},
         "USER_AGENT": BROWSER_DEFAULT,
+        "ROBOTSTXT_OBEY": False,
+        "DEFAULT_REQUEST_HEADERS": {
+            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "accept-language": "en-US,en;q=0.9",
+            "sec-ch-ua": '"Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"Windows"',
+        },
     }
     sitemap_follow = ["opp"]
 
-    def parse(self, response: Response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
         item["lat"] = response.xpath("//@data-latitude").get()
         item["lon"] = response.xpath("//@data-longitude").get()

--- a/locations/spiders/h_r_block.py
+++ b/locations/spiders/h_r_block.py
@@ -1,17 +1,16 @@
-from typing import Any
-
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class HRBlockSpider(SitemapSpider):
+class HRBlockSpider(SitemapSpider, StructuredDataSpider):
     name = "h_r_block"
     item_attributes = {"brand": "H&R Block", "brand_wikidata": "Q5627799"}
     sitemap_urls = ["https://www.hrblock.com/sitemap.xml"]
-    sitemap_rules = [(r"https://www\.hrblock\.com/local-tax-offices/.+/.+/.+/(\d+)/$", "parse")]
+    sitemap_rules = [(r"https://www\.hrblock\.com/local-tax-offices/[^/]+/[^/]+/[^/]+/\d+/$", "parse_sd")]
     custom_settings = {
         "DOWNLOADER_MIDDLEWARES": {"scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware": None},
         "USER_AGENT": BROWSER_DEFAULT,
@@ -25,12 +24,10 @@ class HRBlockSpider(SitemapSpider):
         },
     }
     sitemap_follow = ["opp"]
+    drop_attributes = {"image"}
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["ref"] = response.xpath("//@data-office-id").get()
         item["lat"] = response.xpath("//@data-latitude").get()
         item["lon"] = response.xpath("//@data-longitude").get()
-        item["addr_full"] = response.xpath('//*[@class="lbl-address"]').xpath("normalize-space()").get()
-        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
-        item["ref"] = item["website"] = response.url
         yield item


### PR DESCRIPTION
Added `headers` to get rid of spider blockage. Switched to `StructuredData`.
Summary generated for about `1k` POIs.

```python
{'atp/brand/H&R Block': 1017,
 'atp/brand_wikidata/Q5627799': 1017,
 'atp/category/office/tax_advisor': 1017,
 'atp/country/US': 1017,
 'atp/field/branch/missing': 1017,
 'atp/field/email/missing': 1017,
 'atp/field/image/missing': 1017,
 'atp/field/opening_hours/missing': 1017,
 'atp/field/operator/missing': 1017,
 'atp/field/operator_wikidata/missing': 1017,
 'atp/item_scraped_host_count/www.hrblock.com': 1023,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1017,
 'downloader/request_bytes': 737417,
 'downloader/request_count': 1031,
 'downloader/request_method_count/GET': 1031,
 'downloader/response_bytes': 47549778,
 'downloader/response_count': 1031,
 'downloader/response_status_count/200': 1027,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 2,
 'elapsed_time_seconds': 46.242086,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 4, 21, 12, 45, 18, 8567, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 25,
 'httpcache/hit': 1006,
 'httpcache/miss': 25,
 'httpcache/store': 25,
 'httpcompression/response_bytes': 237928363,
 'httpcompression/response_count': 1027,
 'item_dropped_count': 6,
 'item_dropped_reasons_count/DropItem': 6,
 'item_scraped_count': 1017,
 'items_per_minute': None,
 'log_count/DEBUG': 2066,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 1027,
 'responses_per_minute': None,
 'scheduler/dequeued': 1031,
 'scheduler/dequeued/memory': 1031,
 'scheduler/enqueued': 8630,
 'scheduler/enqueued/memory': 8630,
 'start_time': datetime.datetime(2025, 4, 21, 12, 44, 31, 766481, tzinfo=datetime.timezone.utc)}
2025-04-21 18:15:18 [scrapy.core.engine] INFO: Spider closed (closespider_itemcount)
```