### PR TITLE
[Cycle Lab ZA] [The Pro Shop ZA] Fix spiders

### DIFF
--- a/locations/spiders/cycle_lab_za.py
+++ b/locations/spiders/cycle_lab_za.py
@@ -19,9 +19,10 @@ class CycleLabZASpider(Spider):
     no_refs = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//*[@class="Store-Location-Content"]'):
+        for location in response.xpath('//*[@class="Store-Location"]'):
             item = Feature()
             # Only addresses are available, no coordinates are there.
+            item["branch"] = location.xpath('.//*[contains(@class,"card-link")]//p/text()').get("").strip()
             item["addr_full"] = clean_address(
                 location.xpath('.//*[@class="Store-Location-Address"]//p/text()').getall()
             )


### PR DESCRIPTION
`cycle_lab_za` fixed and consequently `the_pro_shop_za` is also fixed, since the later inherits the first.

**cycle_lab_za**
```python
{'atp/brand/Cycle Lab': 8,
 'atp/brand_wikidata/Q130487839': 8,
 'atp/category/shop/bicycle': 8,
 'atp/clean_strings/phone': 8,
 'atp/country/ZA': 8,
 'atp/field/city/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/email/missing': 8,
 'atp/field/image/missing': 8,
 'atp/field/lat/missing': 8,
 'atp/field/lon/missing': 8,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/postcode/missing': 8,
 'atp/field/state/missing': 8,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 8,
 'atp/field/website/missing': 8,
 'atp/item_scraped_host_count/www.cyclelab.com': 8,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 8,
 'downloader/request_bytes': 663,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 39628,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.750106,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 28, 13, 37, 44, 84286, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 418196,
 'httpcompression/response_count': 2,
 'item_scraped_count': 8,
 'items_per_minute': None,
 'log_count/DEBUG': 21,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 28, 13, 37, 40, 334180, tzinfo=datetime.timezone.utc)}
```
**the_pro_shop_za**
```python
{'atp/brand/The Pro Shop': 38,
 'atp/brand_wikidata/Q130488660': 38,
 'atp/category/shop/sports': 38,
 'atp/clean_strings/email': 27,
 'atp/clean_strings/phone': 38,
 'atp/country/ZA': 38,
 'atp/field/city/missing': 38,
 'atp/field/country/from_spider_name': 38,
 'atp/field/email/missing': 11,
 'atp/field/image/missing': 38,
 'atp/field/lat/missing': 38,
 'atp/field/lon/missing': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/postcode/missing': 38,
 'atp/field/state/missing': 38,
 'atp/field/street_address/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/field/website/missing': 38,
 'atp/item_scraped_host_count/www.theproshop.co.za': 38,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 38,
 'downloader/request_bytes': 671,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 38753,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 11.010668,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 28, 13, 37, 3, 946392, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 448040,
 'httpcompression/response_count': 2,
 'item_scraped_count': 38,
 'items_per_minute': None,
 'log_count/DEBUG': 51,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 28, 13, 36, 52, 935724, tzinfo=datetime.timezone.utc)}
```