### PR TITLE
[Applegreen] Fix Spider

### DIFF
--- a/locations/spiders/applegreen.py
+++ b/locations/spiders/applegreen.py
@@ -1,47 +1,27 @@
+from urllib.parse import urljoin
+
 from scrapy import Spider
-from scrapy.http import JsonRequest
 
 from locations.categories import Access, Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class ApplegreenSpider(Spider):
     name = "applegreen"
     item_attributes = {"brand": "Applegreen", "brand_wikidata": "Q7178908"}
-    start_urls = ["https://api.applegreenstores.com/v1/locations?limit=1200&radius=600000"]
+    start_urls = ["https://locations.applegreen.com/wp-json/locations/v1/search?distance=100"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response, **kwargs):
-        for location in response.json()["items"]:
-            if location["competitor"]:
-                continue
-            yield JsonRequest(
-                url=f'https://api.applegreenstores.com/v1/locations/{location["id"]}', callback=self.parse_location
-            )
-
-    def parse_location(self, response, **kwargs):
-        location = response.json()["item"]
-        item = DictParser.parse(location)
-        item["lat"] = location["geolat"]
-        item["lon"] = location["geolng"]
-
-        if opening_hours := location["opening_hours"]:
-            item["opening_hours"] = "24/7" if "24 hour" in opening_hours else None
-
-        apply_category(Categories.FUEL_STATION, item)
-
-        apply_yes_no(Extras.ATM, item, location["services"]["has_atm"])
-        apply_yes_no("sells:lottery", item, location["services"]["has_lotto"])
-        apply_yes_no(Extras.BABY_CHANGING_TABLE, item, location["services"]["has_baby_changing"])
-        apply_yes_no(Extras.WIFI, item, location["services"]["has_wifi"])
-        apply_yes_no(Extras.TOILETS, item, location["services"]["toilet"])
-        apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, "Disabled" in location["services"]["toilet"])
-        apply_yes_no(Extras.CAR_WASH, item, location["services"]["carwash"])
-        apply_yes_no(Extras.SHOWERS, item, location["services"]["has_showers"])
-        apply_yes_no(Access.HGV, item, location["services"]["has_truck_stop"])
-
-        for fuel in ["diesel", "unleaded"]:
-            if price := location["prices"].get(fuel):
-                apply_yes_no("fuel:{}".format(fuel), item, True)
-                item["extras"]["charge:{}".format(fuel)] = "{} {}/1 litre".format(price, location["prices"]["currency"])
-
-        yield item
+        for location in response.json()["data"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["street_address"] = merge_address_lines([location["address_1"], location["address_2"]])
+            item["website"] = urljoin("https://locations.applegreen.com/locations", location["link"])
+            apply_category(Categories.FUEL_STATION, item)
+            apply_yes_no(Extras.TOILETS, item, location["toilet"])
+            apply_yes_no(Extras.CAR_WASH, item, location["car_wash"])
+            apply_yes_no(Extras.ICE_CREAM, item, location["icecream"])
+            apply_yes_no(Access.HGV, item, location["hgv"])
+            yield item

--- a/locations/spiders/applegreen_ie.py
+++ b/locations/spiders/applegreen_ie.py
@@ -7,8 +7,8 @@ from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class ApplegreenSpider(Spider):
-    name = "applegreen"
+class ApplegreenIESpider(Spider):
+    name = "applegreen_ie"
     item_attributes = {"brand": "Applegreen", "brand_wikidata": "Q7178908"}
     start_urls = ["https://locations.applegreen.com/wp-json/locations/v1/search?distance=100"]
     custom_settings = {"ROBOTSTXT_OBEY": False}


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Applegreen': 186,
 'atp/brand_wikidata/Q7178908': 186,
 'atp/category/amenity/fuel': 186,
 'atp/country/IE': 186,
 'atp/field/country/from_reverse_geocoding': 186,
 'atp/field/email/missing': 186,
 'atp/field/image/missing': 186,
 'atp/field/opening_hours/missing': 186,
 'atp/field/operator/missing': 186,
 'atp/field/operator_wikidata/missing': 186,
 'atp/field/phone/missing': 186,
 'atp/field/postcode/missing': 186,
 'atp/field/state/missing': 9,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 186,
 'atp/item_scraped_host_count/locations.applegreen.com': 186,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 186,
 'downloader/request_bytes': 372,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 13903,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.548754,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 5, 30, 10, 42, 58, 851044, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 122743,
 'httpcompression/response_count': 1,
 'item_scraped_count': 186,
 'items_per_minute': None,
 'log_count/DEBUG': 199,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 5, 30, 10, 42, 56, 302290, tzinfo=datetime.timezone.utc)}
```