### PR TITLE
[Bata] Try with proxy to fix spider

### DIFF
--- a/locations/spiders/bata.py
+++ b/locations/spiders/bata.py
@@ -23,6 +23,7 @@ class BataSpider(JSONBlobSpider):
     ]
     user_agent = FIREFOX_LATEST
     locations_key = "stores"
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["addr_full"] = None


### PR DESCRIPTION
Spider works fine from `IN`.
```python
{'atp/brand/Bata': 3246,
 'atp/brand_wikidata/Q688082': 3246,
 'atp/category/shop/shoes': 3246,
 'atp/clean_strings/city': 14,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/ref': 387,
 'atp/clean_strings/state': 88,
 'atp/clean_strings/street_address': 120,
 'atp/country/CL': 245,
 'atp/country/CZ': 52,
 'atp/country/ID': 421,
 'atp/country/IN': 1886,
 'atp/country/IT': 182,
 'atp/country/MY': 239,
 'atp/country/SK': 8,
 'atp/country/TH': 213,
 'atp/duplicate_count': 45,
 'atp/field/branch/missing': 3246,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 2,
 'atp/field/email/missing': 3246,
 'atp/field/image/missing': 3246,
 'atp/field/opening_hours/missing': 3246,
 'atp/field/operator/missing': 3246,
 'atp/field/operator_wikidata/missing': 3246,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 255,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 4,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 3246,
 'atp/item_scraped_host_count/www.bata.com': 3291,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 3246,
 'downloader/request_bytes': 6293,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 272936,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 11.304964,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 11, 9, 14, 12, 719850, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1911262,
 'httpcompression/response_count': 9,
 'item_dropped_count': 45,
 'item_dropped_reasons_count/DropItem': 45,
 'item_scraped_count': 3246,
 'items_per_minute': None,
 'log_count/DEBUG': 3311,
 'log_count/INFO': 9,
 'response_received_count': 9,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2025, 8, 11, 9, 14, 1, 414886, tzinfo=datetime.timezone.utc)}
```

