### PR TITLE
[Tgi Fridays US] Fix spider

### DIFF
--- a/locations/spiders/tgi_fridays_us.py
+++ b/locations/spiders/tgi_fridays_us.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,3 +11,7 @@ class TgiFridaysUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://locations.tgifridays.com/robots.txt"]
     sitemap_rules = [(r"locations\.tgifridays\.com/[a-z]{2}/[-\w]+/[-\w]+\.html$", "parse_sd")]
     drop_attributes = {"facebook", "twitter"}
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").split(",")[0].title()
+        yield item

--- a/locations/spiders/tgi_fridays_us.py
+++ b/locations/spiders/tgi_fridays_us.py
@@ -1,8 +1,11 @@
-from locations.storefinders.yext_answers import YextAnswersSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class TgiFridaysUSSpider(YextAnswersSpider):
+class TgiFridaysUSSpider(SitemapSpider, StructuredDataSpider):
     name = "tgi_fridays_us"
     item_attributes = {"brand": "TGI Fridays", "brand_wikidata": "Q1524184"}
-    api_key = "96b4f9cb0c9c2f050eeec613af5b5340"
-    experience_key = "tgi-fridays-search"
+    sitemap_urls = ["https://locations.tgifridays.com/robots.txt"]
+    sitemap_rules = [(r"locations\.tgifridays\.com/[a-z]{2}/[-\w]+/[-\w]+\.html$", "parse_sd")]
+    drop_attributes = {"facebook", "twitter"}


### PR DESCRIPTION
```python
{'atp/brand/TGI Fridays': 85,
 'atp/brand_wikidata/Q1524184': 85,
 'atp/category/amenity/restaurant': 85,
 'atp/cdn/cloudflare/response_count': 88,
 'atp/cdn/cloudflare/response_status_count/200': 88,
 'atp/clean_strings/branch': 1,
 'atp/country/US': 85,
 'atp/field/email/missing': 85,
 'atp/field/image/dropped': 85,
 'atp/field/image/missing': 85,
 'atp/field/operator/missing': 85,
 'atp/field/operator_wikidata/missing': 85,
 'atp/field/twitter/missing': 85,
 'atp/item_scraped_host_count/locations.tgifridays.com': 85,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 85,
 'downloader/request_bytes': 35131,
 'downloader/request_count': 88,
 'downloader/request_method_count/GET': 88,
 'downloader/response_bytes': 6751696,
 'downloader/response_count': 88,
 'downloader/response_status_count/200': 88,
 'elapsed_time_seconds': 3.992743,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 29, 12, 17, 3, 702310, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 88,
 'httpcompression/response_bytes': 89274876,
 'httpcompression/response_count': 88,
 'item_scraped_count': 85,
 'items_per_minute': None,
 'log_count/DEBUG': 185,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 88,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 87,
 'scheduler/dequeued/memory': 87,
 'scheduler/enqueued': 87,
 'scheduler/enqueued/memory': 87,
 'start_time': datetime.datetime(2025, 4, 29, 12, 16, 59, 709567, tzinfo=datetime.timezone.utc)}
```