### PR TITLE
[Planet Fitness] Fix spider

### DIFF
--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -1,9 +1,5 @@
-import re
-from typing import Any, Iterable
-
-from geonamescache import GeonamesCache
-from scrapy import Request
-from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
@@ -11,9 +7,14 @@ from locations.user_agents import BROWSER_DEFAULT
 
 
 # Sitemap https://www.planetfitness.com/sitemap.xml isn't accessible for the spider.
-class PlanetFitnessSpider(StructuredDataSpider):
+class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
     name = "planet_fitness"
     item_attributes = {"brand": "Planet Fitness", "brand_wikidata": "Q7201095"}
+    start_urls = ["https://www.planetfitness.com/clubs"]
+    rules = [
+        Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/?$")),
+        Rule(LinkExtractor(allow="/gyms/[-\w]+/?$"), callback="parse_sd"),
+    ]
     requires_proxy = True
     user_agent = BROWSER_DEFAULT
     is_playwright_spider = True
@@ -23,11 +24,3 @@ class PlanetFitnessSpider(StructuredDataSpider):
         "DOWNLOAD_DELAY": 3,
         "RETRY_TIMES": 5,
     }
-
-    def start_requests(self) -> Iterable[Request]:
-        for state in GeonamesCache().get_us_states_by_names():
-            yield Request(f'https://www.planetfitness.com/gyms.data?limit=1000&q={state.lower().replace(" ", "-")}')
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for slug in set(re.findall(r"planetfitness\.com/gyms/([-\w]+)/offers", response.text)):
-            yield Request(url=f"https://www.planetfitness.com/gyms/{slug}", callback=self.parse_sd)

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -16,6 +16,7 @@ class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
     ]
     rules = [
         Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/?$")),
+        Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/[-\w]+?$")),
         Rule(LinkExtractor(allow="/gyms/[-\w]+/?$"), callback="parse_sd"),
     ]
     requires_proxy = True

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -26,7 +26,6 @@ class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/[-\w]+?$", deny=r"/[a-z]{2}/clubs")),
         Rule(LinkExtractor(allow=r"/gyms/[-\w]+/?$", deny=r"/[a-z]{2}/gyms"), callback="parse_sd"),
     ]
-    requires_proxy = True
     user_agent = BROWSER_DEFAULT
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -1,20 +1,33 @@
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Any, Iterable
 
-from locations.linked_data_parser import LinkedDataParser
+from geonamescache import GeonamesCache
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class PlanetFitnessSpider(SitemapSpider):
+# Sitemap https://www.planetfitness.com/sitemap.xml isn't accessible for the spider.
+class PlanetFitnessSpider(StructuredDataSpider):
     name = "planet_fitness"
     item_attributes = {"brand": "Planet Fitness", "brand_wikidata": "Q7201095"}
-    download_delay = 4
-    sitemap_urls = [
-        "https://www.planetfitness.com/sitemap.xml",
-    ]
-    sitemap_rules = [
-        (r"https://www.planetfitness.com/gyms/", "parse"),
-    ]
     requires_proxy = True
+    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "ROBOTSTXT_OBEY": False,
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000,
+        "DOWNLOAD_DELAY": 3,
+        "RETRY_TIMES": 5,
+    }
 
-    def parse(self, response):
-        item = LinkedDataParser.parse(response, "ExerciseGym")
-        yield item
+    def start_requests(self) -> Iterable[Request]:
+        for state in GeonamesCache().get_us_states_by_names():
+            yield Request(f'https://www.planetfitness.com/gyms.data?limit=1000&q={state.lower().replace(" ", "-")}')
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for slug in set(re.findall(r"planetfitness\.com/gyms/([-\w]+)/offers", response.text)):
+            yield Request(url=f"https://www.planetfitness.com/gyms/{slug}", callback=self.parse_sd)

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -43,5 +43,6 @@ class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
             item["opening_hours"] = "24/7"
         else:
             for rule in hours.xpath(".//li/text() | .//p/text()").getall():
