### PR TITLE
New spider: Quarterra apartments (56 locations)

### DIFF
--- a/locations/spiders/quarterra_us.py
+++ b/locations/spiders/quarterra_us.py
@@ -1,0 +1,53 @@
+from scrapy.http import JsonRequest
+
+from locations.categories import apply_category
+from locations.json_blob_spider import JSONBlobSpider
+
+QUERY = """query {
+  locations: entries(section: "communities", showInListing: true) {
+    id
+    title
+    url
+    ... on communities_community_Entry {
+      thumbnail {
+        url @transform(format: "jpg")
+      }
+      stateAndCity {
+        title
+        level
+        ... on statesCities_Category {
+          stateCode
+        }
+      }
+      position: location {
+        lat
+        lng
+      }
+    }
+  }
+}
+"""
+
+
+class QuarterraUSSpider(JSONBlobSpider):
+    name = "quarterra_us"
+    item_attributes = {
+        "operator": "Quarterra",
+        "operator_wikidata": "Q134723073",
+    }
+    locations_key = ["data", "locations"]
+
+    def start_requests(self):
+        yield JsonRequest("https://quarterra.com/api", data={"query": QUERY})
+
+    def post_process_item(self, item, response, feature):
+        if len(feature["thumbnail"]) > 0:
+            item["image"] = feature["thumbnail"][0]["url"]
+        if states := [sc for sc in feature["stateAndCity"] if sc["level"] == 1]:
+            item["state"] = states[0]["stateCode"]
+        if cities := [sc for sc in feature["stateAndCity"] if sc["level"] == 2]:
+            item["city"] = cities[0]["title"]
+
+        apply_category({"landuse": "residential", "residential": "apartments"}, item)
+
+        yield item


### PR DESCRIPTION
```py
{'atp/category/landuse/residential': 56,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/US': 56,
 'atp/field/branch/missing': 56,
 'atp/field/brand/missing': 56,
 'atp/field/brand_wikidata/missing': 56,
 'atp/field/country/from_spider_name': 56,
 'atp/field/email/missing': 56,
 'atp/field/opening_hours/missing': 56,
 'atp/field/phone/missing': 56,
 'atp/field/postcode/missing': 56,
 'atp/field/street_address/missing': 56,
 'atp/field/twitter/missing': 56,
 'atp/item_scraped_host_count/quarterra.com': 56,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 56,
 'atp/operator/Quarterra': 56,
 'atp/operator_wikidata/Q134723073': 56,
 'downloader/request_bytes': 1114,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 7685,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.866473,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 24, 23, 27, 37, 941993, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 26098,
 'httpcompression/response_count': 2,
 'item_scraped_count': 56,
 'items_per_minute': None,
 'log_count/DEBUG': 69,
 'log_count/INFO': 10,
 'memusage/max': 273555456,
 'memusage/startup': 273555456,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 24, 23, 27, 35, 75520, tzinfo=datetime.timezone.utc)}
```