### PR TITLE
[Palm Beach Tan US] Fix Spider

### DIFF
--- a/locations/spiders/palm_beach_tan_us.py
+++ b/locations/spiders/palm_beach_tan_us.py
@@ -4,14 +4,16 @@ from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class PalmBeachTanUSSpider(SitemapSpider):
     name = "palm_beach_tan_us"
     item_attributes = {"brand": "Palm Beach Tan", "brand_wikidata": "Q64027086"}
-    allowed_domains = ["palmbeachtan.com"]
+    # allowed_domains = ["palmbeachtan.com"]
     sitemap_urls = ["https://palmbeachtan.com/sitemap-locations.xml"]
-    sitemap_rules = [(r"palmbeachtan.com/locations/[A-Z]{2}/\w+", "parse")]
+    sitemap_rules = [(r"https://palmbeachtan.com/locations/[^/]+/[a-z0-9-]+", "parse")]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response):
         properties = {

--- a/locations/spiders/palm_beach_tan_us.py
+++ b/locations/spiders/palm_beach_tan_us.py
@@ -1,5 +1,7 @@
 import re
+from typing import Any
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_EN, OpeningHours
@@ -14,10 +16,10 @@ class PalmBeachTanUSSpider(SitemapSpider):
     sitemap_rules = [(r"https://palmbeachtan.com/locations/[^/]+/[a-z0-9-]+", "parse")]
     user_agent = BROWSER_DEFAULT
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         properties = {
             "ref": response.url,
-            "name": " ".join(response.xpath("//main/section[1]/div[1]/h1/text()[2]").get().split())
+            "branch": " ".join(response.xpath("//main/section[1]/div[1]/h1/text()[2]").get().split())
             .replace(" - NOW HIRING!", "")
             .replace(" - Now Hiring!", "")
             .replace(" - NOW OPEN!", "")

--- a/locations/spiders/palm_beach_tan_us.py
+++ b/locations/spiders/palm_beach_tan_us.py
@@ -10,10 +10,9 @@ from locations.user_agents import BROWSER_DEFAULT
 class PalmBeachTanUSSpider(SitemapSpider):
     name = "palm_beach_tan_us"
     item_attributes = {"brand": "Palm Beach Tan", "brand_wikidata": "Q64027086"}
-    # allowed_domains = ["palmbeachtan.com"]
     sitemap_urls = ["https://palmbeachtan.com/sitemap-locations.xml"]
     sitemap_rules = [(r"https://palmbeachtan.com/locations/[^/]+/[a-z0-9-]+", "parse")]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    user_agent = BROWSER_DEFAULT
 
     def parse(self, response):
         properties = {


### PR DESCRIPTION
**_Fixes : updated sitemap rules to fix spider_**

```python
{'atp/brand/Palm Beach Tan': 644,
 'atp/brand_wikidata/Q64027086': 644,
 'atp/category/shop/beauty': 644,
 'atp/clean_strings/addr_full': 1,
 'atp/country/US': 644,
 'atp/field/branch/missing': 644,
 'atp/field/city/missing': 644,
 'atp/field/country/from_spider_name': 644,
 'atp/field/email/missing': 644,
 'atp/field/image/missing': 644,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 644,
 'atp/field/operator_wikidata/missing': 644,
 'atp/field/postcode/missing': 644,
 'atp/field/state/from_reverse_geocoding': 644,
 'atp/field/street_address/missing': 644,
 'atp/field/twitter/missing': 644,
 'atp/item_scraped_host_count/palmbeachtan.com': 644,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 644,
 'downloader/request_bytes': 726098,
 'downloader/request_count': 646,
 'downloader/request_method_count/GET': 646,
 'downloader/response_bytes': 32751910,
 'downloader/response_count': 646,
 'downloader/response_status_count/200': 646,
 'elapsed_time_seconds': 787.577127,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 14, 10, 15, 21, 4203, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 156075505,
 'httpcompression/response_count': 646,
 'item_scraped_count': 644,
 'items_per_minute': None,
 'log_count/DEBUG': 1301,
 'log_count/INFO': 22,
 'request_depth_max': 1,
 'response_received_count': 646,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 645,
 'scheduler/dequeued/memory': 645,
 'scheduler/enqueued': 645,
 'scheduler/enqueued/memory': 645,
 'start_time': datetime.datetime(2025, 8, 14, 10, 2, 13, 427076, tzinfo=datetime.timezone.utc)}
```