### PR TITLE
[Royal Lepage] Fix spider

### DIFF
--- a/locations/spiders/royal_lepage.py
+++ b/locations/spiders/royal_lepage.py
@@ -1,26 +1,34 @@
 import re
+from typing import Any
 
-import scrapy
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.items import Feature
 
 
-class RoyalLepageSpider(scrapy.Spider):
+class RoyalLepageSpider(CrawlSpider):
     name = "royal_lepage"
     item_attributes = {"brand": "Royal LePage", "brand_wikidata": "Q7374385"}
     allowed_domains = ["royallepage.ca"]
     start_urls = [
         "https://www.royallepage.ca/en/search/offices/?lat=&lng=&address=&designations=&address_type=&city_name=&prov_code=&sortby=&transactionType=OFFICE&name=&location=&language=&specialization=All"
     ]
+    rules = [
+        Rule(LinkExtractor(allow="/office/", restrict_xpaths="//address"), callback="parse"),
+        Rule(
+            LinkExtractor(allow=r"/offices/\d+/", restrict_xpaths='//*[contains(@class, "paginator__pages")]'),
+        ),
+    ]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse_location(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         map_script = response.xpath('//script/text()[contains(., "staticMap")]').get()
         lat = re.search("latitude: (.*?),?$", map_script, flags=re.M).group(1)
         lon = re.search("longitude: (.*?),?$", map_script, flags=re.M).group(1)
 
         properties = {
-            "brand": "Royal LePage",
             "ref": re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1),
             "name": response.xpath('normalize-space(//*[@itemprop="name"]//text())').extract_first().strip(" *"),
             "addr_full": response.xpath('normalize-space(//*[@itemprop="address"]/p/text())').extract_first(),
@@ -32,14 +40,3 @@ class RoyalLepageSpider(scrapy.Spider):
         }
 
         yield Feature(**properties)
-
-    def parse(self, response):
-        urls = response.xpath("//address//a/@href").extract()
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url), callback=self.parse_location)
-
-        next_page = response.xpath(
-            '//div[contains(@class, "paginator")]//li[@class="is-active"]/following-sibling::li//a/@href'
-        ).extract_first()
-        if next_page:
-            yield scrapy.Request(response.urljoin(next_page))

--- a/locations/spiders/royal_lepage.py
+++ b/locations/spiders/royal_lepage.py
@@ -12,6 +12,7 @@ class RoyalLepageSpider(scrapy.Spider):
     start_urls = [
         "https://www.royallepage.ca/en/search/offices/?lat=&lng=&address=&designations=&address_type=&city_name=&prov_code=&sortby=&transactionType=OFFICE&name=&location=&language=&specialization=All"
     ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse_location(self, response):
         map_script = response.xpath('//script/text()[contains(., "staticMap")]').get()


### PR DESCRIPTION
```python
{'atp/brand/Royal LePage': 491,
 'atp/brand_wikidata/Q7374385': 491,
 'atp/category/office/estate_agent': 491,
 'atp/country/CA': 491,
 'atp/field/branch/missing': 491,
 'atp/field/city/missing': 491,
 'atp/field/email/missing': 491,
 'atp/field/image/missing': 491,
 'atp/field/opening_hours/missing': 491,
 'atp/field/operator/missing': 491,
 'atp/field/operator_wikidata/missing': 491,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 491,
 'atp/field/state/from_reverse_geocoding': 491,
 'atp/field/state/missing': 5,
 'atp/field/street_address/missing': 491,
 'atp/field/twitter/missing': 491,
 'atp/item_scraped_host_count/www.royallepage.ca': 491,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 491,
 'downloader/exception_count': 21,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 21,
 'downloader/request_bytes': 411335,
 'downloader/request_count': 544,
 'downloader/request_method_count/GET': 544,
 'downloader/response_bytes': 8808785,
 'downloader/response_count': 523,
 'downloader/response_status_count/200': 523,
 'dupefilter/filtered': 323,
 'elapsed_time_seconds': 677.556337,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 22, 5, 50, 22, 782515, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 523,
 'httpcache/miss': 544,
 'httpcache/store': 523,
 'httpcompression/response_bytes': 35166566,
 'httpcompression/response_count': 523,
 'item_scraped_count': 491,
 'items_per_minute': None,
 'log_count/DEBUG': 1048,
 'log_count/INFO': 21,
 'request_depth_max': 7,
 'response_received_count': 523,
 'responses_per_minute': None,
 'retry/count': 21,
 'retry/reason_count/twisted.internet.error.TimeoutError': 21,
 'scheduler/dequeued': 544,
 'scheduler/dequeued/memory': 544,
 'scheduler/enqueued': 544,
 'scheduler/enqueued/memory': 544,
 'start_time': datetime.datetime(2025, 4, 22, 5, 39, 5, 226178, tzinfo=datetime.timezone.utc)}
```