### PR TITLE
[McDonalds BE] Fix Spider

### DIFF
--- a/locations/spiders/mcdonalds_be.py
+++ b/locations/spiders/mcdonalds_be.py
@@ -17,6 +17,7 @@ class McdonaldsBESpider(Spider):
     allowed_domains = ["www.mcdonalds.be"]
     start_urls = ["https://www.mcdonalds.be/en/restaurants/api/restaurants"]
     user_agent = FIREFOX_LATEST
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():


### PR DESCRIPTION
**_Fixes : added flag as requires proxy_**

```python
{"atp/brand/McDonald's": 126,
 'atp/brand_wikidata/Q38076': 126,
 'atp/category/amenity/fast_food': 126,
 'atp/clean_strings/phone': 9,
 'atp/clean_strings/street': 7,
 'atp/country/BE': 126,
 'atp/field/country/from_spider_name': 126,
 'atp/field/email/missing': 126,
 'atp/field/image/missing': 126,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 126,
 'atp/field/operator_wikidata/missing': 126,
 'atp/field/state/missing': 126,
 'atp/field/street_address/missing': 126,
 'atp/field/twitter/missing': 126,
 'atp/item_scraped_host_count/www.mcdonalds.be': 126,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 126,
 'downloader/request_bytes': 998,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 644996,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.578954,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 11, 8, 14, 22, 309141, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 126,
 'items_per_minute': None,
 'log_count/DEBUG': 139,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 11, 8, 14, 16, 730187, tzinfo=datetime.timezone.utc)}

```