### PR TITLE
[Key Bank US] Fix Spider

### DIFF
--- a/locations/spiders/keybank_us.py
+++ b/locations/spiders/keybank_us.py
@@ -2,7 +2,7 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class KeybankUSSpider(SitemapSpider, StructuredDataSpider):
@@ -11,7 +11,7 @@ class KeybankUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.key.com/about/seo.sitemap-locator.xml"]
     sitemap_rules = [(r"locations/.*/.*/.*/.*", "parse_sd")]
     time_format = "%H:%M:%S"
-    user_agent = BROWSER_DEFAULT
+    user_agent = FIREFOX_LATEST
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = response.css("h1.address__title::text").get()


### PR DESCRIPTION
**_Fixes : updated user agents to fix spider_**

```python
{'atp/brand/KeyBank': 978,
 'atp/brand_wikidata/Q1740314': 978,
 'atp/category/amenity/bank': 978,
 'atp/country/US': 978,
 'atp/field/branch/missing': 978,
 'atp/field/country/from_spider_name': 978,
 'atp/field/email/missing': 978,
 'atp/field/image/missing': 978,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 978,
 'atp/field/operator_wikidata/missing': 978,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 978,
 'atp/item_scraped_host_count/www.key.com': 978,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 978,
 'downloader/request_bytes': 1905458,
 'downloader/request_count': 1083,
 'downloader/request_method_count/GET': 1083,
 'downloader/response_bytes': 9034645,
 'downloader/response_count': 1083,
 'downloader/response_status_count/200': 980,
 'downloader/response_status_count/404': 103,
 'elapsed_time_seconds': 1338.349167,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 28, 4, 10, 5, 354561, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 52050275,
 'httpcompression/response_count': 1083,
 'httperror/response_ignored_count': 103,
 'httperror/response_ignored_status_count/404': 103,
 'item_scraped_count': 978,
 'items_per_minute': None,
 'log_count/DEBUG': 2078,
 'log_count/INFO': 134,
 'request_depth_max': 1,
 'response_received_count': 1083,
 'responses_per_minute': None,
 'scheduler/dequeued': 1083,
 'scheduler/dequeued/memory': 1083,
 'scheduler/enqueued': 1083,
 'scheduler/enqueued/memory': 1083,
 'start_time': datetime.datetime(2025, 4, 28, 3, 47, 47, 5394, tzinfo=datetime.timezone.utc)}
```