### PR TITLE
[Mitsubishi BY RU] Fix  spider

### DIFF
--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -17,9 +17,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
     no_refs = True
 
     def extract_json(self, response: Response) -> list[dict]:
-        return list(chompjs.parse_js_objects(response.xpath('//script[contains(text(), "placemarks")]/text()').get()))[
-            -1
-        ]
+        return chompjs.parse_js_object(response.xpath('//script[contains(text(), "placemarks")]/text()').get())
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         extract_phone(item, Selector(text=feature["phone"]))


### PR DESCRIPTION
```python
{'atp/brand/Mitsubishi': 87,
 'atp/brand_wikidata/Q36033': 87,
 'atp/category/shop/car': 87,
 'atp/clean_strings/addr_full': 2,
 'atp/country/BY': 4,
 'atp/country/RU': 83,
 'atp/field/branch/missing': 87,
 'atp/field/city/missing': 87,
 'atp/field/country/from_website_url': 87,
 'atp/field/email/missing': 87,
 'atp/field/image/missing': 87,
 'atp/field/opening_hours/missing': 87,
 'atp/field/operator/missing': 87,
 'atp/field/operator_wikidata/missing': 87,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 87,
 'atp/field/state/missing': 87,
 'atp/field/street_address/missing': 87,
 'atp/field/twitter/missing': 87,
 'atp/item_scraped_host_count/www.mitsubishi-motors.ru': 87,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 87,
 'downloader/request_bytes': 739,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 22959,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.996738,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 13, 6, 2, 32, 209860, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 129678,
 'httpcompression/response_count': 2,
 'item_scraped_count': 87,
 'items_per_minute': None,
 'log_count/DEBUG': 100,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 13, 6, 2, 29, 213122, tzinfo=datetime.timezone.utc)}
```