### PR TITLE
[A1 MK] Fix Drop Count 

### DIFF
--- a/locations/spiders/a1_mk.py
+++ b/locations/spiders/a1_mk.py
@@ -1,5 +1,4 @@
 from scrapy import Spider
-from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -8,18 +7,15 @@ from locations.hours import OpeningHours
 class A1MKSpider(Spider):
     name = "a1_mk"
     item_attributes = {"brand": "A1", "brand_wikidata": "Q24589907"}
-    allowed_domains = ["www.a1.mk"]
     start_urls = ["https://www.a1.mk/o/StoreFinder-portlet/rest/api/shops/"]
-
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
 
     def parse(self, response):
         for location in response.json():
             if not location.get("isOpen"):
                 continue
             item = DictParser.parse(location)
+            item["branch"] = location["nameMK"]
+
             if location["shopType"]["shopGroup"]["metadata"] != "centers":
                 # Ignore partner stores.
                 continue
@@ -40,5 +36,4 @@ class A1MKSpider(Spider):
                 item["opening_hours"].add_range("Sa", *location["saturdayWorkingPeriod"].split(" - "), "%H:%M")
             if location.get("sundayWorkingPeriod") and location["sundayWorkingPeriod"].strip() != "-":
                 item["opening_hours"].add_range("Su", *location["sundayWorkingPeriod"].split(" - "), "%H:%M")
-            yield item
             yield item


### PR DESCRIPTION
**_code cleaned up and fixes drop count_**

```python
{'atp/brand/A1': 28,
 'atp/brand_wikidata/Q24589907': 28,
 'atp/category/shop/telecommunication': 28,
 'atp/country/MK': 28,
 'atp/field/country/from_reverse_geocoding': 28,
 'atp/field/email/missing': 28,
 'atp/field/image/missing': 28,
 'atp/field/operator/missing': 28,
 'atp/field/operator_wikidata/missing': 28,
 'atp/field/phone/missing': 28,
 'atp/field/postcode/missing': 28,
 'atp/field/twitter/missing': 28,
 'atp/field/website/missing': 28,
 'atp/item_scraped_host_count/www.a1.mk': 28,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 28,
 'downloader/request_bytes': 327,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 8219,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.328527,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 22, 8, 27, 23, 570654, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 56388,
 'httpcompression/response_count': 1,
 'item_scraped_count': 28,
 'items_per_minute': None,
 'log_count/DEBUG': 40,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 22, 8, 27, 20, 242127, tzinfo=datetime.timezone.utc)}
```