### PR TITLE
[Penningtons CA] Fix spider

### DIFF
--- a/locations/spiders/penningtons_ca.py
+++ b/locations/spiders/penningtons_ca.py
@@ -1,3 +1,8 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
 from locations.storefinders.uberall import UberallSpider
 
 
@@ -8,3 +13,10 @@ class PenningtonsCASpider(UberallSpider):
         "brand": "Penningtons",
     }
     key = "plEhL7SEWWjub5NBhsr8Iidzl8GgaX"
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["ref"] = location["ref"].removeprefix("Store ")
+        item["website"] = (
+            f'https://locations.penningtons.com/{item["state"]}-{item["city"]}-{item["ref"]}'.lower().replace(" ", "-")
+        )
+        yield item

--- a/locations/spiders/penningtons_ca.py
+++ b/locations/spiders/penningtons_ca.py
@@ -1,13 +1,10 @@
-from locations.storefinders.sweetiq import SweetIQSpider
+from locations.storefinders.uberall import UberallSpider
 
 
-class PenningtonsCASpider(SweetIQSpider):
+class PenningtonsCASpider(UberallSpider):
     name = "penningtons_ca"
     item_attributes = {
         "brand_wikidata": "Q16956527",
         "brand": "Penningtons",
     }
-    allowed_domains = ["locations.penningtons.com", "sls-api-service.sweetiq-sls-production-east.sweetiq.com"]
-    start_urls = [
-        "https://locations.penningtons.com/en",
-    ]
+    key = "plEhL7SEWWjub5NBhsr8Iidzl8GgaX"


### PR DESCRIPTION
```python
{'atp/brand/Penningtons': 86,
 'atp/brand_wikidata/Q16956527': 86,
 'atp/category/shop/clothes': 86,
 'atp/country/CA': 86,
 'atp/field/branch/missing': 86,
 'atp/field/email/missing': 86,
 'atp/field/image/missing': 81,
 'atp/field/operator/missing': 86,
 'atp/field/operator_wikidata/missing': 86,
 'atp/field/state/from_reverse_geocoding': 14,
 'atp/field/twitter/missing': 86,
 'atp/item_scraped_host_count/uberall.com': 86,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 86,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13036,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.373204,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 23, 8, 59, 36, 407036, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 107034,
 'httpcompression/response_count': 2,
 'item_scraped_count': 86,
 'items_per_minute': None,
 'log_count/DEBUG': 99,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 23, 8, 59, 33, 33832, tzinfo=datetime.timezone.utc)}
```