### PR TITLE
[KFC HK] Fix  spider

### DIFF
--- a/locations/spiders/kfc_hk.py
+++ b/locations/spiders/kfc_hk.py
@@ -19,6 +19,7 @@ class KfcHKSpider(scrapy.Spider):
                 "actionName": "candao.storeStandard.getStoreList",
                 "langType": 2,
                 "content": {
+                    "cityId": 810000,
                     "businessType": ["3"],
                     "searchName": "",
                     "pageNow": 1,


### PR DESCRIPTION
```python
{'atp/brand/KFC': 82,
 'atp/brand_wikidata/Q524757': 82,
 'atp/category/amenity/fast_food': 82,
 'atp/clean_strings/addr_full': 4,
 'atp/country/HK': 82,
 'atp/field/branch/missing': 2,
 'atp/field/city/missing': 61,
 'atp/field/country/from_spider_name': 82,
 'atp/field/email/missing': 82,
 'atp/field/image/missing': 82,
 'atp/field/operator/missing': 82,
 'atp/field/operator_wikidata/missing': 82,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 82,
 'atp/field/state/missing': 82,
 'atp/field/street_address/missing': 82,
 'atp/field/twitter/missing': 82,
 'atp/field/website/missing': 82,
 'atp/item_scraped_host_count/ordering.kfchk.com': 82,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 82,
 'downloader/request_bytes': 977,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 22109,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.055828,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 16, 7, 48, 35, 44260, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 366524,
 'httpcompression/response_count': 2,
 'item_scraped_count': 82,
 'items_per_minute': None,
 'log_count/DEBUG': 271,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 16, 7, 48, 31, 988432, tzinfo=datetime.timezone.utc)}
```