### PR TITLE
[Spar AL] Try with proxy to fix spider

### DIFF
--- a/locations/spiders/spar_al.py
+++ b/locations/spiders/spar_al.py
@@ -12,6 +12,7 @@ class SparALSpider(Spider):
     item_attributes = SPAR_SHARED_ATTRIBUTES
     start_urls = ["https://www.spar.al/index.php/en/spar-map"]
     no_refs = True
+    requires_proxy = True
 
     def parse(self, response: Response) -> Iterable[Feature]:
         for location in response.xpath('//select[@id="toPMAddressPlgPM1"]/option'):


### PR DESCRIPTION
Works fine from `IN`. 

```python
{'atp/brand/Spar': 75,
 'atp/brand_wikidata/Q610492': 75,
 'atp/category/shop/supermarket': 75,
 'atp/clean_strings/lon': 1,
 'atp/country/AL': 75,
 'atp/field/branch/missing': 75,
 'atp/field/city/missing': 75,
 'atp/field/country/from_spider_name': 75,
 'atp/field/email/missing': 75,
 'atp/field/image/missing': 75,
 'atp/field/opening_hours/missing': 75,
 'atp/field/operator/missing': 75,
 'atp/field/operator_wikidata/missing': 75,
 'atp/field/phone/missing': 75,
 'atp/field/postcode/missing': 75,
 'atp/field/state/missing': 75,
 'atp/field/street_address/missing': 75,
 'atp/field/twitter/missing': 75,
 'atp/field/website/missing': 75,
 'atp/item_scraped_host_count/www.spar.al': 75,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 75,
 'downloader/request_bytes': 669,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 17453,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.893362,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 1, 6, 17, 18, 928285, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 88621,
 'httpcompression/response_count': 2,
 'item_scraped_count': 75,
 'items_per_minute': None,
 'log_count/DEBUG': 88,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 1, 6, 17, 15, 34923, tzinfo=datetime.timezone.utc)}
```