### PR TITLE
[Vodafone IT] Fix Spider

### DIFF
--- a/locations/spiders/vodafone_it.py
+++ b/locations/spiders/vodafone_it.py
@@ -13,9 +13,8 @@ class VodafoneITSpider(YextAnswersSpider):
     locale = "it"
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
-        self.crawler.stats.inc_value("x/c_storeType/{}".format(location["data"].get("c_storeType")))
-        if location["data"].get("c_storeType") != "Vodafone Store":
+        self.crawler.stats.inc_value("x/c_storeType/{}".format(location.get("c_storeType")))
+        if location.get("c_storeType") != "Vodafone Store":
             return None
-
         item["branch"] = item.pop("name").removeprefix("Vodafone Store").strip(" |")
         yield item


### PR DESCRIPTION
**_Fixes: updated parse_item method to fix spider_**

```python
{'atp/brand/Vodafone': 328,
 'atp/brand_wikidata/Q122141': 328,
 'atp/category/shop/mobile_phone': 328,
 'atp/cdn/cloudflare/response_count': 89,
 'atp/cdn/cloudflare/response_status_count/200': 88,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/IT': 328,
 'atp/duplicate_count': 108,
 'atp/field/email/invalid': 6,
 'atp/field/email/missing': 179,
 'atp/field/image/missing': 328,
 'atp/field/operator/missing': 328,
 'atp/field/operator_wikidata/missing': 328,
 'atp/field/phone/missing': 3,
 'atp/field/twitter/missing': 326,
 'atp/field/website/missing': 5,
 'atp/item_scraped_host_count/liveapi.yext.com': 436,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 328,
 'downloader/request_bytes': 92662,
 'downloader/request_count': 89,
 'downloader/request_method_count/GET': 89,
 'downloader/response_bytes': 1321414,
 'downloader/response_count': 89,
 'downloader/response_status_count/200': 88,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 109.139068,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 29, 12, 22, 22, 880982, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12061817,
 'httpcompression/response_count': 88,
 'item_dropped_count': 108,
 'item_dropped_reasons_count/DropItem': 108,
 'item_scraped_count': 328,
 'items_per_minute': None,
 'log_count/DEBUG': 536,
 'log_count/INFO': 10,
 'log_count/WARNING': 6,
 'request_depth_max': 87,
 'response_received_count': 89,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 88,
 'scheduler/dequeued/memory': 88,
 'scheduler/enqueued': 88,
 'scheduler/enqueued/memory': 88,
 'start_time': datetime.datetime(2025, 5, 29, 12, 20, 33, 741914, tzinfo=datetime.timezone.utc),
 'x/c_storeType/Fastweb Store': 210,
 'x/c_storeType/Grande distribuzione': 133,
 'x/c_storeType/None': 262,
 'x/c_storeType/Rivenditore Autorizzato': 3272,
 'x/c_storeType/Vodafone Multiservizi': 74,
 'x/c_storeType/Vodafone Store': 436}
```