### PR TITLE
[Lloyds Bank GB] Update spider to add ATM locations

### DIFF
--- a/locations/spiders/lloyds_bank_gb.py
+++ b/locations/spiders/lloyds_bank_gb.py
@@ -1,7 +1,7 @@
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -11,10 +11,9 @@ class LloydsBankGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Lloyds Bank",
         "brand_wikidata": "Q1152847",
-        "extras": Categories.BANK.value,
     }
     sitemap_urls = ["https://branches.lloydsbank.com/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/branches\.lloydsbank\.com\/[-\w]+\/[-\/'\w]+$", "parse_sd")]
+    sitemap_rules = [(r"https://branches\.lloydsbank\.com/[^/]+/[^/]+", "parse_sd")]
     drop_attributes = {"image"}
 
     def sitemap_filter(self, entries):
@@ -31,4 +30,14 @@ class LloydsBankGBSpider(SitemapSpider, StructuredDataSpider):
             bank in location_type for bank in ["Halifax", "Bank of Scotland"]
         ):  # Skip locations already covered by their individual brand spiders
             return
+
+        if location_type == "Cash In & Out Machine":
+            apply_category(Categories.ATM, item)
+            apply_yes_no(Extras.CASH_IN, item, True)
+            apply_yes_no(Extras.CASH_OUT, item, True)
+        elif location_type == "Cashpoint®":
+            apply_category(Categories.ATM, item)
+        else:
+            apply_category(Categories.BANK, item)
+
         yield item

--- a/locations/spiders/lloyds_bank_gb.py
+++ b/locations/spiders/lloyds_bank_gb.py
@@ -24,6 +24,12 @@ class LloydsBankGBSpider(SitemapSpider, StructuredDataSpider):
                         entry.pop("phone", None)
                 yield entry
 
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        opening_hours = []
+        for rule in ld_data.get("openingHours", []):
+            opening_hours.append(rule.replace(".", ":"))
+        ld_data["openingHours"] = opening_hours
+
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         location_type = response.xpath('//*[@class="LocationName-brand"]/text()').get("").strip()
         if any(

--- a/locations/spiders/lloyds_bank_gb.py
+++ b/locations/spiders/lloyds_bank_gb.py
@@ -1,6 +1,8 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -22,3 +24,11 @@ class LloydsBankGBSpider(SitemapSpider, StructuredDataSpider):
                     if entry["phone"].replace(" ", "").startswith("+443"):
                         entry.pop("phone", None)
                 yield entry
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        location_type = response.xpath('//*[@class="LocationName-brand"]/text()').get("").strip()
+        if any(
+            bank in location_type for bank in ["Halifax", "Bank of Scotland"]
+        ):  # Skip locations already covered by their individual brand spiders
+            return
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Lloyds Bank': 1103,
 'atp/brand_wikidata/Q1152847': 1103,
 'atp/category/amenity/atm': 444,
 'atp/category/amenity/bank': 659,
 'atp/cdn/cloudflare/response_count': 1530,
 'atp/cdn/cloudflare/response_status_count/200': 1529,
 'atp/cdn/cloudflare/response_status_count/502': 1,
 'atp/country/GB': 1103,
 'atp/field/branch/missing': 1103,
 'atp/field/email/missing': 1103,
 'atp/field/image/missing': 1103,
 'atp/field/opening_hours/missing': 230,
 'atp/field/operator/missing': 659,
 'atp/field/operator_wikidata/missing': 659,
 'atp/field/phone/missing': 674,
 'atp/field/state/missing': 1103,
 'atp/item_scraped_host_count/branches.lloydsbank.com': 1103,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1103,
 'atp/operator/Lloyds Bank': 444,
 'atp/operator_wikidata/Q1152847': 444,
 'atp/structured_data/unmapped/amenity_features': 1526,
 'downloader/request_bytes': 646190,
 'downloader/request_count': 1532,
 'downloader/request_method_count/GET': 1532,
 'downloader/response_bytes': 24403015,
 'downloader/response_count': 1532,
 'downloader/response_status_count/200': 1529,
 'downloader/response_status_count/502': 3,
 'elapsed_time_seconds': 26.159408,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 6, 15, 12, 28, 324390, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1532,
 'httpcompression/response_bytes': 132416070,
 'httpcompression/response_count': 1529,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/502': 1,
 'item_scraped_count': 1103,
 'items_per_minute': None,
 'log_count/DEBUG': 4173,
 'log_count/ERROR': 1,
 'log_count/INFO': 1537,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 1530,
 'responses_per_minute': None,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/502 Bad Gateway': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1531,
 'scheduler/dequeued/memory': 1531,
 'scheduler/enqueued': 1531,
 'scheduler/enqueued/memory': 1531,
 'start_time': datetime.datetime(2025, 8, 6, 15, 12, 2, 164982, tzinfo=datetime.timezone.utc)}
```