### PR TITLE
[Bambu] Fix Spider

### DIFF
--- a/locations/spiders/bambu.py
+++ b/locations/spiders/bambu.py
@@ -15,6 +15,7 @@ class BambuSpider(Spider):
 
     # Start by acquiring a session cookie
     start_urls = ["https://www.drinkbambu.com/_api/v1/access-tokens"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response):
         # Now that we have a session cookie, send the actual request


### PR DESCRIPTION
**_Fixes : Flag robots.txt as False to fix spider_**

```python
{'atp/brand/Bambu': 64,
 'atp/brand_wikidata/Q83437245': 64,
 'atp/category/amenity/cafe': 64,
 'atp/country/CA': 2,
 'atp/country/PH': 2,
 'atp/country/US': 56,
 'atp/field/city/missing': 4,
 'atp/field/country/missing': 4,
 'atp/field/email/missing': 27,
 'atp/field/image/missing': 64,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 64,
 'atp/field/operator_wikidata/missing': 64,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 5,
 'atp/field/state/from_reverse_geocoding': 58,
 'atp/field/state/missing': 6,
 'atp/field/street_address/missing': 48,
 'atp/field/twitter/missing': 64,
 'atp/item_scraped_host_count/www.drinkbambu.com': 64,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 64,
 'downloader/request_bytes': 2868,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 53940,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.112345,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 28, 9, 14, 40, 559498, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 392525,
 'httpcompression/response_count': 2,
 'item_scraped_count': 64,
 'items_per_minute': None,
 'log_count/DEBUG': 77,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': None,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 8, 28, 9, 14, 36, 447153, tzinfo=datetime.timezone.utc)}
```