### PR TITLE
[Gulf PR US] Fix spider

### DIFF
--- a/locations/spiders/gulf_pr_us.py
+++ b/locations/spiders/gulf_pr_us.py
@@ -12,7 +12,7 @@ from locations.items import Feature
 class GulfPRUSSpider(Spider):
     name = "gulf_pr_us"
     item_attributes = {"brand": "Gulf", "brand_wikidata": "Q5617505"}
-    allowed_domains = ["www.gulfoil.com"]
+    allowed_domains = ["www.gulfinc.com"]
 
     @staticmethod
     def make_request(page: int) -> FormRequest:
@@ -25,7 +25,7 @@ class GulfPRUSSpider(Spider):
             "view_display_id": "block_2",
         }
         return FormRequest(
-            url="https://www.gulfoil.com/views/ajax?_wrapper_format=drupal_ajax",
+            url="https://www.gulfinc.com/views/ajax?_wrapper_format=drupal_ajax",
             formdata=formdata,
             method="POST",
             meta={"page": page},
@@ -46,7 +46,7 @@ class GulfPRUSSpider(Spider):
             return
 
         for result in results.xpath('//section[@role="article"]'):
-            url = "https://www.gulfoil.com" + result.xpath("./@about").get()
+            url = "https://www.gulfinc.com" + result.xpath("./@about").get()
             meta = {
                 "atm": result.xpath('.//li[contains(text(), "ATM")]/text()').get() is not None,
                 "convenience_store": result.xpath('.//li[contains(text(), "Convenience Store")]/text()').get()


### PR DESCRIPTION
```python
{'atp/brand/Gulf': 1102,
 'atp/brand_wikidata/Q5617505': 1102,
 'atp/category/amenity/fuel': 1102,
 'atp/clean_strings/street': 149,
 'atp/country/PR': 251,
 'atp/country/US': 851,
 'atp/field/branch/missing': 1102,
 'atp/field/email/missing': 1102,
 'atp/field/image/missing': 1102,
 'atp/field/opening_hours/missing': 1102,
 'atp/field/operator/missing': 1102,
 'atp/field/operator_wikidata/missing': 1102,
 'atp/field/phone/missing': 253,
 'atp/field/state/missing': 251,
 'atp/field/street_address/missing': 1102,
 'atp/field/twitter/missing': 1102,
 'atp/item_scraped_host_count/www.gulfinc.com': 1102,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1102,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 506496,
 'downloader/request_count': 1178,
 'downloader/request_method_count/GET': 1103,
 'downloader/request_method_count/POST': 75,
 'downloader/response_bytes': 5269174,
 'downloader/response_count': 1177,
 'downloader/response_status_count/200': 1177,
 'elapsed_time_seconds': 1463.601019,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 9, 7, 42, 44, 561540, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24610295,
 'httpcompression/response_count': 1177,
 'item_scraped_count': 1102,
 'items_per_minute': None,
 'log_count/DEBUG': 2291,
 'log_count/INFO': 33,
 'request_depth_max': 74,
 'response_received_count': 1177,
 'responses_per_minute': None,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1177,
 'scheduler/dequeued/memory': 1177,
 'scheduler/enqueued': 1177,
 'scheduler/enqueued/memory': 1177,
 'start_time': datetime.datetime(2025, 9, 9, 7, 18, 20, 960521, tzinfo=datetime.timezone.utc)}
```