### PR TITLE
[Smoothie King KY US TT] Fix timeout error for spider and add coordinates

### DIFF
--- a/locations/spiders/smoothie_king_ky_us_tt.py
+++ b/locations/spiders/smoothie_king_ky_us_tt.py
@@ -13,5 +13,6 @@ class SmoothieKingKYUSTTSpider(Where2GetItSpider):
     download_timeout = 180
 
     def parse_item(self, item: Feature, location: dict, **kwargs):
+        item["name"] = None
         item["lat"], item["lon"] = location["latitude"], location["longitude"]
         yield item


### PR DESCRIPTION
```
{'atp/brand/Smoothie King': 1253,
 'atp/brand_wikidata/Q5491421': 1253,
 'atp/category/amenity/fast_food': 1253,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/city': 12,
 'atp/country/KY': 1,
 'atp/country/TT': 2,
 'atp/country/US': 1250,
 'atp/field/branch/missing': 1253,
 'atp/field/email/missing': 824,
 'atp/field/image/missing': 1253,
 'atp/field/opening_hours/missing': 1253,
 'atp/field/operator/missing': 1253,
 'atp/field/operator_wikidata/missing': 1253,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 1253,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/locations.smoothieking.com': 1253,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1253,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TCPTimedOutError': 1,
 'downloader/request_bytes': 1000,
 'downloader/request_count': 2,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 24262552,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 208.427767,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 2, 15, 1, 55, 598432, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 154986264,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1253,
 'items_per_minute': None,
 'log_count/DEBUG': 1266,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TCPTimedOutError': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 7, 2, 14, 58, 27, 170665, tzinfo=datetime.timezone.utc)}
```