### PR TITLE
[Cbre] Fix spider

### DIFF
--- a/locations/spiders/cbre.py
+++ b/locations/spiders/cbre.py
@@ -26,10 +26,9 @@ class CbreSpider(Spider):
             yield response.follow(url=country_url, callback=self.parse_cities, cb_kwargs=dict(country=country))
 
     def parse_cities(self, response: Response, country: str) -> Any:
-        cities = response.xpath(
+        if cities := response.xpath(
             '//a[contains(@href, "offices") and not(contains(@class, "countrySelector")) and not(contains(@href, "mediaasset"))]/@href'
-        ).getall()
-        if cities:
+        ).getall():
             for city_url in cities:
                 yield response.follow(url=city_url, callback=self.parse_locations, cb_kwargs=dict(country=country))
         else:
@@ -38,10 +37,9 @@ class CbreSpider(Spider):
     def parse_locations(self, response: Response, country: str) -> Any:
         country = self.country_map.get(country, country)
         primary_location = response.xpath('//*[contains(@class,"contactCardWrapper")]')
-        locations = response.xpath(
+        if locations := response.xpath(
             '//*[contains(@class,"listCards--office")]'
-        )  # multiple locations including primary one
-        if locations:
+        ):  # multiple locations including primary one
             for location in locations:
                 item = Feature()
                 # Few duplicate locations from different urls are there, that's why we should make addr_full as ref.


### PR DESCRIPTION
`coordinates` are not available for all locations.

