### PR TITLE
[Ncp GB] Use playwright to fix spider

### DIFF
--- a/locations/spiders/ncp_gb.py
+++ b/locations/spiders/ncp_gb.py
@@ -7,6 +7,7 @@ from locations.categories import Categories, Extras, PaymentMethods, apply_categ
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.central_england_cooperative import set_operator
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -25,7 +26,8 @@ class NcpGBSpider(SitemapSpider):
     name = "ncp_gb"
     sitemap_urls = ["https://www.ncp.co.uk/uploads/sitemap.xml"]
     sitemap_rules = [("/find-a-car-park/car-parks/", "parse_pois")]
-    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
     download_delay = 2.0
 
     def parse_pois(self, response):


### PR DESCRIPTION
```python
{'atp/category/amenity/parking': 612,
 'atp/clean_strings/name': 2,
 'atp/country/GB': 612,
 'atp/field/branch/missing': 612,
 'atp/field/brand/missing': 612,
 'atp/field/brand_wikidata/missing': 612,
 'atp/field/city/missing': 612,
 'atp/field/country/from_spider_name': 612,
 'atp/field/email/missing': 612,
 'atp/field/image/missing': 612,
 'atp/field/opening_hours/missing': 560,
 'atp/field/operator/missing': 1,
 'atp/field/operator_wikidata/missing': 55,
 'atp/field/phone/missing': 329,
 'atp/field/postcode/missing': 612,
 'atp/field/state/missing': 612,
 'atp/field/twitter/missing': 612,
 'atp/item_scraped_host_count/www.ncp.co.uk': 612,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 557,
 'atp/operator/Airport Parking & Hotels': 54,
 'atp/operator/National Car Parks': 557,
 'atp/operator_wikidata/Q6971273': 557,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/playwright._impl._errors.Error': 2,
 'downloader/request_bytes': 334428,
 'downloader/request_count': 847,
 'downloader/request_method_count/GET': 847,
 'downloader/response_bytes': 138308130,
 'downloader/response_count': 845,
 'downloader/response_status_count/200': 844,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 2084.231755,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 14, 6, 52, 29, 129180, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 612,
 'items_per_minute': None,
 'log_count/DEBUG': 64740,
 'log_count/ERROR': 2,
 'log_count/INFO': 49,
 'log_count/WARNING': 2,
 'ncp/unknown_supplier/Undefined': 1,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 847,
 'playwright/page_count/closed': 847,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 31210,
 'playwright/request_count/aborted': 29516,
 'playwright/request_count/method/GET': 31210,
 'playwright/request_count/navigation': 1694,
 'playwright/request_count/resource_type/document': 1694,
 'playwright/request_count/resource_type/font': 6,
 'playwright/request_count/resource_type/image': 12523,
 'playwright/request_count/resource_type/script': 14451,
 'playwright/request_count/resource_type/stylesheet': 1692,
 'playwright/request_count/resource_type/xhr': 844,
 'playwright/response_count': 1692,
 'playwright/response_count/method/GET': 1692,
 'playwright/response_count/resource_type/document': 1692,
 'request_depth_max': 1,
 'response_received_count': 845,
 'responses_per_minute': None,
 'scheduler/dequeued': 847,
 'scheduler/dequeued/memory': 847,
 'scheduler/enqueued': 847,
 'scheduler/enqueued/memory': 847,
 'start_time': datetime.datetime(2025, 5, 14, 6, 17, 44, 897425, tzinfo=datetime.timezone.utc)}

```