### PR TITLE
[Marks CA] Fix Spider

### DIFF
--- a/locations/spiders/marks_ca.py
+++ b/locations/spiders/marks_ca.py
@@ -10,14 +10,14 @@ from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.user_agents import BROWSER_DEFAULT
+from locations.user_agents import FIREFOX_LATEST
 
 
 class MarksCASpider(Spider):
     name = "marks_ca"
     item_attributes = {"brand": "Mark's", "brand_wikidata": "Q6766373"}
     start_urls = ["https://www.marks.com/sitemap_Store-en_CA-CAD.xml"]
-    user_agent = BROWSER_DEFAULT
+    user_agent = FIREFOX_LATEST
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for url in iterloc(Sitemap(response.body)):

--- a/locations/spiders/marks_ca.py
+++ b/locations/spiders/marks_ca.py
@@ -18,6 +18,7 @@ class MarksCASpider(Spider):
     item_attributes = {"brand": "Mark's", "brand_wikidata": "Q6766373"}
     start_urls = ["https://www.marks.com/sitemap_Store-en_CA-CAD.xml"]
     user_agent = FIREFOX_LATEST
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for url in iterloc(Sitemap(response.body)):

--- a/locations/spiders/marks_ca.py
+++ b/locations/spiders/marks_ca.py
@@ -10,14 +10,14 @@ from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.user_agents import FIREFOX_LATEST
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class MarksCASpider(Spider):
     name = "marks_ca"
     item_attributes = {"brand": "Mark's", "brand_wikidata": "Q6766373"}
     start_urls = ["https://www.marks.com/sitemap_Store-en_CA-CAD.xml"]
-    user_agent = FIREFOX_LATEST
+    user_agent = BROWSER_DEFAULT
     requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
**_Fixes : updated user agent to fix spider_**

```python
{"atp/brand/Mark's": 384,
 'atp/brand_wikidata/Q6766373': 384,
 'atp/category/shop/clothes': 384,
 'atp/country/CA': 384,
 'atp/field/city/missing': 384,
 'atp/field/image/missing': 384,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/name/missing': 384,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 384,
 'atp/field/operator_wikidata/missing': 384,
 'atp/field/twitter/missing': 384,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/apim.marks.com': 384,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 384,
 'downloader/request_bytes': 821271,
 'downloader/request_count': 387,
 'downloader/request_method_count/GET': 387,
 'downloader/response_bytes': 1013156,
 'downloader/response_count': 387,
 'downloader/response_status_count/200': 386,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 470.02675,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 1, 8, 43, 10, 818265, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1766696,
 'httpcompression/response_count': 385,
 'item_scraped_count': 384,
 'items_per_minute': None,
 'log_count/DEBUG': 783,
 'log_count/INFO': 16,
 'request_depth_max': 1,
 'response_received_count': 387,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 385,
 'scheduler/dequeued/memory': 385,
 'scheduler/enqueued': 385,
 'scheduler/enqueued/memory': 385,
 'start_time': datetime.datetime(2025, 8, 1, 8, 35, 20, 791515, tzinfo=datetime.timezone.utc)}
```