### PR TITLE
[Race Trac US] Fix Spider

### DIFF
--- a/locations/spiders/race_trac_us.py
+++ b/locations/spiders/race_trac_us.py
@@ -37,7 +37,6 @@ class RaceTracUSSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["www.racetrac.com"]
     sitemap_urls = ["https://www.racetrac.com/robots.txt"]
     sitemap_rules = [(r"/locations/[^/]+/[^/]+/[^/]+$", "parse_sd")]
-    wanted_types = ["GasStation"]
 
     def sitemap_filter(self, entries):
         for entry in entries:


### PR DESCRIPTION
**_Fixes : removed wanted types to fix spider_**

```python
{'atp/brand/RaceTrac': 592,
 'atp/brand_wikidata/Q735942': 592,
 'atp/category/amenity/fuel': 592,
 'atp/cdn/cloudflare/response_count': 596,
 'atp/cdn/cloudflare/response_status_count/200': 595,
 'atp/cdn/cloudflare/response_status_count/403': 1,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 19,
 'atp/clean_strings/street_address': 2,
 'atp/country/US': 592,
 'atp/field/branch/missing': 592,
 'atp/field/email/missing': 592,
 'atp/field/image/dropped': 592,
 'atp/field/image/missing': 592,
 'atp/field/opening_hours/missing': 592,
 'atp/field/operator/missing': 592,
 'atp/field/operator_wikidata/missing': 592,
 'atp/item_scraped_host_count/www.racetrac.com': 592,
 'atp/lineage': 'S_?',
 'atp/racetrac_us/unmapped_attribute/Bulk DEF': 70,
 'atp/racetrac_us/unmapped_attribute/Certified Truck Scales': 43,
 'atp/racetrac_us/unmapped_attribute/Check Cashing': 53,
 'atp/racetrac_us/unmapped_attribute/Gaming Machines': 6,
 'atp/racetrac_us/unmapped_attribute/Online Ordering': 558,
 'atp/racetrac_us/unmapped_attribute/Reserved Truck Parking': 8,
 'atp/racetrac_us/unmapped_attribute/Seating Area': 458,
 'atp/racetrac_us/unmapped_attribute/Swirl World': 468,
 'atp/racetrac_us/unmapped_attribute/Travel Center': 49,
 'atp/racetrac_us/unmapped_attribute/Truck Merchandise': 50,
 'atp/racetrac_us/unmapped_attribute/Truck Parking': 8,
 'downloader/request_bytes': 493776,
 'downloader/request_count': 596,
 'downloader/request_method_count/GET': 596,
 'downloader/response_bytes': 10935665,
 'downloader/response_count': 596,
 'downloader/response_status_count/200': 595,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 736.846166,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 9, 3, 47, 636161, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 63147476,
 'httpcompression/response_count': 596,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/403': 1,
 'item_scraped_count': 592,
 'items_per_minute': None,
 'log_count/DEBUG': 1189,
 'log_count/INFO': 22,
 'request_depth_max': 2,
 'response_received_count': 596,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 595,
 'scheduler/dequeued/memory': 595,
 'scheduler/enqueued': 595,
 'scheduler/enqueued/memory': 595,
 'start_time': datetime.datetime(2025, 5, 27, 8, 51, 30, 789995, tzinfo=datetime.timezone.utc)}
```