### PR TITLE
[Unicredit Bank IT] Add spider (7279 locations)

### DIFF
--- a/locations/spiders/unicredit_bank_it.py
+++ b/locations/spiders/unicredit_bank_it.py
@@ -24,7 +24,7 @@ class UnicreditBankITSpider(CrawlSpider):
     ]
     url_match = re.compile(r"url[:\s]+\'(.+?)\'")
     user_agent = BROWSER_DEFAULT
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 180}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         website = response.url

--- a/locations/spiders/unicredit_bank_it.py
+++ b/locations/spiders/unicredit_bank_it.py
@@ -1,0 +1,80 @@
+import re
+from typing import Any
+
+import chompjs
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class UnicreditBankITSpider(CrawlSpider):
+    name = "unicredit_bank_it"
+    item_attributes = {"brand": "UniCredit Bank", "brand_wikidata": "Q45568"}
+    start_urls = ["https://www.unicredit.it/it/contatti-e-agenzie/lista-agenzie.html"]
+    rules = [
+        Rule(LinkExtractor(allow=r"/contatti-e-agenzie/lista-agenzie/[a-z]{2}\.html$")),
+        Rule(LinkExtractor(allow=r"/contatti-e-agenzie/lista-agenzie/[a-z]{2}/[-\w]+\.html$")),
+        Rule(LinkExtractor(allow=r"/contatti-e-agenzie/lista-agenzie/[a-z]{2}/[-\w]+/[-\w]+\.html$"), callback="parse"),
+    ]
+    url_match = re.compile(r"url[:\s]+\'(.+?)\'")
+    user_agent = BROWSER_DEFAULT
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        website = response.url
+        for url in re.findall(self.url_match, response.text):
+            if "AgencyLocator" in url:
+                yield Request(url, callback=self.parse_branches, cb_kwargs=dict(website=website))
+            elif "ATMLocator" in url:
+                yield Request(url, callback=self.parse_atms, cb_kwargs=dict(website=website))
+            else:
+                continue
+
+    def parse_branches(self, response: Response, website: str) -> Any:
+        locations = chompjs.parse_js_object(response.text)
+        if locations.get("total") == 0:
+            return
+        for location in locations["layers"][0].get("objects", []):
+            coordinates = location["geom"]
+            location = location["data"]["main"]
+            item = Feature()
+            item["lat"] = coordinates.get("lat")
+            item["lon"] = coordinates.get("lng")
+            item["ref"] = location.get("TG_COD_DIP")
+            item["street_address"] = location.get("TG_VIA_FIL")
+            item["city"] = location.get("TG_LOC_FIL")
+            item["state"] = location.get("TG_SGL_PRO")
+            item["postcode"] = location.get("TG_CAP_FIL")
+            item["phone"] = (
+                location["TG_TEL_PRN"] + location["TG_TEL_NUM"]
+                if location.get("TG_TEL_PRN")
+                else location.get("TG_TEL_NUM")
+            )
+            item["email"] = location.get("TG_IN_MAIL")
+            item["website"] = website
+            apply_category(Categories.BANK, item)
+            apply_yes_no(Extras.ATM, item, location.get("ATM") == "1")
+            yield item
+
+    def parse_atms(self, response: Response, website: str) -> Any:
+        locations = chompjs.parse_js_object(response.text)
+        if locations.get("total") == 0:
+            return
+        for location in locations["layers"][0].get("objects", []):
+            coordinates = location["geom"]
+            location = location["data"]["main"]
+            item = Feature()
+            item["lat"] = coordinates.get("lat")
+            item["lon"] = coordinates.get("lng")
+            item["ref"] = location.get("TG_COD_ATM")
+            item["street_address"] = location.get("TG_INDIRIZZO_ATM")
+            item["city"] = location.get("TG_LOCALITA")
+            item["state"] = location.get("TG_PROVINCIA")
+            item["website"] = website
+            apply_category(Categories.ATM, item)
+            yield item

