### PR TITLE
[Banana Tree GB] Fix Spider

### DIFF
--- a/locations/spiders/banana_tree_gb.py
+++ b/locations/spiders/banana_tree_gb.py
@@ -1,15 +1,30 @@
-from typing import Iterable
+from typing import Any
 
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.google_url import extract_google_position
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.spiders.frankie_and_bennys_gb import FrankieAndBennysGBSpider
 
 
-class BananaTreeGBSpider(FrankieAndBennysGBSpider):
+class BananaTreeGBSpider(SitemapSpider):
     name = "banana_tree_gb"
     item_attributes = {"brand": "Banana Tree", "brand_wikidata": "Q123013837"}
-    brand_key = "banana"
+    sitemap_urls = ["https://bananatree.co.uk/sitemap.xml"]
+    sitemap_rules = [("/restaurants/", "parse")]
 
-    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        item["website"] = "https://bananatree.co.uk/restaurants/{}/".format(location["slug"])
-
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["branch"] = response.xpath('//*[@class="about-contact-info"]/h1/text()').get()
+        item["addr_full"] = response.xpath('//*[@class="address"]/text()').get()
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        item["ref"] = item["website"] = response.url
+        extract_google_position(item, response)
+        oh = OpeningHours()
+        for day_time in response.xpath('//*[@class="opening-hours-day"]'):
+            day = day_time.xpath(".//span").xpath("normalize-space()").get()
+            open_time, close_time = day_time.xpath(".//span[2]").xpath("normalize-space()").get().split(" - ")
+            oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        item["opening_hours"] = oh
         yield item


### PR DESCRIPTION
**_Fixes : updated code to use sitemap to fix spider_**

```python
{'atp/brand/Banana Tree': 22,
 'atp/brand_wikidata/Q123013837': 22,
 'atp/category/amenity/restaurant': 22,
 'atp/cdn/cloudflare/response_count': 24,
 'atp/cdn/cloudflare/response_status_count/200': 24,
 'atp/clean_strings/addr_full': 22,
 'atp/clean_strings/branch': 22,
 'atp/country/GB': 22,
 'atp/field/city/missing': 22,
 'atp/field/country/from_spider_name': 22,
 'atp/field/email/missing': 22,
 'atp/field/image/missing': 22,
 'atp/field/operator/missing': 22,
 'atp/field/operator_wikidata/missing': 22,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 22,
 'atp/field/street_address/missing': 22,
 'atp/field/twitter/missing': 22,
 'atp/item_scraped_host_count/bananatree.co.uk': 22,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 22,
 'downloader/request_bytes': 13268,
 'downloader/request_count': 24,
 'downloader/request_method_count/GET': 24,
 'downloader/response_bytes': 2232331,
 'downloader/response_count': 24,
 'downloader/response_status_count/200': 24,
 'elapsed_time_seconds': 30.296638,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 3, 8, 6, 40, 170740, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 16593342,
 'httpcompression/response_count': 24,
 'item_scraped_count': 22,
 'items_per_minute': None,
 'log_count/DEBUG': 57,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 24,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 23,
 'scheduler/dequeued/memory': 23,
 'scheduler/enqueued': 23,
 'scheduler/enqueued/memory': 23,
 'start_time': datetime.datetime(2025, 9, 3, 8, 6, 9, 874102, tzinfo=datetime.timezone.utc)}
```