### PR TITLE
[Wimpy GB] Fix Spider

### DIFF
--- a/locations/spiders/wimpy_gb.py
+++ b/locations/spiders/wimpy_gb.py
@@ -12,7 +12,7 @@ class WimpyGBSpider(scrapy.Spider):
     def parse(self, response, **kwargs):
         for location in response.json()["locations"]:
             item = DictParser.parse(location)
-            if item.get("addr_full"):
-                item.pop("addr_full")
+            item["branch"] = item.pop("name").removeprefix("Wimpy ")
+            item.pop("addr_full", None)
             item["street_address"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
             yield item

--- a/locations/spiders/wimpy_gb.py
+++ b/locations/spiders/wimpy_gb.py
@@ -1,18 +1,25 @@
-import scrapy
+from typing import Any
 
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class WimpyGBSpider(scrapy.Spider):
+class WimpyGBSpider(Spider):
     name = "wimpy_gb"
     item_attributes = {"brand": "Wimpy", "brand_wikidata": "Q2811992"}
     start_urls = ["https://wimpy.uk.com/api/v2/locations?all=true"]
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["locations"]:
             item = DictParser.parse(location)
             item["branch"] = item.pop("name").removeprefix("Wimpy ")
             item.pop("addr_full", None)
             item["street_address"] = merge_address_lines([location["address_line_1"], location["address_line_2"]])
+
+            apply_category(Categories.FAST_FOOD, item)
+
             yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Wimpy': 57,
 'atp/brand_wikidata/Q2811992': 57,
 'atp/category/amenity/fast_food': 57,
 'atp/country/GB': 57,
 'atp/field/branch/missing': 57,
 'atp/field/email/missing': 56,
 'atp/field/image/missing': 57,
 'atp/field/opening_hours/missing': 57,
 'atp/field/operator/missing': 57,
 'atp/field/operator_wikidata/missing': 57,
 'atp/field/twitter/missing': 57,
 'atp/item_scraped_host_count/wimpy.uk.com': 57,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 57,
 'downloader/request_bytes': 675,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16938,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.409263,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 12, 5, 26, 7, 231576, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 123398,
 'httpcompression/response_count': 1,
 'item_scraped_count': 57,
 'items_per_minute': None,
 'log_count/DEBUG': 70,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 12, 5, 26, 3, 822313, tzinfo=datetime.timezone.utc)}
```