### PR TITLE
[Acom JP] add spider

### DIFF
--- a/locations/spiders/acom_jp.py
+++ b/locations/spiders/acom_jp.py
@@ -5,7 +5,7 @@ from locations.dict_parser import DictParser
 
 class AcomJPSpider(scrapy.Spider):
     name = "acom_jp"
-    
+
     item_attributes = {
         "brand": "アコム",
         "brand_wikidata": "Q4674469",


### PR DESCRIPTION
'atp/brand/アコム': 534,
 'atp/brand_wikidata/Q4674469': 534,
 'atp/category/shop/money_lender': 534,
 'atp/country/JP': 534,
 'atp/field/city/missing': 534,
 'atp/field/country/from_spider_name': 534,
 'atp/field/email/missing': 534,
 'atp/field/image/missing': 534,
 'atp/field/opening_hours/missing': 534,
 'atp/field/operator/missing': 534,
 'atp/field/operator_wikidata/missing': 534,
 'atp/field/phone/missing': 534,
 'atp/field/state/missing': 534,
 'atp/field/street_address/missing': 534,
 'atp/field/twitter/missing': 534,
 'atp/item_scraped_host_count/store.acom.co.jp': 534,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 534,
 'downloader/request_bytes': 1248,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 49500,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.511639,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 8, 31, 11, 26, 25, 79902, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 338818,
 'httpcompression/response_count': 3,
 'item_scraped_count': 534,
 'items_per_minute': None,
 'log_count/DEBUG': 548,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 8, 31, 11, 26, 20, 568263, tzinfo=datetime.timezone.utc)