### PR TITLE
[Kidstuff AU] Fix spider

### DIFF
--- a/locations/spiders/kidstuff_au.py
+++ b/locations/spiders/kidstuff_au.py
@@ -14,5 +14,6 @@ class KidstuffAUSpider(StockInStoreSpider):
 
     def parse_item(self, item: Feature, location: dict):
         item["website"] = urljoin(self.api_origin, item["website"])
+        item["branch"] = item.pop("name").removeprefix("Kidstuff ")
         apply_category(Categories.SHOP_TOYS, item)
         yield item

--- a/locations/spiders/kidstuff_au.py
+++ b/locations/spiders/kidstuff_au.py
@@ -1,8 +1,15 @@
-from locations.categories import Categories
-from locations.storefinders.stockist import StockistSpider
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.stockinstore import StockInStoreSpider
 
 
-class KidstuffAUSpider(StockistSpider):
+class KidstuffAUSpider(StockInStoreSpider):
     name = "kidstuff_au"
-    item_attributes = {"brand": "Kidstuff", "brand_wikidata": "Q117746407", "extras": Categories.SHOP_TOYS.value}
-    key = "u8053"
+    item_attributes = {"brand": "Kidstuff", "brand_wikidata": "Q117746407"}
+    api_site_id = "10041"
+    api_widget_id = "48"
+    api_origin = "https://www.kidstuff.com.au"
+
+    def parse_item(self, item: Feature, location: dict):
+        apply_category(Categories.SHOP_TOYS, item)
+        yield item

--- a/locations/spiders/kidstuff_au.py
+++ b/locations/spiders/kidstuff_au.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.stockinstore import StockInStoreSpider
@@ -11,5 +13,6 @@ class KidstuffAUSpider(StockInStoreSpider):
     api_origin = "https://www.kidstuff.com.au"
 
     def parse_item(self, item: Feature, location: dict):
+        item["website"] = urljoin(self.api_origin, item["website"])
         apply_category(Categories.SHOP_TOYS, item)
         yield item

--- a/locations/storefinders/stockinstore.py
+++ b/locations/storefinders/stockinstore.py
@@ -28,10 +28,10 @@ from locations.items import Feature
 
 class StockInStoreSpider(Spider):
     dataset_attributes = {"source": "api", "api": "stockinstore.com"}
-    api_site_id: str = None
-    api_widget_id: str = None
-    api_widget_type: str = None
-    api_origin: str = None
+    api_site_id: str = ""
+    api_widget_id: str = ""
+    api_widget_type: str = ""
+    api_origin: str = ""
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):


### PR DESCRIPTION
```python
{'atp/brand/Kidstuff': 57,
 'atp/brand_wikidata/Q117746407': 57,
 'atp/category/shop/toys': 57,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/country/AU': 57,
 'atp/field/image/missing': 57,
 'atp/field/operator/missing': 57,
 'atp/field/operator_wikidata/missing': 57,
 'atp/field/twitter/missing': 57,
 'atp/item_scraped_host_count/stockinstore.net': 57,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 57,
 'downloader/request_bytes': 515,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 11534,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.237879,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 23, 6, 52, 41, 985529, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 142456,
 'httpcompression/response_count': 1,
 'item_scraped_count': 57,
 'items_per_minute': None,
 'log_count/DEBUG': 69,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 23, 6, 52, 39, 747650, tzinfo=datetime.timezone.utc)}
```