### PR TITLE
[Sbarro] Flag sbarro as requires proxy to fix spider

### DIFF
--- a/locations/spiders/sbarro.py
+++ b/locations/spiders/sbarro.py
@@ -10,6 +10,7 @@ class SbarroSpider(scrapy.Spider):
     item_attributes = {"brand": "Sbarro", "brand_wikidata": "Q2589409"}
     allowed_domains = ["sbarro.com"]
     start_urls = ["https://sbarro.com/locations/?user_search=78749&radius=50000&count=5000"]
+    requires_proxy = True
 
     def parse_store(self, response):
         try:


### PR DESCRIPTION
**_Fixes : Flag spider as requires proxy to fix spider_**

```python
{'atp/brand/Sbarro': 696,
 'atp/brand_wikidata/Q2589409': 696,
 'atp/category/amenity/fast_food': 696,
 'atp/clean_strings/addr_full': 66,
 'atp/clean_strings/city': 19,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/state': 43,
 'atp/country/AE': 3,
 'atp/country/AL': 1,
 'atp/country/AR': 8,
 'atp/country/AW': 3,
 'atp/country/BE': 3,
 'atp/country/BO': 7,
 'atp/country/BS': 2,
 'atp/country/CA': 4,
 'atp/country/CO': 26,
 'atp/country/CR': 2,
 'atp/country/EG': 2,
 'atp/country/GB': 17,
 'atp/country/GE': 1,
 'atp/country/GH': 4,
 'atp/country/GU': 1,
 'atp/country/IE': 4,
 'atp/country/IN': 36,
 'atp/country/IS': 9,
 'atp/country/MK': 2,
 'atp/country/MX': 23,
 'atp/country/PA': 9,
 'atp/country/PH': 40,
 'atp/country/PL': 2,
 'atp/country/PY': 3,
 'atp/country/SA': 14,
 'atp/country/SJ': 1,
 'atp/country/TR': 106,
 'atp/country/US': 355,
 'atp/country/UY': 8,
 'atp/field/branch/missing': 696,
 'atp/field/city/missing': 91,
 'atp/field/country/from_reverse_geocoding': 696,
 'atp/field/email/missing': 696,
 'atp/field/lat/invalid': 1,
 'atp/field/lat/missing': 5,
 'atp/field/lon/missing': 5,
 'atp/field/opening_hours/missing': 696,
 'atp/field/operator/missing': 696,
 'atp/field/operator_wikidata/missing': 696,
 'atp/field/phone/missing': 696,
 'atp/field/postcode/missing': 270,
 'atp/field/state/missing': 6,
 'atp/field/street_address/missing': 696,
 'atp/geometry/null_island': 4,
 'atp/item_scraped_host_count/sbarro.com': 696,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 696,
 'downloader/request_bytes': 471158,
 'downloader/request_count': 763,
 'downloader/request_method_count/GET': 763,
 'downloader/response_bytes': 6174149,
 'downloader/response_count': 763,
 'downloader/response_status_count/200': 702,
 'downloader/response_status_count/301': 61,
 'dupefilter/filtered': 59,
 'elapsed_time_seconds': 935.060917,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 2, 5, 49, 56, 36865, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24848706,
 'httpcompression/response_count': 702,
 'item_scraped_count': 696,
 'items_per_minute': None,
 'log_count/DEBUG': 1466,
 'log_count/INFO': 24,
 'request_depth_max': 1,
 'response_received_count': 702,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 762,
 'scheduler/dequeued/memory': 762,
 'scheduler/enqueued': 762,
 'scheduler/enqueued/memory': 762,
 'start_time': datetime.datetime(2025, 9, 2, 5, 34, 20, 975948, tzinfo=datetime.timezone.utc)}
```