### PR TITLE
[Gscaltex KR] Fix spider

### DIFF
--- a/locations/spiders/gscaltex_kr.py
+++ b/locations/spiders/gscaltex_kr.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 class GscaltexKRSpider(Spider):
     name = "gscaltex_kr"
     item_attributes = {"brand_wikidata": "Q624012"}
-    start_urls = ["https://www.gscenergyplus.com/data/station/map.json"]
+    start_urls = ["https://www.gscenergyplus.com/static/epweb/map.json"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["siteList"]:


### PR DESCRIPTION
```python
{'atp/brand/GS칼텍스': 2287,
 'atp/brand_wikidata/Q624012': 2287,
 'atp/category/amenity/fuel': 2287,
 'atp/clean_strings/street_address': 7,
 'atp/country/KR': 2287,
 'atp/field/branch/missing': 2287,
 'atp/field/city/missing': 2287,
 'atp/field/country/from_spider_name': 2287,
 'atp/field/email/missing': 2287,
 'atp/field/image/missing': 2287,
 'atp/field/opening_hours/missing': 2287,
 'atp/field/operator/missing': 2287,
 'atp/field/operator_wikidata/missing': 2287,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 11,
 'atp/field/state/missing': 2287,
 'atp/field/twitter/missing': 2287,
 'atp/field/website/missing': 2287,
 'atp/item_scraped_host_count/www.gscenergyplus.com': 2287,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 2287,
 'downloader/request_bytes': 689,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 200928,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.048565,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 8, 11, 37, 6, 297577, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1538575,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2287,
 'items_per_minute': None,
 'log_count/DEBUG': 2300,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 8, 11, 37, 2, 249012, tzinfo=datetime.timezone.utc)}
```