### PR TITLE
[Chase US] Fix spider

### DIFF
--- a/locations/spiders/chase_us.py
+++ b/locations/spiders/chase_us.py
@@ -13,6 +13,8 @@ class ChaseUSSpider(YextSpider):
     api_version = "20240816"
 
     def parse_item(self, item: Feature, location: dict, **kwargs: Any) -> Any:
+        item["website"] = item["website"].split("?")[0].replace("locator.chase.com", "www.chase.com/locator/banking/us")
+
         if item["name"] == "Chase Bank":
             item.pop("name")
             apply_category(Categories.BANK, item)

--- a/locations/spiders/chase_us.py
+++ b/locations/spiders/chase_us.py
@@ -1,28 +1,22 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.storefinders.yext import YextSpider
 
 
-class ChaseUSSpider(SitemapSpider, StructuredDataSpider):
+class ChaseUSSpider(YextSpider):
     name = "chase_us"
     item_attributes = {"brand": "Chase", "brand_wikidata": "Q524629"}
-    drop_attributes = {"image"}
-    allowed_domains = ["locator.chase.com"]
-    sitemap_urls = ["https://locator.chase.com/sitemap.xml"]
-    sitemap_rules = [(r"^https:\/\/locator\.chase\.com\/(?!es)[a-z]{2}\/[\w\-]+\/[\w\-]+$", "parse_sd")]
-    search_for_facebook = False
-    search_for_twitter = False
+    drop_attributes = {"twitter"}
+    api_key = "e8996b1ad0e9b3a59e3d1251bbcc0b4b"
+    api_version = "20240816"
 
-    def pre_process_data(self, ld_data, **kwargs):
-        for i in range(0, len(ld_data.get("openingHours", []))):
-            ld_data["openingHours"][i] = ld_data["openingHours"][i].replace("00:00-00:00", "Closed")
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def parse_item(self, item: Feature, location: dict, **kwargs: Any) -> Any:
         if item["name"] == "Chase Bank":
             item.pop("name")
             apply_category(Categories.BANK, item)
-            apply_yes_no(Extras.ATM, item, "ATM services" in response.text)
+            apply_yes_no(Extras.ATM, item, any("ATM" in service for service in location["services"]))
         elif item["name"] == "Chase ATM":
             apply_category(Categories.ATM, item)
 

--- a/locations/spiders/chase_us.py
+++ b/locations/spiders/chase_us.py
@@ -18,7 +18,7 @@ class ChaseUSSpider(YextSpider):
         if item["name"] == "Chase Bank":
             item.pop("name")
             apply_category(Categories.BANK, item)
-            apply_yes_no(Extras.ATM, item, any("ATM" in service for service in location["services"]))
+            apply_yes_no(Extras.ATM, item, location.get("c_primaryATM"))
         elif item["name"] == "Chase ATM":
             apply_category(Categories.ATM, item)
 


### PR DESCRIPTION
Data in POI pages are getting populated dynamically, hence code refactored using `Yext` API to fix the spider.

```python
{'atp/brand/Chase': 3781,
 'atp/brand_wikidata/Q524629': 3781,
 'atp/category/amenity/atm': 117,
 'atp/category/amenity/bank': 3664,
 'atp/cdn/cloudflare/response_count': 201,
 'atp/cdn/cloudflare/response_status_count/200': 200,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/US': 3781,
 'atp/field/branch/missing': 3781,
 'atp/field/email/missing': 3781,
 'atp/field/image/missing': 3781,
 'atp/field/opening_hours/missing': 24,
 'atp/field/operator/missing': 3664,
 'atp/field/operator_wikidata/missing': 3664,
 'atp/field/twitter/missing': 3781,
 'atp/item_scraped_host_count/cdn.yextapis.com': 3781,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 3781,
 'atp/operator/Chase': 117,
 'atp/operator_wikidata/Q524629': 117,
 'downloader/request_bytes': 127711,
 'downloader/request_count': 201,
 'downloader/request_method_count/GET': 201,
 'downloader/response_bytes': 53603202,
 'downloader/response_count': 201,
 'downloader/response_status_count/200': 200,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 67.996985,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 4, 15, 23, 38, 797493, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 33,
 'httpcache/hit': 168,
 'httpcache/miss': 33,
 'httpcache/store': 33,
 'httpcompression/response_bytes': 229367645,
 'httpcompression/response_count': 200,
 'item_scraped_count': 3781,
 'items_per_minute': None,
 'log_count/DEBUG': 3994,
 'log_count/INFO': 10,
 'request_depth_max': 199,
 'response_received_count': 201,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 200,
 'scheduler/dequeued/memory': 200,
 'scheduler/enqueued': 200,
 'scheduler/enqueued/memory': 200,
 'start_time': datetime.datetime(2025, 7, 4, 15, 22, 30, 800508, tzinfo=datetime.timezone.utc)}
```