### PR TITLE
[Maxmara] Fix spider

### DIFF
--- a/locations/spiders/maxmara.py
+++ b/locations/spiders/maxmara.py
@@ -1,9 +1,12 @@
+import chompjs
 import scrapy
 from geonamescache import GeonamesCache
+from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, OpeningHours
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -11,21 +14,18 @@ class MaxmaraSpider(scrapy.Spider):
     name = "maxmara"
     item_attributes = {"brand": "Max Mara", "brand_wikidata": "Q1151774"}
     gc = GeonamesCache()
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def start_requests(self):
         for country_code in self.gc.get_countries().keys():
-            url = f"https://world.maxmara.com/store-locator?listJson=true&withoutRadius=false&country={country_code}"
-            headers = {
-                "authority": "world.maxmara.com",
-                "referer": "https://world.maxmara.com/store-locator",
-                "user-agent": BROWSER_DEFAULT,
-                "x-requested-with": "XMLHttpRequest",
-            }
-            yield scrapy.Request(url=url, headers=headers, callback=self.parse)
+            yield JsonRequest(
+                url=f"https://us.maxmara.com/store-locator?listJson=true&withoutRadius=false&country={country_code}"
+            )
 
     def parse(self, response):
-        stores = response.json().get("features")
+        stores = chompjs.parse_js_object(response.text).get("features", [])
         for store in stores:
             if not store.get("storeHidden"):
                 store_info = store["properties"]


### PR DESCRIPTION
```python
{'atp/brand/Max Mara': 540,
 'atp/brand_wikidata/Q1151774': 540,
 'atp/category/shop/clothes': 540,
 'atp/clean_strings/name': 13,
 'atp/country/AE': 3,
 'atp/country/AM': 1,
 'atp/country/AR': 1,
 'atp/country/AT': 3,
 'atp/country/AU': 6,
 'atp/country/AZ': 1,
 'atp/country/BE': 7,
 'atp/country/BG': 1,
 'atp/country/BH': 1,
 'atp/country/BR': 1,
 'atp/country/CA': 8,
 'atp/country/CH': 6,
 'atp/country/CL': 1,
 'atp/country/CN': 69,
 'atp/country/CO': 1,
 'atp/country/CY': 1,
 'atp/country/CZ': 2,
 'atp/country/DE': 16,
 'atp/country/DK': 3,
 'atp/country/EE': 1,
 'atp/country/EG': 1,
 'atp/country/ES': 27,
 'atp/country/FR': 20,
 'atp/country/GB': 7,
 'atp/country/GE': 1,
 'atp/country/GR': 6,
 'atp/country/GT': 1,
 'atp/country/HK': 5,
 'atp/country/HR': 3,
 'atp/country/HU': 1,
 'atp/country/ID': 1,
 'atp/country/IT': 117,
 'atp/country/JP': 47,
 'atp/country/KG': 1,
 'atp/country/KR': 26,
 'atp/country/KW': 2,
 'atp/country/KZ': 4,
 'atp/country/LB': 1,
 'atp/country/LT': 1,
 'atp/country/LU': 1,
 'atp/country/LV': 1,
 'atp/country/MA': 4,
 'atp/country/MC': 1,
 'atp/country/ME': 2,
 'atp/country/MN': 1,
 'atp/country/MO': 1,
 'atp/country/MT': 1,
 'atp/country/MX': 6,
 'atp/country/MY': 1,
 'atp/country/NL': 10,
 'atp/country/NO': 1,
 'atp/country/NZ': 1,
 'atp/country/PE': 1,
 'atp/country/PH': 1,
 'atp/country/PL': 12,
 'atp/country/PT': 6,
 'atp/country/QA': 1,
 'atp/country/RO': 1,
 'atp/country/RS': 1,
 'atp/country/RU': 27,
 'atp/country/SA': 1,
 'atp/country/SE': 1,
 'atp/country/SG': 1,
 'atp/country/SI': 1,
 'atp/country/SK': 1,
 'atp/country/TH': 2,
 'atp/country/TN': 1,
 'atp/country/TR': 4,
 'atp/country/TW': 6,
 'atp/country/UA': 6,
 'atp/country/US': 29,
 'atp/country/UZ': 1,
 'atp/field/branch/missing': 540,
 'atp/field/country/from_reverse_geocoding': 14,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 218,
 'atp/field/image/missing': 540,
 'atp/field/opening_hours/missing': 28,
 'atp/field/operator/missing': 540,
 'atp/field/operator_wikidata/missing': 540,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 16,
 'atp/field/state/from_reverse_geocoding': 37,
 'atp/field/state/missing': 492,
 'atp/field/street_address/missing': 540,
 'atp/field/twitter/missing': 540,
 'atp/field/website/missing': 540,
 'atp/item_scraped_host_count/us.maxmara.com': 540,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 540,
 'downloader/request_bytes': 217263,
 'downloader/request_count': 253,
 'downloader/request_method_count/GET': 253,
 'downloader/response_bytes': 1413189,
 'downloader/response_count': 253,
 'downloader/response_status_count/200': 253,
 'elapsed_time_seconds': 318.121048,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 13, 11, 48, 23, 751735, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 540,
 'items_per_minute': None,
 'log_count/DEBUG': 1570,
 'log_count/INFO': 20,
 'log_count/WARNING': 2,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 253,
 'playwright/page_count/closed': 253,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 253,
 'playwright/request_count/method/GET': 253,
 'playwright/request_count/navigation': 253,
 'playwright/request_count/resource_type/document': 253,
 'playwright/response_count': 253,
 'playwright/response_count/method/GET': 253,
 'playwright/response_count/resource_type/document': 253,
 'response_received_count': 253,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 252,
 'scheduler/dequeued/memory': 252,
 'scheduler/enqueued': 252,
 'scheduler/enqueued/memory': 252,
 'start_time': datetime.datetime(2025, 5, 13, 11, 43, 5, 630687, tzinfo=datetime.timezone.utc)}

```