### PR TITLE
[Sleep Number US] Update custom settings & requests to fix low count for spider

### DIFF
--- a/locations/spiders/sleep_number_us.py
+++ b/locations/spiders/sleep_number_us.py
@@ -5,24 +5,26 @@ from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
 from locations.hours import OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class SleepNumberUSSpider(Spider):
     name = "sleep_number_us"
     item_attributes = {"brand": "Sleep Number", "brand_wikidata": "Q7447640"}
-    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
+    custom_settings = {
+        "USER_AGENT": BROWSER_DEFAULT,
+        "DOWNLOAD_TIMEOUT": 90,
+        "CONCURRENT_REQUESTS": 1,
+        "RETRY_TIMES": 5,
+        "DOWNLOAD_DELAY": 3,
+    }
 
     def start_requests(self):
-        for lat, lon in [
-            (21.30694, -157.85833),
-            (26.12231, -80.14338),
-            (30.44332, -91.18747),
-            (39.95238, -75.16362),
-            (44.97997, -93.26384),
-        ]:
+        for lat, lon in country_iseadgg_centroids("US", 458):
             yield JsonRequest(
-                url="https://www.sleepnumber.com/api/storefront/store-locations?lat={}&lng={}&limit=190&radius=25000".format(
+                url="https://www.sleepnumber.com/api/storefront/store-locations?lat={}&lng={}&limit=100&radius=300".format(
                     lat, lon
                 )
             )


### PR DESCRIPTION
Spider was not generating expected count, [last run](https://alltheplaces-data.openaddresses.io/runs/2025-05-10-13-32-08/stats/sleep_number_us.json) resulted `442`. Fixes have been applied to fix the low scraped count.

```python
{'atp/brand/Sleep Number': 636,
 'atp/brand_wikidata/Q7447640': 636,
 'atp/category/shop/bed': 636,
 'atp/country/US': 636,
 'atp/field/branch/missing': 636,
 'atp/field/email/missing': 636,
 'atp/field/image/missing': 636,
 'atp/field/operator/missing': 636,
 'atp/field/operator_wikidata/missing': 636,
 'atp/field/twitter/missing': 636,
 'atp/item_scraped_host_count/www.sleepnumber.com': 4200,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 636,
 'downloader/request_bytes': 14989,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 43,
 'downloader/response_bytes': 1046053,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'elapsed_time_seconds': 739.214778,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 15, 8, 54, 25, 934572, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8221991,
 'httpcompression/response_count': 43,
 'item_dropped_count': 3564,
 'item_dropped_reasons_count/DropItem': 3564,
 'item_scraped_count': 636,
 'items_per_minute': None,
 'log_count/DEBUG': 4254,
 'log_count/INFO': 21,
 'response_received_count': 43,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 42,
 'scheduler/dequeued/memory': 42,
 'scheduler/enqueued': 42,
 'scheduler/enqueued/memory': 42,
 'start_time': datetime.datetime(2025, 5, 15, 8, 42, 6, 719794, tzinfo=datetime.timezone.utc)}
```