### PR TITLE
added the_body_shop_au_ca & the_body_shop_gb spiders

### DIFF
--- a/locations/spiders/the_body_shop_au_ca.py
+++ b/locations/spiders/the_body_shop_au_ca.py
@@ -1,0 +1,17 @@
+from scrapy.http import JsonRequest
+
+from locations.storefinders.stockist import StockistSpider
+
+
+class TheBodyShopAUCASpider(StockistSpider):
+    name = "the_body_shop_au_ca"
+    item_attributes = {"brand": "The Body Shop", "brand_wikidata": "Q837851"}
+    keys = ["map_g3y2xkzq", "map_r325r4wq"]
+
+    def start_requests(self):
+        for key in self.keys:
+            yield JsonRequest(
+                url=f"https://stockist.co/api/v1/{key}/locations/all",
+                callback=self.parse_all_locations,
+                errback=self.parse_all_locations_error,
+            )

--- a/locations/spiders/the_body_shop_gb.py
+++ b/locations/spiders/the_body_shop_gb.py
@@ -1,0 +1,8 @@
+from locations.storefinders.storeify import StoreifySpider
+
+
+class TheBodyShopGBSpider(StoreifySpider):
+    name = "the_body_shop_gb"
+    item_attributes = {"brand": "The Body Shop", "brand_wikidata": "Q837851"}
+    api_key = "the-body-shop-uk.myshopify.com"
+    domain = "https://www.thebodyshop.com/"


### PR DESCRIPTION
**_Almost all countries now require separate spiders because the websites for nearly all of them have changed. I have added few countries spiders which possess high POI count_**

**_GB:_**
```python
{'atp/brand/The Body Shop': 109,
 'atp/brand_wikidata/Q837851': 109,
 'atp/category/shop/cosmetics': 109,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/country/GB': 109,
 'atp/field/branch/missing': 109,
 'atp/field/email/missing': 109,
 'atp/field/image/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/state/missing': 109,
 'atp/field/street_address/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/item_scraped_host_count/sl.storeify.app': 109,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 109,
 'downloader/request_bytes': 373,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 17936,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.740852,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 7, 13, 4, 31, 787365, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 152735,
 'httpcompression/response_count': 1,
 'item_scraped_count': 109,
 'items_per_minute': None,
 'log_count/DEBUG': 122,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 7, 13, 4, 30, 46513, tzinfo=datetime.timezone.utc)}
```

**_AU & CA_**

```python
{'atp/brand/The Body Shop': 155,
 'atp/brand_wikidata/Q837851': 155,
 'atp/category/shop/cosmetics': 155,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AU': 93,
 'atp/country/CA': 62,
 'atp/field/branch/missing': 155,
 'atp/field/country/from_reverse_geocoding': 93,
 'atp/field/email/missing': 155,
 'atp/field/image/missing': 155,
 'atp/field/opening_hours/missing': 155,
 'atp/field/operator/missing': 155,
 'atp/field/operator_wikidata/missing': 155,
 'atp/field/twitter/missing': 155,
 'atp/field/website/missing': 154,
 'atp/item_scraped_host_count/stockist.co': 155,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 155,
 'downloader/request_bytes': 680,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14657,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.672527,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 7, 13, 6, 38, 174630, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 88689,
 'httpcompression/response_count': 2,
 'item_scraped_count': 155,
 'items_per_minute': None,
 'log_count/DEBUG': 169,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 5, 7, 13, 6, 34, 502103, tzinfo=datetime.timezone.utc)}
```