### PR TITLE
[Banana Republic Home US] Fix Spider

### DIFF
--- a/locations/spiders/banana_republic_home_us.py
+++ b/locations/spiders/banana_republic_home_us.py
@@ -1,29 +1,33 @@
-from typing import Iterable
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.categories import Categories
-from locations.hours import OpeningHours
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.storefinders.stockist import StockistSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class BananaRepublicHomeUSSpider(StockistSpider):
+class BananaRepublicHomeUSSpider(CrawlSpider, StructuredDataSpider):
     name = "banana_republic_home_us"
     item_attributes = {
         "brand": "Banana Republic Home",
         "brand_wikidata": "Q129793169",
-        "extras": Categories.SHOP_FURNITURE.value,
     }
-    key = "u17439"
+    start_urls = ["https://bananarepublic.gap.com/stores#browse-by-state-section"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"/stores/[^/]+/$"),
+        ),
+        Rule(
+            LinkExtractor(allow=r"/stores/[^/]+/[^/]+/$"),
+        ),
+        Rule(LinkExtractor(allow=r"/stores/[^/]+/[^/]+/[^/]+$"), "parse_sd"),
+    ]
 
-    def parse_item(self, item: Feature, feature: dict) -> Iterable[Feature]:
-        if "COMING SOON" in item["name"].upper():
-            return
+    # wanted_types = ["ClothingStore"]
 
-        if branch_name := item.pop("name", None):
-            item["branch"] = branch_name.removeprefix("BR HOME ")
-
-        if hours_string := feature.get("description", None):
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(hours_string)
-
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removesuffix("| Banana Republic")
+        item["name"] = self.item_attributes["brand"]
+        apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Banana Republic Home': 318,
 'atp/brand_wikidata/Q129793169': 318,
 'atp/category/shop/clothes': 318,
 'atp/clean_strings/branch': 318,
 'atp/country/US': 318,
 'atp/field/country/from_spider_name': 318,
 'atp/field/email/missing': 318,
 'atp/field/image/dropped': 318,
 'atp/field/image/missing': 318,
 'atp/field/operator/missing': 318,
 'atp/field/operator_wikidata/missing': 318,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 318,
 'atp/item_scraped_host_count/bananarepublic.gap.com': 318,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 318,
 'downloader/request_bytes': 1536697,
 'downloader/request_count': 980,
 'downloader/request_method_count/GET': 980,
 'downloader/response_bytes': 91146526,
 'downloader/response_count': 980,
 'downloader/response_status_count/200': 650,
 'downloader/response_status_count/308': 330,
 'elapsed_time_seconds': 21.499966,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 20, 4, 42, 54, 766134, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 523238215,
 'httpcompression/response_count': 650,
 'item_scraped_count': 318,
 'items_per_minute': None,
 'log_count/DEBUG': 1310,
 'log_count/INFO': 9,
 'request_depth_max': 3,
 'response_received_count': 650,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 979,
 'scheduler/dequeued/memory': 979,
 'scheduler/enqueued': 979,
 'scheduler/enqueued/memory': 979,
 'start_time': datetime.datetime(2025, 6, 20, 4, 42, 33, 266168, tzinfo=datetime.timezone.utc)}
```