### PR TITLE
[Albert Heijn] Split spider

### DIFF
--- a/locations/spiders/albert_heijn_be.py
+++ b/locations/spiders/albert_heijn_be.py
@@ -1,0 +1,7 @@
+from locations.spiders.albert_heijn_nl import AlbertHeijnNLSpider
+
+
+class AlbertHeijnBESpider(AlbertHeijnNLSpider):
+    name = "albert_heijn_be"
+    allowed_domains = ["www.ah.be"]
+    start_urls = ["https://www.ah.be/winkels"]

--- a/locations/spiders/albert_heijn_nl.py
+++ b/locations/spiders/albert_heijn_nl.py
@@ -11,10 +11,10 @@ from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AlbertHeijnSpider(Spider):
-    name = "albert_heijn"
-    allowed_domains = ["www.ah.nl", "www.ah.be"]
-    start_urls = ["https://www.ah.nl/winkels", "https://www.ah.be/winkels"]
+class AlbertHeijnNLSpider(Spider):
+    name = "albert_heijn_nl"
+    allowed_domains = ["www.ah.nl"]
+    start_urls = ["https://www.ah.nl/winkels"]
     user_agent = BROWSER_DEFAULT
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS


### PR DESCRIPTION
The spider is [wobbly](https://alltheplaces.xyz/spiders.html?search=albert_heijn), recently it's not fetched both countries, the time it "worked" it only got 1 country. Albert Heijn is keeping the connection open and the spider is never timing out, this is bad enough with 1 spider, it takes up a slot in the weekly for the full 8 hours, with 2 spiders the potential is even worse, 2x8 hour blocks wasted.

However with the 2 spiders, I've not hit the issue locally. Hopefully this works for us.