### PR TITLE
[Talisman Hire] Fix spider

### DIFF
--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -1,7 +1,11 @@
-from locations.storefinders.location_bank import LocationBankSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class TalismanHireSpider(LocationBankSpider):
+class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
     name = "talisman_hire"
-    client_id = "e291ff7a-451d-4eee-a25b-a834c9fe6eeb"
     item_attributes = {"brand": "Talisman Hire", "brand_wikidata": "Q120885726"}
+    allowed_domains = ["www.talisman.co.za"]
+    sitemap_urls = ["https://www.talisman.co.za/googlesitemap"]
+    sitemap_rules = [(r"talisman\.co\.za/[-\w]+/[-\w]+/talisman-hire-[-\w]+$", "parse_sd")]

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -2,6 +2,8 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.spiders.buco_na_za import BucoNAZASpider
+from locations.spiders.builders import BuildersSpider
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -22,4 +24,18 @@ class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
         item["branch"] = item.pop("name").removeprefix("Talisman Hire ")
         if item.get("state") == "Mpumalanga":  # country wrongly reverse geocoded as SZ
             item["country"] = "ZA"
+
+        if "inside-" in response.url:
+            located_in_location = response.url.split("inside-")[-1].strip("/") if "inside-" in response.url else ""
+            if located_in_location == "buco":
+                item["located_in"] = BucoNAZASpider.item_attributes["brand"]
+                item["located_in_wikidata"] = BucoNAZASpider.item_attributes["brand_wikidata"]
+            elif located_in_location == "builders":
+                item["located_in"] = BuildersSpider.item_attributes["brand"]
+                item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
+            elif located_in_location == "builders-express":
+                item["located_in"] = located_in_location.replace("-", " ").title()
+                item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
+            else:
+                item["located_in"] = located_in_location.replace("-", " ").title()
         yield item

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -26,7 +26,7 @@ class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
             item["country"] = "ZA"
 
         if "inside-" in response.url:
-            located_in_location = response.url.split("inside-")[-1].strip("/") if "inside-" in response.url else ""
+            located_in_location = response.url.split("inside-")[-1].strip("/")
             if located_in_location == "buco":
                 item["located_in"] = BucoNAZASpider.item_attributes["brand"]
                 item["located_in_wikidata"] = BucoNAZASpider.item_attributes["brand_wikidata"]

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,3 +11,13 @@ class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["www.talisman.co.za"]
     sitemap_urls = ["https://www.talisman.co.za/googlesitemap"]
     sitemap_rules = [(r"talisman\.co\.za/[-\w]+/[-\w]+/talisman-hire-[-\w]+$", "parse_sd")]
+    skip_auto_cc_spider_name = True
+    skip_auto_cc_domain = True
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data.get("address", {}).pop("addressCountry", None)  # It's always ZA, which isn't true
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item.get("state") == "Mpumalanga":  # country wrongly reverse geocoded as SZ
+            item["country"] = "ZA"
+        yield item

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -18,6 +18,7 @@ class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
         ld_data.get("address", {}).pop("addressCountry", None)  # It's always ZA, which isn't true
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Talisman Hire ")
         if item.get("state") == "Mpumalanga":  # country wrongly reverse geocoded as SZ
             item["country"] = "ZA"
         yield item

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -13,6 +13,7 @@ class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"talisman\.co\.za/[-\w]+/[-\w]+/talisman-hire-[-\w]+$", "parse_sd")]
     skip_auto_cc_spider_name = True
     skip_auto_cc_domain = True
+    drop_attributes = {"facebook", "twitter"}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.get("address", {}).pop("addressCountry", None)  # It's always ZA, which isn't true


### PR DESCRIPTION
```python
{'atp/brand/Talisman Hire': 138,
 'atp/brand_wikidata/Q120885726': 138,
 'atp/category/shop/tool_hire': 138,
 'atp/country/BW': 1,
 'atp/country/NA': 1,
 'atp/country/ZA': 135,
 'atp/country/ZM': 1,
 'atp/field/country/from_reverse_geocoding': 128,
 'atp/field/email/missing': 138,
 'atp/field/image/missing': 138,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 138,
 'atp/field/operator_wikidata/missing': 138,
 'atp/field/postcode/missing': 2,
 'atp/field/twitter/missing': 138,
 'atp/item_scraped_host_count/www.talisman.co.za': 138,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 138,
 'downloader/request_bytes': 66942,
 'downloader/request_count': 140,
 'downloader/request_method_count/GET': 140,
 'downloader/response_bytes': 2785187,
 'downloader/response_count': 140,
 'downloader/response_status_count/200': 140,
 'elapsed_time_seconds': 3.082622,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 23, 12, 11, 20, 368569, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 140,
 'httpcompression/response_bytes': 16119512,
 'httpcompression/response_count': 139,
 'item_scraped_count': 138,
 'items_per_minute': None,
 'log_count/DEBUG': 290,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 140,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 139,
 'scheduler/dequeued/memory': 139,
 'scheduler/enqueued': 139,
 'scheduler/enqueued/memory': 139,
 'start_time': datetime.datetime(2025, 5, 23, 12, 11, 17, 285947, tzinfo=datetime.timezone.utc)}
```