### PR TITLE
[Costco CA] Fix spider

### DIFF
--- a/locations/spiders/costco_ca.py
+++ b/locations/spiders/costco_ca.py
@@ -1,10 +1,12 @@
 from typing import Any
 
+import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -12,10 +14,11 @@ class CostcoCASpider(Spider):
     name = "costco_ca"
     item_attributes = {"brand": "Costco", "brand_wikidata": "Q715583"}
     start_urls = ["https://www.costco.ca/AjaxWarehouseBrowseLookupView?countryCode=CA"]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json():
+        for store in chompjs.parse_js_object(response.text):  # JSON is embedded within HTML
             if not isinstance(store, dict):
                 continue
             item = DictParser.parse(store)


### PR DESCRIPTION
```python
{'atp/brand/Costco': 109,
 'atp/brand_wikidata/Q715583': 109,
 'atp/category/shop/wholesale': 109,
 'atp/clean_strings/phone': 109,
 'atp/country/CA': 109,
 'atp/field/email/missing': 109,
 'atp/field/image/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/item_scraped_host_count/www.costco.ca': 109,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 109,
 'downloader/request_bytes': 292,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 93058,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 11.825513,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 25, 6, 2, 17, 632994, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 109,
 'items_per_minute': None,
 'log_count/DEBUG': 130,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 25, 6, 2, 5, 807481, tzinfo=datetime.timezone.utc)}
```