### PR TITLE
[Walmart CA] Fix spider

### DIFF
--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -28,7 +28,7 @@ class WalmartCASpider(scrapy.Spider):
 
     def start_requests(self) -> Iterable[JsonRequest]:
         # Tried raw GraphQL query, but it's blocked, hash appears to be stable and required for successful requests.
-        for city in city_locations("CA", min_population=50000):
+        for city in city_locations("CA", min_population=15000):
             variables = {
                 "input": {
                     "postalCode": "",

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -1,14 +1,18 @@
+import json
+from typing import Any, Iterable
+from urllib.parse import urlencode
+
 import scrapy
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
 from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
 
 
-# On the date of writing (2023-12-20) the website blocks the spider with a captcha
-# after ~150 requests with current settings, so we are not getting all POIs.
 class WalmartCASpider(scrapy.Spider):
     name = "walmart_ca"
     allowed_domains = ["www.walmart.ca"]
@@ -19,41 +23,61 @@ class WalmartCASpider(scrapy.Spider):
         "DOWNLOAD_DELAY": 15,
         "ROBOTSTXT_OBEY": False,
     }
+    base_url = "https://www.walmart.ca/orchestra/graphql/nearByNodes"
+    hash = "383d44ac5962240870e513c4f53bb3d05a143fd7b19acb32e8a83e39f1ed266c"
 
-    def start_requests(self):
-        url_template = "https://www.walmart.ca/en/stores-near-me/api/searchStores?singleLineAddr={city}"
-        for city in city_locations("CA"):
-            yield scrapy.Request(url_template.format(city=city["name"]))
+    def start_requests(self) -> Iterable[JsonRequest]:
+        # Tried raw GraphQL query, but it's blocked, hash appears to be stable and required for successful requests.
+        for city in city_locations("CA", min_population=50000):
+            variables = {
+                "input": {
+                    "postalCode": "",
+                    "accessTypes": ["PICKUP_INSTORE", "PICKUP_CURBSIDE"],
+                    "nodeTypes": ["STORE", "PICKUP_SPOKE", "PICKUP_POPUP"],
+                    "latitude": city["latitude"],
+                    "longitude": city["longitude"],
+                    "radius": 100,
+                },
+                "checkItemAvailability": False,
+                "checkWeeklyReservation": False,
+                "enableStoreSelectorMarketplacePickup": False,
+                "enableVisionStoreSelector": False,
+                "enableStorePagesAndFinderPhase2": False,
+                "enableStoreBrandFormat": False,
+                "disableNodeAddressPostalCode": False,
+            }
+            yield JsonRequest(
+                url=f"{self.base_url}/{self.hash}?{urlencode({'variables': json.dumps(variables)})}",
+                headers={
+                    "x-apollo-operation-name": "nearByNodes",
+                    "x-o-bu": "WALMART-CA",
+                    "x-o-segment": "oaoh",
+                    "Cookie": f'walmart.nearestLatLng="{city["latitude"]},{city["longitude"]}"',
+                },
+            )
 
-    def parse(self, response):
-        if "blocked" in response.url:
-            self.logger.error(f"Blocked by Walmart {response.url}")
-            raise scrapy.exceptions.CloseSpider("blocked")
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location_nodes = response.json().get("data", {}).get("nearByNodes") or {}
+        for location in location_nodes.get("nodes", []):
+            item = DictParser.parse(location)
+            item["street_address"] = merge_address_lines(
+                [location["address"].get("addressLineOne"), location["address"].get("addressLineTwo")]
+            )
+            item["opening_hours"] = self.parse_hours(location.get("operationalHours", []))
 
-        self.logger.info(f"Parsing {response.url}")
-        self.logger.info(f"GOT POIs: {len(response.json()['payload']['stores'])}")
-        for poi in response.json()["payload"]["stores"]:
-            if poi.get("deleted"):
-                self.crawler.stats.inc_value("atp/poi/closed")
-                continue
-
-            item = DictParser.parse(poi)
-
-            item["opening_hours"] = self.parse_hours(poi.get("regularHours"))
-
-            # TODO: parse more categories under 'servicesMap' key
             apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
-
             yield item
 
-    def parse_hours(self, hours):
+    def parse_hours(self, hours: list) -> OpeningHours | None:
         if not hours:
             return None
 
         try:
             oh = OpeningHours()
-            for hour in hours:
-                oh.add_range(hour.get("day"), hour.get("start"), hour.get("end"))
+            for rule in hours:
+                if rule.get("closed"):
+                    oh.set_closed(rule.get("day"))
+                oh.add_range(rule.get("day"), rule.get("start"), rule.get("end"))
             return oh
         except Exception as e:
             self.logger.error(f"Failed to parse hours: {hours}, {e}")

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -20,7 +20,7 @@ class WalmartCASpider(scrapy.Spider):
     custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
-        "DOWNLOAD_DELAY": 15,
+        "DOWNLOAD_DELAY": 5,
         "ROBOTSTXT_OBEY": False,
     }
     base_url = "https://www.walmart.ca/orchestra/graphql/nearByNodes"
