### PR TITLE
[Macys Backstage] Fix Spider

### DIFF
--- a/locations/spiders/macys_backstage.py
+++ b/locations/spiders/macys_backstage.py
@@ -14,7 +14,7 @@ class MacysBackstageSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/backstage/\w\w/[^/]+/$")),
         Rule(LinkExtractor(r"/stores/backstage/\w\w/[^/]+/[^/]+\_(\d+b).html$"), "parse"),
     ]
-    wanted_types = ["Store"]
+    wanted_types = ["store"]
     user_agent = BROWSER_DEFAULT
 
     def post_process_item(self, item, response, ld_data, **kwargs):


### PR DESCRIPTION
```python
{"atp/brand/Macy's Backstage": 297,
 'atp/brand_wikidata/Q122914589': 297,
 'atp/category/shop/department_store': 297,
 'atp/country/US': 297,
 'atp/field/branch/missing': 297,
 'atp/field/country/from_reverse_geocoding': 297,
 'atp/field/email/missing': 297,
 'atp/field/image/dropped': 297,
 'atp/field/image/missing': 297,
 'atp/field/operator/missing': 297,
 'atp/field/operator_wikidata/missing': 297,
 'atp/item_scraped_host_count/www.macys.com': 297,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 297,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 2,
 'downloader/request_bytes': 1642040,
 'downloader/request_count': 620,
 'downloader/request_method_count/GET': 620,
 'downloader/response_bytes': 31209111,
 'downloader/response_count': 620,
 'downloader/response_status_count/200': 619,
 'downloader/response_status_count/302': 1,
 'dupefilter/filtered': 279,
 'elapsed_time_seconds': 767.541891,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 7, 6, 27, 40, 118208, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 122303557,
 'httpcompression/response_count': 618,
 'item_scraped_count': 297,
 'items_per_minute': None,
 'log_count/DEBUG': 938,
 'log_count/INFO': 21,
 'request_depth_max': 3,
 'response_received_count': 619,
 'responses_per_minute': None,
 'robotstxt/forbidden': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 620,
 'scheduler/dequeued/memory': 620,
 'scheduler/enqueued': 620,
 'scheduler/enqueued/memory': 620,
 'start_time': datetime.datetime(2025, 8, 7, 6, 14, 52, 576317, tzinfo=datetime.timezone.utc)}
```