### PR TITLE
[Mcdonalds PH] Try playwright with custom settings to fix spider

### DIFF
--- a/locations/spiders/mcdonalds_ph.py
+++ b/locations/spiders/mcdonalds_ph.py
@@ -7,14 +7,22 @@ from locations.categories import Categories, Extras, apply_category, apply_yes_n
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.mcdonalds import McdonaldsSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class McdonaldsPHSpider(scrapy.Spider):
     name = "mcdonalds_ph"
     item_attributes = McdonaldsSpider.item_attributes
     start_urls = ["https://www.mcdonalds.com.ph/store-locator"]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 120}
+    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000,
+        "DOWNLOAD_DELAY": 10,
+        "RETRY_TIMES": 10,
+    }
 
     def parse(self, response: XmlResponse, **kwargs):
         for location in json.loads(response.xpath("//store-locator").attrib[":stores"]):


### PR DESCRIPTION
Server is unstable, sometimes throws `504` and sometimes `500` error. Used `playwright` with `custom_settings` to fix the spider.

```python
{"atp/brand/McDonald's": 746,
 'atp/brand_wikidata/Q38076': 746,
 'atp/category/amenity/fast_food': 746,
 'atp/country/PH': 746,
 'atp/field/branch/missing': 746,
 'atp/field/country/from_spider_name': 746,
 'atp/field/email/missing': 746,
 'atp/field/image/missing': 746,
 'atp/field/opening_hours/missing': 45,
 'atp/field/operator/missing': 746,
 'atp/field/operator_wikidata/missing': 746,
 'atp/field/phone/missing': 746,
 'atp/field/postcode/missing': 746,
 'atp/field/street_address/missing': 746,
 'atp/field/twitter/missing': 746,
 'atp/field/website/missing': 746,
 'atp/item_scraped_host_count/www.mcdonalds.com.ph': 746,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 746,
 'downloader/request_bytes': 1421,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 2691075,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/500': 3,
 'elapsed_time_seconds': 59.549145,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 19, 9, 40, 3, 933296, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 746,
 'items_per_minute': None,
 'log_count/DEBUG': 839,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 5,
 'playwright/page_count/closed': 5,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 29,
 'playwright/request_count/aborted': 24,
 'playwright/request_count/method/GET': 29,
 'playwright/request_count/navigation': 5,
 'playwright/request_count/resource_type/document': 5,
 'playwright/request_count/resource_type/font': 10,
 'playwright/request_count/resource_type/image': 5,
 'playwright/request_count/resource_type/other': 1,
 'playwright/request_count/resource_type/script': 6,
 'playwright/request_count/resource_type/stylesheet': 2,
 'playwright/response_count': 5,
 'playwright/response_count/method/GET': 5,
 'playwright/response_count/resource_type/document': 5,
 'response_received_count': 2,
 'responses_per_minute': None,
 'retry/count': 3,
 'retry/reason_count/500 Internal Server Error': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2025, 5, 19, 9, 39, 4, 384151, tzinfo=datetime.timezone.utc)}
```