### PR TITLE
[Pandora] Switch to centroid search to fix spider

### DIFF
--- a/locations/spiders/pandora.py
+++ b/locations/spiders/pandora.py
@@ -1,5 +1,8 @@
 from typing import Iterable
 
+from scrapy.http import JsonRequest
+
+from locations.geo import point_locations
 from locations.items import Feature
 from locations.storefinders.rio_seo import RioSeoSpider
 
@@ -8,10 +11,21 @@ class PandoraSpider(RioSeoSpider):
     name = "pandora"
     item_attributes = {"brand": "Pandora", "brand_wikidata": "Q2241604"}
     end_point = "https://maps.pandora.net"
+    radius = 346
+
+    def start_requests(self) -> JsonRequest:
+        for lat, lng in point_locations("earth_centroids_iseadgg_346km_radius.csv"):
+            yield JsonRequest(
+                f"{self.end_point}/api/getAsyncLocations?template={self.template}&level={self.template}&radius={self.radius}&limit={self.limit}&lat={lat}&lng={lng}",
+                callback=self.parse,
+            )
 
     def post_process_feature(self, feature: Feature, location: dict) -> Iterable[Feature]:
+        if location.get("Store Type_CS") == "Authorized Retailers":
+            return
         feature["phone"] = location.get("location_phone") or location.get("local_phone")
         feature["postcode"] = location.get("location_post_code") or location.get("post_code")
-        feature["website"] = "https://stores.pandora.net/"
-        if location.get("Store Type_CS") != "Authorized Retailers":
-            yield feature
+        feature["country"] = feature["ref"][:2].upper()
+        feature["website"] = "https:" + location["indy_url"]
+        feature["branch"] = feature.pop("name").removeprefix("Pandora ").removeprefix("Store ").removeprefix("@ ")
+        yield feature

--- a/locations/storefinders/rio_seo.py
+++ b/locations/storefinders/rio_seo.py
@@ -21,7 +21,7 @@ class RioSeoSpider(Spider):
         `?template=search&level=search`
       - `template`: mandatory parameter, should be either "domain" or "search"
       - `radius`: optional parameter, default value is 20038
-      - `limit`: optional parameter, default value is 3000
+      - `limit`: optional parameter, default value is 10000
     """
 
     dataset_attributes = {"source": "api", "api": "rio_seo"}


### PR DESCRIPTION
Previously, the single request was causing an internal server error. My assumption is that it's a timeout, i.e. too many results. I changed only the Pandora spider and not the base Rio SEO storefinder because I don't know if lat/lon search works for all brands.

Also take this opportunity to clean up the country, name, and website tags.