### PR TITLE
[Panera  Bread US] Try spider without proxy

### DIFF
--- a/locations/spiders/panera_bread_us.py
+++ b/locations/spiders/panera_bread_us.py
@@ -14,7 +14,6 @@ def slugify(s):
 class PaneraBreadUSSpider(Spider):
     name = "panera_bread_us"
     item_attributes = {"brand": "Panera Bread", "brand_wikidata": "Q7130852"}
-    requires_proxy = True
 
     def start_requests(self):
         for state in GeonamesCache().get_us_states():


### PR DESCRIPTION
```python
{'atp/brand/Panera Bread': 2225,
 'atp/brand_wikidata/Q7130852': 2225,
 'atp/category/amenity/fast_food': 2225,
 'atp/country/US': 2225,
 'atp/field/email/missing': 2225,
 'atp/field/image/missing': 2225,
 'atp/field/opening_hours/missing': 2225,
 'atp/field/operator/missing': 2225,
 'atp/field/operator_wikidata/missing': 2225,
 'atp/field/twitter/missing': 2225,
 'atp/item_scraped_host_count/www-api.panerabread.com': 2225,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2225,
 'downloader/request_bytes': 70371,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 252030,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 52,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 67.180303,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 5, 11, 37, 14, 1352, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1359083,
 'httpcompression/response_count': 50,
 'item_scraped_count': 2225,
 'items_per_minute': None,
 'log_count/DEBUG': 2515,
 'log_count/INFO': 10,
 'response_received_count': 52,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 51,
 'scheduler/dequeued/memory': 51,
 'scheduler/enqueued': 51,
 'scheduler/enqueued/memory': 51,
 'start_time': datetime.datetime(2025, 5, 5, 11, 36, 6, 821049, tzinfo=datetime.timezone.utc)}
```