### PR TITLE
[Oporto AU] Fix Spider

### DIFF
--- a/locations/spiders/oporto_au.py
+++ b/locations/spiders/oporto_au.py
@@ -8,17 +8,13 @@ from locations.hours import OpeningHours
 class OportoAUSpider(Spider):
     name = "oporto_au"
     item_attributes = {"brand": "Oporto", "brand_wikidata": "Q4412342"}
-    allowed_domains = ["www.oporto.com.au"]
-    start_urls = ["https://www.oporto.com.au/api-proxy/stores?include=amenities,collection,storeAddress"]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,  # robots.txt does not exist and HTML page returned instead.
-        "DOWNLOAD_TIMEOUT": 60,
-    }
+    start_urls = ["https://d3c377j0gjsips.cloudfront.net/opo_all_store_sync.json?t=202508131411"]
 
     def parse(self, response):
         for location in response.json()["data"]:
             item = DictParser.parse(location["attributes"])
-            item["ref"] = location["attributes"]["storeNumber"]
+            item["ref"] = location["id"]
+            item["branch"] = item.pop("name")
             if location["relationships"].get("storeAddress"):
                 address = location["relationships"]["storeAddress"]["data"]["attributes"]["addressComponents"]
                 if address["floor"]["value"]:
@@ -31,14 +27,12 @@ class OportoAUSpider(Spider):
                 item["state"] = address["state"]["value"]
                 item["country"] = address["country"]["longValue"]
                 item["postcode"] = address["postcode"]["value"]
+                item["lat"] = address["latitude"]["value"]
+                item["lon"] = address["longitude"]["value"]
             item["phone"] = location["attributes"]["storePhone"]
             item["email"] = location["attributes"]["storeEmail"]
-            item["website"] = "https://www.oporto.com.au/locations/" + location["attributes"][
-                "accountName"
-            ].lower().replace(" ", "-")
-            apply_yes_no(Extras.DRIVE_THROUGH, item, location["attributes"]["pickupTypes"]["driveThru"], False)
-            apply_yes_no(Extras.TAKEAWAY, item, location["attributes"]["pickupTypes"]["instore"], False)
-            apply_yes_no(Extras.DELIVERY, item, location["attributes"]["isDeliveryEnabled"], False)
+            item["website"] = "https://www.oporto.com.au/locations/" + item["branch"].lower().replace(" ", "-")
+
             extra_features = [
                 k for k, v in location["relationships"]["amenities"]["data"]["attributes"].items() if v is True
             ]


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Oporto': 237,
 'atp/brand_wikidata/Q4412342': 237,
 'atp/category/amenity/fast_food': 237,
 'atp/country/AU': 237,
 'atp/field/city/missing': 3,
 'atp/field/country/from_spider_name': 8,
 'atp/field/image/missing': 237,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 237,
 'atp/field/operator_wikidata/missing': 237,
 'atp/field/phone/invalid': 1,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 3,
 'atp/field/street_address/missing': 237,
 'atp/field/twitter/missing': 237,
 'atp/item_scraped_host_count/d3c377j0gjsips.cloudfront.net': 237,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 237,
 'downloader/request_bytes': 722,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 114888,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 4.513193,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 13, 10, 9, 20, 746683, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1399951,
 'httpcompression/response_count': 1,
 'item_scraped_count': 237,
 'items_per_minute': None,
 'log_count/DEBUG': 250,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 13, 10, 9, 16, 233490, tzinfo=datetime.timezone.utc)}
```