### PR TITLE
[Century 21] Fix Spider

### DIFF
--- a/locations/spiders/century_21.py
+++ b/locations/spiders/century_21.py
@@ -7,13 +7,14 @@ from locations.dict_parser import DictParser
 class Century21Spider(scrapy.Spider):
     name = "century_21"
     item_attributes = {"brand": "Century 21", "brand_wikidata": "Q1054480"}
-    start_urls = ["https://www.century21global.com/en/countries"]
+    start_urls = ["https://www.century21global.com/api/website-builder/location-profile?size=100&page=0&language=en"]
     total_results = {}
 
     def parse(self, response):
         # Taking text rather than slug from url because at the moment at least
         # "Cyprus Northern Territory" points to the wrong url and returns different results
-        for country in response.xpath('//a[contains(@href, "/en/countries/")]/div/span/text()').getall():
+        for data in response.json()["content"]:
+            country = data["searchParameters"]["country"]
             self.logger.debug(f"Starting requests for {country.strip()}")
             yield self.make_request(country.strip(), 0, True)
 


### PR DESCRIPTION
**_Fixes : updated start_urls to fix spider_**

```python
{'atp/brand/Century 21': 13254,
 'atp/brand_wikidata/Q1054480': 13254,
 'atp/category/office/estate_agent': 13254,
 'atp/cdn/cloudflare/response_count': 364,
 'atp/cdn/cloudflare/response_status_count/200': 364,
 'atp/clean_strings/name': 36,
 'atp/clean_strings/postcode': 3,
 'atp/clean_strings/street_address': 1269,
 'atp/country/AL': 50,
 'atp/country/AR': 106,
 'atp/country/AU': 137,
 'atp/country/AW': 1,
 'atp/country/BE': 116,
 'atp/country/BO': 67,
 'atp/country/BZ': 1,
 'atp/country/CA': 395,
 'atp/country/CL': 2,
 'atp/country/CN': 7687,
 'atp/country/CO': 37,
 'atp/country/CR': 24,
 'atp/country/CY': 1,
 'atp/country/DE': 74,
 'atp/country/DO': 4,
 'atp/country/EC': 11,
 'atp/country/ES': 74,
 'atp/country/FR': 933,
 'atp/country/GB': 24,
 'atp/country/GD': 1,
 'atp/country/GP': 1,
 'atp/country/GT': 1,
 'atp/country/GY': 1,
 'atp/country/HN': 1,
 'atp/country/HR': 7,
 'atp/country/IL': 7,
 'atp/country/IT': 25,
 'atp/country/JM': 1,
 'atp/country/JP': 791,
 'atp/country/KH': 18,
 'atp/country/KY': 1,
 'atp/country/LU': 3,
 'atp/country/MN': 28,
 'atp/country/MQ': 1,
 'atp/country/MT': 2,
 'atp/country/MX': 199,
 'atp/country/NI': 1,
 'atp/country/NZ': 8,
 'atp/country/PA': 1,
 'atp/country/PE': 38,
 'atp/country/PT': 182,
 'atp/country/PY': 43,
 'atp/country/QA': 1,
 'atp/country/SI': 14,
 'atp/country/SV': 1,
 'atp/country/SX': 1,
 'atp/country/TC': 1,
 'atp/country/TR': 104,
 'atp/country/TW': 93,
 'atp/country/US': 1718,
 'atp/country/UY': 4,
 'atp/country/VE': 74,
 'atp/country/ZA': 42,
 'atp/country/cyprus northern territory': 1,
 'atp/country/czech republic': 95,
 'atp/duplicate_count': 11,
 'atp/field/branch/missing': 13254,
 'atp/field/city/missing': 234,
 'atp/field/country/invalid': 96,
 'atp/field/email/missing': 13254,
 'atp/field/image/missing': 13254,
 'atp/field/lat/missing': 1941,
 'atp/field/lon/missing': 1941,
 'atp/field/opening_hours/missing': 13254,
 'atp/field/operator/missing': 13254,
 'atp/field/operator_wikidata/missing': 13254,
 'atp/field/phone/missing': 13254,
 'atp/field/postcode/missing': 8436,
 'atp/field/state/from_reverse_geocoding': 4,
 'atp/field/state/missing': 9684,
 'atp/field/street_address/missing': 1320,
 'atp/field/twitter/missing': 13254,
 'atp/item_scraped_host_count/www.century21global.com': 13265,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 13254,
 'downloader/request_bytes': 219046,
 'downloader/request_count': 364,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 362,
 'downloader/response_bytes': 2010291,
 'downloader/response_count': 364,
 'downloader/response_status_count/200': 364,
 'elapsed_time_seconds': 454.167001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 1, 8, 35, 49, 52091, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 13314735,
 'httpcompression/response_count': 364,
 'item_dropped_count': 11,
 'item_dropped_reasons_count/DropItem': 11,
 'item_scraped_count': 13254,
 'items_per_minute': None,
 'log_count/DEBUG': 13700,
 'log_count/ERROR': 96,
 'log_count/INFO': 71,
 'request_depth_max': 155,
 'response_received_count': 364,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 363,
 'scheduler/dequeued/memory': 363,
 'scheduler/enqueued': 363,
 'scheduler/enqueued/memory': 363,
 'start_time': datetime.datetime(2025, 7, 1, 8, 28, 14, 885090, tzinfo=datetime.timezone.utc)}
```