### PR TITLE
[Hyundai CZ] Fix Spider

### DIFF
--- a/locations/spiders/hyundai_gb.py
+++ b/locations/spiders/hyundai_gb.py
@@ -80,6 +80,8 @@ class HyundaiGBSpider(JSONBlobSpider):
                 continue
             elif service["serviceId"] == "door-to-door":
                 continue
+            elif service["serviceId"] == "FleetBusinessCenter":
+                continue
             else:
                 raise ValueError("Unknown feature type: {} ({})".format(service["serviceTitle"], service["serviceId"]))
 


### PR DESCRIPTION
**_Fixes : added condition for fleet business centre in hyundai_gb spider to fix spider_**


```python
{'atp/brand/Hyundai': 182,
 'atp/brand_wikidata/Q55931': 182,
 'atp/category/shop/car': 61,
 'atp/category/shop/car_parts': 60,
 'atp/category/shop/car_repair': 61,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/email': 9,
 'atp/clean_strings/phone': 6,
 'atp/country/CZ': 182,
 'atp/duplicate_count': 2,
 'atp/field/country/from_spider_name': 182,
 'atp/field/image/missing': 182,
 'atp/field/name/missing': 60,
 'atp/field/operator/missing': 182,
 'atp/field/operator_wikidata/missing': 182,
 'atp/field/twitter/missing': 182,
 'atp/item_scraped_host_count/www.hyundai.com': 184,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 122,
 'atp/nsi/match_failed': 60,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 29290,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.46938,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 11, 12, 7, 59, 96900, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 241104,
 'httpcompression/response_count': 2,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 182,
 'items_per_minute': None,
 'log_count/DEBUG': 197,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 11, 12, 7, 56, 627520, tzinfo=datetime.timezone.utc)}
```