### PR TITLE
[Hackett London] Add spider

### DIFF
--- a/locations/spiders/hackett_london.py
+++ b/locations/spiders/hackett_london.py
@@ -1,0 +1,28 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class HackettLondonSpider(SitemapSpider, StructuredDataSpider):
+    name = "hackett_london"
+    item_attributes = {"brand": "Hackett London", "brand_wikidata": "Q1136426"}
+    sitemap_urls = ["https://storelocator.hackett.com/sitemap.xml"]
+    sitemap_rules = [
+        ("https://storelocator.hackett.com/hackett-", "parse"),
+        # ("https://storelocator.hackett.com/hackett-london-regent-street-193-564e196a7412", "parse"),
+    ]
+    wanted_types = ["ClothingStore"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item["name"].startswith("Hackett Outlet "):
+            item["branch"] = item.pop("name").removeprefix("Hackett Outlet ")
+            item["name"] = "Hackett Outlet"
+        else:
+            item["branch"] = item.pop("name").removeprefix("Hackett ").removeprefix("London ")
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+
+        yield item


### PR DESCRIPTION
Fixes #13857
```python
{'atp/brand/Hackett London': 121,
 'atp/brand_wikidata/Q1136426': 121,
 'atp/category/shop/clothes': 121,
 'atp/cdn/cloudflare/response_count': 125,
 'atp/cdn/cloudflare/response_status_count/200': 124,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/AT': 1,
 'atp/country/BE': 4,
 'atp/country/CH': 3,
 'atp/country/CL': 1,
 'atp/country/DE': 7,
 'atp/country/ES': 63,
 'atp/country/FR': 7,
 'atp/country/GB': 20,
 'atp/country/IE': 1,
 'atp/country/MX': 8,
 'atp/country/PT': 6,
 'atp/duplicate_count': 2,
 'atp/field/country/from_reverse_geocoding': 121,
 'atp/field/email/missing': 16,
 'atp/field/image/missing': 3,
 'atp/field/opening_hours/missing': 36,
 'atp/field/operator/missing': 121,
 'atp/field/operator_wikidata/missing': 121,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 121,
 'atp/item_scraped_host_count/storelocator.hackett.com': 123,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 121,
 'atp/structured_data/unmapped/payment_accepted/ANDROIDPAY': 121,
 'downloader/request_bytes': 77315,
 'downloader/request_count': 125,
 'downloader/request_method_count/GET': 125,
 'downloader/response_bytes': 5968185,
 'downloader/response_count': 125,
 'downloader/response_status_count/200': 124,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.70576,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 7, 31, 14, 12, 31, 620012, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 125,
 'httpcompression/response_bytes': 57673464,
 'httpcompression/response_count': 125,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 121,
 'items_per_minute': None,
 'log_count/INFO': 131,
 'log_count/WARNING': 1,
 'memusage/max': 277807104,
 'memusage/startup': 277807104,
 'request_depth_max': 1,
 'response_received_count': 125,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 124,
 'scheduler/dequeued/memory': 124,
 'scheduler/enqueued': 124,
 'scheduler/enqueued/memory': 124,
 'start_time': datetime.datetime(2025, 7, 31, 14, 12, 28, 914252, tzinfo=datetime.timezone.utc)}
```