### PR TITLE
[Athena] Add spider for cryptocurrency ATMs in US, CO, SV, AR

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -1447,7 +1447,7 @@ class OpeningHours:
                 )
                 for time_range in time_ranges:
                     time_start_hour = time_range[0]
-                    if time_start_hour == "00":
+                    if time_start_hour == "00" or time_start_hour == "0":
                         time_start_hour = "12"
                     if time_range[1]:
                         time_start = f"{time_start_hour}:{time_range[1]}"
@@ -1461,7 +1461,7 @@ class OpeningHours:
                     time_start_24h = time.strptime(time_start, "%I:%M%p")
                     time_start_24h = time.strftime("%H:%M", time_start_24h)
                     time_end_hour = time_range[3]
-                    if time_end_hour == "00":
+                    if time_end_hour == "00" or time_end_hour == "0":
                         time_end_hour = "12"
                     if time_range[4]:
                         time_end = f"{time_end_hour}:{time_range[4]}"

--- a/locations/spiders/athena.py
+++ b/locations/spiders/athena.py
@@ -38,6 +38,10 @@ class AthenaSpider(StoreRocketSpider):
                     item["country"] = "US"
                     item["extras"]["currency:USD"] = "yes"
             case _:
-                self.logger.warning("ATM is located in country '{}' for which the local currency is undefined by this spider. The spider should be updated to map a currency for this country.".format(item.get("country")))
+                self.logger.warning(
+                    "ATM is located in country '{}' for which the local currency is undefined by this spider. The spider should be updated to map a currency for this country.".format(
+                        item.get("country")
+                    )
+                )
 
         yield item

--- a/locations/spiders/athena.py
+++ b/locations/spiders/athena.py
@@ -1,0 +1,43 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.storerocket import StoreRocketSpider
+
+
+class AthenaSpider(StoreRocketSpider):
+    name = "athena"
+    item_attributes = {"brand": "Athena", "brand_wikidata": "Q135280046"}
+    storerocket_id = "vZ4v6A94Qd"
+    time_hours_format = 12
+    iseadgg_countries_list = ["US", "SV", "CO", "AR"]
+    search_radius = 200
+
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        item["ref"] = str(item["ref"])
+        item.pop("name", None)
+        item.pop("facebook", None)
+        item["extras"].pop("contact:instragram", None)
+
+        for field in location.get("fields", {}):
+            if field["name"] == "Located Inside:":
+                item["located_in"] = field["pivot_field_value"]
+
+        apply_category(Categories.ATM, item)
+        item["extras"]["currency:XBT"] = "yes"
+        item["extras"]["cash_in"] = "yes"
+        match location.get("country"):
+            case "Argentina":
+                item["extras"]["currency:ARS"] = "yes"
+            case "Colombia":
+                item["extras"]["currency:COP"] = "yes"
+            case "El Salvador":
+                item["extras"]["currency:USD"] = "yes"
+            case None | "":
+                if location.get("timezone", "").startswith("America/") or location.get("phone").startswith("+1 "):
+                    item["country"] = "US"
+                    item["extras"]["currency:USD"] = "yes"
+            case _:
+                self.logger.warning("ATM is located in country '{}' for which the local currency is undefined by this spider. The spider should be updated to map a currency for this country.".format(item.get("country")))
+
+        yield item

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -1,7 +1,10 @@
+from typing import Iterable
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids, point_locations
 from locations.hours import OpeningHours
 from locations.items import Feature, SocialMedia, set_social_media
 
@@ -15,20 +18,104 @@ class StoreRocketSpider(Spider):
       - `storerocket_id`: mandatory parameter
       - `base_url`: optional parameter, sets the base URL for individual
         location pages (which may be provided as a URL slug by this API)
