### PR TITLE
[Macys Backstage] Fix Spider

### DIFF
--- a/locations/spiders/macys_backstage.py
+++ b/locations/spiders/macys_backstage.py
@@ -15,7 +15,8 @@ class MacysBackstageSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/backstage/\w\w/[^/]+/[^/]+\_(\d+b).html$"), "parse"),
     ]
     wanted_types = ["store"]
-    user_agent = BROWSER_DEFAULT
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None


### PR DESCRIPTION
**_Fixes : Flag macys_backstage as requires proxy to fix spider_**

```python
{"atp/brand/Macy's Backstage": 299,
 'atp/brand_wikidata/Q122914589': 299,
 'atp/category/shop/department_store': 299,
 'atp/country/US': 299,
 'atp/field/branch/missing': 299,
 'atp/field/country/from_reverse_geocoding': 299,
 'atp/field/email/missing': 299,
 'atp/field/image/dropped': 299,
 'atp/field/image/missing': 299,
 'atp/field/operator/missing': 299,
 'atp/field/operator_wikidata/missing': 299,
 'atp/item_scraped_host_count/www.macys.com': 299,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 299,
 'downloader/request_bytes': 1660420,
 'downloader/request_count': 644,
 'downloader/request_method_count/GET': 644,
 'downloader/response_bytes': 30573875,
 'downloader/response_count': 644,
 'downloader/response_status_count/200': 623,
 'downloader/response_status_count/302': 21,
 'dupefilter/filtered': 282,
 'elapsed_time_seconds': 763.655654,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 4, 11, 39, 6, 338013, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 120559553,
 'httpcompression/response_count': 623,
 'item_scraped_count': 299,
 'items_per_minute': None,
 'log_count/DEBUG': 956,
 'log_count/INFO': 21,
 'request_depth_max': 3,
 'response_received_count': 623,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'scheduler/dequeued': 623,
 'scheduler/dequeued/memory': 623,
 'scheduler/enqueued': 623,
 'scheduler/enqueued/memory': 623,
 'start_time': datetime.datetime(2025, 9, 4, 11, 26, 22, 682359, tzinfo=datetime.timezone.utc)}
```