### PR TITLE
[Circle K NO] Fix spider

### DIFF
--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -23,6 +23,7 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
             ld_data.pop("openingHours")
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = self.item_attributes["brand"]
         if not ld_data.get("openingHours"):
             ld_data["openingHours"] = []
             for rule in response.xpath('//*[@itemprop="openingHours"]'):

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -36,12 +36,18 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
             item["opening_hours"] = None
 
         extract_google_position(item, response)
-        apply_category(Categories.FUEL_STATION, item)
 
         fuels = [
             fuel.split("FeatureFuel")[-1]
             for fuel in response.xpath('//img[contains(@src,"FeatureFuel")]/@src').getall()
         ]
+        charging_station = response.xpath('//img[contains(@src,"FeatureEVCharger")]/@src').get()
+        if not fuels and charging_station:
+            apply_category(Categories.CHARGING_STATION, item)
+        else:
+            apply_category(Categories.FUEL_STATION, item)
+            apply_yes_no(Fuel.ELECTRIC, item, bool(charging_station))
+
         apply_yes_no(Fuel.ADBLUE, item, "AdBlue" in fuels)
         apply_yes_no(Fuel.OCTANE_95, item, "Miles95" in fuels)
         apply_yes_no(Fuel.OCTANE_95, item, "MilesPlus95" in fuels)

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -4,7 +4,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.google_url import extract_google_position
 from locations.hours import sanitise_day
 from locations.items import Feature
@@ -33,4 +33,16 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
 
         extract_google_position(item, response)
         apply_category(Categories.FUEL_STATION, item)
+
+        fuels = [
+            fuel.split("FeatureFuel")[-1]
+            for fuel in response.xpath('//img[contains(@src,"FeatureFuel")]/@src').getall()
+        ]
+        apply_yes_no(Fuel.ADBLUE, item, "AdBlue" in fuels)
+        apply_yes_no(Fuel.OCTANE_95, item, "Miles95" in fuels)
+        apply_yes_no(Fuel.OCTANE_95, item, "MilesPlus95" in fuels)
+        apply_yes_no(Fuel.DIESEL, item, "MilesDiesel" in fuels)
+        apply_yes_no(Fuel.DIESEL, item, "MilesPlusDiesel" in fuels)
+        apply_yes_no(Fuel.UNTAXED_DIESEL, item, "Anleggsdiesel" in fuels)
+        apply_yes_no(Fuel.BIODIESEL, item, "MilesBioHVO100" in fuels)
         yield item

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -1,15 +1,16 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKNOSpider(SitemapSpider, StructuredDataSpider):
+class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
     name = "circle_k_no"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
