### PR TITLE
[Barclays GB] Add Spider (1132 locations)

### DIFF
--- a/locations/spiders/barclays_gb.py
+++ b/locations/spiders/barclays_gb.py
@@ -1,0 +1,53 @@
+from typing import Any
+from urllib.parse import urljoin
+
+import scrapy
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class BarclaysGBSpider(scrapy.Spider):
+    name = "barclays_gb"
+    item_attributes = {"brand": "Barclays", "brand_wikidata": "Q245343"}
+
+    def start_requests(self):
+        for city in city_locations("GB", 10000):
+            url = f'https://search.barclays.co.uk/content/bf/en/4_0/branches_atms?lat={city["latitude"]}&lng={city["longitude"]}'
+            yield JsonRequest(url=url, callback=self.parse)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = response.json()
+        for branch in data.get("branches", []):
+            yield self.parse_location(branch, is_atm=False)
+
+        for atm in data.get("atms", []):
+            yield self.parse_location(atm, is_atm=True)
+
+    def parse_location(self, location_data: dict, is_atm: bool) -> Feature:
+        item = DictParser.parse(location_data)
+        item["ref"] = f'{location_data["outletId"]} - {"ATM" if is_atm else "Bank"}'
+        item["branch"] = item.pop("name", None)
+        item["street_address"] = merge_address_lines(
+            [location_data["address"].get("line1", ""), location_data["address"].get("line2", "")]
+        )
+        item["website"] = urljoin("https://www.barclays.co.uk", item.get("website", ""))
+        apply_category(Categories.ATM if is_atm else Categories.BANK, item)
+
+        item["opening_hours"] = OpeningHours()
+        for day, time in location_data.get("openingHours", {}).items():
+            if isinstance(time, list):
+                continue
+            open_time = time.get("openTime")
+            close_time = time.get("closeTime")
+            if open_time == "00:00" and close_time == "00:00":
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+
+        return item


### PR DESCRIPTION
```python
{'atp/brand/Barclays': 1132,
 'atp/brand_wikidata/Q245343': 1132,
 'atp/category/amenity/atm': 369,
 'atp/category/amenity/bank': 763,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 17,
 'atp/clean_strings/postcode': 12,
 'atp/clean_strings/state': 19,
 'atp/clean_strings/street_address': 107,
 'atp/country/GB': 1132,
 'atp/duplicate_count': 15228,
 'atp/field/country/from_spider_name': 3,
 'atp/field/email/missing': 1132,
 'atp/field/name/missing': 369,
 'atp/field/operator/missing': 763,
 'atp/field/operator_wikidata/missing': 763,
 'atp/field/phone/missing': 1132,
 'atp/field/state/missing': 64,
 'atp/item_scraped_host_count/search.barclays.co.uk': 16360,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1132,
 'atp/operator/Barclays': 369,
 'atp/operator_wikidata/Q245343': 369,
 'downloader/request_bytes': 440627,
 'downloader/request_count': 852,
 'downloader/request_method_count/GET': 852,
 'downloader/response_bytes': 54421174,
 'downloader/response_count': 852,
 'downloader/response_status_count/200': 818,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/502': 33,
 'elapsed_time_seconds': 172.08849,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 14, 7, 5, 51, 985162, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 11,
 'httperror/response_ignored_status_count/502': 11,
 'item_dropped_count': 15228,
 'item_dropped_reasons_count/DropItem': 15228,
 'item_scraped_count': 1132,
 'items_per_minute': None,
 'log_count/DEBUG': 17225,
 'log_count/ERROR': 11,
 'log_count/INFO': 22,
 'response_received_count': 830,
 'responses_per_minute': None,
 'retry/count': 22,
 'retry/max_reached': 11,
 'retry/reason_count/502 Bad Gateway': 22,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 851,
 'scheduler/dequeued/memory': 851,
 'scheduler/enqueued': 851,
 'scheduler/enqueued/memory': 851,
 'start_time': datetime.datetime(2025, 7, 14, 7, 2, 59, 896672, tzinfo=datetime.timezone.utc)}
 
```