### PR TITLE
[BNP Paribas Fortis BE] Added ATM Info

### DIFF
--- a/locations/spiders/bnp_paribas_fortis_be.py
+++ b/locations/spiders/bnp_paribas_fortis_be.py
@@ -3,7 +3,7 @@ import re
 import scrapy
 from chompjs import chompjs
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, sanitise_day
 
@@ -45,4 +45,5 @@ class BnpParibasFortisBESpider(scrapy.Spider):
                 oh.add_range(day, open_time.strip(), close_time.strip())
                 item["opening_hours"] = oh
             apply_category(Categories.BANK, item)
+            apply_yes_no(Extras.ATM, item, "ATM" in store["text2"])
             yield item


### PR DESCRIPTION
```python
{'atp/brand/BNP Paribas Fortis': 916,
 'atp/brand_wikidata/Q796827': 916,
 'atp/category/amenity/bank': 916,
 'atp/country/BE': 916,
 'atp/duplicate_count': 8244,
 'atp/field/branch/missing': 916,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 916,
 'atp/field/email/missing': 916,
 'atp/field/image/missing': 916,
 'atp/field/opening_hours/missing': 260,
 'atp/field/operator/missing': 916,
 'atp/field/operator_wikidata/missing': 916,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 916,
 'atp/field/twitter/missing': 916,
 'atp/item_scraped_host_count/branch.bnpparibasfortis.be': 9160,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 916,
 'downloader/request_bytes': 471106,
 'downloader/request_count': 917,
 'downloader/request_method_count/GET': 917,
 'downloader/response_bytes': 2789767,
 'downloader/response_count': 917,
 'downloader/response_status_count/200': 917,
 'elapsed_time_seconds': 107.527214,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 6, 9, 7, 22, 183579, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10967855,
 'httpcompression/response_count': 917,
 'item_dropped_count': 8244,
 'item_dropped_reasons_count/DropItem': 8244,
 'item_scraped_count': 916,
 'items_per_minute': None,
 'log_count/DEBUG': 10089,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 917,
 'responses_per_minute': None,
 'scheduler/dequeued': 917,
 'scheduler/dequeued/memory': 917,
 'scheduler/enqueued': 917,
 'scheduler/enqueued/memory': 917,
 'start_time': datetime.datetime(2025, 8, 6, 9, 5, 34, 656365, tzinfo=datetime.timezone.utc)}
```