### PR TITLE
[Aswak Assalam MA] Sync brand with NSI

### DIFF
--- a/locations/spiders/aswak_assalam_ma.py
+++ b/locations/spiders/aswak_assalam_ma.py
@@ -5,7 +5,7 @@ from locations.items import Feature
 
 class AswakAssalamMASpider(Spider):
     name = "aswak_assalam_ma"
-    item_attributes = {"brand": "Aswak Assalam", "brand_wikidata": "Q2868678"}
+    item_attributes = {"brand_wikidata": "Q2868678"}
     allowed_domains = ["www.aswakassalam.com"]
     start_urls = ["https://www.aswakassalam.com/nos-magasins/"]
 


### PR DESCRIPTION
:( I don't like multiple values space separated in `brand`.

```
ERROR    root:test_item_attributes.py:59 aswak_assalam_ma: "brand" tag "Aswak Assalam" does not match expected {'Aswak Assalam أسواق السلام'}
```