### PR TITLE
[Societe Generale] Add protection against timeout error for spider

### DIFF
--- a/locations/spiders/societe_generale.py
+++ b/locations/spiders/societe_generale.py
@@ -17,6 +17,7 @@ class SocieteGeneraleSpider(SitemapSpider, StructuredDataSpider):
         "distributeur-automate/sitemap_pois",
     ]
     sitemap_rules = [(r"/.+-id(\d+)$", "parse_sd")]
+    download_timeout = 300
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         ld_data.pop("@id", None)


### PR DESCRIPTION
Some times it fails because of `timeout`, specially running from outside `US`.