### PR TITLE
[ScotRail GB] Fix coord extraction

### DIFF
--- a/locations/spiders/scotrail_gb.py
+++ b/locations/spiders/scotrail_gb.py
@@ -1,8 +1,11 @@
-import re
+import json
+from typing import Any
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.items import Feature
 
 
@@ -13,13 +16,20 @@ class ScotrailGBSpider(SitemapSpider):
     sitemap_rules = [(r"/plan-your-journey", "parse")]
     requires_proxy = True
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
         item["ref"] = item["extras"]["ref:crs"] = response.url.split("/")[-1]
         item["name"] = response.xpath("//h1/text()").get().replace("Station", "").strip()
-        item["lat"] = re.search(r'"lat":(-?\d+\.\d+),', response.text).group(1)
-        item["lon"] = re.search(r'"lon":(-?\d+\.\d+),', response.text).group(1)
+
         item["website"] = response.url
+
+        for marker in DictParser.get_nested_key(
+            json.loads(response.xpath('//script[@data-drupal-selector="drupal-settings-json"]/text()').get()), "markers"
+        ):
+            if marker["location_type"] == "location":
+                item["lat"] = marker["lat"]
+                item["lon"] = marker["lon"]
+                break
 
         apply_category(Categories.TRAIN_STATION, item)
 


### PR DESCRIPTION
```python
{'atp/category/railway/station': 364,
 'atp/cdn/cloudflare/response_count': 366,
 'atp/cdn/cloudflare/response_status_count/200': 366,
 'atp/country/GB': 364,
 'atp/field/branch/missing': 364,
 'atp/field/brand/missing': 364,
 'atp/field/brand_wikidata/missing': 364,
 'atp/field/city/missing': 364,
 'atp/field/country/from_spider_name': 364,
 'atp/field/email/missing': 364,
 'atp/field/image/missing': 364,
 'atp/field/opening_hours/missing': 364,
 'atp/field/phone/missing': 364,
 'atp/field/postcode/missing': 364,
 'atp/field/state/missing': 364,
 'atp/field/street_address/missing': 364,
 'atp/field/twitter/missing': 364,
 'atp/item_scraped_host_count/www.scotrail.co.uk': 364,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/operator_missing': 364,
 'atp/operator/ScotRail': 364,
 'atp/operator_wikidata/Q18356161': 364,
 'downloader/request_bytes': 201368,
 'downloader/request_count': 366,
 'downloader/request_method_count/GET': 366,
 'downloader/response_bytes': 17168838,
 'downloader/response_count': 366,
 'downloader/response_status_count/200': 366,
 'elapsed_time_seconds': 7.271796,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 25, 9, 8, 11, 898399, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 366,
 'httpcompression/response_bytes': 175864544,
 'httpcompression/response_count': 366,
 'item_scraped_count': 364,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 283246592,
 'memusage/startup': 283246592,
 'request_depth_max': 1,
 'response_received_count': 366,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 365,
 'scheduler/dequeued/memory': 365,
 'scheduler/enqueued': 365,
 'scheduler/enqueued/memory': 365,
 'start_time': datetime.datetime(2025, 6, 25, 9, 8, 4, 626603, tzinfo=datetime.timezone.utc)}
```