### PR TITLE
[Allpoint] Fix low scraped count for spider

### DIFF
--- a/locations/spiders/allpoint.py
+++ b/locations/spiders/allpoint.py
@@ -10,7 +10,9 @@ from locations.dict_parser import DictParser
 class AllpointSpider(Spider):
     name = "allpoint"
     item_attributes = {"brand": "Allpoint", "brand_wikidata": "Q4733264"}
-    download_timeout = 50
+    download_timeout = 180
+    total_count = 0
+    page_size = 0
 
     def make_request(self, page: int) -> Request:
         return JsonRequest(
@@ -30,9 +32,17 @@ class AllpointSpider(Spider):
         yield self.make_request(1)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        if response.json()["data"]["ATMInfo"]:
-            for atm in response.json()["data"]["ATMInfo"]:
-                item = DictParser.parse(atm)
-                item["street_address"] = item.pop("street", None)
-                yield item
+        results = response.json()["data"]
+        if not self.total_count:
+            # Initialize total_count and page_size only once, when data is available
+            self.total_count = results["TotalRecCount"]
+            self.page_size = results["PageSize"]
+
+        locations = results.get("ATMInfo") or []
+        for atm in locations:
+            item = DictParser.parse(atm)
+            item["street_address"] = item.pop("street", None)
+            yield item
+
+        if (kwargs["current_page"] * self.page_size) < self.total_count:
             yield self.make_request(kwargs["current_page"] + 1)


### PR DESCRIPTION
```python
{'atp/brand/Allpoint': 37705,
 'atp/brand_wikidata/Q4733264': 37705,
 'atp/category/amenity/atm': 37705,
 'atp/clean_strings/city': 12,
 'atp/clean_strings/street_address': 8,
 'atp/country/AU': 322,
 'atp/country/CA': 320,
 'atp/country/GB': 8939,
 'atp/country/MX': 362,
 'atp/country/US': 27762,
 'atp/duplicate_count': 21057,
 'atp/field/branch/missing': 37705,
 'atp/field/email/missing': 37705,
 'atp/field/image/missing': 37705,
 'atp/field/name/missing': 37705,
 'atp/field/opening_hours/missing': 37705,
 'atp/field/operator/missing': 37705,
 'atp/field/operator_wikidata/missing': 37705,
 'atp/field/phone/missing': 37705,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 37705,
 'atp/field/website/missing': 37705,
 'atp/item_scraped_host_count/clsws.locatorsearch.net': 58762,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 37705,
 'downloader/request_bytes': 550791,
 'downloader/request_count': 590,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 589,
 'downloader/response_bytes': 77513573,
 'downloader/response_count': 590,
 'downloader/response_status_count/200': 589,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 132.275112,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 8, 11, 1, 27, 868247, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 590,
 'item_dropped_count': 21057,
 'item_dropped_reasons_count/DropItem': 21057,
 'item_scraped_count': 37705,
 'items_per_minute': None,
 'log_count/DEBUG': 59371,
 'log_count/INFO': 11,
 'request_depth_max': 588,
 'response_received_count': 590,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 589,
 'scheduler/dequeued/memory': 589,
 'scheduler/enqueued': 589,
 'scheduler/enqueued/memory': 589,
 'start_time': datetime.datetime(2025, 8, 8, 10, 59, 15, 593135, tzinfo=datetime.timezone.utc)}
```