### PR TITLE
[Ottos CH] Fix spider

### DIFF
--- a/locations/spiders/ottos_ch.py
+++ b/locations/spiders/ottos_ch.py
@@ -53,5 +53,9 @@ class OttosCHSpider(scrapy.Spider):
                 item["branch"] = store["displayName"].removeprefix("OTTO'S ")
                 apply_category(Categories.SHOP_VARIETY_STORE, item)
 
-            item["website"] = urljoin("https://www.ottos.ch", store["storeDetailUrl"]).replace(".ch/", ".ch/de/")
+            slug = store["storeDetailUrl"].removeprefix("/")
+            item["website"] = item["extras"]["website:de"] = urljoin("https://www.ottos.ch/de/", slug)
+            item["extras"]["website:it"] = urljoin("https://www.ottos.ch/it/", slug)
+            item["extras"]["website:de"] = urljoin("https://www.ottos.ch/fr/", slug)
+
             yield item


### PR DESCRIPTION
```python
{"atp/brand/Otto's": 141,
 'atp/brand_wikidata/Q2041507': 141,
 'atp/category/shop/cosmetics': 9,
 'atp/category/shop/sports': 9,
 'atp/category/shop/variety_store': 123,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/CH': 141,
 'atp/field/email/missing': 141,
 'atp/field/image/missing': 141,
 'atp/field/operator/missing': 141,
 'atp/field/operator_wikidata/missing': 141,
 'atp/field/state/missing': 140,
 'atp/field/twitter/missing': 141,
 'atp/item_scraped_host_count/api.ottos.ch': 141,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 141,
 'downloader/request_bytes': 1346,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29002,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.563886,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 5, 14, 18, 46, 418997, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 549358,
 'httpcompression/response_count': 2,
 'item_scraped_count': 141,
 'items_per_minute': None,
 'log_count/DEBUG': 155,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 5, 14, 18, 40, 855111, tzinfo=datetime.timezone.utc)}
```