### PR TITLE
storefinders/where2getit: add limit=10000 parameter

### DIFF
--- a/locations/storefinders/where2getit.py
+++ b/locations/storefinders/where2getit.py
@@ -115,7 +115,10 @@ class Where2GetItSpider(Spider):
             url=url,
             # For hosted.where2getit.com a "limit" parameter value >10000 is rejected.
             data={
-                "request": {"appkey": self.api_key, "formdata": {"objectname": "Locator::Store", "limit": 10000, "where": where_clause}}
+                "request": {
+                    "appkey": self.api_key,
+                    "formdata": {"objectname": "Locator::Store", "limit": 10000, "where": where_clause},
+                }
             },
             method="POST",
             callback=self.parse_locations,
@@ -158,7 +161,9 @@ class Where2GetItSpider(Spider):
 
         locations = response.json()["response"]["collection"]
         if len(locations) == 10000:
-            raise RuntimeError("Locations have probably been truncated due to 10000 features being returned by a single query and the observed maximum limit which can be specified for query results being 10000. Try setting the api_filter_admin_level to a more specific value to avoid 10000 features being returned in any given request.")
+            raise RuntimeError(
+                "Locations have probably been truncated due to 10000 features being returned by a single query and the observed maximum limit which can be specified for query results being 10000. Try setting the api_filter_admin_level to a more specific value to avoid 10000 features being returned in any given request."
+            )
 
         for location in response.json()["response"]["collection"]:
             self.pre_process_data(location)


### PR DESCRIPTION
There has been (or is now) a limit parameter for the Where2GetIt storefinder API method which was used, allowing a limit of up to 10000 results per query to be returned. Previously this wasn't observed to be required for the ross_dress_for_less_us spider but more recently the default limit for this brand appears to have been changed to 1000 results per query, versus the 1847 features this spider should be expected to return. All 1847 features of this spider are again returned if we manually set the limit to 10000 results per query.