### PR TITLE
[KFC PH] Fix XMLSyntaxError for spider

### DIFF
--- a/locations/spiders/kfc_ph.py
+++ b/locations/spiders/kfc_ph.py
@@ -1,4 +1,10 @@
+from typing import Iterable
+
+from scrapy import Request
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
+from scrapy.spiders.sitemap import iterloc, logger
+from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.structured_data_spider import StructuredDataSpider
@@ -12,3 +18,32 @@ class KfcPHSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"-fast-food-restaurant-.+-\d+\/Map$", "parse_sd")]
     wanted_types = ["Restaurant"]
     time_format = "%I:%M %p"
+
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
+        if response.url.endswith("/robots.txt"):
+            for url in sitemap_urls_from_robots(response.text, base_url=response.url):
+                if url.endswith("locations.xml"):
+                    yield Request(url, callback=self._parse_sitemap)
+        else:
+            body = self._get_sitemap_body(response)
+            if body is None:
+                logger.warning(
+                    "Ignoring invalid sitemap: %(response)s",
+                    {"response": response},
+                    extra={"spider": self},
+                )
+                return
+
+            s = Sitemap(body)
+            it = self.sitemap_filter(s)
+
+            if s.type == "sitemapindex":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    if any(x.search(loc) for x in self._follow):
+                        yield Request(loc, callback=self._parse_sitemap)
+            elif s.type == "urlset":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    for r, c in self._cbs:
+                        if r.search(loc):
+                            yield Request(loc, callback=c)
+                            break


### PR DESCRIPTION
```python
{'atp/brand/KFC': 425,
 'atp/brand_wikidata/Q524757': 425,
 'atp/category/amenity/fast_food': 425,
 'atp/clean_strings/street_address': 41,
 'atp/country/PH': 425,
 'atp/field/branch/missing': 425,
 'atp/field/email/missing': 425,
 'atp/field/image/missing': 425,
 'atp/field/operator/missing': 425,
 'atp/field/operator_wikidata/missing': 425,
 'atp/field/phone/invalid': 31,
 'atp/field/street_address/missing': 1,
 'atp/item_scraped_host_count/stores.kfc.com.ph': 425,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 425,
 'downloader/request_bytes': 277196,
 'downloader/request_count': 563,
 'downloader/request_method_count/GET': 563,
 'downloader/response_bytes': 4745934,
 'downloader/response_count': 563,
 'downloader/response_status_count/200': 563,
 'elapsed_time_seconds': 675.727251,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 1, 13, 53, 36, 161365, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 20649246,
 'httpcompression/response_count': 563,
 'item_scraped_count': 425,
 'items_per_minute': None,
 'log_count/DEBUG': 999,
 'log_count/INFO': 20,
 'log_count/WARNING': 3,
 'request_depth_max': 3,
 'response_received_count': 563,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 562,
 'scheduler/dequeued/memory': 562,
 'scheduler/enqueued': 562,
 'scheduler/enqueued/memory': 562,
 'start_time': datetime.datetime(2025, 9, 1, 13, 42, 20, 434114, tzinfo=datetime.timezone.utc)}
```