### PR TITLE
[Astron Energy ZA] Fix spider

### DIFF
--- a/locations/spiders/astron_energy_za.py
+++ b/locations/spiders/astron_energy_za.py
@@ -43,6 +43,7 @@ class AstronEnergyZASpider(JSONBlobSpider):
     item_attributes = {"brand": "Astron Energy", "brand_wikidata": "Q120752181"}
     start_urls = ["https://www.astronenergy.co.za/umbraco/api/station/Stations"]
     locations_key = "stations"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         for url in self.start_urls:

--- a/locations/spiders/astron_energy_za.py
+++ b/locations/spiders/astron_energy_za.py
@@ -59,8 +59,9 @@ class AstronEnergyZASpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
         item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
-        if len(location["images"]) > 0:
-            item["image"] = "https://www.astronenergy.co.za" + location["images"][0]
+        images = location.get("imageUrls") or []
+        if images:
+            item["image"] = "https://www.astronenergy.co.za" + images[0]
         for tag, service in ASTRON_PROPERTIES.items():
             apply_yes_no(service, item, location["properties"].get(tag), False)
         item["opening_hours"] = OpeningHours()

--- a/locations/spiders/astron_energy_za.py
+++ b/locations/spiders/astron_energy_za.py
@@ -61,7 +61,7 @@ class AstronEnergyZASpider(JSONBlobSpider):
         item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
         images = location.get("imageUrls") or []
         if images:
-            item["image"] = "https://www.astronenergy.co.za" + images[0]
+            item["image"] = response.urljoin(images[0])
         for tag, service in ASTRON_PROPERTIES.items():
             apply_yes_no(service, item, location["properties"].get(tag), False)
         item["opening_hours"] = OpeningHours()


### PR DESCRIPTION
```python
{'atp/brand/Astron Energy': 527,
 'atp/brand_wikidata/Q120752181': 527,
 'atp/category/amenity/fuel': 527,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/city': 5,
 'atp/clean_strings/street_address': 520,
 'atp/country/ZA': 527,
 'atp/field/country/from_spider_name': 527,
 'atp/field/email/missing': 527,
 'atp/field/image/missing': 433,
 'atp/field/opening_hours/missing': 11,
 'atp/field/operator/missing': 527,
 'atp/field/operator_wikidata/missing': 527,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 8,
 'atp/field/postcode/missing': 527,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 527,
 'atp/field/website/missing': 527,
 'atp/item_scraped_host_count/www.astronenergy.co.za': 527,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 527,
 'downloader/request_bytes': 373,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 63650,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.385011,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 13, 15, 11, 47, 997035, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 483127,
 'httpcompression/response_count': 1,
 'item_scraped_count': 527,
 'items_per_minute': None,
 'log_count/DEBUG': 539,
 'log_count/INFO': 10,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 13, 15, 11, 45, 612024, tzinfo=datetime.timezone.utc)}
```