### PR TITLE
[Dedeman RO] Fix Spider

### DIFF
--- a/locations/spiders/dedeman_ro.py
+++ b/locations/spiders/dedeman_ro.py
@@ -14,7 +14,7 @@ class DedemanROSpider(JSONBlobSpider):
 
     def extract_json(self, response: Response) -> list[dict]:
         return chompjs.parse_js_object(
-            response.xpath('//*[@class="dedeman-network"]/@data-mage-init').re_first('{\s*"stores":\s*(\[.+?]),')
+            response.xpath('//*[@class="dedeman-network"]/@data-mage-init').re_first(r'{\s*"stores":\s*(\[.+?]),')
         )
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:


### PR DESCRIPTION
```python
{'atp/brand/Dedeman': 64,
 'atp/brand_wikidata/Q5249762': 64,
 'atp/category/shop/doityourself': 64,
 'atp/clean_strings/branch': 1,
 'atp/country/RO': 64,
 'atp/field/city/missing': 64,
 'atp/field/country/from_spider_name': 64,
 'atp/field/email/missing': 64,
 'atp/field/image/missing': 64,
 'atp/field/opening_hours/missing': 64,
 'atp/field/operator/missing': 64,
 'atp/field/operator_wikidata/missing': 64,
 'atp/field/phone/missing': 64,
 'atp/field/postcode/missing': 64,
 'atp/field/state/missing': 64,
 'atp/field/street_address/missing': 64,
 'atp/field/twitter/missing': 64,
 'atp/item_scraped_host_count/www.dedeman.ro': 64,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 64,
 'downloader/request_bytes': 688,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 83200,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.086264,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 11, 53, 16, 390277, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 391489,
 'httpcompression/response_count': 2,
 'item_scraped_count': 64,
 'items_per_minute': None,
 'log_count/DEBUG': 77,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 27, 11, 53, 8, 304013, tzinfo=datetime.timezone.utc)}
```