### PR TITLE
Fix time out error for Burger King BS Spider

### DIFF
--- a/locations/spiders/burger_king_bs.py
+++ b/locations/spiders/burger_king_bs.py
@@ -17,6 +17,7 @@ class BurgerKingBSSpider(Spider):
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
     host = "https://www.burgerking.bs"
     country_code = "BS"
+    download_timeout = 180
 
     def start_requests(self):
         for city in city_locations(self.country_code):


### PR DESCRIPTION
[Last run](https://alltheplaces-data.openaddresses.io/runs/2025-07-05-13-32-10/stats/burger_king_bs.json) yielded just `4` POIs because of `TimeoutError`. Sometimes this spider yields no POI because of the timeout. Hence increased `download_timeout` to fix this issue.

```python
{'atp/brand/Burger King': 7,
 'atp/brand_wikidata/Q177054': 7,
 'atp/category/amenity/fast_food': 7,
 'atp/country/BS': 7,
 'atp/field/email/missing': 7,
 'atp/field/image/missing': 7,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 7,
 'atp/field/operator_wikidata/missing': 7,
 'atp/field/postcode/missing': 4,
 'atp/field/state/missing': 7,
 'atp/field/twitter/missing': 7,
 'atp/field/website/missing': 7,
 'atp/item_scraped_host_count/www.burgerking.bs': 7,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 7,
 'downloader/request_bytes': 2265,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 36256,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 5,
 'elapsed_time_seconds': 7.803752,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 8, 5, 38, 10, 148968, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 126200,
 'httpcompression/response_count': 5,
 'item_scraped_count': 7,
 'items_per_minute': None,
 'log_count/DEBUG': 23,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 5,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2025, 7, 8, 5, 38, 2, 345216, tzinfo=datetime.timezone.utc)}
```