### PR TITLE
New spider: UDR apartments (171 locations)

### DIFF
--- a/locations/spiders/udr_us.py
+++ b/locations/spiders/udr_us.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class UdrUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "udr_us"
+    item_attributes = {
+        "operator": "UDR",
+        "operator_wikidata": "Q27988153",
+    }
+    sitemap_urls = ["https://www.udr.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"^https://www.udr.com/[\w-]+/[\w-]+/[\w-]+/$", "parse"),
+    ]
+    wanted_types = ["ApartmentComplex"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["image"] = response.xpath("//meta[@property='og:image']/@content").get()
+        apply_category({"landuse": "residential", "residential": "apartments"}, item)
+        yield item


### PR DESCRIPTION
```py
{'atp/category/landuse/residential': 171,
 'atp/cdn/cloudflare/response_count': 173,
 'atp/cdn/cloudflare/response_status_count/200': 173,
 'atp/country/US': 171,
 'atp/duplicate_count': 342,
 'atp/field/branch/missing': 171,
 'atp/field/brand/missing': 171,
 'atp/field/brand_wikidata/missing': 171,
 'atp/field/country/from_spider_name': 171,
 'atp/field/email/missing': 171,
 'atp/field/opening_hours/missing': 171,
 'atp/field/twitter/missing': 171,
 'atp/item_scraped_host_count/www.udr.com': 513,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 171,
 'atp/operator/UDR': 171,
 'atp/operator_wikidata/Q27988153': 171,
 'downloader/request_bytes': 115301,
 'downloader/request_count': 173,
 'downloader/request_method_count/GET': 173,
 'downloader/response_bytes': 9672721,
 'downloader/response_count': 173,
 'downloader/response_status_count/200': 173,
 'elapsed_time_seconds': 204.686592,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 24, 23, 55, 27, 171620, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 65881314,
 'httpcompression/response_count': 173,
 'item_dropped_count': 342,
 'item_dropped_reasons_count/DropItem': 342,
 'item_scraped_count': 171,
 'items_per_minute': None,
 'log_count/DEBUG': 697,
 'log_count/INFO': 13,
 'memusage/max': 445734912,
 'memusage/startup': 273776640,
 'request_depth_max': 1,
 'response_received_count': 173,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 172,
 'scheduler/dequeued/memory': 172,
 'scheduler/enqueued': 172,
 'scheduler/enqueued/memory': 172,
 'start_time': datetime.datetime(2025, 6, 24, 23, 52, 2, 485028, tzinfo=datetime.timezone.utc)}
```