### PR TITLE
[Shopko] Fix Spider

### DIFF
--- a/locations/spiders/shopko.py
+++ b/locations/spiders/shopko.py
@@ -1,22 +1,32 @@
-import re
+from typing import Iterable
 
 import scrapy
+from scrapy import Request
+from scrapy.http import JsonRequest
 
-from locations.linked_data_parser import LinkedDataParser
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
 
 
-class ShopkoSpider(scrapy.spiders.SitemapSpider):
+class ShopkoSpider(scrapy.Spider):
     name = "shopko"
     item_attributes = {"brand": "Shopko Optical", "brand_wikidata": "Q109228833"}
-    allowed_domains = ["shopko.com"]
-    sitemap_urls = [
-        "https://www.shopko.com/robots.txt",
-    ]
-    sitemap_rules = [
-        (r"/store-\d", "parse"),
-    ]
+
+    def start_requests(self) -> Iterable[Request]:
+        yield JsonRequest(
+            url="https://api.scheduler.fielmannusa.com/api/FindNearestRetailStores",
+            data={"latitude": 41.8780025, "longitude": -93.097702},
+            method="POST",
+        )
 
     def parse(self, response):
-        item = LinkedDataParser.parse(response, "Optometric")
-        item["ref"] = re.search(r"/store-(\d+)", response.url)[1]
-        yield item
+        for store in response.json():
+            item = DictParser.parse(store)
+            item["branch"] = item.pop("name")
+            oh = OpeningHours()
+            for day, time in store["openingHours"].items():
+                day = DAYS_FULL[int(day)]
+                open_time, close_time = time.split(" - ")
+                oh.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M %p")
+            item["opening_hours"] = oh
+            yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Shopko Optical': 149,
 'atp/brand_wikidata/Q109228833': 149,
 'atp/category/shop/optician': 149,
 'atp/country/US': 149,
 'atp/field/city/missing': 149,
 'atp/field/country/from_reverse_geocoding': 149,
 'atp/field/email/missing': 149,
 'atp/field/image/missing': 149,
 'atp/field/operator/missing': 149,
 'atp/field/operator_wikidata/missing': 149,
 'atp/field/postcode/missing': 149,
 'atp/field/street_address/missing': 149,
 'atp/field/twitter/missing': 149,
 'atp/field/website/missing': 149,
 'atp/item_scraped_host_count/api.scheduler.fielmannusa.com': 149,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 149,
 'downloader/request_bytes': 776,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 71505,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.453039,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 5, 10, 11, 15, 679201, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2,
 'item_scraped_count': 149,
 'items_per_minute': None,
 'log_count/DEBUG': 164,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 5, 10, 11, 13, 226162, tzinfo=datetime.timezone.utc)}
```