### PR TITLE
[Denner CH] Fix spider

### DIFF
--- a/locations/spiders/denner_ch.py
+++ b/locations/spiders/denner_ch.py
@@ -1,30 +1,41 @@
-from typing import Any
+from typing import Iterable
 
-import scrapy
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class DennerCHSpider(StructuredDataSpider):
+class DennerCHSpider(SitemapSpider, StructuredDataSpider):
     name = "denner_ch"
     item_attributes = {"brand": "Denner", "brand_wikidata": "Q379911"}
-    start_urls = ["https://www.denner.ch/de/index.php?type=667&tx_dennerstores_storelocator%5Baction%5D=mapdata"]
+    sitemap_urls = ["https://www.denner.ch/sitemap.store.xml"]
+    sitemap_rules = [("/de/filialen/", "parse_sd")]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json().values():
-            yield scrapy.Request(url=response.urljoin(store["uri"]), callback=self.parse_sd, meta={"list_entry": store})
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            if isinstance(ld_obj.get("@graph"), list):
+                ld_obj = ld_obj["@graph"][0]
+
+            if not ld_obj.get("@type"):
+                continue
+
+            types = ld_obj["@type"]
+
+            if not isinstance(types, list):
+                types = [types]
+
+            types = [LinkedDataParser.clean_type(t) for t in types]
+
+            for wanted_types in self.wanted_types:
+                if isinstance(wanted_types, list):
+                    if all(wanted in types for wanted in wanted_types):
+                        yield ld_obj
+                elif wanted_types in types:
+                    yield ld_obj
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["name"] = response.meta["list_entry"]["name"]
-
-        if response.meta["list_entry"]["name"] == "Denner Express":
-            apply_category(Categories.SHOP_CONVENIENCE, item)
-        else:
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-
-        item["lat"] = response.xpath('//*[@id="storeLatitude"]/@value').get()
-        item["lon"] = response.xpath('//*[@id="storeLongitude"]/@value').get()
+        item["name"] = ld_data["name"].removesuffix(" Filiale")
         yield item

--- a/locations/spiders/denner_ch.py
+++ b/locations/spiders/denner_ch.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.hours import DAYS_FULL
 from locations.items import Feature
 from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
@@ -35,6 +36,12 @@ class DennerCHSpider(SitemapSpider, StructuredDataSpider):
                         yield ld_obj
                 elif wanted_types in types:
                     yield ld_obj
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        for index, rule in enumerate(
+            ld_data.get("openingHoursSpecification", [])
+        ):  # Actual hours starts from Monday, but raw data wrongly starts from Tuesday
+            rule["dayOfWeek"] = DAYS_FULL[index]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["name"] = ld_data["name"].removesuffix(" Filiale")


### PR DESCRIPTION
```python
{'atp/brand/Denner': 874,
 'atp/brand_wikidata/Q379911': 874,
 'atp/category/missing': 874,
 'atp/country/CH': 874,
 'atp/field/branch/missing': 874,
 'atp/field/city/missing': 874,
 'atp/field/email/missing': 874,
 'atp/field/image/missing': 874,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 874,
 'atp/field/operator_wikidata/missing': 874,
 'atp/field/phone/missing': 610,
 'atp/field/state/missing': 874,
 'atp/field/twitter/missing': 874,
 'atp/item_scraped_host_count/www.denner.ch': 874,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 874,
 'downloader/request_bytes': 335932,
 'downloader/request_count': 876,
 'downloader/request_method_count/GET': 876,
 'downloader/response_bytes': 71280635,
 'downloader/response_count': 876,
 'downloader/response_status_count/200': 876,
 'elapsed_time_seconds': 13.246811,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 28, 8, 26, 50, 659117, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 876,
 'httpcompression/response_bytes': 351701230,
 'httpcompression/response_count': 875,
 'item_scraped_count': 874,
 'items_per_minute': None,
 'log_count/DEBUG': 1762,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 876,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 875,
 'scheduler/dequeued/memory': 875,
 'scheduler/enqueued': 875,
 'scheduler/enqueued/memory': 875,
 'start_time': datetime.datetime(2025, 4, 28, 8, 26, 37, 412306, tzinfo=datetime.timezone.utc)}
```