### PR TITLE
[Aveda] Fix Spider

### DIFF
--- a/locations/spiders/aveda.py
+++ b/locations/spiders/aveda.py
@@ -10,7 +10,7 @@ class AvedaSpider(scrapy.Spider):
         "brand": "Aveda",
         "brand_wikidata": "Q4827965",
     }
-    allowed_domains = ["aveda.com"]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 100}
 
     def start_requests(self):
         url = "https://www.aveda.com/rpc/jsonrpc.tmpl?dbgmethod=locator.doorsandevents"


### PR DESCRIPTION
**_Fixes : added timeout delay to fix spider_**

```python
{'atp/brand/Aveda': 250,
 'atp/brand_wikidata/Q4827965': 250,
 'atp/category/shop/cosmetics': 250,
 'atp/clean_strings/street_address': 1,
 'atp/country/AU': 7,
 'atp/country/BE': 6,
 'atp/country/CA': 12,
 'atp/country/CH': 3,
 'atp/country/DE': 12,
 'atp/country/DK': 2,
 'atp/country/ES': 6,
 'atp/country/FR': 6,
 'atp/country/GB': 25,
 'atp/country/GR': 2,
 'atp/country/HR': 1,
 'atp/country/IT': 15,
 'atp/country/JP': 9,
 'atp/country/KR': 2,
 'atp/country/MX': 3,
 'atp/country/MY': 1,
 'atp/country/NL': 5,
 'atp/country/NO': 1,
 'atp/country/RU': 1,
 'atp/country/SG': 1,
 'atp/country/TR': 6,
 'atp/country/US': 124,
 'atp/field/branch/missing': 250,
 'atp/field/email/invalid': 4,
 'atp/field/email/missing': 153,
 'atp/field/image/missing': 250,
 'atp/field/opening_hours/missing': 250,
 'atp/field/operator/missing': 250,
 'atp/field/operator_wikidata/missing': 250,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 28,
 'atp/field/state/missing': 4,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 250,
 'atp/field/website/invalid': 9,
 'atp/field/website/missing': 144,
 'atp/item_scraped_host_count/www.aveda.com': 250,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 124,
 'atp/nsi/match_failed': 126,
 'downloader/request_bytes': 1882,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 71580,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 39.418507,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 7, 13, 11, 19, 60130, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 290262,
 'httpcompression/response_count': 2,
 'item_scraped_count': 250,
 'items_per_minute': None,
 'log_count/DEBUG': 264,
 'log_count/INFO': 9,
 'log_count/WARNING': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 7, 13, 10, 39, 641623, tzinfo=datetime.timezone.utc)}
```