### PR TITLE
[Circle K SE] Fix spider

### DIFF
--- a/locations/spiders/circle_k_se.py
+++ b/locations/spiders/circle_k_se.py
@@ -1,48 +1,31 @@
 from typing import Iterable
 
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.google_url import extract_google_position
-from locations.hours import sanitise_day
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
-from locations.structured_data_spider import StructuredDataSpider
+from locations.spiders.circle_k_dk import CircleKDKSpider
 
 
-class CircleKSESpider(CrawlSpider, StructuredDataSpider):
+class CircleKSESpider(CircleKDKSpider):
     name = "circle_k_se"
-    item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
     start_urls = ["https://www.circlek.se/stations"]
-    rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
-
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours
-            ld_data.pop("openingHours")
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["name"] = self.item_attributes["brand"]
-        if not ld_data.get("openingHours"):
-            ld_data["openingHours"] = []
-            for rule in response.xpath('//*[@itemprop="openingHours"]'):
-                day = rule.xpath("./@content").get()
-                hours = rule.xpath("./text()").get("").replace("Open 24h", "00:00-23:59")
-                ld_data["openingHours"].append(f"{day} {hours}")
-        try:
-            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
-        except:
-            self.logger.error(f'Failed to parse opening hours: {ld_data.get("openingHours")}')
-            item["opening_hours"] = None
+        if item["name"].startswith("CIRCLE K TRUCK "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K TRUCK ")
+            item["name"] = "Circle K Truck"
+        elif item["name"].startswith("CIRCLE K "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K ")
 
         extract_google_position(item, response)
 
         fuels = [
             fuel.split("FeatureFuel")[-1]
-            for fuel in response.xpath('//img[contains(@src,"FeatureFuel")]/@src').getall()
+            for fuel in response.xpath('//img[contains(@src, "FeatureFuel")]/@src').getall()
         ]
-        charging_station = response.xpath('//img[contains(@src,"FeatureEVCharger")]/@src').get()
+        charging_station = response.xpath('//img[contains(@src, "FeatureEVCharger")]/@src').get()
         if not fuels and charging_station:
             apply_category(Categories.CHARGING_STATION, item)
         else:
@@ -60,4 +43,5 @@ class CircleKSESpider(CrawlSpider, StructuredDataSpider):
         apply_yes_no(Fuel.CNG, item, "CNG" in fuels)
         apply_yes_no(Fuel.BIODIESEL, item, "B100" in fuels)
         apply_yes_no(Fuel.BIODIESEL, item, "HVO100" in fuels)
+
         yield item

--- a/locations/spiders/circle_k_se.py
+++ b/locations/spiders/circle_k_se.py
@@ -1,20 +1,16 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKSESpider(SitemapSpider, StructuredDataSpider):
+class CircleKSESpider(CrawlSpider, StructuredDataSpider):
     name = "circle_k_se"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
-    sitemap_urls = ["https://www.circlek.se/stations/sitemap.xml"]
-    sitemap_rules = [("/station/circle-k-", "parse")]
-
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            entry["loc"] = entry["loc"].replace("172.16.34.158", "www.circlek.se")
-            yield entry
+    start_urls = ["https://www.circlek.se/stations"]
+    rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         extract_google_position(item, response)

--- a/locations/spiders/circle_k_se.py
+++ b/locations/spiders/circle_k_se.py
@@ -1,8 +1,14 @@
+from typing import Iterable
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
+from locations.hours import sanitise_day
+from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -12,7 +18,24 @@ class CircleKSESpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.circlek.se/stations"]
     rules = [Rule(LinkExtractor(allow=r"/station/circle-k-[-\w]+/?$"), callback="parse")]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        if any(sanitise_day(rule) for rule in ld_data.get("openingHours", [])):  # day without hours
+            ld_data.pop("openingHours")
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = self.item_attributes["brand"]
+        if not ld_data.get("openingHours"):
+            ld_data["openingHours"] = []
+            for rule in response.xpath('//*[@itemprop="openingHours"]'):
+                day = rule.xpath("./@content").get()
+                hours = rule.xpath("./text()").get("").replace("Open 24h", "00:00-23:59")
+                ld_data["openingHours"].append(f"{day} {hours}")
+        try:
+            item["opening_hours"] = LinkedDataParser.parse_opening_hours(ld_data)
+        except:
+            self.logger.error(f'Failed to parse opening hours: {ld_data.get("openingHours")}')
+            item["opening_hours"] = None
+
         extract_google_position(item, response)
         apply_category(Categories.FUEL_STATION, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 439,
 'atp/brand_wikidata/Q3268010': 439,
 'atp/category/amenity/charging_station': 2,
 'atp/category/amenity/fuel': 437,
 'atp/country/SE': 439,
 'atp/field/branch/missing': 439,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 439,
 'atp/field/image/missing': 439,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 437,
 'atp/field/operator_wikidata/missing': 437,
 'atp/field/state/missing': 439,
 'atp/field/twitter/missing': 439,
 'atp/item_scraped_host_count/www.circlek.se': 439,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 439,
 'atp/operator/Circle K': 2,
 'atp/operator_wikidata/Q3268010': 2,
 'downloader/request_bytes': 174798,
 'downloader/request_count': 441,
 'downloader/request_method_count/GET': 441,
 'downloader/response_bytes': 6258994,
 'downloader/response_count': 441,
 'downloader/response_status_count/200': 441,
 'elapsed_time_seconds': 6.205279,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 8, 11, 2, 17, 851433, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 441,
 'httpcompression/response_bytes': 37154003,
 'httpcompression/response_count': 441,
 'item_scraped_count': 439,
 'items_per_minute': None,
 'log_count/DEBUG': 892,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 441,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 440,
 'scheduler/dequeued/memory': 440,
 'scheduler/enqueued': 440,
 'scheduler/enqueued/memory': 440,
 'start_time': datetime.datetime(2025, 7, 8, 11, 2, 11, 646154, tzinfo=datetime.timezone.utc)}
```