### PR TITLE
[Terminix] Fix Spier

### DIFF
--- a/locations/spiders/terminix.py
+++ b/locations/spiders/terminix.py
@@ -2,6 +2,7 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class TerminixSpider(SitemapSpider, StructuredDataSpider):
@@ -10,11 +11,12 @@ class TerminixSpider(SitemapSpider, StructuredDataSpider):
         "brand": "Terminix",
         "brand_wikidata": "Q7702831",
     }
-    sitemap_urls = ["https://www.terminix.com/sitemap.xml"]
+    sitemap_urls = ["https://www.terminix.com/sitemap_index.xml"]
     sitemap_rules = [
         (r"/exterminators/\w+/[\w\-]+-(\d+)/$", "parse_sd"),
     ]
     requires_proxy = True
+    user_agent = BROWSER_DEFAULT
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data.pop("image", None)


### PR DESCRIPTION
**_Fixes : added user_agent to fix spider_**

```python
{'atp/brand/Terminix': 533,
 'atp/brand_wikidata/Q7702831': 533,
 'atp/category/shop/pest_control': 533,
 'atp/cdn/cloudflare/response_count': 544,
 'atp/cdn/cloudflare/response_status_count/200': 544,
 'atp/country/US': 533,
 'atp/duplicate_count': 2,
 'atp/field/branch/missing': 533,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/email/missing': 533,
 'atp/field/image/missing': 533,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 533,
 'atp/field/operator_wikidata/missing': 533,
 'atp/field/twitter/missing': 533,
 'atp/item_scraped_host_count/missouri.bugoutservice.com': 1,
 'atp/item_scraped_host_count/www.terminix.com': 534,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 533,
 'downloader/request_bytes': 478246,
 'downloader/request_count': 545,
 'downloader/request_method_count/GET': 545,
 'downloader/response_bytes': 25354053,
 'downloader/response_count': 545,
 'downloader/response_status_count/200': 544,
 'downloader/response_status_count/301': 1,
 'dupefilter/filtered': 534,
 'elapsed_time_seconds': 667.217915,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 2, 10, 12, 14, 546005, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 95936282,
 'httpcompression/response_count': 544,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 533,
 'items_per_minute': None,
 'log_count/DEBUG': 1093,
 'log_count/INFO': 20,
 'request_depth_max': 2,
 'response_received_count': 544,
 'responses_per_minute': None,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 543,
 'scheduler/dequeued/memory': 543,
 'scheduler/enqueued': 543,
 'scheduler/enqueued/memory': 543,
 'start_time': datetime.datetime(2025, 9, 2, 10, 1, 7, 328090, tzinfo=datetime.timezone.utc)}

```