### PR TITLE
[YextAnswers] Fix opening_hours parsing

### DIFF
--- a/locations/storefinders/yext_answers.py
+++ b/locations/storefinders/yext_answers.py
@@ -98,11 +98,13 @@ class YextAnswersSpider(Spider):
 
             item["opening_hours"] = self.parse_opening_hours(location.get("hours"))
             if delivery_hours := location.get("deliveryHours"):
-                item["extras"]["opening_hours:delivery"] = self.parse_opening_hours(delivery_hours)
+                item["extras"]["opening_hours:delivery"] = self.parse_opening_hours(delivery_hours).as_opening_hours()
             if happy_hours := location.get("happyHours"):
-                item["extras"]["happy_hours"] = self.parse_opening_hours(happy_hours)
+                item["extras"]["happy_hours"] = self.parse_opening_hours(happy_hours).as_opening_hours()
             if drive_through_hours := location.get("driveThroughHours"):
-                item["extras"]["opening_hours:drive_through"] = self.parse_opening_hours(drive_through_hours)
+                item["extras"]["opening_hours:drive_through"] = self.parse_opening_hours(
+                    drive_through_hours
+                ).as_opening_hours()
 
             self.parse_payment_methods(location, item)
             self.parse_google_attributes(location, item)


### PR DESCRIPTION
Commit aed3b661c3f97000133f35e9f921c51690e32235 caused `TypeError: Object of type OpeningHours is not JSON serializable` errors.

Should be ok to call `parse_opening_hours().as_opening_hours()` in these cases because `parse_opening_hours` only returns `None` if the input is `None`, and that's already checked for.