### PR TITLE
[Hemkop SE] Fix spider

### DIFF
--- a/locations/spiders/hemkop_se.py
+++ b/locations/spiders/hemkop_se.py
@@ -13,7 +13,7 @@ class HemkopSESpider(scrapy.Spider):
     def parse(self, response):
         for store in response.json()["results"]:
             item = DictParser.parse(store)
-            item["branch"] = item.pop("name").removeprefix("Hemköp ")
+            item["branch"] = (item.pop("name", "") or "").removeprefix("Hemköp ")
             item["phone"] = store["address"]["phoneNumber"]
             item["website"] = "https://www.hemkop.se/butik/{}".format(item["ref"])
 


### PR DESCRIPTION
Prevents `AttributeError` in spider execution like that happened in [last run](https://alltheplaces-data.openaddresses.io/runs/2025-05-17-13-31-55/logs/hemkop_se.txt). Though, currently it is not happening for me, but it will protect if it occurs again in future.

```
{'atp/brand/Hemköp': 203,
 'atp/brand_wikidata/Q10521746': 203,
 'atp/category/shop/supermarket': 203,
 'atp/cdn/cloudfront/response_count': 1,
 'atp/cdn/cloudfront/response_status_count/200': 1,
 'atp/country/SE': 203,
 'atp/field/country/from_spider_name': 203,
 'atp/field/email/missing': 203,
 'atp/field/image/missing': 203,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 203,
 'atp/field/operator_wikidata/missing': 203,
 'atp/field/state/missing': 203,
 'atp/field/twitter/missing': 203,
 'atp/item_scraped_host_count/www.hemkop.se': 203,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 203,
 'downloader/request_bytes': 371,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 16660,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.295141,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 22, 5, 9, 31, 705554, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 148796,
 'httpcompression/response_count': 1,
 'item_scraped_count': 203,
 'items_per_minute': None,
 'log_count/DEBUG': 215,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 22, 5, 9, 28, 410413, tzinfo=datetime.timezone.utc)}
```