### PR TITLE
[Primark] Fix Spider

### DIFF
--- a/locations/spiders/primark.py
+++ b/locations/spiders/primark.py
@@ -6,7 +6,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class PrimarkSpider(SitemapSpider, StructuredDataSpider):
@@ -34,7 +34,7 @@ class PrimarkSpider(SitemapSpider, StructuredDataSpider):
         (r"/sk-sk/stores/[^/]+/[^/]+$", "parse"),
         (r"/en-us/stores/[^/]+/[^/]+$", "parse"),
     ]
-    user_agent = BROWSER_DEFAULT
+    user_agent = FIREFOX_LATEST
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None

--- a/locations/spiders/primark.py
+++ b/locations/spiders/primark.py
@@ -35,6 +35,7 @@ class PrimarkSpider(SitemapSpider, StructuredDataSpider):
         (r"/en-us/stores/[^/]+/[^/]+$", "parse"),
     ]
     user_agent = FIREFOX_LATEST
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None


### PR DESCRIPTION
**_Fixes : updated user_agent to fix spider_**

```python
{'atp/brand/Primark': 452,
 'atp/brand_wikidata/Q137023': 452,
 'atp/category/shop/clothes': 452,
 'atp/country/AT': 5,
 'atp/country/BE': 8,
 'atp/country/CZ': 3,
 'atp/country/DE': 27,
 'atp/country/ES': 62,
 'atp/country/FR': 27,
 'atp/country/GB': 197,
 'atp/country/IE': 35,
 'atp/country/IT': 19,
 'atp/country/NL': 20,
 'atp/country/PL': 7,
 'atp/country/PT': 11,
 'atp/country/RO': 2,
 'atp/country/SI': 1,
 'atp/country/SK': 1,
 'atp/country/US': 27,
 'atp/field/city/missing': 81,
 'atp/field/email/missing': 452,
 'atp/field/image/missing': 452,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 452,
 'atp/field/operator_wikidata/missing': 452,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 81,
 'atp/field/state/from_reverse_geocoding': 27,
 'atp/field/state/missing': 425,
 'atp/field/street_address/missing': 81,
 'atp/field/twitter/missing': 452,
 'atp/item_scraped_host_count/www.primark.com': 452,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 452,
 'atp/structured_data/unmapped/payment_accepted/Contactless Payment': 16,
 'atp/structured_data/unmapped/payment_accepted/Credit card': 13,
 'atp/structured_data/unmapped/payment_accepted/Debit card': 13,
 'atp/structured_data/unmapped/payment_accepted/Me2You': 34,
 'atp/structured_data/unmapped/payment_accepted/One4all': 222,
 'downloader/request_bytes': 1639864,
 'downloader/request_count': 608,
 'downloader/request_method_count/GET': 608,
 'downloader/response_bytes': 107335773,
 'downloader/response_count': 608,
 'downloader/response_status_count/200': 599,
 'downloader/response_status_count/404': 9,
 'dupefilter/filtered': 19,
 'elapsed_time_seconds': 741.5503,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 14, 10, 49, 1, 445846, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 883854544,
 'httpcompression/response_count': 590,
 'httperror/response_ignored_count': 9,
 'httperror/response_ignored_status_count/404': 9,
 'item_scraped_count': 452,
 'items_per_minute': None,
 'log_count/DEBUG': 1370,
 'log_count/INFO': 328,
 'request_depth_max': 3,
 'response_received_count': 608,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 607,
 'scheduler/dequeued/memory': 607,
 'scheduler/enqueued': 607,
 'scheduler/enqueued/memory': 607,
 'start_time': datetime.datetime(2025, 5, 14, 10, 36, 39, 895546, tzinfo=datetime.timezone.utc)}
```