### PR TITLE
[Seims JP] add spider

### DIFF
--- a/locations/spiders/seims_jp.py
+++ b/locations/spiders/seims_jp.py
@@ -26,9 +26,9 @@ class SeimsJPSpider(Spider):
             item["extras"]["addr:province"] = store["extra_fields"]["都道府県"]
             item["extras"]["branch:ja-Hira"] = store["extra_fields"]["店名かな"]
 
-            if store["extra_fields"]["電話番号"] != None:
+            if store["extra_fields"]["電話番号"] is not None:
                 item["phone"] = f"+81 {store['extra_fields']['電話番号']}"
-                if store["extra_fields"]["調剤電話番号"] != None:
+                if store["extra_fields"]["調剤電話番号"] is not None:
                     item["extras"]["phone:pharmacy"] = f"+81 {store['extra_fields']['調剤電話番号']}"
             else:
                 item["phone"] = f"+81 {store['extra_fields']['調剤電話番号']}"

--- a/locations/spiders/seims_jp.py
+++ b/locations/spiders/seims_jp.py
@@ -19,20 +19,20 @@ class SeimsJPSpider(Spider):
         for store in response.json()["items"]:
 
             item = DictParser.parse(store)
-            
+
             item["brand"] = store["marker"]["ja"]["name"]
-            
+
             item["postcode"] = store["extra_fields"]["郵便番号"]
             item["extras"]["addr:province"] = store["extra_fields"]["都道府県"]
             item["extras"]["branch:ja-Hira"] = store["extra_fields"]["店名かな"]
-            
-            if store['extra_fields']['電話番号'] != None:
+
+            if store["extra_fields"]["電話番号"] != None:
                 item["phone"] = f"+81 {store['extra_fields']['電話番号']}"
-                if store['extra_fields']['調剤電話番号'] != None:
+                if store["extra_fields"]["調剤電話番号"] != None:
                     item["extras"]["phone:pharmacy"] = f"+81 {store['extra_fields']['調剤電話番号']}"
             else:
                 item["phone"] = f"+81 {store['extra_fields']['調剤電話番号']}"
-            
+
             item["website"] = f"https://store.seims.co.jp/map/{store['key']}/"
             item["ref"] = store["key"]
             if store["extra_fields"]["ドラッグストア"] == "1":
@@ -40,5 +40,5 @@ class SeimsJPSpider(Spider):
             if store["extra_fields"]["処方せん受付店舗"] == "1":
                 apply_category(Categories.PHARMACY, item)
                 item["extras"]["dispensing"] = "yes"
-            
+
             yield item

--- a/locations/spiders/seims_jp.py
+++ b/locations/spiders/seims_jp.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class SeimsJPSpider(Spider):
+    name = "seims_jp"
+    start_urls = ["https://store.seims.co.jp/api/point/xn/"]
+    allowed_domains = ["store.seims.co.jp"]
+    item_attributes = {
+        "brand_wikidata": "Q11456137",
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["items"]:
+
+            item = DictParser.parse(store)
+            
+            item["brand"] = store["marker"]["ja"]["name"]
+            
+            item["postcode"] = store["extra_fields"]["郵便番号"]
+            item["extras"]["addr:province"] = store["extra_fields"]["都道府県"]
+            item["extras"]["branch:ja-Hira"] = store["extra_fields"]["店名かな"]
+            
+            if store['extra_fields']['電話番号'] != None:
+                item["phone"] = f"+81 {store['extra_fields']['電話番号']}"
+                if store['extra_fields']['調剤電話番号'] != None:
+                    item["extras"]["phone:pharmacy"] = f"+81 {store['extra_fields']['調剤電話番号']}"
+            else:
+                item["phone"] = f"+81 {store['extra_fields']['調剤電話番号']}"
+            
+            item["website"] = f"https://store.seims.co.jp/map/{store['key']}/"
+            item["ref"] = store["key"]
+            if store["extra_fields"]["ドラッグストア"] == "1":
+                apply_category(Categories.SHOP_CHEMIST, item)
+            if store["extra_fields"]["処方せん受付店舗"] == "1":
+                apply_category(Categories.PHARMACY, item)
+                item["extras"]["dispensing"] = "yes"
+            
+            yield item


### PR DESCRIPTION
```
'atp/brand/アメリカンドラッグ': 89,
 'atp/brand/スーパードラッグキリン': 4,
 'atp/brand/ドラッグストアスマイル': 9,
 'atp/brand/ドラッグセイムス': 774,
 'atp/brand/ドラッグユタカ': 224,
 'atp/brand_wikidata/Q11456137': 1100,
 'atp/category/amenity/pharmacy': 522,
 'atp/category/multiple': 522,
 'atp/category/shop/chemist': 578,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/postcode': 1,
 'atp/country/JP': 1100,
 'atp/field/branch/missing': 1100,
 'atp/field/city/missing': 1100,
 'atp/field/country/from_spider_name': 1100,
 'atp/field/email/missing': 1100,
 'atp/field/image/missing': 1100,
 'atp/field/opening_hours/missing': 1100,
 'atp/field/operator/missing': 1100,
 'atp/field/operator_wikidata/missing': 1100,
 'atp/field/state/missing': 1100,
 'atp/field/street_address/missing': 1100,
 'atp/field/twitter/missing': 1100,
 'atp/item_scraped_host_count/store.seims.co.jp': 1100,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 1100,
 'downloader/request_bytes': 673,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 144720,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.018861,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 29, 12, 28, 30, 313419, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4295829,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1100,
 'items_per_minute': None,
 'log_count/DEBUG': 1113,
 'log_count/INFO': 10,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 8, 29, 12, 28, 22, 294558, tzinfo=datetime.timezone.utc)
```