### PR TITLE
[KPN NL] Fix spider

### DIFF
--- a/locations/spiders/kpn_nl.py
+++ b/locations/spiders/kpn_nl.py
@@ -19,12 +19,11 @@ class KpnNLSpider(SitemapSpider, StructuredDataSpider):
         ld_data["openingHours"] = hours
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["branch"] = (
-            item.pop("name")
-            .removesuffix(" | KPN")
-            .removeprefix("KPN XL winkel ")
-            .removeprefix("KPN winkel ")
-            .removeprefix("KPN Experience Store ")
-        )
+        if item["name"].startswith("KPN XL winkel"):
+            item["name"] = "KPN XL"
+        elif item["name"].startswith("KPN winkel"):
+            item["name"] = "KPN"
+        elif item["name"].startswith("KPN Experience Store"):
+            item["name"] = "KPN Experience Store"
         apply_category(Categories.SHOP_MOBILE_PHONE, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/KPN': 90,
 'atp/brand_wikidata/Q338633': 90,
 'atp/category/shop/mobile_phone': 90,
 'atp/country/NL': 90,
 'atp/field/country/from_spider_name': 90,
 'atp/field/email/missing': 90,
 'atp/field/operator/missing': 90,
 'atp/field/operator_wikidata/missing': 90,
 'atp/field/phone/missing': 90,
 'atp/field/state/missing': 90,
 'atp/field/twitter/missing': 90,
 'atp/item_scraped_host_count/www.kpn.com': 90,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 90,
 'atp/structured_data/unmapped/payment_accepted/Creditcards (VISA & MasterCard)': 90,
 'atp/structured_data/unmapped/payment_accepted/PIN': 90,
 'downloader/request_bytes': 36846,
 'downloader/request_count': 92,
 'downloader/request_method_count/GET': 92,
 'downloader/response_bytes': 2722656,
 'downloader/response_count': 92,
 'downloader/response_status_count/200': 92,
 'elapsed_time_seconds': 2.350732,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 27, 13, 52, 31, 188269, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 92,
 'httpcompression/response_bytes': 19230313,
 'httpcompression/response_count': 90,
 'item_scraped_count': 90,
 'items_per_minute': None,
 'log_count/DEBUG': 374,
 'log_count/INFO': 189,
 'request_depth_max': 1,
 'response_received_count': 92,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 91,
 'scheduler/dequeued/memory': 91,
 'scheduler/enqueued': 91,
 'scheduler/enqueued/memory': 91,
 'start_time': datetime.datetime(2025, 5, 27, 13, 52, 28, 837537, tzinfo=datetime.timezone.utc)}
```