### PR TITLE
[Subway spiders] apply category explicitly

### DIFF
--- a/locations/spiders/subway.py
+++ b/locations/spiders/subway.py
@@ -7,6 +7,8 @@ from locations.structured_data_spider import StructuredDataSpider
 
 
 class SubwaySpider(SitemapSpider, StructuredDataSpider):
+    """Also see SubwayWorldwideSpider for API-based spider."""
+
     name = "subway"
     item_attributes = {"brand": "Subway", "brand_wikidata": "Q244457"}
     allowed_domains = ["restaurants.subway.com"]

--- a/locations/spiders/subway_hk.py
+++ b/locations/spiders/subway_hk.py
@@ -2,6 +2,7 @@ import json
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.spiders.subway import SubwaySpider
 
@@ -17,4 +18,7 @@ class SubwayHKSpider(scrapy.Spider):
         )
         for store in data.values():
             item = DictParser.parse(store)
+            apply_category(Categories.FAST_FOOD, item)
+            item["extras"]["cuisine"] = "sandwich"
+            item["extras"]["takeaway"] = "yes"
             yield item

--- a/locations/spiders/subway_kr.py
+++ b/locations/spiders/subway_kr.py
@@ -4,6 +4,7 @@ from scrapy import Request
 from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.subway import SubwaySpider
@@ -40,4 +41,7 @@ class SubwayKRSpider(scrapy.Spider):
         item["addr_full"] = merge_address_lines([data.get("storAddr1"), data.get("storAddr2")])
         item["phone"] = data.get("storTel")
         item["ref"] = item["website"] = response.url
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "sandwich"
+        item["extras"]["takeaway"] = "yes"
         yield item

--- a/locations/spiders/subway_sg.py
+++ b/locations/spiders/subway_sg.py
@@ -1,3 +1,9 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.spiders.subway import SubwaySpider
 from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
 
@@ -6,3 +12,9 @@ class SubwaySGSpider(AgileStoreLocatorSpider):
     name = "subway_sg"
     item_attributes = SubwaySpider.item_attributes
     allowed_domains = ["subwayisfresh.com.sg"]
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "sandwich"
+        item["extras"]["takeaway"] = "yes"
+        yield item

--- a/locations/spiders/subway_th.py
+++ b/locations/spiders/subway_th.py
@@ -6,6 +6,7 @@ import chompjs
 from scrapy import Selector, Spider
 from scrapy.http import Request, Response
 
+from locations.categories import Categories, apply_category
 from locations.country_utils import CountryUtils, get_locale
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
@@ -86,6 +87,9 @@ class SubwayWorldwideSpider(Spider):
             item["street_address"] = clean_address(
                 [address.get("Address1"), address.get("Address2"), address.get("Address3")]
             )
+            apply_category(Categories.FAST_FOOD, item)
+            item["extras"]["cuisine"] = "sandwich"
+            item["extras"]["takeaway"] = "yes"
             yield item
 
         if int(current) < int(total):

--- a/locations/spiders/subway_tw.py
+++ b/locations/spiders/subway_tw.py
@@ -1,12 +1,14 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.spiders.subway import SubwaySpider
 
 
 class SubwayTWSpider(CrawlSpider):
     name = "subway_tw"
-    item_attributes = {"brand": "Subway", "brand_wikidata": "Q244457"}
+    item_attributes = SubwaySpider.item_attributes
     start_urls = ["https://subway.com.tw/en/include/index.php#newStore"]
     rules = [
         Rule(LinkExtractor(allow=r"pageNum"), callback="parse", follow=True),
@@ -20,4 +22,7 @@ class SubwayTWSpider(CrawlSpider):
             item["phone"] = store.xpath('.//a[contains(@href, "tel")]/@href').get()
             item["ref"] = store.xpath('./*[@data-title="NO"]/text()').get().strip()
             item["website"] = response.url
+            apply_category(Categories.FAST_FOOD, item)
+            item["extras"]["cuisine"] = "sandwich"
+            item["extras"]["takeaway"] = "yes"
             yield item


### PR DESCRIPTION
Spiders lost categories because NSI match failed ([we have cameras entry](https://nsi.guide/index.html?t=operators&k=man_made&v=surveillance&tt=subway)).

I tested all of the changes in this PR.