### PR TITLE
[Tmobile CZ] Fix Spider

### DIFF
--- a/locations/spiders/tmobile_cz.py
+++ b/locations/spiders/tmobile_cz.py
@@ -15,7 +15,11 @@ class TmobileCZSpider(JSONBlobSpider):
     def extract_json(self, response):
         p = re.compile(r"new AO\(([a-z0-9., ';-]+{[^}]+})\)")
         for m in p.finditer(response.text):
-            item_str = "[" + m.group(1).replace("'", '"') + "]"
+            item_str = (
+                "["
+                + m.group(1).replace("'", '"').replace('<BR><div class="siebui-emr-greeting">&nbsp;</div>', "")
+                + "]"
+            )
             item_json = json.loads(item_str)
             _shape, _coords, _x, _y, id, _descr, _pos, data = item_json
             data["id"] = id


### PR DESCRIPTION
**_Fixes : updated raw string to fix spider_**
```python
{'atp/brand/T-Mobile': 101,
 'atp/brand_wikidata/Q327634': 101,
 'atp/category/shop/mobile_phone': 101,
 'atp/country/CZ': 101,
 'atp/field/branch/missing': 101,
 'atp/field/country/from_spider_name': 101,
 'atp/field/image/missing': 101,
 'atp/field/operator/missing': 101,
 'atp/field/operator_wikidata/missing': 101,
 'atp/field/phone/missing': 79,
 'atp/field/state/missing': 101,
 'atp/field/twitter/missing': 101,
 'atp/field/website/missing': 101,
 'atp/item_scraped_host_count/coveragemap-tmcz.position.cz': 101,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 101,
 'downloader/request_bytes': 364,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 9481,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.578469,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 28, 5, 24, 19, 869341, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 42246,
 'httpcompression/response_count': 1,
 'item_scraped_count': 101,
 'items_per_minute': None,
 'log_count/DEBUG': 113,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 28, 5, 24, 17, 290872, tzinfo=datetime.timezone.utc)}
```