### PR TITLE
[Big Echo JP] add spider

### DIFF
--- a/locations/spiders/bigecho_jp.py
+++ b/locations/spiders/bigecho_jp.py
@@ -1,0 +1,28 @@
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+
+
+class BigechoJPSpider(Spider):
+    name = "bigecho_jp"
+
+    start_urls = ["https://shop.big-echo.jp/api/point"]
+    allowed_domains = ["shop.big-echo.jp"]
+    item_attributes = {
+        "brand_wikidata": "Q15831707",
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["items"]:
+
+            item = DictParser.parse(store)
+            
+            item["extras"]["amenity"] = "karaoke_box"
+            item["website"] = f"https://reserve.big-echo.jp/r/{store['key']}"
+            item["ref"] = store["key"]
+            
+            yield item


### PR DESCRIPTION
```
 'atp/brand/ビッグエコー': 442,
 'atp/brand_wikidata/Q15831707': 442,
 'atp/category/amenity/karaoke_box': 442,
 'atp/clean_strings/addr_full': 173,
 'atp/clean_strings/name': 1,
 'atp/country/JP': 442,
 'atp/field/branch/missing': 442,
 'atp/field/city/missing': 442,
 'atp/field/country/from_spider_name': 442,
 'atp/field/email/missing': 442,
 'atp/field/image/missing': 442,
 'atp/field/opening_hours/missing': 442,
 'atp/field/operator/missing': 442,
 'atp/field/operator_wikidata/missing': 442,
 'atp/field/phone/missing': 442,
 'atp/field/postcode/missing': 442,
 'atp/field/state/missing': 442,
 'atp/field/street_address/missing': 442,
 'atp/field/twitter/missing': 442,
 'atp/item_scraped_host_count/shop.big-echo.jp': 442,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 442,
 'downloader/request_bytes': 667,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 34560,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.054873,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 29, 11, 3, 18, 347334, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 170235,
 'httpcompression/response_count': 2,
 'item_scraped_count': 442,
 'items_per_minute': None,
 'log_count/DEBUG': 455,
 'log_count/INFO': 10,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 29, 11, 3, 14, 292461, tzinfo=datetime.timezone.utc)
```