### PR TITLE
[Carls Jr NZ] Fix Spider

### DIFF
--- a/locations/spiders/carls_jr_nz.py
+++ b/locations/spiders/carls_jr_nz.py
@@ -36,12 +36,6 @@ class CarlsJrNZSpider(Spider):
                 store.get("operatingHoursDriveThru")
             ).as_opening_hours()
 
-            if False:  # delivery area
-                item["geometry"] = {"type": "LineString", "coordinates": []}
-                for coords in store["polygon"].split(" "):
-                    lat, lon = coords.split("|")
-                    item["geometry"]["coordinates"].append([float(lon), float(lat)])
-
             yield item
 
     def parse_opening_hours(self, rules: list) -> OpeningHours:


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{"atp/brand/Carl's Jr.": 19,
 'atp/brand_wikidata/Q1043486': 19,
 'atp/category/amenity/fast_food': 19,
 'atp/clean_strings/city': 1,
 'atp/country/NZ': 19,
 'atp/field/country/from_website_url': 19,
 'atp/field/email/missing': 19,
 'atp/field/image/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/state/missing': 19,
 'atp/field/street_address/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/item_scraped_host_count/api.carlsjr.co.nz': 19,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 19,
 'downloader/request_bytes': 5096,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 25767,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 12,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 17.582946,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 6, 12, 53, 47, 151665, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 60836,
 'httpcompression/response_count': 11,
 'item_scraped_count': 19,
 'items_per_minute': None,
 'log_count/DEBUG': 44,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 13,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2025, 6, 6, 12, 53, 29, 568719, tzinfo=datetime.timezone.utc)}
```