### PR TITLE
Rename lululemon spider to lululemon_ca_us

### DIFF
--- a/locations/spiders/lululemon_ca_us.py
+++ b/locations/spiders/lululemon_ca_us.py
@@ -6,8 +6,8 @@ from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
-class LululemonSpider(SitemapSpider):
-    name = "lululemon"
+class LululemonCAUSSpider(SitemapSpider):
+    name = "lululemon_ca_us"
     item_attributes = {"brand": "Lululemon", "brand_wikidata": "Q6702957"}
     sitemap_urls = ("https://shop.lululemon.com/sitemap.xml",)
     sitemap_rules = [


### PR DESCRIPTION
because the spider only covers those countries, and to better communicate the spider's coverage. Related to, but does not fix, #12690. Seemingly the websites for every country other than CA and US each have a Demandware storefinder that has global coverage, but is protected by Cloudflare.