### PR TITLE
[Arbys CA] Fix spider

### DIFF
--- a/locations/spiders/arbys_ca.py
+++ b/locations/spiders/arbys_ca.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any, Iterable
 
 from scrapy.http import JsonRequest, Response
@@ -29,8 +30,8 @@ class ArbysCASpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in json.loads(response.json()["d"]):
             item = DictParser.parse(location)
-            item["branch"] = item.pop("name").rsplit("-", 1)[0].removeprefix("Arby’s ")
-            item["website"] = "https://arbys.ca"
+            if m := re.match(r"(?:Arby’s )?(.+)\s-\s*(\d+)", item.pop("name")):
+                item["branch"], item["ref"] = m.groups()
             apply_yes_no(Extras.DELIVERY, item, location.get("allowDelivery"))
             apply_yes_no(Extras.TAKEAWAY, item, location.get("allowTakeWay"))
             apply_yes_no(Extras.DRIVE_THROUGH, item, location.get("allowdriveThru"))


### PR DESCRIPTION
```python
{"atp/brand/Arby's": 57,
 'atp/brand_wikidata/Q630866': 57,
 'atp/category/amenity/fast_food': 57,
 'atp/clean_strings/branch': 57,
 'atp/country/CA': 57,
 'atp/field/city/missing': 57,
 'atp/field/country/from_spider_name': 57,
 'atp/field/email/missing': 57,
 'atp/field/image/missing': 57,
 'atp/field/opening_hours/missing': 57,
 'atp/field/operator/missing': 57,
 'atp/field/operator_wikidata/missing': 57,
 'atp/field/phone/missing': 57,
 'atp/field/postcode/missing': 57,
 'atp/field/state/from_reverse_geocoding': 57,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 57,
 'atp/field/twitter/missing': 57,
 'atp/item_scraped_host_count/arbys.ca': 57,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 57,
 'downloader/request_bytes': 1623,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 42497,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/302': 1,
 'elapsed_time_seconds': 4.313063,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 11, 9, 22, 2, 700186, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 189529,
 'httpcompression/response_count': 2,
 'item_scraped_count': 57,
 'items_per_minute': None,
 'log_count/DEBUG': 335,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 11, 9, 21, 58, 387123, tzinfo=datetime.timezone.utc)}
```