### PR TITLE
[FDSN] Add spider for federated network of seismic stations (89k stations)

### DIFF
--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -58,7 +58,7 @@ class FdsnSeismicStationsSpider(Spider):
                 }
                 station_active = True
                 if end_date_string := station.xpath("./@endDate").get():
-                    end_date = datetime.fromisoformat(f"{end_date_string}+00:00")
+                    end_date = datetime.fromisoformat(end_date_string).replace(tzinfo=UTC)
                     if datetime.now(UTC) > end_date:
                         # Station has an end date in the past and therefore has
                         # been shutdown/removed. Extract the station as a

--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -55,7 +55,7 @@ class FdsnSeismicStationsSpider(Spider):
                     # continues to be a feature of interest.
                     properties["extras"]["removed:man_made"] = "monitoring_station"
                     properties["extras"]["removed:monitoring_station"] = "seismic_activity"
-                    properties["extras"]["end_date"] = station.xpath("./@endDate").get().split("T", 1)[0]
+                    properties["extras"]["end_date"] = end_date.split("T", 1)[0]
                 else:
                     # Station has no end date and therefore is active and
                     # continues to exist.

--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -26,33 +26,33 @@ class FdsnSeismicStationsSpider(Spider):
     def parse_station_list(self, response: Response) -> Iterable[Feature]:
         document = Selector(response=response, type="xml")
         document.register_namespace("s", "http://www.fdsn.org/xml/station/1")
-        for network in document.xpath('//s:Network'):
-            for station in network.xpath('./s:Station'):
-                if station.xpath('./@endDate').get():
+        for network in document.xpath("//s:Network"):
+            for station in network.xpath("./s:Station"):
+                if station.xpath("./@endDate").get():
                     # Station has an end date and therefore no longer exists.
                     # Ignore historical stations.
                     continue
                 properties = {
-                    "ref": network.xpath('./@code').get() + "-" + station.xpath('./@code').get(),
-                    "name": station.xpath('./s:Site/s:Name/text()').get(),
-                    "lat": station.xpath('./s:Latitude/text()').get(),
-                    "lon": station.xpath('./s:Longitude/text()').get(),
+                    "ref": network.xpath("./@code").get() + "-" + station.xpath("./@code").get(),
+                    "name": station.xpath("./s:Site/s:Name/text()").get(),
+                    "lat": station.xpath("./s:Latitude/text()").get(),
+                    "lon": station.xpath("./s:Longitude/text()").get(),
                 }
-                if end_date := station.xpath('./@endDate').get():
+                if end_date := station.xpath("./@endDate").get():
                     # Station has an end date and therefore has been shutdown/
                     # removed. Extract the point as a historical feature as
                     # there is historical data at this location which
                     # continues to be a feature of interest.
                     properties["extras"]["removed:man_made"] = "monitoring_station"
                     properties["extras"]["removed:monitoring_station"] = "seismic_activity"
-                    properties["extras"]["end_date"] = station.xpath('./@endDate').get()
+                    properties["extras"]["end_date"] = station.xpath("./@endDate").get()
                 else:
                     # Station has no end date and therefore is active and
                     # continues to exist.
                     apply_category(Categories.MONITORING_STATION, properties)
                     apply_yes_no(MonitoringTypes.SEISMIC_ACTIVITY, properties, True)
-                properties["extras"]["ref:fdsn:network"] = network.xpath('./@code').get()
-                properties["extras"]["ref:fdsn:station"] = station.xpath('./@code').get()
-                properties["extras"]["ele"] = station.xpath('./s:Elevation/text()').get()
-                properties["extras"]["start_date"] = station.xpath('./@startDate').get()
+                properties["extras"]["ref:fdsn:network"] = network.xpath("./@code").get()
+                properties["extras"]["ref:fdsn:station"] = station.xpath("./@code").get()
+                properties["extras"]["ele"] = station.xpath("./s:Elevation/text()").get()
+                properties["extras"]["start_date"] = station.xpath("./@startDate").get()
                 yield Feature(**properties)

