### PR TITLE
[Las Iguanas GB] Fix Spider

### DIFF
--- a/locations/spiders/las_iguanas_gb.py
+++ b/locations/spiders/las_iguanas_gb.py
@@ -1,14 +1,23 @@
-from typing import Iterable
+from scrapy.spiders import SitemapSpider
 
+from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.spiders.frankie_and_bennys_gb import FrankieAndBennysGBSpider
 
 
-class LasIguanasGBSpider(FrankieAndBennysGBSpider):
+class LasIguanasGBSpider(SitemapSpider):
     name = "las_iguanas_gb"
     item_attributes = {"brand": "Las Iguanas", "brand_wikidata": "Q19875012"}
-    brand_key = "iguanas"
+    sitemap_urls = ["https://www.iguanas.co.uk/sitemap.xml"]
+    sitemap_rules = [(r"/restaurants/[^/]+/", "parse")]
 
-    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        item["website"] = "https://www.iguanas.co.uk/restaurants/{}/".format(location["slug"])
+    def parse(self, response, **kwargs):
+        item = Feature()
+        item["branch"] = response.xpath("//h1/span/text()").get()
+        item["addr_full"] = (
+            response.xpath('//*[@class="contact-info"]//*[@class="my-4"]//p').xpath("normalize-space()").get()
+        )
+        item["email"] = response.xpath('//*[contains(@href,"mailto:")]/text()').get()
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/span/text()').get()
+        item["ref"] = item["website"] = response.url
+        extract_google_position(item, response)
         yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Las Iguanas': 51,
 'atp/brand_wikidata/Q19875012': 51,
 'atp/category/amenity/restaurant': 51,
 'atp/cdn/cloudflare/response_count': 53,
 'atp/cdn/cloudflare/response_status_count/200': 53,
 'atp/clean_strings/phone': 1,
 'atp/country/GB': 51,
 'atp/field/city/missing': 51,
 'atp/field/country/from_spider_name': 51,
 'atp/field/email/missing': 51,
 'atp/field/image/missing': 51,
 'atp/field/opening_hours/missing': 51,
 'atp/field/operator/missing': 51,
 'atp/field/operator_wikidata/missing': 51,
 'atp/field/state/missing': 51,
 'atp/field/street_address/missing': 51,
 'atp/field/twitter/missing': 51,
 'atp/item_scraped_host_count/www.iguanas.co.uk': 51,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 51,
 'downloader/request_bytes': 21044,
 'downloader/request_count': 53,
 'downloader/request_method_count/GET': 53,
 'downloader/response_bytes': 4959782,
 'downloader/response_count': 53,
 'downloader/response_status_count/200': 53,
 'elapsed_time_seconds': 65.946573,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 4, 11, 15, 22, 74675, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 53,
 'httpcache/miss': 53,
 'httpcache/store': 53,
 'httpcompression/response_bytes': 35214841,
 'httpcompression/response_count': 53,
 'item_scraped_count': 51,
 'items_per_minute': None,
 'log_count/DEBUG': 116,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 53,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 52,
 'scheduler/dequeued/memory': 52,
 'scheduler/enqueued': 52,
 'scheduler/enqueued/memory': 52,
 'start_time': datetime.datetime(2025, 9, 4, 11, 14, 16, 128102, tzinfo=datetime.timezone.utc)}
```