### PR TITLE
Chico's: Remove Off The Rack from start_urls; use name as brand key

### DIFF
--- a/locations/spiders/chicos.py
+++ b/locations/spiders/chicos.py
@@ -9,14 +9,13 @@ from locations.structured_data_spider import StructuredDataSpider
 class ChicosSpider(CrawlSpider, StructuredDataSpider):
     name = "chicos"
     BRANDS = {
-        "chicos": ("Chico's", "Q5096393"),
-        "chicosofftherack": ("Chico's Off The Rack", "Q5096393"),
-        "whitehouseblackmarket": ("White House Black Market", "Q7994858"),
-        "soma": ("Soma", "Q69882213"),
+        "Chico's": "Q5096393",
+        "Chico's Off The Rack": "Q5096393",
+        "White House Black Market": "Q7994858",
+        "Soma": "Q69882213",
     }
     start_urls = [
         "https://www.chicos.com/locations/locations-list/",
-        "https://www.chicosofftherack.com/locations/locations-list/",
         "https://www.soma.com/locations/locations-list/",
         "https://www.whitehouseblackmarket.com/locations/locations-list/",
     ]
@@ -29,11 +28,14 @@ class ChicosSpider(CrawlSpider, StructuredDataSpider):
         ),
     ]
     time_format = "%H:%M:%S"
-    drop_attributes = {"email"}
+    search_for_email = False
+    search_for_facebook = False
+    search_for_twitter = False
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        brand = response.url.split(".")[1]
-        if brand_details := self.BRANDS.get(brand):
-            item["brand"], item["brand_wikidata"] = brand_details
+        item["brand"] = item["name"]
+        item["brand_wikidata"] = self.BRANDS.get(item["name"])
+        full_name = response.xpath("//h1/text()").get()
+        item["branch"] = fullname[full_name.casefold().find(" at ") + 4 :]
         apply_category(Categories.SHOP_CLOTHES, item)
         yield item

--- a/locations/spiders/chicos.py
+++ b/locations/spiders/chicos.py
@@ -9,10 +9,10 @@ from locations.structured_data_spider import StructuredDataSpider
 class ChicosSpider(CrawlSpider, StructuredDataSpider):
     name = "chicos"
     BRANDS = {
-        "Chico's": "Q5096393",
-        "Chico's Off The Rack": "Q5096393",
-        "White House Black Market": "Q7994858",
-        "Soma": "Q69882213",
+        "chico's": ("Chico's", "Q5096393"),
+        "chico's off the rack": ("Chico's Off The Rack", "Q5096393"),
+        "white house black market": ("White House Black Market", "Q7994858"),
+        "soma": ("Soma", "Q69882213"),
     }
     start_urls = [
         "https://www.chicos.com/locations/locations-list/",
@@ -33,9 +33,9 @@ class ChicosSpider(CrawlSpider, StructuredDataSpider):
     search_for_twitter = False
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["brand"] = item["name"]
-        item["brand_wikidata"] = self.BRANDS.get(item["name"])
+        if brand_tags := self.BRANDS.get(item["name"].casefold()):
+            item["brand"], item["brand_wikidata"] = brand_tags
         full_name = response.xpath("//h1/text()").get()
-        item["branch"] = fullname[full_name.casefold().find(" at ") + 4 :]
+        item["branch"] = full_name[full_name.casefold().find(" at ") + 4 :]
         apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
This only fixes an error that wasn't affecting scraping. chicosofftherack.com doesn't exist any more, instead all OTR locations are on the main chicos.com. That means that we can't use the website domain to get the specific brand, but the brand is in the structured data, so use that.

Also get the branch name.