### PR TITLE
[Sams Club] Fix Spider

### DIFF
--- a/locations/spiders/sams_club.py
+++ b/locations/spiders/sams_club.py
@@ -5,6 +5,7 @@ import scrapy
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.user_agents import FIREFOX_LATEST
 
 
 class SamsClubSpider(scrapy.spiders.SitemapSpider):
@@ -14,6 +15,7 @@ class SamsClubSpider(scrapy.spiders.SitemapSpider):
     sitemap_urls = [
         "https://www.samsclub.com/sitemap_locators.xml",
     ]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST}
 
     def parse(self, response):
         [script] = filter(


### PR DESCRIPTION
**_Fixes : added custom_settings to fix spider_**

```python
{"atp/brand/Sam's Club": 603,
 'atp/brand_wikidata/Q1972120': 603,
 'atp/category/shop/wholesale': 603,
 'atp/clean_strings/name': 1,
 'atp/country/US': 603,
 'atp/field/branch/missing': 603,
 'atp/field/email/missing': 603,
 'atp/field/operator/missing': 603,
 'atp/field/operator_wikidata/missing': 603,
 'atp/field/twitter/missing': 603,
 'atp/item_scraped_host_count/www.samsclub.com': 603,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 603,
 'downloader/request_bytes': 1522848,
 'downloader/request_count': 638,
 'downloader/request_method_count/GET': 638,
 'downloader/response_bytes': 65299327,
 'downloader/response_count': 638,
 'downloader/response_status_count/200': 605,
 'downloader/response_status_count/301': 33,
 'elapsed_time_seconds': 785.809274,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 5, 12, 56, 551892, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 272662107,
 'httpcompression/response_count': 605,
 'item_scraped_count': 603,
 'items_per_minute': None,
 'log_count/DEBUG': 1256,
 'log_count/INFO': 22,
 'request_depth_max': 1,
 'response_received_count': 605,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 637,
 'scheduler/dequeued/memory': 637,
 'scheduler/enqueued': 637,
 'scheduler/enqueued/memory': 637,
 'start_time': datetime.datetime(2025, 5, 27, 4, 59, 50, 742618, tzinfo=datetime.timezone.utc)}
```