--- a/locations/spiders/unicredit_bank_it.py
+++ b/locations/spiders/unicredit_bank_it.py
@@ -50,11 +50,18 @@ class UnicreditBankITSpider(CrawlSpider):
             item["city"] = location.get("TG_LOC_FIL")
             item["state"] = location.get("TG_SGL_PRO")
             item["postcode"] = location.get("TG_CAP_FIL")
-            item["phone"] = (
-                location["TG_TEL_PRN"] + location["TG_TEL_NUM"]
-                if location.get("TG_TEL_PRN")
-                else location.get("TG_TEL_NUM")
-            )
+
+            for contact_type in ["TEL", "FAX"]:
+                contact = (
+                    location[f"TG_{contact_type}_PRN"] + location[f"TG_{contact_type}_NUM"]
+                    if location.get(f"TG_{contact_type}_PRN")
+                    else location.get(f"TG_{contact_type}_NUM")
+                )
+                if contact_type == "TEL":
+                    item["phone"] = contact
+                else:
+                    item["extras"]["fax"] = contact
+
             item["email"] = location.get("TG_IN_MAIL")
             item["website"] = website
             apply_category(Categories.BANK, item)

--- a/locations/spiders/unicredit_bank_it.py
+++ b/locations/spiders/unicredit_bank_it.py
@@ -71,7 +71,7 @@ class UnicreditBankITSpider(CrawlSpider):
             item = Feature()
             item["lat"] = coordinates.get("lat")
             item["lon"] = coordinates.get("lng")
-            item["ref"] = location.get("TG_COD_ATM")
+            item["ref"] = location.get("TG_COD_DIP") + "-" + location.get("TG_COD_ATM")
             item["street_address"] = location.get("TG_INDIRIZZO_ATM")
             item["city"] = location.get("TG_LOCALITA")
             item["state"] = location.get("TG_PROVINCIA")


### PR DESCRIPTION
```python
{'atp/brand/UniCredit Bank': 7279,
 'atp/brand_wikidata/Q45568': 7279,
 'atp/category/amenity/atm': 5067,
 'atp/category/amenity/bank': 2212,
 'atp/country/IT': 7279,
 'atp/field/branch/missing': 7279,
 'atp/field/country/from_spider_name': 7279,
 'atp/field/email/missing': 5080,
 'atp/field/image/missing': 7279,
 'atp/field/name/missing': 5067,
 'atp/field/opening_hours/missing': 5328,
 'atp/field/operator/missing': 2212,
 'atp/field/operator_wikidata/missing': 2212,
 'atp/field/phone/missing': 5180,
 'atp/field/postcode/missing': 5067,
 'atp/field/twitter/missing': 7279,
 'atp/item_scraped_host_count/www.geocms.it': 7279,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 7279,
 'atp/operator/UniCredit Bank': 5067,
 'atp/operator_wikidata/Q45568': 5067,
 'downloader/request_bytes': 9177957,
 'downloader/request_count': 11843,
 'downloader/request_method_count/GET': 11843,
 'downloader/response_bytes': 160114960,
 'downloader/response_count': 11843,
 'downloader/response_status_count/200': 8134,
 'downloader/response_status_count/301': 3709,
 'dupefilter/filtered': 1390,
 'elapsed_time_seconds': 254.13115,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 15, 12, 24, 1, 631924, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 11843,
 'httpcompression/response_bytes': 287764058,
 'httpcompression/response_count': 3710,
 'item_scraped_count': 7279,
 'items_per_minute': None,
 'log_count/DEBUG': 19135,
 'log_count/INFO': 13,
 'request_depth_max': 4,
 'response_received_count': 8134,
 'responses_per_minute': None,
 'scheduler/dequeued': 11843,
 'scheduler/dequeued/memory': 11843,
 'scheduler/enqueued': 11843,
 'scheduler/enqueued/memory': 11843,
 'start_time': datetime.datetime(2025, 7, 15, 12, 19, 47, 500774, tzinfo=datetime.timezone.utc)}
```