### PR TITLE
[Cisalfa Sport IT] Add spider (165 locations)

### DIFF
--- a/locations/spiders/cisalfa_sport_it.py
+++ b/locations/spiders/cisalfa_sport_it.py
@@ -1,0 +1,28 @@
+from typing import Iterable
+
+from scrapy.http import JsonRequest, Response
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class CisalfaSportITSpider(JSONBlobSpider):
+    name = "cisalfa_sport_it"
+    item_attributes = {"brand": "Cisalfa Sport", "brand_wikidata": "Q113535511"}
+    user_agent = BROWSER_DEFAULT
+    locations_key = "stores"
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://api.retailtune.com/storelocator/it/?rt_api_key=LgLwP3qejs1nUXFMt4rNSyZO5Iif0pXVw9wUmlcaWRe40uYfXqekTj7SytclsWxuHwBhHiHn7bwxttY9hMdFbv9uNu0jK44bJ1Bs",
+            headers={
+                "Accept": "application/json",
+                "Origin": "https://www.cisalfasport.it",
+                "Referer": "https://www.cisalfasport.it/",
+            },
+        )
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["state"] = item["state"]["name"]
+        yield item

--- a/locations/spiders/cisalfa_sport_it.py
+++ b/locations/spiders/cisalfa_sport_it.py
@@ -17,12 +17,16 @@ class CisalfaSportITSpider(JSONBlobSpider):
         yield JsonRequest(
             url="https://api.retailtune.com/storelocator/it/?rt_api_key=LgLwP3qejs1nUXFMt4rNSyZO5Iif0pXVw9wUmlcaWRe40uYfXqekTj7SytclsWxuHwBhHiHn7bwxttY9hMdFbv9uNu0jK44bJ1Bs",
             headers={
-                "Accept": "application/json",
                 "Origin": "https://www.cisalfasport.it",
                 "Referer": "https://www.cisalfasport.it/",
             },
         )
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if item["name"].startswith("Cisalfa Outlet "):
+            item["branch"] = item.pop("name").removeprefix("Cisalfa Outlet ")
+            item["name"] = "Cisalfa Outlet"
+        else:
+            item["branch"] = item.pop("name").removeprefix("Cisalfa Sport ")
         item["state"] = item["state"]["name"]
         yield item


### PR DESCRIPTION
Add [Cisalfa Sport](https://www.cisalfasport.it/), a sports store chain in IT.

```
2025-08-14 19:06:36 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Cisalfa Sport': 165,
 'atp/brand_wikidata/Q113535511': 165,
 'atp/category/shop/sports': 165,
 'atp/clean_strings/street_address': 1,
 'atp/country/IT': 165,
 'atp/field/branch/missing': 165,
 'atp/field/country/from_spider_name': 165,
 'atp/field/email/missing': 165,
 'atp/field/image/missing': 165,
 'atp/field/opening_hours/missing': 165,
 'atp/field/operator/missing': 165,
 'atp/field/operator_wikidata/missing': 165,
 'atp/field/phone/invalid': 3,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 165,
 'atp/item_scraped_host_count/api.retailtune.com': 165,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 165,
```