### PR TITLE
[Lacoste] Fix Spider

### DIFF
--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -13,6 +13,7 @@ class LacosteSpider(JSONBlobSpider):
     item_attributes = {"brand": "Lacoste", "brand_wikidata": "Q309031"}
     start_urls = ["https://www.lacoste.com/us/stores?country=&city=&json=true"]
     user_agent = FIREFOX_LATEST
+    requires_proxy = True
 
     def extract_json(self, response: Response) -> list:
         return response.json()["stores"]


### PR DESCRIPTION
**_Fixes : Flag lacoste as requires proxy to fix spider_**

```python
{'atp/brand/Lacoste': 3395,
 'atp/brand_wikidata/Q309031': 3395,
 'atp/category/shop/clothes': 3395,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/city': 398,
 'atp/clean_strings/name': 24,
 'atp/clean_strings/phone': 9,
 'atp/clean_strings/postcode': 88,
 'atp/clean_strings/street_address': 1346,
 'atp/closed_check': 7,
 'atp/country/AD': 1,
 'atp/country/AE': 21,
 'atp/country/AF': 2,
 'atp/country/AM': 4,
 'atp/country/AR': 85,
 'atp/country/AT': 9,
 'atp/country/AU': 25,
 'atp/country/AZ': 2,
 'atp/country/BA': 2,
 'atp/country/BE': 10,
 'atp/country/BG': 2,
 'atp/country/BH': 2,
 'atp/country/BR': 74,
 'atp/country/BY': 1,
 'atp/country/CA': 37,
 'atp/country/CH': 40,
 'atp/country/CI': 1,
 'atp/country/CL': 9,
 'atp/country/CN': 462,
 'atp/country/CO': 18,
 'atp/country/CR': 1,
 'atp/country/CW': 2,
 'atp/country/CY': 10,
 'atp/country/CZ': 10,
 'atp/country/DE': 58,
 'atp/country/DK': 4,
 'atp/country/DO': 1,
 'atp/country/DZ': 5,
 'atp/country/EC': 2,
 'atp/country/EE': 2,
 'atp/country/EG': 5,
 'atp/country/ES': 118,
 'atp/country/FR': 516,
 'atp/country/GB': 36,
 'atp/country/GE': 4,
 'atp/country/GR': 39,
 'atp/country/GT': 2,
 'atp/country/HN': 3,
 'atp/country/HR': 6,
 'atp/country/HU': 1,
 'atp/country/ID': 50,
 'atp/country/IE': 3,
 'atp/country/IL': 3,
 'atp/country/IN': 55,
 'atp/country/IQ': 5,
 'atp/country/IT': 160,
 'atp/country/JO': 1,
 'atp/country/JP': 120,
 'atp/country/KE': 1,
 'atp/country/KG': 1,
 'atp/country/KH': 6,
 'atp/country/KR': 337,
 'atp/country/KW': 4,
 'atp/country/KZ': 6,
 'atp/country/LA': 2,
 'atp/country/LB': 6,
 'atp/country/LT': 1,
 'atp/country/LU': 2,
 'atp/country/LV': 1,
 'atp/country/MA': 24,
 'atp/country/MD': 2,
 'atp/country/ME': 1,
 'atp/country/MM': 3,
 'atp/country/MN': 1,
 'atp/country/MT': 1,
 'atp/country/MU': 2,
 'atp/country/MV': 1,
 'atp/country/MX': 121,
 'atp/country/MY': 24,
 'atp/country/MZ': 1,
 'atp/country/NA': 1,
 'atp/country/NG': 4,
 'atp/country/NI': 1,
 'atp/country/NL': 12,
 'atp/country/NO': 2,
 'atp/country/NZ': 1,
 'atp/country/OM': 6,
 'atp/country/PA': 7,
 'atp/country/PE': 2,
 'atp/country/PH': 55,
 'atp/country/PL': 19,
 'atp/country/PR': 4,
 'atp/country/PT': 29,
 'atp/country/QA': 2,
 'atp/country/RO': 7,
 'atp/country/RS': 6,
 'atp/country/RU': 16,
 'atp/country/SA': 10,
 'atp/country/SE': 6,
 'atp/country/SG': 7,
 'atp/country/SK': 2,
 'atp/country/SR': 1,
 'atp/country/SV': 2,
 'atp/country/TH': 204,
 'atp/country/TM': 1,
 'atp/country/TN': 4,
 'atp/country/TR': 87,
 'atp/country/TW': 36,
 'atp/country/UA': 15,
 'atp/country/US': 222,
 'atp/country/UY': 2,
 'atp/country/UZ': 4,
 'atp/country/VE': 8,
 'atp/country/VN': 19,
 'atp/country/XK': 1,
 'atp/country/YE': 1,
 'atp/country/ZA': 12,
 'atp/field/branch/missing': 3395,
 'atp/field/country/from_reverse_geocoding': 752,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 2166,
 'atp/field/image/missing': 3395,
 'atp/field/lat/missing': 16,
 'atp/field/lon/missing': 16,
 'atp/field/opening_hours/missing': 3395,
 'atp/field/operator/missing': 3395,
 'atp/field/operator_wikidata/missing': 3395,
 'atp/field/phone/invalid': 268,
 'atp/field/phone/missing': 410,
 'atp/field/postcode/missing': 339,
 'atp/field/state/from_reverse_geocoding': 37,
 'atp/field/state/missing': 2607,
 'atp/field/twitter/missing': 3395,
 'atp/geometry/null_island': 5,
 'atp/item_scraped_host_count/www.lacoste.com': 3395,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3395,
 'downloader/request_bytes': 1000,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 393843,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 17.343584,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 4, 9, 17, 9, 737699, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2060915,
 'httpcompression/response_count': 2,
 'item_scraped_count': 3395,
 'items_per_minute': None,
 'log_count/DEBUG': 3409,
 'log_count/INFO': 9,
 'log_count/WARNING': 7,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 4, 9, 16, 52, 394115, tzinfo=datetime.timezone.utc)}
```