### PR TITLE
[Swarovski US][Swarovski EU] Fix spiders

### DIFF
--- a/locations/spiders/swarovski_eu.py
+++ b/locations/spiders/swarovski_eu.py
@@ -14,5 +14,4 @@ class SwarovskiEUSpider(SwarovskiUSSpider):
         for lat, lon in point_locations(point_files):
             yield Request(
                 url=f"https://www.swarovski.com/en-LU/store-finder/stores/?geoPoint.latitude={lat}&geoPoint.longitude={lon}&provider=GOOGLE&allBaseStores=true&radius=120&clientTimeZoneOffset=-60",
-                headers=self.headers,
             )

--- a/locations/spiders/swarovski_eu.py
+++ b/locations/spiders/swarovski_eu.py
@@ -1,46 +1,18 @@
-import re
-
-import scrapy
+from scrapy import Request
 
 from locations.geo import point_locations
-from locations.linked_data_parser import LinkedDataParser
-from locations.user_agents import FIREFOX_LATEST
+from locations.spiders.swarovski_us import SwarovskiUSSpider
 
 
-class SwarovskiEUSpider(scrapy.Spider):
+class SwarovskiEUSpider(SwarovskiUSSpider):
     name = "swarovski_eu"
     item_attributes = {"brand": "Swarovski", "brand_wikidata": "Q611115"}
     allowed_domains = ["swarovski.com"]
-    headers = {"User-Agent": FIREFOX_LATEST}
 
     def start_requests(self):
         point_files = "eu_centroids_120km_radius_country.csv"
         for lat, lon in point_locations(point_files):
