### PR TITLE
[Argenta BE] Add spider (351 locations)

### DIFF
--- a/locations/spiders/argenta_be.py
+++ b/locations/spiders/argenta_be.py
@@ -1,0 +1,37 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class ArgentaBESpider(JSONBlobSpider):
+    name = "argenta_be"
+    item_attributes = {"brand": "Argenta", "brand_wikidata": "Q932856"}
+    start_urls = ["https://www.argenta.be/content/argenta/nl/kantoren/_jcr_content.complete.nl.json"]
+    locations_key = "offices"
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("general"))
+        feature.update(feature.pop("officeAddress"))
+        feature.update(feature.pop("officeContact"))
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature.get("officeNumber")
+        item["housenumber"] = feature.get("houseNr")
+        item["street"] = feature.get("localizedStreet")
+        item["city"] = feature.get("localizedCity")
+        item["state"] = feature.get("rpr")
+        item["extras"]["addr:street:nl"] = feature["street"].get("languageDescription", {}).get("nl", {}).get("value")
+        item["extras"]["addr:street:fr"] = feature["street"].get("languageDescription", {}).get("fr", {}).get("value")
+        item["extras"]["addr:city:nl"] = feature["city"].get("languageDescription", {}).get("nl", {}).get("value")
+        item["extras"]["addr:city:fr"] = feature["city"].get("languageDescription", {}).get("fr", {}).get("value")
+        item["extras"]["website:nl"] = item["website"]
+        item["extras"]["website:fr"] = item["website"].replace("/nl/kantoren/", "/fr/agences/")
+        item["extras"]["fax"] = feature.get("formattedFax")
+
+        apply_category(Categories.BANK, item)
+        apply_yes_no(Extras.ATM, item, feature.get("atm"))
+        yield item


### PR DESCRIPTION
Brand is mainly present in `BE`. Couldn't find POI locator for [NL](https://www.argenta.nl/) and [LU](https://www.argenta.lu/).

```python
{'atp/brand/Argenta': 351,
 'atp/brand_wikidata/Q932856': 351,
 'atp/category/amenity/bank': 351,
 'atp/clean_strings/name': 1,
 'atp/country/BE': 351,
 'atp/field/branch/missing': 351,
 'atp/field/country/from_spider_name': 351,
 'atp/field/image/missing': 351,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 351,
 'atp/field/operator_wikidata/missing': 351,
 'atp/field/phone/missing': 1,
 'atp/field/street_address/missing': 351,
 'atp/field/twitter/missing': 351,
 'atp/item_scraped_host_count/www.argenta.be': 351,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 351,
 'downloader/request_bytes': 711,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 98325,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.01357,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 9, 7, 58, 19, 648651, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 946113,
 'httpcompression/response_count': 2,
 'item_scraped_count': 351,
 'items_per_minute': None,
 'log_count/DEBUG': 364,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 9, 7, 58, 16, 635081, tzinfo=datetime.timezone.utc)}
```