+      - `time_hours_format`: optional parameter that is '24' by default and
+        can be changed to '12' if the opening hours are specified in 12 hr
+        time notation (e.g. 2:00 AM). This attribute is used in determining
+        whether to replace "24 HOURS" with a 24h or 12h time notation range.
+
+    Some StoreRocket accounts will not return all features at once in a
+    single API call. If this is the case, there are two alternative methods
+    available for use of this storefinder:
+
+    PREFERRED
+    1. Supply a list of ISO-3166 alpha-2 country codes as the
+       iseadgg_countries_list parameter and a suitable non-zero search_radius
+       value in miles. The API only accepts a pre-configured set of search
+       radiuses and these change per StoreRocket account. Check the store
+       finder page for a drop-down box listing valid search radius values.
+
+       Example:
+         iseadgg_countries_list = ["US", "CA"]
+         search_radius = 100
+
+         In this example, a 158km ISEADGG centroid grid will automatically
+         be selected as the most appropriate to use against a 100mi search
+         radius accepted by the API endpoint.
+
+    NONPREFERRED
+    2. Supply a list of searchable_points_files = [x, y..] suitable for use
+       with the point_locations function of locations.geo and a suitable
+       non-zero search_radius value in miles. The API only accepts a
+       pre-configured set of search radiuses and these change per StoreRocket
+       account. Check the store finder page for a drop-down box listing valid
+       search radius values.
     """
 
     dataset_attributes = {"source": "api", "api": "storerocket.io"}
     storerocket_id: str = ""
     base_url: str | None = None
+    time_hours_format: str = 24  # or 12
+    iseadgg_countries_list: list[str] = []
+    searchable_points_files: list[str] = []
+    search_radius: int = 0
+    max_results: int = 1000
 
-    def start_requests(self):
-        yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations")
+    def start_requests(self) -> Iterable[JsonRequest]:
+        if len(self.iseadgg_countries_list) == 0 and len(self.searchable_points_files) == 0:
+            # PREFERRED approach of requesting all features at once in a
+            # single API call. Note that some StoreRocket instances enforce a
+            # maximum number of results returned and if this is the case, a
+            # geographic search method is required to be used.
+            yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations")
+        elif len(self.iseadgg_countries_list) > 0 and self.search_radius != 0 and self.max_results != 0:
+            # SECOND PREFERENCE geographic radius search method using ISEADGG
+            # centroids for a supplied list of ISO-3166 alpha-2 country codes.
+            if self.search_radius >= 285:
+                iseadgg_radius = 458
+            elif self.search_radius >= 200:
+                iseadgg_radius = 315
+            elif self.search_radius >= 100:
+                iseadgg_radius = 158
+            elif self.search_radius >= 60:
+                iseadgg_radius = 94
+            elif self.search_radius >= 50:
+                iseadgg_radius = 79
+            elif self.search_radius >= 30:
+                iseadgg_radius = 48
+            elif self.search_radius >= 15:
+                iseadgg_radius = 24
+            else:
+                raise RuntimeError(
+                    "A minimum search_radius of 15 (miles) is required to be used for the ISEADGG geographic radius search method."
+                )
+            for lat, lon in country_iseadgg_centroids(self.iseadgg_countries_list, iseadgg_radius):
+                yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}")
+        elif len(self.searchable_points_files) > 0 and self.search_radius != 0 and self.max_results != 0:
+            # THIRD PREFERENCE geographic radius search method using a manually
+            # specified list of searchable_points_file containing centroids.
+            for searchable_points_file in self.searchable_points_files:
+                for lat, lon in point_locations(searchable_points_file):
+                    yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}")
 
-    def parse(self, response, **kwargs):
+    def parse(self, response, **kwargs) -> Iterable[Feature]:
         if not response.json()["success"]:
             return
 
-        for location in response.json()["results"]["locations"]:
+        locations = response.json()["results"]["locations"]
+
+        if len(self.iseadgg_countries_list) != 0 or len(self.searchable_points_files) != 0:
+            if len(locations) >= self.max_results:
+                raise RuntimeError(
+                    "Locations have probably been truncated due to max_results (or more) locations being returned by a single geographic radius search. Use a smaller search_radius."
+                )
+
+            if len(locations) > 0:
+                self.crawler.stats.inc_value("atp/geo_search/hits")
+            else:
+                self.crawler.stats.inc_value("atp/geo_search/misses")
+            self.crawler.stats.max_value("atp/geo_search/max_features_returned", len(locations))
+
+        for location in locations:
             self.pre_process_data(location)
             item = DictParser.parse(location)
 
@@ -46,12 +133,16 @@ class StoreRocketSpider(Spider):
             hours_string = ""
             for day_name, day_hours in location["hours"].items():
                 hours_string = hours_string + f" {day_name}: {day_hours}"
+            if self.time_hours_format == 24:
+                hours_string = hours_string.upper().replace("24 HOURS", "00:00 - 23:59")
+            else:
+                hours_string = hours_string.upper().replace("24 HOURS", "12:00 AM - 11:59 PM")
             item["opening_hours"].add_ranges_from_string(hours_string)
 
             yield from self.parse_item(item, location) or []
 
-    def parse_item(self, item: Feature, location: dict, **kwargs):
+    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
         yield item
 
-    def pre_process_data(self, location, **kwargs):
+    def pre_process_data(self, location, **kwargs) -> None:
         """Override with any pre-processing on the item."""

--- a/locations/storefinders/storerocket.py
+++ b/locations/storefinders/storerocket.py
@@ -89,13 +89,17 @@ class StoreRocketSpider(Spider):
                     "A minimum search_radius of 15 (miles) is required to be used for the ISEADGG geographic radius search method."
                 )
             for lat, lon in country_iseadgg_centroids(self.iseadgg_countries_list, iseadgg_radius):
-                yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}")
+                yield JsonRequest(
+                    url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}"
+                )
         elif len(self.searchable_points_files) > 0 and self.search_radius != 0 and self.max_results != 0:
             # THIRD PREFERENCE geographic radius search method using a manually
             # specified list of searchable_points_file containing centroids.
             for searchable_points_file in self.searchable_points_files:
                 for lat, lon in point_locations(searchable_points_file):
-                    yield JsonRequest(url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}")
+                    yield JsonRequest(
+                        url=f"https://storerocket.io/api/user/{self.storerocket_id}/locations?lat={lat}&lng={lon}&radius={self.search_radius}&limit={self.max_results}"
+                    )
 
     def parse(self, response, **kwargs) -> Iterable[Feature]:
         if not response.json()["success"]:

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -253,6 +253,10 @@ def test_add_ranges_from_string():
     assert o.as_opening_hours() == "Mo-Th 07:00-19:00; Fr 00:00-24:00; Sa-Su closed"
 
     o = OpeningHours()
+    o.add_ranges_from_string("Monday to Tuesday 0:45 AM to 11:45 PM")
+    assert o.as_opening_hours() == "Mo-Tu 00:45-23:45"
+
+    o = OpeningHours()
     o.add_ranges_from_string("Sunday to Thursday 0800-1400, Wed-Sat 1300-1800")
     assert o.as_opening_hours() == "Mo-Tu 08:00-14:00; We-Th 08:00-14:00,13:00-18:00; Fr-Sa 13:00-18:00; Su 08:00-14:00"
 


### PR DESCRIPTION
To support this new spider, the existing StoreRocket storefinder has been significantly improved to add geographic search methods for returning features. Athena's StoreRocket instance caps features returned to 25 by default, and this can be increased to 1000, but this still isn't enough to capture all features particularly across the US. Therefore a large ISEADGG search radius is used to keep result sets under 1000 features per search.