### PR TITLE
Add Bissú MX (313 shops)

### DIFF
--- a/locations/spiders/bissu_mx.py
+++ b/locations/spiders/bissu_mx.py
@@ -13,7 +13,7 @@ class BissuMXSpider(CrawlSpider):
     name = "bissu_mx"
     item_attributes = {"brand": "Bissú", "brand_wikidata": "Q130466489"}
     start_urls = ["https://bissu.com/tiendas"]
-    rules = [Rule(LinkExtractor(allow=r"/tiendas/"), callback="parse")]
+    rules = [Rule(LinkExtractor(allow=r"/tiendas/", restrict_text="Bissú"), callback="parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         item = Feature()

--- a/locations/spiders/bissu_mx.py
+++ b/locations/spiders/bissu_mx.py
@@ -1,0 +1,36 @@
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.items import Feature
+
+
+class BissuMXSpider(CrawlSpider):
+    name = "bissu_mx"
+    item_attributes = {"brand": "Bissú", "brand_wikidata": "Q130466489"}
+    start_urls = ["https://bissu.com/tiendas"]
+    rules = [Rule(LinkExtractor(allow=r"/tiendas/"), callback="parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        item = Feature()
+        item["ref"] = response.url.rsplit("/", 1)[1]
+        item["website"] = response.url
+        item["name"] = response.xpath("//h1/span/text()").get()
+        properties = {
+            "postcode": "Código Postal",
+            "city": "Ciudad",
+            "street_address": "Dirección",
+        }
+        for key, label in properties.items():
+            query = f'(//div[@class="amlocator-block"]/span[preceding-sibling::span/text()="{label}:"])[last()]/text()'
+            item[key] = response.xpath(query).get().strip()
+        phone = response.xpath('//a/@href[contains(., "tel:")]').get()
+        if phone:
+            item["phone"] = phone.replace("tel:", "")
+        location_script = response.xpath('//script[contains(., "locationData")]/text()')
+        latlon_re = r"locationData:\s*{[^}]*lat:\s*([^,]*),\s*lng:\s*([^,]*)[^}]*}"
+        item["lat"], item["lon"] = location_script.re(latlon_re, re.DOTALL)
+        yield item

--- a/locations/spiders/bissu_mx.py
+++ b/locations/spiders/bissu_mx.py
@@ -5,12 +5,13 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories
 from locations.items import Feature
 
 
 class BissuMXSpider(CrawlSpider):
     name = "bissu_mx"
-    item_attributes = {"brand": "Bissú", "brand_wikidata": "Q130466489"}
+    item_attributes = {"brand": "Bissú", "brand_wikidata": "Q130466489", "extras": Categories.SHOP_COSMETICS.value}
     start_urls = ["https://bissu.com/tiendas"]
     rules = [Rule(LinkExtractor(allow=r"/tiendas/"), callback="parse")]
 


### PR DESCRIPTION
Add [Bissú](https://bissu.com/), a cosmetics brand from MX.

```
2025-06-08 22:14:41 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Bissú': 313,
 'atp/brand_wikidata/Q130466489': 313,
 'atp/category/missing': 313,
 'atp/clean_strings/name': 134,
 'atp/country/MX': 313,
 'atp/field/branch/missing': 313,
 'atp/field/country/from_spider_name': 313,
 'atp/field/email/missing': 313,
 'atp/field/image/missing': 313,
 'atp/field/opening_hours/missing': 313,
 'atp/field/operator/missing': 313,
 'atp/field/operator_wikidata/missing': 313,
 'atp/field/phone/invalid': 14,
 'atp/field/phone/missing': 29,
 'atp/field/state/missing': 313,
 'atp/field/twitter/missing': 313,
 'atp/item_scraped_host_count/bissu.com': 313,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 313,
```