### PR TITLE
[Massage Envy] Fix Spider

### DIFF
--- a/locations/spiders/massage_envy.py
+++ b/locations/spiders/massage_envy.py
@@ -1,15 +1,35 @@
+import re
+from typing import Any
+
+import chompjs
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
-class MassageEnvySpider(SitemapSpider, StructuredDataSpider):
+class MassageEnvySpider(SitemapSpider):
     name = "massage_envy"
     item_attributes = {"brand": "Massage Envy", "brand_wikidata": "Q10327170"}
     allowed_domains = ["locations.massageenvy.com"]
     sitemap_urls = ("https://locations.massageenvy.com/sitemap.xml",)
     sitemap_rules = [
-        (r"^https://locations.massageenvy.com/[^/]+/[^/]+/[^/]+.html$", "parse_sd"),
+        (r"^https://locations.massageenvy.com/[^/]+/[^/]+/[^/]+.html$", "parse"),
     ]
-    wanted_types = ["LocalBusiness"]
-    drop_attributes = {"image"}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        script_text = response.xpath('//*[contains(text(),"application/ld+json")]/text()').get()
+        raw_data = chompjs.parse_js_object(
+            re.search(r"structuredDataTextReview\s*\+=\s*`([^`]*)`", script_text).group(1) + "}"
+        )
+        item = DictParser.parse(raw_data)
+        item["ref"] = response.url
+        oh = OpeningHours()
+        for day_time in raw_data["openingHoursSpecification"]:
+            day = day_time["dayOfWeek"][0]
+            open_time = day_time["opens"]
+            close_time = day_time["closes"]
+            oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        item["opening_hours"] = oh
+        yield item


### PR DESCRIPTION
**_Fixes : updated code to fix spider_**

```python
{'atp/brand/Massage Envy': 998,
 'atp/brand_wikidata/Q10327170': 998,
 'atp/category/shop/massage': 998,
 'atp/cdn/cloudflare/response_count': 1000,
 'atp/cdn/cloudflare/response_status_count/200': 999,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/closed_check': 1,
 'atp/country/US': 998,
 'atp/field/branch/missing': 998,
 'atp/field/email/missing': 998,
 'atp/field/image/missing': 998,
 'atp/field/operator/missing': 998,
 'atp/field/operator_wikidata/missing': 998,
 'atp/field/twitter/missing': 998,
 'atp/item_scraped_host_count/locations.massageenvy.com': 998,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 998,
 'downloader/request_bytes': 432667,
 'downloader/request_count': 1000,
 'downloader/request_method_count/GET': 1000,
 'downloader/response_bytes': 39242870,
 'downloader/response_count': 1000,
 'downloader/response_status_count/200': 999,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1231.546094,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 2, 9, 26, 19, 772944, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 402074382,
 'httpcompression/response_count': 1000,
 'item_scraped_count': 998,
 'items_per_minute': None,
 'log_count/DEBUG': 2009,
 'log_count/INFO': 29,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 1000,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 999,
 'scheduler/dequeued/memory': 999,
 'scheduler/enqueued': 999,
 'scheduler/enqueued/memory': 999,
 'start_time': datetime.datetime(2025, 9, 2, 9, 5, 48, 226850, tzinfo=datetime.timezone.utc)}
```