### PR TITLE
[Rebel Architette] Fix Spider

### DIFF
--- a/locations/spiders/rebel_architette.py
+++ b/locations/spiders/rebel_architette.py
@@ -9,6 +9,8 @@ class RebelArchitetteSpider(JSONBlobSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     start_urls = ["https://www.rebelarchitette.it/"]
     no_refs = True
+    download_timeout = 200
+    requires_proxy = True
 
     def extract_json(self, response):
         cdata = response.xpath('//script[contains(text(), "var eltdMultipleMapVars = ")]/text()').get()


### PR DESCRIPTION
**_Fixes : Flag rebel_architette as requires proxy to fix spider_**

```python
{'atp/category/office/architect': 1129,
 'atp/clean_strings/name': 59,
 'atp/country/AO': 2,
 'atp/country/AR': 11,
 'atp/country/AT': 18,
 'atp/country/AU': 30,
 'atp/country/BD': 1,
 'atp/country/BE': 8,
 'atp/country/BG': 1,
 'atp/country/BR': 21,
 'atp/country/CA': 32,
 'atp/country/CG': 1,
 'atp/country/CH': 20,
 'atp/country/CI': 1,
 'atp/country/CL': 4,
 'atp/country/CM': 1,
 'atp/country/CN': 39,
 'atp/country/CO': 1,
 'atp/country/CR': 1,
 'atp/country/CV': 2,
 'atp/country/CY': 2,
 'atp/country/CZ': 10,
 'atp/country/DE': 21,
 'atp/country/DK': 9,
 'atp/country/DO': 1,
 'atp/country/EC': 1,
 'atp/country/EE': 1,
 'atp/country/ES': 77,
 'atp/country/ET': 1,
 'atp/country/FI': 6,
 'atp/country/FR': 96,
 'atp/country/GB': 78,
 'atp/country/GH': 1,
 'atp/country/GR': 8,
 'atp/country/GT': 8,
 'atp/country/HK': 7,
 'atp/country/HR': 2,
 'atp/country/IE': 6,
 'atp/country/IL': 4,
 'atp/country/IN': 15,
 'atp/country/IR': 1,
 'atp/country/IS': 3,
 'atp/country/IT': 168,
 'atp/country/JO': 1,
 'atp/country/JP': 11,
 'atp/country/KE': 1,
 'atp/country/KR': 30,
 'atp/country/LB': 2,
 'atp/country/LU': 1,
 'atp/country/MA': 2,
 'atp/country/ME': 1,
 'atp/country/MK': 1,
 'atp/country/MX': 37,
 'atp/country/NA': 1,
 'atp/country/NE': 1,
 'atp/country/NG': 2,
 'atp/country/NL': 11,
 'atp/country/NO': 8,
 'atp/country/NZ': 32,
 'atp/country/PE': 5,
 'atp/country/PL': 2,
 'atp/country/PR': 1,
 'atp/country/PT': 42,
 'atp/country/PY': 1,
 'atp/country/RO': 1,
 'atp/country/RS': 5,
 'atp/country/RU': 1,
 'atp/country/SE': 18,
 'atp/country/SG': 1,
 'atp/country/SI': 6,
 'atp/country/SK': 1,
 'atp/country/SV': 1,
 'atp/country/TD': 1,
 'atp/country/TH': 3,
 'atp/country/TR': 2,
 'atp/country/TW': 2,
 'atp/country/UG': 1,
 'atp/country/US': 153,
 'atp/country/VA': 6,
 'atp/country/VN': 2,
 'atp/country/ZA': 10,
 'atp/field/branch/missing': 1129,
 'atp/field/brand/missing': 1129,
 'atp/field/brand_wikidata/missing': 1129,
 'atp/field/city/missing': 1129,
 'atp/field/country/from_reverse_geocoding': 1127,
 'atp/field/country/missing': 2,
 'atp/field/email/missing': 1129,
 'atp/field/image/missing': 1129,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/name/missing': 10,
 'atp/field/opening_hours/missing': 1129,
 'atp/field/operator/missing': 1129,
 'atp/field/operator_wikidata/missing': 1129,
 'atp/field/phone/missing': 1129,
 'atp/field/postcode/missing': 1048,
 'atp/field/state/missing': 11,
 'atp/field/street_address/missing': 1129,
 'atp/field/twitter/missing': 1129,
 'atp/field/website/missing': 1129,
 'atp/item_scraped_host_count/www.rebelarchitette.it': 1129,
 'atp/lineage': 'S_?',
 'downloader/request_bytes': 330,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 126459,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 14.886874,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 8, 5, 19, 38, 85907, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 564643,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1129,
 'items_per_minute': None,
 'log_count/DEBUG': 1131,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 8, 5, 19, 23, 199033, tzinfo=datetime.timezone.utc)}
```