### PR TITLE
[ATS Euromaster GB] Fix Spider

### DIFF
--- a/locations/spiders/ats_euromaster_gb.py
+++ b/locations/spiders/ats_euromaster_gb.py
@@ -1,18 +1,25 @@
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class AtsEuromasterGBSpider(SitemapSpider, StructuredDataSpider):
+class AtsEuromasterGBSpider(CrawlSpider, StructuredDataSpider):
     name = "ats_euromaster_gb"
     item_attributes = {"brand": "ATS Euromaster", "brand_wikidata": "Q4654920"}
-    sitemap_urls = ["https://www.atseuromaster.co.uk/robots.txt"]
-    sitemap_rules = [(r"/centres/[^/]+/[^/]+/[^/]+$", "parse")]
+    start_urls = ["https://www.atseuromaster.co.uk/centres"]
+    rules = [
+        Rule(LinkExtractor(allow="/centres/[^/]+$")),
+        Rule(LinkExtractor(allow=r"/centres/[^/]+/[^/]+$")),
+        Rule(LinkExtractor(allow=r"/centres/[^/]+/[^/]+/[^/]+$"), callback="parse_sd"),
+    ]
     wanted_types = ["AutoRepair"]
     time_format = "%H:%M:%S"
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["facebook"] = None


### PR DESCRIPTION
**Fixes : code updated to use crawl spider to fix spider**

```python
{'atp/brand/ATS Euromaster': 150,
 'atp/brand_wikidata/Q4654920': 150,
 'atp/category/shop/car_repair': 150,
 'atp/country/GB': 150,
 'atp/field/country/from_spider_name': 150,
 'atp/field/email/missing': 150,
 'atp/field/image/missing': 150,
 'atp/field/operator/missing': 150,
 'atp/field/operator_wikidata/missing': 150,
 'atp/item_scraped_host_count/www.atseuromaster.co.uk': 150,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 150,
 'downloader/request_bytes': 149817,
 'downloader/request_count': 370,
 'downloader/request_method_count/GET': 370,
 'downloader/response_bytes': 9754115,
 'downloader/response_count': 370,
 'downloader/response_status_count/200': 368,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 452.614949,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 6, 5, 54, 25, 805092, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 145968530,
 'httpcompression/response_count': 368,
 'item_scraped_count': 150,
 'items_per_minute': None,
 'log_count/DEBUG': 536,
 'log_count/INFO': 16,
 'request_depth_max': 3,
 'response_received_count': 368,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 369,
 'scheduler/dequeued/memory': 369,
 'scheduler/enqueued': 369,
 'scheduler/enqueued/memory': 369,
 'start_time': datetime.datetime(2025, 8, 6, 5, 46, 53, 190143, tzinfo=datetime.timezone.utc)}
```