### PR TITLE
[Accenture] Fix Spider

### DIFF
--- a/locations/spiders/accenture.py
+++ b/locations/spiders/accenture.py
@@ -1,38 +1,33 @@
+import html
+import json
+
 import scrapy
 from scrapy.http import JsonRequest
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class AccentureSpider(scrapy.Spider):
     name = "accenture"
     item_attributes = {"brand": "Accenture", "brand_wikidata": "Q29123313"}
-    allowed_domains = ["accenture.com"]
-    start_urls = ["https://www.accenture.com/us-en/about/location-index"]
+    start_urls = ["https://www.accenture.com/us-en/about/location"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
     no_refs = True
 
     def parse(self, response, **kwargs):
-        for country in response.xpath('//li[@class="cmp-link-teaser__list-item"]/a/text()').getall():
+        for country in response.xpath('//li[@class="rad-link-list__list-item"]/a/text()').getall():
             yield JsonRequest(
-                url=f"https://www.accenture.com/api/sitecore/LocationsHeroModule/GetLocation?query={country}&from=0&size=10000&language=en",
+                url=f"https://www.accenture.com/us-en/about/locations/office-details/jcr:content/root/container_main/locationhero_copy.result.html?query={country}&from=0&size=1500",
                 callback=self.parse_country,
             )
 
     def parse_country(self, response, **kwargs):
-        for store_data in response.json()["documents"]:
-            properties = {
-                "name": store_data["LocationName"],
-                "street_address": store_data["Address"],
-                "image": store_data["ExternalImageURL"],
-                "city": store_data["CityName"],
-                "state": store_data["StateCode"],
-                "postcode": store_data["PostalZipCode"],
-                "country": store_data["Country"],
-                "phone": store_data.get("ContactTel"),
-                "lat": float(store_data["Latitude"]),
-                "lon": float(store_data["Longitude"]),
-                "website": store_data.get("LocationURL"),
-            }
-
-            yield Feature(**properties)
+        for office in json.loads(html.unescape(response.text)):
+            item = DictParser.parse(office)
+            item.pop("state")
+            item["branch"] = item.pop("name")
+            item["name"] = self.item_attributes["brand"]
+            item["street_address"] = item.pop("addr_full")
+            item["postcode"] = office.get("postalZipCode", "")
+            item["phone"] = office.get("contactTel", "")
+            yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Accenture': 321,
 'atp/brand_wikidata/Q29123313': 321,
 'atp/category/missing': 321,
 'atp/country/AE': 2,
 'atp/country/AR': 4,
 'atp/country/AT': 1,
 'atp/country/AU': 6,
 'atp/country/BE': 1,
 'atp/country/BG': 2,
 'atp/country/BR': 11,
 'atp/country/CA': 13,
 'atp/country/CH': 9,
 'atp/country/CL': 1,
 'atp/country/CN': 12,
 'atp/country/CO': 3,
 'atp/country/CR': 1,
 'atp/country/CZ': 2,
 'atp/country/DE': 21,
 'atp/country/DK': 3,
 'atp/country/ES': 13,
 'atp/country/FI': 2,
 'atp/country/FR': 6,
 'atp/country/GB': 7,
 'atp/country/GR': 2,
 'atp/country/HK': 1,
 'atp/country/HU': 2,
 'atp/country/ID': 2,
 'atp/country/IE': 4,
 'atp/country/IL': 2,
 'atp/country/IN': 29,
 'atp/country/IT': 16,
 'atp/country/JP': 12,
 'atp/country/LT': 1,
 'atp/country/LU': 1,
 'atp/country/LV': 1,
 'atp/country/MA': 1,
 'atp/country/MU': 4,
 'atp/country/MX': 4,
 'atp/country/MY': 10,
 'atp/country/NL': 2,
 'atp/country/NO': 3,
 'atp/country/NZ': 2,
 'atp/country/PH': 8,
 'atp/country/PL': 9,
 'atp/country/PR': 1,
 'atp/country/PT': 3,
 'atp/country/QA': 1,
 'atp/country/RO': 6,
 'atp/country/SA': 3,
 'atp/country/SE': 4,
 'atp/country/SG': 2,
 'atp/country/SK': 3,
 'atp/country/TH': 3,
 'atp/country/TR': 1,
 'atp/country/TW': 1,
 'atp/country/US': 54,
 'atp/country/VN': 1,
 'atp/country/ZA': 2,
 'atp/field/country/from_reverse_geocoding': 16,
 'atp/field/email/missing': 321,
 'atp/field/image/missing': 321,
 'atp/field/opening_hours/missing': 321,
 'atp/field/operator/missing': 321,
 'atp/field/operator_wikidata/missing': 321,
 'atp/field/postcode/missing': 5,
 'atp/field/state/from_reverse_geocoding': 67,
 'atp/field/state/missing': 238,
 'atp/field/twitter/missing': 321,
 'atp/field/website/missing': 321,
 'atp/item_scraped_host_count/www.accenture.com': 321,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 321,
 'downloader/request_bytes': 30276,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 242605,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 54,
 'dupefilter/filtered': 53,
 'elapsed_time_seconds': 4.089201,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 13, 9, 55, 54, 732618, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2497153,
 'httpcompression/response_count': 54,
 'item_scraped_count': 321,
 'items_per_minute': None,
 'log_count/DEBUG': 388,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 54,
 'responses_per_minute': None,
 'scheduler/dequeued': 54,
 'scheduler/dequeued/memory': 54,
 'scheduler/enqueued': 54,
 'scheduler/enqueued/memory': 54,
 'start_time': datetime.datetime(2025, 6, 13, 9, 55, 50, 643417, tzinfo=datetime.timezone.utc)}
```