-            url = f"https://www.swarovski.com/en-LU/store-finder/stores/?geoPoint.latitude={lat}&geoPoint.longitude={lon}&provider=GOOGLE&allBaseStores=true&radius=120&clientTimeZoneOffset=-60"
-            yield scrapy.Request(url=url, headers=self.headers)
-
-    def parse(self, response):
-        if response.xpath('//div[contains(text(), "stores")]/text()').get():
-            stores = response.xpath(
-                '//div[@id="swa-store-locator__tab-list"]/div[contains(@class,"swa-store-view__store")]'
+            yield Request(
+                url=f"https://www.swarovski.com/en-LU/store-finder/stores/?geoPoint.latitude={lat}&geoPoint.longitude={lon}&provider=GOOGLE&allBaseStores=true&radius=120&clientTimeZoneOffset=-60",
+                headers=self.headers,
             )
-            for store in stores:
-                coords = {"lat": store.xpath("./@data-latitude").get(), "lon": store.xpath("./@data-longitude").get()}
-                url = store.xpath('.//a[contains(@href, "store")]/@href').get()
-                yield scrapy.Request(
-                    url=f"https://www.{self.allowed_domains[0]}{url}",
-                    headers=self.headers,
-                    callback=self.parse_store,
-                    cb_kwargs={"coords": coords},
-                )
-
-    def parse_store(self, response, coords):
-        type_store = response.xpath('//span[@class="swa-headlines__subheadline swa-label-sans--medium"]/text()').get()
-        if not type_store:
-            item = LinkedDataParser.parse(response, "Store")
-            item["ref"] = re.findall("[0-9]+", response.url)[0]
-            item["lat"] = coords.get("lat")
-            item["lon"] = coords.get("lon")
-            item["addr_full"] = item.pop("street_address").replace("<br>", "")
-
-            yield item

--- a/locations/spiders/swarovski_us.py
+++ b/locations/spiders/swarovski_us.py
@@ -7,14 +7,14 @@ from scrapy.http import Response
 from locations.geo import point_locations
 from locations.linked_data_parser import LinkedDataParser
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import FIREFOX_LATEST
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class SwarovskiUSSpider(Spider):
     name = "swarovski_us"
     item_attributes = {"brand": "Swarovski", "brand_wikidata": "Q611115"}
     allowed_domains = ["swarovski.com"]
-    headers = {"User-Agent": FIREFOX_LATEST}
+    user_agent = BROWSER_DEFAULT
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
@@ -23,31 +23,30 @@ class SwarovskiUSSpider(Spider):
         for lat, lon in point_locations(point_files):
             yield Request(
                 url=f"https://www.swarovski.com/en-LU/store-finder/stores/?geoPoint.latitude={lat}&geoPoint.longitude={lon}&provider=GOOGLE&allBaseStores=true&radius=120&clientTimeZoneOffset=-60",
-                headers=self.headers,
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         if response.xpath('//div[contains(text(), "stores")]/text()').get():
-            stores = response.xpath(
+            for store in response.xpath(
                 '//div[@id="swa-store-locator__tab-list"]/div[contains(@class,"swa-store-view__store")]'
-            )
-            for store in stores:
-                coords = {"lat": store.xpath("./@data-latitude").get(), "lon": store.xpath("./@data-longitude").get()}
+            ):
                 url = store.xpath('.//a[contains(@href, "store")]/@href').get()
                 yield Request(
                     url=f"https://www.{self.allowed_domains[0]}{url}",
-                    headers=self.headers,
                     callback=self.parse_store,
-                    cb_kwargs={"coords": coords},
+                    cb_kwargs={
+                        "lat": store.xpath("./@data-latitude").get(),
+                        "lon": store.xpath("./@data-longitude").get(),
+                    },
                 )
 
-    def parse_store(self, response: Response, coords: dict) -> Any:
+    def parse_store(self, response: Response, lat: str, lon: str) -> Any:
         type_store = response.xpath('//span[@class="swa-headlines__subheadline swa-label-sans--medium"]/text()').get()
         if not type_store:
             item = LinkedDataParser.parse(response, "Store")
             item["ref"] = re.findall("[0-9]+", response.url)[0]
-            item["lat"] = coords.get("lat")
-            item["lon"] = coords.get("lon")
+            item["lat"] = lat
+            item["lon"] = lon
             item["addr_full"] = item.pop("street_address").replace("<br>", "")
 
             yield item


### PR DESCRIPTION
Summaries created for limited count.

**US**
```python
{'atp/brand/Swarovski': 53,
 'atp/brand_wikidata/Q611115': 53,
 'atp/category/shop/jewelry': 53,
 'atp/country/US': 53,
 'atp/field/branch/missing': 53,
 'atp/field/country/from_spider_name': 53,
 'atp/field/email/missing': 53,
 'atp/field/image/dropped': 53,
 'atp/field/image/missing': 53,
 'atp/field/operator/missing': 53,
 'atp/field/operator_wikidata/missing': 53,
 'atp/field/phone/missing': 1,
 'atp/field/state/from_reverse_geocoding': 53,
 'atp/field/street_address/missing': 53,
 'atp/field/twitter/missing': 53,
 'atp/item_scraped_host_count/www.swarovski.com': 53,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 53,
 'downloader/request_bytes': 169975,
 'downloader/request_count': 294,
 'downloader/request_method_count/GET': 294,
 'downloader/response_bytes': 81722401,
 'downloader/response_count': 294,
 'downloader/response_status_count/200': 294,
 'dupefilter/filtered': 33,
 'elapsed_time_seconds': 380.129632,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 8, 25, 13, 25, 4, 365275, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 53,
 'items_per_minute': None,
 'log_count/DEBUG': 18347,
 'log_count/INFO': 20,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 294,
 'playwright/page_count/closed': 294,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 8843,
 'playwright/request_count/aborted': 8549,
 'playwright/request_count/method/GET': 8843,
 'playwright/request_count/navigation': 294,
 'playwright/request_count/resource_type/document': 294,
 'playwright/request_count/resource_type/image': 2179,
 'playwright/request_count/resource_type/script': 5402,
 'playwright/request_count/resource_type/stylesheet': 968,
 'playwright/response_count': 294,
 'playwright/response_count/method/GET': 294,
 'playwright/response_count/resource_type/document': 294,
 'request_depth_max': 1,
 'response_received_count': 294,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 293,
 'scheduler/dequeued/memory': 293,
 'scheduler/enqueued': 319,
 'scheduler/enqueued/memory': 319,
 'start_time': datetime.datetime(2025, 8, 25, 13, 18, 44, 235643, tzinfo=datetime.timezone.utc)}
```

**EU**
```python
{'atp/brand/Swarovski': 54,
 'atp/brand_wikidata/Q611115': 54,
 'atp/category/shop/jewelry': 54,
 'atp/country/AT': 11,
 'atp/country/CH': 10,
 'atp/country/CZ': 10,
 'atp/country/DE': 19,
 'atp/country/FR': 1,
 'atp/country/NL': 1,
 'atp/country/PL': 2,
 'atp/field/branch/missing': 54,
 'atp/field/country/from_reverse_geocoding': 54,
 'atp/field/email/missing': 54,
 'atp/field/image/dropped': 54,
 'atp/field/image/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/phone/missing': 1,
 'atp/field/street_address/missing': 54,
 'atp/field/twitter/missing': 54,
 'atp/item_scraped_host_count/www.swarovski.com': 54,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 54,
 'downloader/request_bytes': 146836,
 'downloader/request_count': 257,
 'downloader/request_method_count/GET': 257,
 'downloader/response_bytes': 77756414,
 'downloader/response_count': 257,
 'downloader/response_status_count/200': 254,
 'downloader/response_status_count/503': 3,
 'dupefilter/filtered': 374,
 'elapsed_time_seconds': 325.997929,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2025, 8, 25, 13, 36, 7, 81660, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/503': 1,
 'item_scraped_count': 54,
 'items_per_minute': None,
 'log_count/DEBUG': 16671,
 'log_count/ERROR': 1,
 'log_count/INFO': 20,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 257,
 'playwright/page_count/closed': 257,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 8043,
 'playwright/request_count/aborted': 7783,
 'playwright/request_count/method/GET': 8043,
 'playwright/request_count/navigation': 257,
 'playwright/request_count/resource_type/document': 257,
 'playwright/request_count/resource_type/image': 1982,
 'playwright/request_count/resource_type/script': 4914,
 'playwright/request_count/resource_type/stylesheet': 890,
 'playwright/response_count': 257,
 'playwright/response_count/method/GET': 257,
 'playwright/response_count/resource_type/document': 257,
 'request_depth_max': 1,
 'response_received_count': 255,
 'responses_per_minute': None,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/503 Service Unavailable': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 256,
 'scheduler/dequeued/memory': 256,
 'scheduler/enqueued': 490,
 'scheduler/enqueued/memory': 490,
 'start_time': datetime.datetime(2025, 8, 25, 13, 30, 41, 83731, tzinfo=datetime.timezone.utc)}
```