### PR TITLE
Correct constructed website URL in CeX spider

### DIFF
--- a/locations/spiders/cex.py
+++ b/locations/spiders/cex.py
@@ -32,7 +32,7 @@ class CexSpider(scrapy.Spider):
         item["city"] = store["city"]
         item["state"] = store["county"]
         item["postcode"] = store["postcode"]
-        item["website"] = "https://uk.webuy.com/site/storeDetail/?branchId=" + ref
+        item["website"] = "https://uk.webuy.com/site/storeDetail?branchId=" + ref
         item["ref"] = ref
         item["image"] = ";".join(store["storeImageUrls"])
 


### PR DESCRIPTION
The URLs for the individual CeX store pages have changed slightly. Rather than https://uk.webuy.com/site/storeDetail/?branchId=91 they are now https://uk.webuy.com/site/storeDetail?branchId=91 . (No terminal forward slash before the query string.)