### PR TITLE
[Citgo] Fix spider

### DIFF
--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -19,6 +19,7 @@ class CitgoSpider(SitemapSpider, StructuredDataSpider):
         (r"/station-locator/locations/(\d+)", "parse_sd"),
     ]
     user_agent = BROWSER_DEFAULT
+    drop_attributes = {"facebook", "twitter"}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         if opening_hours := ld_data.get("openingHours"):

--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -6,6 +6,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class CitgoSpider(SitemapSpider, StructuredDataSpider):
@@ -16,6 +17,7 @@ class CitgoSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"/station-locator/locations/(\d+)", "parse_sd"),
     ]
+    user_agent = BROWSER_DEFAULT
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
         apply_category(Categories.FUEL_STATION, item)

--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -1,3 +1,4 @@
+import re
 from typing import Iterable
 
 from scrapy.http import Response
@@ -18,6 +19,10 @@ class CitgoSpider(SitemapSpider, StructuredDataSpider):
         (r"/station-locator/locations/(\d+)", "parse_sd"),
     ]
     user_agent = BROWSER_DEFAULT
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        if opening_hours := ld_data.get("openingHours"):
+            ld_data["openingHours"] = re.sub(r"24:00[-\s]+24:00", "00:00-23:59", opening_hours)
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item.pop("name")

--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -1,83 +1,22 @@
-import json
-import re
+from typing import Iterable
 
-import scrapy
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
 from locations.items import Feature
-
-SERVICE_VALUES = {"Yes": True, "No": False, "NR": None}
-TIME_PATTERN = re.compile(r"\d{2}:\d{2}")
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CitgoSpider(scrapy.Spider):
+class CitgoSpider(SitemapSpider, StructuredDataSpider):
     name = "citgo"
     item_attributes = {"brand": "Citgo", "brand_wikidata": "Q2974437"}
     allowed_domains = ["citgo.com"]
+    sitemap_urls = ["https://www.citgo.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"/station-locator/locations/(\d+)", "parse_sd"),
+    ]
 
-    start_urls = ["https://citgo.com/locator/store-locators/store-locator"]
-
-    def parse(self, response):
-        if response.request.method == "GET":
-            # We first need to fetch the page normally and extract some required tokens from the form
-            yield scrapy.FormRequest(
-                self.start_urls[0],
-                method="POST",
-                formdata={
-                    "__CMSCsrfToken": response.css("#__CMSCsrfToken::attr(value)").get(),
-                    "__VIEWSTATE": response.css("#__VIEWSTATE::attr(value)").get(),
-                    "__CALLBACKID": "p$lt$WebPartZone3$PageContent$pageplaceholder$p$lt$WebPartZone3$Widgets$StoreLocator",
-                    "__CALLBACKPARAM": "66952|10000",
-                },
-            )
-        else:
-            # The first character of the response is `s`; after that it's JSON
-            result = json.loads(response.text[1:])
-
-            for location in result["Locations"]:
-                opening_hours = OpeningHours()
-                services = location["services"]
-
-                for hours_key in ["sun", "mon", "tues", "wed", "thurs", "fri", "sat"]:
-                    open_time = location[f"hrs{hours_key}start"]
-                    close_time = location[f"hrs{hours_key}start"]
-
-                    if not (TIME_PATTERN.match(open_time) and TIME_PATTERN.match(close_time)):
-                        continue
-
-                    if int(open_time[0:2]) >= 24:
-                        open_time = f"{(int(open_time[0:2]) - 24):02d}{open_time[2:]}"
-
-                    if int(close_time[0:2]) >= 24:
-                        close_time = f"{(int(close_time[0:2]) - 24):02d}{close_time[2:]}"
-
-                    opening_hours.add_range(
-                        day=hours_key[:2].capitalize(),
-                        open_time=open_time,
-                        close_time=close_time,
-                        time_format="%H:%M",
-                    )
-
-                item = Feature(
-                    ref=location["number"],
-                    lon=location["longitude"],
-                    lat=location["latitude"],
-                    name=location["name"],
-                    addr_full=location["address"],
-                    city=location["city"],
-                    state=location["state"],
-                    postcode=location["zip"],
-                    country=location["country"],
-                    phone=location["phone"],
-                    opening_hours=opening_hours,
-                    extras={
-                        "atm": SERVICE_VALUES.get(services["atm"]),
-                        "car_wash": SERVICE_VALUES.get(services["carwash"]),
-                        "fuel:diesel": SERVICE_VALUES.get(services["diesel"]),
-                        "hgv": SERVICE_VALUES.get(services["truckstop"]),
-                        "wheelchair": SERVICE_VALUES.get(services["handicapaccess"]),
-                    },
-                )
-                apply_category(Categories.FUEL_STATION, item)
-                yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.FUEL_STATION, item)
+        yield item

