### PR TITLE
Add Chestertons (GB) (38 locations) (fix #13363)

### DIFF
--- a/locations/spiders/chestertons_gb.py
+++ b/locations/spiders/chestertons_gb.py
@@ -1,0 +1,27 @@
+from scrapy import Request
+
+from locations.categories import apply_category
+from locations.dict_parser import DictParser
+from locations.json_blob_spider import JSONBlobSpider
+from locations.react_server_components import parse_rsc
+
+
+class ChestertonsGBSpider(JSONBlobSpider):
+    name = "chestertons_gb"
+    item_attributes = {
+        "brand": "Chestertons",
+        "brand_wikidata": "Q24298789",
+    }
+
+    def start_requests(self):
+        yield Request("https://www.chestertons.co.uk/estate-agents", headers={"RSC": 1})
+
+    def extract_json(self, response):
+        return DictParser.get_nested_key(dict(parse_rsc(response.body)), "branches")
+
+    def post_process_item(self, item, response, location):
+        item["addr_full"] = location["displayAddress"]
+        item["branch"] = item.pop("name")
+        item["website"] = f"https://www.chestertons.co.uk/estate-agents/{location['slug']}"
+        apply_category({"office": "estate_agent"}, item)
+        yield item

--- a/locations/spiders/chestertons_gb.py
+++ b/locations/spiders/chestertons_gb.py
@@ -1,17 +1,19 @@
-from scrapy import Request
+from typing import Iterable
+from urllib.parse import urljoin
 
-from locations.categories import apply_category
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.react_server_components import parse_rsc
 
 
 class ChestertonsGBSpider(JSONBlobSpider):
     name = "chestertons_gb"
-    item_attributes = {
-        "brand": "Chestertons",
-        "brand_wikidata": "Q24298789",
-    }
+    item_attributes = {"brand": "Chestertons", "brand_wikidata": "Q24298789"}
 
     def start_requests(self):
         yield Request("https://www.chestertons.co.uk/estate-agents", headers={"RSC": 1})
@@ -19,9 +21,11 @@ class ChestertonsGBSpider(JSONBlobSpider):
     def extract_json(self, response):
         return DictParser.get_nested_key(dict(parse_rsc(response.body)), "branches")
 
-    def post_process_item(self, item, response, location):
-        item["addr_full"] = location["displayAddress"]
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
-        item["website"] = f"https://www.chestertons.co.uk/estate-agents/{location['slug']}"
-        apply_category({"office": "estate_agent"}, item)
+        item["addr_full"] = feature["displayAddress"]
+        item["website"] = urljoin("https://www.chestertons.co.uk/estate-agents/", feature["slug"])
+
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+
         yield item


### PR DESCRIPTION
```py
{'atp/brand/Chestertons': 38,
 'atp/brand_wikidata/Q24298789': 38,
 'atp/category/office/estate_agent': 38,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/branch': 1,
 'atp/country/GB': 38,
 'atp/field/city/missing': 38,
 'atp/field/country/from_spider_name': 38,
 'atp/field/image/missing': 38,
 'atp/field/name/missing': 38,
 'atp/field/opening_hours/missing': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/phone/missing': 38,
 'atp/field/state/missing': 38,
 'atp/field/street_address/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/item_scraped_host_count/www.chestertons.co.uk': 38,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 38,
 'downloader/request_bytes': 689,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 70241,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.03566,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 11, 20, 31, 21, 637416, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 449369,
 'httpcompression/response_count': 2,
 'item_scraped_count': 38,
 'items_per_minute': None,
 'log_count/DEBUG': 51,
 'log_count/INFO': 9,
 'memusage/max': 266043392,
 'memusage/startup': 266043392,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 11, 20, 31, 18, 601756, tzinfo=datetime.timezone.utc)}
```