### PR TITLE
[sixt]  Fix country

### DIFF
--- a/locations/spiders/sixt.py
+++ b/locations/spiders/sixt.py
@@ -14,5 +14,5 @@ class SixtSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, location):
         item["country"] = item.pop("state")
-    
+
         yield item

--- a/locations/spiders/sixt.py
+++ b/locations/spiders/sixt.py
@@ -11,6 +11,7 @@ class SixtSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"\/car-hire\/[-\w]+\/[-\w]+\/[-\w]+\/$", "parse_sd")]
     user_agent = BROWSER_DEFAULT
     sitemap_follow = ["/car-hire/"]
+    skip_auto_cc_domain = True
 
     def post_process_item(self, item, response, location):
         item["country"] = item.pop("state")

--- a/locations/spiders/sixt.py
+++ b/locations/spiders/sixt.py
@@ -11,3 +11,8 @@ class SixtSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"\/car-hire\/[-\w]+\/[-\w]+\/[-\w]+\/$", "parse_sd")]
     user_agent = BROWSER_DEFAULT
     sitemap_follow = ["/car-hire/"]
+
+    def post_process_item(self, item, response, location):
+        item["country"] = item.pop("state")
+    
+        yield item


### PR DESCRIPTION
state was being populated with country.  and all countries incorrectly populated as GB.   
```
{'atp/brand/SIXT': 2066,
 'atp/brand_wikidata/Q705664': 2066,
 'atp/category/amenity/car_rental': 2066,
 'atp/country/AE': 5,
 'atp/country/AL': 5,
 'atp/country/AM': 3,
 'atp/country/AO': 1,
 'atp/country/AR': 23,
 'atp/country/AT': 21,
 'atp/country/AU': 140,
 'atp/country/AW': 1,
 'atp/country/AZ': 2,
 'atp/country/BA': 5,
 'atp/country/BB': 2,
 'atp/country/BE': 9,
 'atp/country/BG': 10,
 'atp/country/BH': 5,
 'atp/country/BL': 2,
 'atp/country/CA': 4,
 'atp/country/CH': 19,
 'atp/country/CO': 5,
 'atp/country/CR': 11,
 'atp/country/CS': 10,
 'atp/country/CW': 4,
 'atp/country/CY': 6,
 'atp/country/CZ': 7,
 'atp/country/DE': 336,
 'atp/country/DK': 13,
 'atp/country/DO': 3,
 'atp/country/EC': 4,
 'atp/country/EE': 7,
 'atp/country/EG': 26,
 'atp/country/ES': 93,
 'atp/country/FI': 27,
 'atp/country/FO': 1,
 'atp/country/FR': 185,
 'atp/country/GB': 58,
 'atp/country/GE': 4,
 'atp/country/GF': 3,
 'atp/country/GG': 1,
 'atp/country/GP': 4,
 'atp/country/GR': 21,
 'atp/country/GT': 1,
 'atp/country/GU': 2,
 'atp/country/HN': 4,
 'atp/country/HR': 22,
 'atp/country/HU': 13,
 'atp/country/IE': 9,
 'atp/country/IL': 26,
 'atp/country/IQ': 4,
 'atp/country/IS': 3,
 'atp/country/IT': 60,
 'atp/country/JM': 3,
 'atp/country/JO': 9,
 'atp/country/JP': 41,
 'atp/country/KW': 1,
 'atp/country/LA': 2,
 'atp/country/LB': 2,
 'atp/country/LC': 8,
 'atp/country/LK': 3,
 'atp/country/LT': 11,
 'atp/country/LU': 3,
 'atp/country/LV': 10,
 'atp/country/LY': 4,
 'atp/country/MA': 20,
 'atp/country/MC': 1,
 'atp/country/MD': 5,
 'atp/country/ME': 9,
 'atp/country/MF': 1,
 'atp/country/MK': 9,
 'atp/country/MN': 8,
 'atp/country/MQ': 3,
 'atp/country/MT': 1,
 'atp/country/MU': 14,
 'atp/country/MX': 31,
 'atp/country/MY': 8,
 'atp/country/MZ': 1,
 'atp/country/NA': 2,
 'atp/country/NC': 4,
 'atp/country/NG': 7,
 'atp/country/NL': 20,
 'atp/country/NO': 72,
 'atp/country/NZ': 7,
 'atp/country/OM': 3,
 'atp/country/PA': 5,
 'atp/country/PE': 7,
 'atp/country/PL': 23,
 'atp/country/PR': 2,
 'atp/country/PT': 43,
 'atp/country/PY': 3,
 'atp/country/QA': 3,
 'atp/country/RE': 1,
 'atp/country/RO': 16,
 'atp/country/SA': 16,
 'atp/country/SC': 4,
 'atp/country/SE': 106,
 'atp/country/SG': 3,
 'atp/country/SI': 10,
 'atp/country/SK': 4,
 'atp/country/SN': 3,
 'atp/country/SX': 2,
 'atp/country/TC': 3,
 'atp/country/TH': 17,
 'atp/country/TR': 40,
 'atp/country/TT': 2,
 'atp/country/UA': 23,
 'atp/country/US': 129,
 'atp/country/UY': 6,
 'atp/country/UZ': 18,
 'atp/country/ZA': 24,
 'atp/field/branch/missing': 2066,
 'atp/field/country/from_website_url': 3,
 'atp/field/email/missing': 2066,
 'atp/field/operator/missing': 2066,
 'atp/field/operator_wikidata/missing': 2066,
 'atp/field/phone/missing': 2066,
 'atp/field/postcode/missing': 93,
 'atp/field/state/from_reverse_geocoding': 133,
 'atp/field/state/missing': 1933,
 'atp/field/street_address/missing': 1,
 'atp/item_scraped_host_count/www.sixt.co.uk': 2066,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 2066,
 'downloader/request_bytes': 1118338,
 'downloader/request_count': 2069,
 'downloader/request_method_count/GET': 2069,
 'downloader/response_bytes': 57170226,
 'downloader/response_count': 2069,
 'downloader/response_status_count/200': 2069,
 'elapsed_time_seconds': 2521.644847,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 23, 17, 55, 32, 225768, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 374245026,
 'httpcompression/response_count': 2068,
 'item_scraped_count': 2066,
 'items_per_minute': None,
 'log_count/INFO': 52,
 'memusage/max': 559271936,
 'memusage/startup': 263589888,
 'request_depth_max': 2,
 'response_received_count': 2069,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2068,
 'scheduler/dequeued/memory': 2068,
 'scheduler/enqueued': 2068,
 'scheduler/enqueued/memory': 2068,
 'start_time': datetime.datetime(2025, 4, 23, 17, 13, 30, 580921, tzinfo=datetime.timezone.utc)}
```