### PR TITLE
[Natwest GB] Add ATM locations for spider

### DIFF
--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -54,7 +54,9 @@ class NatwestGBSpider(Spider):
                 location["location"] = coordinates
             item = DictParser.parse(location)
             item["website"] = (
-                location["c_listing_URL"].replace("/personal", "") if location.get("c_listing_URL") else None
+                location["c_listing_URL"].replace("/personal", "").replace(" ", "-")
+                if location.get("c_listing_URL")
+                else None
             )
 
             if location.get("c_launch") == "ACTIVE_BRANCH":

--- a/locations/spiders/natwest_gb.py
+++ b/locations/spiders/natwest_gb.py
@@ -6,7 +6,7 @@ from scrapy import Request, Spider
 from scrapy.exceptions import CloseSpider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.geo import postal_regions
 from locations.hours import OpeningHours
@@ -28,7 +28,17 @@ class NatwestGBSpider(Spider):
                             "search_limit": "50",
                             "search_radius": "2000",
                             "filter": json.dumps(
-                                {"$and": [{"c_brand": {"$eq": "NatWest"}}, {"c_launch": {"$eq": "ACTIVE_BRANCH"}}]}
+                                {
+                                    "$and": [
+                                        {"c_brand": {"$eq": "NatWest"}},
+                                        {
+                                            "$or": [
+                                                {"meta.entityType": {"$eq": "atm"}},
+                                                {"c_launch": {"$eq": "ACTIVE_BRANCH"}},
+                                            ]
+                                        },
+                                    ]
+                                }
                             ),
                         }
                     ),
@@ -38,28 +48,40 @@ class NatwestGBSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         resp = response.json()["response"]
         self.total_pois = max([self.total_pois, resp["count"]])
-        for location, dist in zip(resp["entities"], resp["distances"]):
+        for location in resp["entities"]:
+            location.update(location.pop("meta", {}))
             if coordinates := location.get("displayCoordinate"):
                 location["location"] = coordinates
             item = DictParser.parse(location)
-            item["ref"] = dist["id"]
-            item["website"] = location["c_listing_URL"].replace("/personal", "")
-            item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
-            item["extras"]["ref:facebook"] = location.get("" "facebookPageUrl", "").split("/")[-1]
-            item["extras"]["ref:google:place_id"] = location["googlePlaceId"]
+            item["website"] = (
+                location["c_listing_URL"].replace("/personal", "") if location.get("c_listing_URL") else None
+            )
 
-            if "phone" in item and item["phone"].replace(" ", "").startswith("+443"):
-                # not a phone number specific to given branch
-                item["phone"] = None
+            if location.get("c_launch") == "ACTIVE_BRANCH":
+                apply_category(Categories.BANK, item)
+                apply_yes_no(
+                    Extras.ATM, item, location.get("c_externalATM") == "1" or location.get("c_internalATM") == "1"
+                )
 
-            item["opening_hours"] = OpeningHours()
-            for day, rule in location["hours"].items():
-                if rule.get("isClosed"):
-                    continue
-                for time in rule["openIntervals"]:
-                    item["opening_hours"].add_range(day, time["start"], time["end"])
+                item["facebook"] = "https://www.facebook.com/{}".format(location["facebookVanityUrl"])
+                item["extras"]["ref:facebook"] = location.get("facebookPageUrl", "").split("/")[-1]
+                item["extras"]["ref:google:place_id"] = location["googlePlaceId"]
 
-            apply_category(Categories.BANK, item)
+                if "phone" in item and item["phone"].replace(" ", "").startswith("+443"):
+                    # not a phone number specific to given branch
+                    item["phone"] = None
+
+            else:
+                apply_category(Categories.ATM, item)
+                apply_yes_no(Extras.CASH_IN, item, location.get("c_cashdepositMachine") == "1")
+
+            if hours := location.get("hours"):
+                item["opening_hours"] = OpeningHours()
+                for day, rule in hours.items():
+                    if rule.get("isClosed"):
+                        continue
+                    for time in rule["openIntervals"]:
+                        item["opening_hours"].add_range(day, time["start"], time["end"])
 
             yield item
             self.seen_refs.add(item["ref"])


### PR DESCRIPTION
```python
{'atp/brand/NatWest': 847,
 'atp/brand_wikidata/Q2740021': 847,
 'atp/category/amenity/atm': 509,
 'atp/category/amenity/bank': 338,
 'atp/country/GB': 847,
 'atp/duplicate_count': 50253,
 'atp/field/branch/missing': 847,
 'atp/field/email/missing': 847,
 'atp/field/image/missing': 847,
 'atp/field/opening_hours/missing': 510,
 'atp/field/operator/missing': 338,
 'atp/field/operator_wikidata/missing': 338,
 'atp/field/phone/missing': 847,
 'atp/field/state/missing': 56,
 'atp/field/twitter/missing': 847,
 'atp/field/website/missing': 11,
 'atp/item_scraped_host_count/www.natwest.com': 51100,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 847,
 'atp/operator/NatWest': 509,
 'atp/operator_wikidata/Q2740021': 509,
 'downloader/request_bytes': 830907,
 'downloader/request_count': 1086,
 'downloader/request_method_count/GET': 1086,
 'downloader/response_bytes': 12772976,
 'downloader/response_count': 1086,
 'downloader/response_status_count/200': 1086,
 'elapsed_time_seconds': 34.760528,
 'finish_reason': 'cancelled',
 'finish_time': datetime.datetime(2025, 8, 5, 6, 44, 57, 982975, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1086,
 'httpcompression/response_bytes': 212083212,
 'httpcompression/response_count': 1086,
 'item_dropped_count': 50253,
 'item_dropped_reasons_count/DropItem': 50253,
 'item_scraped_count': 847,
 'items_per_minute': None,
 'log_count/DEBUG': 52198,
 'log_count/INFO': 9,
 'response_received_count': 1086,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1085,
 'scheduler/dequeued/memory': 1085,
 'scheduler/enqueued': 1086,
 'scheduler/enqueued/memory': 1086,
 'start_time': datetime.datetime(2025, 8, 5, 6, 44, 23, 222447, tzinfo=datetime.timezone.utc)}
```