### PR TITLE
Add Piazza Italia IT (279 stores)

### DIFF
--- a/locations/spiders/piazza_italia_it.py
+++ b/locations/spiders/piazza_italia_it.py
@@ -1,0 +1,41 @@
+import logging
+import re
+
+import chompjs
+
+from locations.hours import DAYS, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class PiazzaItaliaITSpider(JSONBlobSpider):
+    name = "piazza_italia_it"
+    item_attributes = {"brand": "Piazza Italia", "brand_wikidata": "Q3902241"}
+    allowed_domains = ["www.piazzaitalia.it"]
+    start_urls = ["https://www.piazzaitalia.it/it-it/store-locator"]
+    re_period = re.compile(r"\s*[,;]\s*")
+
+    def extract_json(self, response):
+        store_locator_data = chompjs.parse_js_object(
+            response.xpath('//script[contains(text(), "loaderData")][1]/text()').get()
+        )
+        return store_locator_data["state"]["loaderData"]["routes/($lang).store-locator"]["stores"]
+
+    def pre_process_data(self, location):
+        location["website"] = "https://www.piazzaitalia.it/it-it/store-locator/" + location["handle"]
+        location["ref"] = location.pop("handle")
+        location["street_address"] = location.pop("address")
+
+    def post_process_item(self, item, response, location):
+        item["branch"] = item.pop("name")
+        hours = OpeningHours()
+        for index, day in enumerate(DAYS):
+            day_definition = location["openings"][str(index + 1)]
+            for period in self.re_period.split(day_definition):
+                if "-" in period:
+                    try:
+                        open_time, close_time = period.split("-")
+                        hours.add_range(day, open_time.strip(), close_time.strip(), "%H:%M")
+                    except ValueError:
+                        logging.warning("Invalid opening hours period '%s'", period)
+        item["opening_hours"] = hours
+        yield item


### PR DESCRIPTION
Add [Piazza Italia](https://www.piazzaitalia.it/), a clothes store chain in Italy.

```
2025-06-08 22:34:30 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Piazza Italia': 279,
 'atp/brand_wikidata/Q3902241': 279,
 'atp/category/shop/clothes': 279,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/email': 1,
 'atp/clean_strings/phone': 8,
 'atp/clean_strings/postcode': 6,
 'atp/clean_strings/street_address': 2,
 'atp/country/IT': 279,
 'atp/field/image/missing': 279,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 279,
 'atp/field/operator_wikidata/missing': 279,
 'atp/field/phone/missing': 2,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 279,
 'atp/item_scraped_host_count/www.piazzaitalia.it': 279,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 279,
```