### PR TITLE
[Cadence Bank US] Add Spider (391 locations)

### DIFF
--- a/locations/spiders/cadence_bank_us.py
+++ b/locations/spiders/cadence_bank_us.py
@@ -1,0 +1,20 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CadenceBankUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "cadence_bank_us"
+    item_attributes = {"brand": "Cadence Bank", "brand_wikidata": "Q4854138"}
+    sitemap_urls = ["https://cadencebank.com/sitemap.xml"]
+    sitemap_rules = [("/find-a-location/", "parse_sd")]
+    time_format = "%H:%M:%S"
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        apply_category(Categories.BANK, item)
+        if "ATM" in response.xpath('//*[@class="location-detail-hero-wrapper"]//h3//text()').get():
+            apply_yes_no(Extras.ATM, item, True)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Cadence Bank': 391,
 'atp/brand_wikidata/Q4854138': 391,
 'atp/category/amenity/bank': 391,
 'atp/cdn/cloudflare/response_count': 394,
 'atp/cdn/cloudflare/response_status_count/200': 394,
 'atp/country/US': 391,
 'atp/field/branch/missing': 391,
 'atp/field/country/from_spider_name': 391,
 'atp/field/email/missing': 391,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 391,
 'atp/field/operator_wikidata/missing': 391,
 'atp/field/phone/missing': 5,
 'atp/item_scraped_host_count/cadencebank.com': 391,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 391,
 'downloader/request_bytes': 291758,
 'downloader/request_count': 395,
 'downloader/request_method_count/GET': 395,
 'downloader/response_bytes': 8300939,
 'downloader/response_count': 395,
 'downloader/response_status_count/200': 394,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 492.229615,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 15, 10, 35, 8, 236454, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 35060685,
 'httpcompression/response_count': 394,
 'item_scraped_count': 391,
 'items_per_minute': None,
 'log_count/DEBUG': 797,
 'log_count/INFO': 17,
 'request_depth_max': 1,
 'response_received_count': 394,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 394,
 'scheduler/dequeued/memory': 394,
 'scheduler/enqueued': 394,
 'scheduler/enqueued/memory': 394,
 'start_time': datetime.datetime(2025, 7, 15, 10, 26, 56, 6839, tzinfo=datetime.timezone.utc)}
```