### PR TITLE
[Rema 1000 DK] Fix spider

### DIFF
--- a/locations/spiders/rema_1000_dk.py
+++ b/locations/spiders/rema_1000_dk.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
-import pytz
 from scrapy import Spider
 from scrapy.http import Response
 
@@ -41,6 +41,5 @@ class Rema1000DKSpider(Spider):
 
     def calculate_local_time(self, time_string: str) -> str:
         utc_datetime = datetime.fromisoformat(time_string)
-        denmark_tz = pytz.timezone("Europe/Copenhagen")
-        local_time = utc_datetime.astimezone(denmark_tz)
+        local_time = utc_datetime.astimezone(ZoneInfo("Europe/Copenhagen"))
         return local_time.strftime("%H:%M")

--- a/locations/spiders/rema_1000_dk.py
+++ b/locations/spiders/rema_1000_dk.py
@@ -8,6 +8,7 @@ from scrapy.http import Response
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import SocialMedia, set_social_media
 
 
 class Rema1000DKSpider(Spider):
@@ -23,6 +24,7 @@ class Rema1000DKSpider(Spider):
             item["street_address"] = item.pop("addr_full", None)
             item["website"] = f'https://rema1000.dk/find-butik-og-abningstider/{item["ref"]}'
             apply_category(Categories.SHOP_SUPERMARKET, item)
+            set_social_media(item, SocialMedia.FACEBOOK, location.get("facebook_page_url"))
 
             try:
                 item["opening_hours"] = OpeningHours()

--- a/locations/spiders/rema_1000_dk.py
+++ b/locations/spiders/rema_1000_dk.py
@@ -34,6 +34,8 @@ class Rema1000DKSpider(Spider):
                         open_time = self.calculate_local_time(rule["opening_at"])
                         close_time = self.calculate_local_time(rule["closing_at"])
                         item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+                    else:
+                        item["opening_hours"].set_closed(day)
             except Exception as e:
                 self.logger.warning(f"Failed to parse opening hours: {e}")
                 self.crawler.stats.inc_value(f"atp/{self.name}/hours/failed")

--- a/locations/spiders/rema_1000_dk.py
+++ b/locations/spiders/rema_1000_dk.py
@@ -1,38 +1,23 @@
+from typing import Any
+
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_NO, OpeningHours
 
 
 class Rema1000DKSpider(Spider):
     name = "rema_1000_dk"
     item_attributes = {"brand": "Rema 1000", "brand_wikidata": "Q28459"}
-    allowed_domains = ["www.rema1000.dk"]
-    start_urls = ["https://www.rema1000.dk/api/v2/stores"]
+    start_urls = ["https://cphapp.rema1000.dk/api/v3/stores?per_page=1000"]
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url)
-
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["data"]:
-            if location.get("permanently_closed") or location.get("temporarily_closed_until"):
-                continue
-
             item = DictParser.parse(location)
-            item["website"] = location.get("store_link")
-
-            hours_string = ""
-            for day_hours in location.get("opening_hours", {}).values():
-                hours_string = "{} {}: {} - {}".format(
-                    hours_string, day_hours.get("day"), day_hours.get("open"), day_hours.get("close")
-                )
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(hours_string, days=DAYS_NO)
-            item["postcode"] = str(item["postcode"])
-
+            item["ref"] = location.get("internal_id")
+            item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("addr_full", None)
+            item["website"] = f'https://rema1000.dk/find-butik-og-abningstider/{item["ref"]}'
             apply_category(Categories.SHOP_SUPERMARKET, item)
-
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Rema 1000': 427,
 'atp/brand_wikidata/Q28459': 427,
 'atp/category/shop/supermarket': 427,
 'atp/country/DK': 427,
 'atp/field/country/from_spider_name': 427,
 'atp/field/email/missing': 427,
 'atp/field/image/missing': 427,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 427,
 'atp/field/operator_wikidata/missing': 427,
 'atp/field/phone/invalid': 8,
 'atp/field/state/missing': 427,
 'atp/field/twitter/missing': 427,
 'atp/item_scraped_host_count/cphapp.rema1000.dk': 427,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 427,
 'downloader/request_bytes': 689,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 623535,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.59748,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 19, 8, 8, 57, 971742, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 427,
 'items_per_minute': None,
 'log_count/DEBUG': 440,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 19, 8, 8, 51, 374262, tzinfo=datetime.timezone.utc)}
```