### PR TITLE
[Sdek] Fix spider

### DIFF
--- a/locations/spiders/sdek.py
+++ b/locations/spiders/sdek.py
@@ -16,7 +16,6 @@ class SdekSpider(scrapy.Spider):
     allowed_domains = ["www.cdek.ru"]
     item_attributes = {"brand": "СДЭК", "brand_wikidata": "Q28665980", "extras": {"brand:en": "SDEK"}}
     user_agent = BROWSER_DEFAULT
-    requires_proxy = True
 
     # Because of bot detection after certain no. of requests querying GraphQL API https://www.cdek.ru/api-site/v1/graphql/ for individual POI details is no longer feasible.
     def make_request(self, page: int, limit: int = 100) -> JsonRequest:

--- a/locations/spiders/sdek.py
+++ b/locations/spiders/sdek.py
@@ -6,6 +6,7 @@ from scrapy.http import JsonRequest
 from locations.categories import Categories, PaymentMethods, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 PAYMENT_MAPPING = {
     "CASH": PaymentMethods.CASH,
@@ -19,6 +20,7 @@ class SdekSpider(scrapy.Spider):
     allowed_domains = ["www.cdek.ru"]
     start_urls = ["https://www.cdek.ru/api-site/website/office/map/?websiteId=ru&locale=ru"]
     item_attributes = {"brand": "СДЭК", "brand_wikidata": "Q28665980", "extras": {"brand:en": "SDEK"}}
+    user_agent = BROWSER_DEFAULT
     requires_proxy = True
 
     def parse(self, response):

--- a/locations/spiders/sdek.py
+++ b/locations/spiders/sdek.py
@@ -1,59 +1,57 @@
-from urllib.parse import urljoin
+from typing import Any, Iterable
 
 import scrapy
-from scrapy.http import JsonRequest
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, PaymentMethods, apply_category, apply_yes_no
+from locations.categories import Categories, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
-
-PAYMENT_MAPPING = {
-    "CASH": PaymentMethods.CASH,
-    "HAVE_TERMINAL": PaymentMethods.CARDS,
-    "HAVE_CASHLESS": None,
-}
 
 
 class SdekSpider(scrapy.Spider):
     name = "sdek"
     allowed_domains = ["www.cdek.ru"]
-    start_urls = ["https://www.cdek.ru/api-site/website/office/map/?websiteId=ru&locale=ru"]
     item_attributes = {"brand": "СДЭК", "brand_wikidata": "Q28665980", "extras": {"brand:en": "SDEK"}}
     user_agent = BROWSER_DEFAULT
     requires_proxy = True
 
-    def parse(self, response):
-        data = response.json()
-        for poi in data.get("data", {}).get("data", []):
-            yield JsonRequest(
-                "https://www.cdek.ru/api-site/v1/graphql/", data=self.graphql_query(poi["id"]), callback=self.parse_poi
-            )
+    # Because of bot detection after certain no. of requests querying GraphQL API https://www.cdek.ru/api-site/v1/graphql/ for individual POI details is no longer feasible.
+    def make_request(self, page: int, limit: int = 100) -> JsonRequest:
+        return JsonRequest(
+            url=f"https://www.cdek.ru/api-site/website/office/?locale=ru&coords[startLat]=-90&coords[startLong]=-180&coords[endLat]=90&coords[endLong]=180&limit={limit}&page={page}",
+            meta={"page": page},
+            dont_filter=True,
+        )
 
-    def parse_poi(self, response):
-        data = response.json()
-        poi = data.get("data", {}).get("websiteOffice")
-        item = DictParser.parse(poi)
-        item["street_address"] = item.pop("addr_full")
-        item["ref"] = poi.get("code")
-        item["website"] = urljoin("https://www.cdek.ru", poi.get("pathForWebView"))
-        item["phone"] = "; ".join(poi.get("contactPhone"))
-        item["email"] = "; ".join(poi.get("contactEmail"))
-        item["lat"] = poi.get("geoLatitude")
-        item["lon"] = poi.get("geoLongitude")
+    def start_requests(self) -> Iterable[Request]:
+        yield self.make_request(1)
 
-        category = poi.get("type")
-        if category == "PVZ":
-            apply_category(Categories.POST_OFFICE, item)
-        elif category == "POSTAMAT":
-            apply_category(Categories.PARCEL_LOCKER, item)
-            apply_yes_no("parcel_mail_in", item, poi.get("isReception"))
-            apply_yes_no("parcel_pickup", item, poi.get("isHangout"))
-        self.parse_hours(item, poi)
-        self.parse_payment(item, poi)
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json().get("data", {}).get("data", []):
+            item = DictParser.parse(poi)
+            item["street_address"] = item.pop("addr_full")
+            item["ref"] = poi.get("code")
+            item["website"] = f'https://www.cdek.ru/ru/offices/view/{item["ref"]}/'
+            item["lat"] = poi.get("geoLatitude")
+            item["lon"] = poi.get("geoLongitude")
 
-    def parse_hours(self, item, poi):
+            category = poi.get("type")
+            if category == "PVZ":
+                apply_category(Categories.POST_OFFICE, item)
+            elif category == "POSTAMAT":
+                apply_category(Categories.PARCEL_LOCKER, item)
+                apply_yes_no("parcel_mail_in", item, poi.get("isReception"))
+                apply_yes_no("parcel_pickup", item, poi.get("isHangout"))
+            self.parse_hours(item, poi)
+            yield item
+
+        if response.json()["data"]["count"] == 100:
+            yield self.make_request(response.meta["page"] + 1)
+
+    def parse_hours(self, item: Feature, poi: dict) -> Any:
         if hours := poi.get("worktimes"):
             try:
                 oh = OpeningHours()
@@ -64,77 +62,6 @@ class SdekSpider(scrapy.Spider):
                         close_time=hour["stopTime"],
                         time_format="%H:%M:%S",
                     )
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
             except Exception as e:
                 self.logger.warning(f"Failed to parse hours: {hours}, {e}")