-                item["opening_hours"].add_ranges_from_string(html.unescape(rule).replace("&", "-"))
+                rule = html.unescape(rule).replace("&", "-").replace("12:00 AM - 12:00 AM", "12:00 AM - 11:59 AM")
+                item["opening_hours"].add_ranges_from_string(rule)
         yield item

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -20,9 +20,11 @@ class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
         "https://www.planetfitness.ca/clubs",
     ]
     rules = [
-        Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/?$")),
-        Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/[-\w]+?$")),
-        Rule(LinkExtractor(allow="/gyms/[-\w]+/?$"), callback="parse_sd"),
+        Rule(
+            LinkExtractor(allow=r"/clubs/[a-z]{2}/?$", deny=r"/[a-z]{2}/clubs")
+        ),  # Deny language-specific versions like /es/
+        Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/[-\w]+?$", deny=r"/[a-z]{2}/clubs")),
+        Rule(LinkExtractor(allow=r"/gyms/[-\w]+/?$", deny=r"/[a-z]{2}/gyms"), callback="parse_sd"),
     ]
     requires_proxy = True
     user_agent = BROWSER_DEFAULT

--- a/locations/spiders/planet_fitness.py
+++ b/locations/spiders/planet_fitness.py
@@ -10,7 +10,10 @@ from locations.user_agents import BROWSER_DEFAULT
 class PlanetFitnessSpider(CrawlSpider, StructuredDataSpider):
     name = "planet_fitness"
     item_attributes = {"brand": "Planet Fitness", "brand_wikidata": "Q7201095"}
-    start_urls = ["https://www.planetfitness.com/clubs"]
+    start_urls = [
+        "https://www.planetfitness.com/clubs",
+        "https://www.planetfitness.ca/clubs",
+    ]
     rules = [
         Rule(LinkExtractor(allow=r"/clubs/[a-z]{2}/?$")),
         Rule(LinkExtractor(allow="/gyms/[-\w]+/?$"), callback="parse_sd"),


### PR DESCRIPTION
Summary created for about `500` POIs.

```python
{'atp/brand/Planet Fitness': 513,
 'atp/brand_wikidata/Q7201095': 513,
 'atp/category/leisure/fitness_centre': 513,
 'atp/country/CA': 38,
 'atp/country/US': 475,
 'atp/field/branch/missing': 513,
 'atp/field/email/missing': 513,
 'atp/field/image/missing': 513,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 513,
 'atp/field/operator_wikidata/missing': 513,
 'atp/field/phone/missing': 5,
 'atp/field/twitter/missing': 513,
 'atp/item_scraped_host_count/www.planetfitness.ca': 38,
 'atp/item_scraped_host_count/www.planetfitness.com': 475,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 513,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/builtins.Exception': 1,
 'downloader/request_bytes': 465650,
 'downloader/request_count': 646,
 'downloader/request_method_count/GET': 646,
 'downloader/response_bytes': 142428653,
 'downloader/response_count': 645,
 'downloader/response_status_count/200': 591,
 'downloader/response_status_count/404': 54,
 'dupefilter/filtered': 133,
 'elapsed_time_seconds': 1260.105759,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 5, 30, 14, 35, 21, 914565, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 357,
 'httpcache/hit': 288,
 'httpcache/miss': 358,
 'httpcache/store': 357,
 'item_scraped_count': 513,
 'items_per_minute': None,
 'log_count/DEBUG': 69803,
 'log_count/INFO': 38,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 357,
 'playwright/page_count/closed': 357,
 'playwright/page_count/max_concurrent': 3,
 'playwright/request_count': 34133,
 'playwright/request_count/aborted': 33578,
 'playwright/request_count/method/GET': 34133,
 'playwright/request_count/navigation': 555,
 'playwright/request_count/resource_type/document': 555,
 'playwright/request_count/resource_type/font': 1428,
 'playwright/request_count/resource_type/image': 22373,
 'playwright/request_count/resource_type/script': 9415,
 'playwright/request_count/resource_type/stylesheet': 362,
 'playwright/response_count': 555,
 'playwright/response_count/method/GET': 555,
 'playwright/response_count/resource_type/document': 555,
 'request_depth_max': 3,
 'response_received_count': 645,
 'responses_per_minute': None,
 'scheduler/dequeued': 646,
 'scheduler/dequeued/memory': 646,
 'scheduler/enqueued': 784,
 'scheduler/enqueued/memory': 784,
 'start_time': datetime.datetime(2025, 5, 30, 14, 14, 21, 808806, tzinfo=datetime.timezone.utc)}
```