### PR TITLE
[Independent Financial US] Fix Spider

### DIFF
--- a/locations/spiders/independent_financial_us.py
+++ b/locations/spiders/independent_financial_us.py
@@ -1,20 +1,35 @@
+import scrapy
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
 
 
-class IndependentFinancialUSSpider(SitemapSpider, StructuredDataSpider):
+class IndependentFinancialUSSpider(scrapy.Spider):
     name = "independent_financial_us"
     item_attributes = {"brand": "Independent Financial", "brand_wikidata": "Q6016398"}
-    sitemap_urls = ["https://locations.ifinancial.com/sitemap.xml"]
-    sitemap_rules = [(r"https://locations.ifinancial.com/\w+/[a-z-0-9]+/[a-z-0-9]+", "parse_sd")]
+    start_urls = ["https://www.independentbank.com/find-a-location/"]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        if "/atm" in response.url:
-            apply_category(Categories.ATM, item)
-        else:
-            apply_category(Categories.BANK, item)
-        yield item
+    def parse(self, response: Response, **kwargs):
+        for location in response.xpath('//*[@class="locations-listings"]//article'):
+            item = Feature()
+            item["branch"] = location.xpath(".//@aria-label").get()
+            item["name"] = self.item_attributes["brand"]
+            item["ref"] = location.xpath(".//@id").get()
+            item["lat"] = location.xpath(".//@data-lat").get()
+            item["lon"] = location.xpath(".//@data-lng").get()
+            item["addr_full"] = location.xpath(".//@data-address").get()
+            location_type = (
+                location.xpath('.//*[@class="location-item__options options"]/span').xpath("normalize-space()").getall()
+            )
+            if "Bank" in location_type:
+                apply_category(
+                    Categories.BANK,
+                    item,
+                )
+                apply_yes_no(Extras.ATM, item, ("ATM" in location_type))
+            elif location_type in [["ATM"], ["Drive Up"]]:
+                apply_category(Categories.ATM, item)
+            elif location_type in [["Mortgage & Loan Center"], ["Commercial Loan Center"]]:
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Independent Financial': 86,
 'atp/brand_wikidata/Q6016398': 86,
 'atp/category/amenity/atm': 12,
 'atp/category/amenity/bank': 57,
 'atp/category/office/financial': 17,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/addr_full': 2,
 'atp/clean_strings/branch': 8,
 'atp/country/US': 86,
 'atp/field/city/missing': 86,
 'atp/field/country/from_spider_name': 86,
 'atp/field/email/missing': 86,
 'atp/field/image/missing': 86,
 'atp/field/opening_hours/missing': 86,
 'atp/field/operator/missing': 86,
 'atp/field/operator_wikidata/missing': 86,
 'atp/field/phone/missing': 86,
 'atp/field/postcode/missing': 86,
 'atp/field/state/from_reverse_geocoding': 86,
 'atp/field/street_address/missing': 86,
 'atp/field/twitter/missing': 86,
 'atp/field/website/missing': 86,
 'atp/item_scraped_host_count/www.independentbank.com': 86,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 86,
 'downloader/request_bytes': 961,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 39339,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 13.062215,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 9, 8, 21, 44, 368528, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 586733,
 'httpcompression/response_count': 2,
 'item_scraped_count': 86,
 'items_per_minute': None,
 'log_count/DEBUG': 105,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 9, 8, 21, 31, 306313, tzinfo=datetime.timezone.utc)}

```