### PR TITLE
[Leeann Chin US] Fix spider

### DIFF
--- a/locations/spiders/leeann_chin_us.py
+++ b/locations/spiders/leeann_chin_us.py
@@ -18,6 +18,7 @@ class LeeannChinUSSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.leeannchin.com/locations"]
     rules = [Rule(LinkExtractor(allow=r"/restaurant/[-\w]+/[-\w]+/?$"), callback="parse_sd")]
     json_parser = "chompjs"
+    drop_attributes = {"facebook", "twitter"}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.pop("openingHoursSpecification", None)  # Current day is missing from ld_data

--- a/locations/spiders/leeann_chin_us.py
+++ b/locations/spiders/leeann_chin_us.py
@@ -1,35 +1,14 @@
-from typing import Iterable
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-import chompjs
-from scrapy import Selector
-from scrapy.http import Response
-
-from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LeeannChinUSSpider(JSONBlobSpider):
+class LeeannChinUSSpider(CrawlSpider, StructuredDataSpider):
     name = "leeann_chin_us"
     item_attributes = {
         "brand": "Leeann Chin",
         "brand_wikidata": "Q6515716",
     }
     start_urls = ["https://www.leeannchin.com/locations"]
-
-    def extract_json(self, response: Response) -> list:
-        return chompjs.parse_js_object(response.xpath('//script[contains(text(), "var jsonContent")]/text()').get())[
-            "data"
-        ]
-
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["street"] = feature.get("address_route")
-        item["addr_full"] = feature.get("location")
-        item["branch"] = item.pop("name")
-        item["name"] = self.item_attributes["brand"]
-        hours_info = Selector(text=feature.get("hours", ""))
-        item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_ranges_from_string(", ".join(hours_info.xpath("//li/text()").getall()))
-        apply_category(Categories.RESTAURANT, item)
-        yield item
+    rules = [Rule(LinkExtractor(allow=r"/restaurant/[-\w]+/[-\w]+/?$"), callback="parse_sd")]

--- a/locations/spiders/leeann_chin_us.py
+++ b/locations/spiders/leeann_chin_us.py
@@ -1,6 +1,11 @@
+from typing import Iterable
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,3 +18,12 @@ class LeeannChinUSSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.leeannchin.com/locations"]
     rules = [Rule(LinkExtractor(allow=r"/restaurant/[-\w]+/[-\w]+/?$"), callback="parse_sd")]
     json_parser = "chompjs"
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data.pop("openingHoursSpecification", None)  # Current day is missing from ld_data
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["opening_hours"] = OpeningHours()
+        for rule in response.xpath('//*[@class="opening-hours"]//li'):
+            item["opening_hours"].add_ranges_from_string(rule.xpath("./text()").get())
+        yield item

--- a/locations/spiders/leeann_chin_us.py
+++ b/locations/spiders/leeann_chin_us.py
@@ -12,3 +12,4 @@ class LeeannChinUSSpider(CrawlSpider, StructuredDataSpider):
     }
     start_urls = ["https://www.leeannchin.com/locations"]
     rules = [Rule(LinkExtractor(allow=r"/restaurant/[-\w]+/[-\w]+/?$"), callback="parse_sd")]
+    json_parser = "chompjs"

--- a/locations/spiders/leeann_chin_us.py
+++ b/locations/spiders/leeann_chin_us.py
@@ -23,6 +23,7 @@ class LeeannChinUSSpider(CrawlSpider, StructuredDataSpider):
         ld_data.pop("openingHoursSpecification", None)  # Current day is missing from ld_data
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = item["name"].removesuffix(" Fresh Asian Flavors")
         item["opening_hours"] = OpeningHours()
         for rule in response.xpath('//*[@class="opening-hours"]//li'):
             item["opening_hours"].add_ranges_from_string(rule.xpath("./text()").get())


### PR DESCRIPTION
`JSON Blob` earlier used, is giving some decode error, hence `Structured Data` is used to refactor and fix the spider. [Sitemap](https://www.leeannchin.com/sitemap.xml) gives one POI less (url redirects to store locator) , hence ignored.

```python
{'atp/brand/Leeann Chin': 41,
 'atp/brand_wikidata/Q6515716': 41,
 'atp/category/amenity/restaurant': 41,
 'atp/country/US': 41,
 'atp/field/branch/missing': 41,
 'atp/field/email/missing': 41,
 'atp/field/image/dropped': 41,
 'atp/field/image/missing': 41,
 'atp/field/operator/missing': 41,
 'atp/field/operator_wikidata/missing': 41,
 'atp/field/twitter/missing': 41,
 'atp/item_scraped_host_count/www.leeannchin.com': 41,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 41,
 'downloader/request_bytes': 18190,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 43,
 'downloader/response_bytes': 937677,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'elapsed_time_seconds': 55.350625,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 28, 8, 28, 51, 951193, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5796738,
 'httpcompression/response_count': 43,
 'item_scraped_count': 41,
 'items_per_minute': None,
 'log_count/DEBUG': 102,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 43,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 42,
 'scheduler/dequeued/memory': 42,
 'scheduler/enqueued': 42,
 'scheduler/enqueued/memory': 42,
 'start_time': datetime.datetime(2025, 5, 28, 8, 27, 56, 600568, tzinfo=datetime.timezone.utc)}
```