### PR TITLE
[Blink] Fix low scraped count and add download delay to avoid http 429 error

### DIFF
--- a/locations/spiders/blink.py
+++ b/locations/spiders/blink.py
@@ -28,6 +28,7 @@ class BlinkSpider(Spider):
         "operator_wikidata": "Q62065645",
     }
     handle_httpstatus_list = [404]
+    custom_settings = {"CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 5}
 
     # First request the map, but it only returns lat/lon/ID for each station
     def start_requests(self) -> Iterable[JsonRequest]:


### PR DESCRIPTION
Fixed low scraped count. Also added `custom_settings` to avoid API rate limit error. Setting lower than `download_delay=5`, results `http 429` error.