### PR TITLE
[Libro AT] Fix spider

### DIFF
--- a/locations/spiders/libro_at.py
+++ b/locations/spiders/libro_at.py
@@ -5,6 +5,7 @@ from scrapy import Request, Selector
 from scrapy.http import Response
 
 from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
 from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
 
 
@@ -20,5 +21,6 @@ class LibroATSpider(AmastyStoreLocatorSpider):
 
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
         item["ref"], item["street_address"] = item.pop("name").split(": ", 1)
+        item["addr_full"] = clean_address(popup_html.xpath("//span/text()").getall()).removesuffix(", Filiale wählen")
 
         yield item

--- a/locations/spiders/libro_at.py
+++ b/locations/spiders/libro_at.py
@@ -22,5 +22,5 @@ class LibroATSpider(AmastyStoreLocatorSpider):
     def post_process_item(self, item: Feature, feature: dict, popup_html: Selector) -> Iterable[Feature]:
         item["ref"], item["street_address"] = item.pop("name").split(": ", 1)
         item["addr_full"] = clean_address(popup_html.xpath("//span/text()").getall()).removesuffix(", Filiale wählen")
-
+        item["website"] = f'https://www.libro.at/filialfinder/{item["ref"]}/'
         yield item

--- a/locations/spiders/libro_at.py
+++ b/locations/spiders/libro_at.py
@@ -1,7 +1,7 @@
 from json import loads
 from typing import Iterable
 
-from scrapy import Selector
+from scrapy import Request, Selector
 from scrapy.http import Response
 
 from locations.items import Feature
@@ -11,7 +11,9 @@ from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
 class LibroATSpider(AmastyStoreLocatorSpider):
     name = "libro_at"
     item_attributes = {"brand": "Libro", "brand_wikidata": "Q1823138"}
-    start_urls = ["https://www.libro.at/rest/V1/mthecom/storelocator/locations"]
+
+    def start_requests(self) -> Iterable[Request]:
+        yield Request(url="https://www.libro.at/rest/V1/mthecom/storelocator/locations")
 
     def parse(self, response: Response) -> Iterable[Feature]:
         yield from self.parse_features(loads(response.xpath("/response/text()").get())["items"])


### PR DESCRIPTION
```python
{'atp/brand/Libro': 165,
 'atp/brand_wikidata/Q1823138': 165,
 'atp/category/shop/books': 165,
 'atp/country/AT': 165,
 'atp/field/branch/missing': 165,
 'atp/field/city/missing': 165,
 'atp/field/country/from_spider_name': 165,
 'atp/field/email/missing': 165,
 'atp/field/image/missing': 165,
 'atp/field/opening_hours/missing': 165,
 'atp/field/operator/missing': 165,
 'atp/field/operator_wikidata/missing': 165,
 'atp/field/phone/missing': 165,
 'atp/field/postcode/missing': 165,
 'atp/field/state/missing': 165,
 'atp/field/twitter/missing': 165,
 'atp/item_scraped_host_count/www.libro.at': 165,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 165,
 'downloader/request_bytes': 745,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29514,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.107792,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 5, 16, 1, 17, 234293, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 256446,
 'httpcompression/response_count': 2,
 'item_scraped_count': 165,
 'items_per_minute': None,
 'log_count/DEBUG': 178,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 5, 16, 1, 13, 126501, tzinfo=datetime.timezone.utc)}
```