--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -1,0 +1,58 @@
+from typing import Iterable
+from urllib.parse import urljoin
+
+from scrapy import Selector, Spider
+from scrapy.http import JsonRequest, Request, Response
+
+from locations.categories import Categories, MonitoringTypes, apply_category, apply_yes_no
+from locations.items import Feature
+
+
+class FdsnSeismicStationsSpider(Spider):
+    name = "fdsn_seismic_stations"
+    start_urls = ["https://www.fdsn.org/ws/datacenters/1/query"]
+    custom_settings = {"RETRY_ENABLED": False}
+
+    def start_requests(self) -> Iterable[JsonRequest]:
+        yield JsonRequest(url=self.start_urls[0], callback=self.parse_datacenters)
+
+    def parse_datacenters(self, response: Response) -> Iterable[JsonRequest]:
+        for datacenter in response.json()["datacenters"]:
+            for repository in datacenter["repositories"]:
+                for service in repository["services"]:
+                    if service["name"] == "fdsnws-station-1":
+                        yield Request(url=urljoin(service["url"], "query"), callback=self.parse_station_list)
+
+    def parse_station_list(self, response: Response) -> Iterable[Feature]:
+        document = Selector(response=response, type="xml")
+        document.register_namespace("s", "http://www.fdsn.org/xml/station/1")
+        for network in document.xpath('//s:Network'):
+            for station in network.xpath('./s:Station'):
+                if station.xpath('./@endDate').get():
+                    # Station has an end date and therefore no longer exists.
+                    # Ignore historical stations.
+                    continue
+                properties = {
+                    "ref": network.xpath('./@code').get() + "-" + station.xpath('./@code').get(),
+                    "name": station.xpath('./s:Site/s:Name/text()').get(),
+                    "lat": station.xpath('./s:Latitude/text()').get(),
+                    "lon": station.xpath('./s:Longitude/text()').get(),
+                }
+                if end_date := station.xpath('./@endDate').get():
+                    # Station has an end date and therefore has been shutdown/
+                    # removed. Extract the point as a historical feature as
+                    # there is historical data at this location which
+                    # continues to be a feature of interest.
+                    properties["extras"]["removed:man_made"] = "monitoring_station"
+                    properties["extras"]["removed:monitoring_station"] = "seismic_activity"
+                    properties["extras"]["end_date"] = station.xpath('./@endDate').get()
+                else:
+                    # Station has no end date and therefore is active and
+                    # continues to exist.
+                    apply_category(Categories.MONITORING_STATION, properties)
+                    apply_yes_no(MonitoringTypes.SEISMIC_ACTIVITY, properties, True)
+                properties["extras"]["ref:fdsn:network"] = network.xpath('./@code').get()
+                properties["extras"]["ref:fdsn:station"] = station.xpath('./@code').get()
+                properties["extras"]["ele"] = station.xpath('./s:Elevation/text()').get()
+                properties["extras"]["start_date"] = station.xpath('./@startDate').get()
+                yield Feature(**properties)

--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from typing import Iterable
 
 from scrapy import Selector, Spider
@@ -17,7 +17,12 @@ class FdsnSeismicStationsSpider(Spider):
     # The largest "datacenter" is service.iris.edu which takes a few minutes
     # to prepare and download a full list of stations. The total size of the
     # XML document returned is over 32MiB but less then 64MiB.
-    custom_settings = {"RETRY_ENABLED": False, "DOWNLOAD_TIMEOUT": 360, "DOWNLOAD_WARNSIZE": 67108864, "ROBOTSTXT_OBEY": False}
+    custom_settings = {
+        "RETRY_ENABLED": False,
+        "DOWNLOAD_TIMEOUT": 360,
+        "DOWNLOAD_WARNSIZE": 67108864,
+        "ROBOTSTXT_OBEY": False,
+    }
 
     def start_requests(self) -> Iterable[JsonRequest]:
         yield JsonRequest(url=self.start_urls[0], callback=self.parse_datacenters)

