### PR TITLE
[Flippin Pizza US] Fix Spider

### DIFF
--- a/locations/spiders/flippin_pizza_us.py
+++ b/locations/spiders/flippin_pizza_us.py
@@ -1,15 +1,25 @@
-from locations.json_blob_spider import JSONBlobSpider
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from locations.items import Feature
 
 
-# A variant on the SuperStoreFinder plugin
-class FlippinPizzaUSSpider(JSONBlobSpider):
+class FlippinPizzaUSSpider(scrapy.Spider):
     name = "flippin_pizza_us"
-    locations_key = "item"
     item_attributes = {
         "brand_wikidata": "Q113138241",
         "brand": "Flippin' Pizza",
     }
-    allowed_domains = [
-        "flippinpizza.com",
-    ]
-    start_urls = ["https://flippinpizza.com/wp-content/uploads/ssf-wp-uploads/ssf-data.json"]
+
+    start_urls = ["https://flippinpizza.com/locations"]
+    no_refs = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.xpath('//*[@class="w-dyn-list"]//*[@role="listitem"]'):
+            item = Feature()
+            item["branch"] = store.xpath('.//*[@class="product-card-title"]/text()').get()
+            item["addr_full"] = store.xpath('.//*[@class="product-card-top-description"]/text()').get()
+            item["phone"] = store.xpath('.//*[@class="product-card-top-description"][3]/text()').get()
+            yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{"atp/brand/Flippin' Pizza": 11,
 'atp/brand_wikidata/Q113138241': 11,
 'atp/category/amenity/fast_food': 11,
 'atp/clean_strings/phone': 3,
 'atp/country/US': 11,
 'atp/field/city/missing': 11,
 'atp/field/country/from_spider_name': 11,
 'atp/field/email/missing': 11,
 'atp/field/image/missing': 11,
 'atp/field/lat/missing': 11,
 'atp/field/lon/missing': 11,
 'atp/field/opening_hours/missing': 11,
 'atp/field/operator/missing': 11,
 'atp/field/operator_wikidata/missing': 11,
 'atp/field/postcode/missing': 11,
 'atp/field/state/missing': 11,
 'atp/field/street_address/missing': 11,
 'atp/field/twitter/missing': 11,
 'atp/field/website/missing': 11,
 'atp/item_scraped_host_count/www.flippinpizza.com': 11,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 11,
 'downloader/request_bytes': 1680,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 16076,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 4.610257,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 31, 12, 29, 1, 758473, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 49800,
 'httpcompression/response_count': 3,
 'item_scraped_count': 11,
 'items_per_minute': None,
 'log_count/DEBUG': 27,
 'log_count/INFO': 9,
 'response_received_count': 3,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 7, 31, 12, 28, 57, 148216, tzinfo=datetime.timezone.utc)}
```