### PR TITLE
[mac_cosmetics] Add spider (3599 locations)

### DIFF
--- a/locations/spiders/mac_cosmetics.py
+++ b/locations/spiders/mac_cosmetics.py
@@ -1,0 +1,129 @@
+import json
+import re
+from typing import Any, Iterable
+
+from requests import Response
+from scrapy import FormRequest, Request, Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
+
+
+class MacCosmeticsSpider(Spider):
+    name = "mac_cosmetics"
+    item_attributes = {"brand": "MAC Cosmetics", "brand_wikidata": "Q2624442"}
+    allowed_domains = ["maccosmetics.com"]
+    only_hour = re.compile(r"^(\d\d?)([ap]m)", re.IGNORECASE)
+    colon_missing = re.compile(r"^(\d?\d)(\d\d[ap]m)", re.IGNORECASE)
+    am_missing = re.compile(r"^(\d?\d(:\d\d)?)$")
+    whitespace_before_am = re.compile(r"\s([ap]m)", re.IGNORECASE)
+    time_dot = re.compile(r"(\d?\d)\.(\d\d[ap]m)", re.IGNORECASE)
+    am_dot = re.compile(r"([ap]m)\.", re.IGNORECASE)
+    pm_with_24h = re.compile(r"(1[3-9]|2\d)((?::\d\d)?\s*pm)")
+    re_period = re.compile(r"\s*[,/&]\s*")
+    re_range = re.compile(r"\s*(?:-|–| to )\s*")
+
+    def start_requests(self) -> Iterable[Request]:
+        jsonrpc = [
+            {
+                "method": "locator.doorsandevents",
+                "id": 3,
+                "params": [
+                    {
+                        "fields": "DOOR_ID,DOORNAME,EVENT_NAME,SUB_HEADING,EVENT_START_DATE,EVENT_END_DATE,"
+                        "EVENT_IMAGE,EVENT_FEATURES,EVENT_TIMES,SERVICES,STORE_HOURS,ADDRESS,ADDRESS2,"
+                        "STATE_OR_PROVINCE,CITY,REGION,COUNTRY,ZIP_OR_POSTAL,PHONE1,PHONE2,"
+                        "STORE_TYPE,LONGITUDE,LATITUDE,COMMENTS",
+                        "country": "United States",
+                        "latitude": 0.0,
+                        "longitude": 0.0,
+                        "uom": "mile",
+                        "region_id": 0,
+                        "radius": 25000,
+                    }
+                ],
+            }
+        ]
+        yield FormRequest(
+            "https://www.maccosmetics.com/rpc/jsonrpc.tmpl?dbgmethod=locator.doorsandevents",
+            method="POST",
+            formdata={"JSONRPC": json.dumps(jsonrpc)},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        stores = response.json()[0]["result"]["value"]["results"]
+        rename = {
+            "DOOR_ID": "ref",
+            "DOORNAME": "name",
+            "ADDRESS": "street_address",
+            "ADDRESS2": "street2",
+            "ZIP_OR_POSTAL": "postcode",
+            "PHONE1": "phone",
+        }
+        for feature in stores.values():
+            for old, new in rename.items():
+                if old in feature:
+                    feature[new] = feature.pop(old)
+            item = DictParser.parse(feature)
+            if len(feature.get("STORE_TYPE", "")) > 0:
+                item["extras"]["store_type"] = feature["STORE_TYPE"]
+            any_open = True
+            if "STORE_HOURS" in feature and isinstance(feature["STORE_HOURS"], list):
+                any_open, opening_hours = self.parse_opening_hours(feature)
+                item["opening_hours"] = opening_hours
+            if any_open and not item["name"].endswith("- Closed"):
+                yield item
+
+    def parse_opening_hours(self, feature):
+        any_open = False
+        opening_hours = OpeningHours()
+        for day_definition in feature["STORE_HOURS"]:
+            try:
+                day = DAYS_EN[day_definition["day"]]
+                if (
+                    day_definition.get("hours") is not None
+                    and len(day_definition["hours"]) > 0
+                    and day_definition["hours"].lower() != "closed"
+                ):
+                    for period in self.re_period.split(day_definition["hours"]):
+                        try:
+                            opening_time, closing_time = self.re_range.split(period.strip())
+                            if "m" in opening_time.lower() or "m" in closing_time.lower():  # 12-hour format
+                                opening_time = self.fix_time_format(opening_time)
+                                closing_time = self.fix_time_format(closing_time)
+                                try:
+                                    opening_hours.add_range(day, opening_time, closing_time, "%I:%M%p")
+                                except ValueError:
+                                    self.logger.warning(
+                                        "Invalid opening hours format <%s>, <%s>", opening_time, closing_time
+                                    )
+                            else:  # 24-hour format
+                                try:
+                                    opening_hours.add_range(day, opening_time, closing_time, "%H:%M")
+                                except ValueError:
+                                    self.logger.warning(
+                                        "Invalid opening hours format <%s>, <%s>", opening_time, closing_time
+                                    )
+                            any_open = True
+                        except ValueError:
+                            self.logger.warning("Invalid opening hours format: '%s'", period)
+            except KeyError:
+                self.logger.warning(
+                    "Bad \"day\" in the opening hours definition: '%s', for store '%s'",
+                    day_definition["day"],
+                    feature.get("name"),
+                )
+        return any_open, opening_hours
+
+    def fix_time_format(self, time: str) -> str:
+        time = self.whitespace_before_am.sub(r"\1", time)
+        time = time.replace("mn", "pm")
+        time = self.am_missing.sub(r"\1am", time)
+        time = self.am_dot.sub(r"\1", time)
+        time = self.time_dot.sub(r"\1:\2", time)
+        time = self.only_hour.sub(r"\1:00\2", time)
+        time = self.colon_missing.sub(r"\1:\2", time)
+        match = self.pm_with_24h.match(time)
+        if match:
+            time = f"{int(match.group(1)) - 12:02d}{match.group(2)}"
+        return time


### PR DESCRIPTION
Add [MAC Cosmetics](https://www.maccosmetics.com/), an international cosmetics store chain with 3599 stores globally, out of which 1964 in the US.

```
{'atp/brand/MAC Cosmetics': 3599,
 'atp/brand_wikidata/Q2624442': 3599,
 'atp/category/shop/cosmetics': 3599,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 3,
 'atp/clean_strings/phone': 79,
 'atp/clean_strings/postcode': 6,
 'atp/clean_strings/street_address': 236,
 'atp/country/AE': 38,
 'atp/country/AM': 1,
 'atp/country/AR': 15,
 'atp/country/AT': 22,
 'atp/country/AU': 75,
 'atp/country/AW': 1,
 'atp/country/AZ': 3,
 'atp/country/BA': 1,
 'atp/country/BB': 2,
 'atp/country/BE': 5,
 'atp/country/BG': 3,
 'atp/country/BH': 3,
 'atp/country/BR': 66,
 'atp/country/BS': 3,
 'atp/country/CH': 27,
 'atp/country/CI': 3,
 'atp/country/CL': 21,
 'atp/country/CN': 72,
 'atp/country/CO': 8,
 'atp/country/CR': 6,
 'atp/country/CW': 1,
 'atp/country/CY': 6,
 'atp/country/CZ': 9,
 'atp/country/DE': 87,
 'atp/country/DK': 14,
 'atp/country/DO': 5,
 'atp/country/EC': 6,
 'atp/country/EE': 1,
 'atp/country/ES': 61,
 'atp/country/ET': 1,
 'atp/country/FI': 9,
 'atp/country/FJ': 4,
 'atp/country/FR': 36,
 'atp/country/GB': 110,
 'atp/country/GE': 1,
 'atp/country/GH': 2,
 'atp/country/GP': 1,
 'atp/country/GR': 40,
 'atp/country/GT': 2,
 'atp/country/GU': 3,
 'atp/country/HK': 19,
 'atp/country/HR': 4,
 'atp/country/HU': 7,
 'atp/country/ID': 13,
 'atp/country/IE': 13,
 'atp/country/IL': 11,
 'atp/country/IN': 36,
 'atp/country/IS': 2,
 'atp/country/IT': 48,
 'atp/country/JM': 1,
 'atp/country/JP': 91,
 'atp/country/KE': 6,
 'atp/country/KH': 1,
 'atp/country/KR': 56,
 'atp/country/KW': 9,
 'atp/country/KY': 1,
 'atp/country/KZ': 3,
 'atp/country/LB': 4,
 'atp/country/LT': 5,
 'atp/country/LU': 1,
 'atp/country/LV': 2,
 'atp/country/MA': 4,
 'atp/country/MK': 1,
 'atp/country/MO': 6,
 'atp/country/MP': 1,
 'atp/country/MQ': 1,
 'atp/country/MT': 2,
 'atp/country/MX': 56,
 'atp/country/MY': 28,
 'atp/country/NA': 1,
 'atp/country/NC': 2,
 'atp/country/NG': 6,
 'atp/country/NL': 32,
 'atp/country/NO': 13,
 'atp/country/NZ': 18,
 'atp/country/OM': 4,
 'atp/country/PA': 5,
 'atp/country/PE': 9,
 'atp/country/PF': 2,
 'atp/country/PH': 25,
 'atp/country/PL': 23,
 'atp/country/PR': 4,
 'atp/country/PT': 10,
 'atp/country/PY': 4,
 'atp/country/QA': 5,
 'atp/country/RO': 11,
 'atp/country/RS': 5,
 'atp/country/SA': 42,
 'atp/country/SE': 16,
 'atp/country/SG': 16,
 'atp/country/SI': 1,
 'atp/country/SK': 1,
 'atp/country/SN': 1,
 'atp/country/SV': 4,
 'atp/country/SX': 1,
 'atp/country/TH': 50,
 'atp/country/TN': 2,
 'atp/country/TR': 43,
 'atp/country/TT': 1,
 'atp/country/TW': 10,
 'atp/country/TZ': 1,
 'atp/country/UA': 4,
 'atp/country/UG': 1,
 'atp/country/US': 1964,
 'atp/country/UY': 3,
 'atp/country/VE': 1,
 'atp/country/VN': 10,
 'atp/country/ZA': 40,
 'atp/country/ZM': 1,
 'atp/country/ZW': 1,
 'atp/field/branch/missing': 3599,
 'atp/field/city/missing': 3,
 'atp/field/country/from_reverse_geocoding': 183,
 'atp/field/email/missing': 3599,
 'atp/field/image/missing': 3599,
 'atp/field/opening_hours/missing': 2856,
 'atp/field/operator/missing': 3599,
 'atp/field/operator_wikidata/missing': 3599,
 'atp/field/phone/invalid': 105,
 'atp/field/phone/missing': 198,
 'atp/field/postcode/missing': 212,
 'atp/field/state/from_reverse_geocoding': 1962,
 'atp/field/state/missing': 1459,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 3599,
 'atp/field/website/missing': 3599,
 'atp/item_scraped_host_count/www.maccosmetics.com': 3599,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 3599,
```