### PR TITLE
[Coto AR] Fix Spider

### DIFF
--- a/locations/spiders/coto_ar.py
+++ b/locations/spiders/coto_ar.py
@@ -1,33 +1,19 @@
 import scrapy
 
-from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 
 class CotoARSpider(scrapy.Spider):
     name = "coto_ar"
     item_attributes = {"brand": "Coto", "brand_wikidata": "Q5175411"}
-    start_urls = ["http://www.coto.com.ar/mapassucursales/Sucursales/ListadoSucursalesPorDistancia.json.aspx"]
+    start_urls = ["https://www.coto.com.ar/sucursales/index.asp"]
 
     def parse(self, response, **kwargs):
-        results = response.json()
-        for data in results["results"]:
-            opening_hours = OpeningHours()
-            for days, field in [(DAYS[0:4], "hor_lu_a_ju"), (["Fr"], "hor_vi"), (["Sa"], "hor_sa"), (["Su"], "hor_do")]:
-                if times := data.get(field):
-                    if times == "Cerrado":
-                        continue
-                    times_split = times.split(" a ")
-                    if len(times_split) == 2:
-                        opening_hours.add_days_range(days, times_split[0], times_split[1])
-
-            yield Feature(
-                ref=data["id_suc"],
-                lat=data["latitud"],
-                lon=data["longitud"],
-                name="Coto " + data["desc_suc"],
-                country="AR",
-                phone=data["telefono"],
-                addr_full=data["direccion"],
-                opening_hours=opening_hours,
-            )
+        for store in response.xpath("//tbody/tr"):
+            item = Feature()
+            item["name"] = self.item_attributes["brand"]
+            item["branch"] = store.xpath('.//*[@data-label="Barrio"]/text()').get()
+            item["street_address"] = store.xpath('.//*[@data-label="Direccion"]/text()').get()
+            item["phone"] = store.xpath('.//*[@data-label="Telefono"]/text()').get()
+            item["ref"] = store.xpath('.//*[@data-label="Suc"]/text()').get()
+            yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Coto': 122,
 'atp/brand_wikidata/Q5175411': 122,
 'atp/category/shop/supermarket': 122,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/street_address': 22,
 'atp/country/AR': 122,
 'atp/field/city/missing': 122,
 'atp/field/country/from_spider_name': 122,
 'atp/field/email/missing': 122,
 'atp/field/image/missing': 122,
 'atp/field/lat/missing': 122,
 'atp/field/lon/missing': 122,
 'atp/field/opening_hours/missing': 122,
 'atp/field/operator/missing': 122,
 'atp/field/operator_wikidata/missing': 122,
 'atp/field/phone/invalid': 116,
 'atp/field/postcode/missing': 122,
 'atp/field/state/missing': 122,
 'atp/field/twitter/missing': 122,
 'atp/field/website/missing': 122,
 'atp/item_scraped_host_count/www.coto.com.ar': 122,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 122,
 'downloader/request_bytes': 676,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 99788,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.153449,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 27, 6, 18, 14, 174442, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 122,
 'items_per_minute': None,
 'log_count/DEBUG': 135,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 6, 27, 6, 18, 9, 20993, tzinfo=datetime.timezone.utc)}
```