### PR TITLE
Using removeprefix() instead of lstrip(). 

### DIFF
--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -66,7 +66,7 @@ class NSI(metaclass=Singleton):
         for wikidata_code, org_parameters in self.wikidata_json.items():
             for official_website in org_parameters.get("officialWebsites", []):
                 official_website_domain = urlparse(official_website).netloc
-                if official_website_domain.lstrip("www.") == supplied_url_domain.lstrip("www."):
+                if official_website_domain.removeprefix("www.") == supplied_url_domain.removeprefix("www."):
                     return wikidata_code
         # Last attempt to find a fuzzy match for registered domain (excluding subdomains)
         for wikidata_code, org_parameters in self.wikidata_json.items():


### PR DESCRIPTION
Changed `lstrip()` to `removeprefix()`.


`lstrip()`'s argument is a string specifying the set of characters to be removed **not a prefix.**
`removeprefix()`is a method that will remove a single prefix string rather than all of a set of characters. 


For example in our case:

```
site = "www.wikipedia.com"

site.lstrip("www.wikipedia.com")
# Outputs  >>  ikipedia.com

site.removeprefix("www.wikipedia.com")
# Outputs  >>  wikipedia.com

```



For Reference:  https://docs.python.org/3/library/stdtypes.html#str.lstrip





