### PR TITLE
[Fairmont] Fix Spider

### DIFF
--- a/locations/spiders/fairmont.py
+++ b/locations/spiders/fairmont.py
@@ -3,6 +3,7 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.spiders.central_england_cooperative import set_operator
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,5 +14,11 @@ class FairmontSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [("/hotels/[^/]+/[^/]+html$", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item["name"].startswith("Fairmont"):
+            item.update(self.FAIRMONT)
+        elif item["name"].endswith("A Fairmont Managed Hotel"):
+            set_operator(self.FAIRMONT, item)
+            item["nsi_id"] = "N/A"
+
         apply_category(Categories.HOTEL, item)
         yield item


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/category/tourism/hotel': 91,
 'atp/country/AE': 5,
 'atp/country/AZ': 1,
 'atp/country/BB': 1,
 'atp/country/BM': 2,
 'atp/country/BR': 1,
 'atp/country/CA': 19,
 'atp/country/CH': 2,
 'atp/country/CN': 6,
 'atp/country/CZ': 1,
 'atp/country/DE': 1,
 'atp/country/EG': 1,
 'atp/country/ES': 1,
 'atp/country/GB': 3,
 'atp/country/ID': 1,
 'atp/country/IE': 1,
 'atp/country/IN': 2,
 'atp/country/JO': 1,
 'atp/country/JP': 1,
 'atp/country/KE': 3,
 'atp/country/KR': 1,
 'atp/country/MA': 4,
 'atp/country/MC': 1,
 'atp/country/MX': 3,
 'atp/country/PH': 1,
 'atp/country/PR': 1,
 'atp/country/QA': 1,
 'atp/country/SA': 3,
 'atp/country/SG': 1,
 'atp/country/TR': 1,
 'atp/country/UA': 1,
 'atp/country/US': 19,
 'atp/country/ZA': 1,
 'atp/field/branch/missing': 91,
 'atp/field/brand/missing': 91,
 'atp/field/brand_wikidata/missing': 91,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/image/missing': 64,
 'atp/field/opening_hours/missing': 91,
 'atp/field/operator/missing': 91,
 'atp/field/operator_wikidata/missing': 91,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/from_reverse_geocoding': 38,
 'atp/field/state/missing': 52,
 'atp/field/twitter/invalid': 1,
 'atp/field/twitter/missing': 37,
 'atp/item_scraped_host_count/www.fairmont.com': 91,
 'atp/lineage': 'S_?',
 'atp/structured_data/unmapped/amenity_features': 91,
 'downloader/request_bytes': 63886,
 'downloader/request_count': 93,
 'downloader/request_method_count/GET': 93,
 'downloader/response_bytes': 20960737,
 'downloader/response_count': 93,
 'downloader/response_status_count/200': 93,
 'elapsed_time_seconds': 109.842343,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 13, 6, 24, 31, 302859, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 121120595,
 'httpcompression/response_count': 93,
 'item_scraped_count': 91,
 'items_per_minute': None,
 'log_count/DEBUG': 276,
 'log_count/INFO': 101,
 'request_depth_max': 1,
 'response_received_count': 93,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 92,
 'scheduler/dequeued/memory': 92,
 'scheduler/enqueued': 92,
 'scheduler/enqueued/memory': 92,
 'start_time': datetime.datetime(2025, 6, 13, 6, 22, 41, 460516, tzinfo=datetime.timezone.utc)}
```