### PR TITLE
[Mitre 10 NZ] Fix  Spider

### DIFF
--- a/locations/spiders/mitre_10_nz.py
+++ b/locations/spiders/mitre_10_nz.py
@@ -11,7 +11,7 @@ class Mitre10NZSpider(Spider):
     item_attributes = {"brand": "Mitre 10", "brand_wikidata": "Q6882394"}
     allowed_domains = ["ccapi.mitre10.co.nz"]
     start_urls = [
-        "https://ccapi.mitre10.co.nz/mitre10webservices/v2/mitre10/geolocation/store-locator?fields=FULL&page=0&pageSize=1000&storeCode=28&lang=en&curr=NZD"
+        "https://ccapi.mitre10.co.nz/occ/v2/mitre10/geolocation/store-locator?fields=FULL&page=0&pageSize=1000&storeCode=28&lang=en&curr=NZD"
     ]
     requires_proxy = "NZ"
 


### PR DESCRIPTION
```python
{'atp/brand/Mitre 10': 86,
 'atp/brand_wikidata/Q6882394': 86,
 'atp/category/shop/doityourself': 86,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/NZ': 86,
 'atp/field/branch/missing': 1,
 'atp/field/image/missing': 86,
 'atp/field/operator/missing': 86,
 'atp/field/operator_wikidata/missing': 86,
 'atp/field/state/missing': 86,
 'atp/field/twitter/missing': 86,
 'atp/item_scraped_host_count/ccapi.mitre10.co.nz': 86,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 86,
 'downloader/request_bytes': 970,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 31537,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.186622,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 2, 10, 27, 33, 875810, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 585191,
 'httpcompression/response_count': 2,
 'item_scraped_count': 86,
 'items_per_minute': None,
 'log_count/DEBUG': 100,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 2, 10, 27, 29, 689188, tzinfo=datetime.timezone.utc)}
```