@@ -60,6 +60,7 @@ class WalmartCASpider(scrapy.Spider):
         location_nodes = response.json().get("data", {}).get("nearByNodes") or {}
         for location in location_nodes.get("nodes", []):
             item = DictParser.parse(location)
+            item["branch"] = location.get("displayName", "").split(",")[0].strip()
             item["street_address"] = merge_address_lines(
                 [location["address"].get("addressLineOne"), location["address"].get("addressLineTwo")]
             )

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -52,8 +52,8 @@ class WalmartCASpider(scrapy.Spider):
                     "x-apollo-operation-name": "nearByNodes",
                     "x-o-bu": "WALMART-CA",
                     "x-o-segment": "oaoh",
-                    "Cookie": f'walmart.nearestLatLng="{city["latitude"]},{city["longitude"]}"',
                 },
+                cookies={"walmart.nearestLatLng": f'{city["latitude"]},{city["longitude"]}'},
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -66,7 +66,11 @@ class WalmartCASpider(scrapy.Spider):
             )
             item["opening_hours"] = self.parse_hours(location.get("operationalHours", []))
 
-            apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+            if location["name"] == "Walmart":
+                apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+            elif location["name"] == "Walmart Supercenter":
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+
             yield item
 
     def parse_hours(self, hours: list) -> OpeningHours | None:
@@ -76,9 +80,10 @@ class WalmartCASpider(scrapy.Spider):
         try:
             oh = OpeningHours()
             for rule in hours:
-                if rule.get("closed"):
+                if rule.get("closed") is True:
                     oh.set_closed(rule.get("day"))
-                oh.add_range(rule.get("day"), rule.get("start"), rule.get("end"))
+                else:
+                    oh.add_range(rule.get("day"), rule.get("start"), rule.get("end"))
             return oh
         except Exception as e:
             self.logger.error(f"Failed to parse hours: {hours}, {e}")


### PR DESCRIPTION
```python
{'atp/brand/Walmart': 387,
 'atp/brand_wikidata/Q483551': 387,
 'atp/category/shop/department_store': 387,
 'atp/country/CA': 387,
 'atp/duplicate_count': 11691,
 'atp/field/email/missing': 387,
 'atp/field/image/missing': 387,
 'atp/field/operator/missing': 387,
 'atp/field/operator_wikidata/missing': 387,
 'atp/field/phone/missing': 387,
 'atp/field/twitter/missing': 387,
 'atp/field/website/missing': 387,
 'atp/item_scraped_host_count/www.walmart.ca': 12078,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 387,
 'downloader/request_bytes': 725972,
 'downloader/request_count': 330,
 'downloader/request_method_count/GET': 330,
 'downloader/response_bytes': 4056394,
 'downloader/response_count': 330,
 'downloader/response_status_count/200': 330,
 'elapsed_time_seconds': 16.081036,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 4, 11, 24, 13, 126549, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 330,
 'httpcompression/response_bytes': 20595288,
 'httpcompression/response_count': 330,
 'item_dropped_count': 11691,
 'item_dropped_reasons_count/DropItem': 11691,
 'item_scraped_count': 387,
 'items_per_minute': None,
 'log_count/DEBUG': 12420,
 'log_count/INFO': 9,
 'response_received_count': 330,
 'responses_per_minute': None,
 'scheduler/dequeued': 330,
 'scheduler/dequeued/memory': 330,
 'scheduler/enqueued': 330,
 'scheduler/enqueued/memory': 330,
 'start_time': datetime.datetime(2025, 7, 4, 11, 23, 57, 45513, tzinfo=datetime.timezone.utc)}
```