### PR TITLE
[Fairmont] Fix Spider

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,parsel,pdfplumber,phonenumbers,phpserialize,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,shapely,tldextract,unidecode,w3lib,xmltodict
+known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,h2,ijson,json5,lxml,msilib,openpyxl,parsel,pdfplumber,phonenumbers,phpserialize,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,shapely,tldextract,unidecode,w3lib,xmltodict

--- a/locations/spiders/fairmont.py
+++ b/locations/spiders/fairmont.py
@@ -1,5 +1,4 @@
 from msilib import Feature
-
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 

--- a/locations/spiders/fairmont.py
+++ b/locations/spiders/fairmont.py
@@ -1,56 +1,18 @@
-from typing import Any
+from msilib import Feature
 
-import xmltodict
-from scrapy import Spider
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.spiders.central_england_cooperative import set_operator
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FairmontSpider(Spider):
+class FairmontSpider(SitemapSpider, StructuredDataSpider):
     name = "fairmont"
     FAIRMONT = {"brand": "Fairmont", "brand_wikidata": "Q1393345"}
-    start_urls = ["https://www.fairmont.com/frhiuploadedfiles/fairmontpropertymap.xml"]
+    sitemap_urls = ["https://www.fairmont.com/en.sitemap.xml"]
+    sitemap_rules = [("/hotels/[^/]+/[^/]+\.html$", "parse_sd")]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('/properties/status[@status="Operational"]/region/property'):
-            if location.xpath("./guestrooms/text()").get() == "0":
-                continue
-            item = DictParser.parse(xmltodict.parse(location.get())["property"])
-
-            slug = location.xpath("./url/text()").get()
-            item["city"] = location.xpath("./city/text()").get()
-            item["state"] = location.xpath("./province/text()").get()
-            item["country"] = location.xpath("./country/text()").get()
-            item["addr_full"] = location.xpath("./address/text()").get()
-            item["website"] = "https://www.fairmont.com{}".format(slug)
-            item["extras"]["fax"] = location.xpath("./fax/text()").get()
-            item["extras"]["rooms"] = location.xpath("./guestrooms/text()").get()
-            item["ref"] = location.xpath("@propid").get()
-
-            for lang, domain in [
-                ("de", "https://www.fairmont.de"),
-                ("en", "https://www.fairmont.com"),
-                ("es", "https://www.fairmont.mx"),
-                ("fr", "https://www.fairmont.fr"),
-                ("pt", "https://www.fairmont.net.br"),
-                ("tr", "https://www.fairmont-tr.com"),
-                ("ru", "https://www.fairmont-ru.com"),
-                ("ar", "https://www.fairmont.ae"),
-                ("cn", "https://www.fairmont.cn"),
-                ("ja", "https://www.fairmont.jp"),
-                ("ko", "https://www.fairmont.co.kr"),
-            ]:
-                item["extras"]["website:{}".format(lang)] = "{}{}".format(domain, slug)
-
-            if item["name"].startswith("Fairmont"):
-                item.update(self.FAIRMONT)
-            elif item["name"].endswith("A Fairmont Managed Hotel"):
-                set_operator(self.FAIRMONT, item)
-                item["nsi_id"] = "N/A"
-
-            apply_category(Categories.HOTEL, item)
-
-            yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        apply_category(Categories.HOTEL, item)
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/category/tourism/hotel': 91,
 'atp/country/AE': 5,
 'atp/country/AZ': 1,
 'atp/country/BB': 1,
 'atp/country/BM': 2,
 'atp/country/BR': 1,
 'atp/country/CA': 19,
 'atp/country/CH': 2,
 'atp/country/CN': 6,
 'atp/country/CZ': 1,
 'atp/country/DE': 1,
 'atp/country/EG': 1,
 'atp/country/ES': 1,
 'atp/country/GB': 3,
 'atp/country/ID': 1,
 'atp/country/IE': 1,
 'atp/country/IN': 2,
 'atp/country/JO': 1,
 'atp/country/JP': 1,
 'atp/country/KE': 3,
 'atp/country/KR': 1,
 'atp/country/MA': 4,
 'atp/country/MC': 1,
 'atp/country/MX': 3,
 'atp/country/PH': 1,
 'atp/country/PR': 1,
 'atp/country/QA': 1,
 'atp/country/SA': 3,
 'atp/country/SG': 1,
 'atp/country/TR': 1,
 'atp/country/UA': 1,
 'atp/country/US': 19,
 'atp/country/ZA': 1,
 'atp/field/branch/missing': 91,
 'atp/field/brand/missing': 91,
 'atp/field/brand_wikidata/missing': 91,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/image/missing': 64,
 'atp/field/opening_hours/missing': 91,
 'atp/field/operator/missing': 91,
 'atp/field/operator_wikidata/missing': 91,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/from_reverse_geocoding': 38,
 'atp/field/state/missing': 52,
 'atp/field/twitter/invalid': 1,
 'atp/field/twitter/missing': 37,
 'atp/item_scraped_host_count/www.fairmont.com': 91,
 'atp/lineage': 'S_?',
 'atp/structured_data/unmapped/amenity_features': 91,
 'downloader/request_bytes': 96535,
 'downloader/request_count': 93,
 'downloader/request_method_count/GET': 93,
 'downloader/response_bytes': 20962327,
 'downloader/response_count': 93,
 'downloader/response_status_count/200': 93,
 'elapsed_time_seconds': 115.358552,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 13, 6, 13, 13, 677314, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 121120596,
 'httpcompression/response_count': 93,
 'item_scraped_count': 91,
 'items_per_minute': None,
 'log_count/DEBUG': 276,
 'log_count/INFO': 101,
 'request_depth_max': 1,
 'response_received_count': 93,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 92,
 'scheduler/dequeued/memory': 92,
 'scheduler/enqueued': 92,
 'scheduler/enqueued/memory': 92,
 'start_time': datetime.datetime(2025, 6, 13, 6, 11, 18, 318762, tzinfo=datetime.timezone.utc)}

```