### PR TITLE
[Sleep Number US] Fix Spider

### DIFF
--- a/locations/spiders/sleep_number_us.py
+++ b/locations/spiders/sleep_number_us.py
@@ -1,4 +1,5 @@
 from scrapy import Spider
+from scrapy.http import JsonRequest
 
 from locations.categories import Categories
 from locations.dict_parser import DictParser
@@ -8,9 +9,18 @@ from locations.hours import DAYS_FULL, OpeningHours
 class SleepNumberUSSpider(Spider):
     name = "sleep_number_us"
     item_attributes = {"brand_wikidata": "Q7447640", "brand": "Sleep Number", "extras": Categories.SHOP_BED.value}
-    start_urls = [
-        "https://www.sleepnumber.com/api/storefront/store-locations?lat=42.8473561&lng=-106.26166833&limit=10000&radius=25000"
-    ]
+
+    def start_requests(self):
+        for city in [
+            (21.30694, -157.85833),
+            (26.12231, -80.14338),
+            (30.44332, -91.18747),
+            (39.95238, -75.16362),
+            (44.97997, -93.26384),
+        ]:
+            yield JsonRequest(
+                url=f"https://www.sleepnumber.com/api/storefront/store-locations?lat={city[0]}&lng={city[1]}&limit=190&radius=25000"
+            )
 
     def parse(self, response):
         for store in response.json()["entities"]:

--- a/locations/spiders/sleep_number_us.py
+++ b/locations/spiders/sleep_number_us.py
@@ -1,17 +1,20 @@
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from typing import Any
 
-from locations.categories import Categories
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 
 
 class SleepNumberUSSpider(Spider):
     name = "sleep_number_us"
-    item_attributes = {"brand_wikidata": "Q7447640", "brand": "Sleep Number", "extras": Categories.SHOP_BED.value}
+    item_attributes = {"brand": "Sleep Number", "brand_wikidata": "Q7447640"}
+    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
 
     def start_requests(self):
-        for city in [
+        for lat, lon in [
             (21.30694, -157.85833),
             (26.12231, -80.14338),
             (30.44332, -91.18747),
@@ -19,10 +22,12 @@ class SleepNumberUSSpider(Spider):
             (44.97997, -93.26384),
         ]:
             yield JsonRequest(
-                url=f"https://www.sleepnumber.com/api/storefront/store-locations?lat={city[0]}&lng={city[1]}&limit=190&radius=25000"
+                url="https://www.sleepnumber.com/api/storefront/store-locations?lat={}&lng={}&limit=190&radius=25000".format(
+                    lat, lon
+                )
             )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["entities"]:
             item = DictParser.parse(store)
             item["ref"] = store["cid"]
@@ -34,5 +39,6 @@ class SleepNumberUSSpider(Spider):
                     continue
                 for time_period in day_hours["openIntervals"]:
                     item["opening_hours"].add_range(day_name.title(), time_period["start"], time_period["end"])
+            apply_category(Categories.SHOP_BED, item)
 
             yield item

--- a/locations/spiders/sleep_number_us.py
+++ b/locations/spiders/sleep_number_us.py
@@ -32,6 +32,7 @@ class SleepNumberUSSpider(Spider):
             item = DictParser.parse(store)
             item["ref"] = store["cid"]
             item["website"] = store["c_storePagesURLURL"]
+            item["extras"]["ref:google:place_id"] = store.get("googlePlaceId")
 
             try:
                 item["opening_hours"] = self.parse_opening_hours(store.get("hours", {}))


### PR DESCRIPTION
**_Fixes : added start_request to fix spider_**

```python
{'atp/brand/Sleep Number': 636,
 'atp/brand_wikidata/Q7447640': 636,
 'atp/category/shop/bed': 636,
 'atp/country/US': 636,
 'atp/field/branch/missing': 636,
 'atp/field/email/missing': 636,
 'atp/field/image/missing': 636,
 'atp/field/operator/missing': 636,
 'atp/field/operator_wikidata/missing': 636,
 'atp/field/twitter/missing': 636,
 'atp/item_scraped_host_count/www.sleepnumber.com': 950,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 636,
 'downloader/request_bytes': 1976,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 224604,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 5,
 'elapsed_time_seconds': 3.616159,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 7, 10, 5, 7, 994049, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1866132,
 'httpcompression/response_count': 5,
 'item_dropped_count': 314,
 'item_dropped_reasons_count/DropItem': 314,
 'item_scraped_count': 636,
 'items_per_minute': None,
 'log_count/DEBUG': 967,
 'log_count/INFO': 9,
 'response_received_count': 5,
 'responses_per_minute': None,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2025, 5, 7, 10, 5, 4, 377890, tzinfo=datetime.timezone.utc)}
```