### PR TITLE
[McDonalds BE] Fix Spider

### DIFF
--- a/locations/spiders/mcdonalds_be.py
+++ b/locations/spiders/mcdonalds_be.py
@@ -1,7 +1,8 @@
 import re
+from typing import Any
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import Response
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
@@ -15,16 +16,12 @@ class McdonaldsBESpider(Spider):
     item_attributes = McdonaldsSpider.item_attributes
     allowed_domains = ["www.mcdonalds.be"]
     start_urls = ["https://www.mcdonalds.be/en/restaurants/api/restaurants"]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST, "DOWNLOAD_TIMEOUT": 220}
+    user_agent = FIREFOX_LATEST
 
-    def start_requests(self):
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
-
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
             item = DictParser.parse(location)
-            item["name"] = re.sub(r"\(\s*(Drive|Mall|In-Store)\s*\)", "", item["name"], re.IGNORECASE).strip()
+            item["branch"] = re.sub(r"\(\s*(Drive|Mall|In-Store)\s*\)", "", item.pop("name"), re.IGNORECASE).strip()
             item["housenumber"] = location.get("nr")
             item["street"] = location.get("street_en")
             item["city"] = location.get("city_en")

--- a/locations/spiders/mcdonalds_be.py
+++ b/locations/spiders/mcdonalds_be.py
@@ -7,6 +7,7 @@ from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.spiders.mcdonalds import McdonaldsSpider
+from locations.user_agents import FIREFOX_LATEST
 
 
 class McdonaldsBESpider(Spider):
@@ -14,6 +15,7 @@ class McdonaldsBESpider(Spider):
     item_attributes = McdonaldsSpider.item_attributes
     allowed_domains = ["www.mcdonalds.be"]
     start_urls = ["https://www.mcdonalds.be/en/restaurants/api/restaurants"]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST, "DOWNLOAD_TIMEOUT": 220}
 
     def start_requests(self):
         for url in self.start_urls:


### PR DESCRIPTION
**_Fixes : added custom_settings to fix spider_**

```python
{"atp/brand/McDonald's": 124,
 'atp/brand_wikidata/Q38076': 124,
 'atp/category/amenity/fast_food': 124,
 'atp/clean_strings/phone': 9,
 'atp/clean_strings/street': 7,
 'atp/country/BE': 124,
 'atp/field/branch/missing': 124,
 'atp/field/country/from_spider_name': 124,
 'atp/field/email/missing': 124,
 'atp/field/image/missing': 124,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 124,
 'atp/field/operator_wikidata/missing': 124,
 'atp/field/state/missing': 124,
 'atp/field/street_address/missing': 124,
 'atp/field/twitter/missing': 124,
 'atp/item_scraped_host_count/www.mcdonalds.be': 124,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 124,
 'downloader/request_bytes': 301,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 631274,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.303037,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 24, 5, 54, 28, 190006, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 124,
 'items_per_minute': None,
 'log_count/DEBUG': 136,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 24, 5, 54, 24, 886969, tzinfo=datetime.timezone.utc)}
```