### PR TITLE
[Mcdonalds SI] Fix spider

### DIFF
--- a/locations/spiders/mcdonalds_si.py
+++ b/locations/spiders/mcdonalds_si.py
@@ -12,7 +12,7 @@ from locations.spiders.mcdonalds import McdonaldsSpider
 class McdonaldsSISpider(scrapy.Spider):
     name = "mcdonalds_si"
     item_attributes = McdonaldsSpider.item_attributes
-    start_urls = ["https://www.mcdonalds.si/restavracije/"]
+    start_urls = ["https://mcdonalds.si/restavracije"]
 
     def parse(self, response, **kwargs):
         for location in json.loads(re.search(r"docs = (\[.+\])\.map", response.text).group(1)):

--- a/locations/spiders/mcdonalds_si.py
+++ b/locations/spiders/mcdonalds_si.py
@@ -27,6 +27,7 @@ class McdonaldsSISpider(scrapy.Spider):
 
             item["opening_hours"] = OpeningHours()
             for rule in location["hours_shop"]:
-                item["opening_hours"].add_range(DAYS[rule["day"] - 1], rule["time_from"], rule["time_to"])
+                if rule.get("time_from") and rule.get("time_to"):
+                    item["opening_hours"].add_range(DAYS[rule["day"] - 1], rule["time_from"], rule["time_to"])
 
             yield item


### PR DESCRIPTION
```python
{"atp/brand/McDonald's": 28,
 'atp/brand_wikidata/Q38076': 28,
 'atp/category/amenity/fast_food': 28,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/SI': 28,
 'atp/field/branch/missing': 28,
 'atp/field/city/missing': 4,
 'atp/field/country/from_spider_name': 28,
 'atp/field/email/missing': 28,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 28,
 'atp/field/operator_wikidata/missing': 28,
 'atp/field/phone/missing': 28,
 'atp/field/postcode/missing': 28,
 'atp/field/state/missing': 28,
 'atp/field/street_address/missing': 28,
 'atp/field/twitter/missing': 28,
 'atp/item_scraped_host_count/mcdonalds.si': 28,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 28,
 'downloader/request_bytes': 608,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 20175,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.433051,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 28, 9, 26, 19, 878165, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 165761,
 'httpcompression/response_count': 2,
 'item_scraped_count': 28,
 'items_per_minute': None,
 'log_count/DEBUG': 41,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 4, 28, 9, 26, 16, 445114, tzinfo=datetime.timezone.utc)}
```