### PR TITLE
[Gucci] Fix spider

### DIFF
--- a/locations/spiders/gucci.py
+++ b/locations/spiders/gucci.py
@@ -1,17 +1,20 @@
 from typing import Any
 
+import chompjs
 from scrapy import Request, Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import FIREFOX_LATEST
 
 
 class GucciSpider(Spider):
     name = "gucci"
     item_attributes = {"brand": "Gucci", "brand_wikidata": "Q178516"}
-    custom_settings = {"ROBOTSTXT_OBEY": False}
     user_agent = FIREFOX_LATEST
+    is_playwright_spider = True
+    custom_settings = {"ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def start_requests(self):
         yield Request(
@@ -20,7 +23,7 @@ class GucciSpider(Spider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["features"]:
+        for location in chompjs.parse_js_object(response.text)["features"]:
             if location["properties"]["active"] is not True:
                 continue
             item = DictParser.parse(location["properties"])


### PR DESCRIPTION
```python
{'atp/brand/Gucci': 636,
 'atp/brand_wikidata/Q178516': 636,
 'atp/category/shop/clothes': 636,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/country': 3,
 'atp/clean_strings/name': 8,
 'atp/clean_strings/phone': 10,
 'atp/clean_strings/street_address': 21,
 'atp/clean_strings/website': 2,
 'atp/country/AE': 11,
 'atp/country/AT': 2,
 'atp/country/AU': 11,
 'atp/country/AW': 1,
 'atp/country/AZ': 2,
 'atp/country/BE': 1,
 'atp/country/BH': 1,
 'atp/country/BR': 10,
 'atp/country/BS': 2,
 'atp/country/CA': 12,
 'atp/country/CH': 5,
 'atp/country/CL': 1,
 'atp/country/CN': 88,
 'atp/country/CZ': 1,
 'atp/country/DE': 12,
 'atp/country/DK': 2,
 'atp/country/ES': 8,
 'atp/country/FR': 28,
 'atp/country/GB': 23,
 'atp/country/GR': 4,
 'atp/country/GU': 2,
 'atp/country/HK': 9,
 'atp/country/HU': 1,
 'atp/country/ID': 3,
 'atp/country/IE': 2,
 'atp/country/IL': 1,
 'atp/country/IN': 4,
 'atp/country/IT': 32,
 'atp/country/JP': 85,
 'atp/country/KR': 56,
 'atp/country/KW': 4,
 'atp/country/KZ': 1,
 'atp/country/LB': 1,
 'atp/country/LU': 1,
 'atp/country/MA': 1,
 'atp/country/MC': 2,
 'atp/country/MO': 7,
 'atp/country/MX': 14,
 'atp/country/MY': 5,
 'atp/country/NL': 6,
 'atp/country/NO': 1,
 'atp/country/NZ': 2,
 'atp/country/PA': 1,
 'atp/country/PH': 4,
 'atp/country/PL': 1,
 'atp/country/PR': 1,
 'atp/country/PT': 1,
 'atp/country/QA': 6,
 'atp/country/SA': 4,
 'atp/country/SE': 1,
 'atp/country/SG': 6,
 'atp/country/TH': 9,
 'atp/country/TR': 7,
 'atp/country/TW': 15,
 'atp/country/UA': 1,
 'atp/country/US': 109,
 'atp/country/VN': 2,
 'atp/country/ZA': 3,
 'atp/duplicate_count': 10,
 'atp/field/branch/missing': 636,
 'atp/field/email/missing': 636,
 'atp/field/image/missing': 636,
 'atp/field/opening_hours/missing': 636,
 'atp/field/operator/missing': 636,
 'atp/field/operator_wikidata/missing': 636,
 'atp/field/phone/invalid': 26,
 'atp/field/phone/missing': 22,
 'atp/field/postcode/missing': 636,
 'atp/field/state/from_reverse_geocoding': 121,
 'atp/field/state/missing': 517,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 636,
 'atp/field/website/invalid': 3,
 'atp/item_scraped_host_count/www.gucci.com': 646,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 636,
 'downloader/request_bytes': 414,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 2231153,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 17.440292,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 25, 10, 20, 57, 652176, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 10,
 'item_dropped_reasons_count/DropItem': 10,
 'item_scraped_count': 636,
 'items_per_minute': None,
 'log_count/DEBUG': 667,
 'log_count/INFO': 14,
 'log_count/WARNING': 3,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 25, 10, 20, 40, 211884, tzinfo=datetime.timezone.utc),
 'z/type/flagship': 45,
 'z/type/store': 601}
```