### PR TITLE
[Iceland Foods] Fix spider

### DIFF
--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -54,6 +54,10 @@ class IcelandFoodsSpider(Spider):
                 else:
                     item["opening_hours"].add_range(rule["day"], rule["open"], rule["close"], "%I:%M%p")
 
+            item["website"] = (
+                f'https://www.iceland.co.uk/store-finder/store?StoreID={item["ref"]}&StoreName={item["branch"].replace(" ", "-")}'
+            )
+
             yield item
 
         if next_page := response.json().get("next"):

--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -1,51 +1,54 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any, Iterable
 
-from locations.hours import OpeningHours
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class IcelandFoodsSpider(SitemapSpider, StructuredDataSpider):
+class IcelandFoodsSpider(Spider):
     name = "iceland_foods"
     item_attributes = {"brand": "Iceland", "brand_wikidata": "Q721810"}
-    allowed_domains = ["www.iceland.co.uk"]
-    sitemap_urls = ["https://www.iceland.co.uk/sitemap-store-site-map.xml"]
-    sitemap_rules = [
-        (
-            r"https://www\.iceland\.co\.uk/store-finder/store\?StoreID=(\d+)&StoreName=",
-            "parse_sd",
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    access_token = ""
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://www.iceland.co.uk/mobify/proxy/ocapi/on/demandware.store/Sites-icelandfoodsuk-Site/default/Account-GetAccessToken",
+            data={},
         )
-    ]
-    wanted_types = ["LocalBusiness"]
-    search_for_phone = False
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["extras"]["branch"] = response.xpath("/html/head/title/text()").get()
-        item["name"] = None
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        self.access_token = response.json()["access_token"]
+        yield JsonRequest(
+            url="https://prd.cc-iceland.co.uk/s/icelandfoodsuk/dw/shop/v22_6/stores?count=200&start=0&distance_unit=mi&max_distance=500&latitude=51.5072178&longitude=-0.1275862",
+            headers={"authorization": f"Bearer {self.access_token}"},
+            callback=self.parse_stores,
+        )
 
-        if "FWH" in item["extras"]["branch"] or "Food Ware" in item["extras"]["branch"]:
-            # The Food Warehouse, obtained via its own spider
-            # The name usually ends with FWH or has Food Warehouse, sometime truncated.
-            return
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["data"]:
+            item = DictParser.parse(store)
 
-        item["opening_hours"] = OpeningHours()
-        for rule in response.xpath("//store-hours/div"):
-            day = rule.xpath("./text()").get()
-            times = rule.xpath('.//div[@class="store-opening-hours"]/text()').getall()
-            if times == ["Closed"]:
+            item["branch"] = item.pop("name")
+            if "FWH" in item["branch"] or "Food Ware" in item["branch"]:
+                # The Food Warehouse, obtained via its own spider
+                # The name usually ends with FWH or has Food Warehouse, sometime truncated.
                 continue
-            item["opening_hours"].add_range(day, times[0].strip(), times[1].strip(), time_format="%I:%M%p")
 
-        if item["opening_hours"].as_opening_hours() == "24/7":
-            # Closed stores, but with the website left up :(
-            # eg https://www.iceland.co.uk/store-finder/store?StoreID=88&StoreName=BATH%20HAM%20GDNS
-            return
+            item["street_address"] = merge_address_lines([store.get("address1"), store.get("address2")])
+            item["state"] = store.get("c_storeRegion")
 
-        if "IRELAND" in item["extras"]["branch"]:
-            item["country"] = "IE"
-        else:
-            item["country"] = "GB"
+            if "IRELAND" in item["branch"]:
+                item["country"] = "IE"
+            else:
+                item["country"] = "GB"
 
-        if phone := response.xpath('//div[@class="phone"]/text()').get():
-            item["phone"] = phone.strip()
+            yield item
 
-        yield item
+        if next_page := response.json().get("next"):
+            yield JsonRequest(
+                url=next_page, headers={"authorization": f"Bearer {self.access_token}"}, callback=self.parse_stores
+            )

--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -4,6 +4,7 @@ from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -45,6 +46,13 @@ class IcelandFoodsSpider(Spider):
                 item["country"] = "IE"
             else:
                 item["country"] = "GB"
+
+            item["opening_hours"] = OpeningHours()
+            for rule in store.get("c_storeHoursJson", []):
+                if rule["open"].upper() == "CLOSED":
+                    item["opening_hours"].set_closed(rule["day"])
+                else:
+                    item["opening_hours"].add_range(rule["day"], rule["open"], rule["close"], "%I:%M%p")
 
             yield item
 


### PR DESCRIPTION
`POI` data is dynamically loaded in the ultimate page, so `sitemap` is no longer useful. Hence, code refactored using `API` to fix the spider.

````python
{'atp/brand/Iceland': 801,
 'atp/brand_wikidata/Q721810': 801,
 'atp/category/shop/frozen_food': 801,
 'atp/cdn/cloudflare/response_count': 6,
 'atp/cdn/cloudflare/response_status_count/200': 6,
 'atp/country/GB': 789,
 'atp/country/IE': 12,
 'atp/field/city/missing': 35,
 'atp/field/email/missing': 797,
 'atp/field/image/missing': 801,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 801,
 'atp/field/operator_wikidata/missing': 801,
 'atp/field/phone/missing': 2,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 31,
 'atp/field/twitter/missing': 801,
 'atp/item_scraped_host_count/prd.cc-iceland.co.uk': 801,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 801,
 'downloader/request_bytes': 12121,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 5,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 106739,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 3.732557,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 16, 15, 57, 51, 968356, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 6,
 'httpcompression/response_bytes': 1682297,
 'httpcompression/response_count': 6,
 'item_scraped_count': 801,
 'items_per_minute': None,
 'log_count/DEBUG': 819,
 'log_count/INFO': 9,
 'request_depth_max': 5,
 'response_received_count': 6,
 'responses_per_minute': None,
 'scheduler/dequeued': 6,
 'scheduler/dequeued/memory': 6,
 'scheduler/enqueued': 6,
 'scheduler/enqueued/memory': 6,
 'start_time': datetime.datetime(2025, 5, 16, 15, 57, 48, 235799, tzinfo=datetime.timezone.utc)}
