### PR TITLE
[IHG Hotels] Fix Spider

### DIFF
--- a/locations/spiders/ihg_hotels.py
+++ b/locations/spiders/ihg_hotels.py
@@ -10,7 +10,7 @@ class IhgHotelsSpider(SitemapSpider, StructuredDataSpider):
     name = "ihg_hotels"
     allowed_domains = ["ihg.com"]
     sitemap_urls = ["https://www.ihg.com/bin/sitemapindex.xml"]
-    sitemap_follow = ["en.hoteldetail"]
+    sitemap_follow = ["en-US.hoteldetail"]
     sitemap_rules = [(r"/hotels/us/en/[-\w]+/[-\w]+/hoteldetail$", "parse")]
     wanted_types = ["Hotel"]
     json_parser = "chompjs"


### PR DESCRIPTION
**_Fixes : updated sitemap follow rules to fix spider_**

```python
{'atp/brand/Army Hotels': 60,
 'atp/brand/Avid Hotels': 83,
 'atp/brand/Candlewood Suites': 417,
 'atp/brand/Crowne Plaza': 426,
 'atp/brand/Even Hotels': 41,
 'atp/brand/Holiday Inn': 1145,
 'atp/brand/Holiday Inn Express': 3303,
 'atp/brand/Hotel Indigo': 195,
 'atp/brand/Kimpton': 85,
 'atp/brand/Regent': 8,
 'atp/brand/Staybridge Suites': 351,
 'atp/brand/Voco Hotels': 119,
 'atp/brand_wikidata/Q16994722': 60,
 'atp/brand_wikidata/Q2717882': 1145,
 'atp/brand_wikidata/Q2746220': 426,
 'atp/brand_wikidata/Q3250375': 8,
 'atp/brand_wikidata/Q5032010': 417,
 'atp/brand_wikidata/Q5416522': 41,
 'atp/brand_wikidata/Q5880423': 3303,
 'atp/brand_wikidata/Q5911596': 195,
 'atp/brand_wikidata/Q60749907': 83,
 'atp/brand_wikidata/Q60750454': 119,
 'atp/brand_wikidata/Q6410248': 85,
 'atp/brand_wikidata/Q7605116': 351,
 'atp/category/tourism/hotel': 6572,
 'atp/clean_strings/city': 41,
 'atp/clean_strings/country': 1,
 'atp/clean_strings/name': 18,
 'atp/clean_strings/street_address': 61,
 'atp/country/${hotelInfo.address.country.name}': 8,
 'atp/country/AE': 26,
 'atp/country/AL': 1,
 'atp/country/AM': 2,
 'atp/country/AQ': 1,
 'atp/country/AR': 4,
 'atp/country/AT': 11,
 'atp/country/AU': 48,
 'atp/country/AW': 2,
 'atp/country/AZ': 1,
 'atp/country/BB': 1,
 'atp/country/BD': 2,
 'atp/country/BE': 16,
 'atp/country/BG': 1,
 'atp/country/BH': 1,
 'atp/country/BR': 9,
 'atp/country/BS': 1,
 'atp/country/BY': 1,
 'atp/country/CA': 194,
 'atp/country/CH': 12,
 'atp/country/CL': 6,
 'atp/country/CN': 794,
 'atp/country/CO': 12,
 'atp/country/CR': 4,
 'atp/country/CY': 2,
 'atp/country/CZ': 2,
 'atp/country/DE': 179,
 'atp/country/DK': 1,
 'atp/country/DO': 9,
 'atp/country/DZ': 1,
 'atp/country/EC': 4,
 'atp/country/EG': 7,
 'atp/country/ES': 43,
 'atp/country/FI': 6,
 'atp/country/FJ': 3,
 'atp/country/FR': 62,
 'atp/country/GB': 363,
 'atp/country/GE': 4,
 'atp/country/GH': 1,
 'atp/country/GI': 1,
 'atp/country/GR': 5,
 'atp/country/GT': 1,
 'atp/country/GU': 1,
 'atp/country/HK': 10,
 'atp/country/HN': 2,
 'atp/country/HU': 5,
 'atp/country/ID': 27,
 'atp/country/IE': 6,
 'atp/country/IL': 4,
 'atp/country/IN': 46,
 'atp/country/IT': 31,
 'atp/country/JM': 3,
 'atp/country/JO': 4,
 'atp/country/JP': 48,
 'atp/country/KE': 1,
 'atp/country/KR': 7,
 'atp/country/KW': 5,
 'atp/country/KY': 3,
 'atp/country/KZ': 6,
 'atp/country/LA': 2,
 'atp/country/LB': 3,
 'atp/country/LT': 1,
 'atp/country/MA': 2,
 'atp/country/ME': 3,
 'atp/country/MK': 1,
 'atp/country/MN': 1,
 'atp/country/MO': 4,
 'atp/country/MP': 1,
 'atp/country/MT': 2,
 'atp/country/MU': 1,
 'atp/country/MV': 2,
 'atp/country/MX': 173,
 'atp/country/MY': 12,
 'atp/country/NI': 4,
 'atp/country/NL': 25,
 'atp/country/NP': 2,
 'atp/country/NZ': 10,
 'atp/country/OM': 7,
 'atp/country/PA': 4,
 'atp/country/PE': 7,
 'atp/country/PG': 3,
 'atp/country/PH': 6,
 'atp/country/PL': 16,
 'atp/country/PR': 4,
 'atp/country/PT': 26,
 'atp/country/PW': 1,
 'atp/country/PY': 1,
 'atp/country/QA': 5,
 'atp/country/RO': 3,
 'atp/country/RS': 3,
 'atp/country/SA': 31,
 'atp/country/SE': 1,
 'atp/country/SG': 11,
 'atp/country/SI': 1,
 'atp/country/SK': 3,
 'atp/country/SV': 1,
 'atp/country/TH': 34,
 'atp/country/TJ': 1,
 'atp/country/TN': 3,
 'atp/country/TR': 33,
 'atp/country/TT': 1,
 'atp/country/TW': 13,
 'atp/country/TZ': 1,
 'atp/country/UA': 1,
 'atp/country/US': 4014,
 'atp/country/UY': 1,
 'atp/country/UZ': 5,
 'atp/country/VC': 1,
 'atp/country/VN': 10,
 'atp/country/VU': 1,
 'atp/country/ZA': 5,
 'atp/country/ZM': 1,
 'atp/country/ZW': 3,
 'atp/field/branch/missing': 6572,
 'atp/field/brand/missing': 339,
 'atp/field/brand_wikidata/missing': 339,
 'atp/field/country/from_reverse_geocoding': 843,
 'atp/field/country/invalid': 8,
 'atp/field/email/invalid': 8,
 'atp/field/email/missing': 268,
 'atp/field/image/invalid': 8,
 'atp/field/image/missing': 438,
 'atp/field/lat/missing': 9,
 'atp/field/lon/missing': 9,
 'atp/field/opening_hours/missing': 6572,
 'atp/field/operator/missing': 6572,
 'atp/field/operator_wikidata/missing': 6572,
 'atp/field/phone/invalid': 30,
 'atp/field/phone/missing': 66,
 'atp/field/postcode/missing': 127,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/state/missing': 1241,
 'atp/item_scraped_host_count/www.ihg.com': 6572,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 68,
 'atp/nsi/match_failed': 3303,
 'atp/nsi/perfect_match': 2862,
 'atp/structured_data/unmapped/amenity_features': 6326,
 'downloader/exception_count': 175,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 175,
 'downloader/request_bytes': 12175821,
 'downloader/request_count': 6885,
 'downloader/request_method_count/GET': 6885,
 'downloader/response_bytes': 188249974,
 'downloader/response_count': 6710,
 'downloader/response_status_count/200': 6629,
 'downloader/response_status_count/301': 57,
 'downloader/response_status_count/302': 21,
 'downloader/response_status_count/303': 2,
 'downloader/response_status_count/500': 1,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 8471.981856,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 24, 11, 48, 53, 247579, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1275207911,
 'httpcompression/response_count': 6627,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/500': 1,
 'item_scraped_count': 6572,
 'items_per_minute': None,
 'log_count/DEBUG': 19791,
 'log_count/ERROR': 15,
 'log_count/INFO': 6477,
 'log_count/WARNING': 8,
 'request_depth_max': 2,
 'response_received_count': 6628,
 'responses_per_minute': None,
 'retry/count': 173,
 'retry/max_reached': 3,
 'retry/reason_count/twisted.internet.error.TimeoutError': 173,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6884,
 'scheduler/dequeued/memory': 6884,
 'scheduler/enqueued': 6884,
 'scheduler/enqueued/memory': 6884,
 'start_time': datetime.datetime(2025, 7, 24, 9, 27, 41, 265723, tzinfo=datetime.timezone.utc)}
```