### PR TITLE
[Pizzeria 105 PL] Ref from url regex group

### DIFF
--- a/locations/spiders/pizzeria_105_pl.py
+++ b/locations/spiders/pizzeria_105_pl.py
@@ -8,5 +8,5 @@ class Pizzeria105PLSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["105.pl"]
     item_attributes = {"brand": "Pizzeria 105", "brand_wikidata": "Q123090276"}
     sitemap_urls = ["https://105.pl/sitemap.xml"]
-    sitemap_rules = [(r"https://105.pl/pizzeria-.*", "parse_sd")]
+    sitemap_rules = [(r"https://105.pl/pizzeria-(.*)/", "parse_sd")]
     wanted_types = ["Place"]

--- a/locations/structured_data_spider.py
+++ b/locations/structured_data_spider.py
@@ -361,16 +361,16 @@ class StructuredDataSpider(Spider):
         if hasattr(self, "rules"):  # Attempt to pull a match from CrawlSpider.rules
             for rule in getattr(self, "rules"):
                 for allow in rule.link_extractor.allow_res:
-                    if match := re.search(allow, url):
+                    if match := re.search(allow, response.url):
                         if len(match.groups()) > 0:
                             return match.group(1)
         elif hasattr(self, "sitemap_rules"):
             # Attempt to pull a match from SitemapSpider.sitemap_rules
             for rule in getattr(self, "sitemap_rules"):
-                if match := re.search(rule[0], url):
+                if match := re.search(rule[0], response.url):
                     if len(match.groups()) > 0:
                         return match.group(1)
-        return url
+        return response.url
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         """Override with any pre-processing on the item."""


### PR DESCRIPTION
Note it also changes `url` to `response.url` in `StructuredDataSpider`.
For pizzeria_105_pl `url` is https://105.pl for every place, `response.url` changes e. g. https://105.pl/pizzeria-warszawa-wlochy/

I haven't checked impact on other spiders.
Perhaps configuration only for this spider should be modified.

`'extras': {'@source_uri': 'https://105.pl/pizzeria-warszawa-stegny/'},` contains full url so `ref` could be calculated from it.
I am not sure whether the same `url` is a bug or a feature :smile: 