### PR TITLE
[Cricket Wireless] Fix Spider

### DIFF
--- a/locations/spiders/cricket_wireless.py
+++ b/locations/spiders/cricket_wireless.py
@@ -9,19 +9,11 @@ class CricketWirelessSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "Cricket Wireless", "brand_wikidata": "Q5184987"}
     start_urls = ["https://www.cricketwireless.com/stores/index.html"]
     rules = [
+        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link orc-link standalone flex gap-1 w-fit")]')),
+        Rule(LinkExtractor(restrict_xpaths='//a[contains(@class, "Link orc-link standalone flex gap-1 w-fit")]')),
         Rule(
             LinkExtractor(
-                restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]'
-            )
-        ),
-        Rule(
-            LinkExtractor(
-                restrict_xpaths='//a[contains(@class, "Link text-base hover:underline a4-Link flex gap-1 w-fit")]'
-            )
-        ),
-        Rule(
-            LinkExtractor(
-                restrict_xpaths='//a[contains(@class, "Link flex items-center gap-1 w-fit text-brand-blue a4-Link")]',
+                restrict_xpaths='//a[contains(@class, "Link orc-link standalone flex items-center gap-1 w-fit")]',
                 deny_domains=["www.google.com"],
             ),
             callback="parse",


### PR DESCRIPTION
**_Fixes : updated rules to extract the web link_**

```python
{'atp/brand/Cricket Wireless': 3337,
 'atp/brand_wikidata/Q5184987': 3337,
 'atp/category/shop/mobile_phone': 3337,
 'atp/country/US': 3337,
 'atp/field/branch/missing': 3337,
 'atp/field/email/missing': 3337,
 'atp/field/opening_hours/missing': 22,
 'atp/field/operator/missing': 3337,
 'atp/field/operator_wikidata/missing': 3337,
 'atp/field/phone/missing': 21,
 'atp/item_scraped_host_count/www.cricketwireless.com': 3337,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3337,
 'downloader/exception_count': 31,
 'downloader/exception_type_count/twisted.internet.error.ConnectError': 24,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 7,
 'downloader/request_bytes': 13803251,
 'downloader/request_count': 12493,
 'downloader/request_method_count/GET': 12493,
 'downloader/response_bytes': 390413183,
 'downloader/response_count': 12462,
 'downloader/response_status_count/200': 9128,
 'downloader/response_status_count/302': 3334,
 'elapsed_time_seconds': 8243.23968,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 9, 8, 7, 38, 581392, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1580652031,
 'httpcompression/response_count': 9128,
 'item_scraped_count': 3337,
 'items_per_minute': None,
 'log_count/DEBUG': 15845,
 'log_count/INFO': 146,
 'request_depth_max': 3,
 'response_received_count': 9128,
 'responses_per_minute': None,
 'retry/count': 31,
 'retry/reason_count/twisted.internet.error.ConnectError': 24,
 'retry/reason_count/twisted.internet.error.TimeoutError': 7,
 'scheduler/dequeued': 12493,
 'scheduler/dequeued/memory': 12493,
 'scheduler/enqueued': 12493,
 'scheduler/enqueued/memory': 12493,
 'start_time': datetime.datetime(2025, 9, 9, 5, 50, 15, 341712, tzinfo=datetime.timezone.utc)}
```