### PR TITLE
[Mitre 10 AU] Fix Spider

### DIFF
--- a/locations/spiders/mitre_10_au.py
+++ b/locations/spiders/mitre_10_au.py
@@ -1,7 +1,9 @@
 import json
 
 import scrapy
+from scrapy.http import Response
 
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -20,3 +22,10 @@ class Mitre10AUSpider(StructuredDataSpider):
         stores = data_json["*"]["Magento_Ui/js/core/app"]["components"]["store-locator-search"]["markers"]
         for store in stores:
             yield scrapy.Request(store["url"], self.parse_sd)
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item.pop("facebook")
+        item.pop("image")
+        item["branch"] = item.pop("name").removesuffix("Mitre 10")
+        item["addr_full"] = response.xpath('//*[@class="address"]').xpath("normalize-space()").get()
+        yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Mitre 10': 421,
 'atp/brand_wikidata/Q6882393': 421,
 'atp/category/shop/doityourself': 421,
 'atp/country/AU': 421,
 'atp/field/branch/missing': 421,
 'atp/field/country/from_website_url': 421,
 'atp/field/email/missing': 421,
 'atp/field/operator/missing': 421,
 'atp/field/operator_wikidata/missing': 421,
 'atp/field/postcode/missing': 421,
 'atp/field/twitter/missing': 421,
 'atp/field/website/invalid': 1,
 'atp/item_scraped_host_count/www.mitre10.com.au': 421,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 421,
 'downloader/request_bytes': 200324,
 'downloader/request_count': 423,
 'downloader/request_method_count/GET': 423,
 'downloader/response_bytes': 55720442,
 'downloader/response_count': 423,
 'downloader/response_status_count/200': 423,
 'elapsed_time_seconds': 514.069304,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 2, 11, 46, 46, 827369, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 458211960,
 'httpcompression/response_count': 423,
 'item_scraped_count': 421,
 'items_per_minute': None,
 'log_count/DEBUG': 855,
 'log_count/INFO': 17,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 423,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 422,
 'scheduler/dequeued/memory': 422,
 'scheduler/enqueued': 422,
 'scheduler/enqueued/memory': 422,
 'start_time': datetime.datetime(2025, 9, 2, 11, 38, 12, 758065, tzinfo=datetime.timezone.utc)}
```