### PR TITLE
[Burger King PY] Fix low scraped count because of timeout error for spider

### DIFF
--- a/locations/spiders/burger_king_py.py
+++ b/locations/spiders/burger_king_py.py
@@ -6,3 +6,4 @@ class BurgerKingPYSpider(BurgerKingBSSpider):
     allowed_domains = ["www.burgerking.com.py"]
     host = "https://www.burgerking.com.py"
     country_code = "PY"
+    download_timeout = 120


### PR DESCRIPTION
```python
{'atp/brand/Burger King': 38,
 'atp/brand_wikidata/Q177054': 38,
 'atp/category/amenity/fast_food': 38,
 'atp/country/PY': 38,
 'atp/duplicate_count': 194,
 'atp/field/branch/missing': 8,
 'atp/field/city/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/email/missing': 38,
 'atp/field/image/missing': 38,
 'atp/field/opening_hours/missing': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 13,
 'atp/field/state/missing': 38,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 38,
 'atp/field/website/missing': 38,
 'atp/item_scraped_host_count/www.burgerking.com.py': 232,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 38,
 'downloader/request_bytes': 41700,
 'downloader/request_count': 75,
 'downloader/request_method_count/GET': 75,
 'downloader/response_bytes': 649411,
 'downloader/response_count': 75,
 'downloader/response_status_count/200': 75,
 'elapsed_time_seconds': 105.312391,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 4, 7, 45, 43, 773581, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2487753,
 'httpcompression/response_count': 75,
 'item_dropped_count': 194,
 'item_dropped_reasons_count/DropItem': 194,
 'item_scraped_count': 38,
 'items_per_minute': None,
 'log_count/DEBUG': 318,
 'log_count/INFO': 10,
 'request_depth_max': 6,
 'response_received_count': 75,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 74,
 'scheduler/dequeued/memory': 74,
 'scheduler/enqueued': 74,
 'scheduler/enqueued/memory': 74,
 'start_time': datetime.datetime(2025, 6, 4, 7, 43, 58, 461190, tzinfo=datetime.timezone.utc)}
```