### PR TITLE
[Sleep Outfitters US] Fix Spider

### DIFF
--- a/locations/spiders/sleep_outfitters_us.py
+++ b/locations/spiders/sleep_outfitters_us.py
@@ -1,46 +1,45 @@
-from urllib.parse import urlencode
+import re
+from typing import Any
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.items import Feature
 
 
-class SleepOutfittersUSSpider(Spider):
+class SleepOutfittersUSSpider(CrawlSpider):
     name = "sleep_outfitters_us"
     item_attributes = {"brand": "Sleep Outfitters", "brand_wikidata": "Q120509459"}
-    offset = 0
-    page_size = 20
-    fields = ["address", "address2", "city", "state", "postal", "lat", "lng", "hours_summary", "phone", "storefront"]
-    api = "https://www.sleepoutfitters.com/api/cms/v2/retail-location-pages/"
+    start_urls = ["https://sleepoutfitters.com/store-locator"]
 
-    def next_request(self) -> JsonRequest:
-        return JsonRequest(
-            url="{}?{}".format(
-                self.api,
-                urlencode(
-                    {
-                        "offset": self.offset,
-                        "limit": self.page_size,
-                        "fields": ",".join(self.fields),
-                    }
-                ),
-            )
+    rules = [
+        Rule(LinkExtractor(allow=r"/store-locator/[a-z]+$")),
+        Rule(
+            LinkExtractor(allow=r"/store-locator/mattress-stores-in"),
+            callback="parse",
+            follow=True,
+        ),
+    ]
+
+    store_link_extractor = LinkExtractor(allow=r"/store-locator/sleep-outfitters-of-")
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        lat_lon_data = re.findall(
+            r"(\d+\.\d+),.*?(-?\d+\.\d+)", response.xpath('//*[contains(text(),"loaderData")]/text()').get(default="")
         )
+        links = self.store_link_extractor.extract_links(response)
+        for link in links:
+            for lat_lon in lat_lon_data:
+                yield Request(url=link.url, callback=self.parse_details, cb_kwargs={"lat_lon": lat_lon})
 
-    def start_requests(self):
-        yield self.next_request()
-
-    def parse(self, response, **kwargs):
-        for location in response.json()["items"]:
-            item = DictParser.parse(location)
-            item["street_address"] = merge_address_lines([item.pop("addr_full", None), location["address2"]])
-            item["image"] = location.get("storefront", {}).get("meta", {}).get("download_url")
-            item["branch"] = item.pop("name", "").replace("Sleep Outfitters", "").strip(", !")
-
-            yield item
-
-        if len(response.json()["items"]) == self.page_size:
-            self.offset += self.page_size
-            yield self.next_request()
+    def parse_details(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["branch"] = response.xpath("//h1/div[2]/text()").get()
+        item["addr_full"] = response.xpath('//*[@class="flex items-center gap-3"]//text()').get()
+        item["email"] = response.xpath('//*[contains(@href,"mailto:")]/text()').get()
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        item["ref"] = item["website"] = response.url
+        item["lat"], item["lon"] = kwargs.get("lat_lon", (None, None))
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Sleep Outfitters': 104,
 'atp/brand_wikidata/Q120509459': 104,
 'atp/category/shop/bed': 104,
 'atp/cdn/cloudflare/response_count': 199,
 'atp/cdn/cloudflare/response_status_count/200': 199,
 'atp/country/US': 104,
 'atp/field/city/missing': 104,
 'atp/field/country/from_spider_name': 104,
 'atp/field/image/missing': 104,
 'atp/field/opening_hours/missing': 104,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/postcode/missing': 104,
 'atp/field/state/from_reverse_geocoding': 104,
 'atp/field/street_address/missing': 104,
 'atp/field/twitter/missing': 104,
 'atp/item_scraped_host_count/sleepoutfitters.com': 104,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 104,
 'downloader/request_bytes': 93278,
 'downloader/request_count': 199,
 'downloader/request_method_count/GET': 199,
 'downloader/response_bytes': 5513286,
 'downloader/response_count': 199,
 'downloader/response_status_count/200': 199,
 'dupefilter/filtered': 74,
 'elapsed_time_seconds': 243.936211,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 26, 5, 21, 5, 919949, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 22275713,
 'httpcompression/response_count': 199,
 'item_scraped_count': 104,
 'items_per_minute': None,
 'log_count/DEBUG': 315,
 'log_count/INFO': 13,
 'request_depth_max': 3,
 'response_received_count': 199,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 198,
 'scheduler/dequeued/memory': 198,
 'scheduler/enqueued': 198,
 'scheduler/enqueued/memory': 198,
 'start_time': datetime.datetime(2025, 5, 26, 5, 17, 1, 983738, tzinfo=datetime.timezone.utc)}
```