### PR TITLE
[Mens Wearhouse] Fix Spider

### DIFF
--- a/locations/spiders/mens_wearhouse.py
+++ b/locations/spiders/mens_wearhouse.py
@@ -13,3 +13,4 @@ class MensWearhouseSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/store-locator/[0-9]+", "parse_sd")]
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
     wanted_types = ["MensClothingStore"]
+    requires_proxy = True


### PR DESCRIPTION
_**Fixes : added wanted types to fix spider**_


```python
{"atp/brand/Men's Wearhouse": 628,
 'atp/brand_wikidata/Q57405513': 628,
 'atp/category/shop/clothes': 628,
 'atp/cdn/cloudflare/response_count': 629,
 'atp/cdn/cloudflare/response_status_count/200': 629,
 'atp/country/US': 628,
 'atp/field/branch/missing': 628,
 'atp/field/email/missing': 628,
 'atp/field/image/dropped': 628,
 'atp/field/image/missing': 628,
 'atp/field/operator/missing': 628,
 'atp/field/operator_wikidata/missing': 628,
 'atp/item_scraped_host_count/www.menswearhouse.com': 628,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 628,
 'downloader/request_bytes': 1786292,
 'downloader/request_count': 642,
 'downloader/request_method_count/GET': 642,
 'downloader/response_bytes': 44722796,
 'downloader/response_count': 642,
 'downloader/response_status_count/200': 630,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/302': 11,
 'dupefilter/filtered': 10,
 'elapsed_time_seconds': 777.077425,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 5, 10, 21, 54, 101111, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 356575374,
 'httpcompression/response_count': 630,
 'item_scraped_count': 628,
 'items_per_minute': None,
 'log_count/DEBUG': 1282,
 'log_count/INFO': 22,
 'request_depth_max': 1,
 'response_received_count': 630,
 'responses_per_minute': None,
 'scheduler/dequeued': 642,
 'scheduler/dequeued/memory': 642,
 'scheduler/enqueued': 642,
 'scheduler/enqueued/memory': 642,
 'start_time': datetime.datetime(2025, 8, 5, 10, 8, 57, 23686, tzinfo=datetime.timezone.utc)}
```