### PR TITLE
[L'Occitane au Bresil] Add spider (230 locations)

### DIFF
--- a/locations/spiders/l_occitane_au_bresil_br.py
+++ b/locations/spiders/l_occitane_au_bresil_br.py
@@ -1,0 +1,29 @@
+from typing import Any, Iterable
+
+import scrapy
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.items import Feature
+
+
+class LOccitaneAuBresilBRSpider(Spider):
+    name = "l_occitane_au_bresil_br"
+    item_attributes = {"brand": "L'Occitane", "brand_wikidata": "Q1880676"}
+    url_template = "https://br.loccitaneaubresil.com/on/demandware.store/Sites-LoccitaneBR-Site/pt_BR/Stores-FindStores?showMap=true&radius=300&cityName={}"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def start_requests(self) -> Iterable[scrapy.Request]:
+        for city in city_locations("BR", 100_000):
+            yield scrapy.Request(self.url_template.format(city["name"]), callback=self.parse)
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for store in response.json()["stores"]:
+            item = DictParser.parse(store)
+            item["branch"] = item.pop("name")
+            item["addr_full"] = item.pop("street_address")
+            apply_category(Categories.SHOP_COSMETICS, item)
+            yield item


### PR DESCRIPTION
Add a new spider for [L’Occitane au Brésil](https://br.loccitaneaubresil.com/), a cosmetics chain from Brazil.

```
2025-08-14 17:53:04 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{"atp/brand/L'Occitane": 230,
 'atp/brand_wikidata/Q1880676': 230,
 'atp/category/shop/cosmetics': 230,
 'atp/cdn/cloudflare/response_count': 239,
 'atp/cdn/cloudflare/response_status_count/200': 239,
 'atp/clean_strings/name': 8,
 'atp/clean_strings/phone': 1,
 'atp/country/BR': 162,
 'atp/country/US': 68,
 'atp/duplicate_count': 9,
 'atp/field/branch/missing': 230,
 'atp/field/country/from_spider_name': 162,
 'atp/field/email/missing': 230,
 'atp/field/image/missing': 230,
 'atp/field/opening_hours/missing': 230,
 'atp/field/operator/missing': 230,
 'atp/field/operator_wikidata/missing': 230,
 'atp/field/phone/invalid': 76,
 'atp/field/phone/missing': 96,
 'atp/field/state/from_reverse_geocoding': 60,
 'atp/field/state/missing': 60,
 'atp/field/twitter/missing': 230,
 'atp/field/website/missing': 230,
 'atp/item_scraped_host_count/br.loccitaneaubresil.com': 239,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 230,
```