### PR TITLE
[Toyota Sacu] Fix Spider

### DIFF
--- a/locations/spiders/toyota_sacu.py
+++ b/locations/spiders/toyota_sacu.py
@@ -12,6 +12,7 @@ BRANDS = {
 class ToyotaSacuSpider(JSONBlobSpider):
     name = "toyota_sacu"
     start_urls = ["https://api-toyota.azure-api.net/suppliers?filter[where][supplierType]=dealer"]
+    requires_proxy = True
 
     def post_process_item(self, item, response, location):
         brands = []

--- a/locations/spiders/toyota_sacu.py
+++ b/locations/spiders/toyota_sacu.py
@@ -1,6 +1,7 @@
 from locations.categories import Categories, apply_category
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.toyota_au import TOYOTA_SHARED_ATTRIBUTES
+from locations.user_agents import BROWSER_DEFAULT
 
 BRANDS = {
     "toyotaSupplier": TOYOTA_SHARED_ATTRIBUTES,
@@ -13,6 +14,7 @@ class ToyotaSacuSpider(JSONBlobSpider):
     name = "toyota_sacu"
     start_urls = ["https://api-toyota.azure-api.net/suppliers?filter[where][supplierType]=dealer"]
     requires_proxy = True
+    custom_settings = {"USER_AGENT":BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, location):
         brands = []

--- a/locations/spiders/toyota_sacu.py
+++ b/locations/spiders/toyota_sacu.py
@@ -14,7 +14,7 @@ class ToyotaSacuSpider(JSONBlobSpider):
     name = "toyota_sacu"
     start_urls = ["https://api-toyota.azure-api.net/suppliers?filter[where][supplierType]=dealer"]
     requires_proxy = True
-    custom_settings = {"USER_AGENT":BROWSER_DEFAULT}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, location):
         brands = []


### PR DESCRIPTION
**_Flag toyota_sacu as requires proxy to fix spider_**

```python
{'atp/brand/Hino Motors': 50,
 'atp/brand/Lexus': 15,
 'atp/brand/Toyota': 167,
 'atp/brand/Toyota;Hino Motors': 20,
 'atp/brand/Toyota;Lexus': 15,
 'atp/brand/Toyota;Lexus;Hino Motors': 1,
 'atp/brand_wikidata/Q35919': 15,
 'atp/brand_wikidata/Q53268': 167,
 'atp/brand_wikidata/Q53268;Q35919': 15,
 'atp/brand_wikidata/Q53268;Q35919;Q867667': 1,
 'atp/brand_wikidata/Q53268;Q867667': 20,
 'atp/brand_wikidata/Q867667': 50,
 'atp/category/shop/car': 209,
 'atp/category/shop/car_repair': 10,
 'atp/category/shop/truck': 50,
 'atp/clean_strings/street_address': 101,
 'atp/country/BW': 10,
 'atp/country/LS': 1,
 'atp/country/NA': 16,
 'atp/country/SZ': 3,
 'atp/country/ZA': 239,
 'atp/field/branch/missing': 269,
 'atp/field/brand/missing': 1,
 'atp/field/brand_wikidata/invalid': 36,
 'atp/field/brand_wikidata/missing': 1,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 269,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 269,
 'atp/field/operator/missing': 269,
 'atp/field/operator_wikidata/missing': 269,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 13,
 'atp/field/state/missing': 31,
 'atp/field/twitter/missing': 269,
 'atp/item_scraped_host_count/api-toyota.azure-api.net': 269,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 36,
 'atp/nsi/cc_match': 182,
 'atp/nsi/match_failed': 50,
 'downloader/request_bytes': 726,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 34012,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 6.92946,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 4, 9, 30, 30, 112838, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 120122,
 'httpcompression/response_count': 1,
 'item_scraped_count': 269,
 'items_per_minute': None,
 'log_count/DEBUG': 283,
 'log_count/INFO': 9,
 'log_count/WARNING': 36,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 4, 9, 30, 23, 183378, tzinfo=datetime.timezone.utc)}
```
