### PR TITLE
[Nissan] Update spider to add Nissan's sub brand Infiniti locations

### DIFF
--- a/locations/spiders/nissan.py
+++ b/locations/spiders/nissan.py
@@ -1,9 +1,11 @@
 import locale
 import re
+from typing import Any, Iterable
 
 import scrapy
+from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.country_utils import CountryUtils
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
@@ -12,32 +14,38 @@ from locations.hours import DAYS, OpeningHours
 # Although API url appears to be covering EU only, but actually scrapes multiple non EU countries as well.
 class NissanSpider(scrapy.Spider):
     name = "nissan"
-    item_attributes = {"brand": "Nissan", "brand_wikidata": "Q20165", "extras": Categories.SHOP_CAR.value}
+    BRANDS = {
+        "nissan": {"brand": "Nissan", "brand_wikidata": "Q20165"},
+        "infiniti": {"brand": "Infiniti", "brand_wikidata": "Q29714"},
+    }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._countries = CountryUtils().gc.get_countries_by_names()
 
-    def start_requests(self):
-        for loc in locale.locale_alias.keys():
-            if not re.fullmatch("[a-z]{2}_[a-z]{2}", loc):
-                continue
-            loc = loc[:3] + loc[3:].upper()
-            yield scrapy.Request(
-                url=f"https://eu.nissan-api.net/v2/publicAccessToken?locale={loc}&scope=READ&proxy=*&brand=nissan&environment=prod",
-                headers={"origin": "https://www.nissan-global.com"},
-                callback=self.parse_token,
-            )
+    def start_requests(self) -> Iterable[JsonRequest]:
+        for brand in self.BRANDS:
+            for loc in locale.locale_alias.keys():
+                if not re.fullmatch("[a-z]{2}_[a-z]{2}", loc):
+                    continue
+                loc = loc[:3] + loc[3:].upper()
+                yield JsonRequest(
+                    url=f"https://eu.nissan-api.net/v2/publicAccessToken?locale={loc}&scope=READ&proxy=*&brand={brand}&environment=prod",
+                    headers={"origin": "https://www.nissan-global.com"},
+                    callback=self.parse_token,
+                    cb_kwargs={"brand": brand},
+                )
 
-    def parse_token(self, response, **kwargs):
+    def parse_token(self, response: Response, brand: str) -> Any:
         token = response.json()["access_token"]
-        yield scrapy.Request(
+        yield JsonRequest(
             url="https://eu.nissan-api.net/v2/dealers?size=-1&include=openingHours",
             headers={"accesstoken": f"Bearer {token}"},
             callback=self.parse_dealers,
+            cb_kwargs={"brand": brand},
             dont_filter=True,
         )
 
-    def parse_dealers(self, response, **kwargs):
+    def parse_dealers(self, response: Response, brand: str) -> Any:
         for dealer in response.json()["dealers"]:
             dealer["id"] = dealer.pop("dealerId")
             item = DictParser.parse(dealer)
@@ -46,6 +54,7 @@ class NissanSpider(scrapy.Spider):
             for w in dealer["contact"].get("websites", []):
                 item["website"] = w.get("url")
                 break
+
             oh = OpeningHours()
             for day in dealer.get("openingHours", {}).get("regularOpeningHours", []):
                 for interval in day.get("openIntervals", []):
@@ -57,6 +66,9 @@ class NissanSpider(scrapy.Spider):
                         time_format="%H:%M",
                     )
             item["opening_hours"] = oh
+
+            item.update(self.BRANDS[brand])
+            apply_category(Categories.SHOP_CAR, item)
             yield item
 
     @staticmethod


