### PR TITLE
[Bmo] Recover lost US POIs for the spider and fix missing fields

### DIFF
--- a/locations/spiders/bmo.py
+++ b/locations/spiders/bmo.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
@@ -44,11 +46,14 @@ class BmoSpider(Where2GetItSpider):
     name = "bmo"
     item_attributes = {"brand": "BMO", "brand_wikidata": "Q4835981"}
     api_endpoint = "https://branchlocator.bmo.com/rest/getlist"
-    api_key = "343095D0-C235-11E6-93AB-1BF70C70A832"
+    api_key = [
+        "343095D0-C235-11E6-93AB-1BF70C70A832",  # CA
+        "D07C1CB0-80A3-11ED-BCB3-F57F326043C3",  # US
+    ]
     api_filter_admin_level = 2
 
     # flake8: noqa: C901
-    def parse_item(self, item: Feature, location: dict):
+    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
         item["ref"] = location["clientkey"]
         item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
         if location["country"] == "CA":

--- a/locations/spiders/bmo.py
+++ b/locations/spiders/bmo.py
@@ -54,6 +54,8 @@ class BmoSpider(Where2GetItSpider):
 
     # flake8: noqa: C901
     def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
+        item["lat"] = location.get("latitude")
+        item["lon"] = location.get("longitude")
         item["ref"] = location["clientkey"]
         item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
         if location["country"] == "CA":

--- a/locations/spiders/bmo.py
+++ b/locations/spiders/bmo.py
@@ -58,8 +58,17 @@ class BmoSpider(Where2GetItSpider):
         item["lon"] = location.get("longitude")
         item["ref"] = location["clientkey"]
         item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
+
+        base_url = ""
         if location["country"] == "CA":
             item["state"] = location["province"]
+            base_url = "https://branches.bmo.com"
+        elif location["country"] == "US":
+            base_url = "https://usbranches.bmo.com"
+
+        item["website"] = f'{base_url}/{item["state"]}/{item["city"]}/{location["clientkey"]}/'.lower().replace(
+            " ", "-"
+        )
 
         try:
             item["opening_hours"] = self.parse_opening_hours(location)


### PR DESCRIPTION
```python
{'atp/brand/BMO': 47616,
 'atp/brand_wikidata/Q4835981': 47616,
 'atp/category/amenity/atm': 45794,
 'atp/category/amenity/bank': 1822,
 'atp/cdn/cloudflare/response_count': 142,
 'atp/cdn/cloudflare/response_status_count/200': 142,
 'atp/closed_check': 1,
 'atp/country/CA': 3008,
 'atp/country/US': 44608,
 'atp/field/branch/missing': 47616,
 'atp/field/email/missing': 47615,
 'atp/field/image/missing': 47616,
 'atp/field/opening_hours/missing': 43637,
 'atp/field/operator/missing': 3998,
 'atp/field/operator_wikidata/missing': 3998,
 'atp/field/phone/missing': 45792,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/twitter/missing': 47616,
 'atp/item_scraped_host_count/branchlocator.bmo.com': 47616,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 44608,
 'atp/nsi/match_failed': 3008,
 'atp/operator/BMO': 43618,
 'atp/operator_wikidata/Q4835981': 43618,
 'downloader/request_bytes': 86019,
 'downloader/request_count': 143,
 'downloader/request_method_count/POST': 143,
 'downloader/response_bytes': 10666113,
 'downloader/response_count': 143,
 'downloader/response_status_count/200': 142,
 'downloader/response_status_count/502': 1,
 'elapsed_time_seconds': 171.338549,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 28, 9, 37, 59, 220483, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 349119067,
 'httpcompression/response_count': 142,
 'item_scraped_count': 47616,
 'items_per_minute': None,
 'log_count/DEBUG': 47770,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 142,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/502 Bad Gateway': 1,
 'scheduler/dequeued': 143,
 'scheduler/dequeued/memory': 143,
 'scheduler/enqueued': 143,
 'scheduler/enqueued/memory': 143,
 'start_time': datetime.datetime(2025, 8, 28, 9, 35, 7, 881934, tzinfo=datetime.timezone.utc)}
```