### PR TITLE
[HSBC UK GB] Fix Spider

### DIFF
--- a/locations/spiders/hsbc_uk_gb.py
+++ b/locations/spiders/hsbc_uk_gb.py
@@ -1,19 +1,19 @@
 from typing import Iterable
 
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class HsbcUkGBSpider(SitemapSpider, StructuredDataSpider):
+class HsbcUkGBSpider(CrawlSpider, StructuredDataSpider):
     name = "hsbc_uk_gb"
     item_attributes = {"brand": "HSBC UK", "brand_wikidata": "Q64767453"}
     start_urls = ["https://www.hsbc.co.uk/branch-list/"]
-    sitemap_urls = ["https://www.hsbc.co.uk/sitemaps-pages.xml"]
-    sitemap_rules = [(r"/branch-list/(.+)/$", "parse_sd")]
+    rules = [Rule(LinkExtractor(allow="/branch-list//"), callback="parse_sd")]
 
     def iter_linked_data(self, response: Response) -> Iterable[dict]:
         for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):


### PR DESCRIPTION
Fixes : updated spider to use crawl spider to fix spider

```python
{'atp/brand/HSBC UK': 525,
 'atp/brand_wikidata/Q64767453': 525,
 'atp/category/amenity/bank': 525,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/street_address': 6,
 'atp/closed_check': 1,
 'atp/country/GB': 525,
 'atp/field/branch/missing': 525,
 'atp/field/email/missing': 525,
 'atp/field/image/missing': 525,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 525,
 'atp/field/operator_wikidata/missing': 525,
 'atp/field/phone/missing': 525,
 'atp/field/state/missing': 525,
 'atp/item_scraped_host_count/www.hsbc.co.uk': 525,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 525,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 490865,
 'downloader/request_count': 1053,
 'downloader/request_method_count/GET': 1053,
 'downloader/response_bytes': 14931864,
 'downloader/response_count': 1052,
 'downloader/response_status_count/200': 527,
 'downloader/response_status_count/301': 525,
 'elapsed_time_seconds': 1253.527618,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 7, 6, 17, 28, 235790, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 99778327,
 'httpcompression/response_count': 527,
 'item_scraped_count': 525,
 'items_per_minute': None,
 'log_count/DEBUG': 1590,
 'log_count/INFO': 29,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 527,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1052,
 'scheduler/dequeued/memory': 1052,
 'scheduler/enqueued': 1052,
 'scheduler/enqueued/memory': 1052,
 'start_time': datetime.datetime(2025, 8, 7, 5, 56, 34, 708172, tzinfo=datetime.timezone.utc),}
```