### PR TITLE
[Walmart US] Fix spider

### DIFF
--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -66,6 +66,9 @@ class WalmartUSSpider(Spider):
             item["street_address"] = merge_address_lines(
                 [location["address"].get("addressLineOne"), location["address"].get("addressLineTwo")]
             )
+            item["website"] = f'https://www.walmart.com/store/{item["ref"]}-{item["city"]}-{item["state"]}'.replace(
+                " ", "-"
+            )
             item["opening_hours"] = self.parse_hours(location.get("operationalHours", []))
 
             if location["name"] == "Walmart":

--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -1,105 +1,100 @@
 import json
+from typing import Any, Iterable
+from urllib.parse import urlencode
 
-from scrapy.spiders import SitemapSpider
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.geo import city_locations
 from locations.hours import OpeningHours
-from locations.pipelines.address_clean_up import clean_address
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class WalmartUSSpider(SitemapSpider):
+class WalmartUSSpider(Spider):
     name = "walmart_us"
     item_attributes = {"brand": "Walmart", "brand_wikidata": "Q483551"}
-    allowed_domains = ["walmart.com"]
-    sitemap_urls = ["https://www.walmart.com/sitemap_store_main.xml"]
-    sitemap_rules = [("", "parse_store")]
-    requires_proxy = True
-
-    CATEGORIES = {
-        "GAS_STATION": None,  # It may be Walmart or Murphy
-        "PHARMACY": Categories.PHARMACY,
-        "STORE": None,
+    allowed_domains = ["www.walmart.com"]
+    custom_settings = {
+        "USER_AGENT": BROWSER_DEFAULT,
+        "CONCURRENT_REQUESTS": 1,
+        "DOWNLOAD_DELAY": 5,
+        "ROBOTSTXT_OBEY": False,
     }
+    base_url = "https://www.walmart.com/orchestra/home/graphql/nearByNodes"
+    hash = "383d44ac5962240870e513c4f53bb3d05a143fd7b19acb32e8a83e39f1ed266c"
 
-    def store_hours(self, store) -> OpeningHours | str:
-        if store.get("open24Hours") is True:
-            return "24/7"
-        elif rules := store.get("operationalHours"):
-            oh = OpeningHours()
-            for rule in rules:
-                if rule.get("closed") is True:
-                    oh.set_closed(rule["day"])
-                else:
-                    oh.add_range(rule["day"], rule["start"], rule["end"])
-
-            return oh
-
-    def parse_store(self, response):
-        script = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
-
-        if script is None:
-            return
-
-        data = json.loads(script)
-
-        if data is None:
-            return
-
-        store = data["props"]["pageProps"]["initialData"]["initialDataNodeDetail"]["data"]["nodeDetail"]
-
-        if store is None:
-            return
-
-        item = DictParser.parse(store)
-
-        item["phone"] = store.get("phoneNumber")
-        item["name"] = store.get("displayName")
-        item["opening_hours"] = self.store_hours(store)
-
-        if addr := store.get("address"):
-            item["street_address"] = clean_address(
-                [
-                    addr.get("addressLineOne"),
-                    addr.get("addressLineTwo"),
-                ]
+    def start_requests(self) -> Iterable[JsonRequest]:
+        for city in city_locations("US", min_population=15000):
+            variables = {
+                "input": {
+                    "postalCode": "",
+                    "accessTypes": ["PICKUP_INSTORE", "PICKUP_CURBSIDE"],
+                    "nodeTypes": ["STORE", "PICKUP_SPOKE", "PICKUP_POPUP"],
+                    "latitude": city["latitude"],
+                    "longitude": city["longitude"],
+                    "radius": 100,
+                },
+                "checkItemAvailability": False,
+                "checkWeeklyReservation": False,
+                "enableStoreSelectorMarketplacePickup": False,
+                "enableVisionStoreSelector": False,
+                "enableStorePagesAndFinderPhase2": False,
+                "enableStoreBrandFormat": False,
+                "disableNodeAddressPostalCode": False,
+            }
+            yield JsonRequest(
+                url=f"{self.base_url}/{self.hash}?{urlencode({'variables': json.dumps(variables)})}",
+                headers={
+                    "x-apollo-operation-name": "nearByNodes",
+                    "x-o-bu": "WALMART-US",
+                    "x-o-gql-query": "query nearByNodes",
+                    "x-o-platform": "rweb",
+                    "x-o-platform-version": "usweb-1.220.0-ada3f07b1e1f576f89fca794606c73b0cd2ce649-8211424r",
+                    "x-o-segment": "oaoh",
+                },
+                cookies={"walmart.nearestLatLng": f'{city["latitude"]},{city["longitude"]}'},
             )
-        item["website"] = response.url
 
-        for service in store["services"]:
-            if not self.CATEGORIES.get(service["name"]):
-                self.crawler.stats.inc_value("atp/walmart/ignored/{}".format(service["name"]))
-                continue
-            poi = item.deepcopy()
-            poi["ref"] += service["name"]
-            poi["name"] = service["displayName"]
-            poi["phone"] = service["phone"]
-            poi["opening_hours"] = self.store_hours(service)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location_nodes = response.json().get("data", {}).get("nearByNodes") or {}
+        for location in location_nodes.get("nodes", []):
+            item = DictParser.parse(location)
+            item["branch"] = location.get("displayName", "").split(",")[0].strip()
+            item["street_address"] = merge_address_lines(
+                [location["address"].get("addressLineOne"), location["address"].get("addressLineTwo")]
+            )
+            item["opening_hours"] = self.parse_hours(location.get("operationalHours", []))
 
-            apply_category(self.CATEGORIES[service["name"]], poi)
+            if location["name"] == "Walmart":
+                apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+            elif location["name"] == "Walmart Supercenter":
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+            elif item["name"].endswith("Neighborhood Market"):
+                item["name"] = "Walmart Neighborhood Market"
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+            elif item["name"].endswith("Pharmacy"):
+                item["name"] = "Walmart Pharmacy"
+                apply_category(Categories.PHARMACY, item)
+            else:
+                self.logger.error("Unknown store format: {}".format(item["name"]))
 
-            yield poi
+            yield item
 
-        if item["name"].endswith("Supercenter"):
-            item["name"] = "Walmart Supercenter"
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-        elif item["name"].endswith("Neighborhood Market"):
-            item["name"] = "Walmart Neighborhood Market"
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-        elif item["name"].endswith(" Walmart Pickup Store"):
-            item["name"] = "Walmart Pickup Store"
-            apply_category(Categories.SHOP_OUTPOST, item)
-        elif item["name"].endswith("Store"):
-            item["name"] = "Walmart"
-            apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
-        elif item["name"].endswith("Pharmacy"):
-            item["name"] = "Walmart Pharmacy"
-            apply_category(Categories.PHARMACY, item)
-        elif item["name"].endswith("Gas Station"):
-            item["name"] = "Walmart"
-            item["brand_wikidata"] = "Q62606411"
-            apply_category(Categories.FUEL_STATION, item)
-        else:
-            self.logger.error("Unknown store format: {}".format(item["name"]))
+    def parse_hours(self, hours: list) -> OpeningHours | None:
+        if not hours:
+            return None
 
-        yield item
+        try:
+            oh = OpeningHours()
+            for rule in hours:
+                if rule.get("closed") is True:
+                    oh.set_closed(rule.get("day"))
+                else:
+                    oh.add_range(rule.get("day"), rule.get("start"), rule.get("end"))
+            return oh
+        except Exception as e:
+            self.logger.error(f"Failed to parse hours: {hours}, {e}")
+            return None


### PR DESCRIPTION
`GraphQL` API used to avoid `captcha` blockage for fixing the spider.

```
{'atp/brand/Walmart': 4220,
 'atp/brand_wikidata/Q483551': 4220,
 'atp/category/amenity/pharmacy': 2,
 'atp/category/multiple': 2,
 'atp/category/shop/department_store': 329,
 'atp/category/shop/supermarket': 3889,
 'atp/country/US': 4220,
 'atp/duplicate_count': 68478,
 'atp/field/email/missing': 4220,
 'atp/field/image/missing': 4220,
 'atp/field/operator/missing': 4220,
 'atp/field/operator_wikidata/missing': 4220,
 'atp/field/phone/missing': 4220,
 'atp/field/twitter/missing': 4220,
 'atp/item_scraped_host_count/www.walmart.com': 72698,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4220,
 'downloader/request_bytes': 8005786,
 'downloader/request_count': 3272,
 'downloader/request_method_count/GET': 3272,
 'downloader/response_bytes': 20488700,
 'downloader/response_count': 3272,
 'downloader/response_status_count/200': 1560,
 'downloader/response_status_count/412': 1712,
 'elapsed_time_seconds': 101.989916,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 1, 8, 34, 30, 610248, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 3272,
 'httpcompression/response_bytes': 106803119,
 'httpcompression/response_count': 1560,
 'httperror/response_ignored_count': 1712,
 'httperror/response_ignored_status_count/412': 1712,
 'item_dropped_count': 68478,
 'item_dropped_reasons_count/DropItem': 68478,
 'item_scraped_count': 4220,
 'items_per_minute': None,
 'log_count/DEBUG': 75982,
 'log_count/INFO': 1722,
 'response_received_count': 3272,
 'responses_per_minute': None,
 'scheduler/dequeued': 3272,
 'scheduler/dequeued/memory': 3272,
 'scheduler/enqueued': 3272,
 'scheduler/enqueued/memory': 3272,
 'start_time': datetime.datetime(2025, 9, 1, 8, 32, 48, 620332, tzinfo=datetime.timezone.utc)}
```