### PR TITLE
[Staples] Fix Spider

### DIFF
--- a/locations/spiders/staples.py
+++ b/locations/spiders/staples.py
@@ -1,76 +1,8 @@
-import re
-
-import scrapy
-
-from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.storefinders.yext import YextSpider
 
 
-class StaplesSpider(scrapy.Spider):
+class StaplesSpider(YextSpider):
     name = "staples"
     item_attributes = {"brand": "Staples", "brand_wikidata": "Q785943"}
-    allowed_domains = ["stores.staples.com"]
-    start_urls = ("https://stores.staples.com/",)
-
-    def parse_hours(self, elements):
-        opening_hours = OpeningHours()
-
-        for elem in elements:
-            day = elem.xpath('.//td[@class="c-hours-details-row-day"]/text()').extract_first()
-            intervals = elem.xpath('.//td[@class="c-hours-details-row-intervals"]')
-
-            if intervals.xpath("./text()").extract_first() == "Closed":
-                continue
-            if intervals.xpath("./span/text()").extract_first() == "Open 24 hours":
-                opening_hours.add_range(day=day, open_time="0:00", close_time="23:59")
-            else:
-                start_time = elem.xpath(
-                    './/span[@class="c-hours-details-row-intervals-instance-open"]/text()'
-                ).extract_first()
-                end_time = elem.xpath(
-                    './/span[@class="c-hours-details-row-intervals-instance-close"]/text()'
-                ).extract_first()
-                opening_hours.add_range(day=day, open_time=start_time, close_time=end_time, time_format="%I:%M %p")
-
-        return opening_hours
-
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+)$", response.url).group(1)
-
-        address1 = response.xpath('//span[@class="c-address-street-1"]/text()').extract_first()
-        address2 = response.xpath('//span[@class="c-address-street-2"]/text()').extract_first() or ""
-
-        properties = {
-            "street_address": merge_address_lines([address1, address2]),
-            "phone": response.xpath('//span[@itemprop="telephone"]/text()').extract_first(),
-            "city": response.xpath('//span[@class="c-address-city"]/text()').extract_first(),
-            "state": response.xpath('//abbr[@itemprop="addressRegion"]/text()').extract_first(),
-            "postcode": response.xpath('//span[@itemprop="postalCode"]/text()').extract_first(),
-            "country": response.xpath('//abbr[@itemprop="addressCountry"]/text()').extract_first(),
-            "ref": ref,
-            "website": response.url,
-            "lat": float(response.xpath('//meta[@itemprop="latitude"]/@content').extract_first()),
-            "lon": float(response.xpath('//meta[@itemprop="longitude"]/@content').extract_first()),
-            "name": response.xpath('//h1[@itemprop="name"]/text()').extract_first(),
-        }
-
-        hours = self.parse_hours(response.xpath('//table[@class="c-hours-details"]//tbody/tr'))
-
-        if hours:
-            properties["opening_hours"] = hours
-
-        yield Feature(**properties)
-
-    def parse(self, response):
-        urls = response.xpath('//a[@class="Directory-listLink"]/@href').extract()
-        is_store_list = response.xpath('//section[contains(@class,"LocationList")]').extract()
-
-        if not urls and is_store_list:
-            urls = response.xpath('//a[contains(@class,"Teaser-titleLink")]/@href').extract()
-
-        for url in urls:
-            if re.search(r".{2}/.+/.+", url):
-                yield scrapy.Request(response.urljoin(url), callback=self.parse_store)
-            else:
-                yield scrapy.Request(response.urljoin(url))
+    api_key = "a05b56686f7bf3558831122f8a32e69f"
+    api_version = "20220927"


### PR DESCRIPTION
**_Fixes : code refactored to use YextSpider to fix spider_**

```python
{'atp/brand/Staples': 2807,
 'atp/brand_wikidata/Q785943': 2807,
 'atp/category/shop/stationery': 2807,
 'atp/cdn/cloudflare/response_count': 91,
 'atp/cdn/cloudflare/response_status_count/200': 90,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/US': 2807,
 'atp/field/branch/missing': 2807,
 'atp/field/email/missing': 2807,
 'atp/field/image/missing': 2807,
 'atp/field/operator/missing': 2807,
 'atp/field/operator_wikidata/missing': 2807,
 'atp/field/phone/missing': 1,
 'atp/item_scraped_host_count/cdn.yextapis.com': 2807,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2807,
 'downloader/request_bytes': 57641,
 'downloader/request_count': 91,
 'downloader/request_method_count/GET': 91,
 'downloader/response_bytes': 30557978,
 'downloader/response_count': 91,
 'downloader/response_status_count/200': 90,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 129.326962,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 2, 10, 25, 59, 435878, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 168611584,
 'httpcompression/response_count': 90,
 'item_scraped_count': 2807,
 'items_per_minute': None,
 'log_count/DEBUG': 2915,
 'log_count/INFO': 11,
 'request_depth_max': 89,
 'response_received_count': 91,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 90,
 'scheduler/dequeued/memory': 90,
 'scheduler/enqueued': 90,
 'scheduler/enqueued/memory': 90,
 'start_time': datetime.datetime(2025, 6, 2, 10, 23, 50, 108916, tzinfo=datetime.timezone.utc)}
```