### PR TITLE
[Euromobil NL] Fix Spider

### DIFF
--- a/locations/spiders/euromobil_nl.py
+++ b/locations/spiders/euromobil_nl.py
@@ -1,35 +1,15 @@
-import json
-import re
-
 import scrapy
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class EuromobilNLSpider(scrapy.Spider):
     name = "euromobil_nl"
-    start_urls = ["https://euromobil.nl/contact/"]
-
     item_attributes = {"brand": "Euromobil", "brand_wikidata": "Q1375118"}
+    start_urls = ["https://euromobil.nl/wp-admin/admin-ajax.php?action=store_search&autoload=1"]
 
     def parse(self, response, **kwargs):
-        pattern = r"var\s+partners\s*=\s*(\[.*?\]);\s*var"
-        raw = response.xpath("//script[contains(., 'var stores =')]/text()")
-        stores_json = json.loads(re.search(pattern, raw.extract_first(), re.DOTALL).group(1))
-        for store in stores_json:
-            coordinates = store.get("geo")
-            yield Feature(
-                {
-                    "ref": store.get("nummer"),
-                    "name": store.get("title"),
-                    "street_address": store.get("adres"),
-                    "addr_full": coordinates.get("address"),
-                    "phone": store.get("phone"),
-                    "email": store.get("email"),
-                    "postcode": store.get("zip"),
-                    "city": store.get("plaats"),
-                    "website": store.get("website"),
-                    "lat": coordinates.get("lat"),
-                    "lon": coordinates.get("lng"),
-                }
-            )
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full")
+            yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Euromobil': 65,
 'atp/brand_wikidata/Q1375118': 65,
 'atp/category/amenity/car_rental': 65,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/NL': 65,
 'atp/field/branch/missing': 65,
 'atp/field/country/from_spider_name': 65,
 'atp/field/email/missing': 12,
 'atp/field/image/missing': 65,
 'atp/field/opening_hours/missing': 65,
 'atp/field/operator/missing': 65,
 'atp/field/operator_wikidata/missing': 65,
 'atp/field/phone/missing': 13,
 'atp/field/postcode/missing': 64,
 'atp/field/state/missing': 65,
 'atp/field/twitter/missing': 65,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 4,
 'atp/item_scraped_host_count/euromobil.nl': 65,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 65,
 'downloader/request_bytes': 704,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5480,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.812772,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 10, 20, 47, 44880, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 20470,
 'httpcompression/response_count': 2,
 'item_scraped_count': 65,
 'items_per_minute': None,
 'log_count/DEBUG': 78,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 27, 10, 20, 43, 232108, tzinfo=datetime.timezone.utc)}
```