### PR TITLE
[John Lewis GB] Fix Spider

### DIFF
--- a/locations/spiders/john_lewis_gb.py
+++ b/locations/spiders/john_lewis_gb.py
@@ -14,6 +14,7 @@ class JohnLewisGBSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.johnlewis.com/shops-services.xml"]
     sitemap_rules = [("/our-shops/", "parse_sd")]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["name"] = None


### PR DESCRIPTION
**_Fixes : Flag john_lewis_gb as requires proxy to fix spider_**

```python
{'atp/brand/John Lewis': 36,
 'atp/brand_wikidata/Q1918981': 36,
 'atp/category/shop/department_store': 36,
 'atp/country/GB': 36,
 'atp/field/branch/missing': 36,
 'atp/field/email/missing': 36,
 'atp/field/image/missing': 36,
 'atp/field/operator/missing': 36,
 'atp/field/operator_wikidata/missing': 36,
 'atp/field/state/missing': 36,
 'atp/item_scraped_host_count/www.johnlewis.com': 36,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 36,
 'downloader/request_bytes': 28810,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 1648461,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 39,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 51.213536,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 15, 11, 19, 15, 962158, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9875909,
 'httpcompression/response_count': 39,
 'item_scraped_count': 36,
 'items_per_minute': None,
 'log_count/DEBUG': 87,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 39,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2025, 5, 15, 11, 18, 24, 748622, tzinfo=datetime.timezone.utc)}
```