### PR TITLE
[Dominos Pizza FR] Fix Spider

### DIFF
--- a/locations/spiders/dominos_pizza_fr.py
+++ b/locations/spiders/dominos_pizza_fr.py
@@ -13,7 +13,7 @@ class DominosPizzaFRSpider(SitemapSpider):
     sitemap_urls = ["https://www.dominos.fr/sitemap.aspx"]
     sitemap_rules = [
         (
-            r"https:\/\/www\.dominos\.fr\/magasin\/([-\w.]+)_(unknown|[\d]+)$",
+            r"https:\/\/www\.dominos\.fr\/magasin\/\/?([-\w.]+)_(unknown|[\d]+)$",
             "parse_store",
         )
     ]

--- a/locations/spiders/dominos_pizza_fr.py
+++ b/locations/spiders/dominos_pizza_fr.py
@@ -1,5 +1,9 @@
+from typing import Any
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 from locations.user_agents import BROWSER_DEFAULT
@@ -11,21 +15,19 @@ class DominosPizzaFRSpider(SitemapSpider):
     allowed_domains = ["dominos.fr"]
     user_agent = BROWSER_DEFAULT
     sitemap_urls = ["https://www.dominos.fr/sitemap.aspx"]
-    sitemap_rules = [
-        (
-            r"https:\/\/www\.dominos\.fr\/magasin\/\/?([-\w.]+)_(unknown|[\d]+)$",
-            "parse_store",
-        )
-    ]
+    sitemap_rules = [(r"https:\/\/www\.dominos\.fr\/magasin\/\/?([-\w.]+)_(unknown|[\d]+)$", "parse")]
 
-    def parse_store(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         properties = {
             "ref": response.url,
-            "name": response.xpath('//h2[@class="storetitle"]/text()').extract_first(),
-            "addr_full": clean_address(response.xpath('//a[@id="open-map-address"]/text()').extract()),
+            "branch": response.xpath('//h1[@class="storetitle"]/text()').get().removeprefix("Domino's Pizza "),
+            "addr_full": clean_address(response.xpath('//a[@id="open-map-address"]/text()').get()),
             "lat": response.xpath('//input[@id="store-lat"]/@value').get().replace(",", "."),
             "lon": response.xpath('//input[@id="store-lon"]/@value').get().replace(",", "."),
             "phone": response.xpath('//div[@class="store-phone"]/a/text()').get(),
             "website": response.url,
         }
+
+        apply_category(Categories.FAST_FOOD, properties)
+
         yield Feature(**properties)


### PR DESCRIPTION
**_Fixes : updated sitemap rules to fix spider_**

```python
{"atp/brand/Domino's": 435,
 'atp/brand_wikidata/Q839466': 435,
 'atp/category/amenity/fast_food': 435,
 'atp/country/FR': 435,
 'atp/field/branch/missing': 435,
 'atp/field/city/missing': 435,
 'atp/field/country/from_spider_name': 435,
 'atp/field/email/missing': 435,
 'atp/field/image/missing': 435,
 'atp/field/opening_hours/missing': 435,
 'atp/field/operator/missing': 435,
 'atp/field/operator_wikidata/missing': 435,
 'atp/field/postcode/missing': 435,
 'atp/field/state/missing': 435,
 'atp/field/street_address/missing': 435,
 'atp/field/twitter/missing': 435,
 'atp/item_scraped_host_count/www.dominos.fr': 435,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 435,
 'downloader/request_bytes': 419982,
 'downloader/request_count': 440,
 'downloader/request_method_count/GET': 440,
 'downloader/response_bytes': 6942496,
 'downloader/response_count': 440,
 'downloader/response_status_count/200': 437,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 544.267382,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 6, 30, 11, 25, 40, 237989, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 23653541,
 'httpcompression/response_count': 437,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 435,
 'items_per_minute': None,
 'log_count/DEBUG': 888,
 'log_count/INFO': 19,
 'request_depth_max': 1,
 'response_received_count': 438,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 439,
 'scheduler/dequeued/memory': 439,
 'scheduler/enqueued': 439,
 'scheduler/enqueued/memory': 439,
 'start_time': datetime.datetime(2025, 6, 30, 11, 16, 35, 970607, tzinfo=datetime.timezone.utc)}

```