### PR TITLE
[Carrefour AR] Fix spider

### DIFF
--- a/locations/spiders/carrefour_ar.py
+++ b/locations/spiders/carrefour_ar.py
@@ -1,8 +1,8 @@
 import re
-from typing import Any
+from typing import Any, Iterable
 
 import scrapy
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
@@ -16,18 +16,72 @@ from locations.spiders.carrefour_fr import (
 
 class CarrefourARSpider(scrapy.Spider):
     name = "carrefour_ar"
-    # TODO: I suspect other Carrefour domains have this very same interface
-    # TODO: Figure out how to handle change of sha256Hash of persistedQuery.
-    start_urls = [
-        """https://www.carrefour.com.ar/_v/public/graphql/v1?workspace=master&maxAge=short&appsEtag=remove&domain=store&locale=es-AR&operationName=getStoreLocations&extensions={"persistedQuery":{"version":1,"sha256Hash":"81646d6f8cea93c5500fb78cce9a7e282b0a8585bb77079f6085d8e7f5036127","sender":"valtech.carrefourar-store-locator@0.x","provider":"vtex.store-graphql@2.x"},"variables":"eyJhY2NvdW50IjoiY2FycmVmb3VyYXIifQ=="}"""
-    ]
-
     brands = {
         "Express": CARREFOUR_EXPRESS,
         "Hipermercado": CARREFOUR_SUPERMARKET,
         "Market": CARREFOUR_MARKET,
         "Maxi": CARREFOUR_SUPERMARKET,
     }
+
+    def start_requests(self) -> Iterable[JsonRequest]:
+        yield JsonRequest(
+            url="https://www.carrefour.com.ar/_v/public/graphql/v1",
+            data={
+                "query": """
+                    query getStoreLocations($account: String)
+                      @context(sender: "valtech.carrefourar-store-locator@0.1.0") {
+
+                      documents(
+                        acronym: "SL",
+                        schema: "mdv1",
+                        fields: [
+                          "id",
+                          "coverPhoto",
+                          "addressLineOne",
+                          "addressLineTwo",
+                          "addressLineThree",
+                          "addressLineFour",
+                          "addressLineFive",
+                          "administrativeArea",
+                          "businessName",
+                          "additionalCategories",
+                          "labels",
+                          "locality",
+                          "subLocality",
+                          "latitude",
+                          "longitude",
+                          "postalCode",
+                          "mondayHours",
+                          "tuesdayHours",
+                          "wednesdayHours",
+                          "thursdayHours",
+                          "fridayHours",
+                          "saturdayHours",
+                          "sundayHours",
+                          "holidayHours",
+                          "specialHours",
+                          "openingDate",
+                          "storeCode",
+                          "primaryPhone",
+                          "fromTheBusiness",
+                        ],
+                        sort: "storeCode ASC",
+                        account: $account,
+                        pageSize: 1000
+                      )
+                      @context(provider: "vtex.store-graphql") {
+                        id
+                        fields {
+                          key
+                          value
+                        }
+                      }
+                    }
+                """,
+                "variables": {"account": "carrefourar"},
+                "operationName": "getStoreLocations",
+            },
+        )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for data in response.json()["data"]["documents"]:


### PR DESCRIPTION
Used `GraphQL` query and dropped volatile persisted query to fix the spider.

```python
{'atp/brand/Carrefour': 118,
 'atp/brand/Carrefour Express': 460,
 'atp/brand/Carrefour Market': 85,
 'atp/brand_wikidata/Q217599': 118,
 'atp/brand_wikidata/Q2689639': 85,
 'atp/brand_wikidata/Q2940190': 460,
 'atp/category/shop/convenience': 460,
 'atp/category/shop/supermarket': 203,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AR': 663,
 'atp/field/branch/missing': 663,
 'atp/field/country/from_spider_name': 663,
 'atp/field/email/missing': 663,
 'atp/field/image/missing': 663,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 663,
 'atp/field/operator_wikidata/missing': 663,
 'atp/field/phone/missing': 37,
 'atp/field/postcode/missing': 594,
 'atp/field/state/missing': 35,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 663,
 'atp/field/website/missing': 663,
 'atp/item_scraped_host_count/www.carrefour.com.ar': 663,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 118,
 'atp/nsi/match_failed': 85,
 'atp/nsi/perfect_match': 460,
 'downloader/request_bytes': 3065,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 47049,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.458301,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 25, 13, 42, 26, 125259, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 882533,
 'httpcompression/response_count': 2,
 'item_scraped_count': 663,
 'items_per_minute': None,
 'log_count/DEBUG': 676,
 'log_count/INFO': 9,
 'memusage/max': 279175168,
 'memusage/startup': 279175168,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 25, 13, 42, 19, 666958, tzinfo=datetime.timezone.utc)}
```