### PR TITLE
[Fulton Bank US] Add spider (222 locations)

### DIFF
--- a/locations/spiders/fulton_bank_us.py
+++ b/locations/spiders/fulton_bank_us.py
@@ -1,0 +1,39 @@
+from typing import Any, Iterable
+
+from scrapy import FormRequest, Selector, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.pipelines.address_clean_up import clean_address
+
+
+class FultonBankUSSpider(Spider):
+    name = "fulton_bank_us"
+    item_attributes = {"brand": "Fulton Bank", "brand_wikidata": "Q16976594"}
+
+    def start_requests(self) -> Iterable[FormRequest]:
+        yield FormRequest(
+            url="https://www.fultonbank.com/api/Branches/Search",
+            formdata={
+                "QueryModel.SearchTerm": "kansas",
+                "QueryModel.Radius": "5000",
+            },  # center location with search radius
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        branch_popups = Selector(text=response.json()["branchFlyouts"])  # contains extra info
+
+        for location in Selector(text=response.json()["branchResults"]).xpath("//*[@data-lat]"):
+            item = Feature()
+            item["ref"] = location.xpath("./@data-id").get()
+            item["lat"] = location.xpath("./@data-lat").get()
+            item["lon"] = location.xpath("./@data-long").get()
+            item["branch"] = location.xpath("./@data-name").get()
+            item["addr_full"] = clean_address(location.xpath('.//*[@class="location-address"]/text()').get(""))
+
+            # Use data-id to extract phone, opening hours etc. from branch_popups
+            location_details = branch_popups.xpath(f'.//*[@data-id="{item["ref"]}"]')
+            item["phone"] = location_details.xpath('.//a[contains(@href, "tel:")]/@href').get()
+            apply_category(Categories.BANK, item)
+            yield item

--- a/locations/spiders/fulton_bank_us.py
+++ b/locations/spiders/fulton_bank_us.py
@@ -42,7 +42,10 @@ class FultonBankUSSpider(Spider):
             ).getall()
             item["opening_hours"] = self.parse_opening_hours(opening_hours)
 
-            apply_category(Categories.BANK, item)
+            if "ATM Only" in location_details.get(""):
+                apply_category(Categories.ATM, item)
+            else:
+                apply_category(Categories.BANK, item)
             yield item
 
     def parse_opening_hours(self, opening_hours: list) -> OpeningHours:


### PR DESCRIPTION
```python
{'atp/brand/Fulton Bank': 222,
 'atp/brand_wikidata/Q16976594': 222,
 'atp/category/amenity/atm': 17,
 'atp/category/amenity/bank': 205,
 'atp/clean_strings/branch': 5,
 'atp/country/US': 222,
 'atp/field/city/missing': 222,
 'atp/field/country/from_spider_name': 222,
 'atp/field/email/missing': 222,
 'atp/field/image/missing': 222,
 'atp/field/name/missing': 17,
 'atp/field/opening_hours/missing': 17,
 'atp/field/operator/missing': 205,
 'atp/field/operator_wikidata/missing': 205,
 'atp/field/phone/missing': 17,
 'atp/field/postcode/missing': 222,
 'atp/field/state/from_reverse_geocoding': 222,
 'atp/field/street_address/missing': 222,
 'atp/field/twitter/missing': 222,
 'atp/field/website/missing': 222,
 'atp/item_scraped_host_count/www.fultonbank.com': 222,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 222,
 'atp/operator/Fulton Bank': 17,
 'atp/operator_wikidata/Q16976594': 17,
 'downloader/request_bytes': 1615,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1832682,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 14.086446,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 17, 10, 24, 34, 62479, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 222,
 'items_per_minute': None,
 'log_count/DEBUG': 235,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 17, 10, 24, 19, 976033, tzinfo=datetime.timezone.utc)}
```