### PR TITLE
[Bred FR] Add Spider (376 locations)

### DIFF
--- a/locations/spiders/bred_fr.py
+++ b/locations/spiders/bred_fr.py
@@ -30,7 +30,11 @@ class BredFRSpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for day, times in branch_data["openingHours"].items():
-            for time in times.values():
-                item["opening_hours"].add_range(day, time.get("start"), time.get("end"))
+            if times["morning"].get("isClosed") is True and times["afternoon"].get("isClosed") is True:
+                item["opening_hours"].set_closed(day)
+            else:
+                for time in times.values():
+                    if time.get("isClosed") is not True:
+                        item["opening_hours"].add_range(day, time["start"], time["end"])
 
         yield item

--- a/locations/spiders/bred_fr.py
+++ b/locations/spiders/bred_fr.py
@@ -1,0 +1,37 @@
+import json
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+
+class BredFRSpider(SitemapSpider):
+    name = "bred_fr"
+    item_attributes = {"brand": "BRED", "brand_wikidata": "Q2877455"}
+    sitemap_urls = ["https://www.bred.fr/sitemap.xml"]
+    sitemap_rules = [("/les-agences/", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = json.loads(response.xpath('//*[@type="application/json"]/text()').get())
+        keys = list(raw_data.keys())
+        branch_data = raw_data[keys[0]]["b"]["store"]
+        item = DictParser.parse(branch_data)
+        item["branch"] = item.pop("name")
+        item["street_address"] = item.pop("addr_full")
+        item["phone"] = item["phone"]["text"]
+        item["email"] = branch_data["contact"]["mail"]["text"]
+        item["postcode"], item["city"] = item["postcode"].split(" ", 1)
+        item["website"] = response.url
+        apply_category(Categories.BANK, item)
+        item["opening_hours"] = OpeningHours()
+        for key, val in branch_data["openingHours"].items():
+            day = key
+            for open_close_time in val.values():
+                open_time = open_close_time.get("start")
+                close_time = open_close_time.get("end")
+                item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+        yield item

--- a/locations/spiders/bred_fr.py
+++ b/locations/spiders/bred_fr.py
@@ -27,11 +27,10 @@ class BredFRSpider(SitemapSpider):
         item["postcode"], item["city"] = item["postcode"].split(" ", 1)
         item["website"] = response.url
         apply_category(Categories.BANK, item)
+
         item["opening_hours"] = OpeningHours()
-        for key, val in branch_data["openingHours"].items():
-            day = key
-            for open_close_time in val.values():
-                open_time = open_close_time.get("start")
-                close_time = open_close_time.get("end")
-                item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+        for day, times in branch_data["openingHours"].items():
+            for time in times.values():
+                item["opening_hours"].add_range(day, time.get("start"), time.get("end"))
+
         yield item

--- a/locations/spiders/bred_fr.py
+++ b/locations/spiders/bred_fr.py
@@ -20,7 +20,7 @@ class BredFRSpider(SitemapSpider):
         keys = list(raw_data.keys())
         branch_data = raw_data[keys[0]]["b"]["store"]
         item = DictParser.parse(branch_data)
-        item["branch"] = item.pop("name")
+        item["branch"] = item.pop("name").removeprefix("Agence ")
         item["street_address"] = item.pop("addr_full")
         item["phone"] = item["phone"]["text"]
         item["email"] = branch_data["contact"]["mail"]["text"]


### PR DESCRIPTION
```python
{'atp/brand/BRED': 376,
 'atp/brand_wikidata/Q2877455': 376,
 'atp/category/amenity/bank': 376,
 'atp/country/FR': 376,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 376,
 'atp/field/email/missing': 12,
 'atp/field/image/missing': 376,
 'atp/field/operator/missing': 376,
 'atp/field/operator_wikidata/missing': 376,
 'atp/field/phone/invalid': 17,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 376,
 'atp/field/twitter/missing': 376,
 'atp/item_scraped_host_count/www.bred.fr': 376,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 376,
 'downloader/request_bytes': 183504,
 'downloader/request_count': 378,
 'downloader/request_method_count/GET': 378,
 'downloader/response_bytes': 44759614,
 'downloader/response_count': 378,
 'downloader/response_status_count/200': 378,
 'elapsed_time_seconds': 477.453549,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 11, 11, 40, 31, 326954, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 376,
 'items_per_minute': None,
 'log_count/DEBUG': 765,
 'log_count/INFO': 16,
 'request_depth_max': 1,
 'response_received_count': 378,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 377,
 'scheduler/dequeued/memory': 377,
 'scheduler/enqueued': 377,
 'scheduler/enqueued/memory': 377,
 'start_time': datetime.datetime(2025, 7, 11, 11, 32, 33, 873405, tzinfo=datetime.timezone.utc)}
```