### PR TITLE
Vivacom bg

### DIFF
--- a/locations/spiders/vivacom_bg.py
+++ b/locations/spiders/vivacom_bg.py
@@ -1,6 +1,9 @@
 import re
+from typing import Any
 
+import chompjs
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.items import Feature
 
@@ -14,8 +17,8 @@ class VivacomBGSpider(Spider):
     }
     start_urls = ["https://www.vivacom.bg/bg/stores/xhr?method=getJSON"]
 
-    def parse(self, response):
-        for store in response.json():
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in chompjs.parse_js_object(response.text):  # Sometimes server sends JSON embedded within HTML
             if "partners" in store["store_img"]:
                 continue
 

--- a/locations/spiders/vivacom_bg.py
+++ b/locations/spiders/vivacom_bg.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any
 
 import chompjs
@@ -6,6 +5,7 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_BG, OpeningHours
 
 
 class VivacomBGSpider(Spider):
@@ -25,33 +25,7 @@ class VivacomBGSpider(Spider):
             item = DictParser.parse(store)
             item["lat"], item["lon"] = store["latlng"].split(",")
 
-            opening_hours = (
-                store["store_time"]
-                .strip()
-                .replace("почивен ден", "off")
-                .replace("пон.", "Mo")
-                .replace("пт.", "Fr")
-                .replace("пет.", "Fr")
-                .replace("съб.", "Sa")
-                .replace("съб", "Sa")
-                .replace("нед.", "Su")
-                .replace("нд.", "Su")
-                .replace("  ", " ")
-            )
-            oh = []
-            for rule in re.findall(
-                r"(\w{2})\s?-?\s?(\w{2})?:?\s?(\d{2}(\.|:)\d{2})\s?-\s?(\d{2}(\.|:)\d{2})",
-                opening_hours,
-            ):
-                start_day, end_day, start_time, _, end_time, _ = rule
-                start_time = start_time.replace(".", ":")
-                end_time = end_time.replace(".", ":")
-
-                if end_day:
-                    oh.append(f"{start_day}-{end_day} {start_time}-{end_time}")
-                else:
-                    oh.append(f"{start_day} {start_time}-{end_time}")
-
-            item["opening_hours"] = "; ".join(oh)
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(store["store_time"].replace(".", ""), days=DAYS_BG)
 
             yield item

--- a/locations/spiders/vivacom_bg.py
+++ b/locations/spiders/vivacom_bg.py
@@ -5,7 +5,7 @@ import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class VivacomBGSpider(Spider):
@@ -22,12 +22,8 @@ class VivacomBGSpider(Spider):
             if "partners" in store["store_img"]:
                 continue
 
-            item = Feature()
-
-            item["ref"] = store["store_id"]
+            item = DictParser.parse(store)
             item["lat"], item["lon"] = store["latlng"].split(",")
-            item["name"] = store["store_name"]
-            item["phone"] = store["store_phone"]
 
             opening_hours = (
                 store["store_time"]


### PR DESCRIPTION
Fixed `JSONDecodeError` scenario like in last [run](https://alltheplaces-data.openaddresses.io/runs/2025-05-10-13-32-08/stats/vivacom_bg.json). Also done some code clean up.

```python
{'atp/brand/Vivacom': 194,
 'atp/brand_wikidata/Q7937522': 194,
 'atp/category/shop/telecommunication': 194,
 'atp/clean_strings/name': 14,
 'atp/country/BG': 194,
 'atp/field/branch/missing': 194,
 'atp/field/city/missing': 194,
 'atp/field/email/missing': 194,
 'atp/field/image/missing': 194,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 194,
 'atp/field/operator_wikidata/missing': 194,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 194,
 'atp/field/state/missing': 194,
 'atp/field/street_address/missing': 194,
 'atp/field/twitter/missing': 194,
 'atp/field/website/missing': 194,
 'atp/item_scraped_host_count/www.vivacom.bg': 194,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 194,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 315374,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.616014,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 13, 8, 5, 45, 994875, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17243296,
 'httpcompression/response_count': 1,
 'item_scraped_count': 194,
 'items_per_minute': None,
 'log_count/DEBUG': 207,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 13, 8, 5, 41, 378861, tzinfo=datetime.timezone.utc)}

```