### PR TITLE
[Kruidvat ] Add custom settings to fix Spider

### DIFF
--- a/locations/spiders/kruidvat.py
+++ b/locations/spiders/kruidvat.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -13,10 +14,16 @@ class KruidvatSpider(scrapy.Spider):
     name = "kruidvat"
     item_attributes = {"brand": "Kruidvat", "brand_wikidata": "Q2226366"}
     start_urls = [
-        "https://www.kruidvat.be/api/v2/kvb/stores?lang=nl_BE&radius=100000&pageSize=10000&fields=FULL",
-        "https://www.kruidvat.nl/api/v2/kvn/stores?lang=nl&radius=100000&pageSize=10000&fields=FULL",
+        "https://www.kruidvat.be/api/v2/kvb/stores?lang=nl_BE&radius=100&pageSize=3000&fields=FULL",
+        "https://www.kruidvat.nl/api/v2/kvn/stores?lang=nl&radius=500&pageSize=3000&fields=FULL",
     ]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": BROWSER_DEFAULT,
+        "DOWNLOAD_TIMEOUT": 120,
+        "CONCURRENT_REQUESTS": 1,
+    }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.xpath("//stores"):


### PR DESCRIPTION
```python
{'atp/brand/Kruidvat': 1477,
 'atp/brand_wikidata/Q2226366': 1477,
 'atp/category/shop/chemist': 1477,
 'atp/country/BE': 347,
 'atp/country/NL': 1130,
 'atp/field/branch/missing': 1477,
 'atp/field/city/missing': 1477,
 'atp/field/country/from_website_url': 1477,
 'atp/field/email/missing': 1477,
 'atp/field/image/missing': 1477,
 'atp/field/lat/missing': 187,
 'atp/field/lon/missing': 187,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 1477,
 'atp/field/operator_wikidata/missing': 1477,
 'atp/field/phone/missing': 1477,
 'atp/field/state/missing': 12,
 'atp/field/twitter/missing': 1477,
 'atp/geometry/null_island': 187,
 'atp/item_scraped_host_count/www.kruidvat.be': 347,
 'atp/item_scraped_host_count/www.kruidvat.nl': 1130,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1477,
 'downloader/request_bytes': 627,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5403284,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 38.843272,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 24, 14, 25, 12, 686007, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1477,
 'items_per_minute': None,
 'log_count/DEBUG': 1502,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': None,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 4, 24, 14, 24, 33, 842735, tzinfo=datetime.timezone.utc)}
```