### PR TITLE
[Cornerstone Healthcare Group US] Fix Spider

### DIFF
--- a/locations/spiders/cornerstone_healthcare_group_us.py
+++ b/locations/spiders/cornerstone_healthcare_group_us.py
@@ -13,13 +13,13 @@ class CornerstoneHealthcareGroupUSSpider(CrawlSpider):
     name = "cornerstone_healthcare_group_us"
     item_attributes = {"brand": "Cornerstone Healthcare Group"}
     start_urls = ["https://cornerstonehospitals.com/locations"]
-    rules = [Rule(LinkExtractor(r"https://www.cornerstonehospitals.com/locations/[^/]+/[^/]+$"), callback="parse")]
+    rules = [Rule(LinkExtractor(r"/locations/[^/]+/[^/]+$"), callback="parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
         item["name"] = self.item_attributes["brand"]
         item["branch"] = response.xpath("//h1//text()").get()
-        item["addr_full"] = response.xpath('//*[@id="text-cf7b8a0952"]//p//text()').get()
+        item["addr_full"] = response.xpath('//*[@class="cmp-text"]//p//text()').get().replace("|", "")
         item["website"] = item["ref"] = response.url
         extract_google_position(item, response)
         apply_category(Categories.HOSPITAL, item)


### PR DESCRIPTION
**_Fixes : updated rules and xpath to fix spider_**

```python
{'atp/brand/Cornerstone Healthcare Group': 8,
 'atp/category/amenity/hospital': 8,
 'atp/category/multiple': 8,
 'atp/clean_strings/addr_full': 8,
 'atp/country/US': 8,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/city/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/email/missing': 8,
 'atp/field/image/missing': 8,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/phone/missing': 8,
 'atp/field/postcode/missing': 8,
 'atp/field/state/from_reverse_geocoding': 8,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 8,
 'atp/item_scraped_host_count/cornerstonehospitals.com': 8,
 'atp/lineage': 'S_?',
 'downloader/request_bytes': 4295,
 'downloader/request_count': 10,
 'downloader/request_method_count/GET': 10,
 'downloader/response_bytes': 87756,
 'downloader/response_count': 10,
 'downloader/response_status_count/200': 10,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 11.937434,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 6, 13, 24, 20, 567111, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 549084,
 'httpcompression/response_count': 9,
 'item_scraped_count': 8,
 'items_per_minute': None,
 'log_count/DEBUG': 20,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 10,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 9,
 'scheduler/dequeued/memory': 9,
 'scheduler/enqueued': 9,
 'scheduler/enqueued/memory': 9,
 'start_time': datetime.datetime(2025, 8, 6, 13, 24, 8, 629677, tzinfo=datetime.timezone.utc)}
```