### PR TITLE
[Societe Generale] Add ATM locations

### DIFF
--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -15,11 +15,14 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
     ]
     sitemap_rules = [(r"/.+-id(\d+)$", "parse_sd")]
 
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        ld_data.pop("@id", None)
+
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Agence ").title()
-        item["ref"] = response.url
 
         if "distributeur-automate" in response.url:
+            item["ref"] += "_atm"
             apply_category(Categories.ATM, item)
         else:
             apply_category(Categories.BANK, item)

--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -9,13 +9,20 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"name": "SG", "brand": "SG", "brand_wikidata": "Q270363"}
     allowed_domains = ["agences.sg.fr"]
     sitemap_urls = ["https://agences.sg.fr/banque-assurance/sitemap_index.xml"]
-    sitemap_follow = ["particulier/sitemap_pois"]
-    sitemap_rules = [(r"banque-assurance/particulier/.+-id(\d+)$", "parse_sd")]
+    sitemap_follow = [
+        "particulier/sitemap_pois",
+        "distributeur-automate/sitemap_pois",
+    ]
+    sitemap_rules = [(r"/.+-id(\d+)$", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Agence ").title()
+        item["ref"] = response.url
 
-        apply_category(Categories.BANK, item)
+        if "distributeur-automate" in response.url:
+            apply_category(Categories.ATM, item)
+        else:
+            apply_category(Categories.BANK, item)
 
         if item.get("image") and "agence-sg.jpg" in item["image"]:
             # Ignore generic image of a store that is used as a placeholder

--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -1,12 +1,15 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
     name = "societe_generale"
-    item_attributes = {"name": "SG", "brand": "SG", "brand_wikidata": "Q270363"}
+    SG = {"name": "SG", "brand": "SG", "brand_wikidata": "Q270363"}
+    CASH_SERVICE = {"brand": "Cash Service", "brand_wikidata": ""}
     allowed_domains = ["agences.sg.fr"]
     sitemap_urls = ["https://agences.sg.fr/banque-assurance/sitemap_index.xml"]
     sitemap_follow = [
@@ -18,8 +21,12 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.pop("@id", None)
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("Agence ").title()
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if "Cash Service" in item["name"].title():
+            item.update(self.CASH_SERVICE)
+        else:
+            item["branch"] = item.pop("name").title().removeprefix("Agence ")
+            item.update(self.SG)
 
         if "distributeur-automate" in response.url:
             item["ref"] += "_atm"


### PR DESCRIPTION
```python
{'atp/brand/Cash Service': 8,
 'atp/brand/SG': 508,
 'atp/brand_wikidata/Q270363': 508,
 'atp/category/amenity/atm': 19,
 'atp/category/amenity/bank': 497,
 'atp/country/FR': 516,
 'atp/field/branch/missing': 8,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/email/missing': 516,
 'atp/field/image/missing': 381,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 505,
 'atp/field/operator_wikidata/missing': 505,
 'atp/field/phone/missing': 19,
 'atp/field/state/missing': 516,
 'atp/item_scraped_host_count/agences.sg.fr': 516,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 508,
 'atp/operator/Société Générale': 11,
 'atp/operator_wikidata/Q270363': 11,
 'downloader/request_bytes': 268985,
 'downloader/request_count': 520,
 'downloader/request_method_count/GET': 520,
 'downloader/response_bytes': 7300878,
 'downloader/response_count': 520,
 'downloader/response_status_count/200': 520,
 'elapsed_time_seconds': 647.717705,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 7, 31, 13, 6, 46, 378759, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 27573889,
 'httpcompression/response_count': 519,
 'item_scraped_count': 516,
 'items_per_minute': None,
 'log_count/DEBUG': 1047,
 'log_count/INFO': 19,
 'request_depth_max': 2,
 'response_received_count': 520,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 519,
 'scheduler/dequeued/memory': 519,
 'scheduler/enqueued': 5874,
 'scheduler/enqueued/memory': 5874,
 'start_time': datetime.datetime(2025, 7, 31, 12, 55, 58, 661054, tzinfo=datetime.timezone.utc)}
```