### PR TITLE
[Macys] Fix Spider

### DIFF
--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -17,6 +17,7 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
     ]
     wanted_types = ["Store"]
     user_agent = BROWSER_DEFAULT
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None


### PR DESCRIPTION
**_Fixes : Flag macys as requires proxy to fix spider_**

```python
{"atp/brand/Macy's": 443,
 'atp/brand_wikidata/Q629269': 443,
 'atp/category/shop/department_store': 443,
 'atp/country/GU': 1,
 'atp/country/PR': 2,
 'atp/country/US': 440,
 'atp/field/branch/missing': 443,
 'atp/field/country/from_reverse_geocoding': 443,
 'atp/field/email/missing': 442,
 'atp/field/image/dropped': 443,
 'atp/field/image/missing': 443,
 'atp/field/operator/missing': 443,
 'atp/field/operator_wikidata/missing': 443,
 'atp/field/twitter/missing': 443,
 'atp/item_scraped_host_count/www.macys.com': 443,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 443,
 'downloader/exception_count': 4,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 4,
 'downloader/request_bytes': 2311721,
 'downloader/request_count': 876,
 'downloader/request_method_count/GET': 876,
 'downloader/response_bytes': 33911401,
 'downloader/response_count': 876,
 'downloader/response_status_count/200': 875,
 'downloader/response_status_count/302': 1,
 'dupefilter/filtered': 384,
 'elapsed_time_seconds': 1084.177497,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 3, 5, 36, 14, 485300, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 135751016,
 'httpcompression/response_count': 874,
 'item_scraped_count': 443,
 'items_per_minute': None,
 'log_count/DEBUG': 1335,
 'log_count/INFO': 27,
 'request_depth_max': 3,
 'response_received_count': 875,
 'responses_per_minute': None,
 'robotstxt/forbidden': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 878,
 'scheduler/dequeued/memory': 878,
 'scheduler/enqueued': 878,
 'scheduler/enqueued/memory': 878,
 'start_time': datetime.datetime(2025, 9, 3, 5, 18, 10, 307803, tzinfo=datetime.timezone.utc)}

```