### PR TITLE
[Swarovski US] Fix Spider

### DIFF
--- a/locations/spiders/swarovski_us.py
+++ b/locations/spiders/swarovski_us.py
@@ -4,14 +4,14 @@ import scrapy
 
 from locations.geo import point_locations
 from locations.linked_data_parser import LinkedDataParser
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class SwarovskiUSSpider(scrapy.Spider):
     name = "swarovski_us"
     item_attributes = {"brand": "Swarovski", "brand_wikidata": "Q611115"}
     allowed_domains = ["swarovski.com"]
-    headers = {"User-Agent": BROWSER_DEFAULT}
+    headers = {"User-Agent": FIREFOX_LATEST}
 
     def start_requests(self):
         point_files = "us_centroids_100mile_radius_state.csv"


### PR DESCRIPTION
**_Fixes : updated user_agents to fix spider_**

```python
{'atp/brand/Swarovski': 220,
 'atp/brand_wikidata/Q611115': 220,
 'atp/category/shop/jewelry': 220,
 'atp/clean_strings/name': 1,
 'atp/country/US': 220,
 'atp/field/branch/missing': 220,
 'atp/field/country/from_spider_name': 220,
 'atp/field/email/missing': 220,
 'atp/field/image/dropped': 220,
 'atp/field/image/missing': 220,
 'atp/field/operator/missing': 220,
 'atp/field/operator_wikidata/missing': 220,
 'atp/field/phone/missing': 5,
 'atp/field/state/from_reverse_geocoding': 178,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 220,
 'atp/field/twitter/missing': 220,
 'atp/item_scraped_host_count/www.swarovski.com': 220,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 220,
 'downloader/request_bytes': 1323588,
 'downloader/request_count': 1413,
 'downloader/request_method_count/GET': 1413,
 'downloader/response_bytes': 36785158,
 'downloader/response_count': 1413,
 'downloader/response_status_count/200': 1413,
 'dupefilter/filtered': 399,
 'elapsed_time_seconds': 1728.733411,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 4, 30, 8, 41, 32, 361357, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 317616536,
 'httpcompression/response_count': 1412,
 'item_scraped_count': 220,
 'items_per_minute': None,
 'log_count/DEBUG': 1641,
 'log_count/ERROR': 4,
 'log_count/INFO': 37,
 'request_depth_max': 1,
 'response_received_count': 1409,
 'responses_per_minute': None,
 'scheduler/dequeued': 1413,
 'scheduler/dequeued/memory': 1413,
 'scheduler/enqueued': 1413,
 'scheduler/enqueued/memory': 1413,
 'start_time': datetime.datetime(2025, 4, 30, 8, 12, 43, 627946, tzinfo=datetime.timezone.utc)}
```