### PR TITLE
[Distriktstandvården SE] Collect coords

### DIFF
--- a/locations/spiders/distriktstandvarden_se.py
+++ b/locations/spiders/distriktstandvarden_se.py
@@ -1,5 +1,7 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -7,3 +9,10 @@ class DistriktstandvardenSESpider(SitemapSpider, StructuredDataSpider):
     name = "distriktstandvarden_se"
     item_attributes = {"brand": "Distriktstandvården", "brand_wikidata": "Q10474535"}
     sitemap_urls = ["https://distriktstandvarden.se/dtv_clinic-sitemap.xml"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if coords := response.xpath('//img[@class="clinic-static-map"]/@src').re(
+            r"png%7C(-?\d+\.\d+)%2C(-?\d+\.\d+)%26style"
+        ):
+            item["lat"], item["lon"] = coords
+        yield item

--- a/locations/spiders/distriktstandvarden_se.py
+++ b/locations/spiders/distriktstandvarden_se.py
@@ -1,6 +1,7 @@
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -16,4 +17,15 @@ class DistriktstandvardenSESpider(SitemapSpider, StructuredDataSpider):
             r"png%7C(-?\d+\.\d+)%2C(-?\d+\.\d+)%26style"
         ):
             item["lat"], item["lon"] = coords
+
+        if item["name"].startswith("Välkommen till specialistkliniken på "):
+            item["branch"] = item["name"].removeprefix("Välkommen till specialistkliniken på ")
+            item["name"] = "Distriktstandvården Specialistkliniken"
+        elif item["name"].startswith("Välkommen till din tandläkare i "):
+            item["branch"] = item.pop("name").removeprefix("Välkommen till din tandläkare i ")
+        else:
+            item["name"] = None
+
+        apply_category(Categories.DENTIST, item)
+
         yield item

--- a/locations/spiders/distriktstandvarden_se.py
+++ b/locations/spiders/distriktstandvarden_se.py
@@ -9,6 +9,7 @@ class DistriktstandvardenSESpider(SitemapSpider, StructuredDataSpider):
     name = "distriktstandvarden_se"
     item_attributes = {"brand": "Distriktstandvården", "brand_wikidata": "Q10474535"}
     sitemap_urls = ["https://distriktstandvarden.se/dtv_clinic-sitemap.xml"]
+    sitemap_rules = [(r"distriktstandvarden\.se/(?!mobil-)([^/]+)/", "parse")]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if coords := response.xpath('//img[@class="clinic-static-map"]/@src').re(


### PR DESCRIPTION
```python
{'atp/brand/Distriktstandvården': 38,
 'atp/brand_wikidata/Q10474535': 38,
 'atp/category/amenity/dentist': 38,
 'atp/category/multiple': 38,
 'atp/country/SE': 38,
 'atp/field/branch/missing': 7,
 'atp/field/country/from_spider_name': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/state/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/item_scraped_host_count/distriktstandvarden.se': 38,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 38,
 'downloader/request_bytes': 16197,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 1403187,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 40,
 'elapsed_time_seconds': 2.000391,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 3, 11, 38, 10, 26398, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 40,
 'httpcompression/response_bytes': 4953742,
 'httpcompression/response_count': 40,
 'item_scraped_count': 38,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 279785472,
 'memusage/startup': 279785472,
 'request_depth_max': 1,
 'response_received_count': 40,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2025, 6, 3, 11, 38, 8, 26007, tzinfo=datetime.timezone.utc)}
```