### PR TITLE
[Baylor Scott White Health] Fix and rename spider

### DIFF
--- a/locations/spiders/baylor_scott_white_health_us.py
+++ b/locations/spiders/baylor_scott_white_health_us.py
@@ -1,11 +1,14 @@
-import scrapy
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 
-class BaylorScottWhiteHealthUSSpider(scrapy.Spider):
+class BaylorScottWhiteHealthUSSpider(Spider):
     name = "baylor_scott_white_health_us"
     item_attributes = {"operator": "Baylor Scott & White Health", "operator_wikidata": "Q41568258"}
     allowed_domains = ["phyndapi.bswapi.com"]
@@ -14,28 +17,26 @@ class BaylorScottWhiteHealthUSSpider(scrapy.Spider):
         "x-bsw-clientid": "BSWHealth.com",
     }
 
-    def start_requests(self):
-        yield scrapy.Request(
-            self.base_url + "?perPage=1",
+    def start_requests(self) -> Iterable[JsonRequest]:
+        yield JsonRequest(
+            url=self.base_url + "?perPage=1",
             headers=self.headers,
             callback=self.get_pages,
         )
 
-    def get_pages(self, response):
+    def get_pages(self, response: Response) -> Iterable[JsonRequest]:
         total_count = response.json()["locationCount"]
         page_number = 0
         page_size = 100
 
         while page_number * page_size < total_count:
-            yield scrapy.Request(
+            yield JsonRequest(
                 self.base_url + f"?perPage={page_size}&pageNumber={page_number + 1}", headers=self.headers
             )
             page_number += 1
 
-    def parse(self, response):
-        ldata = response.json()["locationResults"]
-
-        for row in ldata:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for row in response.json()["locationResults"]:
             properties = {
                 "ref": row["locationID"],
                 "name": row["locationName"],


### PR DESCRIPTION
```python
{'atp/category/amenity/hospital': 985,
 'atp/category/multiple': 985,
 'atp/clean_strings/name': 4,
 'atp/clean_strings/phone': 4,
 'atp/country/US': 985,
 'atp/field/branch/missing': 985,
 'atp/field/brand/missing': 985,
 'atp/field/brand_wikidata/missing': 985,
 'atp/field/country/from_spider_name': 985,
 'atp/field/email/missing': 985,
 'atp/field/image/invalid': 4,
 'atp/field/image/missing': 438,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 394,
 'atp/field/twitter/missing': 985,
 'atp/field/website/invalid': 5,
 'atp/field/website/missing': 34,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/phyndapi.bswapi.com': 985,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 985,
 'atp/operator/Baylor Scott & White Health': 985,
 'atp/operator_wikidata/Q41568258': 985,
 'downloader/request_bytes': 5653,
 'downloader/request_count': 12,
 'downloader/request_method_count/GET': 12,
 'downloader/response_bytes': 2878057,
 'downloader/response_count': 12,
 'downloader/response_status_count/200': 11,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 19.968937,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 24, 12, 20, 14, 997266, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 12,
 'httpcache/miss': 12,
 'httpcache/store': 12,
 'httpcompression/response_bytes': 12358845,
 'httpcompression/response_count': 10,
 'item_scraped_count': 985,
 'items_per_minute': None,
 'log_count/DEBUG': 1009,
 'log_count/INFO': 9,
 'log_count/WARNING': 9,
 'request_depth_max': 1,
 'response_received_count': 12,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 11,
 'scheduler/dequeued/memory': 11,
 'scheduler/enqueued': 11,
 'scheduler/enqueued/memory': 11,
 'start_time': datetime.datetime(2025, 6, 24, 12, 19, 55, 28329, tzinfo=datetime.timezone.utc)}
```