### PR TITLE
[Triumph] Fix spider

### DIFF
--- a/locations/spiders/triumph.py
+++ b/locations/spiders/triumph.py
@@ -9,3 +9,6 @@ class TriumphSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["storelocator.triumph.com"]
     sitemap_urls = ["https://storelocator.triumph.com/en/sitemap.xml"]
     sitemap_rules = [(r"/en/.+/triumph-[-\w]+-(\d+)/?$", "parse_sd")]
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data.pop("@id", None)  # capture store id as ref instead of website

--- a/locations/spiders/triumph.py
+++ b/locations/spiders/triumph.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -12,3 +14,8 @@ class TriumphSpider(SitemapSpider, StructuredDataSpider):
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.pop("@id", None)  # capture store id as ref instead of website
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if "Partner" in item["name"].title():
+            return
+        yield item

--- a/locations/spiders/triumph.py
+++ b/locations/spiders/triumph.py
@@ -1,15 +1,11 @@
-from locations.storefinders.stockinstore import StockInStoreSpider
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class TriumphSpider(StockInStoreSpider):
+class TriumphSpider(SitemapSpider, StructuredDataSpider):
     name = "triumph"
     item_attributes = {"brand": "Triumph", "brand_wikidata": "Q671216"}
-    api_site_id = "10113"
-    api_widget_id = "120"
-    api_widget_type = "storelocator"
-    api_origin = "https://au.triumph.com"
-
-    def parse_item(self, item, location):
-        if "Triumph " not in item["name"]:
-            return
-        yield item
+    allowed_domains = ["storelocator.triumph.com"]
+    sitemap_urls = ["https://storelocator.triumph.com/en/sitemap.xml"]
+    sitemap_rules = [(r"/en/.+/triumph-[-\w]+-(\d+)/?$", "parse_sd")]

--- a/locations/spiders/triumph.py
+++ b/locations/spiders/triumph.py
@@ -18,4 +18,8 @@ class TriumphSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if "Partner" in item["name"].title():
             return
+        if "Outlet" in item["name"].title():
+            item["name"] = "Triumph Outlet"
+        else:
+            item["name"] = "Triumph"
         yield item

--- a/locations/spiders/triumph.py
+++ b/locations/spiders/triumph.py
@@ -11,6 +11,7 @@ class TriumphSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["storelocator.triumph.com"]
     sitemap_urls = ["https://storelocator.triumph.com/en/sitemap.xml"]
     sitemap_rules = [(r"/en/.+/triumph-[-\w]+-(\d+)/?$", "parse_sd")]
+    drop_attributes = {"facebook"}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.pop("@id", None)  # capture store id as ref instead of website


### PR DESCRIPTION
`StockInStoreSpider` not working, hence code refactored using `Structured Data` to fix the spider. It gives better worldwide POIs count.

```python
{'atp/brand/Triumph': 323,
 'atp/brand_wikidata/Q671216': 323,
 'atp/category/shop/clothes': 323,
 'atp/country/AT': 49,
 'atp/country/BE': 2,
 'atp/country/BG': 8,
 'atp/country/CH': 9,
 'atp/country/CZ': 11,
 'atp/country/DE': 46,
 'atp/country/DK': 8,
 'atp/country/ES': 8,
 'atp/country/FR': 22,
 'atp/country/GG': 2,
 'atp/country/GR': 11,
 'atp/country/HR': 2,
 'atp/country/HU': 18,
 'atp/country/IL': 3,
 'atp/country/IT': 32,
 'atp/country/JE': 2,
 'atp/country/LU': 1,
 'atp/country/MT': 1,
 'atp/country/NL': 12,
 'atp/country/NO': 5,
 'atp/country/PL': 35,
 'atp/country/PT': 23,
 'atp/country/SE': 8,
 'atp/country/SI': 5,
 'atp/field/branch/missing': 323,
 'atp/field/email/missing': 323,
 'atp/field/image/missing': 323,
 'atp/field/opening_hours/missing': 15,
 'atp/field/operator/missing': 323,
 'atp/field/operator_wikidata/missing': 323,
 'atp/field/postcode/missing': 10,
 'atp/field/state/missing': 323,
 'atp/field/twitter/missing': 323,
 'atp/item_scraped_host_count/storelocator.triumph.com': 323,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 323,
 'downloader/request_bytes': 220485,
 'downloader/request_count': 466,
 'downloader/request_method_count/GET': 466,
 'downloader/response_bytes': 97323334,
 'downloader/response_count': 466,
 'downloader/response_status_count/200': 465,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 19.716264,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 29, 6, 34, 4, 171108, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 466,
 'httpcompression/response_bytes': 730016587,
 'httpcompression/response_count': 465,
 'item_scraped_count': 323,
 'items_per_minute': None,
 'log_count/DEBUG': 1205,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 465,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 464,
 'scheduler/dequeued/memory': 464,
 'scheduler/enqueued': 464,
 'scheduler/enqueued/memory': 464,
 'start_time': datetime.datetime(2025, 5, 29, 6, 33, 44, 454844, tzinfo=datetime.timezone.utc)}
```