### PR TITLE
[Citiwood ZA] Fix spider

### DIFF
--- a/locations/spiders/citiwood_za.py
+++ b/locations/spiders/citiwood_za.py
@@ -21,6 +21,7 @@ class CitiwoodZASpider(SitemapSpider):
     def parse(self, response: Response) -> Iterable[Feature]:
         item = Feature()
         item["ref"] = response.url.split("citiwood-")[-1].strip("/")
+        item["branch"] = item["ref"].title()
         item["website"] = response.url
         item["addr_full"] = clean_address(response.xpath('//*[contains(@class, "address_physical")]//p/text()').get(""))
         apply_category(Categories.SHOP_TRADE, item)

--- a/locations/spiders/citiwood_za.py
+++ b/locations/spiders/citiwood_za.py
@@ -27,5 +27,7 @@ class CitiwoodZASpider(SitemapSpider):
         item["phone"] = response.xpath(
             '//*[contains(@class, "contact_phone_office")]//a[contains(@href,"tel:")]/@href'
         ).get()
+        email = response.xpath('//meta[@property="og:description"]/@content').get("").split("Email:")[-1].strip()
+        item["email"] = email if "@" in email else None
         apply_category(Categories.SHOP_TRADE, item)
         yield item

--- a/locations/spiders/citiwood_za.py
+++ b/locations/spiders/citiwood_za.py
@@ -24,5 +24,8 @@ class CitiwoodZASpider(SitemapSpider):
         item["branch"] = item["ref"].title()
         item["website"] = response.url
         item["addr_full"] = clean_address(response.xpath('//*[contains(@class, "address_physical")]//p/text()').get(""))
+        item["phone"] = response.xpath(
+            '//*[contains(@class, "contact_phone_office")]//a[contains(@href,"tel:")]/@href'
+        ).get()
         apply_category(Categories.SHOP_TRADE, item)
         yield item

--- a/locations/spiders/citiwood_za.py
+++ b/locations/spiders/citiwood_za.py
@@ -1,38 +1,27 @@
-from html import unescape
-from json import loads
 from typing import Iterable
 
-from scrapy import Selector, Spider
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.pipelines.address_clean_up import clean_address
 
 
-class CitiwoodZASpider(Spider):
+class CitiwoodZASpider(SitemapSpider):
     name = "citiwood_za"
     item_attributes = {
         "brand": "Citiwood",
         "brand_wikidata": "Q130407139",
     }
     allowed_domains = ["citiwood.co.za"]
-    start_urls = ["https://citiwood.co.za/contacts/"]
-    no_refs = True
+    sitemap_urls = ["https://citiwood.co.za/store-locations-sitemap.xml"]
+    sitemap_rules = [(r"/store-location/citiwood-[-\w+]", "parse")]
 
     def parse(self, response: Response) -> Iterable[Feature]:
-        locations = loads(unescape(response.xpath('//div[@class="mdp-gmaper-elementor-box"]/@data-markers').get()))
-        for location in locations:
-            properties = {
-                "branch": location["pin_item_title"].removeprefix("Citiwood "),
-                "lat": location["pin_latitude"],
-                "lon": location["pin_longitude"],
-                "addr_full": merge_address_lines(
-                    filter(
-                        lambda x: x not in ["Get Directions", "Address"],
-                        Selector(text=location["pin_item_description"]).xpath("//text()").getall(),
-                    )
-                ).strip(" :"),
-            }
-            apply_category(Categories.SHOP_TRADE, properties)
-            yield Feature(**properties)
+        item = Feature()
+        item["ref"] = response.url.split("citiwood-")[-1].strip("/")
+        item["website"] = response.url
+        item["addr_full"] = clean_address(response.xpath('//*[contains(@class, "address_physical")]//p/text()').get(""))
+        apply_category(Categories.SHOP_TRADE, item)
+        yield item


### PR DESCRIPTION
`coordinates` are not available.
```python
{'atp/brand/Citiwood': 3,
 'atp/brand_wikidata/Q130407139': 3,
 'atp/category/shop/trade': 3,
 'atp/cdn/cloudflare/response_count': 5,
 'atp/cdn/cloudflare/response_status_count/200': 5,
 'atp/country/ZA': 3,
 'atp/field/city/missing': 3,
 'atp/field/country/from_spider_name': 3,
 'atp/field/image/missing': 3,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/name/missing': 3,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 3,
 'atp/field/operator_wikidata/missing': 3,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 3,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 3,
 'atp/item_scraped_host_count/citiwood.co.za': 3,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 3,
 'downloader/request_bytes': 1920,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 76839,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 5,
 'elapsed_time_seconds': 8.895651,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 27, 14, 54, 36, 297374, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 373262,
 'httpcompression/response_count': 5,
 'item_scraped_count': 3,
 'items_per_minute': None,
 'log_count/DEBUG': 19,
 'log_count/INFO': 9,
 'memusage/max': 278073344,
 'memusage/startup': 278073344,
 'request_depth_max': 1,
 'response_received_count': 5,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2025, 6, 27, 14, 54, 27, 401723, tzinfo=datetime.timezone.utc)}
```