### PR TITLE
[Argos] Fix spider

### DIFF
--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -11,8 +11,9 @@ from locations.user_agents import BROWSER_DEFAULT
 class ArgosSpider(SitemapSpider, StructuredDataSpider):
     name = "argos"
     item_attributes = {"brand": "Argos", "brand_wikidata": "Q4789707"}
-    sitemap_urls = ["https://www.argos.co.uk/stores_sitemap.xml"]
+    sitemap_urls = ["https://www.argos.co.uk/robots.txt"]
     sitemap_rules = [(r"https://www.argos.co.uk/stores/([\d]+)-([\w-]+)", "parse")]
+    sitemap_follow = ["stores"]
     user_agent = BROWSER_DEFAULT
     requires_proxy = True
 

--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -1,3 +1,6 @@
+from typing import Iterable
+
+from locations.items import Feature
 from locations.storefinders.yext_answers import YextAnswersSpider
 
 
@@ -8,3 +11,8 @@ class ArgosSpider(YextAnswersSpider):
     experience_key = "argos-locator"
     api_key = "5295de161feec2b9e1ca6f483e9f77dd"
     locale = "en-GB"
+
+    def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
+        if "Collection Point" in item["name"]:
+            return
+        yield item

--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -1,38 +1,10 @@
-import re
-
-from scrapy.spiders import SitemapSpider
-
-from locations.spiders.sainsburys import SainsburysSpider
-from locations.spiders.tesco_gb import set_located_in
-from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class ArgosSpider(SitemapSpider, StructuredDataSpider):
+class ArgosSpider(YextAnswersSpider):
     name = "argos"
     item_attributes = {"brand": "Argos", "brand_wikidata": "Q4789707"}
-    sitemap_urls = ["https://www.argos.co.uk/robots.txt"]
-    sitemap_rules = [(r"https://www.argos.co.uk/stores/([\d]+)-([\w-]+)", "parse")]
-    sitemap_follow = ["stores"]
-    user_agent = BROWSER_DEFAULT
-    requires_proxy = True
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        if item["name"].startswith("Closed - "):
-            return
-
-        if m := re.search(r"((?:in|inside|) Sainsbury'?s?)", item["name"], flags=re.IGNORECASE):
-            item["name"] = item["name"].replace(m.group(1), "").strip()
-            set_located_in(SainsburysSpider.SAINSBURYS, item)
-        if item["name"].endswith(" Local"):
-            item["name"] = item["name"].removesuffix(" Local")
-            set_located_in(SainsburysSpider.SAINSBURYS_LOCAL, item)
-
-        if m := re.search(r'"type":(\d),"lat":(-?\d+\.\d+),"lng":(-?\d+\.\d+),', response.text):
-            store_type, item["lat"], item["lon"] = m.groups()
-            if store_type == "1" or "Collection Point" in item["name"] or "CP" in item["name"]:
-                return
-
-        item.pop("name", None)
-
-        yield item
+    endpoint = "https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query"
+    experience_key = "argos-locator"
+    api_key = "5295de161feec2b9e1ca6f483e9f77dd"
+    locale = "en-GB"

--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -1,6 +1,9 @@
+import re
 from typing import Iterable
 
 from locations.items import Feature
+from locations.spiders.sainsburys import SainsburysSpider
+from locations.spiders.tesco_gb import set_located_in
 from locations.storefinders.yext_answers import YextAnswersSpider
 
 
@@ -15,4 +18,10 @@ class ArgosSpider(YextAnswersSpider):
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         if "Collection Point" in item["name"]:
             return
+        if m := re.search(r"((?:in|inside|) Sainsbury'?s?)", item["name"], flags=re.IGNORECASE):
+            item["name"] = item["name"].replace(m.group(1), "").replace("()", "").strip()
+            set_located_in(SainsburysSpider.SAINSBURYS, item)
+        if item["name"].endswith(" Local"):
+            item["name"] = item["name"].removesuffix(" Local")
+            set_located_in(SainsburysSpider.SAINSBURYS_LOCAL, item)
         yield item

--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -24,4 +24,5 @@ class ArgosSpider(YextAnswersSpider):
         if item["name"].endswith(" Local"):
             item["name"] = item["name"].removesuffix(" Local")
             set_located_in(SainsburysSpider.SAINSBURYS_LOCAL, item)
+        item["branch"] = item.pop("name").removesuffix(" Argos")
         yield item

--- a/locations/spiders/argos.py
+++ b/locations/spiders/argos.py
@@ -25,4 +25,5 @@ class ArgosSpider(YextAnswersSpider):
             item["name"] = item["name"].removesuffix(" Local")
             set_located_in(SainsburysSpider.SAINSBURYS_LOCAL, item)
         item["branch"] = item.pop("name").removesuffix(" Argos")
+        item["website"] = item["website"].replace("(", "").replace(")", "").replace("'", "")
         yield item


### PR DESCRIPTION
Available `Yext` API is utilized to refactor and fix the spider to get better `POI` data. Also, it helps to get rid of proxy requirement.

```python
{'atp/brand/Argos': 665,
 'atp/brand_wikidata/Q4789707': 665,
 'atp/category/shop/catalogue': 665,
 'atp/cdn/cloudflare/response_count': 25,
 'atp/cdn/cloudflare/response_status_count/200': 24,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/GB': 665,
 'atp/field/email/missing': 665,
 'atp/field/image/missing': 665,
 'atp/field/operator/missing': 665,
 'atp/field/operator_wikidata/missing': 665,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 665,
 'atp/item_scraped_host_count/prod-cdn.us.yextapis.com': 665,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 665,
 'downloader/request_bytes': 22854,
 'downloader/request_count': 25,
 'downloader/request_method_count/GET': 25,
 'downloader/response_bytes': 882664,
 'downloader/response_count': 25,
 'downloader/response_status_count/200': 24,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 32.717649,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 9, 30, 37, 17089, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 15412385,
 'httpcompression/response_count': 24,
 'item_scraped_count': 665,
 'items_per_minute': None,
 'log_count/DEBUG': 701,
 'log_count/INFO': 9,
 'request_depth_max': 23,
 'response_received_count': 25,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 24,
 'scheduler/dequeued/memory': 24,
 'scheduler/enqueued': 24,
 'scheduler/enqueued/memory': 24,
 'start_time': datetime.datetime(2025, 5, 27, 9, 30, 4, 299440, tzinfo=datetime.timezone.utc)}
```