### PR TITLE
[Home Depot] Fix Spider

### DIFF
--- a/locations/spiders/home_depot.py
+++ b/locations/spiders/home_depot.py
@@ -13,7 +13,6 @@ from locations.user_agents import BROWSER_DEFAULT
 class HomeDepotSpider(CrawlSpider, StructuredDataSpider):
     name = "home_depot"
     item_attributes = {"brand": "The Home Depot", "brand_wikidata": "Q864407"}
-    # allowed_domains = ["www.homedepot.com"]
     start_urls = ["https://www.homedepot.com/l/storeDirectory"]
     rules = [
         Rule(LinkExtractor(allow=r"^https:\/\/www.homedepot.com\/l\/..$")),


### PR DESCRIPTION
**_Fixes : added user_agent to fix spider_**

```python
{'atp/brand/The Home Depot': 1971,
 'atp/brand_wikidata/Q864407': 1971,
 'atp/category/shop/doityourself': 1971,
 'atp/country/GU': 1,
 'atp/country/PR': 10,
 'atp/country/US': 1958,
 'atp/country/VI': 2,
 'atp/field/country/from_reverse_geocoding': 1971,
 'atp/field/email/missing': 1971,
 'atp/field/image/missing': 1971,
 'atp/field/name/missing': 13,
 'atp/field/operator/missing': 1971,
 'atp/field/operator_wikidata/missing': 1971,
 'atp/item_scraped_host_count/www.homedepot.com': 1971,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1958,
 'atp/nsi/match_failed': 13,
 'downloader/request_bytes': 5506890,
 'downloader/request_count': 2027,
 'downloader/request_method_count/GET': 2027,
 'downloader/response_bytes': 384713366,
 'downloader/response_count': 2027,
 'downloader/response_status_count/200': 2027,
 'dupefilter/filtered': 98,
 'elapsed_time_seconds': 2507.804144,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 29, 5, 25, 29, 173951, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2462881479,
 'httpcompression/response_count': 2027,
 'item_scraped_count': 1971,
 'items_per_minute': None,
 'log_count/DEBUG': 4010,
 'log_count/INFO': 50,
 'log_count/WARNING': 1971,
 'request_depth_max': 2,
 'response_received_count': 2027,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2026,
 'scheduler/dequeued/memory': 2026,
 'scheduler/enqueued': 2026,
 'scheduler/enqueued/memory': 2026,
 'start_time': datetime.datetime(2025, 5, 29, 4, 43, 41, 369807, tzinfo=datetime.timezone.utc)}

``