### PR TITLE
[Subway KR] Fix low scraped count for spider

### DIFF
--- a/locations/spiders/subway_kr.py
+++ b/locations/spiders/subway_kr.py
@@ -1,46 +1,44 @@
-import chompjs
-import scrapy
-from scrapy import Request
+import json
+from typing import Iterable
+
+from scrapy import FormRequest
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.subway import SubwaySpider
 
 
-class SubwayKRSpider(scrapy.Spider):
+class SubwayKRSpider(JSONBlobSpider):
     name = "subway_kr"
     item_attributes = SubwaySpider.item_attributes
-    link_extractor = LinkExtractor(allow="/storeDetail?")
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+    }
+    locations_key = "searchResult"
 
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-
-    def start_requests(self):
-        yield Request("https://www.subway.co.kr/storeSearch?page=1", meta={"page": 1})
-
-    def parse(self, response: Response, **kwargs):
-        links = self.link_extractor.extract_links(response)
-        if len(links) == 0:
-            return
-        else:
-            next_page = response.meta["page"] + 1
-            yield Request(f"https://www.subway.co.kr/storeSearch?page={next_page}", meta={"page": next_page})
-
-            for link in links:
-                yield Request(link.url, callback=self.parse_store)
-
-    def parse_store(self, response, **kwargs):
-        data = chompjs.parse_js_object(
-            response.xpath('//script[contains(text(), "var storeInfo")]/text()').re_first(r"var storeInfo = (\{.*\});")
+    def start_requests(self) -> Iterable[FormRequest]:
+        yield FormRequest(
+            url="https://www.subway.co.kr/ajaxStoreSearch",
+            formdata={
+                "keyword": "",
+                "page": "1",
+                "pagination": json.dumps({"pageNo": 1, "itemCountPerPage": 1500, "displayPageNoCount": 1500}),
+            },
         )
-        data.update(data.pop("franchiseDetail"))
-        item = DictParser.parse(data)
-        item["name"] = data.get("storNm")
-        item["addr_full"] = merge_address_lines([data.get("storAddr1"), data.get("storAddr2")])
-        item["phone"] = data.get("storTel")
-        item["ref"] = item["website"] = response.url
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature.get("openYn") == "N":  # coming soon or not in operation
+            return
+        item["addr_full"] = merge_address_lines([feature.get("storAddr1"), feature.get("storAddr2")])
+        if not item["addr_full"] or feature.get("lat") in ["0", ""]:
+            return
+        item["ref"] = feature.get("storCd")
+        item["branch"] = feature.get("storNm")
+        item["phone"] = feature.get("storTel")
+        item["website"] = f'https://www.subway.co.kr/storeDetail?franchiseNo={feature.get("franchiseNo")}'
         apply_category(Categories.FAST_FOOD, item)
         item["extras"]["cuisine"] = "sandwich"
         item["extras"]["takeaway"] = "yes"


### PR DESCRIPTION
Many of the store [pages ](https://www.subway.co.kr/storeDetail?franchiseNo=706) result in http `500` error while crawling and thus resulting in lower scraped count in last [run](https://alltheplaces-data.openaddresses.io/runs/2025-07-22-02-29-22/stats/subway_kr.json). Code refactored to fix this and make the spider stable against http `500` errors.

```
{'atp/brand/Subway': 641,
 'atp/brand_wikidata/Q244457': 641,
 'atp/category/amenity/fast_food': 641,
 'atp/clean_strings/phone': 6,
 'atp/country/KR': 641,
 'atp/field/city/missing': 641,
 'atp/field/country/from_spider_name': 641,
 'atp/field/email/missing': 641,
 'atp/field/image/missing': 641,
 'atp/field/opening_hours/missing': 641,
 'atp/field/operator/missing': 641,
 'atp/field/operator_wikidata/missing': 641,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 641,
 'atp/field/state/missing': 641,
 'atp/field/street_address/missing': 641,
 'atp/field/twitter/missing': 641,
 'atp/item_scraped_host_count/www.subway.co.kr': 641,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 641,
 'downloader/request_bytes': 509,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1033935,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.374923,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 24, 12, 16, 2, 875228, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 641,
 'items_per_minute': None,
 'log_count/DEBUG': 653,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 24, 12, 15, 59, 500305, tzinfo=datetime.timezone.utc)}
```