### PR TITLE
[Oakley] New spider (189 locations)

### DIFF
--- a/locations/spiders/oakley.py
+++ b/locations/spiders/oakley.py
@@ -1,0 +1,44 @@
+import json
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class OakleySpider(SitemapSpider, StructuredDataSpider):
+    name = "oakley"
+    item_attributes = {
+        "brand": "Oakley",
+        "brand_wikidata": "Q161906",
+    }
+    sitemap_urls = ["https://stores.oakley.com/sitemap1.xml"]
+    sitemap_rules = [
+        (r"https://stores.oakley.com/[a-z]{2}/[\w.-]+/[\w.-]+/[\w.-]+", "parse"),
+    ]
+    search_for_email = False
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_OPTICIAN, item)
+
+        script = response.xpath("//script[starts-with(text(), 'window.__INITIAL__DATA__ = ')]/text()").get()
+        initial_data = json.loads(script[len("window.__INITIAL__DATA__ = ") :])
+        document = initial_data["document"]
+
+        item["branch"] = document.get("address", {}).get("extraDescription")
+        item["image"] = document.get("c_locationPhoto", {}).get("image", {}).get("url")
+        item["ref"] = document.get("id", response.url)
+        item["lat"] = document.get("yextDisplayCoordinate", {}).get("latitude")
+        item["lon"] = document.get("yextDisplayCoordinate", {}).get("longitude")
+
+        yield item
+
+    def extract_payment_accepted(self, item, response, ld_item):
+        if "paymentAccepted" not in ld_item:
+            return
+        if "TRAVELERSCHECK" in ld_item["paymentAccepted"]:
+            ld_item["paymentAccepted"].remove("TRAVELERSCHECK")
+            apply_yes_no("payment:travellers_cheque", item, True)
+        super().extract_payment_accepted(item, response, ld_item)


### PR DESCRIPTION
```py
{'atp/brand/Oakley': 189,
 'atp/brand_wikidata/Q161906': 189,
 'atp/category/shop/optician': 189,
 'atp/cdn/cloudflare/response_count': 191,
 'atp/cdn/cloudflare/response_status_count/200': 191,
 'atp/country/CA': 9,
 'atp/country/GB': 4,
 'atp/country/IT': 1,
 'atp/country/NL': 2,
 'atp/country/PR': 2,
 'atp/country/US': 171,
 'atp/field/branch/missing': 7,
 'atp/field/email/missing': 189,
 'atp/field/image/missing': 7,
 'atp/field/operator/missing': 189,
 'atp/field/operator_wikidata/missing': 189,
 'atp/field/twitter/missing': 189,
 'atp/item_scraped_host_count/stores.oakley.com': 189,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_failed': 189,
 'downloader/request_bytes': 114123,
 'downloader/request_count': 191,
 'downloader/request_method_count/GET': 191,
 'downloader/response_bytes': 3600269,
 'downloader/response_count': 191,
 'downloader/response_status_count/200': 191,
 'elapsed_time_seconds': 230.511162,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 19, 23, 29, 57, 606859, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17889674,
 'httpcompression/response_count': 191,
 'item_scraped_count': 189,
 'items_per_minute': None,
 'log_count/DEBUG': 391,
 'log_count/INFO': 13,
 'memusage/max': 445403136,
 'memusage/startup': 273678336,
 'request_depth_max': 1,
 'response_received_count': 191,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 190,
 'scheduler/dequeued/memory': 190,
 'scheduler/enqueued': 190,
 'scheduler/enqueued/memory': 190,
 'start_time': datetime.datetime(2025, 8, 19, 23, 26, 7, 95697, tzinfo=datetime.timezone.utc)}
```