### PR TITLE
[H R Block] Fix spider

### DIFF
--- a/locations/spiders/h_r_block.py
+++ b/locations/spiders/h_r_block.py
@@ -11,7 +11,7 @@ class HRBlockSpider(SitemapSpider, StructuredDataSpider):
     name = "h_r_block"
     item_attributes = {"brand": "H&R Block", "brand_wikidata": "Q5627799"}
     sitemap_urls = ["https://www.hrblock.com/sitemap.xml"]
-    sitemap_rules = [(r"https://www\.hrblock\.com/local-tax-offices/[^/]+/[^/]+/[^/]+/\d+/$", "parse_sd")]
+    sitemap_rules = [(r"/tax-office-near-me/[^/]+/[^/]+/\d+/?$", "parse_sd")]
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "METAREFRESH_ENABLED": False,


### PR DESCRIPTION
Summary created for about `200` POIs.

```python
{'atp/brand/H&R Block': 217,
 'atp/brand_wikidata/Q5627799': 217,
 'atp/category/office/tax_advisor': 217,
 'atp/country/US': 217,
 'atp/duplicate_count': 6,
 'atp/field/branch/missing': 217,
 'atp/field/email/missing': 217,
 'atp/field/image/missing': 217,
 'atp/field/opening_hours/missing': 217,
 'atp/field/operator/missing': 217,
 'atp/field/operator_wikidata/missing': 217,
 'atp/item_scraped_host_count/www.hrblock.com': 223,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 217,
 'downloader/request_bytes': 135957,
 'downloader/request_count': 227,
 'downloader/request_method_count/GET': 227,
 'downloader/response_bytes': 54872411,
 'downloader/response_count': 227,
 'downloader/response_status_count/200': 227,
 'elapsed_time_seconds': 42.650693,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 7, 31, 7, 42, 28, 307942, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 16,
 'httpcache/hit': 211,
 'httpcache/miss': 16,
 'httpcache/store': 16,
 'item_dropped_count': 6,
 'item_dropped_reasons_count/DropItem': 6,
 'item_scraped_count': 217,
 'items_per_minute': None,
 'log_count/DEBUG': 3158,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 16,
 'playwright/page_count/closed': 16,
 'playwright/page_count/max_concurrent': 6,
 'playwright/request_count': 1337,
 'playwright/request_count/aborted': 1321,
 'playwright/request_count/method/GET': 1337,
 'playwright/request_count/navigation': 16,
 'playwright/request_count/resource_type/document': 16,
 'playwright/request_count/resource_type/font': 48,
 'playwright/request_count/resource_type/image': 266,
 'playwright/request_count/resource_type/script': 677,
 'playwright/request_count/resource_type/stylesheet': 330,
 'playwright/response_count': 16,
 'playwright/response_count/method/GET': 16,
 'playwright/response_count/resource_type/document': 16,
 'request_depth_max': 2,
 'response_received_count': 227,
 'responses_per_minute': None,
 'scheduler/dequeued': 227,
 'scheduler/dequeued/memory': 227,
 'scheduler/enqueued': 8624,
 'scheduler/enqueued/memory': 8624,
 'start_time': datetime.datetime(2025, 7, 31, 7, 41, 45, 657249, tzinfo=datetime.timezone.utc)}
```