### PR TITLE
[Aesop] Fix Spider

### DIFF
--- a/locations/spiders/aesop.py
+++ b/locations/spiders/aesop.py
@@ -14,8 +14,9 @@ class AesopSpider(SitemapSpider):
     name = "aesop"
     item_attributes = {"brand": "Aesop", "brand_wikidata": "Q4688560"}
     allowed_domains = ["www.aesop.com"]
-    sitemap_urls = ["https://www.aesop.com/static/stores/en-AU.xml"]
+    sitemap_urls = ["https://www.aesop.com/us/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/www\.aesop\.com\/[a-z]{2}\/r\/[\w\-]+\/$", "parse")]
+    sitemap_follow = ["stores"]
 
     def parse(self, response: Response) -> Iterable[Feature]:
         next_data = loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())


### PR DESCRIPTION
**_Fixes : updated sitemap_urls to fix spider_**

```python
{'atp/brand/Aesop': 276,
 'atp/brand_wikidata/Q4688560': 276,
 'atp/category/shop/cosmetics': 276,
 'atp/clean_strings/addr_full': 8,
 'atp/clean_strings/branch': 5,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/email': 8,
 'atp/clean_strings/phone': 4,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/street_address': 6,
 'atp/country/AT': 1,
 'atp/country/AU': 42,
 'atp/country/BE': 2,
 'atp/country/CA': 11,
 'atp/country/CH': 7,
 'atp/country/CN': 1,
 'atp/country/DE': 11,
 'atp/country/DK': 3,
 'atp/country/ES': 4,
 'atp/country/FR': 13,
 'atp/country/GB': 29,
 'atp/country/HK': 13,
 'atp/country/IT': 7,
 'atp/country/JP': 24,
 'atp/country/KR': 9,
 'atp/country/MO': 3,
 'atp/country/MY': 1,
 'atp/country/NL': 3,
 'atp/country/NO': 2,
 'atp/country/NZ': 4,
 'atp/country/PH': 1,
 'atp/country/SE': 2,
 'atp/country/SG': 8,
 'atp/country/TH': 2,
 'atp/country/TW': 7,
 'atp/country/US': 66,
 'atp/field/city/missing': 29,
 'atp/field/email/missing': 18,
 'atp/field/image/missing': 276,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 276,
 'atp/field/operator_wikidata/missing': 276,
 'atp/field/phone/missing': 6,
 'atp/field/postcode/missing': 67,
 'atp/field/state/missing': 116,
 'atp/field/street_address/missing': 6,
 'atp/field/twitter/missing': 276,
 'atp/item_scraped_host_count/www.aesop.com': 276,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 276,
 'downloader/request_bytes': 399997,
 'downloader/request_count': 281,
 'downloader/request_method_count/GET': 281,
 'downloader/response_bytes': 13168466,
 'downloader/response_count': 281,
 'downloader/response_status_count/200': 280,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 349.324528,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 6, 11, 40, 4, 326021, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 80612381,
 'httpcompression/response_count': 279,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 276,
 'items_per_minute': None,
 'log_count/DEBUG': 568,
 'log_count/INFO': 15,
 'request_depth_max': 2,
 'response_received_count': 281,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 280,
 'scheduler/dequeued/memory': 280,
 'scheduler/enqueued': 280,
 'scheduler/enqueued/memory': 280,
 'start_time': datetime.datetime(2025, 6, 6, 11, 34, 15, 1493, tzinfo=datetime.timezone.utc)}
```