### PR TITLE
[Supercor ES] Fix spider

### DIFF
--- a/locations/spiders/supercor_es.py
+++ b/locations/spiders/supercor_es.py
@@ -5,6 +5,8 @@ from chompjs import parse_js_object
 from locations.categories import Categories
 from locations.hours import DAYS_ES, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class SupercorESSpider(JSONBlobSpider):
@@ -12,6 +14,9 @@ class SupercorESSpider(JSONBlobSpider):
     item_attributes = {"brand": "Supercor", "brand_wikidata": "Q6135841", "extras": Categories.SHOP_SUPERMARKET.value}
     allowed_domains = ["www.supercor.es"]
     start_urls = ["https://www.supercor.es/tiendas/"]
+    user_agent = BROWSER_DEFAULT
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def extract_json(self, response):
         js_blob = response.xpath('//script[contains(text(), "var tiendas = `")]/text()').get()

--- a/locations/spiders/supercor_es.py
+++ b/locations/spiders/supercor_es.py
@@ -37,6 +37,11 @@ class SupercorESSpider(JSONBlobSpider):
         item["ref"] = sha1(location["direccion"].encode("UTF-8")).hexdigest()
         item["postcode"] = location["cp"]
 
+        if "Exprés" in item["name"].title():
+            item["name"] = "Supercor Exprés"
+        else:
+            item["name"] = "Supercor"
+
         hours_text = " ".join(location["horario"]).replace(":|", ": ")
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(hours_text, days=DAYS_ES)

--- a/locations/spiders/supercor_es.py
+++ b/locations/spiders/supercor_es.py
@@ -2,7 +2,7 @@ from hashlib import sha1
 
 from chompjs import parse_js_object
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_ES, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
@@ -11,7 +11,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class SupercorESSpider(JSONBlobSpider):
     name = "supercor_es"
-    item_attributes = {"brand": "Supercor", "brand_wikidata": "Q6135841", "extras": Categories.SHOP_SUPERMARKET.value}
+    item_attributes = {"brand": "Supercor", "brand_wikidata": "Q6135841"}
     allowed_domains = ["www.supercor.es"]
     start_urls = ["https://www.supercor.es/tiendas/"]
     user_agent = BROWSER_DEFAULT
@@ -45,5 +45,7 @@ class SupercorESSpider(JSONBlobSpider):
         hours_text = " ".join(location["horario"]).replace(":|", ": ")
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(hours_text, days=DAYS_ES)
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
 
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Supercor': 131,
 'atp/brand_wikidata/Q6135841': 131,
 'atp/category/shop/supermarket': 131,
 'atp/country/ES': 131,
 'atp/field/branch/missing': 131,
 'atp/field/country/from_spider_name': 131,
 'atp/field/email/missing': 131,
 'atp/field/image/missing': 131,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 131,
 'atp/field/operator_wikidata/missing': 131,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 20,
 'atp/field/state/missing': 131,
 'atp/field/street_address/missing': 131,
 'atp/field/twitter/missing': 131,
 'atp/field/website/missing': 131,
 'atp/item_scraped_host_count/www.supercor.es': 131,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 131,
 'downloader/request_bytes': 534,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 146643,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 12.542936,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 2, 7, 28, 26, 63084, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 131,
 'items_per_minute': None,
 'log_count/DEBUG': 257,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 52,
 'playwright/request_count/aborted': 50,
 'playwright/request_count/method/GET': 52,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/image': 14,
 'playwright/request_count/resource_type/script': 25,
 'playwright/request_count/resource_type/stylesheet': 11,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 2, 7, 28, 13, 520148, tzinfo=datetime.timezone.utc)}

```