### PR TITLE
[Ameriprisse US] Fix Spider

### DIFF
--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -1,38 +1,42 @@
-from scrapy.spiders import SitemapSpider
+import json
 
-from locations.google_url import extract_google_position
-from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
+import scrapy
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class AmeripriseUSSpider(SitemapSpider):
+class AmeripriseUSSpider(Spider):
     name = "ameriprise_us"
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
-    sitemap_urls = ["https://www.ameripriseadvisors.com/robots.txt"]
-    sitemap_rules = [(r"/contact/$", "parse")]
-    drop_attributes = {"image"}
+    start_urls = ["https://www.ameripriseadvisors.com/find-a-financial-advisor-by-state/"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response):
-        properties = LinkedDataParser.parse(response, "ContactPage")
-        extract_google_position(properties, response)
-        properties.update(
-            {
-                "ref": response.url,
-                "website": response.urljoin(response.xpath('//*[.="Home"]//@href').get()),
-                "name": response.css(".advisor-or-team-name ::text").get(),
-                "street_address": response.css("[id$=AddressLine1] ::text").get(),
-                "extras": {
-                    "addr:unit": response.css("[id$=AddressLine2] ::text").get(),
-                    "fax": response.css("[id$=AddressFax] ::text").get(),
-                },
-                "city": response.css("[id$=AddressCity] ::text").get(),
-                "state": response.css("[id$=AddressState] ::text").get(),
-                "postcode": response.css("[id$=AddressZip] ::text").get(),
-                "phone": response.css("[id$=AddressPhone] ::text").get(),
-                "email": response.css("[id$=AddressEmail] ::text").get(),
-            }
-        )
-        properties["opening_hours"] = LinkedDataParser.parse_opening_hours(
-            {"openingHours": response.css('[itemprop="openingHours"]::attr(content)').getall()}
-        )
-        yield Feature(properties)
+        # Extract list of states
+        state_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
+        for state in state_list:
+            state_url = response.urljoin(state)
+            yield scrapy.Request(url=state_url, callback=self.parse_city, cb_kwargs={"state": state})
+
+    def parse_city(self, response, state):
+        # Extract list of cities for the given state
+        city_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
+        for city in city_list:
+            payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "50", "searchType": "city, state"}
+            yield scrapy.FormRequest(
+                url="https://www.ameripriseadvisors.com/webservices/advisorSearch.aspx",
+                formdata={"criteria": json.dumps(payload)},
+                headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+                method="POST",
+                callback=self.parse_details,
+            )
+
+    def parse_details(self, response):
+        for advisor in response.json().get("locatorResultModels", []):
+            for location in advisor.get("locations", []):
+                item = DictParser.parse(location)
+                item.pop("name")
+                item["ref"] = item["addr_full"] = merge_address_lines([location["address1"], location["address2"]])
+                yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Ameriprise Financial': 3088,
 'atp/brand_wikidata/Q2843129': 3088,
 'atp/category/office/financial_advisor': 3088,
 'atp/country/US': 3088,
 'atp/duplicate_count': 16934,
 'atp/field/branch/missing': 3088,
 'atp/field/country/from_spider_name': 3088,
 'atp/field/email/missing': 1427,
 'atp/field/opening_hours/missing': 3088,
 'atp/field/operator/missing': 3088,
 'atp/field/operator_wikidata/missing': 3088,
 'atp/field/phone/missing': 30,
 'atp/field/twitter/missing': 3088,
 'atp/field/website/missing': 3088,
 'atp/item_scraped_host_count/www.ameripriseadvisors.com': 20022,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3088,
 'downloader/request_bytes': 1925017,
 'downloader/request_count': 2033,
 'downloader/request_method_count/GET': 103,
 'downloader/request_method_count/POST': 1930,
 'downloader/response_bytes': 42646517,
 'downloader/response_count': 2033,
 'downloader/response_status_count/200': 1852,
 'downloader/response_status_count/301': 51,
 'downloader/response_status_count/404': 130,
 'elapsed_time_seconds': 99.451243,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 28, 16, 22, 44, 853277, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 130,
 'httperror/response_ignored_status_count/404': 130,
 'item_dropped_count': 16934,
 'item_dropped_reasons_count/DropItem': 16934,
 'item_scraped_count': 3088,
 'items_per_minute': None,
 'log_count/DEBUG': 22067,
 'log_count/INFO': 140,
 'request_depth_max': 2,
 'response_received_count': 1982,
 'responses_per_minute': None,
 'scheduler/dequeued': 2033,
 'scheduler/dequeued/memory': 2033,
 'scheduler/enqueued': 2033,
 'scheduler/enqueued/memory': 2033,
 'start_time': datetime.datetime(2025, 7, 28, 16, 21, 5, 402034, tzinfo=datetime.timezone.utc)}
 
```