```python
{'atp/brand/CBRE': 298,
 'atp/brand_wikidata/Q1023013': 298,
 'atp/category/office/estate_agent': 298,
 'atp/clean_strings/phone': 2,
 'atp/country/AE': 4,
 'atp/country/AR': 1,
 'atp/country/AT': 4,
 'atp/country/AU': 13,
 'atp/country/BH': 2,
 'atp/country/BR': 6,
 'atp/country/CA': 25,
 'atp/country/CN': 10,
 'atp/country/CO': 1,
 'atp/country/DK': 2,
 'atp/country/GB': 16,
 'atp/country/HK': 4,
 'atp/country/HU': 1,
 'atp/country/ID': 1,
 'atp/country/IE': 3,
 'atp/country/IL': 3,
 'atp/country/IN': 16,
 'atp/country/IT': 1,
 'atp/country/JP': 9,
 'atp/country/KR': 2,
 'atp/country/LU': 1,
 'atp/country/MX': 4,
 'atp/country/MY': 1,
 'atp/country/NO': 1,
 'atp/country/NZ': 21,
 'atp/country/PH': 1,
 'atp/country/PK': 1,
 'atp/country/RO': 1,
 'atp/country/SA': 4,
 'atp/country/SK': 4,
 'atp/country/TH': 2,
 'atp/country/TR': 1,
 'atp/country/TW': 1,
 'atp/country/US': 128,
 'atp/country/VN': 3,
 'atp/duplicate_count': 68,
 'atp/field/branch/missing': 298,
 'atp/field/city/missing': 298,
 'atp/field/country/from_website_url': 14,
 'atp/field/email/missing': 298,
 'atp/field/image/missing': 298,
 'atp/field/lat/missing': 166,
 'atp/field/lon/missing': 166,
 'atp/field/opening_hours/missing': 298,
 'atp/field/operator/missing': 298,
 'atp/field/operator_wikidata/missing': 298,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 16,
 'atp/field/postcode/missing': 280,
 'atp/field/state/from_reverse_geocoding': 91,
 'atp/field/state/missing': 207,
 'atp/field/street_address/missing': 298,
 'atp/field/twitter/missing': 298,
 'atp/item_scraped_host_count/indonesia.cbre.com': 1,
 'atp/item_scraped_host_count/pakistan.cbre.com': 1,
 'atp/item_scraped_host_count/philippines.cbre.com': 1,
 'atp/item_scraped_host_count/www.cbre.ae': 4,
 'atp/item_scraped_host_count/www.cbre.at': 5,
 'atp/item_scraped_host_count/www.cbre.bh': 2,
 'atp/item_scraped_host_count/www.cbre.ca': 54,
 'atp/item_scraped_host_count/www.cbre.co.il': 3,
 'atp/item_scraped_host_count/www.cbre.co.in': 16,
 'atp/item_scraped_host_count/www.cbre.co.jp': 9,
 'atp/item_scraped_host_count/www.cbre.co.nz': 21,
 'atp/item_scraped_host_count/www.cbre.co.th': 2,
 'atp/item_scraped_host_count/www.cbre.co.uk': 16,
 'atp/item_scraped_host_count/www.cbre.com': 166,
 'atp/item_scraped_host_count/www.cbre.com.ar': 1,
 'atp/item_scraped_host_count/www.cbre.com.au': 13,
 'atp/item_scraped_host_count/www.cbre.com.br': 6,
 'atp/item_scraped_host_count/www.cbre.com.cn': 10,
 'atp/item_scraped_host_count/www.cbre.com.co': 1,
 'atp/item_scraped_host_count/www.cbre.com.hk': 4,
 'atp/item_scraped_host_count/www.cbre.com.mx': 4,
 'atp/item_scraped_host_count/www.cbre.com.my': 1,
 'atp/item_scraped_host_count/www.cbre.com.tr': 1,
 'atp/item_scraped_host_count/www.cbre.com.tw': 1,
 'atp/item_scraped_host_count/www.cbre.dk': 2,
 'atp/item_scraped_host_count/www.cbre.hu': 1,
 'atp/item_scraped_host_count/www.cbre.ie': 3,
 'atp/item_scraped_host_count/www.cbre.it': 1,
 'atp/item_scraped_host_count/www.cbre.lu': 1,
 'atp/item_scraped_host_count/www.cbre.no': 1,
 'atp/item_scraped_host_count/www.cbre.ro': 1,
 'atp/item_scraped_host_count/www.cbre.sa': 4,
 'atp/item_scraped_host_count/www.cbre.sk': 4,
 'atp/item_scraped_host_count/www.cbrekorea.com': 2,
 'atp/item_scraped_host_count/www.cbrevietnam.com': 3,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 298,
 'downloader/request_bytes': 269520,
 'downloader/request_count': 460,
 'downloader/request_method_count/GET': 460,
 'downloader/response_bytes': 74992856,
 'downloader/response_count': 460,
 'downloader/response_status_count/200': 450,
 'downloader/response_status_count/404': 10,
 'dupefilter/filtered': 259,
 'elapsed_time_seconds': 405.243542,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 26, 13, 43, 26, 720571, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 7,
 'httperror/response_ignored_status_count/404': 7,
 'item_dropped_count': 68,
 'item_dropped_reasons_count/DropItem': 68,
 'item_scraped_count': 298,
 'items_per_minute': None,
 'log_count/DEBUG': 26325,
 'log_count/INFO': 27,
 'log_count/WARNING': 83,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 460,
 'playwright/page_count/closed': 460,
 'playwright/page_count/max_concurrent': 16,
 'playwright/request_count': 12371,
 'playwright/request_count/aborted': 11753,
 'playwright/request_count/method/GET': 12370,
 'playwright/request_count/method/POST': 1,
 'playwright/request_count/navigation': 610,
 'playwright/request_count/resource_type/document': 610,
 'playwright/request_count/resource_type/fetch': 6,
 'playwright/request_count/resource_type/font': 23,
 'playwright/request_count/resource_type/image': 2674,
 'playwright/request_count/resource_type/other': 1,
 'playwright/request_count/resource_type/script': 6880,
 'playwright/request_count/resource_type/stylesheet': 2176,
 'playwright/request_count/resource_type/xhr': 1,
 'playwright/response_count': 610,
 'playwright/response_count/method/GET': 610,
 'playwright/response_count/resource_type/document': 610,
 'request_depth_max': 2,
 'response_received_count': 460,
 'responses_per_minute': None,
 'robotstxt/request_count': 63,
 'robotstxt/response_count': 63,
 'robotstxt/response_status_count/200': 60,
 'robotstxt/response_status_count/404': 3,
 'scheduler/dequeued': 397,
 'scheduler/dequeued/memory': 397,
 'scheduler/enqueued': 397,
 'scheduler/enqueued/memory': 397,
 'start_time': datetime.datetime(2025, 6, 26, 13, 36, 41, 477029, tzinfo=datetime.timezone.utc)}
```