### PR TITLE
[Österreichische Post AT] Add spider

### DIFF
--- a/locations/spiders/osterreichische_post_at.py
+++ b/locations/spiders/osterreichische_post_at.py
@@ -7,10 +7,11 @@ from locations.categories import Categories, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_AT, OpeningHours, sanitise_day
 
+POST_AT = {"operator": "Österreichische Post AG", "operator_wikidata": "Q1763505"}
+
 
 class OsterreichischePostATSpider(Spider):
     name = "osterreichische_post_at"
-    item_attributes = {"operator": "Österreichische Post AG", "operator_wikidata": "Q1763505"}
     download_timeout = 180
 
     def start_requests(self) -> Iterable[Request]:
@@ -71,18 +72,22 @@ class OsterreichischePostATSpider(Spider):
 
             if location["type"] == "BRIEFKASTEN":
                 item["name"] = None
+                item.update(POST_AT)
                 apply_category(Categories.POST_BOX, item)
             elif location["type"] == "POSTPARTNER":
                 if ", " in location["longname"]:
                     item["name"] = location["longname"].split(", ", 1)[1]
                 else:
                     item["name"] = None
+                item["extras"]["post_office:brand"] = "Österreichische Post"
                 apply_category(Categories.GENERIC_POI, item)
                 apply_yes_no("post_office=post_partner", item, True)
             elif location["type"] == "FILIALE":
+                item.update(POST_AT)
                 apply_category(Categories.POST_OFFICE, item)
             elif location["type"] == "ABHOLSTATION":
                 item["name"] = None
+                item.update(POST_AT)
                 apply_category(Categories.PARCEL_LOCKER, item)
             elif location["type"] in ("PAKET_PUNKT", "HERMES"):
                 continue

--- a/locations/spiders/osterreichische_post_at.py
+++ b/locations/spiders/osterreichische_post_at.py
@@ -1,0 +1,104 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_AT, OpeningHours, sanitise_day
+
+
+class OsterreichischePostATSpider(Spider):
+    name = "osterreichische_post_at"
+    item_attributes = {"operator": "Österreichische Post AG", "operator_wikidata": "Q1763505"}
+    download_timeout = 180
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://api.post.at/branchservice/core/graphql",
+            data={
+                "query": """query {
+                                branches {
+                                    branchkey
+                                    isactive
+                                    longname
+                                    name
+                                    orgpostalcode
+                                    type
+                                    address {
+                                        country
+                                        pac
+                                        postalcode
+                                        streetname
+                                        streetnumber
+                                        city
+                                        coordinates {
+                                            latitudewgs84
+                                            longitudewgs84
+                                        }
+                                    }
+                                    contact {
+                                        emailaddress
+                                        phonenumber
+                                    }
+                                    standardstorehours {
+                                        closinghour
+                                        openinghour
+                                        dayofweek
+                                        middayclosures {
+                                            closinghour
+                                            openinghour
+                                        }
+                                    }
+                                }
+                            }""",
+            },
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]["branches"]:
+            if location["isactive"] is False:
+                continue
+            item = DictParser.parse(location)
+            item["ref"] = location["branchkey"]
+            item["lat"] = location["address"]["coordinates"]["latitudewgs84"]
+            item["lon"] = location["address"]["coordinates"]["longitudewgs84"]
+            item["website"] = "https://www.post.at/en/sf/locationfinder?branch={}".format(location["branchkey"])
+            item["opening_hours"] = self.parse_opening_hours(location["standardstorehours"])
+
+            if item["name"] != location["longname"]:
+                item["extras"]["full_name"] = location["longname"]
+
+            if location["type"] == "BRIEFKASTEN":
+                item["name"] = None
+                apply_category(Categories.POST_BOX, item)
+            elif location["type"] == "POSTPARTNER":
+                if ", " in location["longname"]:
+                    item["name"] = location["longname"].split(", ", 1)[1]
+                else:
+                    item["name"] = None
+                apply_category(Categories.GENERIC_POI, item)
+                apply_yes_no("post_office=post_partner", item, True)
+            elif location["type"] == "FILIALE":
+                apply_category(Categories.POST_OFFICE, item)
+            elif location["type"] == "ABHOLSTATION":
+                item["name"] = None
+                apply_category(Categories.PARCEL_LOCKER, item)
+            elif location["type"] in ("PAKET_PUNKT", "HERMES"):
+                continue
+            else:
+                self.logger.warning("Unexpected type: {}".format(location["type"]))
+                continue
+
+            yield item
+
+    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in rules or []:
+            day = sanitise_day(rule["dayofweek"], DAYS_AT)
+            if rule["middayclosures"]:
+                oh.add_range(day, rule["openinghour"], rule["middayclosures"]["closinghour"], time_format="%H:%M:%S")
+                oh.add_range(day, rule["middayclosures"]["openinghour"], rule["closinghour"], time_format="%H:%M:%S")
+            else:
+                oh.add_range(day, rule["openinghour"], rule["closinghour"], time_format="%H:%M:%S")
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Post Abholstation': 1492,
 'atp/brand_wikidata/Q110748491': 1492,
 'atp/category/amenity/parcel_locker': 1492,
 'atp/category/amenity/post_box': 13758,
 'atp/category/amenity/post_office': 356,
 'atp/category/amenity/yes': 1344,
 'atp/clean_strings/name': 86,
 'atp/clean_strings/phone': 6,
 'atp/clean_strings/street': 5,
 'atp/country/AT': 16950,
 'atp/field/branch/missing': 16950,
 'atp/field/brand/missing': 15458,
 'atp/field/brand_wikidata/missing': 15458,
 'atp/field/city/missing': 3,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 15251,
 'atp/field/image/missing': 16950,
 'atp/field/name/missing': 13761,
 'atp/field/opening_hours/missing': 14930,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 15436,
 'atp/field/state/missing': 16950,
 'atp/field/street_address/missing': 16950,
 'atp/field/twitter/missing': 16950,
 'atp/item_scraped_host_count/api.post.at': 16950,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 15606,
 'atp/nsi/match_failed': 1344,
 'atp/operator/Österreichische Post AG': 16950,
 'atp/operator_wikidata/Q1763505': 16950,
 'downloader/request_bytes': 2357,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 10701536,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 16.780524,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 27, 14, 14, 28, 317310, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1,
 'httpcache/hit': 1,
 'httpcache/miss': 1,
 'httpcache/store': 1,
 'item_scraped_count': 16950,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 2,
 'memusage/max': 278482944,
 'memusage/startup': 278482944,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 27, 14, 14, 11, 536786, tzinfo=datetime.timezone.utc)}
```