### PR TITLE
[Pandora] Fix Spider

### DIFF
--- a/locations/spiders/pandora.py
+++ b/locations/spiders/pandora.py
@@ -1,17 +1,11 @@
-from typing import Iterable
+from scrapy.spiders import SitemapSpider
 
-from locations.items import Feature
-from locations.storefinders.rio_seo import RioSeoSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PandoraSpider(RioSeoSpider):
+class PandoraSpider(SitemapSpider, StructuredDataSpider):
     name = "pandora"
     item_attributes = {"brand": "Pandora", "brand_wikidata": "Q2241604"}
-    end_point = "https://maps.pandora.net"
-
-    def post_process_feature(self, feature: Feature, location: dict) -> Iterable[Feature]:
-        feature["phone"] = location.get("location_phone") or location.get("local_phone")
-        feature["postcode"] = location.get("location_post_code") or location.get("post_code")
-        feature["website"] = "https://stores.pandora.net/"
-        if location.get("Store Type_CS") != "Authorized Retailers":
-            yield feature
+    sitemap_urls = ["https://stores.pandora.net/sitemap.xml"]
+    sitemap_rules = [(r"https:\/\/stores\.pandora\.net\/[a-z-0-9]+\/[a-z-0-9]+\/[a-z-0-9]+\/.+html$", "parse_sd")]
+    custom_settings = {"REDIRECT_ENABLED": False}


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/brand/Pandora': 3235,
 'atp/brand_wikidata/Q2241604': 3235,
 'atp/category/shop/jewelry': 3235,
 'atp/clean_strings/name': 436,
 'atp/clean_strings/phone': 1,
 'atp/country/AR': 32,
 'atp/country/AU': 239,
 'atp/country/BR': 157,
 'atp/country/CA': 334,
 'atp/country/CL': 71,
 'atp/country/CO': 70,
 'atp/country/CR': 5,
 'atp/country/FR': 371,
 'atp/country/GB': 286,
 'atp/country/GT': 6,
 'atp/country/JP': 51,
 'atp/country/MX': 289,
 'atp/country/NZ': 45,
 'atp/country/PA': 9,
 'atp/country/PE': 41,
 'atp/country/SV': 5,
 'atp/country/US': 1224,
 'atp/field/branch/missing': 3235,
 'atp/field/email/missing': 2904,
 'atp/field/image/dropped': 3235,
 'atp/field/image/missing': 3235,
 'atp/field/lat/missing': 18,
 'atp/field/lon/missing': 18,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 3235,
 'atp/field/operator_wikidata/missing': 3235,
 'atp/field/phone/invalid': 24,
 'atp/field/phone/missing': 369,
 'atp/field/postcode/missing': 9,
 'atp/field/twitter/missing': 1725,
 'atp/item_scraped_host_count/stores.pandora.net': 3235,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3235,
 'atp/tt_locate/fail': 18,
 'downloader/request_bytes': 1521713,
 'downloader/request_count': 3244,
 'downloader/request_method_count/GET': 3244,
 'downloader/response_bytes': 363834361,
 'downloader/response_count': 3244,
 'downloader/response_status_count/200': 3237,
 'downloader/response_status_count/301': 7,
 'elapsed_time_seconds': 488.090062,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 30, 5, 10, 44, 411435, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2792920697,
 'httpcompression/response_count': 3237,
 'httperror/response_ignored_count': 7,
 'httperror/response_ignored_status_count/301': 7,
 'item_scraped_count': 3235,
 'items_per_minute': None,
 'log_count/DEBUG': 6491,
 'log_count/INFO': 24,
 'log_count/WARNING': 18,
 'request_depth_max': 1,
 'response_received_count': 3244,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3243,
 'scheduler/dequeued/memory': 3243,
 'scheduler/enqueued': 3243,
 'scheduler/enqueued/memory': 3243,
 'start_time': datetime.datetime(2025, 7, 30, 5, 2, 36, 321373, tzinfo=datetime.timezone.utc),
 'tt_requires_proxy': False}
```