### PR TITLE
ultra_tune_au: fix spider

### DIFF
--- a/locations/storefinders/agile_store_locator.py
+++ b/locations/storefinders/agile_store_locator.py
@@ -54,6 +54,9 @@ class AgileStoreLocatorSpider(Spider):
             return oh
 
         for day_name, hours_ranges in hours_json.items():
+            if not hours_ranges or hours_ranges == "0":
+                oh.set_closed(day_name)
+                continue
             for hours_range in hours_ranges:
                 hours_range = hours_range.upper()
                 if not hours_range or hours_range == "0":


### PR DESCRIPTION
Allow AgileStoreLocatorSpider to process opening hours where a day is specified with hours of an integer 0. This appears to be used to denote a closed day.