-    sitemap_urls = ["https://www.circlek.no/stations/sitemap.xml"]
-    sitemap_rules = [("/station/circle-k-", "parse")]
+    start_urls = ["https://www.circlek.no/stations"]
+    rules = [Rule(LinkExtractor(allow=r"/station/[-\w]+/?$"), callback="parse")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         extract_google_position(item, response)

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -17,6 +17,7 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     start_urls = ["https://www.circlek.no/stations"]
     rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
+    drop_attributes = {"facebook"}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -1,49 +1,37 @@
-from typing import Iterable
-
 from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import Rule
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.google_url import extract_google_position
-from locations.hours import sanitise_day
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
-from locations.structured_data_spider import StructuredDataSpider
+from locations.spiders.circle_k_dk import CircleKDKSpider
 
 
-class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
+class CircleKNOSpider(CircleKDKSpider):
     name = "circle_k_no"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     start_urls = ["https://www.circlek.no/stations"]
-    rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
-    drop_attributes = {"facebook"}
+    rules = [Rule(LinkExtractor(allow="/station/circle"), callback="parse")]
 
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours
-            ld_data.pop("openingHours")
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["name"] = self.item_attributes["brand"]
-        if not ld_data.get("openingHours"):
-            ld_data["openingHours"] = []
-            for rule in response.xpath('//*[@itemprop="openingHours"]'):
-                day = rule.xpath("./@content").get()
-                hours = rule.xpath("./text()").get("").replace("Døgnåpent", "00:00-23:59")  # open 24 hours
-                ld_data["openingHours"].append(f"{day} {hours}")
-        try:
-            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
-        except:
-            self.logger.error(f'Failed to parse opening hours: {ld_data.get("openingHours")}')
-            item["opening_hours"] = None
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item["name"].startswith("CIRCLE K AUTOMAT "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K AUTOMAT ")
+        elif item["name"].startswith("CIRCLE K TRUCK "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K TRUCK ")
+            item["name"] = "Circle K Truck"
+        elif item["name"].startswith("CIRCLE K LADER "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K LADER ")
+        elif item["name"].startswith("CIRCLE K "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K ")
 
         extract_google_position(item, response)
 
         fuels = [
             fuel.split("FeatureFuel")[-1]
-            for fuel in response.xpath('//img[contains(@src,"FeatureFuel")]/@src').getall()
+            for fuel in response.xpath('//img[contains(@src, "FeatureFuel")]/@src').getall()
         ]
-        charging_station = response.xpath('//img[contains(@src,"FeatureEVCharger")]/@src').get()
+        charging_station = response.xpath('//img[contains(@src, "FeatureEVCharger")]/@src').get()
         if not fuels and charging_station:
             apply_category(Categories.CHARGING_STATION, item)
         else:
@@ -57,4 +45,5 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
         apply_yes_no(Fuel.DIESEL, item, "MilesPlusDiesel" in fuels)
         apply_yes_no(Fuel.UNTAXED_DIESEL, item, "Anleggsdiesel" in fuels)
         apply_yes_no(Fuel.BIODIESEL, item, "MilesBioHVO100" in fuels)
+
         yield item

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -16,7 +16,7 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
     name = "circle_k_no"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     start_urls = ["https://www.circlek.no/stations"]
-    rules = [Rule(LinkExtractor(allow=r"/station/[-\w]+/?$"), callback="parse")]
+    rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -1,8 +1,14 @@
+from typing import Iterable
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
+from locations.hours import sanitise_day
+from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -12,7 +18,19 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.circlek.no/stations"]
     rules = [Rule(LinkExtractor(allow=r"/station/[-\w]+/?$"), callback="parse")]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours
+            ld_data.pop("openingHours")
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if not ld_data.get("openingHours"):
+            ld_data["openingHours"] = []
+            for rule in response.xpath('//*[@itemprop="openingHours"]'):
+                day = rule.xpath("./@content").get()
+                hours = rule.xpath("./text()").get("").replace("Døgnåpent", "00:00-23:59")  # open 24 hours
+                ld_data["openingHours"].append(f"{day} {hours}")
+        item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
+
         extract_google_position(item, response)
         apply_category(Categories.FUEL_STATION, item)
         yield item

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -29,7 +29,11 @@ class CircleKNOSpider(CrawlSpider, StructuredDataSpider):
                 day = rule.xpath("./@content").get()
                 hours = rule.xpath("./text()").get("").replace("Døgnåpent", "00:00-23:59")  # open 24 hours
                 ld_data["openingHours"].append(f"{day} {hours}")
-        item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
+        try:
+            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
+        except:
+            self.logger.error(f'Failed to parse opening hours: {ld_data.get("openingHours")}')
+            item["opening_hours"] = None
 
         extract_google_position(item, response)
         apply_category(Categories.FUEL_STATION, item)


### PR DESCRIPTION
Desired `Sitemap` no longer exists. Hence, switched to `CrawlSpider`.

```python
{'atp/brand/Circle K': 470,
 'atp/brand_wikidata/Q3268010': 470,
 'atp/category/amenity/charging_station': 7,
 'atp/category/amenity/fuel': 463,
 'atp/country/NO': 470,
 'atp/field/branch/missing': 470,
 'atp/field/city/missing': 2,
 'atp/field/email/missing': 470,
 'atp/field/image/missing': 470,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 463,
 'atp/field/operator_wikidata/missing': 463,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 470,
 'atp/field/twitter/missing': 470,
 'atp/item_scraped_host_count/www.circlek.no': 470,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 470,
 'atp/operator/Circle K': 7,
 'atp/operator_wikidata/Q3268010': 7,
 'downloader/request_bytes': 185121,
 'downloader/request_count': 472,
 'downloader/request_method_count/GET': 472,
 'downloader/response_bytes': 6412952,
 'downloader/response_count': 472,
 'downloader/response_status_count/200': 472,
 'elapsed_time_seconds': 6.053429,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 8, 9, 24, 57, 278116, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 472,
 'httpcompression/response_bytes': 37809675,
 'httpcompression/response_count': 472,
 'item_scraped_count': 470,
 'items_per_minute': None,
 'log_count/DEBUG': 954,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 472,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 471,
 'scheduler/dequeued/memory': 471,
 'scheduler/enqueued': 471,
 'scheduler/enqueued/memory': 471,
 'start_time': datetime.datetime(2025, 7, 8, 9, 24, 51, 224687, tzinfo=datetime.timezone.utc)}
```