### PR TITLE
New spider: Greystar apartments (3687 locations)

### DIFF
--- a/locations/spiders/greystar.py
+++ b/locations/spiders/greystar.py
@@ -1,0 +1,25 @@
+from locations.categories import apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class GreystarSpider(JSONBlobSpider):
+    name = "greystar"
+    item_attributes = {
+        "operator": "Greystar",
+        "operator_wikidata": "Q60749135",
+    }
+    start_urls = ["https://www.greystar.com/api/properties/search?Distance=25000&Latitude=0&Longitude=0"]
+    download_timeout = 60
+    locations_key = "Results"
+
+    def post_process_item(self, item, response, location):
+        # "PropertyId" is a better ref than "Id" but it's not clean/unique
+        item["website"] = response.urljoin(location["Path"])
+        item["street_address"] = item.pop("addr_full")
+
+        if len(location["Images"]) > 0:
+            item["image"] = location["Images"][0]["Src"]
+
+        apply_category({"landuse": "residential", "residential": "apartments"}, item)
+
+        yield item

--- a/locations/spiders/greystar.py
+++ b/locations/spiders/greystar.py
@@ -1,5 +1,7 @@
 from locations.categories import apply_category
+from locations.country_utils import CountryUtils
 from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.state_clean_up import STATES
 
 
 class GreystarSpider(JSONBlobSpider):
@@ -19,6 +21,14 @@ class GreystarSpider(JSONBlobSpider):
 
         if len(location["Images"]) > 0:
             item["image"] = location["Images"][0]["Src"]
+
+        # Try to guess the country, given just the state.
+        # Sometimes the "State" field is the country.
+        for country, states in STATES.items():
+            if location["State"] in states:
+                item["country"] = country
+        if not item["country"]:
+            item["country"] = CountryUtils().to_iso_alpha2_country_code(location["State"])
 
         apply_category({"landuse": "residential", "residential": "apartments"}, item)
 


### PR DESCRIPTION
```py
{'atp/category/landuse/residential': 3687,
 'atp/country/AT': 1,
 'atp/country/AU': 2,
 'atp/country/BR': 1,
 'atp/country/CA': 4,
 'atp/country/CL': 3,
 'atp/country/DE': 3,
 'atp/country/ES': 23,
 'atp/country/FR': 2,
 'atp/country/GB': 99,
 'atp/country/IE': 3,
 'atp/country/NL': 7,
 'atp/country/US': 3538,
 'atp/field/branch/missing': 3687,
 'atp/field/brand/missing': 3687,
 'atp/field/brand_wikidata/missing': 3687,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 13,
 'atp/field/country/missing': 1,
 'atp/field/email/invalid': 200,
 'atp/field/email/missing': 281,
 'atp/field/lat/missing': 51,
 'atp/field/lon/missing': 51,
 'atp/field/opening_hours/missing': 3687,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 18,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 5,
 'atp/field/twitter/missing': 3687,
 'atp/item_scraped_host_count/www.greystar.com': 3687,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 3687,
 'atp/operator/Greystar': 3687,
 'atp/operator_wikidata/Q60749135': 3687,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 1100,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 3343678,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 101.61748,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 24, 22, 38, 59, 365373, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 3687,
 'items_per_minute': None,
 'log_count/INFO': 11,
 'log_count/WARNING': 2,
 'memusage/max': 275644416,
 'memusage/startup': 273678336,
 'response_received_count': 2,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 6, 24, 22, 37, 17, 747893, tzinfo=datetime.timezone.utc)}
```