### PR TITLE
[Sainsburys] Fix spider

### DIFF
--- a/locations/spiders/sainsburys.py
+++ b/locations/spiders/sainsburys.py
@@ -14,7 +14,7 @@ class SainsburysSpider(scrapy.Spider):
     SAINSBURYS_LOCAL = {"brand": "Sainsbury's Local", "brand_wikidata": "Q13218434"}
     item_attributes = SAINSBURYS
     allowed_domains = ["stores.sainsburys.co.uk"]
-    start_urls = ["https://stores.sainsburys.co.uk/api/v1/stores?api_client_id=slfe"]
+    start_urls = ["https://api.stores.sainsburys.co.uk/v1/stores/?api_client_id=slfe"]
 
     def parse(self, response):
         data = response.json()

--- a/locations/spiders/sainsburys.py
+++ b/locations/spiders/sainsburys.py
@@ -1,5 +1,7 @@
-import scrapy
-from scrapy import Request
+from typing import Any
+
+from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, Extras, Fuel, PaymentMethods, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -8,7 +10,7 @@ from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 
-class SainsburysSpider(scrapy.Spider):
+class SainsburysSpider(Spider):
     name = "sainsburys"
     SAINSBURYS = {"brand": "Sainsbury's", "brand_wikidata": "Q152096"}
     SAINSBURYS_LOCAL = {"brand": "Sainsbury's Local", "brand_wikidata": "Q13218434"}
@@ -16,7 +18,7 @@ class SainsburysSpider(scrapy.Spider):
     allowed_domains = ["stores.sainsburys.co.uk"]
     start_urls = ["https://api.stores.sainsburys.co.uk/v1/stores/?api_client_id=slfe"]
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
 
         if len(data["results"]) == 0:
@@ -52,7 +54,7 @@ class SainsburysSpider(scrapy.Spider):
             url=f'{self.start_urls[0]}&offset={str(int(data["page_meta"]["offset"] + data["page_meta"]["limit"]))}'
         )
 
-    def parse_extras(self, item: Feature, store: dict):
+    def parse_extras(self, item: Feature, store: dict) -> Feature:
         if fhrs := store["fsa_scores"].get("fhrs_id"):
             item["extras"]["fhrs:id"] = str(fhrs)
 


### PR DESCRIPTION
```python
{"atp/brand/Sainsbury's": 1152,
 "atp/brand/Sainsbury's Local": 858,
 'atp/brand_wikidata/Q13218434': 858,
 'atp/brand_wikidata/Q152096': 1152,
 'atp/category/amenity/bureau_de_change': 227,
 'atp/category/amenity/cafe': 1,
 'atp/category/amenity/fuel': 317,
 'atp/category/shop/convenience': 858,
 'atp/category/shop/supermarket': 607,
 'atp/clean_strings/branch': 1,
 'atp/country/GB': 2010,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 2010,
 'atp/field/image/missing': 2010,
 'atp/field/lat/missing': 5,
 'atp/field/lon/missing': 5,
 'atp/field/name/missing': 228,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 2010,
 'atp/field/operator_wikidata/missing': 2010,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 1987,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2010,
 'atp/item_scraped_host_count/api.stores.sainsburys.co.uk': 2010,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 924,
 'atp/nsi/match_failed': 228,
 'atp/nsi/perfect_match': 858,
 'downloader/request_bytes': 57663,
 'downloader/request_count': 125,
 'downloader/request_method_count/GET': 125,
 'downloader/response_bytes': 9922147,
 'downloader/response_count': 125,
 'downloader/response_status_count/200': 124,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 149.877429,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 10, 8, 50, 17, 810788, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 78040,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2010,
 'items_per_minute': None,
 'log_count/DEBUG': 2147,
 'log_count/INFO': 11,
 'request_depth_max': 123,
 'response_received_count': 125,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 124,
 'scheduler/dequeued/memory': 124,
 'scheduler/enqueued': 124,
 'scheduler/enqueued/memory': 124,
 'start_time': datetime.datetime(2025, 6, 10, 8, 47, 47, 933359, tzinfo=datetime.timezone.utc)}
```