### PR TITLE
[budni_de] Rewrite spider after website change

### DIFF
--- a/locations/spiders/budni_de.py
+++ b/locations/spiders/budni_de.py
@@ -1,40 +1,49 @@
 from typing import Any, Iterable
 
 import scrapy
+from chompjs import chompjs
 from scrapy.http import Response
 
-from locations.hours import OpeningHours
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_DE, OpeningHours
 from locations.items import Feature
+from locations.react_server_components import parse_rsc
 
 
 class BudniDESpider(scrapy.Spider):
     name = "budni_de"
     allowed_domains = ["www.budni.de"]
-    start_urls = ["https://www.budni.de/api/infra/branches"]
+    start_urls = ["https://www.budni.de/filialen"]
     item_attributes = {"brand": "Budni", "brand_wikidata": "Q1001516"}
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        for location_data in response.json():
-            yield Feature(
-                {
-                    "ref": location_data["id"],
-                    "street_address": location_data["street"],
-                    "city": location_data["city"],
-                    "postcode": location_data["zip"],
-                    "country": "DE",
-                    "lat": location_data["location"]["lat"],
-                    "lon": location_data["location"]["lon"],
-                    "website": f'https://www.budni.de{location_data["navigationPath"]}',
-                    "image": location_data["headerImage"],
-                    "opening_hours": self.parse_opening_hours(location_data["openingHours"]),
-                    "email": location_data["email"],
-                }
-            )
-
-    @staticmethod
-    def parse_opening_hours(hours_definition):
-        oh = OpeningHours()
-        for day, interval in hours_definition.items():
-            open_time, close_time = interval.strip().strip(" Uhr").split("-")
-            oh.add_range(day.title(), open_time.replace(":", "."), close_time.replace(":", "."), time_format="%H.%M")
-        return oh
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        data = dict(parse_rsc(rsc))
+        # Look for a list consisting only of '$123' references. This is the list of stores.
+        store_list = []
+        for key, value in data.items():
+            if isinstance(value, list):
+                if all(isinstance(i, str) and i.startswith("$") for i in value):
+                    store_list = value
+        for store_reference in store_list:
+            # Sub-objects are '$123' references and need to be fetched from 'data'
+            reference = int(store_reference.removeprefix("$"), 16)
+            store = data[reference]
+            for key, value in store.items():
+                if isinstance(value, str) and value.startswith("$"):
+                    value_ref = int(value.removeprefix("$"), 16)
+                    store[key] = data[value_ref]
+            # Rename keys to help DictParser find the content
+            store["address"] = store.pop("contact")
+            store["address"]["street_address"] = store["address"].pop("streetAndNumber")
+            store["location"] = store["address"]
+            item = DictParser.parse(store)
+            if item["name"].startswith("budni - "):
+                item["branch"] = item["name"].removeprefix("budni - ")
+                item["name"] = "Budni"
+            hours = OpeningHours()
+            hours.add_ranges_from_string(store["workingDaysSummary"], DAYS_DE)
+            item["opening_hours"] = hours
+            yield item

--- a/locations/spiders/budni_de.py
+++ b/locations/spiders/budni_de.py
@@ -39,7 +39,9 @@ class BudniDESpider(scrapy.Spider):
             store["address"] = store.pop("contact")
             store["address"]["street_address"] = store["address"].pop("streetAndNumber")
             store["location"] = store["address"]
+
             item = DictParser.parse(store)
+            item["website"] = "https://www.budni.de/filialen/{}".format(item["ref"])
             if item["name"].startswith("budni - "):
                 item["branch"] = item["name"].removeprefix("budni - ")
                 item["name"] = "Budni"


### PR DESCRIPTION
The budni.de website was restructured. Shop info is now embedded into the page in a weird Next.js format in <script> blocks.

```
{'atp/brand/Budni': 191,
 'atp/brand_wikidata/Q1001516': 191,
 'atp/category/shop/chemist': 191,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/DE': 191,
 'atp/field/country/from_spider_name': 191,
 'atp/field/email/missing': 191,
 'atp/field/image/missing': 191,
 'atp/field/operator/missing': 191,
 'atp/field/operator_wikidata/missing': 191,
 'atp/field/phone/missing': 191,
 'atp/field/state/missing': 191,
 'atp/field/twitter/missing': 191,
 'atp/field/website/missing': 191,
 'atp/item_scraped_host_count/www.budni.de': 191,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 191,
```