### PR TITLE
[KFC DE] Fix spider

### DIFF
--- a/locations/spiders/kfc_de.py
+++ b/locations/spiders/kfc_de.py
@@ -1,8 +1,13 @@
+from typing import Any
+
+import chompjs
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.user_agents import FIREFOX_LATEST
 
@@ -19,11 +24,12 @@ class KfcDESpider(Spider):
     name = "kfc_de"
     item_attributes = KFC_SHARED_ATTRIBUTES
     start_urls = ["https://api.kfc.de/find-a-kfc/allrestaurant"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
     user_agent = FIREFOX_LATEST
+    is_playwright_spider = True
+    custom_settings = {"ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
 
-    def parse(self, response, **kwargs):
-        for location in response.json():
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in chompjs.parse_js_object(response.text):
             if location["name"].endswith(" - COMING SOON"):
                 continue
             location["street_address"] = location.pop("address")


### PR DESCRIPTION
Used `playwright` to access the unreachable response.

```python
{'atp/brand/KFC': 215,
 'atp/brand_wikidata/Q524757': 215,
 'atp/category/amenity/fast_food': 215,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/street_address': 6,
 'atp/country/DE': 215,
 'atp/field/branch/missing': 215,
 'atp/field/country/from_spider_name': 215,
 'atp/field/email/missing': 215,
 'atp/field/image/missing': 215,
 'atp/field/opening_hours/invalid': 2,
 'atp/field/operator/missing': 215,
 'atp/field/operator_wikidata/missing': 215,
 'atp/field/phone/missing': 215,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 215,
 'atp/field/twitter/missing': 215,
 'atp/item_scraped_host_count/api.kfc.de': 215,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 215,
 'downloader/request_bytes': 274,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 612907,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 11.401602,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 25, 8, 29, 24, 452681, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 215,
 'items_per_minute': None,
 'log_count/DEBUG': 236,
 'log_count/INFO': 14,
 'log_count/WARNING': 377,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 25, 8, 29, 13, 51079, tzinfo=datetime.timezone.utc)}
```