### PR TITLE
[Kitchen Warehouse AU] Fix spider

### DIFF
--- a/locations/spiders/kitchen_warehouse_au.py
+++ b/locations/spiders/kitchen_warehouse_au.py
@@ -13,24 +13,28 @@ class KitchenWarehouseAUSpider(JSONBlobSpider):
     name = "kitchen_warehouse_au"
     item_attributes = {"brand": "Kitchen Warehouse", "brand_wikidata": "Q63603149"}
     allowed_domains = ["kwh-kitchenwarehouse.frontastic.live"]
-    start_urls = ["https://kwh-kitchenwarehouse.frontastic.live/frontastic/action/storelocator/getstatewisestores"]
+    stores_api = "https://kwh-kitchenwarehouse.frontastic.live/frontastic/action"
+    access_token = ""
+    request_body = {}
 
     def start_requests(self) -> Iterable[JsonRequest]:
         yield JsonRequest(
-            url="https://kwh-kitchenwarehouse.frontastic.live/frontastic/action/ct-auth/getAnonymousAccessToken",
+            url=f"{self.stores_api}/ct-auth/getAnonymousAccessToken",
             method="POST",
             callback=self.parse_access_token,
         )
 
     def parse_access_token(self, response: Response) -> Iterable[JsonRequest]:
-        access_token = response.json()["access_token"]
-        data = {
+        self.access_token = response.json()["access_token"]
+        self.request_body = {
             "customer_reference": "",
             "skipIntrospection": True,
-            "token": f"Bearer {access_token}",
+            "token": f"Bearer {self.access_token}",
             "isAnonymousUser": True,
         }
-        yield JsonRequest(url=self.start_urls[0], data=data, meta={"access_token": access_token}, method="POST")
+        yield JsonRequest(
+            url=f"{self.stores_api}/storelocator/getstatewisestores", data=self.request_body, method="POST"
+        )
 
     def extract_json(self, response: Response) -> list[dict]:
         all_stores = []
@@ -45,17 +49,9 @@ class KitchenWarehouseAUSpider(JSONBlobSpider):
         item["street_address"] = merge_address_lines([feature.get("address1"), feature.get("address2")])
         item["website"] = "https://www.kitchenwarehouse.com.au/find-store/" + item["branch"].lower().replace(" ", "-")
         apply_category(Categories.SHOP_HOUSEWARE, item)
-        access_token = response.meta["access_token"]
-        data = {
-            "customer_reference": "",
-            "key": item["ref"],
-            "skipIntrospection": True,
-            "token": f"Bearer {access_token}",
-            "isAnonymousUser": True,
-        }
         yield JsonRequest(
-            url="https://kwh-kitchenwarehouse.frontastic.live/frontastic/action/storelocator/storedetail",
-            data=data,
+            url=f"{self.stores_api}/storelocator/storedetail",
+            data=self.request_body | {"key": item["ref"]},
             meta={"item": item},
             method="POST",
             callback=self.add_opening_hours,

--- a/locations/spiders/kitchen_warehouse_au.py
+++ b/locations/spiders/kitchen_warehouse_au.py
@@ -28,6 +28,7 @@ class KitchenWarehouseAUSpider(JSONBlobSpider):
             "customer_reference": "",
             "skipIntrospection": True,
             "token": f"Bearer {access_token}",
+            "isAnonymousUser": True,
         }
         yield JsonRequest(url=self.start_urls[0], data=data, meta={"access_token": access_token}, method="POST")
 
@@ -50,6 +51,7 @@ class KitchenWarehouseAUSpider(JSONBlobSpider):
             "key": item["ref"],
             "skipIntrospection": True,
             "token": f"Bearer {access_token}",
+            "isAnonymousUser": True,
         }
         yield JsonRequest(
             url="https://kwh-kitchenwarehouse.frontastic.live/frontastic/action/storelocator/storedetail",


### PR DESCRIPTION
```
{'atp/brand/Kitchen Warehouse': 26,
 'atp/brand_wikidata/Q63603149': 26,
 'atp/category/shop/houseware': 26,
 'atp/country/AU': 26,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 26,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 26,
 'atp/field/operator_wikidata/missing': 26,
 'atp/field/twitter/missing': 26,
 'atp/item_scraped_host_count/kwh-kitchenwarehouse.frontastic.live': 26,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 26,
 'downloader/request_bytes': 18331,
 'downloader/request_count': 29,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 28,
 'downloader/response_bytes': 56437,
 'downloader/response_count': 29,
 'downloader/response_status_count/200': 28,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 32.420752,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 28, 7, 25, 5, 243260, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 36404,
 'httpcompression/response_count': 29,
 'item_scraped_count': 26,
 'items_per_minute': None,
 'log_count/DEBUG': 67,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 29,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 28,
 'scheduler/dequeued/memory': 28,
 'scheduler/enqueued': 28,
 'scheduler/enqueued/memory': 28,
 'start_time': datetime.datetime(2025, 5, 28, 7, 24, 32, 822508, tzinfo=datetime.timezone.utc)}
```