### PR TITLE
[Denner CH] Fix spider

### DIFF
--- a/locations/spiders/denner_ch.py
+++ b/locations/spiders/denner_ch.py
@@ -1,50 +1,55 @@
-from typing import Iterable
+from typing import Any, Iterable
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_FULL
-from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_DE, OpeningHours, sanitise_day
 
 
-class DennerCHSpider(SitemapSpider, StructuredDataSpider):
+class DennerCHSpider(Spider):
     name = "denner_ch"
     item_attributes = {"brand": "Denner", "brand_wikidata": "Q379911"}
-    sitemap_urls = ["https://www.denner.ch/sitemap.store.xml"]
-    sitemap_rules = [("/de/filialen/", "parse_sd")]
 
-    def iter_linked_data(self, response: Response) -> Iterable[dict]:
-        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
-            if isinstance(ld_obj.get("@graph"), list):
-                ld_obj = ld_obj["@graph"][0]
+    def make_request(self, page: int) -> JsonRequest:
+        return JsonRequest(
+            url=f"https://www.denner.ch/api/store/list?page={page}",
+            cb_kwargs={"current_page": page},
+        )
 
-            if not ld_obj.get("@type"):
-                continue
+    def start_requests(self) -> Iterable[JsonRequest]:
+        yield self.make_request(1)
 
-            types = ld_obj["@type"]
+    def parse(self, response: Response, current_page: int) -> Any:
+        results = response.json()["data"]
 
-            if not isinstance(types, list):
-                types = [types]
+        for location in results.get("hits", []):
+            location.update(location.pop("_geo"))
+            location["street-number"] = location.pop("number")
+            location["street"] = location.pop("address")
+            item = DictParser.parse(location)
+            item.pop("name")
+            item["website"] = response.urljoin(location["link"])
+            opening_hours = (location.get("openingTimes") or {}).get("weeklyOpeningTimes", [])
+            try:
+                item["opening_hours"] = self.parse_opening_hours(opening_hours)
+            except:
+                self.logger.error(f"Failed to parse opening hours: {opening_hours}")
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+            yield item
 
-            types = [LinkedDataParser.clean_type(t) for t in types]
+        if current_page < results["totalPages"]:
+            yield self.make_request(current_page + 1)
 
-            for wanted_types in self.wanted_types:
-                if isinstance(wanted_types, list):
-                    if all(wanted in types for wanted in wanted_types):
-                        yield ld_obj
-                elif wanted_types in types:
-                    yield ld_obj
-
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        for index, rule in enumerate(
-            ld_data.get("openingHoursSpecification", [])
-        ):  # Actual hours starts from Monday, but raw data wrongly starts from Tuesday
-            rule["dayOfWeek"] = DAYS_FULL[index]
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["name"] = ld_data["name"].removesuffix(" Filiale")
-        apply_category(Categories.SHOP_SUPERMARKET, item)
-        yield item
+    def parse_opening_hours(self, opening_hours: list) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours:
+            if day := sanitise_day(rule.get("weekday"), DAYS_DE):
+                hours_info = rule.get("statements")
+                if hours_info[0]["info"] and hours_info[0]["info"][0].get("name") == "geschlossen":
+                    oh.set_closed(day)
+                else:
+                    for shift in hours_info:
+                        oh.add_range(day, shift["openFrom"], shift["openTo"])
+        return oh


### PR DESCRIPTION
`Sitemap` is not available. `API` provides better data than `Structured Data` here, with lesser no. of requests.

```python
{'atp/brand/Denner': 885,
 'atp/brand_wikidata/Q379911': 885,
 'atp/category/shop/supermarket': 885,
 'atp/country/CH': 885,
 'atp/field/branch/missing': 885,
 'atp/field/country/from_spider_name': 885,
 'atp/field/email/missing': 885,
 'atp/field/image/missing': 885,
 'atp/field/operator/missing': 885,
 'atp/field/operator_wikidata/missing': 885,
 'atp/field/phone/missing': 611,
 'atp/field/state/missing': 885,
 'atp/field/street_address/missing': 885,
 'atp/field/twitter/missing': 885,
 'atp/item_scraped_host_count/www.denner.ch': 885,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 885,
 'downloader/request_bytes': 41591,
 'downloader/request_count': 90,
 'downloader/request_method_count/GET': 90,
 'downloader/response_bytes': 283120,
 'downloader/response_count': 90,
 'downloader/response_status_count/200': 90,
 'elapsed_time_seconds': 12.087009,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 2, 15, 21, 15, 678627, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 90,
 'httpcompression/response_bytes': 1809090,
 'httpcompression/response_count': 90,
 'item_scraped_count': 885,
 'items_per_minute': None,
 'log_count/DEBUG': 987,
 'log_count/INFO': 9,
 'request_depth_max': 88,
 'response_received_count': 90,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 89,
 'scheduler/dequeued/memory': 89,
 'scheduler/enqueued': 89,
 'scheduler/enqueued/memory': 89,
 'start_time': datetime.datetime(2025, 9, 2, 15, 21, 3, 591618, tzinfo=datetime.timezone.utc)}
```