### PR TITLE
[Krefel BE] Fix Spider

### DIFF
--- a/locations/spiders/krefel_be.py
+++ b/locations/spiders/krefel_be.py
@@ -1,38 +1,25 @@
 from typing import Any, Iterable
 
-import xmltodict
 from scrapy import Request, Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class KrefelBESpider(Spider):
     name = "krefel_be"
     item_attributes = {"brand": "Krëfel", "brand_wikidata": "Q3200093"}
-    user_agent = BROWSER_DEFAULT
-    requires_proxy = True
+    user_agent = FIREFOX_LATEST
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self) -> Iterable[Request]:
-        yield JsonRequest(url="https://api.krefel.be/api/v2/krefel/stores?pageSize=100&lang=nl")
+        yield JsonRequest(url="https://api.krefel.be/occ/v2/krefel/stores?fields=STORE_FINDER&pageSize=1000&lang=nl")
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        # API response's content-type is not consistent.
-        if response.headers["Content-Type"] == b"application/json":
-            locations = response.json()["stores"]
-        else:
-            locations = xmltodict.parse(response.text)["storeFinderSearchPage"]["stores"]
-        for location in locations:
-            location["ref"] = location.pop("name")
-            location["phone"] = "; ".join(
-                filter(None, [location["address"].get("phone"), location["address"].get("phone2")])
-            ).replace("/", "")
-            location["address"]["house_number"] = location["address"].pop("line2", "")
-            location["address"]["street"] = location["address"].pop("line1")
-
-            item = DictParser.parse(location)
-            item["website"] = item["extras"]["website:nl"] = f'https://www.krefel.be/nl/winkels/{location["ref"]}'
-            item["extras"]["website:fr"] = f'https://www.krefel.be/fr/magasins/{location["ref"]}'
+        for store in response.json()["stores"]:
+            item = DictParser.parse(store)
             item["branch"] = item.pop("name")
+            item["ref"] = store["krefelId"]
+            item["website"] = "/".join(["https://www.krefel.be/nl/winkels", store["name"].lower()])
             yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Krëfel': 72,
 'atp/brand_wikidata/Q3200093': 72,
 'atp/category/shop/electronics': 72,
 'atp/country/BE': 72,
 'atp/field/country/from_spider_name': 72,
 'atp/field/email/missing': 72,
 'atp/field/image/missing': 72,
 'atp/field/opening_hours/missing': 72,
 'atp/field/operator/missing': 72,
 'atp/field/operator_wikidata/missing': 72,
 'atp/field/phone/missing': 72,
 'atp/field/state/missing': 72,
 'atp/field/twitter/missing': 72,
 'atp/item_scraped_host_count/api.krefel.be': 72,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 72,
 'downloader/request_bytes': 330,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 6780,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.924027,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 30, 6, 10, 24, 858149, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 96020,
 'httpcompression/response_count': 1,
 'item_scraped_count': 72,
 'items_per_minute': None,
 'log_count/DEBUG': 84,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 30, 6, 10, 22, 934122, tzinfo=datetime.timezone.utc)}
```