### PR TITLE
[Burger King CL] Add CL to Burger King Global Spider and Delete broken Spider

### DIFF
--- a/locations/spiders/burger_king.py
+++ b/locations/spiders/burger_king.py
@@ -153,7 +153,7 @@ class BurgerKingSpider(scrapy.Spider):
         us_endpoint = "https://use1-prod-bk.rbictg.com/graphql"
         za_endpoint = "https://www.burgerking.co.za/api/whitelabel"
         ie_endpoint = "https://burgerking.ie/api/whitelabel"
-        ar_endpoint = "https://use2-prod-bk.rbictg.com/graphql"
+        ar_cl_endpoint = "https://use2-prod-bk.rbictg.com/graphql"
 
         # UAE
         for country_code, city_name in [("AE", "Dubai")]:
@@ -191,7 +191,11 @@ class BurgerKingSpider(scrapy.Spider):
 
         # Argentina
         for country_code, city_name in [("AR", "Córdoba")]:
-            yield self.make_city_request(city_name, country_code, 1000000, 20000, ar_endpoint)
+            yield self.make_city_request(city_name, country_code, 1000000, 20000, ar_cl_endpoint)
+
+        # Chile
+        for country_code, city_name in [("CL", "Santiago")]:
+            yield self.make_city_request(city_name, country_code, 1000000, 20000, ar_cl_endpoint)
 
         # USA
         # So many stores in the US that we need to be kind to the BK back end.
@@ -199,12 +203,15 @@ class BurgerKingSpider(scrapy.Spider):
             yield self.make_request(lat, lon, "US", 128000, 20000, us_endpoint)
 
     store_locator_templates = {
+        "AR": "https://burgerking.com.ar/store-locator/store/{}",
         "AT": "https://www.burgerking.at/store-locator/store/{}",
         "CA": "https://www.burgerking.ca/store-locator/store/{}",
         "CH": "https://www.burger-king.ch/store-locator/store/{}",
+        "CL": "https://www.burgerking.cl/en/store-locator/store/{}",
         "CZ": "https://burgerking.cz/store-locator/store/{}",
         "DE": "https://www.burgerking.de/store-locator/store/{}",
         "GB": "https://www.burgerking.co.uk/store-locator/store/{}",
+        "IE": "https://burgerking.ie/store-locator/store/{}",
         "NL": "https://www.burgerking.nl/store-locator/store/{}",
         "NZ": "https://www.burgerking.co.nz/store-locator/store/{}",
         "PL": "https://burgerking.pl/store-locator/store/{}",
@@ -213,8 +220,6 @@ class BurgerKingSpider(scrapy.Spider):
         "SA": "https://www.burgerking.com.sa/ar/store-locator/store/{}",
         "US": "https://www.bk.com/store-locator/store/{}",
         "ZA": "https://www.burgerking.co.za/store-locator/store/{}",
-        "IE": "https://burgerking.ie/store-locator/store/{}",
-        "AR": "https://burgerking.com.ar/store-locator/store/{}",
     }
 
     def parse(self, response, country_code):

--- a/locations/spiders/burger_king_cl.py
+++ b/locations/spiders/burger_king_cl.py
@@ -1,8 +1,0 @@
-from locations.spiders.burger_king_ng import BurgerKingNGSpider
-
-
-class BurgerKingCLSpider(BurgerKingNGSpider):
-    name = "burger_king_cl"
-    start_urls = ["https://api-lac.menu.app/api/directory/search"]
-    request_headers = {"application": "509a993e252fab30945169e15e6ce1cd"}
-    website_root = "https://www.burgerking.cl/locales/"


### PR DESCRIPTION
Broken `Burger King CL Spider` deleted and added `CL` locations to `Burger King Global Spider`.

```python
{'atp/brand/Burger King': 9113,
 'atp/brand_wikidata/Q177054': 9113,
 'atp/category/amenity/fast_food': 9113,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/city': 20,
 'atp/clean_strings/operator': 142,
 'atp/clean_strings/street_address': 12,
 'atp/country/AR': 116,
 'atp/country/AT': 63,
 'atp/country/CA': 322,
 'atp/country/CH': 93,
 'atp/country/CL': 83,
 'atp/country/CZ': 58,
 'atp/country/DE': 760,
 'atp/country/ES': 918,
 'atp/country/NL': 68,
 'atp/country/PL': 72,
 'atp/country/PT': 203,
 'atp/country/RO': 37,
 'atp/country/US': 6320,
```