### PR TITLE
[Bennet IT] Fix Spider

### DIFF
--- a/locations/spiders/bennet_it.py
+++ b/locations/spiders/bennet_it.py
@@ -13,6 +13,7 @@ class BennetITSpider(JSONBlobSpider):
     item_attributes = {"brand": "Bennet", "brand_wikidata": "Q3638281"}
     start_urls = ["https://www.bennet.com/storefinder/nearestList?latitude=0&longitude=0&numberOfPos=1000"]
     custom_settings = {"USER_AGENT": FIREFOX_LATEST}
+    requires_proxy = True
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))


### PR DESCRIPTION
**_Fixes : Flag spider as requires proxy to fix spider_**

```python
{'atp/brand/Bennet': 52,
 'atp/brand_wikidata/Q3638281': 52,
 'atp/category/shop/supermarket': 52,
 'atp/clean_strings/branch': 1,
 'atp/country/IT': 52,
 'atp/field/country/from_spider_name': 52,
 'atp/field/image/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/field/street_address/missing': 52,
 'atp/field/twitter/missing': 52,
 'atp/item_scraped_host_count/www.bennet.com': 52,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 52,
 'downloader/request_bytes': 1023,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28842,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.265532,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 3, 10, 14, 29, 201494, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 788155,
 'httpcompression/response_count': 2,
 'item_scraped_count': 52,
 'items_per_minute': None,
 'log_count/DEBUG': 66,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 3, 10, 14, 24, 935962, tzinfo=datetime.timezone.utc)}
```