### PR TITLE
[KFC FR] Fix spider

### DIFF
--- a/locations/spiders/kfc_fr.py
+++ b/locations/spiders/kfc_fr.py
@@ -1,9 +1,11 @@
+import chompjs
 from scrapy.spiders import Spider
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import set_closed
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.user_agents import FIREFOX_LATEST
 
@@ -12,11 +14,12 @@ class KfcFRSpider(Spider):
     name = "kfc_fr"
     item_attributes = KFC_SHARED_ATTRIBUTES
     start_urls = ["https://api.kfc.fr/stores/allStores"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
     user_agent = FIREFOX_LATEST
+    is_playwright_spider = True
+    custom_settings = {"ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response, **kwargs):
-        for location in response.json():
+        for location in chompjs.parse_js_object(response.text):
             item = DictParser.parse(location)
             item["branch"] = item.pop("name").removeprefix("KFC ")
             item["website"] = "https://www.kfc.fr/nos-restaurants/{}".format(location["url"])


### PR DESCRIPTION
```python
{'atp/brand/KFC': 401,
 'atp/brand_wikidata/Q524757': 401,
 'atp/category/amenity/fast_food': 401,
 'atp/clean_strings/city': 1,
 'atp/country/FR': 401,
 'atp/field/country/from_spider_name': 401,
 'atp/field/email/missing': 401,
 'atp/field/image/missing': 401,
 'atp/field/operator/missing': 401,
 'atp/field/operator_wikidata/missing': 401,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 8,
 'atp/field/state/missing': 401,
 'atp/field/street_address/missing': 401,
 'atp/field/twitter/missing': 401,
 'atp/item_scraped_host_count/api.kfc.fr': 401,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 401,
 'downloader/request_bytes': 266,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 602400,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 11.487104,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 25, 9, 0, 42, 905259, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 401,
 'items_per_minute': None,
 'log_count/DEBUG': 422,
 'log_count/INFO': 14,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 25, 9, 0, 31, 418155, tzinfo=datetime.timezone.utc)}
```