### PR TITLE
[address clean up pipeline] do not remove short Chinese address components

### DIFF
--- a/locations/pipelines/address_clean_up.py
+++ b/locations/pipelines/address_clean_up.py
@@ -6,11 +6,33 @@ from scrapy import Spider
 from locations.items import Feature
 
 
-def merge_address_lines(address_lines: [str]) -> str:
+def merge_address_lines(address_lines: list[str]) -> str:
     return ", ".join(filter(None, [line.strip() if line else None for line in address_lines]))
 
 
 _multiple_spaces = re.compile(r" +")
+
+
+def is_primarily_cjk(text: str) -> bool:
+    """
+    Check if more than half of `text` contains CJK (Chinese, Japanese, Korean) characters.
+    """
+    if not text:
+        return False
+
+    cjk_count = 0
+    for char in text:
+        if any(
+            [
+                "\u4e00" <= char <= "\u9fff",  # CJK Unified Ideographs
+                "\u3040" <= char <= "\u309f",  # Hiragana
+                "\u30a0" <= char <= "\u30ff",  # Katakana
+                "\uac00" <= char <= "\ud7af",  # Hangul
+            ]
+        ):
+            cjk_count += 1
+
+    return cjk_count > len(text) / 2
 
 
 def clean_address(address: list[str] | str, min_length=2) -> str:
@@ -46,8 +68,9 @@ def clean_address(address: list[str] | str, min_length=2) -> str:
                 return_addr.append(line)
     assembled_address = ", ".join(return_addr)
 
-    # If after all of the cleaning our address is very short, its likely to be "-" or similar dud content
-    if len(assembled_address) <= min_length:
+    # If after all of the cleaning our address is very short, its likely to be "-" or similar dud content.
+    # Don't discard valid CJK characters, which may be short.
+    if len(assembled_address) <= min_length and not is_primarily_cjk(assembled_address):
         return ""
 
     return assembled_address

--- a/tests/test_address_clean_up.py
+++ b/tests/test_address_clean_up.py
@@ -61,6 +61,14 @@ def test_clean_address_removes_very_short_addresses():
     assert clean_address("NY", 1) == "NY"
 
 
+def test_clean_address_dont_remove_short_valid_cjk():
+    assert not clean_address("NY", 2)
+    assert clean_address("昆明", 2) == "昆明"
+    assert clean_address("昆明", 1) == "昆明"
+    assert clean_address("昆明, ", 2) == "昆明"
+    assert clean_address("昆明, ", 1) == "昆明"
+
+
 def get_objects(feature):
     spider = Spider(name="test")
     spider.crawler = get_crawler()


### PR DESCRIPTION
Address clean up pipeline removes address components with less than 2 character address components not taking into account Chinese/Japanese/Korean languages where words can consists from one or two characters. Quite some `city` from `tesla` spider is removed because of this ([example](https://www.tesla.com/cua-api/tesla-location?translate=en_US&usetrt=true&id=cnsc10343)).

For implementation I took unicode  ranges from https://jrgraphix.net/research/unicode_blocks.php.
