### PR TITLE
[Jet DE] Fix Spider

### DIFF
--- a/locations/spiders/jet_de.py
+++ b/locations/spiders/jet_de.py
@@ -1,31 +1,20 @@
-import json
-import re
-
 import scrapy
-from scrapy import Selector
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class JetDESpider(scrapy.Spider):
     name = "jet_de"
     item_attributes = {"brand": "JET", "brand_wikidata": "Q568940"}
-    start_urls = ["https://www.jet.de/tankstellen-suche"]
+    start_urls = [
+        "https://www.jet.de/api/v1/stations_within_bounds?n=85.0511287798066&e=180&s=-67.90083807146054&w=-180&withCardHtml=1"
+    ]
 
     def parse(self, response, **kwargs):
-        for location in json.loads(re.search(r"stationsData: (\[.+\])\n}", response.text).group(1)):
-            if "fuel" not in location["features"]:
-                continue
-            item = Feature()
-            item["lat"] = location["lat"]
-            item["lon"] = location["lng"]
-            popup = Selector(text=location["cardHtml"])
-            item["ref"] = item["website"] = response.urljoin(popup.xpath('//a[@class="link-ts-list"]/@href').get())
-            item["addr_full"] = (
-                popup.xpath('normalize-space(//div[contains(@class, "search-result-header")]/h2/text())')
-                .get()
-                .removeprefix("JET ")
-            )
+        for station in response.json()["stations"]:
+            item = DictParser.parse(station)
+            item["ref"] = station["publicId"]
+            item["website"] = station["webUrl"]
             apply_category(Categories.FUEL_STATION, item)
             yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/JET': 713,
 'atp/brand_wikidata/Q568940': 713,
 'atp/category/amenity/fuel': 713,
 'atp/clean_strings/street': 2,
 'atp/country/DE': 713,
 'atp/field/branch/missing': 713,
 'atp/field/country/from_spider_name': 713,
 'atp/field/email/missing': 713,
 'atp/field/image/missing': 713,
 'atp/field/opening_hours/missing': 713,
 'atp/field/operator/missing': 713,
 'atp/field/operator_wikidata/missing': 713,
 'atp/field/state/missing': 713,
 'atp/field/street_address/missing': 713,
 'atp/field/twitter/missing': 713,
 'atp/item_scraped_host_count/www.jet.de': 713,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 713,
 'downloader/request_bytes': 743,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4825328,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.583978,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 29, 9, 5, 16, 944791, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 192,
 'httpcompression/response_count': 1,
 'item_scraped_count': 713,
 'items_per_minute': None,
 'log_count/DEBUG': 726,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 29, 9, 5, 8, 360813, tzinfo=datetime.timezone.utc)}

```