--- a/locations/spiders/infrastructure/fdsn_seismic_stations.py
+++ b/locations/spiders/infrastructure/fdsn_seismic_stations.py
@@ -1,5 +1,4 @@
 from typing import Iterable
-from urllib.parse import urljoin
 
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest, Request, Response
@@ -11,7 +10,13 @@ from locations.items import Feature
 class FdsnSeismicStationsSpider(Spider):
     name = "fdsn_seismic_stations"
     start_urls = ["https://www.fdsn.org/ws/datacenters/1/query"]
-    custom_settings = {"RETRY_ENABLED": False}
+    # Some FDSN registered "datacenters" (respositories) will result in DNS
+    # timeouts or other failures. Don't retry failed requests because it's
+    # probably not going to help.
+    # The largest "datacenter" is service.iris.edu which takes a few minutes
+    # to prepare and download a full list of stations. The total size of the
+    # XML document returned is over 32MiB but less then 64MiB.
+    custom_settings = {"RETRY_ENABLED": False, "DOWNLOAD_TIMEOUT": 180, "DOWNLOAD_WARNSIZE": 67108864}
 
     def start_requests(self) -> Iterable[JsonRequest]:
         yield JsonRequest(url=self.start_urls[0], callback=self.parse_datacenters)
@@ -21,7 +26,12 @@ class FdsnSeismicStationsSpider(Spider):
             for repository in datacenter["repositories"]:
                 for service in repository["services"]:
                     if service["name"] == "fdsnws-station-1":
-                        yield Request(url=urljoin(service["url"], "query"), callback=self.parse_station_list)
+                        station_list_url = service["url"]
+                        if station_list_url.endswith("/"):
+                            station_list_url = f"{station_list_url}query"
+                        else:
+                            station_list_url = f"{station_list_url}/query"
+                        yield Request(url=station_list_url, callback=self.parse_station_list)
 
     def parse_station_list(self, response: Response) -> Iterable[Feature]:
         document = Selector(response=response, type="xml")
@@ -45,7 +55,7 @@ class FdsnSeismicStationsSpider(Spider):
                     # continues to be a feature of interest.
                     properties["extras"]["removed:man_made"] = "monitoring_station"
                     properties["extras"]["removed:monitoring_station"] = "seismic_activity"
-                    properties["extras"]["end_date"] = station.xpath("./@endDate").get()
+                    properties["extras"]["end_date"] = station.xpath("./@endDate").get().split("T", 1)[0]
                 else:
                     # Station has no end date and therefore is active and
                     # continues to exist.
@@ -53,6 +63,8 @@ class FdsnSeismicStationsSpider(Spider):
                     apply_yes_no(MonitoringTypes.SEISMIC_ACTIVITY, properties, True)
                 properties["extras"]["ref:fdsn:network"] = network.xpath("./@code").get()
                 properties["extras"]["ref:fdsn:station"] = station.xpath("./@code").get()
-                properties["extras"]["ele"] = station.xpath("./s:Elevation/text()").get()
-                properties["extras"]["start_date"] = station.xpath("./@startDate").get()
+                if elevation_m := station.xpath("./s:Elevation/text()").get():
+                    properties["extras"]["ele"] = elevation_m
+                if start_date := station.xpath("./@startDate").get():
+                    properties["extras"]["start_date"] = start_date.split("T", 1)[0]
                 yield Feature(**properties)


### PR DESCRIPTION
Note: FDSN contains a list of "datacenters" which are repositories that different country/organisation seismic networks report to. This spider crawls each datacenter API endpoint to list stations which are connected to the repository.

Note: historical seismic stations are also extracted as features as there was once data recorded at a location, and this is a useful geographic feature to be aware of for possible users of ATP. For example, someone scrolling around a map near a dormant volcano might notice that 10 years ago there was a monitoring station present, and archival records exist, and these records are interesting from a historical perspective of understanding a volcanic eruption that occurred 10 years ago.