### PR TITLE
[Consum ES] Add spider

### DIFF
--- a/locations/spiders/consum_es.py
+++ b/locations/spiders/consum_es.py
@@ -1,0 +1,32 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+CHARTER = {"brand": "Charter", "brand_wikidata": "Q95916752"}
+
+
+class ConsumESSpider(SitemapSpider, StructuredDataSpider):
+    name = "consum_es"
+    item_attributes = {"brand": "Consum", "brand_wikidata": "Q8350308"}
+    sitemap_urls = ["https://www.consum.es/robots.txt"]
+    sitemap_rules = [(r"es/supermercados/([^/]+)/", "parse")]
+    wanted_types = ["Store"]
+    requires_proxy = True
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name")
+        item["website"] = response.url
+
+        if ld_data.get("description") == "Charter":
+            item.update(CHARTER)
+
+        item["extras"]["website:es"] = response.xpath('//link[@rel="alternate"][@hreflang="es"]/@href').get()
+        item["extras"]["website:ca"] = response.xpath('//link[@rel="alternate"][@hreflang="ca"]/@href').get()
+        item["extras"]["website:en"] = response.xpath('//link[@rel="alternate"][@hreflang="en"]/@href').get()
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Charter': 495,
 'atp/brand/Consum': 510,
 'atp/brand_wikidata/Q8350308': 510,
 'atp/brand_wikidata/Q95916752': 495,
 'atp/category/shop/supermarket': 1005,
 'atp/country/ES': 1005,
 'atp/field/email/missing': 1005,
 'atp/field/image/missing': 1005,
 'atp/field/opening_hours/missing': 1005,
 'atp/field/operator/missing': 1005,
 'atp/field/operator_wikidata/missing': 1005,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 1005,
 'atp/field/state/missing': 10,
 'atp/item_scraped_host_count/www.consum.es': 1005,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 1005,
 'downloader/request_bytes': 595562,
 'downloader/request_count': 1024,
 'downloader/request_method_count/GET': 1024,
 'downloader/response_bytes': 46313430,
 'downloader/response_count': 1024,
 'downloader/response_status_count/200': 1024,
 'elapsed_time_seconds': 12.122511,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 4, 8, 4, 13, 137127, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1024,
 'httpcompression/response_bytes': 198026521,
 'httpcompression/response_count': 1013,
 'item_scraped_count': 1005,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 284205056,
 'memusage/startup': 284205056,
 'request_depth_max': 3,
 'response_received_count': 1024,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1023,
 'scheduler/dequeued/memory': 1023,
 'scheduler/enqueued': 1023,
 'scheduler/enqueued/memory': 1023,
 'start_time': datetime.datetime(2025, 8, 4, 8, 4, 1, 14616, tzinfo=datetime.timezone.utc)}
```