--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -20,5 +20,6 @@ class CitgoSpider(SitemapSpider, StructuredDataSpider):
     user_agent = BROWSER_DEFAULT
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item.pop("name")
         apply_category(Categories.FUEL_STATION, item)
         yield item

--- a/locations/spiders/citgo.py
+++ b/locations/spiders/citgo.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
+from locations.categories import Access, Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
@@ -27,4 +27,14 @@ class CitgoSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item.pop("name")
         apply_category(Categories.FUEL_STATION, item)
+
+        services = [service.strip() for service in response.xpath('//li[@class="service__item"]/text()').getall()]
+
+        # apply_yes_no(Fuel.OCTANE_87, item, "TOP TIER™ CITGO TriCLEAN® Gasoline" in services)
+        apply_yes_no(Fuel.DIESEL, item, "Diesel" in services)
+        apply_yes_no(Fuel.KEROSENE, item, "Kerosene" in services)
+        apply_yes_no(Fuel.ETHANOL_FREE, item, "Ethanol Free" in services)
+        apply_yes_no(Fuel.E85, item, "E85" in services)
+        apply_yes_no(Access.HGV, item, "Truck Stop" in services)
+        apply_yes_no(Extras.CAR_WASH, item, "Car Wash" in services)
         yield item


### PR DESCRIPTION
`API` is also there but requires `cookies` which gets expire, so doesn't look feasible to utilize. Hence ignored and used `Structured Data` with `Sitemap` to fix the spider.

```python
{'atp/brand/Citgo': 4249,
 'atp/brand_wikidata/Q2974437': 4249,
 'atp/category/amenity/fuel': 4249,
 'atp/clean_strings/street_address': 1,
 'atp/country/US': 4249,
 'atp/field/branch/missing': 4249,
 'atp/field/country/from_reverse_geocoding': 20,
 'atp/field/email/missing': 4249,
 'atp/field/image/missing': 4249,
 'atp/field/opening_hours/missing': 23,
 'atp/field/operator/missing': 4249,
 'atp/field/operator_wikidata/missing': 4249,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 49,
 'atp/field/twitter/missing': 4249,
 'atp/item_scraped_host_count/www.citgo.com': 4249,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 4249,
 'downloader/request_bytes': 4662452,
 'downloader/request_count': 4251,
 'downloader/request_method_count/GET': 4251,
 'downloader/response_bytes': 203791725,
 'downloader/response_count': 4251,
 'downloader/response_status_count/200': 4251,
 'elapsed_time_seconds': 45.934955,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 27, 13, 13, 16, 733628, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 4251,
 'item_scraped_count': 4249,
 'items_per_minute': None,
 'log_count/DEBUG': 8512,
 'log_count/INFO': 10,
 'log_count/WARNING': 10,
 'memusage/max': 278155264,
 'memusage/startup': 278155264,
 'request_depth_max': 1,
 'response_received_count': 4251,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4250,
 'scheduler/dequeued/memory': 4250,
 'scheduler/enqueued': 4250,
 'scheduler/enqueued/memory': 4250,
 'start_time': datetime.datetime(2025, 6, 27, 13, 12, 30, 798673, tzinfo=datetime.timezone.utc)}
```