-
-    def parse_payment(self, item, poi):
-        if payments := poi.get("payments"):
-            for payment in payments:
-                if tag := PAYMENT_MAPPING.get(payment):
-                    apply_yes_no(tag, item, True)
-
-    def graphql_query(self, poi_id):
-        return {
-            "query": """query websiteOffice(
-            $id: UID!
-            ) {
-            websiteOffice(id: $id)
-            {
-                id
-                type
-                name
-                city
-                active
-                contactPhone
-                contactEmail
-                payments
-                isReception
-                isHangout
-                holidays {
-                    dateBegin
-                    dateEnd
-                }
-                shorterDays {
-                    dateBegin
-                    dateEnd
-                    timeBegin
-                    timeEnd
-                }
-                maxDimensions {
-                depth
-                height
-                width
-                }
-                metroStations {
-                name
-                line {
-                    name
-                    color
-                }
-                }
-                geoLatitude
-                geoLongitude
-                weight {
-                    weightMin
-                    weightMax
-                }
-                worktime
-                worktimes {
-                    day
-                    startTime
-                    stopTime
-                }
-                code
-                address
-                pathForWebView
-                dimensions {
-                depth
-                height
-                width
-                }
-                timezone
-            }
-            }""",
-            "variables": {"id": int(poi_id)},
-        }


### PR DESCRIPTION
Making request for individual POI details (`phone`, `email` etc) for about `8k` POIs is no longer feasible. Tried with `custom-settings` and increasing `download_delay`, nothing works and after a certain no. of requests, captch page is served as response. Hence, Alternate API is used to utilize the best possible option.

```python
{'atp/brand/СДЭК': 8249,
 'atp/brand_wikidata/Q28665980': 8249,
 'atp/category/amenity/parcel_locker': 2556,
 'atp/category/amenity/post_office': 5693,
 'atp/clean_strings/street_address': 23,
 'atp/country/RU': 8249,
 'atp/field/branch/missing': 8249,
 'atp/field/city/missing': 8249,
 'atp/field/country/from_website_url': 8249,
 'atp/field/email/missing': 8249,
 'atp/field/image/missing': 8249,
 'atp/field/name/missing': 2556,
 'atp/field/opening_hours/missing': 32,
 'atp/field/operator/missing': 8249,
 'atp/field/operator_wikidata/missing': 8249,
 'atp/field/phone/missing': 8249,
 'atp/field/postcode/missing': 8249,
 'atp/field/state/missing': 8249,
 'atp/field/twitter/missing': 8249,
 'atp/item_scraped_host_count/www.cdek.ru': 8249,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 5693,
 'atp/nsi/match_failed': 2556,
 'downloader/request_bytes': 69068,
 'downloader/request_count': 85,
 'downloader/request_method_count/GET': 85,
 'downloader/response_bytes': 846992,
 'downloader/response_count': 85,
 'downloader/response_status_count/200': 84,
 'downloader/response_status_count/307': 1,
 'elapsed_time_seconds': 192.251722,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 24, 13, 6, 41, 612121, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5890810,
 'httpcompression/response_count': 84,
 'item_scraped_count': 8249,
 'items_per_minute': None,
 'log_count/DEBUG': 8345,
 'log_count/INFO': 12,
 'log_count/WARNING': 32,
 'request_depth_max': 82,
 'response_received_count': 84,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 84,
 'scheduler/dequeued/memory': 84,
 'scheduler/enqueued': 84,
 'scheduler/enqueued/memory': 84,
 'start_time': datetime.datetime(2025, 4, 24, 13, 3, 29, 360399, tzinfo=datetime.timezone.utc)}
```