### PR TITLE
[Repont HU] Fix Spider

### DIFF
--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -25,7 +25,7 @@ class RepontHUSpider(scrapy.Spider):
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
         for poi in response.json():
             yield JsonRequest(
-                f"https://map.mohu.hu/api/Map/GetWastePointDetails?id={poi['id']}", callback=self.parse_details
+                f"https://map.mohu.hu/api/Map/GetDrsPointDetails?id={poi['id']}", callback=self.parse_details
             )
 
     def parse_details(self, response: Response) -> Any:

--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -25,6 +25,7 @@ class RepontHUSpider(scrapy.Spider):
 
     def parse_details(self, response: Response) -> Any:
         item = DictParser.parse(response.json())
+        item["name"] = None
         item["street_address"] = item.pop("addr_full")
         apply_category(Categories.VENDING_MACHINE, item)
         add_vending(Vending.BOTTLE_RETURN, item)

--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -15,12 +15,12 @@ class RepontHUSpider(scrapy.Spider):
         "operator": "MOHU MOL Hulladékgazdálkodási Zrt.",
         "operator_wikidata": "Q130207606",
     }
-    
+
     def start_requests(self) -> Iterable[Request]:
-         yield JsonRequest(
-             "https://map.mohu.hu/api/Map/SearchPoisGeneralData",
-             data={"wastePointTypes": ["repont"], "hideDrsPoints": False},
-         )
+        yield JsonRequest(
+            "https://map.mohu.hu/api/Map/SearchPoisGeneralData",
+            data={"wastePointTypes": ["repont"], "hideDrsPoints": False},
+        )
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
         for poi in response.json():

--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -1,8 +1,9 @@
-from typing import Iterable
+from typing import Any, Iterable
 
 import scrapy
-from scrapy.http import JsonRequest, Request
+from scrapy.http import JsonRequest, Request, Response
 
+from locations.categories import Categories, Vending, add_vending, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -16,13 +17,15 @@ class RepontHUSpider(scrapy.Spider):
     }
     start_urls = ["https://map.mohu.hu/api/Map/GetAllPois"]
 
-    def parse(self, response) -> Iterable[Request]:
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
         for poi in response.json():
             yield JsonRequest(
                 f"https://map.mohu.hu/api/Map/GetWastePointDetails?id={poi['id']}", callback=self.parse_details
             )
 
-    def parse_details(self, response):
+    def parse_details(self, response: Response) -> Any:
         item = DictParser.parse(response.json())
         item["street_address"] = item.pop("addr_full")
+        apply_category(Categories.VENDING_MACHINE, item)
+        add_vending(Vending.BOTTLE_RETURN, item)
         yield item

--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -30,7 +30,7 @@ class RepontHUSpider(scrapy.Spider):
 
     def parse_details(self, response: Response) -> Any:
         item = DictParser.parse(response.json())
-        item["name"] = None
+        item["located_in"] = item.pop("name", None)
         item["street_address"] = item.pop("addr_full")
         apply_category(Categories.VENDING_MACHINE, item)
         add_vending(Vending.BOTTLE_RETURN, item)

--- a/locations/spiders/repont_hu.py
+++ b/locations/spiders/repont_hu.py
@@ -15,7 +15,12 @@ class RepontHUSpider(scrapy.Spider):
         "operator": "MOHU MOL Hulladékgazdálkodási Zrt.",
         "operator_wikidata": "Q130207606",
     }
-    start_urls = ["https://map.mohu.hu/api/Map/GetAllPois"]
+    
+    def start_requests(self) -> Iterable[Request]:
+         yield JsonRequest(
+             "https://map.mohu.hu/api/Map/SearchPoisGeneralData",
+             data={"wastePointTypes": ["repont"], "hideDrsPoints": False},
+         )
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
         for poi in response.json():


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/REpont': 4124,
 'atp/brand_wikidata/Q130348902': 4124,
 'atp/category/amenity/vending_machine': 4124,
 'atp/clean_strings/city': 130,
 'atp/clean_strings/email': 9,
 'atp/clean_strings/name': 65,
 'atp/clean_strings/phone': 6,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street_address': 289,
 'atp/country/HU': 4124,
 'atp/field/branch/missing': 4124,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 4124,
 'atp/field/email/invalid': 61,
 'atp/field/email/missing': 3856,
 'atp/field/image/missing': 4124,
 'atp/field/name/missing': 682,
 'atp/field/opening_hours/missing': 4124,
 'atp/field/phone/invalid': 15,
 'atp/field/phone/missing': 3718,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 4124,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 4124,
 'atp/field/website/missing': 4124,
 'atp/item_scraped_host_count/map.mohu.hu': 4124,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 4124,
 'atp/operator/MOHU MOL Hulladékgazdálkodási Zrt.': 4124,
 'atp/operator_wikidata/Q130207606': 4124,
 'downloader/exception_count': 15,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 15,
 'downloader/request_bytes': 3456992,
 'downloader/request_count': 7495,
 'downloader/request_method_count/GET': 7495,
 'downloader/response_bytes': 13018761,
 'downloader/response_count': 7480,
 'downloader/response_status_count/200': 4126,
 'downloader/response_status_count/404': 3354,
 'dupefilter/filtered': 1371,
 'elapsed_time_seconds': 498.646842,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 3, 4, 9, 53, 63935, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8083617,
 'httpcompression/response_count': 4126,
 'httperror/response_ignored_count': 3354,
 'httperror/response_ignored_status_count/404': 3354,
 'item_scraped_count': 4124,
 'items_per_minute': None,
 'log_count/DEBUG': 11631,
 'log_count/ERROR': 2,
 'log_count/INFO': 3371,
 'log_count/WARNING': 11,
 'request_depth_max': 1,
 'response_received_count': 7480,
 'responses_per_minute': None,
 'retry/count': 14,
 'retry/max_reached': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 14,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7494,
 'scheduler/dequeued/memory': 7494,
 'scheduler/enqueued': 7494,
 'scheduler/enqueued/memory': 7494,
 'start_time': datetime.datetime(2025, 7, 3, 4, 1, 34, 417093, tzinfo=datetime.timezone.utc)}
```