### PR TITLE
batteries_plus: fix spider and rename to batteries_plus_bulbs_pr_us

### DIFF
--- a/locations/spiders/batteries_plus_bulbs_pr_us.py
+++ b/locations/spiders/batteries_plus_bulbs_pr_us.py
@@ -1,16 +1,15 @@
 import json
 
-from locations.categories import Extras, PaymentMethods, apply_yes_no
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
 from locations.items import SocialMedia, set_social_media
 from locations.storefinders.where2getit import Where2GetItSpider
 
 
-class BatteriesPlusSpider(Where2GetItSpider):
-    name = "batteries_plus"
+class BatteriesPlusBulbsPRUSSpider(Where2GetItSpider):
+    name = "batteries_plus_bulbs_pr_us"
     item_attributes = {"brand": "Batteries Plus Bulbs", "brand_wikidata": "Q17005157"}
-    api_endpoint = "https://www.batteriesplus.com/store-locator/rest/getlist"
-    api_key = "9C5DD3EE-C1E6-11EE-903D-65C0A96E38C4"
+    api_key = "EC1E5D98-07CF-11EF-89F1-68CFC87EF9CB"
 
     def parse_item(self, item, location):
         item["branch"] = item.pop("name")
@@ -40,6 +39,7 @@ class BatteriesPlusSpider(Where2GetItSpider):
         apply_yes_no(PaymentMethods.MASTER_CARD, item, "Mastercard" in payment_forms)
         apply_yes_no(PaymentMethods.VISA, item, "Visa" in payment_forms)
 
+        apply_category(Categories.SHOP_ELECTRONICS, item)
         yield item
 
     def apply_attribute(self, attribute, item, attributes, key):

--- a/locations/spiders/batteries_plus_bulbs_pr_us.py
+++ b/locations/spiders/batteries_plus_bulbs_pr_us.py
@@ -1,4 +1,4 @@
-import json
+from json import loads
 
 from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
@@ -10,13 +10,14 @@ class BatteriesPlusBulbsPRUSSpider(Where2GetItSpider):
     name = "batteries_plus_bulbs_pr_us"
     item_attributes = {"brand": "Batteries Plus Bulbs", "brand_wikidata": "Q17005157"}
     api_key = "EC1E5D98-07CF-11EF-89F1-68CFC87EF9CB"
+    api_filter = {"opening_status": {"ne": "permanently_closed"}}
 
     def parse_item(self, item, location):
         item["branch"] = item.pop("name")
         item["ref"] = location["localpage_url_id"].removeprefix("batteries-plus-")
         set_social_media(item, SocialMedia.YELP, location["yelp_url"])
 
-        attributes = {attribute["id"]: attribute["value"] for attribute in json.loads(location["attributes"])}
+        attributes = {attribute["id"]: attribute["value"] for attribute in loads(location["attributes"])}
         self.apply_attribute(PaymentMethods.DEBIT_CARDS, item, attributes, "pay_debit_card")
         self.apply_attribute(PaymentMethods.CREDIT_CARDS, item, attributes, "pay_credit_card")
         self.apply_attribute("recycling:electrical_appliances", item, attributes, "has_recycling_electronics")
@@ -30,7 +31,7 @@ class BatteriesPlusBulbsPRUSSpider(Where2GetItSpider):
                 oh.add_range(day, opening, closing, time_format="%H%M")
         item["opening_hours"] = oh
 
-        payment_forms = set(json.loads(location["payment_forms"]))
+        payment_forms = set(loads(location["payment_forms"]))
         apply_yes_no(PaymentMethods.AMERICAN_EXPRESS, item, "American Express" in payment_forms)
         apply_yes_no(PaymentMethods.APPLE_PAY, item, "Apple Pay" in payment_forms)
         apply_yes_no(PaymentMethods.CASH, item, "Cash" in payment_forms)


### PR DESCRIPTION
* API key has changed.

* API endpoint on official website is blocked by Cloudflare, but it was just a proxy for the hosted Where2GetIt API, so we can directly use this hosted Where2GetIt API instead.

* Sync name of spider with NSI branding.