### PR TITLE
Revert "[Coinstar] Flag coinstar spider as requires proxy"

### DIFF
--- a/locations/spiders/coinstar.py
+++ b/locations/spiders/coinstar.py
@@ -13,7 +13,6 @@ class CoinstarSpider(Spider):
     item_attributes = {"brand": "Coinstar", "brand_wikidata": "Q5141641"}
     start_urls = ["https://www.coinstar.com/findakiosk"]
     max_results = 1000
-    requires_proxy = True
 
     def parse(self, response):
         s = response.xpath("//script[contains(text(), 'csApiToken')]/text()").get()


### PR DESCRIPTION
Reverts alltheplaces/alltheplaces#12616. Previous runs worked fine without the proxy flag. Now it fails due to Zyte limits (this spider makes lots of requests).