### PR TITLE
[Aldi Sud CN] Fix Spider

### DIFF
--- a/locations/spiders/aldi_sud_cn.py
+++ b/locations/spiders/aldi_sud_cn.py
@@ -1,4 +1,9 @@
+import json
+import re
+from typing import Any
+
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
@@ -8,31 +13,22 @@ from locations.items import Feature
 class AldiSudCNSpider(Spider):
     name = "aldi_sud_cn"
     item_attributes = {"brand_wikidata": "Q41171672", "country": "CN"}
-    start_urls = ["https://aldi.cn/assets/json/stores.json"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://aldi.cn/ourshops/physicalstore/"]
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 180}
 
-    def parse(self, response, **kwargs):
-        districts = response.json().values()
-        for district in districts:
-            for store_data in district["district-data"].values():
-                for ref, store in store_data["stores"].items():
-                    item = Feature()
-                    item["ref"] = ref
-                    item["branch"] = store["title-en"].removeprefix("ALDI ").removesuffix(" Store")
-                    item["addr_full"] = store["address-en"]
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store_data in re.findall(r"data_json:\s*\'(\{.+?})\'\s*,", response.text):
+            store = json.loads(store_data)["fields"]
+            item = Feature()
+            item["ref"] = store["mapLink"]
+            item["branch"] = store["storesName"].removesuffix("店").strip()
+            item["addr_full"] = store["storesAddress"]
 
-                    try:
-                        oh = OpeningHours()
-                        start_time, end_time = store["hours"].split("-")
-                        oh.add_days_range(DAYS, start_time, end_time)
-                        item["opening_hours"] = oh
-                    except:
-                        self.logger.error("Error parsing opening hours: {}".format(store["hours"]))
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_days_range(DAYS, store["startTime"], store["endTime"], "%H:%M:%S")
 
-                    # TODO: Transform store["locationX"] store["locationX"]
+            item["extras"] = {"map": store["mapLink"]}
 
-                    item["extras"] = {"map": store["mapLink"]}
+            apply_category(Categories.SHOP_SUPERMARKET, item)
 
-                    apply_category(Categories.SHOP_SUPERMARKET, item)
-
-                    yield item
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Aldi': 75,
 'atp/brand_wikidata/Q41171672': 75,
 'atp/category/shop/supermarket': 75,
 'atp/clean_strings/addr_full': 1,
 'atp/country/CN': 75,
 'atp/field/city/missing': 75,
 'atp/field/email/missing': 75,
 'atp/field/image/missing': 75,
 'atp/field/lat/missing': 75,
 'atp/field/lon/missing': 75,
 'atp/field/operator/missing': 75,
 'atp/field/operator_wikidata/missing': 75,
 'atp/field/phone/missing': 75,
 'atp/field/postcode/missing': 75,
 'atp/field/state/missing': 75,
 'atp/field/street_address/missing': 75,
 'atp/field/twitter/missing': 75,
 'atp/field/website/missing': 75,
 'atp/item_scraped_host_count/aldi.cn': 75,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 75,
 'downloader/request_bytes': 338,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1229394,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 9.218129,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 31, 9, 18, 9, 678319, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 75,
 'items_per_minute': None,
 'log_count/DEBUG': 87,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 7, 31, 9, 18, 0, 460190, tzinfo=datetime.timezone.utc)}
```