### PR TITLE
[Ace Hardware] Fix Spider

### DIFF
--- a/locations/spiders/ace_hardware.py
+++ b/locations/spiders/ace_hardware.py
@@ -1,9 +1,10 @@
 from locations.storefinders.kibo import KiboSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class AceHardwareSpider(KiboSpider):
     name = "ace_hardware"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
-    user_agent = None
+    user_agent = BROWSER_DEFAULT
     requires_proxy = True


### PR DESCRIPTION
**_Fixes : added user_agent to fix spider_**

```python
{'atp/brand/Ace Hardware': 4747,
 'atp/brand_wikidata/Q4672981': 4747,
 'atp/category/shop/doityourself': 4747,
 'atp/cdn/cloudflare/response_count': 6,
 'atp/cdn/cloudflare/response_status_count/200': 6,
 'atp/country/US': 4747,
 'atp/field/branch/missing': 4747,
 'atp/field/email/missing': 1160,
 'atp/field/image/missing': 4747,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 4747,
 'atp/field/operator_wikidata/missing': 4747,
 'atp/field/phone/missing': 11,
 'atp/field/twitter/missing': 4747,
 'atp/field/website/missing': 4747,
 'atp/item_scraped_host_count/www.acehardware.com': 4747,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4747,
 'downloader/request_bytes': 12778,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 1137386,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'dupefilter/filtered': 3996,
 'elapsed_time_seconds': 89.185522,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 18, 12, 4, 17, 57477, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 21131054,
 'httpcompression/response_count': 6,
 'item_scraped_count': 4747,
 'items_per_minute': None,
 'log_count/DEBUG': 4771,
 'log_count/INFO': 10,
 'request_depth_max': 4,
 'response_received_count': 6,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2025, 8, 18, 12, 2, 47, 871955, tzinfo=datetime.timezone.utc)}
```