### PR TITLE
[Goldsmiths GB] Fix Spider

### DIFF
--- a/locations/spiders/goldsmiths_gb.py
+++ b/locations/spiders/goldsmiths_gb.py
@@ -13,20 +13,22 @@ class GoldsmithsGBSpider(Spider):
     item_attributes = {"brand": "Goldsmiths", "brand_wikidata": "Q16993095"}
 
     def start_requests(self) -> Iterable[Request]:
-        yield JsonRequest(url="https://www.goldsmiths.co.uk/store-finder?q=&latitude=0&longitude=0&page=0")
+        yield JsonRequest(
+            url="https://api.thewosgroup.com/occ/v2/Goldsmiths_UK/stores?longitude=0&latitude=0&radius=100000&pageSize=10000"
+        )
 
     def parse(self, response, **kwargs):
-        for location in response.json()["results"]:
+        for location in response.json()["stores"]:
             location["ref"] = location.pop("name")
             location["address"]["street_address"] = clean_address(
                 [location["address"].get("line1"), location["address"].get("line2")]
             )
-            location["address"]["country"] = location["address"]["country"]["isocode"]
-            location["phone"] = location["address"]["phone"]
-            location["email"] = location["address"]["email"]
+            location["phone"] = location["address"].get("phone")
+            location["email"] = location["address"].get("email")
 
             item = DictParser.parse(location)
-
+            item["country"] = "GB"
+            item["branch"] = item.pop("name")
             item["website"] = f'https://www.goldsmiths.co.uk/store/{item["ref"]}'
 
             item["opening_hours"] = OpeningHours()
@@ -41,10 +43,3 @@ class GoldsmithsGBSpider(Spider):
                 )
 
             yield item
-
-        current_page = response.json()["pagination"]["currentPage"]
-        pages = response.json()["pagination"]["numberOfPages"]
-        if current_page < pages:
-            yield JsonRequest(
-                url=f"https://www.goldsmiths.co.uk/store-finder?q=&latitude=0&longitude=0&page={current_page + 1}"
-            )


### PR DESCRIPTION
**_Fixes : updated request url to fix spider_**

```python
{'atp/brand/Goldsmiths': 136,
 'atp/brand_wikidata/Q16993095': 136,
 'atp/category/shop/jewelry': 136,
 'atp/country/GB': 136,
 'atp/field/image/missing': 136,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 136,
 'atp/field/operator_wikidata/missing': 136,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 136,
 'atp/field/twitter/missing': 136,
 'atp/item_scraped_host_count/api.thewosgroup.com': 136,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 136,
 'downloader/request_bytes': 795,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 92391,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.767645,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 1, 5, 10, 36, 170316, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1006122,
 'httpcompression/response_count': 1,
 'item_scraped_count': 136,
 'items_per_minute': None,
 'log_count/DEBUG': 150,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 1, 5, 10, 32, 402671, tzinfo=datetime.timezone.utc)}
```