### PR TITLE
[American Mattress US] Fix spider by updating Amai Promap Spider

### DIFF
--- a/locations/storefinders/amai_promap.py
+++ b/locations/storefinders/amai_promap.py
@@ -15,6 +15,8 @@ class AmaiPromapSpider(JSONBlobSpider):
     To use this spider, simply specify a store page URL with `start_urls`.
     """
 
+    locators = ["amaicdn", "roseperl"]  # Amai ProMap is same as Roseperl ProMap
+
     def start_requests(self):
         for url in self.start_urls:
             yield Request(url=url, callback=self.fetch_js)
@@ -23,7 +25,9 @@ class AmaiPromapSpider(JSONBlobSpider):
         urls = parse_js_object(
             response.xpath('.//script[contains(text(), "var urls =")]/text()').get().split("var urls =")[1]
         )
-        js_url = [u for u in urls if "amaicdn.com/storelocator-prod/wtb/" in u]  # should be only one
+        js_url = [
+            u for u in urls if any(f"{locator}.com/storelocator-prod/wtb/" in u for locator in self.locators)
+        ]  # should be only one
         for url in js_url:
             yield JsonRequest(url=url, callback=self.parse)
 


### PR DESCRIPTION
[Amai ProMap](https://amai.com/apps/promap-store-locator/) URL redirects to [Roseperl ProMap](https://roseperl.com/promap-store-locator/), suggests that the app has migrated. Fix applied to handle both domains in `AmaiPromapSpider`. `Roseperl` domain is now used by `AmericanMattressUSSpider`, that's why it was failing, now fixed.

```python
{'atp/brand/American Mattress': 73,
 'atp/brand_wikidata/Q126896153': 73,
 'atp/category/shop/bed': 73,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/US': 73,
 'atp/field/branch/missing': 73,
 'atp/field/country/from_spider_name': 1,
 'atp/field/image/missing': 5,
 'atp/field/operator/missing': 73,
 'atp/field/operator_wikidata/missing': 73,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/twitter/missing': 73,
 'atp/field/website/missing': 73,
 'atp/item_scraped_host_count/cdn.roseperl.com': 73,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 73,
 'downloader/request_bytes': 1878,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 138054,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 3.907347,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 7, 11, 44, 47, 524393, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 836943,
 'httpcompression/response_count': 3,
 'item_scraped_count': 73,
 'items_per_minute': None,
 'log_count/DEBUG': 88,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 7, 7, 11, 44, 43, 617046, tzinfo=datetime.timezone.utc)}
```