### PR TITLE
[mercedes_benz_group] parse more countries, brands and types

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -92,6 +92,9 @@ class Categories(Enum):
     SHOP_BOOKMAKER = {"shop": "bookmaker"}
     SHOP_BOOKS = {"shop": "books"}
     SHOP_BUTCHER = {"shop": "butcher"}
+    SHOP_BUS = {"shop": "bus"}
+    SHOP_BUS_REPAIR = {"shop": "bus_repair"}
+    SHOP_BUS_PARTS = {"shop": "bus_parts"}
     SHOP_CAMERA = {"shop": "camera"}
     SHOP_CANDLES = {"shop": "candles"}
     SHOP_CANNABIS = {"shop": "cannabis"}

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -14,6 +14,9 @@ from locations.json_blob_spider import JSONBlobSpider
 class MercedesBenzGroupSpider(JSONBlobSpider):
     name = "mercedes_benz_group"
 
+    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
+    locations_key = "dealers"
+
     MERCEDES_BENZ = {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"}
     MERCEDES_BENZ_VANS = {"brand": "Mercedes-Benz Vans", "brand_wikidata": "Q55383469"}
     MERCEDES_BENZ_TRUCKS = {"brand": "Mercedes-Benz Trucks", "brand_wikidata": "Q36008"}
@@ -21,9 +24,13 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
     SETRA = {"brand": "Setra", "brand_wikidata": "Q938615"}
     FUSO = {"brand": "Fuso", "brand_wikidata": "Q1190247"}
     SMART = {"brand": "Smart", "brand_wikidata": "Q156490"}
-    # OMNI_PLUS = {"brand": "OMNIplus", "brand_wikidata": "Q122922653"}
+    OMNI_PLUS = {"brand": "OMNIplus", "brand_wikidata": "Q122922653"}
 
-    DEPARTMENT_MAPPING = {
+    # Each location can have multiple services, each with a brand and product group.
+    # Easiest way to work with this data downstream is to yield a POI for each brand/category combination.
+    # This mapping is a way to manage this.
+    DEPARTMENT_MAPPING: dict[tuple[str, str, str], tuple[dict, Categories | dict]] = {
+        # key = (brand, service, productGroup):
         ("Mercedes-Benz", "New Vehicle Sales", "Passenger Car"): (MERCEDES_BENZ, Categories.SHOP_CAR),
         ("Mercedes-Benz", "New Vehicle Sales", "Vans"): (MERCEDES_BENZ_VANS, Categories.SHOP_CAR),
         ("Mercedes-Benz", "New Vehicle Sales", "Trucks"): (MERCEDES_BENZ_TRUCKS, Categories.SHOP_TRUCK),
@@ -41,10 +48,11 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
         ("smart", "New Vehicle Sales", "Passenger Car"): (SMART, Categories.SHOP_CAR),
         ("smart", "Repair & Maintenance", "Passenger Car"): (SMART, Categories.SHOP_CAR_REPAIR),
         ("smart", "Mercedes-Benz Rent", "Passenger Car"): (SMART, Categories.CAR_RENTAL),
-        # ("Mercedes-Benz", r"OMNIplus .*", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR)
+        ("Mercedes-Benz", "OMNIplus BusPort", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR),
+        ("Mercedes-Benz", "OMNIplus BusWorld", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR),
+        ("Setra", "OMNIplus BusPort", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR),
+        ("Setra", "OMNIplus BusWorld", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR),
     }
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
-    locations_key = "dealers"
 
     def make_request(self, country: str, page: int = 1) -> Request:
         url = "https://api.oneweb.mercedes-benz.com/dms-plus/v3/api/dealers/market?marketCode={}&page={}&size=25&includeFields=*&localeLanguage=true".format(
@@ -59,8 +67,11 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = feature["outletId"]
+
+        # Similar to how it's shown on the website
         item["name"] = feature.get("legalName")
         item["extras"]["alt_name"] = feature.get("nameAddition")
+
         item["state"] = feature.get("address", {}).get("region", {}).get("state")
         item["lat"] = feature.get("address", {}).get("coordinates", {}).get("latitude")
         item["lon"] = feature.get("address", {}).get("coordinates", {}).get("longitude")
@@ -73,10 +84,11 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
                 service.get("service", {}).get("name"),
                 service.get("productGroup", {}).get("name"),
             )
-            self.crawler.stats.inc_value(f"{self.name}/services/{key[0]}/{key[1]}/{key[2]}")
+            # Useful in development:
+            # self.crawler.stats.inc_value(f"{self.name}/services/{key[0]}/{key[1]}/{key[2]}")
             if key in self.DEPARTMENT_MAPPING:
                 branded_item = deepcopy(item)
-                branded_item["ref"] = "-".join([branded_item["ref"], country] + list(key)).replace(" ", "-")
+                branded_item["ref"] = self.make_ref(branded_item, key)
                 brand, category = self.DEPARTMENT_MAPPING[key]
                 branded_item.update(brand)
                 self.parse_contacts(branded_item, service)
@@ -107,3 +119,15 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
                     for period in day.get("periods", []):
                         oh.add_range(day["day"], period["from"], period["until"])
             item["opening_hours"] = oh
+
+    def make_ref(self, item: Feature, key: tuple[str, str, str]) -> str:
+        country = item["country"]
+        brand, service, product_group = key
+
+        if service.startswith("OMNIplus"):
+            # Handle presence of multiple different OMNIplus services at the same location
+            # assuming deduplication pipeline will remove POIs with the same ref
+            service = "OMNIplus"
+            brand = "OMNIplus"
+
+        return "-".join([item["ref"], country, brand, service, product_group]).replace(" ", "-")

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -16,6 +16,7 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
     Main site: https://www.mercedes-benz.com/en/
     API found at https://www.mercedes-benz.dk/passengercars/mercedes-benz-cars/dealer-locator.html
     """
+
     name = "mercedes_benz_group"
 
     custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -1,11 +1,13 @@
-import scrapy
+from typing import Iterable
 
-from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, sanitise_day
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class MercedesBenzGroupSpider(scrapy.Spider):
+class MercedesBenzGroupSpider(JSONBlobSpider):
     name = "mercedes_benz_group"
     available_countries = [
         "VN",
@@ -81,60 +83,35 @@ class MercedesBenzGroupSpider(scrapy.Spider):
         "ES",
         "ZA",
         "KR",
+        "SA",
     ]
 
-    brand_mapping = {
+    BRAND_MAPPING = {
         "Mercedes-Benz": {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"},
         "Maybach": {"brand": "Maybach", "brand_wikidata": "Q35989"},
         "Smart": {"brand": "Smart", "brand_wikidata": "Q156490"},
         "Fuso": {"brand": "Fuso", "brand_wikidata": "Q36033"},
         "Setra": {"brand": "Setra", "brand_wikidata": "Q938615"},
     }
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "45ab9277-3014-4c9e-b059-6c0542ad9484"}}
+    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
+    locations_key = "dealers"
 
-    def start_requests(self):
+    def make_request(self, country: str, page: int = 1) -> Request:
+        url = "https://api.oneweb.mercedes-benz.com/dms-plus/v3/api/dealers/market?marketCode={}&page={}&size=25&includeFields=*&localeLanguage=true".format(
+            country, page
+        )
+        return Request(url, meta={"country": country})
+
+    def start_requests(self) -> Iterable[Request]:
         for country in self.available_countries:
-            url = f"https://api.oneweb.mercedes-benz.com/dlc-dms/v2/dealers/search?configurationExternalId=OneDLC_Dlp&country={country}&strictGeo=true&expand=false&localeLanguage=false&distance=2500km&includeApplicants=true&spellCheck=false&size=-1&searchProfileName=DLp_{country.lower()}"
-            yield scrapy.Request(url=url, callback=self.get_store_info)
+            yield self.make_request(country)
 
-    def get_store_info(self, response):
-        for store in response.json().get("results", []):
-            url = f"https://api.oneweb.mercedes-benz.com/dlc-dms/v2/dealers/search/byId?localeLanguage=false&id={store.get('baseInfo').get('externalId')}&fields=*"
-            yield scrapy.Request(url=url, callback=self.parse)
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["outletId"]
+        item["state"] = feature.get("address", {}).get("region", {}).get("state")
+        yield item
 
-    def parse(self, response):
-        for data in response.json().get("results", []):
-            oh = OpeningHours()
-            for function in data.get("functions"):
-                if function.get("activityCode") != "SALES":
-                    continue
-                for day, hours in function.get("openingHours").items():
-                    day = sanitise_day(day)
-                    if not hours.get("open"):
-                        continue
-                    for periods in hours.get("timePeriods"):
-                        oh.add_range(
-                            day=day, open_time=periods.get("from"), close_time=periods.get("to"), time_format="%H:%M"
-                        )
-
-            item = DictParser.parse(data)
-            address_details = data.get("address")
-            base_info = data.get("baseInfo")
-            item["ref"] = base_info.get("externalId")
-            item["name"] = base_info.get("name1") or data.get("baseInfo").get("name2")
-            item["lat"] = address_details.get("latitude")
-            item["lon"] = address_details.get("longitude")
-            item["opening_hours"] = oh
-            if len(data.get("brands")) > 1:
-                item["brand"] = self.brand_mapping.get("Mercedes-Benz").get("brand")
-                item["brand_wikidata"] = self.brand_mapping.get("Mercedes-Benz").get("brand_wikidata")
-            else:
-                item["brand"] = data.get("brands")[0].get("brand").get("name")
-                item["brand_wikidata"] = self.brand_mapping.get(item["brand"]).get("brand_wikidata")
-
-            if isinstance(item["state"], dict):
-                item["state"] = item["state"].get("region")
-
-            apply_category(Categories.SHOP_CAR, item)
-
-            yield item
+        data = response.json()
+        current_page = data["page"]["number"]
+        if current_page < data["page"]["totalPages"]:
+            yield self.make_request(response.meta["country"], current_page + 1)

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 from typing import Iterable
 
@@ -65,6 +66,20 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
         item["lat"] = feature.get("address", {}).get("coordinates", {}).get("latitude")
         item["lon"] = feature.get("address", {}).get("coordinates", {}).get("longitude")
         country = response.meta["country"]
+        service_products = set([s.get("productGroup", {}).get("name") for s in feature.get("offeredServices", [])])
+
+        if all("Trucks" == sp for sp in service_products):
+            self.crawler.stats.inc_value(f"{self.name}/only/Trucks")
+            self.logger.info(f"Only Trucks for {json.dumps(feature)}")
+        # same as above but for Vans
+        elif all("Vans" == sp for sp in service_products):
+            self.crawler.stats.inc_value(f"{self.name}/only/Vans")
+            self.logger.info(f"Only Vans for {json.dumps(feature)}")
+        # same as above but for Buses
+        elif all("Busses" == sp for sp in service_products):
+            self.crawler.stats.inc_value(f"{self.name}/only/Buses")
+            self.logger.info(f"Only Buses for {json.dumps(feature)}")
+
         for service in feature.get("offeredServices", []):
             if service.get("validity", {}).get("validity") == False:
                 continue

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -14,32 +14,34 @@ from locations.json_blob_spider import JSONBlobSpider
 class MercedesBenzGroupSpider(JSONBlobSpider):
     name = "mercedes_benz_group"
 
-    BRAND_MAPPING = {
-        "Mercedes-Benz": {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"},
-        "Mercedes-Benz Vans": {"brand": "Mercedes-Benz Vans", "brand_wikidata": "Q55383469"},
-        "Mercedes-Benz Trucks": {"brand": "Mercedes-Benz Trucks", "brand_wikidata": "Q36008"},
-        "Maybach": {"brand": "Maybach", "brand_wikidata": "Q35989"},
-        "Smart": {"brand": "Smart", "brand_wikidata": "Q156490"},
-        "Fuso": {"brand": "Fuso", "brand_wikidata": "Q36033"},
-        "Setra": {"brand": "Setra", "brand_wikidata": "Q938615"},
-    }
-
     MERCEDES_BENZ = {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"}
     MERCEDES_BENZ_VANS = {"brand": "Mercedes-Benz Vans", "brand_wikidata": "Q55383469"}
     MERCEDES_BENZ_TRUCKS = {"brand": "Mercedes-Benz Trucks", "brand_wikidata": "Q36008"}
+    MERCEDES_BENZ_BUS = {"brand": "Mercedes-Benz Buses", "brand_wikidata": "Q1427345"}
     SETRA = {"brand": "Setra", "brand_wikidata": "Q938615"}
+    FUSO = {"brand": "Fuso", "brand_wikidata": "Q1190247"}
+    SMART = {"brand": "Smart", "brand_wikidata": "Q156490"}
+    # OMNI_PLUS = {"brand": "OMNIplus", "brand_wikidata": "Q122922653"}
 
     DEPARTMENT_MAPPING = {
         ("Mercedes-Benz", "New Vehicle Sales", "Passenger Car"): (MERCEDES_BENZ, Categories.SHOP_CAR),
         ("Mercedes-Benz", "New Vehicle Sales", "Vans"): (MERCEDES_BENZ_VANS, Categories.SHOP_CAR),
         ("Mercedes-Benz", "New Vehicle Sales", "Trucks"): (MERCEDES_BENZ_TRUCKS, Categories.SHOP_TRUCK),
-        ("Mercedes-Benz", "New Vehicle Sales", "Busses"): (MERCEDES_BENZ, Categories.SHOP_BUS),
+        ("Mercedes-Benz", "New Vehicle Sales", "Busses"): (MERCEDES_BENZ_BUS, Categories.SHOP_BUS),
         ("Mercedes-Benz", "Repair & Maintenance", "Passenger Car"): (MERCEDES_BENZ, Categories.SHOP_CAR_REPAIR),
         ("Mercedes-Benz", "Repair & Maintenance", "Vans"): (MERCEDES_BENZ_VANS, Categories.SHOP_CAR_REPAIR),
         ("Mercedes-Benz", "Repair & Maintenance", "Trucks"): (MERCEDES_BENZ_TRUCKS, Categories.SHOP_TRUCK_REPAIR),
-        ("Mercedes-Benz", "Repair & Maintenance", "Busses"): (MERCEDES_BENZ, Categories.SHOP_BUS_REPAIR),
+        ("Mercedes-Benz", "Repair & Maintenance", "Busses"): (MERCEDES_BENZ_BUS, Categories.SHOP_BUS_REPAIR),
+        ("Mercedes-Benz", "Mercedes-Benz Rent", "Passenger Car"): (MERCEDES_BENZ, Categories.CAR_RENTAL),
+        ("Mercedes-Benz", "Mercedes-Benz Rent", "Vans"): (MERCEDES_BENZ_VANS, Categories.CAR_RENTAL),
         ("Setra", "New Vehicle Sales", "Busses"): (SETRA, Categories.SHOP_BUS),
         ("Setra", "Repair & Maintenance", "Busses"): (SETRA, Categories.SHOP_BUS_REPAIR),
+        ("FUSO", "New Vehicle Sales", "Trucks"): (FUSO, Categories.SHOP_TRUCK),
+        ("FUSO", "Repair & Maintenance", "Trucks"): (FUSO, Categories.SHOP_TRUCK_REPAIR),
+        ("smart", "New Vehicle Sales", "Passenger Car"): (SMART, Categories.SHOP_CAR),
+        ("smart", "Repair & Maintenance", "Passenger Car"): (SMART, Categories.SHOP_CAR_REPAIR),
+        ("smart", "Mercedes-Benz Rent", "Passenger Car"): (SMART, Categories.CAR_RENTAL),
+        # ("Mercedes-Benz", r"OMNIplus .*", "Busses"): (OMNI_PLUS, Categories.SHOP_BUS_REPAIR)
     }
     custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
     locations_key = "dealers"
@@ -57,19 +59,28 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = feature["outletId"]
+        item["name"] = feature.get("legalName")
+        item["extras"]["alt_name"] = feature.get("nameAddition")
         item["state"] = feature.get("address", {}).get("region", {}).get("state")
+        item["lat"] = feature.get("address", {}).get("coordinates", {}).get("latitude")
+        item["lon"] = feature.get("address", {}).get("coordinates", {}).get("longitude")
         country = response.meta["country"]
         for service in feature.get("offeredServices", []):
+            if service.get("validity", {}).get("validity") == False:
+                continue
             key = (
                 service.get("brand", {}).get("name"),
                 service.get("service", {}).get("name"),
                 service.get("productGroup", {}).get("name"),
             )
-            self.crawler.stats.inc_value(f"{self.name}/services/{country}/{key[0]}/{key[1]}/{key[2]}")
+            self.crawler.stats.inc_value(f"{self.name}/services/{key[0]}/{key[1]}/{key[2]}")
             if key in self.DEPARTMENT_MAPPING:
                 branded_item = deepcopy(item)
+                branded_item["ref"] = "-".join([branded_item["ref"], country] + list(key)).replace(" ", "-")
                 brand, category = self.DEPARTMENT_MAPPING[key]
                 branded_item.update(brand)
+                self.parse_contacts(branded_item, service)
+                self.parse_hours(branded_item, service)
                 apply_category(category, branded_item)
                 yield branded_item
 
@@ -80,9 +91,11 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
 
     def parse_contacts(self, item: Feature, service: dict) -> None:
         communication = service.get("communication", {})
-        item["website"] = communication.get("INTERNET")
+        item["website"] = communication.get("INTERNET", "").strip().lower()
         item["email"] = communication.get("EMAIL")
         item["phone"] = communication.get("PHONE")
+        if item.get("website") and not item.get("website", "").startswith("http"):
+            item["website"] = "https://" + item["website"]
 
     def parse_hours(self, item: Feature, service: dict) -> None:
         if hours := service.get("openingHours"):

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -12,6 +12,10 @@ from locations.json_blob_spider import JSONBlobSpider
 
 
 class MercedesBenzGroupSpider(JSONBlobSpider):
+    """
+    Main site: https://www.mercedes-benz.com/en/
+    API found at https://www.mercedes-benz.dk/passengercars/mercedes-benz-cars/dealer-locator.html
+    """
     name = "mercedes_benz_group"
 
     custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
@@ -126,7 +130,7 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
 
         if service.startswith("OMNIplus"):
             # Handle presence of multiple different OMNIplus services at the same location
-            # assuming deduplication pipeline will remove POIs with the same ref
+            # assuming deduplication pipeline is enabled for the spider.
             service = "OMNIplus"
             brand = "OMNIplus"
 

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -1,9 +1,12 @@
+from copy import deepcopy
 from typing import Iterable
 
 from geonamescache import GeonamesCache
 from scrapy import Request
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -13,10 +16,30 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
 
     BRAND_MAPPING = {
         "Mercedes-Benz": {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"},
+        "Mercedes-Benz Vans": {"brand": "Mercedes-Benz Vans", "brand_wikidata": "Q55383469"},
+        "Mercedes-Benz Trucks": {"brand": "Mercedes-Benz Trucks", "brand_wikidata": "Q36008"},
         "Maybach": {"brand": "Maybach", "brand_wikidata": "Q35989"},
         "Smart": {"brand": "Smart", "brand_wikidata": "Q156490"},
         "Fuso": {"brand": "Fuso", "brand_wikidata": "Q36033"},
         "Setra": {"brand": "Setra", "brand_wikidata": "Q938615"},
+    }
+
+    MERCEDES_BENZ = {"brand": "Mercedes-Benz", "brand_wikidata": "Q36008"}
+    MERCEDES_BENZ_VANS = {"brand": "Mercedes-Benz Vans", "brand_wikidata": "Q55383469"}
+    MERCEDES_BENZ_TRUCKS = {"brand": "Mercedes-Benz Trucks", "brand_wikidata": "Q36008"}
+    SETRA = {"brand": "Setra", "brand_wikidata": "Q938615"}
+
+    DEPARTMENT_MAPPING = {
+        ("Mercedes-Benz", "New Vehicle Sales", "Passenger Car"): (MERCEDES_BENZ, Categories.SHOP_CAR),
+        ("Mercedes-Benz", "New Vehicle Sales", "Vans"): (MERCEDES_BENZ_VANS, Categories.SHOP_CAR),
+        ("Mercedes-Benz", "New Vehicle Sales", "Trucks"): (MERCEDES_BENZ_TRUCKS, Categories.SHOP_TRUCK),
+        ("Mercedes-Benz", "New Vehicle Sales", "Busses"): (MERCEDES_BENZ, Categories.SHOP_BUS),
+        ("Mercedes-Benz", "Repair & Maintenance", "Passenger Car"): (MERCEDES_BENZ, Categories.SHOP_CAR_REPAIR),
+        ("Mercedes-Benz", "Repair & Maintenance", "Vans"): (MERCEDES_BENZ_VANS, Categories.SHOP_CAR_REPAIR),
+        ("Mercedes-Benz", "Repair & Maintenance", "Trucks"): (MERCEDES_BENZ_TRUCKS, Categories.SHOP_TRUCK_REPAIR),
+        ("Mercedes-Benz", "Repair & Maintenance", "Busses"): (MERCEDES_BENZ, Categories.SHOP_BUS_REPAIR),
+        ("Setra", "New Vehicle Sales", "Busses"): (SETRA, Categories.SHOP_BUS),
+        ("Setra", "Repair & Maintenance", "Busses"): (SETRA, Categories.SHOP_BUS_REPAIR),
     }
     custom_settings = {"DEFAULT_REQUEST_HEADERS": {"x-apikey": "ce7d9916-6a3d-407a-b086-fea4cbae05f6"}}
     locations_key = "dealers"
@@ -37,13 +60,37 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
         item["state"] = feature.get("address", {}).get("region", {}).get("state")
         country = response.meta["country"]
         for service in feature.get("offeredServices", []):
-            service_name = service.get("service", {}).get("name")
-            brand = service.get("brand", {}).get("name")
-            product_group = service.get("productGroup", {}).get("name")
-            self.crawler.stats.inc_value(f"{self.name}/services/{country}/{brand}/{service_name}/{product_group}")
-        yield item
+            key = (
+                service.get("brand", {}).get("name"),
+                service.get("service", {}).get("name"),
+                service.get("productGroup", {}).get("name"),
+            )
+            self.crawler.stats.inc_value(f"{self.name}/services/{country}/{key[0]}/{key[1]}/{key[2]}")
+            if key in self.DEPARTMENT_MAPPING:
+                branded_item = deepcopy(item)
+                brand, category = self.DEPARTMENT_MAPPING[key]
+                branded_item.update(brand)
+                apply_category(category, branded_item)
+                yield branded_item
 
         data = response.json()
         current_page = data["page"]["number"]
         if current_page < data["page"]["totalPages"]:
             yield self.make_request(country, current_page + 1)
+
+    def parse_contacts(self, item: Feature, service: dict) -> None:
+        communication = service.get("communication", {})
+        item["website"] = communication.get("INTERNET")
+        item["email"] = communication.get("EMAIL")
+        item["phone"] = communication.get("PHONE")
+
+    def parse_hours(self, item: Feature, service: dict) -> None:
+        if hours := service.get("openingHours"):
+            oh = OpeningHours()
+            for day in hours:
+                if day.get("closed"):
+                    oh.set_closed(day["day"])
+                else:
+                    for period in day.get("periods", []):
+                        oh.add_range(day["day"], period["from"], period["until"])
+            item["opening_hours"] = oh

--- a/locations/spiders/mercedes_benz_group.py
+++ b/locations/spiders/mercedes_benz_group.py
@@ -1,4 +1,3 @@
-import json
 from copy import deepcopy
 from typing import Iterable
 
@@ -66,20 +65,6 @@ class MercedesBenzGroupSpider(JSONBlobSpider):
         item["lat"] = feature.get("address", {}).get("coordinates", {}).get("latitude")
         item["lon"] = feature.get("address", {}).get("coordinates", {}).get("longitude")
         country = response.meta["country"]
-        service_products = set([s.get("productGroup", {}).get("name") for s in feature.get("offeredServices", [])])
-
-        if all("Trucks" == sp for sp in service_products):
-            self.crawler.stats.inc_value(f"{self.name}/only/Trucks")
-            self.logger.info(f"Only Trucks for {json.dumps(feature)}")
-        # same as above but for Vans
-        elif all("Vans" == sp for sp in service_products):
-            self.crawler.stats.inc_value(f"{self.name}/only/Vans")
-            self.logger.info(f"Only Vans for {json.dumps(feature)}")
-        # same as above but for Buses
-        elif all("Busses" == sp for sp in service_products):
-            self.crawler.stats.inc_value(f"{self.name}/only/Buses")
-            self.logger.info(f"Only Buses for {json.dumps(feature)}")
-
         for service in feature.get("offeredServices", []):
             if service.get("validity", {}).get("validity") == False:
                 continue


### PR DESCRIPTION
This is probably questionable, so I'm fine if it's not merged.

```python
{'atp/brand/Fuso': 1816,
 'atp/brand/Mercedes-Benz': 6359,
 'atp/brand/Mercedes-Benz Buses': 1478,
 'atp/brand/Mercedes-Benz Trucks': 2817,
 'atp/brand/Mercedes-Benz Vans': 5538,
 'atp/brand/OMNIplus': 564,
 'atp/brand/Setra': 611,
 'atp/brand/Smart': 1704,
 'atp/brand_wikidata/Q1190247': 1816,
 'atp/brand_wikidata/Q122922653': 564,
 'atp/brand_wikidata/Q1427345': 1478,
 'atp/brand_wikidata/Q156490': 1704,
 'atp/brand_wikidata/Q36008': 9176,
 'atp/brand_wikidata/Q55383469': 5538,
 'atp/brand_wikidata/Q938615': 611,
 'atp/category/amenity/car_rental': 580,
 'atp/category/shop/bus': 431,
 'atp/category/shop/bus_repair': 2222,
 'atp/category/shop/car': 4931,
 'atp/category/shop/car_repair': 8090,
 'atp/category/shop/truck': 1638,
 'atp/category/shop/truck_repair': 2995,
 'atp/clean_strings/city': 109,
 'atp/clean_strings/email': 4,
 'atp/clean_strings/housenumber': 170,
 'atp/clean_strings/name': 245,
 'atp/clean_strings/phone': 15,
 'atp/clean_strings/postcode': 45,
 'atp/clean_strings/state': 49,
 'atp/clean_strings/street': 1022,
 'atp/country/AE': 48,
 'atp/country/AL': 11,
 'atp/country/AR': 293,
 'atp/country/AT': 450,
 'atp/country/AU': 520,
 'atp/country/BA': 30,
 'atp/country/BE': 391,
 'atp/country/BG': 50,
 'atp/country/BH': 10,
 'atp/country/BN': 8,
 'atp/country/BO': 41,
 'atp/country/BR': 912,
 'atp/country/CA': 387,
 'atp/country/CH': 544,
 'atp/country/CL': 239,
 'atp/country/CN': 65,
 'atp/country/CO': 174,
 'atp/country/CY': 37,
 'atp/country/CZ': 162,
 'atp/country/DE': 3974,
 'atp/country/DK': 214,
 'atp/country/DO': 30,
 'atp/country/EC': 34,
 'atp/country/EE': 29,
 'atp/country/EG': 52,
 'atp/country/ES': 861,
 'atp/country/FI': 239,
 'atp/country/FR': 1307,
 'atp/country/GB': 720,
 'atp/country/GL': 6,
 'atp/country/GR': 124,
 'atp/country/HK': 20,
 'atp/country/HR': 70,
 'atp/country/HT': 16,
 'atp/country/HU': 110,
 'atp/country/ID': 124,
 'atp/country/IE': 118,
 'atp/country/IN': 205,
 'atp/country/IQ': 28,
 'atp/country/IR': 18,
 'atp/country/IS': 16,
 'atp/country/IT': 1031,
 'atp/country/JO': 12,
 'atp/country/JP': 1169,
 'atp/country/KR': 160,
 'atp/country/KW': 12,
 'atp/country/LB': 16,
 'atp/country/LK': 22,
 'atp/country/LT': 21,
 'atp/country/LU': 27,
 'atp/country/LV': 20,
 'atp/country/MA': 53,
 'atp/country/ME': 11,
 'atp/country/MK': 27,
 'atp/country/MO': 6,
 'atp/country/MT': 8,
 'atp/country/MX': 285,
 'atp/country/MY': 168,
 'atp/country/NL': 392,
 'atp/country/NO': 350,
 'atp/country/NZ': 128,
 'atp/country/OM': 24,
 'atp/country/PA': 23,
 'atp/country/PE': 144,
 'atp/country/PH': 94,
 'atp/country/PL': 358,
 'atp/country/PT': 269,
 'atp/country/PY': 53,
 'atp/country/QA': 14,
 'atp/country/RO': 194,
 'atp/country/RS': 36,
 'atp/country/SA': 49,
 'atp/country/SE': 326,
 'atp/country/SG': 12,
 'atp/country/SI': 48,
 'atp/country/SK': 105,
 'atp/country/TH': 220,
 'atp/country/TN': 43,
 'atp/country/TR': 341,
 'atp/country/TW': 91,
 'atp/country/UA': 118,
 'atp/country/US': 1316,
 'atp/country/UY': 24,
 'atp/country/VE': 16,
 'atp/country/VN': 54,
 'atp/country/ZA': 310,
 'atp/duplicate_count': 3681,
 'atp/field/branch/missing': 20887,
 'atp/field/city/missing': 76,
 'atp/field/email/missing': 11892,
 'atp/field/image/missing': 20887,
 'atp/field/opening_hours/missing': 1770,
 'atp/field/operator/missing': 20887,
 'atp/field/operator_wikidata/missing': 20887,
 'atp/field/phone/invalid': 59,
 'atp/field/phone/missing': 14333,
 'atp/field/postcode/missing': 678,
 'atp/field/state/from_reverse_geocoding': 37,
 'atp/field/state/missing': 2045,
 'atp/field/street_address/missing': 20887,
 'atp/field/twitter/missing': 20887,
 'atp/field/website/missing': 16612,
 'atp/item_scraped_host_count/api.oneweb.mercedes-benz.com': 24568,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 8191,
 'atp/nsi/cc_match': 7602,
 'atp/nsi/match_failed': 5094,
 'downloader/request_bytes': 230304,
 'downloader/request_count': 598,
 'downloader/request_method_count/GET': 598,
 'downloader/response_bytes': 5142364,
 'downloader/response_count': 598,
 'downloader/response_status_count/200': 436,
 'downloader/response_status_count/404': 162,
 'dupefilter/filtered': 8280,
 'elapsed_time_seconds': 15.448897,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 17, 9, 17, 37, 458855, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 598,
 'httpcompression/response_bytes': 76679932,
 'httpcompression/response_count': 432,
 'httperror/response_ignored_count': 161,
 'httperror/response_ignored_status_count/404': 161,
 'item_dropped_count': 3681,
 'item_dropped_reasons_count/DropItem': 3681,
 'item_scraped_count': 20887,
 'items_per_minute': None,
 'log_count/INFO': 171,
 'memusage/max': 233848832,
 'memusage/startup': 233848832,
 'request_depth_max': 58,
 'response_received_count': 598,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 597,
 'scheduler/dequeued/memory': 597,
 'scheduler/enqueued': 597,
 'scheduler/enqueued/memory': 597,
 'start_time': datetime.datetime(2025, 7, 17, 9, 17, 22, 9958, tzinfo=datetime.timezone.utc)}
```