### PR TITLE
[Gridserve GB] Fix Spider

### DIFF
--- a/locations/spiders/gridserve_gb.py
+++ b/locations/spiders/gridserve_gb.py
@@ -1,4 +1,7 @@
+import re
+
 from scrapy import Spider
+from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -7,9 +10,17 @@ from locations.dict_parser import DictParser
 class GridserveGBSpider(Spider):
     name = "gridserve_gb"
     item_attributes = {"operator": "Gridserve", "operator_wikidata": "Q89575318"}
-    start_urls = ["https://gfxpushnode.gridserve.com/api/v1/charging-station-by-locations"]
+    start_urls = ["https://electrichighway.gridserve.com/_next/static/chunks/app/page-0bebb48865ab85ed.js"]
 
     def parse(self, response, **kwargs):
+        token = re.search(r"Q=\"(.*)\";var\s*q", response.text).group(1)
+        yield JsonRequest(
+            url="https://dnms-api.gridserve.com/api/v1/locations/1/All?searchText=&sort=&orderType=asc",
+            headers={"authorization": "Bearer " + token},
+            callback=self.parse_locations,
+        )
+
+    def parse_locations(self, response):
         for location in response.json()["data"]:
             if location["type_status"] != "live":
                 continue


### PR DESCRIPTION
**_Fixes : updated start_url to parse authorization token_**


```python
{'atp/category/amenity/charging_station': 207,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/name': 1,
 'atp/country/GB': 207,
 'atp/field/branch/missing': 207,
 'atp/field/brand/missing': 207,
 'atp/field/brand_wikidata/missing': 207,
 'atp/field/email/missing': 207,
 'atp/field/image/missing': 207,
 'atp/field/opening_hours/missing': 207,
 'atp/field/phone/missing': 207,
 'atp/field/state/missing': 207,
 'atp/field/street_address/missing': 207,
 'atp/field/twitter/missing': 207,
 'atp/field/website/missing': 207,
 'atp/item_scraped_host_count/dnms-api.gridserve.com': 207,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 207,
 'atp/operator/Gridserve': 207,
 'atp/operator_wikidata/Q89575318': 207,
 'downloader/request_bytes': 2356,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 2500145,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 14.383108,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 12, 8, 32, 26, 617326, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 207,
 'items_per_minute': None,
 'log_count/DEBUG': 223,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/404': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 5, 12, 8, 32, 12, 234218, tzinfo=datetime.timezone.utc)}
```