### PR TITLE
[Odido NL] Add spider

### DIFF
--- a/locations/spiders/odido_nl.py
+++ b/locations/spiders/odido_nl.py
@@ -1,0 +1,21 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class OdidoNLSpider(SitemapSpider, StructuredDataSpider):
+    name = "odido_nl"
+    item_attributes = {"brand": "Odido", "brand_wikidata": "Q28406140"}
+    sitemap_urls = ["https://www.odido.nl/robots.txt"]
+    sitemap_rules = [(r"nl/winkels/[^/]+/[^/]+$", "parse")]
+    wanted_types = ["Store"]
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["image"] = (item.get("image") or "").replace("https://www.odido.nlhttps://", "https://")
+        item["branch"] = item.pop("name").removeprefix("Shop ")
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Odido': 117,
 'atp/brand_wikidata/Q28406140': 117,
 'atp/category/shop/mobile_phone': 117,
 'atp/country/NL': 117,
 'atp/field/email/missing': 117,
 'atp/field/opening_hours/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/phone/missing': 117,
 'atp/field/twitter/missing': 117,
 'atp/item_scraped_host_count/www.odido.nl': 117,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 117,
 'downloader/request_bytes': 74687,
 'downloader/request_count': 123,
 'downloader/request_method_count/GET': 123,
 'downloader/response_bytes': 6134094,
 'downloader/response_count': 123,
 'downloader/response_status_count/200': 120,
 'downloader/response_status_count/500': 3,
 'elapsed_time_seconds': 1.654599,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 22, 12, 35, 28, 543741, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 123,
 'httpcompression/response_bytes': 23599727,
 'httpcompression/response_count': 120,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/500': 1,
 'item_scraped_count': 117,
 'items_per_minute': None,
 'log_count/ERROR': 1,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'memusage/max': 291487744,
 'memusage/startup': 291487744,
 'request_depth_max': 2,
 'response_received_count': 121,
 'responses_per_minute': None,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/500 Internal Server Error': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 122,
 'scheduler/dequeued/memory': 122,
 'scheduler/enqueued': 122,
 'scheduler/enqueued/memory': 122,
 'start_time': datetime.datetime(2025, 4, 22, 12, 35, 26, 889142, tzinfo=datetime.timezone.utc)}
```