### PR TITLE
[Halifax GB] Add ATM locations for spider

### DIFF
--- a/locations/spiders/halifax_gb.py
+++ b/locations/spiders/halifax_gb.py
@@ -1,6 +1,8 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,7 +11,6 @@ class HalifaxGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Halifax",
         "brand_wikidata": "Q3310164",
-        "extras": Categories.BANK.value,
     }
     sitemap_urls = ["https://branches.halifax.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/branches\.halifax\.co\.uk\/[-'\w]+\/[-'\/\w]+$", "parse_sd")]
@@ -19,3 +20,21 @@ class HalifaxGBSpider(SitemapSpider, StructuredDataSpider):
         for entry in entries:
             if "event" not in entry["loc"].lower():
                 yield entry
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        location_type = response.xpath('//*[@class="LocationName-brand"]/text()').get("").strip()
+        if any(
+            bank in location_type for bank in ["Lloyds Bank", "Bank of Scotland"]
+        ):  # Skip locations already covered by their individual brand spiders
+            return
+
+        if location_type == "Cash In & Out Machine":
+            apply_category(Categories.ATM, item)
+            apply_yes_no(Extras.CASH_IN, item, True)
+            apply_yes_no(Extras.CASH_OUT, item, True)
+        elif location_type == "Cash machine":
+            apply_category(Categories.ATM, item)
+        else:
+            apply_category(Categories.BANK, item)
+
+        yield item

--- a/locations/spiders/halifax_gb.py
+++ b/locations/spiders/halifax_gb.py
@@ -21,6 +21,12 @@ class HalifaxGBSpider(SitemapSpider, StructuredDataSpider):
             if "event" not in entry["loc"].lower():
                 yield entry
 
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        opening_hours = []
+        for rule in ld_data.get("openingHours", []):
+            opening_hours.append(rule.replace(".", ":"))
+        ld_data["openingHours"] = opening_hours
+
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         location_type = response.xpath('//*[@class="LocationName-brand"]/text()').get("").strip()
         if any(


### PR DESCRIPTION
```python
{'atp/brand/Halifax': 760,
 'atp/brand_wikidata/Q3310164': 760,
 'atp/category/amenity/atm': 326,
 'atp/category/amenity/bank': 434,
 'atp/cdn/cloudflare/response_count': 1292,
 'atp/cdn/cloudflare/response_status_count/200': 1292,
 'atp/country/GB': 760,
 'atp/field/branch/missing': 760,
 'atp/field/email/missing': 760,
 'atp/field/image/missing': 760,
 'atp/field/opening_hours/missing': 112,
 'atp/field/operator/missing': 434,
 'atp/field/operator_wikidata/missing': 434,
 'atp/field/phone/missing': 438,
 'atp/field/state/missing': 760,
 'atp/item_scraped_host_count/branches.halifax.co.uk': 760,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 760,
 'atp/operator/Halifax': 326,
 'atp/operator_wikidata/Q3310164': 326,
 'atp/structured_data/unmapped/amenity_features': 1289,
 'downloader/request_bytes': 538187,
 'downloader/request_count': 1292,
 'downloader/request_method_count/GET': 1292,
 'downloader/response_bytes': 20981102,
 'downloader/response_count': 1292,
 'downloader/response_status_count/200': 1292,
 'elapsed_time_seconds': 20.107143,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 7, 6, 55, 21, 288840, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1292,
 'httpcompression/response_bytes': 115219381,
 'httpcompression/response_count': 1292,
 'item_scraped_count': 760,
 'items_per_minute': None,
 'log_count/DEBUG': 3353,
 'log_count/INFO': 1298,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 1292,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1291,
 'scheduler/dequeued/memory': 1291,
 'scheduler/enqueued': 1291,
 'scheduler/enqueued/memory': 1291,
 'start_time': datetime.datetime(2025, 8, 7, 6, 55, 1, 181697, tzinfo=datetime.timezone.utc)}
```