### PR TITLE
[Auchan PT] Sync brands with NSI

### DIFF
--- a/locations/spiders/auchan_pt.py
+++ b/locations/spiders/auchan_pt.py
@@ -1,41 +1,64 @@
 import re
 
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.spiders.auchan_lu import MY_AUCHAN
 from locations.structured_data_spider import StructuredDataSpider
+
+AUCHAN = {"brand": "Auchan", "brand_wikidata": "Q758603"}
+AUCHAN_SUPERMERCADO = {"brand": "Auchan Supermercado", "brand_wikidata": "Q105857776"}
+MY_AUCHAN = {"brand": "My Auchan", "brand_wikidata": "Q115800307"}
 
 
 class AuchanPTSpider(CrawlSpider, StructuredDataSpider):
     name = "auchan_pt"
-    item_attributes = {"brand": "Auchan", "brand_wikidata": "Q758603"}
-
     start_urls = ["https://www.auchan.pt/pt/lojas"]
-    rules = [
-        Rule(LinkExtractor(allow=r"StoreID="), callback="parse_sd"),
-    ]
+    rules = [Rule(LinkExtractor(allow="StoreID="), callback="parse_sd")]
 
-    def pre_process_data(self, ld_data, **kwargs):
+    def pre_process_data(self, ld_data: dict, **kwargs):
         for rule in ld_data.get("openingHoursSpecification", []):
             if rule.get("opens") and rule.get("opens"):
                 rule["opens"] = rule["opens"].strip()
                 rule["closes"] = rule["closes"].strip()
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["addr_full"] = item.pop("street_address", "")
         item["lat"] = response.xpath('//*[@id="storeLatitude"]/@value').get()
         item["lon"] = response.xpath('//*[@id="storeLongitude"]/@value').get()
         if item["phone"]:
             item["phone"] = re.sub(r"(\(.+\))", "", item["phone"])
         item["email"] = item["email"].strip()
+        if response.url.endswith(".html"):
+            item["ref"] = response.url.removesuffix(".html").rsplit("-", 1)[1]
+        else:
+            item["ref"] = response.url.rsplit("=", 1)[1]
+
         store_type = response.xpath("//@data-store-type").get()
-        if store_type == "MyAuchan":
-            item["brand"] = "My Auchan"
+        if store_type == "Auchan":
+            if item["name"].startswith("My Auchan "):
+                item["branch"] = item.pop("name").removeprefix("My Auchan ")
+                item.update(MY_AUCHAN)
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+            elif item["name"].startswith("Auchan Supermercado "):
+                item["branch"] = item.pop("name").removeprefix("Auchan Supermercado ")
+                item.update(AUCHAN_SUPERMERCADO)
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+            elif item["name"].startswith("Auchan "):
+                item["branch"] = item.pop("name").removeprefix("Auchan ")
+                item.update(AUCHAN)
+                apply_category(Categories.SHOP_SUPERMARKET, item)
         elif store_type == "GasStation":
+            item["branch"] = item.pop("name").removeprefix("Gasolineira ")
             item["opening_hours"] = "24/7"
-            item["nsi_id"] = "N/A"
+            item.update(AUCHAN)
             apply_category(Categories.FUEL_STATION, item)
+        else:
+            self.logger.error("Unexpected type: {}".format(store_type))
+
         if services := response.xpath('//*[contains(@class,"services-item")]//span/text()').getall():
             services = [service.lower() for service in services]
             apply_yes_no(Extras.WIFI, item, "wifi grátis" in services)

--- a/locations/spiders/auchan_pt.py
+++ b/locations/spiders/auchan_pt.py
@@ -11,7 +11,6 @@ from locations.structured_data_spider import StructuredDataSpider
 
 AUCHAN = {"brand": "Auchan", "brand_wikidata": "Q758603"}
 AUCHAN_SUPERMERCADO = {"brand": "Auchan Supermercado", "brand_wikidata": "Q105857776"}
-MY_AUCHAN = {"brand": "My Auchan", "brand_wikidata": "Q115800307"}
 
 
 class AuchanPTSpider(CrawlSpider, StructuredDataSpider):


### PR DESCRIPTION
Rel: https://github.com/osmlab/name-suggestion-index/pull/11163

```python
{'atp/brand/Auchan': 63,
 'atp/brand/Auchan Supermercado': 36,
 'atp/brand/My Auchan': 192,
 'atp/brand_wikidata/Q105857776': 36,
 'atp/brand_wikidata/Q115800307': 192,
 'atp/brand_wikidata/Q758603': 63,
 'atp/category/amenity/fuel': 31,
 'atp/category/shop/convenience': 192,
 'atp/category/shop/supermarket': 68,
 'atp/cdn/cloudflare/response_count': 293,
 'atp/cdn/cloudflare/response_status_count/200': 293,
 'atp/clean_strings/phone': 290,
 'atp/country/PT': 291,
 'atp/field/image/invalid': 2,
 'atp/field/image/missing': 206,
 'atp/field/name/missing': 31,
 'atp/field/opening_hours/missing': 61,
 'atp/field/operator/missing': 291,
 'atp/field/operator_wikidata/missing': 291,
 'atp/field/phone/invalid': 1,
 'atp/field/street_address/missing': 291,
 'atp/field/twitter/missing': 291,
 'atp/item_scraped_host_count/www.auchan.pt': 291,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 32,
 'atp/nsi/match_failed': 31,
 'atp/nsi/perfect_match': 228,
 'downloader/request_bytes': 352998,
 'downloader/request_count': 584,
 'downloader/request_method_count/GET': 584,
 'downloader/response_bytes': 4166833,
 'downloader/response_count': 584,
 'downloader/response_status_count/200': 293,
 'downloader/response_status_count/302': 291,
 'elapsed_time_seconds': 2.789036,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 23, 7, 50, 27, 805750, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 584,
 'httpcompression/response_bytes': 18734280,
 'httpcompression/response_count': 293,
 'item_scraped_count': 291,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 3,
 'memusage/max': 279740416,
 'memusage/startup': 279740416,
 'request_depth_max': 1,
 'response_received_count': 293,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 583,
 'scheduler/dequeued/memory': 583,
 'scheduler/enqueued': 583,
 'scheduler/enqueued/memory': 583,
 'start_time': datetime.datetime(2025, 7, 23, 7, 50, 25, 16714, tzinfo=datetime.timezone.utc)}
```