### PR TITLE
[Alior Bank PL] Add ATM availability info for spider

### DIFF
--- a/locations/spiders/alior_bank_pl.py
+++ b/locations/spiders/alior_bank_pl.py
@@ -1,8 +1,10 @@
 import json
+from typing import Any
 
 from scrapy import Spider
+from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
@@ -12,8 +14,12 @@ class AliorBankPLSpider(Spider):
     item_attributes = {"brand": "Alior Bank", "brand_wikidata": "Q9148395"}
     start_urls = ["https://www.aliorbank.pl/en/branches.html"]
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = json.loads(response.xpath("//script[@id='branch']/text()").get())
+        services = {
+            service.xpath("./@for").get().removeprefix("p[").strip("]"): service.xpath("./text()").get("").strip()
+            for service in response.xpath('//label[contains(@for, "p[")]')
+        }
         for city, branches in data.items():
             for branch in branches:
                 item = Feature()
@@ -26,10 +32,15 @@ class AliorBankPLSpider(Spider):
                 item["ref"] = branch["o"]
                 self.parse_opening_hours(item, branch["h"])
                 apply_category(Categories.BANK, item)
+
+                if branch_service_ids := branch.get("p"):
+                    branch_services = [services.get(service_id) for service_id in branch_service_ids]
+                    apply_yes_no(Extras.ATM, item, "ATM" in branch_services)
+
                 yield item
 
     # based on _renderOpenHours in JavaScript
-    def parse_opening_hours(self, item, openings):
+    def parse_opening_hours(self, item: Feature, openings: list) -> None:
         item["opening_hours"] = OpeningHours()
         if openings[-1]["d"] == "7":
             item["opening_hours"].add_ranges_from_string(f"Mo-Fr {openings[-1]['h']}")


### PR DESCRIPTION
```python
{'atp/brand/Alior Bank': 505,
 'atp/brand_wikidata/Q9148395': 505,
 'atp/category/amenity/bank': 505,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 3,
 'atp/country/PL': 505,
 'atp/duplicate_count': 3,
 'atp/field/branch/missing': 505,
 'atp/field/country/from_spider_name': 505,
 'atp/field/email/missing': 505,
 'atp/field/image/missing': 505,
 'atp/field/operator/missing': 505,
 'atp/field/operator_wikidata/missing': 505,
 'atp/field/phone/missing': 505,
 'atp/field/state/missing': 505,
 'atp/field/twitter/missing': 505,
 'atp/field/website/missing': 505,
 'atp/item_scraped_host_count/www.aliorbank.pl': 508,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 505,
 'downloader/request_bytes': 674,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 53933,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.88112,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 14, 8, 13, 24, 31532, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 282591,
 'httpcompression/response_count': 1,
 'item_dropped_count': 3,
 'item_dropped_reasons_count/DropItem': 3,
 'item_scraped_count': 505,
 'items_per_minute': None,
 'log_count/DEBUG': 521,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 14, 8, 13, 20, 150412, tzinfo=datetime.timezone.utc)}
```