### PR TITLE
[Teremok RU] Fix spider

### DIFF
--- a/locations/spiders/teremok_ru.py
+++ b/locations/spiders/teremok_ru.py
@@ -5,6 +5,7 @@ from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_RU, NAMED_DAY_RANGES_RU, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class TeremokRUSpider(scrapy.Spider):
@@ -12,6 +13,12 @@ class TeremokRUSpider(scrapy.Spider):
     allowed_domains = ["teremok.ru"]
     item_attributes = {"brand": "Теремок", "brand_wikidata": "Q4455593"}
     start_urls = ["https://teremok.ru/"]
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": BROWSER_DEFAULT,
+        "DOWNLOAD_TIMEOUT": 300,
+        "RETRY_TIMES": 10,  # Sometimes connection refused by server, increased retry might help
+    }
 
     def parse(self, response):
         city_selectors = response.xpath("//a[@class='b-geo__link b-link b-link--br-white b-link--thin js-city']")

--- a/locations/spiders/teremok_ru.py
+++ b/locations/spiders/teremok_ru.py
@@ -26,6 +26,7 @@ class TeremokRUSpider(scrapy.Spider):
         for poi in response.json():
             poi.pop("city")  # skip city id, address contains the city name
             item = DictParser.parse(poi)
+            item.pop("name")  # location description?
             item["lat"], item["lon"] = poi.get("map", [None, None])
             item["website"] = urljoin(self.start_urls[0], poi.get("url"))
             self.parse_hours(poi, item)

--- a/locations/spiders/teremok_ru.py
+++ b/locations/spiders/teremok_ru.py
@@ -1,10 +1,12 @@
+from typing import Any
 from urllib.parse import urljoin
 
 import scrapy
-from scrapy.http import JsonRequest
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_RU, NAMED_DAY_RANGES_RU, OpeningHours
+from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -12,7 +14,7 @@ class TeremokRUSpider(scrapy.Spider):
     name = "teremok_ru"
     allowed_domains = ["teremok.ru"]
     item_attributes = {"brand": "Теремок", "brand_wikidata": "Q4455593"}
-    start_urls = ["https://teremok.ru/"]
+    start_urls = ["https://teremok.ru/api/main/place/list"]
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
@@ -20,31 +22,16 @@ class TeremokRUSpider(scrapy.Spider):
         "RETRY_TIMES": 10,  # Sometimes connection refused by server, increased retry might help
     }
 
-    def parse(self, response):
-        city_selectors = response.xpath("//a[@class='b-geo__link b-link b-link--br-white b-link--thin js-city']")
-        for city in city_selectors:
-            city_id = city.xpath("@data-id").get()
-            city_name = city.xpath("text()").get()
-            yield JsonRequest(
-                urljoin(self.start_urls[0], f"/api/main/place/list/?city_id={city_id}"),
-                callback=self.parse_city,
-                meta={"city_name": city_name},
-            )
-
-    def parse_city(self, response):
-        city_name = response.meta["city_name"]
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for poi in response.json():
-            yield self.parse_poi(poi, city_name)
+            poi.pop("city")  # skip city id, address contains the city name
+            item = DictParser.parse(poi)
+            item["lat"], item["lon"] = poi.get("map", [None, None])
+            item["website"] = urljoin(self.start_urls[0], poi.get("url"))
+            self.parse_hours(poi, item)
+            yield item
 
-    def parse_poi(self, poi, city_name):
-        item = DictParser.parse(poi)
-        item["lat"], item["lon"] = poi.get("map", [None, None])
-        item["city"] = city_name
-        item["website"] = urljoin(self.start_urls[0], poi.get("url"))
-        self.parse_hours(poi, item)
-        return item
-
-    def parse_hours(self, poi, item):
+    def parse_hours(self, poi: dict, item: Feature) -> Any:
         if hours := poi.get("mode"):
             ranges = []
             for period in hours:
@@ -54,7 +41,7 @@ class TeremokRUSpider(scrapy.Spider):
             try:
                 oh = OpeningHours()
                 oh.add_ranges_from_string("; ".join(ranges), DAYS_RU, NAMED_DAY_RANGES_RU)
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
             except Exception:
                 self.logger.warning(f"Parse hours failed: {hours}")
                 self.crawler.stats.inc_value("atp/hours/failed")

--- a/locations/spiders/teremok_ru.py
+++ b/locations/spiders/teremok_ru.py
@@ -1,5 +1,4 @@
 from typing import Any
-from urllib.parse import urljoin
 
 import scrapy
 from scrapy.http import Response
@@ -28,7 +27,7 @@ class TeremokRUSpider(scrapy.Spider):
             item = DictParser.parse(poi)
             item.pop("name")  # location description?
             item["lat"], item["lon"] = poi.get("map", [None, None])
-            item["website"] = urljoin(self.start_urls[0], poi.get("url"))
+            item["website"] = response.urljoin(poi.get("url"))
             self.parse_hours(poi, item)
             yield item
 


### PR DESCRIPTION
Tried to fix spider failure like in last [run](https://alltheplaces-data.openaddresses.io/runs/2025-05-17-13-31-55/stats/teremok_ru.json) because of non-responsive server, also performed some code optimization.

```python
{'atp/brand/Теремок': 339,
 'atp/brand_wikidata/Q4455593': 339,
 'atp/category/amenity/fast_food': 339,
 'atp/clean_strings/addr_full': 2,
 'atp/country/RU': 339,
 'atp/field/branch/missing': 339,
 'atp/field/city/missing': 339,
 'atp/field/country/from_spider_name': 339,
 'atp/field/email/missing': 339,
 'atp/field/image/missing': 339,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 339,
 'atp/field/operator_wikidata/missing': 339,
 'atp/field/phone/missing': 339,
 'atp/field/postcode/missing': 339,
 'atp/field/state/missing': 339,
 'atp/field/street_address/missing': 339,
 'atp/field/twitter/missing': 339,
 'atp/item_scraped_host_count/teremok.ru': 339,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 339,
 'downloader/request_bytes': 264,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 29413,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.821385,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 23, 14, 4, 14, 347895, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 196595,
 'httpcompression/response_count': 1,
 'item_scraped_count': 339,
 'items_per_minute': None,
 'log_count/DEBUG': 351,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 23, 14, 4, 11, 526510, tzinfo=datetime.timezone.utc)}
```