### PR TITLE
kaufland: fix invalid hours range interpretation of 00:00-00:00

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -954,6 +954,10 @@ class OpeningHours:
         if isinstance(close_time, str):
             if close_time.lower() in closed:
                 return
+            if open_time in ("00:00", "0:00", "00:00:00") and close_time in ("00:00", "0:00", "00:00:00"):
+                # Invalid range supplied. Probably the source data uses this
+                # notation for closed days.
+                return
             if close_time in ("24:00", "00:00", "0:00"):
                 close_time = "23:59"
             if close_time in ("24:00:00", "00:00:00"):
@@ -967,6 +971,11 @@ class OpeningHours:
                 # may be 0:00 or even more divergent if time_format
                 # parameter was used with some exotic value
                 close_time = time.strptime("23:59", "%H:%M")
+        if open_time.tm_hour == close_time.tm_hour and open_time.tm_min == close_time.tm_min:
+            # A single time of day was provided, not a range. Ignore request.
+            # Sometimes source data uses 00:00-00:00 as a range denoting a
+            # closed day.
+            return
 
         self.days_closed.discard(day)
         self.day_hours[day].add((open_time, close_time))

--- a/locations/spiders/kaufland.py
+++ b/locations/spiders/kaufland.py
@@ -37,7 +37,10 @@ class KauflandSpider(Spider):
             oh = OpeningHours()
             for rule in location["wod"]:
                 day, start_time, end_time = rule.split("|")
-                oh.add_range(day, start_time, end_time)
+                if start_time == "00:00" and end_time == "00:00":
+                    oh.set_closed(day)
+                else:
+                    oh.add_range(day, start_time, end_time)
             item["opening_hours"] = oh
 
             item["website"] = self.website_formats.get(response.url).format(location["friendlyUrl"])

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -41,6 +41,9 @@ def test_times():
     o = OpeningHours()
     o.add_range("Mo", time.strptime("07:00", "%H:%M"), time.strptime("17:00", "%H:%M"))
     o.add_range("Tu", "09:00", "19:00")
+    # Invalid ranges which should be ignored (single times, not ranges).
+    o.add_range("We", "00:00", "00:00")
+    o.add_range("Th", "15:55", "15:55")
 
     assert o.as_opening_hours() == "Mo 07:00-17:00; Tu 09:00-19:00"
 


### PR DESCRIPTION
More generally for other spiders, OpeningHours.add_range has been fixed to ignore any open and close times which are identical for the same day. This is particularly true when the open and close times are both 00:00 (or equivalents thereof). As the kaufland spider demonstrates, this notation generally indicates the spider needs to use OpeningHours.set_closed for such days.

Fixes #12989