### PR TITLE
[T Mobile US] Fix low scraped count for the spider

### DIFF
--- a/locations/spiders/tmobile_us.py
+++ b/locations/spiders/tmobile_us.py
@@ -16,6 +16,7 @@ class TmobileUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/stores/[a-z]{2}/t-mobile-", "parse_sd")]
     allowed_domains = ["www.t-mobile.com"]
     drop_attributes = {"facebook", "twitter"}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 3}
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data["openingHours"] = ld_data.pop("openingHoursSpecification", None)


### PR DESCRIPTION
Applied some `custom_settings` to avoid http `408` error and fix the [low scraped count](https://alltheplaces-data.openaddresses.io/runs/2025-07-22-02-29-22/stats/tmobile_us.json).
```python
{'atp/brand/T-Mobile': 6137,
 'atp/brand_wikidata/Q3511885': 6137,
 'atp/category/shop/mobile_phone': 6137,
 'atp/clean_strings/addr_full': 7,
 'atp/clean_strings/name': 3521,
 'atp/country/US': 6137,
 'atp/field/branch/missing': 6137,
 'atp/field/email/missing': 6137,
 'atp/field/opening_hours/missing': 32,
 'atp/field/operator/missing': 6137,
 'atp/field/operator_wikidata/missing': 6137,
 'atp/field/street_address/missing': 6137,
 'atp/field/twitter/missing': 6137,
 'atp/item_scraped_host_count/www.t-mobile.com': 6137,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 6137,
 'downloader/request_bytes': 9434766,
 'downloader/request_count': 6138,
 'downloader/request_method_count/GET': 6138,
 'downloader/response_bytes': 344463380,
 'downloader/response_count': 6138,
 'downloader/response_status_count/200': 6138,
 'elapsed_time_seconds': 22514.529732,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 28, 14, 3, 51, 688026, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2155638981,
 'httpcompression/response_count': 6138,
 'item_scraped_count': 6137,
 'items_per_minute': None,
 'log_count/DEBUG': 12286,
 'log_count/INFO': 384,
 'request_depth_max': 1,
 'response_received_count': 6138,
 'responses_per_minute': None,
 'scheduler/dequeued': 6138,
 'scheduler/dequeued/memory': 6138,
 'scheduler/enqueued': 6138,
 'scheduler/enqueued/memory': 6138,
 'start_time': datetime.datetime(2025, 7, 28, 7, 48, 37, 158294, tzinfo=datetime.timezone.utc)}
```