### PR TITLE
[Swarovski EU] Fix Spider

### DIFF
--- a/locations/spiders/swarovski_eu.py
+++ b/locations/spiders/swarovski_eu.py
@@ -4,14 +4,14 @@ import scrapy
 
 from locations.geo import point_locations
 from locations.linked_data_parser import LinkedDataParser
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class SwarovskiEUSpider(scrapy.Spider):
     name = "swarovski_eu"
     item_attributes = {"brand": "Swarovski", "brand_wikidata": "Q611115"}
     allowed_domains = ["swarovski.com"]
-    headers = {"User-Agent": BROWSER_DEFAULT}
+    headers = {"User-Agent": FIREFOX_LATEST}
 
     def start_requests(self):
         point_files = "eu_centroids_120km_radius_country.csv"


### PR DESCRIPTION
**_Fixes : updated user agents to fix spider_**

```python
{'atp/brand/Swarovski': 437,
 'atp/brand_wikidata/Q611115': 437,
 'atp/category/shop/jewelry': 437,
 'atp/country/AT': 13,
 'atp/country/BE': 14,
 'atp/country/CH': 25,
 'atp/country/CZ': 10,
 'atp/country/DE': 63,
 'atp/country/ES': 64,
 'atp/country/FR': 64,
 'atp/country/GB': 64,
 'atp/country/GR': 5,
 'atp/country/HU': 7,
 'atp/country/IE': 4,
 'atp/country/IT': 36,
 'atp/country/LU': 5,
 'atp/country/NL': 24,
 'atp/country/PL': 13,
 'atp/country/PT': 14,
 'atp/country/TR': 11,
 'atp/country/VA': 1,
 'atp/field/branch/missing': 437,
 'atp/field/country/from_reverse_geocoding': 437,
 'atp/field/email/missing': 437,
 'atp/field/image/dropped': 437,
 'atp/field/image/missing': 437,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 437,
 'atp/field/operator_wikidata/missing': 437,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 12,
 'atp/field/street_address/missing': 437,
 'atp/field/twitter/missing': 437,
 'atp/item_scraped_host_count/www.swarovski.com': 437,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 437,
 'downloader/request_bytes': 2791601,
 'downloader/request_count': 2982,
 'downloader/request_method_count/GET': 2982,
 'downloader/response_bytes': 89984364,
 'downloader/response_count': 2982,
 'downloader/response_status_count/200': 2958,
 'downloader/response_status_count/503': 24,
 'dupefilter/filtered': 3812,
 'elapsed_time_seconds': 3659.106285,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 30, 6, 46, 1, 121405, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 784088884,
 'httpcompression/response_count': 2958,
 'httperror/response_ignored_count': 8,
 'httperror/response_ignored_status_count/503': 8,
 'item_scraped_count': 437,
 'items_per_minute': None,
 'log_count/DEBUG': 3431,
 'log_count/ERROR': 8,
 'log_count/INFO': 77,
 'request_depth_max': 1,
 'response_received_count': 2966,
 'responses_per_minute': None,
 'retry/count': 16,
 'retry/max_reached': 8,
 'retry/reason_count/503 Service Unavailable': 16,
 'scheduler/dequeued': 2982,
 'scheduler/dequeued/memory': 2982,
 'scheduler/enqueued': 2982,
 'scheduler/enqueued/memory': 2982,
 'start_time': datetime.datetime(2025, 4, 30, 5, 45, 2, 15120, tzinfo=datetime.timezone.utc)}
```