### PR TITLE
[Bper Banca IT] Add  spider (1707 locations)

### DIFF
--- a/locations/spiders/bper_banca_it.py
+++ b/locations/spiders/bper_banca_it.py
@@ -1,0 +1,62 @@
+from typing import Any, Iterable, Optional
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+
+
+class BperBancaITSpider(Spider):
+    name = "bper_banca_it"
+    BRANDS = {
+        "5387": ("BPER Banca", "Q806167"),
+        "3084": ("Banca Cesare Ponti", "Q3633696"),
+        "1015": ("Banco di Sardegna", "Q806205"),
+    }
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://www.bper.it/o/bper-api/subsidiary/search/categories",
+            data={"abiCode": "", "groupId": "2084926082", "categoryIds": []},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for bank in response.json()["payload"]["subsidiaryListGeoloc"]:
+            bank.update(bank.pop("contacts"))
+            bank["street_address"] = bank.pop("address")
+            item = DictParser.parse(bank)
+            item["name"] = bank["bankName"]
+            item["city"] = bank["cityDescription"]
+            item["website"] = response.urljoin(bank["linkSubsidiaryCard"])
+            item["opening_hours"] = self.parse_hours(bank.get("timetables"))
+            item["brand"], item["brand_wikidata"] = self.BRANDS.get(bank.get("bankCode"), (bank.get("bankName"), None))
+
+            services = [service["title"] for service in bank.get("services")]
+            apply_yes_no(Extras.ATM, item, any(service.startswith("ATM ") for service in services))
+
+            apply_category(Categories.BANK, item)
+
+            yield item
+
+    def parse_hours(self, hours: dict) -> Optional[OpeningHours]:
+        try:
+            if hours:
+                oh = OpeningHours()
+                for day in DAYS_FULL:
+                    for range in [f"open{day}Morning", f"open{day}Afternoon"]:
+                        times = hours.get(range)
+                        if " " not in times:
+                            continue
+                        oh.add_range(
+                            day,
+                            times.split(" ")[0],
+                            times.split(" ")[1],
+                            time_format="%H.%M",
+                        )
+                return oh
+        except:
+            self.logger.error(f"Failed to parse opening hours: {hours}")
+        return None


### PR DESCRIPTION
```python
{'atp/brand/BPER Banca': 1322,
 'atp/brand/Banca Cesare Ponti': 110,
 'atp/brand/Banco di Sardegna': 275,
 'atp/brand_wikidata/Q3633696': 110,
 'atp/brand_wikidata/Q806167': 1322,
 'atp/brand_wikidata/Q806205': 275,
 'atp/category/amenity/bank': 1707,
 'atp/country/IT': 1707,
 'atp/field/branch/missing': 1707,
 'atp/field/country/from_spider_name': 1707,
 'atp/field/email/missing': 28,
 'atp/field/image/missing': 1707,
 'atp/field/opening_hours/missing': 150,
 'atp/field/operator/missing': 1707,
 'atp/field/operator_wikidata/missing': 1707,
 'atp/field/phone/missing': 119,
 'atp/field/state/missing': 1707,
 'atp/field/twitter/missing': 1707,
 'atp/item_scraped_host_count/www.bper.it': 1707,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 110,
 'atp/nsi/cc_match': 1597,
 'downloader/request_bytes': 433,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 208158,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 6.190035,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 14, 6, 25, 46, 522160, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5005568,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1707,
 'items_per_minute': None,
 'log_count/DEBUG': 1719,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 14, 6, 25, 40, 332125, tzinfo=datetime.timezone.utc)}
```