### PR TITLE
[Nationwide GB] Identify ATM locations

### DIFF
--- a/locations/spiders/nationwide_gb.py
+++ b/locations/spiders/nationwide_gb.py
@@ -1,7 +1,8 @@
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.categories import Categories
+from locations.categories import Categories, Extras, apply_yes_no
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -28,3 +29,6 @@ class NationwideGBSpider(CrawlSpider, StructuredDataSpider):
             item.pop("phone", None)
 
         yield item
+
+    def extract_amenity_features(self, item, response: Response, ld_item):
+        apply_yes_no(Extras.ATM, item, "Cash machine" in ld_item["amenityFeature"]["name"])


### PR DESCRIPTION
```python
{'atp/brand/Nationwide': 605,
 'atp/brand_wikidata/Q846735': 605,
 'atp/category/amenity/bank': 605,
 'atp/country/GB': 605,
 'atp/field/email/missing': 605,
 'atp/field/image/missing': 605,
 'atp/field/operator/missing': 605,
 'atp/field/operator_wikidata/missing': 605,
 'atp/field/state/missing': 605,
 'atp/item_scraped_host_count/www.nationwide.co.uk': 605,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 605,
 'downloader/request_bytes': 492107,
 'downloader/request_count': 1167,
 'downloader/request_method_count/GET': 1167,
 'downloader/response_bytes': 36417636,
 'downloader/response_count': 1167,
 'downloader/response_status_count/200': 1167,
 'dupefilter/filtered': 7626,
 'elapsed_time_seconds': 19.850823,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 12, 6, 40, 27, 614831, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1167,
 'httpcompression/response_bytes': 237882059,
 'httpcompression/response_count': 1167,
 'item_scraped_count': 605,
 'items_per_minute': None,
 'log_count/DEBUG': 1785,
 'log_count/INFO': 9,
 'request_depth_max': 7,
 'response_received_count': 1167,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1166,
 'scheduler/dequeued/memory': 1166,
 'scheduler/enqueued': 1166,
 'scheduler/enqueued/memory': 1166,
 'start_time': datetime.datetime(2025, 8, 12, 6, 40, 7, 764008, tzinfo=datetime.timezone.utc)}

```