### PR TITLE
[Frankie And Bennys GB] [Cafe Rouge GB] Fix spiders

### DIFF
--- a/locations/spiders/cafe_rouge_gb.py
+++ b/locations/spiders/cafe_rouge_gb.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from scrapy.http import Response
+
 from locations.items import Feature
 from locations.spiders.frankie_and_bennys_gb import FrankieAndBennysGBSpider
 
@@ -7,9 +9,8 @@ from locations.spiders.frankie_and_bennys_gb import FrankieAndBennysGBSpider
 class CafeRougeGBSpider(FrankieAndBennysGBSpider):
     name = "cafe_rouge_gb"
     item_attributes = {"brand": "Café Rouge", "brand_wikidata": "Q5017261"}
-    brand_key = "rouge"
+    sitemap_urls = ["https://www.caferouge.com/sitemap.xml"]
 
-    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        item["website"] = "https://www.caferouge.com/restaurants/{}/{}/".format(location["city"], location["slug"])
-
+    def parse_item(self, item: Feature, response: Response, **kwargs) -> Iterable[Feature]:
+        item["branch"] = response.xpath('//*[@class="restaurant-title"]/text()').get("").removeprefix("Center Parcs ")
         yield item

--- a/locations/spiders/frankie_and_bennys_gb.py
+++ b/locations/spiders/frankie_and_bennys_gb.py
@@ -1,47 +1,34 @@
 from typing import Any, Iterable
-from urllib.parse import urljoin
 
-from scrapy.http import JsonRequest, Response
-from scrapy.spiders import Spider
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-from locations.hours import DAYS_FULL, OpeningHours
+from locations.google_url import extract_google_position
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.spiders.outdoor_supply_hardware_us import decode_email
 
 
-class FrankieAndBennysGBSpider(Spider):
+class FrankieAndBennysGBSpider(SitemapSpider):
     name = "frankie_and_bennys_gb"
     item_attributes = {"brand": "Frankie & Benny's", "brand_wikidata": "Q5490892"}
-    api = "https://netapi.bigtablegroup.com/api/v1/content/search-restaurants/"
-    brand_key = "frankies"
-
-    def start_requests(self) -> Iterable[JsonRequest]:
-        yield JsonRequest(url=self.api, headers={"brandkey": self.brand_key})
+    sitemap_urls = ["https://www.frankieandbennys.com/sitemap.xml"]
+    sitemap_rules = [(r"/restaurants/[-\w]+", "parse")]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["restaurants"]:
-            item = Feature()
-            item["ref"] = location["storeId"]
-            item["lat"] = location["addressLocation"]["lat"]
-            item["lon"] = location["addressLocation"]["lon"]
-            item["branch"] = location["title"]
-            item["street_address"] = merge_address_lines([location["addressLine1"], location["addressLine2"]])
-            item["city"] = location["addressCity"]
-            item["postcode"] = location["postcode"]
-            item["phone"] = location["phoneNumber"]
-            item["email"] = location["email"]
+        item = Feature()
+        extract_google_position(item, response)
+        item["ref"] = item["website"] = response.url
+        item["addr_full"] = response.xpath('//*[@class="address"]/text()').get()
+        item["phone"] = response.xpath('//*[contains(@href, "tel:")]/@href').get()
+        item["email"] = decode_email(response.xpath("//@data-cfemail").get())
+        item["opening_hours"] = OpeningHours()
+        for rule in response.xpath('//*[@class="opening-hours-day"]'):
+            if day := rule.xpath("./span[1]/text()").get():
+                item["opening_hours"].add_ranges_from_string(f"{day}: {rule.xpath('./span[2]/text()').get()}")
 
-            if location.get("hours"):
-                item["opening_hours"] = OpeningHours()
-                for day in map(str.lower, DAYS_FULL):
-                    item["opening_hours"].add_range(
-                        day,
-                        location["hours"]["{}Open".format(day)].strip(),
-                        location["hours"]["{}Close".format(day)].strip(),
-                    )
+        yield from self.parse_item(item, response) or []
 
