### PR TITLE
[Banco Mercantil BR] Add Spider (146 locations)

### DIFF
--- a/locations/spiders/banco_mercantil_br.py
+++ b/locations/spiders/banco_mercantil_br.py
@@ -12,7 +12,6 @@ class BancoMercantilBRSpider(scrapy.Spider):
     name = "banco_mercantil_br"
     item_attributes = {"brand": "Banco Mercantil do Brasil", "brand_wikidata": "Q9645252"}
     custom_settings = {"USER_AGENT": FIREFOX_LATEST, "ROBOTSTXT_OBEY": False}
-    requires_proxy = True
 
     def start_requests(self):
         yield JsonRequest(

--- a/locations/spiders/banco_mercantil_br.py
+++ b/locations/spiders/banco_mercantil_br.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+import scrapy
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class BancoMercantilBRSpider(scrapy.Spider):
+    name = "banco_mercantil_br"
+    item_attributes = {"brand": "Banco Mercantil do Brasil", "brand_wikidata": "Q9645252"}
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://bancomercantil.com.br/_layouts/15/MB.SHP.Internet.Portal.WebParts/ajax.aspx/getAgencias",
+            data={"lat": "-23.5557714", "lng": "-46.6395571", "raio": "430", "domain": "https://bancomercantil.com.br"},
+            callback=self.parse,
+            method="POST",
+            headers={
+                "Origin": "https://bancomercantil.com.br",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+            },
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["d"]["agencias"]:
+            item = Feature()
+            item["branch"] = location["nomeAgencia"]
+            item["ref"] = location["numeroAgencia"]
+            item["addr_full"] = location["endereco"]
+            item["phone"] = location["telefone"]
+            item["lat"] = location["lat"]
+            item["lon"] = location["lng"]
+            apply_category(Categories.BANK, item)
+            yield item

--- a/locations/spiders/banco_mercantil_br.py
+++ b/locations/spiders/banco_mercantil_br.py
@@ -5,11 +5,13 @@ from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.user_agents import FIREFOX_LATEST
 
 
 class BancoMercantilBRSpider(scrapy.Spider):
     name = "banco_mercantil_br"
     item_attributes = {"brand": "Banco Mercantil do Brasil", "brand_wikidata": "Q9645252"}
+    custom_settings = {"USER_AGENT": FIREFOX_LATEST, "ROBOTSTXT_OBEY": False}
 
     def start_requests(self):
         yield JsonRequest(
@@ -19,7 +21,6 @@ class BancoMercantilBRSpider(scrapy.Spider):
             method="POST",
             headers={
                 "Origin": "https://bancomercantil.com.br",
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
             },
         )
 

--- a/locations/spiders/banco_mercantil_br.py
+++ b/locations/spiders/banco_mercantil_br.py
@@ -12,6 +12,7 @@ class BancoMercantilBRSpider(scrapy.Spider):
     name = "banco_mercantil_br"
     item_attributes = {"brand": "Banco Mercantil do Brasil", "brand_wikidata": "Q9645252"}
     custom_settings = {"USER_AGENT": FIREFOX_LATEST, "ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     def start_requests(self):
         yield JsonRequest(


### PR DESCRIPTION
```python
{'atp/brand/Banco Mercantil do Brasil': 146,
 'atp/brand_wikidata/Q9645252': 146,
 'atp/category/amenity/bank': 146,
 'atp/country/BR': 146,
 'atp/field/city/missing': 146,
 'atp/field/country/from_spider_name': 146,
 'atp/field/email/missing': 146,
 'atp/field/image/missing': 146,
 'atp/field/opening_hours/missing': 146,
 'atp/field/operator/missing': 146,
 'atp/field/operator_wikidata/missing': 146,
 'atp/field/phone/missing': 24,
 'atp/field/postcode/missing': 146,
 'atp/field/state/missing': 146,
 'atp/field/street_address/missing': 146,
 'atp/field/twitter/missing': 146,
 'atp/field/website/missing': 146,
 'atp/item_scraped_host_count/bancomercantil.com.br': 146,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 146,
 'downloader/request_bytes': 863,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 13961,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 6.531452,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 18, 6, 17, 2, 934255, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 102441,
 'httpcompression/response_count': 1,
 'item_scraped_count': 146,
 'items_per_minute': None,
 'log_count/DEBUG': 159,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 18, 6, 16, 56, 402803, tzinfo=datetime.timezone.utc)}
```