### PR TITLE
[Blaze Pizza] Fix Spider

### DIFF
--- a/locations/spiders/blaze_pizza.py
+++ b/locations/spiders/blaze_pizza.py
@@ -1,16 +1,10 @@
-from locations.storefinders.nomnom import NomNomSpider, slugify
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class BlazePizzaSpider(NomNomSpider):
+class BlazePizzaSpider(SitemapSpider, StructuredDataSpider):
     name = "blaze_pizza"
     item_attributes = {"brand": "Blaze Pizza", "brand_wikidata": "Q23016666"}
-    domain = "blazepizza.com"
-
-    def post_process_item(self, item, response, feature):
-        item["extras"]["website:menu"] = feature["url"]
-        street_address = feature["streetaddress"]
-        street_address_no_unit = street_address[: street_address.find(",")] if "," in street_address else street_address
-        item["website"] = (
-            f"https://locations.blazepizza.com/{slugify(feature['state'])}/{slugify(feature['city'])}/{slugify(street_address_no_unit)}"
-        )
-        yield item
+    sitemap_urls = ["https://locations.blazepizza.com/sitemap.xml"]
+    sitemap_rules = [(r"https://locations.blazepizza.com/[^/]+/[^/]+/[a-zA-z0-9-]+", "parse_sd")]


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/brand/Blaze Pizza': 315,
 'atp/brand_wikidata/Q23016666': 315,
 'atp/category/amenity/restaurant': 315,
 'atp/cdn/cloudflare/response_count': 317,
 'atp/cdn/cloudflare/response_status_count/200': 317,
 'atp/country/CA': 17,
 'atp/country/US': 298,
 'atp/field/branch/missing': 315,
 'atp/field/email/missing': 315,
 'atp/field/lat/missing': 315,
 'atp/field/lon/missing': 315,
 'atp/field/operator/missing': 315,
 'atp/field/operator_wikidata/missing': 315,
 'atp/field/phone/missing': 1,
 'atp/item_scraped_host_count/locations.blazepizza.com': 315,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 315,
 'downloader/request_bytes': 183868,
 'downloader/request_count': 317,
 'downloader/request_method_count/GET': 317,
 'downloader/response_bytes': 11076004,
 'downloader/response_count': 317,
 'downloader/response_status_count/200': 317,
 'elapsed_time_seconds': 389.18369,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 23, 4, 40, 19, 565977, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 37326785,
 'httpcompression/response_count': 317,
 'item_scraped_count': 315,
 'items_per_minute': None,
 'log_count/DEBUG': 643,
 'log_count/INFO': 15,
 'request_depth_max': 2,
 'response_received_count': 317,
 'responses_per_minute': None,
 'scheduler/dequeued': 317,
 'scheduler/dequeued/memory': 317,
 'scheduler/enqueued': 317,
 'scheduler/enqueued/memory': 317,
 'start_time': datetime.datetime(2025, 4, 23, 4, 33, 50, 382287, tzinfo=datetime.timezone.utc)}
```