### PR TITLE
[NHS Scotland GB] Fix Spider

### DIFF
--- a/locations/spiders/nhs_scotland_gb.py
+++ b/locations/spiders/nhs_scotland_gb.py
@@ -47,7 +47,6 @@ class NhsScotlandGBSpider(Spider):
         "pharmacies": Categories.PHARMACY,
     }
     download_delay = 0.2
-    requires_proxy = True
 
     def start_requests(self):
         for service in self.services.keys():


### PR DESCRIPTION
**_Fixes : remove proxy flag_**

```python
{'atp/category/amenity/clinic': 69,
 'atp/category/amenity/dentist': 1005,
 'atp/category/amenity/doctors': 1057,
 'atp/category/amenity/hospital': 140,
 'atp/category/amenity/pharmacy': 979,
 'atp/category/multiple': 3250,
 'atp/category/shop/optician': 451,
 'atp/country/GB': 3701,
 'atp/field/branch/missing': 3701,
 'atp/field/brand/missing': 3701,
 'atp/field/brand_wikidata/missing': 3701,
 'atp/field/city/missing': 3701,
 'atp/field/country/from_spider_name': 3701,
 'atp/field/email/missing': 3701,
 'atp/field/image/missing': 3701,
 'atp/field/lat/missing': 38,
 'atp/field/lon/missing': 38,
 'atp/field/opening_hours/missing': 65,
 'atp/field/operator/missing': 3701,
 'atp/field/operator_wikidata/missing': 3701,
 'atp/field/phone/missing': 3701,
 'atp/field/postcode/missing': 17,
 'atp/field/state/missing': 3701,
 'atp/field/street_address/missing': 3701,
 'atp/field/twitter/missing': 3701,
 'atp/field/website/invalid': 3,
 'atp/item_scraped_host_count/www.nhsinform.scot': 3701,
 'atp/lineage': 'S_?',
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 1937688,
 'downloader/request_count': 4614,
 'downloader/request_method_count/GET': 4614,
 'downloader/response_bytes': 228159818,
 'downloader/response_count': 4613,
 'downloader/response_status_count/200': 4612,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 1283.36779,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 1, 9, 31, 18, 881591, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1064109402,
 'httpcompression/response_count': 4612,
 'item_scraped_count': 3701,
 'items_per_minute': None,
 'log_count/DEBUG': 8316,
 'log_count/INFO': 30,
 'log_count/WARNING': 3,
 'request_depth_max': 125,
 'response_received_count': 4613,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 4613,
 'scheduler/dequeued/memory': 4613,
 'scheduler/enqueued': 4613,
 'scheduler/enqueued/memory': 4613,
 'start_time': datetime.datetime(2025, 7, 1, 9, 9, 55, 513801, tzinfo=datetime.timezone.utc)}

```