-            yield from self.parse_item(item, location) or []
-
-    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        item["website"] = urljoin("https://www.frankieandbennys.com/restaurants/", location["slug"])
+    def parse_item(self, item: Feature, response: Response, **kwargs) -> Iterable[Feature]:
+        item["branch"] = response.xpath('//*[@class="d-block gamay-extra-bold"]/text()').get()
         yield item

--- a/locations/spiders/frankie_and_bennys_gb.py
+++ b/locations/spiders/frankie_and_bennys_gb.py
@@ -21,7 +21,7 @@ class FrankieAndBennysGBSpider(SitemapSpider):
         item["ref"] = item["website"] = response.url
         item["addr_full"] = response.xpath('//*[@class="address"]/text()').get()
         item["phone"] = response.xpath('//*[contains(@href, "tel:")]/@href').get()
-        item["email"] = decode_email(response.xpath("//@data-cfemail").get())
+        item["email"] = decode_email(response.xpath("//@data-cfemail").get(""))
         item["opening_hours"] = OpeningHours()
         for rule in response.xpath('//*[@class="opening-hours-day"]'):
             if day := rule.xpath("./span[1]/text()").get():


### PR DESCRIPTION
`API` requires `access_token` to fix bad request.  Couldn't find a feasible way to generate `access_token` dynamically,  hence switched to `sitemap` to fix the spider.

**Frankie And Bennys GB**
```
{"atp/brand/Frankie & Benny's": 48,
 'atp/brand_wikidata/Q5490892': 48,
 'atp/category/amenity/restaurant': 48,
 'atp/cdn/cloudflare/response_count': 50,
 'atp/cdn/cloudflare/response_status_count/200': 50,
 'atp/country/GB': 48,
 'atp/field/city/missing': 48,
 'atp/field/country/from_spider_name': 48,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 48,
 'atp/field/operator/missing': 48,
 'atp/field/operator_wikidata/missing': 48,
 'atp/field/state/missing': 48,
 'atp/field/street_address/missing': 48,
 'atp/field/twitter/missing': 48,
 'atp/item_scraped_host_count/www.frankieandbennys.com': 48,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 48,
 'downloader/request_bytes': 28986,
 'downloader/request_count': 50,
 'downloader/request_method_count/GET': 50,
 'downloader/response_bytes': 6154691,
 'downloader/response_count': 50,
 'downloader/response_status_count/200': 50,
 'elapsed_time_seconds': 60.24075,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 4, 9, 12, 9, 691419, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 41749840,
 'httpcompression/response_count': 50,
 'item_scraped_count': 48,
 'items_per_minute': None,
 'log_count/DEBUG': 109,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 50,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 49,
 'scheduler/dequeued/memory': 49,
 'scheduler/enqueued': 49,
 'scheduler/enqueued/memory': 49,
 'start_time': datetime.datetime(2025, 9, 4, 9, 11, 9, 450669, tzinfo=datetime.timezone.utc)}
```
**Cafe Rouge GB**
```
{'atp/brand/Café Rouge': 7,
 'atp/brand_wikidata/Q5017261': 7,
 'atp/category/amenity/restaurant': 7,
 'atp/cdn/cloudflare/response_count': 9,
 'atp/cdn/cloudflare/response_status_count/200': 9,
 'atp/clean_strings/addr_full': 5,
 'atp/clean_strings/branch': 1,
 'atp/country/GB': 7,
 'atp/field/city/missing': 7,
 'atp/field/country/from_spider_name': 7,
 'atp/field/image/missing': 7,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 7,
 'atp/field/operator_wikidata/missing': 7,
 'atp/field/state/missing': 7,
 'atp/field/street_address/missing': 7,
 'atp/field/twitter/missing': 7,
 'atp/item_scraped_host_count/www.caferouge.com': 7,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 7,
 'downloader/request_bytes': 3508,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 791033,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 10.554289,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 4, 9, 2, 6, 500211, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5241510,
 'httpcompression/response_count': 9,
 'item_scraped_count': 7,
 'items_per_minute': None,
 'log_count/DEBUG': 27,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 9,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2025, 9, 4, 9, 1, 55, 945922, tzinfo=datetime.timezone.utc)}
```