### PR TITLE
[Banca Sella IT] Added ATM Info

### DIFF
--- a/locations/spiders/banca_sella_it.py
+++ b/locations/spiders/banca_sella_it.py
@@ -1,4 +1,4 @@
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -14,4 +14,5 @@ class BancaSellaITSpider(JSONBlobSpider):
         item["city"] = location.get("citta")
         item["postcode"] = location.get("cap")
         apply_category(Categories.BANK, item)
+        apply_yes_no(Extras.ATM, item, bool(location["atm"]))
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Banca Sella': 279,
 'atp/brand_wikidata/Q3633749': 279,
 'atp/category/amenity/bank': 279,
 'atp/country/IT': 279,
 'atp/field/branch/missing': 279,
 'atp/field/country/from_spider_name': 279,
 'atp/field/email/missing': 279,
 'atp/field/image/missing': 279,
 'atp/field/opening_hours/missing': 279,
 'atp/field/operator/missing': 279,
 'atp/field/operator_wikidata/missing': 279,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 279,
 'atp/field/twitter/missing': 279,
 'atp/field/website/missing': 279,
 'atp/item_scraped_host_count/www.sella.it': 279,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 279,
 'downloader/request_bytes': 361,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 19185,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.225522,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 30, 7, 58, 14, 970898, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 229361,
 'httpcompression/response_count': 1,
 'item_scraped_count': 279,
 'items_per_minute': None,
 'log_count/DEBUG': 291,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 30, 7, 58, 10, 745376, tzinfo=datetime.timezone.utc)}
```