### PR TITLE
[nespresso] fix spider (986 locations)

### DIFF
--- a/locations/spiders/nespresso.py
+++ b/locations/spiders/nespresso.py
@@ -1,8 +1,7 @@
 import scrapy
 
-from locations.items import Feature
 from locations.geo import city_locations
-
+from locations.items import Feature
 
 
 class NespressoSpider(scrapy.Spider):
@@ -76,13 +75,12 @@ class NespressoSpider(scrapy.Spider):
             "YT",
             "ZA",
         ]
-         
 
-        base_url = "https://www.nespresso.com/storelocator/app/find_poi-v4.php?&lang=EN&lat={lat}&lng={lon}" 
+        base_url = "https://www.nespresso.com/storelocator/app/find_poi-v4.php?&lang=EN&lat={lat}&lng={lon}"
         for country in countries:
             for city in city_locations(country, 1000000):
                 lat, lon = city["latitude"], city["longitude"]
-                url = base_url.format(lat=lat, lon=lon) 
+                url = base_url.format(lat=lat, lon=lon)
                 yield scrapy.Request(url, callback=self.parse)
 
     def parse(self, response):


### PR DESCRIPTION
The url response json was returning the same 499 records (mostly in Europe, Africa, and Eastern South America).  It appears the country filter wasn't doing anything, leading to the same results for each return and incorrect country codes.  
By excluding the country filter and adding a lat/lon filter by looping through cities in the country list, I am getting the correct results.  While this does work, the url return is still a little weird.  It always returns 499 locations.  There are only 900+ in reality. It might be grabbing the closest 499 to the lat lon?  And the original without the lat/lon provided was default?  Unsure.  Regardless, it works, and duplicates are removed.  Set the min pop high to speed up the process.   

```
{'atp/brand/Nespresso': 986,
 'atp/brand_wikidata/Q301301': 986,
 'atp/category/shop/coffee': 986,
 'atp/clean_strings/city': 20,
 'atp/clean_strings/postcode': 14,
 'atp/clean_strings/street_address': 33,
 'atp/country/AD': 1,
 'atp/country/AE': 4,
 'atp/country/AR': 7,
 'atp/country/AT': 19,
 'atp/country/AU': 20,
 'atp/country/BE': 44,
 'atp/country/BH': 1,
 'atp/country/BL': 1,
 'atp/country/BR': 34,
 'atp/country/CA': 38,
 'atp/country/CH': 112,
 'atp/country/CI': 1,
 'atp/country/CL': 9,
 'atp/country/CN': 14,
 'atp/country/CO': 12,
 'atp/country/CY': 2,
 'atp/country/CZ': 10,
 'atp/country/DE': 54,
 'atp/country/DK': 2,
 'atp/country/DZ': 3,
 'atp/country/EG': 3,
 'atp/country/ES': 72,
 'atp/country/FI': 2,
 'atp/country/FR': 58,
 'atp/country/GB': 19,
 'atp/country/GF': 2,
 'atp/country/GP': 5,
 'atp/country/GR': 12,
 'atp/country/HK': 9,
 'atp/country/HU': 8,
 'atp/country/IE': 3,
 'atp/country/IL': 10,
 'atp/country/IT': 126,
 'atp/country/JP': 17,
 'atp/country/KR': 21,
 'atp/country/KW': 2,
 'atp/country/LB': 2,
 'atp/country/LU': 4,
 'atp/country/MA': 4,
 'atp/country/MF': 1,
 'atp/country/MQ': 3,
 'atp/country/MU': 1,
 'atp/country/MX': 19,
 'atp/country/MY': 7,
 'atp/country/NL': 16,
 'atp/country/NO': 4,
 'atp/country/NZ': 5,
 'atp/country/OM': 1,
 'atp/country/PL': 9,
 'atp/country/PT': 27,
 'atp/country/QA': 2,
 'atp/country/RE': 4,
 'atp/country/RO': 10,
 'atp/country/RU': 20,
 'atp/country/SA': 7,
 'atp/country/SE': 4,
 'atp/country/SG': 5,
 'atp/country/SK': 3,
 'atp/country/TH': 5,
 'atp/country/TR': 14,
 'atp/country/TW': 8,
 'atp/country/US': 37,
 'atp/country/VA': 2,
 'atp/country/VE': 1,
 'atp/country/ZA': 4,
 'atp/duplicate_count': 154514,
 'atp/field/branch/missing': 986,
 'atp/field/country/from_reverse_geocoding': 986,
 'atp/field/email/missing': 986,
 'atp/field/image/missing': 986,
 'atp/field/opening_hours/missing': 986,
 'atp/field/operator/missing': 986,
 'atp/field/operator_wikidata/missing': 986,
 'atp/field/postcode/missing': 69,
 'atp/field/state/missing': 11,
 'atp/field/street_address/missing': 21,
 'atp/field/twitter/missing': 986,
 'atp/field/website/missing': 986,
 'atp/item_scraped_host_count/www.nespresso.com': 155500,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 986,
 'downloader/request_bytes': 474266,
 'downloader/request_count': 312,
 'downloader/request_method_count/GET': 312,
 'downloader/response_bytes': 12094529,
 'downloader/response_count': 312,
 'downloader/response_status_count/200': 312,
 'elapsed_time_seconds': 378.097765,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 5, 13, 21, 18, 711975, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 136291107,
 'httpcompression/response_count': 312,
 'item_dropped_count': 154514,
 'item_dropped_reasons_count/DropItem': 154514,
 'item_scraped_count': 986,
 'items_per_minute': None,
 'log_count/INFO': 15,
 'memusage/max': 918413312,
 'memusage/startup': 264331264,
 'response_received_count': 312,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 311,
 'scheduler/dequeued/memory': 311,
 'scheduler/enqueued': 311,
 'scheduler/enqueued/memory': 311,
 'start_time': datetime.datetime(2025, 6, 5, 13, 15, 0, 614210, tzinfo=datetime.timezone.utc)}
```