### PR TITLE
Set cluster-maxzoom in tippecanoe

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -90,6 +90,7 @@ uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPI
 tippecanoe --cluster-distance=25 \
            --drop-rate=1 \
            --maximum-zoom=14 \
+           --cluster-maxzoom=g \
            --maximum-tile-bytes=5000000 \
            --layer="alltheplaces" \
            --read-parallel \


### PR DESCRIPTION
This leaves all data at maxzoom so that we can view clusters, even when points are exactly overlapping and would otherwise get clustered together.

Part of #13488 