### PR TITLE
[Sephora US CA] Fix spider

### DIFF
--- a/locations/spiders/sephora_us_ca.py
+++ b/locations/spiders/sephora_us_ca.py
@@ -32,4 +32,5 @@ class SephoraUSCASpider(SitemapSpider, StructuredDataSpider):
         item["country"] = location_info.get("address", {}).get("country")
         item["lat"] = location_info.get("latitude")
         item["lon"] = location_info.get("longitude")
+        item["branch"] = item.pop("name").title().removeprefix("Sephora ")
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Sephora': 657,
 'atp/brand_wikidata/Q2408041': 657,
 'atp/category/shop/cosmetics': 657,
 'atp/country/CA': 113,
 'atp/country/US': 544,
 'atp/field/branch/missing': 657,
 'atp/field/email/missing': 657,
 'atp/field/image/missing': 657,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 657,
 'atp/field/operator_wikidata/missing': 657,
 'atp/item_scraped_host_count/www.sephora.com': 657,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 657,
 'downloader/request_bytes': 1547607,
 'downloader/request_count': 789,
 'downloader/request_method_count/GET': 789,
 'downloader/response_bytes': 70214694,
 'downloader/response_count': 789,
 'downloader/response_status_count/200': 662,
 'downloader/response_status_count/301': 117,
 'downloader/response_status_count/302': 10,
 'dupefilter/filtered': 12,
 'elapsed_time_seconds': 966.414638,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 11, 16, 44, 2, 436354, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 464401745,
 'httpcompression/response_count': 662,
 'item_scraped_count': 657,
 'items_per_minute': None,
 'log_count/DEBUG': 1458,
 'log_count/INFO': 26,
 'request_depth_max': 1,
 'response_received_count': 662,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 788,
 'scheduler/dequeued/memory': 788,
 'scheduler/enqueued': 788,
 'scheduler/enqueued/memory': 788,
 'start_time': datetime.datetime(2025, 6, 11, 16, 27, 56, 21716, tzinfo=datetime.timezone.utc)}
```