### PR TITLE
[Core] Unify requests user agent string

### DIFF
--- a/contrib/gen_overture2osm.py
+++ b/contrib/gen_overture2osm.py
@@ -7,6 +7,8 @@ import re
 import requests
 from scrapy import Selector
 
+from locations.user_agents import BOT_USER_AGENT_REQUESTS
+
 
 def main():
     mapping = parse_wiki()
@@ -21,14 +23,17 @@ def main():
                 mapping[key] = inherited
                 break
 
-    json.dump(mapping, open("overture2osm.json", mode="w"), sort_keys=True, indent=1)
+    with open("overture2osm.json", mode="w") as f:
+        json.dump(mapping, f, sort_keys=True, indent="\t")
     pprint.pp(mapping)
 
 
 def parse_wiki() -> dict:
     table = {}
     data = requests.get(
-        "https://wiki.openstreetmap.org/w/api.php", {"action": "parse", "page": "Overture_Categories", "format": "json"}
+        "https://wiki.openstreetmap.org/w/api.php",
+        {"action": "parse", "page": "Overture_Categories", "format": "json"},
+        headers={"User-Agent": BOT_USER_AGENT_REQUESTS},
     ).json()
     page_html = Selector(text=data["parse"]["text"]["*"])
     for row in page_html.xpath('//table[@id="mapping_table"]//tr')[1:]:

--- a/locations/commands/insights.py
+++ b/locations/commands/insights.py
@@ -12,6 +12,7 @@ from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 
 from locations.name_suggestion_index import NSI
+from locations.user_agents import BOT_USER_AGENT_REQUESTS
 
 
 def iter_json(stream, file_name):
@@ -215,7 +216,7 @@ class InsightsCommand(ScrapyCommand):
         re_qcode = re.compile(r"^Q\d+")
         osm_url_template = "https://taginfo.openstreetmap.org/api/4/key/values?key=brand%3Awikidata&filter=all&lang=en&sortname=count&sortorder=desc&page={}&rp=999&qtype=value"
         for page in range(1, 1000):
-            response = requests.get(osm_url_template.format(page))
+            response = requests.get(osm_url_template.format(page), headers={"User-Agent": BOT_USER_AGENT_REQUESTS})
             if not response.status_code == 200:
                 raise Exception("Failed to load OSM wikidata tag statistics")
             entries = response.json()["data"]

--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -7,6 +7,8 @@ import requests
 import tldextract
 from unidecode import unidecode
 
+from locations.user_agents import BOT_USER_AGENT_REQUESTS
+
 
 class Singleton(type):
     _instances = {}
@@ -31,7 +33,10 @@ class NSI(metaclass=Singleton):
 
     @staticmethod
     def _request_file(file: str) -> dict:
-        resp = requests.get("https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/" + file)
+        resp = requests.get(
+            "https://raw.githubusercontent.com/osmlab/name-suggestion-index/main/{}".format(file),
+            headers={"User-Agent": BOT_USER_AGENT_REQUESTS},
+        )
         if not resp.status_code == 200:
             raise Exception("NSI load failure")
         return resp.json()

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -21,7 +21,7 @@ COMMANDS_MODULE = "locations.commands"
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) {BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; framework {scrapy.__version__})"
+USER_AGENT = f"Mozilla/5.0 (X11; Linux x86_64) {BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) framework/{scrapy.__version__}"
 
 ROBOTSTXT_USER_AGENT = BOT_NAME
 

--- a/locations/spiders/opentransportdata_swiss.py
+++ b/locations/spiders/opentransportdata_swiss.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 import scrapy
 
 from locations.items import Feature
-from locations.user_agents import BOT_USER_AGENT
+from locations.user_agents import BOT_USER_AGENT_SCRAPY
 
 # To emit proper OpenStreetMap tags for platforms, we need to keep some
 # per-station properties in memory.
@@ -42,7 +42,7 @@ class OpentransportdataSwissSpider(scrapy.Spider):
             "https://query.wikidata.org/sparql?{}".format(
                 urlencode({"query": "SELECT ?item ?sboid WHERE {?item p:P13221 ?s. ?s ps:P13221 ?sboid.}"})
             ),
-            headers={"Accept": "text/csv", "User-Agent": BOT_USER_AGENT},
+            headers={"Accept": "text/csv", "User-Agent": BOT_USER_AGENT_SCRAPY},
             callback=self.handle_wikidata_operators,
         )
 

--- a/locations/user_agents.py
+++ b/locations/user_agents.py
@@ -1,3 +1,9 @@
+import requests
+import scrapy
+
+import locations
+from locations import settings
+
 FIREFOX_ESR_128 = "Mozilla/5.0 (Linux x86_64; rv:128.6) Gecko/20100101 Firefox/128.6"
 FIREFOX_ESR_LATEST = FIREFOX_ESR_128
 
@@ -12,4 +18,5 @@ BROWSER_DEFAULT = FIREFOX_ESR_LATEST
 # Wikimedia sites (including Wikidata) have a policy that automated bots
 # should send a User-Agent containing the string "Bot".
 # https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy/en
-ALLTHEPLACES_BOT = "AllThePlacesBot/1.0 (https://www.alltheplaces.xyz/)"
+BOT_USER_AGENT_SCRAPY = f"{settings.BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) AllThePlacesBot/{locations.__version__} framework/{scrapy.__version__}"
+BOT_USER_AGENT_REQUESTS = f"{settings.BOT_NAME}/{locations.__version__} (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) AllThePlacesBot/{locations.__version__} python-requests/{requests.__version__}"


### PR DESCRIPTION
Sets a reasonable user agent string for none scrapy (requests)

`Mozilla/5.0 (X11; Linux x86_64) locations/1.0 (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) framework/2.12.0`

This is the header spiders use by default, I've slightly altered "framework" to better format the version. See #3680 for "framework" vs "Scrapy".

`locations/1.0 (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) AllThePlacesBot/1.0 framework/2.12.0`

This is currently only used by OpenTransportData.swiss, I've changed this to "locations", this is what we honour in robots.txt. AllThePlacesBot is retained to meet Wikimedias policy.

`locations/1.0 (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) AllThePlacesBot/1.0 python-requests/2.32.3`

This is a new header, used by requests. `framework/2.12.0` is switched to `python-requests/2.32.3`.