### PR TITLE
[Dominos Pizza FR] Fix spider

### DIFF
--- a/locations/spiders/dominos_pizza_fr.py
+++ b/locations/spiders/dominos_pizza_fr.py
@@ -1,33 +1,20 @@
-from typing import Any
+from typing import Iterable
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.http import JsonRequest
 
-from locations.categories import Categories, apply_category
-from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
+from locations.geo import city_locations
+from locations.spiders.dominos_pizza_au import DominosPizzaAUSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class DominosPizzaFRSpider(SitemapSpider):
+class DominosPizzaFRSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_fr"
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     allowed_domains = ["dominos.fr"]
     user_agent = BROWSER_DEFAULT
-    sitemap_urls = ["https://www.dominos.fr/sitemap.aspx"]
-    sitemap_rules = [(r"https:\/\/www\.dominos\.fr\/magasin\/\/?([-\w.]+)_(unknown|[\d]+)$", "parse")]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        properties = {
-            "ref": response.url,
-            "branch": response.xpath('//h1[@class="storetitle"]/text()').get().removeprefix("Domino's Pizza "),
-            "addr_full": clean_address(response.xpath('//a[@id="open-map-address"]/text()').get()),
-            "lat": response.xpath('//input[@id="store-lat"]/@value').get().replace(",", "."),
-            "lon": response.xpath('//input[@id="store-lon"]/@value').get().replace(",", "."),
-            "phone": response.xpath('//div[@class="store-phone"]/a/text()').get(),
-            "website": response.url,
-        }
-
-        apply_category(Categories.FAST_FOOD, properties)
-
-        yield Feature(**properties)
+    def start_requests(self) -> Iterable[JsonRequest]:
+        for city in city_locations("FR", 15000):
+            yield JsonRequest(
+                url=f"https://www.dominos.fr/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}",
+            )

--- a/locations/spiders/dominos_pizza_jp.py
+++ b/locations/spiders/dominos_pizza_jp.py
@@ -1,38 +1,22 @@
-from typing import Any
-from urllib.parse import urljoin
+from typing import Iterable
 
-from scrapy.http import JsonRequest, Response
-from scrapy.spiders import SitemapSpider
+from scrapy.http import JsonRequest
 
-from locations.dict_parser import DictParser
 from locations.geo import city_locations
+from locations.spiders.dominos_pizza_au import DominosPizzaAUSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class DominosPizzaJPSpider(SitemapSpider):
+class DominosPizzaJPSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_jp"
     item_attributes = {
         "brand_wikidata": "Q839466",
         "country": "JP",
     }
-
     user_agent = BROWSER_DEFAULT
 
-    def start_requests(self):
+    def start_requests(self) -> Iterable[JsonRequest]:
         for city in city_locations("JP", 10000):
             yield JsonRequest(
                 url=f"https://www.dominos.jp/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}"
             )
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json()["PickupSearchStore"]:
-            store.update(store["locations"].pop(0))
-            store.update(store["address"].pop("geoLocation"))
-            item = DictParser.parse(store)
-            item["website"] = urljoin("https://www.dominos.jp", store["properties"]["storeUrl"])
-            for location_details in store["address"]["attributes"]:
-                if location_details["key"] == "streetName":
-                    item["street_address"] = location_details["value"]
-                if location_details["key"] == "postcode":
-                    item["postcode"] = location_details["value"]
-            yield item

--- a/locations/spiders/dominos_pizza_jp.py
+++ b/locations/spiders/dominos_pizza_jp.py
@@ -4,16 +4,11 @@ from scrapy.http import JsonRequest
 
 from locations.geo import city_locations
 from locations.spiders.dominos_pizza_au import DominosPizzaAUSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class DominosPizzaJPSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_jp"
-    item_attributes = {
-        "brand_wikidata": "Q839466",
-        "country": "JP",
-    }
-    user_agent = BROWSER_DEFAULT
+    item_attributes = {"brand_wikidata": "Q839466"}
 
     def start_requests(self) -> Iterable[JsonRequest]:
         for city in city_locations("JP", 10000):

