### PR TITLE
[American Golf GB] Fix Spider

### DIFF
--- a/locations/spiders/american_golf_gb.py
+++ b/locations/spiders/american_golf_gb.py
@@ -1,10 +1,11 @@
+import json
+import re
 from typing import Any
 
 from scrapy.http import Response
 from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_FULL, OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
@@ -13,26 +14,21 @@ class AmericanGolfGBSpider(Spider):
     item_attributes = {"brand": "American Golf", "brand_wikidata": "Q62657494"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = [
-        "https://www.americangolf.co.uk/on/demandware.store/Sites-AmericanGolf-GB-Site/en_GB/Stores-GetAllStores"
+        "https://www.americangolf.co.uk/en/find-stores/",
     ]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["stores"]:
+        raw_data = json.loads(
+            re.search(
+                r"channel\":(\[.*\])}},\"content",
+                response.xpath('//*[contains(text(),"address1")]/text()').get().replace("\\", ""),
+            ).group(1)
+        )
+        for location in raw_data:
+            location.update(location.pop("resources"))
+            print(location)
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
+            item["addr_full"] = location["listAddress"]
             item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
-            item["website"] = response.urljoin(location["detailsLink"])
-
-            if location.get("storeHours"):
-                item["opening_hours"] = OpeningHours()
-                for day in map(str.lower, DAYS_FULL):
-                    try:
-                        day_hours = location["storeHours"][day].strip()
-                        if "CLOSED" in day_hours.upper():
-                            item["opening_hours"].set_closed(day)
-                        else:
-                            item["opening_hours"].add_range(day, *day_hours.split(" - "))
-                    except:
-                        continue
-
             yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/American Golf': 73,
 'atp/brand_wikidata/Q62657494': 73,
 'atp/category/shop/sports': 73,
 'atp/country/GB': 73,
 'atp/field/email/missing': 73,
 'atp/field/image/missing': 73,
 'atp/field/opening_hours/missing': 73,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/state/missing': 73,
 'atp/field/twitter/missing': 73,
 'atp/field/website/missing': 73,
 'atp/item_scraped_host_count/www.americangolf.co.uk': 73,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 73,
 'downloader/request_bytes': 345,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 53358,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 57.348357,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 12, 12, 13, 55, 938491, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1,
 'httpcache/miss': 1,
 'httpcache/store': 1,
 'httpcompression/response_bytes': 341840,
 'httpcompression/response_count': 1,
 'item_scraped_count': 73,
 'items_per_minute': None,
 'log_count/DEBUG': 94,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 12, 12, 12, 58, 590134, tzinfo=datetime.timezone.utc)}
```