### PR TITLE
add Bill Gray's US locations spider

### DIFF
--- a/locations/spiders/bill_grays_us.py
+++ b/locations/spiders/bill_grays_us.py
@@ -106,7 +106,7 @@ class BillGraysUSSpider(Spider):
 
         # Extract coordinates from Google Maps link
         extract_google_position(item, response)
-        
+
         # Set defaults
         item["country"] = "US"
         if not item.get("state"):


### PR DESCRIPTION
This pull request introduces a new spider for scraping Bill Gray's restaurant locations in the US. The spider extracts detailed information about each location, including address, phone number, opening hours, and additional amenities. It also distinguishes between regular restaurant locations and tap rooms, applying appropriate categories and attributes.

### New Spider Implementation:

* **`BillGraysUSSpider` class**:
  - Implements a Scrapy spider to scrape location data from the Bill Gray's website, including addresses, phone numbers, and hours. It uses custom headers to mimic a real browser for better compatibility.
  - Differentiates between standard locations and tap rooms, applying appropriate categories (`FAST_FOOD` for restaurants and `BAR` for tap rooms) and setting specific attributes like `extras["tap_room"]`.

### Data Extraction:

* **Location Details**:
  - Extracts location-specific details such as branch name, address, phone number, and opening hours from the HTML content or meta description as a fallback.
  - Parses additional amenities like outdoor seating, frozen custard availability, party room availability, and general manager information.

* **Opening Hours Parsing**:
  - Implements a robust `parse_hours` method to handle various time formats and day ranges (e.g., "Monday - Friday: 11:00 AM to 9:00 PM"). It supports