--- a/locations/spiders/dominos_pizza_nl.py
+++ b/locations/spiders/dominos_pizza_nl.py
@@ -4,13 +4,11 @@ from scrapy.http import JsonRequest
 
 from locations.geo import city_locations
 from locations.spiders.dominos_pizza_au import DominosPizzaAUSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class DominosPizzaNLSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_nl"
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def start_requests(self) -> Iterable[JsonRequest]:
         for city in city_locations("NL", 15000):

--- a/locations/spiders/dominos_pizza_nl.py
+++ b/locations/spiders/dominos_pizza_nl.py
@@ -1,34 +1,19 @@
-from urllib.parse import urljoin
+from typing import Iterable
 
-import scrapy
 from scrapy.http import JsonRequest
 
-from locations.dict_parser import DictParser
 from locations.geo import city_locations
+from locations.spiders.dominos_pizza_au import DominosPizzaAUSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class DominosPizzaNLSpider(scrapy.Spider):
+class DominosPizzaNLSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_nl"
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def start_requests(self):
-        for city in city_locations("NL", 18000):
+    def start_requests(self) -> Iterable[JsonRequest]:
+        for city in city_locations("NL", 15000):
             yield JsonRequest(
                 url=f"https://www.dominos.nl/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}",
             )
-
-    def parse(self, response, **kwargs):
-        for store in response.json()["PickupSearchStore"]:
-            store.update(store["locations"].pop(0))
-            store.update(store.pop("address"))
-            item = DictParser.parse(store)
-            item["branch"] = item.pop("name")
-            item["website"] = urljoin("https://www.dominos.nl", store["properties"]["storeUrl"])
-            for details in store["attributes"]:
-                if details["key"] == "streetName":
-                    item["street_address"] = details["value"]
-                elif details["key"] == "postCode":
-                    item["postcode"] = details["value"]
-            yield item


### PR DESCRIPTION
Final POI [page](https://www.dominos.fr/magasin//paris-17-batignolles_75017) redirects to [404](https://www.dominos.fr/404) page, hence code refactored to use `API`. Some code clean up done for few `Dominos`  spiders using similar `API`.

```python
{"atp/brand/Domino's": 423,
 'atp/brand_wikidata/Q839466': 423,
 'atp/category/amenity/fast_food': 423,
 'atp/country/FR': 423,
 'atp/duplicate_count': 4183,
 'atp/field/email/missing': 423,
 'atp/field/image/missing': 423,
 'atp/field/opening_hours/missing': 423,
 'atp/field/operator/missing': 423,
 'atp/field/operator_wikidata/missing': 423,
 'atp/field/phone/missing': 423,
 'atp/field/twitter/missing': 423,
 'atp/item_scraped_host_count/www.dominos.fr': 4606,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 423,
 'downloader/request_bytes': 444792,
 'downloader/request_count': 650,
 'downloader/request_method_count/GET': 650,
 'downloader/response_bytes': 1490132,
 'downloader/response_count': 650,
 'downloader/response_status_count/200': 650,
 'elapsed_time_seconds': 9.481041,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 22, 14, 28, 32, 343909, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 650,
 'httpcompression/response_bytes': 2180778,
 'httpcompression/response_count': 650,
 'item_dropped_count': 4183,
 'item_dropped_reasons_count/DropItem': 4183,
 'item_scraped_count': 423,
 'items_per_minute': None,
 'log_count/DEBUG': 5269,
 'log_count/INFO': 9,
 'response_received_count': 650,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 649,
 'scheduler/dequeued/memory': 649,
 'scheduler/enqueued': 649,
 'scheduler/enqueued/memory': 649,
 'start_time': datetime.datetime(2025, 8, 22, 14, 28, 22, 862868, tzinfo=datetime.timezone.utc)}
```