### PR TITLE
[Ingo SE] Fix Spider

### DIFF
--- a/locations/spiders/ingo_se.py
+++ b/locations/spiders/ingo_se.py
@@ -8,7 +8,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class IngoSESpider(SitemapSpider, StructuredDataSpider):
     name = "ingo_se"
     item_attributes = {"brand": "Ingo", "brand_wikidata": "Q17048617"}
-    sitemap_urls = ["https://www.ingo.se/stations/sitemap.xml"]
+    sitemap_urls = ["https://www.ingo.se/sitemaps/stations/sitemap.xml"]
     wanted_types = ["GasStation"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):


### PR DESCRIPTION
**_Fixes : updated sitemap_urls to fix spider_**

```python
{'atp/brand/Ingo': 300,
 'atp/brand_wikidata/Q17048617': 300,
 'atp/category/amenity/fuel': 300,
 'atp/country/SE': 300,
 'atp/field/branch/missing': 300,
 'atp/field/email/missing': 300,
 'atp/field/image/missing': 300,
 'atp/field/opening_hours/missing': 300,
 'atp/field/operator/missing': 300,
 'atp/field/operator_wikidata/missing': 300,
 'atp/field/state/missing': 300,
 'atp/field/twitter/missing': 300,
 'atp/item_scraped_host_count/www.ingo.se': 300,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 300,
 'downloader/request_bytes': 122122,
 'downloader/request_count': 302,
 'downloader/request_method_count/GET': 302,
 'downloader/response_bytes': 2750325,
 'downloader/response_count': 302,
 'downloader/response_status_count/200': 302,
 'elapsed_time_seconds': 374.524152,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 19, 10, 19, 8, 477328, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11384613,
 'httpcompression/response_count': 302,
 'item_scraped_count': 300,
 'items_per_minute': None,
 'log_count/DEBUG': 613,
 'log_count/INFO': 15,
 'log_count/WARNING': 300,
 'request_depth_max': 1,
 'response_received_count': 302,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 301,
 'scheduler/dequeued/memory': 301,
 'scheduler/enqueued': 301,
 'scheduler/enqueued/memory': 301,
 'start_time': datetime.datetime(2025, 8, 19, 10, 12, 53, 953176, tzinfo=datetime.timezone.utc)}
```