### PR TITLE
[Fnbc CA] Add spider (3580 locations)

### DIFF
--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -1,0 +1,39 @@
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class FnbcCASpider(Spider):
+    name = "fnbc_ca"
+    FNBC = {"brand": "First Nations Bank of Canada", "brand_wikidata": "Q1419511"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self) -> Iterable[JsonRequest]:
+        yield JsonRequest(
+            url=f"https://api.forge.central1.cc/find-branch-atm-service/v1/places?latitude=58.55148693137242&longitude=-94.06979&radius=4000&type=all&dedupeAtms=true",
+            headers={"c1-tid": "sk_fnbc"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location_type in ["branches", "atms"]:
+            locations = response.json()[location_type]
+            for location in locations:
+                location.update(location.pop("details", {}))
+                item = DictParser.parse(location)
+                item["street_address"] = merge_address_lines(location["address"].get("line"))
+                if location.get("type") == "branch":
+                    item.update(self.FNBC)
+                    apply_category(Categories.BANK, item)
+                elif location.get("type") == "atm":
+                    if item["name"] == self.FNBC["brand"]:
+                        item.update(self.FNBC)
+                    else:
+                        # ATMs of other brands/operators
+                        pass
+                    apply_category(Categories.ATM, item)
+                yield item

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -27,6 +27,7 @@ class FnbcCASpider(Spider):
                 item = DictParser.parse(location)
                 item["street_address"] = merge_address_lines(location["address"].get("line"))
                 if location.get("type") == "branch":
+                    item["branch"] = item.pop("name")
                     item.update(self.FNBC)
                     apply_category(Categories.BANK, item)
                 elif location.get("type") == "atm":

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -28,6 +28,12 @@ class FnbcCASpider(Spider):
                 item["street_address"] = merge_address_lines(location["address"].get("line"))
                 if location.get("type") == "branch":
                     item["branch"] = item.pop("name")
+                    phone_details = location["contacts"][0]["phone"]
+                    item["phone"] = (
+                        str(phone_details["areacode"]) + phone_details["phone"]
+                        if phone_details.get("areacode")
+                        else phone_details["phone"]
+                    )
                     item.update(self.FNBC)
                     apply_category(Categories.BANK, item)
                 elif location.get("type") == "atm":

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -37,6 +37,7 @@ class FnbcCASpider(Spider):
                         else phone_details["phone"]
                     )
                     item["opening_hours"] = self.parse_opening_hours(location["operationHours"]["regularHours"][0])
+                    item["website"] = f'https://www.fnbc.ca/find-a-location?branchId={location["id"]}'
                     item.update(self.FNBC)
                     apply_category(Categories.BANK, item)
 

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -3,7 +3,7 @@ from typing import Any, Iterable
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -40,6 +40,7 @@ class FnbcCASpider(Spider):
                     item["website"] = f'https://www.fnbc.ca/find-a-location?branchId={location["id"]}'
                     item.update(self.FNBC)
                     apply_category(Categories.BANK, item)
+                    apply_yes_no(Extras.ATM, item, "ATM" in location["info"]["service"])
 
                 elif location.get("type") == "atm":
                     if item["name"] == self.FNBC["brand"]:

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -39,6 +39,7 @@ class FnbcCASpider(Spider):
                     item["opening_hours"] = self.parse_opening_hours(location["operationHours"]["regularHours"][0])
                     item["website"] = f'https://www.fnbc.ca/find-a-location?branchId={location["id"]}'
                     item.update(self.FNBC)
+                    item["name"] = item["brand"]
                     apply_category(Categories.BANK, item)
                     apply_yes_no(Extras.ATM, item, "ATM" in location["info"]["service"])
 

--- a/locations/spiders/fnbc_ca.py
+++ b/locations/spiders/fnbc_ca.py
@@ -16,7 +16,7 @@ class FnbcCASpider(Spider):
 
     def start_requests(self) -> Iterable[JsonRequest]:
         yield JsonRequest(
-            url=f"https://api.forge.central1.cc/find-branch-atm-service/v1/places?latitude=58.55148693137242&longitude=-94.06979&radius=4000&type=all&dedupeAtms=true",
+            url="https://api.forge.central1.cc/find-branch-atm-service/v1/places?latitude=58.55148693137242&longitude=-94.06979&radius=4000&type=all&dedupeAtms=true",
             headers={"c1-tid": "sk_fnbc"},
         )
 


### PR DESCRIPTION
 `'item_dropped_count': 152` is due to actual duplicate entries in the data.

```python
{'atp/brand/First Nations Bank of Canada': 31,
 'atp/brand_wikidata/Q1419511': 31,
 'atp/category/amenity/atm': 3558,
 'atp/category/amenity/bank': 22,
 'atp/clean_strings/name': 54,
 'atp/country/CA': 3580,
 'atp/duplicate_count': 152,
 'atp/field/branch/missing': 3558,
 'atp/field/brand/missing': 3549,
 'atp/field/brand_wikidata/missing': 3549,
 'atp/field/country/from_spider_name': 3580,
 'atp/field/email/missing': 3580,
 'atp/field/image/missing': 3580,
 'atp/field/opening_hours/missing': 3558,
 'atp/field/operator/missing': 3580,
 'atp/field/operator_wikidata/missing': 3580,
 'atp/field/phone/missing': 3558,
 'atp/field/twitter/missing': 3580,
 'atp/field/website/missing': 3558,
 'atp/item_scraped_host_count/api.forge.central1.cc': 3732,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 31,
 'downloader/request_bytes': 478,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1906815,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 7.326982,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 16, 8, 50, 35, 220646, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 152,
 'item_dropped_reasons_count/DropItem': 152,
 'item_scraped_count': 3580,
 'items_per_minute': None,
 'log_count/DEBUG': 3744,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 16, 8, 50, 27, 893664, tzinfo=datetime.timezone.utc)}
```