### PR TITLE
[Arvest Bank US] Add Spider (294 locations)

### DIFF
--- a/locations/spiders/arvest_bank_us.py
+++ b/locations/spiders/arvest_bank_us.py
@@ -1,0 +1,18 @@
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.storefinders.momentfeed import MomentFeedSpider
+
+
+class ArvestBankUSSpider(MomentFeedSpider):
+    name = "arvest_bank_us"
+    item_attributes = {"brand": "Arvest Bank", "brand_wikidata": "Q4802393"}
+    api_key = "RCKBBWJSPPOONTUT"
+
+    def parse_item(self, item: Feature, feature: dict, store_info: dict):
+        if "ATM" in item["name"]:
+            apply_category(Categories.ATM, item)
+        else:
+            apply_category(Categories.BANK, item)
+            if data := feature.get("tags"):
+                apply_yes_no(Extras.ATM, item, True if "ATM" in data else False)
+        yield item

--- a/locations/storefinders/momentfeed.py
+++ b/locations/storefinders/momentfeed.py
@@ -35,9 +35,6 @@ class MomentFeedSpider(Spider):
             return
 
         for feature in response.json():
-            if feature["status"] != "open":
-                continue
-
             store_info = feature["store_info"]
             item = DictParser.parse(store_info)
             item["ref"] = store_info["corporate_id"]


### PR DESCRIPTION
```python
{'atp/brand/Arvest Bank': 294,
 'atp/brand_wikidata/Q4802393': 294,
 'atp/category/amenity/atm': 75,
 'atp/category/amenity/bank': 219,
 'atp/country/US': 294,
 'atp/field/branch/missing': 294,
 'atp/field/email/missing': 294,
 'atp/field/image/missing': 294,
 'atp/field/opening_hours/missing': 58,
 'atp/field/operator/missing': 219,
 'atp/field/operator_wikidata/missing': 219,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 294,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/uberall.com': 294,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 294,
 'atp/operator/Arvest Bank': 75,
 'atp/operator_wikidata/Q4802393': 75,
 'downloader/request_bytes': 1917,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 2553234,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 10.159135,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 16, 6, 53, 49, 88320, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10528026,
 'httpcompression/response_count': 4,
 'item_scraped_count': 294,
 'items_per_minute': None,
 'log_count/DEBUG': 309,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 4,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 7, 16, 6, 53, 38, 929185, tzinfo=datetime.timezone.utc)}
```