### PR DESCRIPTION
```python
{'atp/brand/Infiniti': 409,
 'atp/brand/Nissan': 7069,
 'atp/brand_wikidata/Q20165': 7069,
 'atp/brand_wikidata/Q29714': 409,
 'atp/category/shop/car': 7478,
 'atp/clean_strings/city': 41,
 'atp/clean_strings/name': 54,
 'atp/clean_strings/phone': 40,
 'atp/clean_strings/postcode': 12,
 'atp/clean_strings/ref': 2,
 'atp/clean_strings/state': 42,
 'atp/clean_strings/street_address': 182,
 'atp/clean_strings/website': 6,
 'atp/country/AD': 2,
 'atp/country/AR': 87,
 'atp/country/AS': 2,
 'atp/country/AT': 101,
 'atp/country/AU': 177,
 'atp/country/AX': 1,
 'atp/country/BE': 53,
 'atp/country/BG': 12,
 'atp/country/BH': 6,
 'atp/country/BR': 206,
 'atp/country/BW': 3,
 'atp/country/CA': 245,
 'atp/country/CH': 61,
 'atp/country/CL': 52,
 'atp/country/CN': 96,
 'atp/country/CO': 47,
 'atp/country/CR': 10,
 'atp/country/DE': 481,
 'atp/country/DK': 47,
 'atp/country/DO': 7,
 'atp/country/EC': 32,
 'atp/country/EE': 6,
 'atp/country/EG': 44,
 'atp/country/ES': 176,
 'atp/country/FI': 48,
 'atp/country/FO': 1,
 'atp/country/FR': 265,
 'atp/country/GB': 188,
 'atp/country/GE': 46,
 'atp/country/GG': 1,
 'atp/country/GR': 54,
 'atp/country/HR': 16,
 'atp/country/IE': 34,
 'atp/country/IL': 52,
 'atp/country/IM': 1,
 'atp/country/IN': 216,
 'atp/country/IQ': 5,
 'atp/country/IS': 12,
 'atp/country/IT': 220,
 'atp/country/JE': 1,
 'atp/country/JO': 3,
 'atp/country/JP': 2027,
 'atp/country/KW': 18,
 'atp/country/KZ': 1,
 'atp/country/LB': 3,
 'atp/country/LS': 1,
 'atp/country/LU': 3,
 'atp/country/LV': 4,
 'atp/country/ME': 1,
 'atp/country/MX': 251,
 'atp/country/NA': 6,
 'atp/country/NL': 74,
 'atp/country/NO': 51,
 'atp/country/NU': 1,
 'atp/country/NZ': 35,
 'atp/country/OM': 4,
 'atp/country/PA': 1,
 'atp/country/PE': 35,
 'atp/country/PH': 46,
 'atp/country/PK': 2,
 'atp/country/PL': 45,
 'atp/country/PR': 2,
 'atp/country/PS': 3,
 'atp/country/PY': 6,
 'atp/country/QA': 22,
 'atp/country/RO': 14,
 'atp/country/RS': 6,
 'atp/country/SA': 58,
 'atp/country/SE': 63,
 'atp/country/SI': 13,
 'atp/country/SZ': 1,
 'atp/country/TH': 130,
 'atp/country/TR': 42,
 'atp/country/TW': 13,
 'atp/country/UA': 35,
 'atp/country/US': 1210,
 'atp/country/UY': 33,
 'atp/country/VA': 1,
 'atp/country/ZA': 100,
 'atp/duplicate_count': 1759,
 'atp/field/branch/missing': 7478,
 'atp/field/city/missing': 2063,
 'atp/field/country/from_reverse_geocoding': 3230,
 'atp/field/country/from_website_url': 4042,
 'atp/field/email/missing': 7478,
 'atp/field/image/missing': 7478,
 'atp/field/opening_hours/missing': 5360,
 'atp/field/operator/missing': 7478,
 'atp/field/operator_wikidata/missing': 7478,
 'atp/field/phone/invalid': 209,
 'atp/field/phone/missing': 84,
 'atp/field/postcode/missing': 346,
 'atp/field/state/from_reverse_geocoding': 249,
 'atp/field/state/missing': 1427,
 'atp/field/street_address/missing': 51,
 'atp/field/twitter/missing': 7478,
 'atp/field/website/invalid': 10,
 'atp/field/website/missing': 1777,
 'atp/item_scraped_host_count/eu.nissan-api.net': 9237,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 7478,
 'downloader/request_bytes': 375661,
 'downloader/request_count': 767,
 'downloader/request_method_count/GET': 767,
 'downloader/response_bytes': 1668397,
 'downloader/response_count': 767,
 'downloader/response_status_count/200': 292,
 'downloader/response_status_count/400': 354,
 'downloader/response_status_count/404': 1,
 'downloader/response_status_count/500': 120,
 'elapsed_time_seconds': 936.119439,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 21, 10, 18, 15, 401033, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 19128452,
 'httpcompression/response_count': 126,
 'httperror/response_ignored_count': 394,
 'httperror/response_ignored_status_count/400': 354,
 'httperror/response_ignored_status_count/500': 40,
 'item_dropped_count': 1759,
 'item_dropped_reasons_count/DropItem': 1759,
 'item_scraped_count': 7478,
 'items_per_minute': None,
 'log_count/DEBUG': 10016,
 'log_count/ERROR': 40,
 'log_count/INFO': 419,
 'log_count/WARNING': 10,
 'request_depth_max': 1,
 'response_received_count': 687,
 'responses_per_minute': None,
 'retry/count': 80,
 'retry/max_reached': 40,
 'retry/reason_count/500 Internal Server Error': 80,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 766,
 'scheduler/dequeued/memory': 766,
 'scheduler/enqueued': 766,
 'scheduler/enqueued/memory': 766,
 'start_time': datetime.datetime(2025, 8, 21, 10, 2, 39, 281594, tzinfo=datetime.timezone.utc)}
```