### PR TITLE
[YHA AU GB] Fix brand names and Wikidata IDs

### DIFF
--- a/locations/spiders/yha_au.py
+++ b/locations/spiders/yha_au.py
@@ -11,7 +11,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class YhaAUSpider(SitemapSpider, StructuredDataSpider):
     name = "yha_au"
-    item_attributes = {"brand": "YHA", "brand_wikidata": "Q118234608"}
+    item_attributes = {"brand": "Youth Hostels Association", "brand_wikidata": "Q8045885"}
     sitemap_urls = ["https://www.yha.com.au/en/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/www\.yha\.com\.au\/hostels(?:\/[^\/]+){3}\/?$", "parse_sd")]
 

--- a/locations/spiders/yha_gb.py
+++ b/locations/spiders/yha_gb.py
@@ -11,7 +11,7 @@ from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 class YhaGBSpider(Spider):
     name = "yha_gb"
-    item_attributes = {"brand": "YHA", "brand_wikidata": "Q118234608"}
+    item_attributes = {"brand": "Youth Hostels Association", "brand_wikidata": "Q8059214"}
     start_urls = ["https://www.yha.org.uk/hostels/all-youth-hostels"]
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS


### PR DESCRIPTION
NSI/Wikidata both split "YHA" into country-specific brands/items. Use the correct names and Wikidata IDs per NSI.