### PR TITLE
[Icici Bank IN] Fix spider

### DIFF
--- a/locations/spiders/icici_bank_in.py
+++ b/locations/spiders/icici_bank_in.py
@@ -1,7 +1,9 @@
 import json
 import re
+from typing import Any
 
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -13,9 +15,9 @@ class IciciBankINSpider(Spider):
     name = "icici_bank_in"
     item_attributes = {"brand": "ICICI Bank", "brand_wikidata": "Q1653258"}
     start_urls = ["https://maps.icicibank.com/content/icicibank/in/en.microsite.json"]
-    user_agent = BROWSER_DEFAULT
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for branch in json.loads(response.text)["branch"]:
             item = DictParser.parse(branch)
             item["street_address"] = item.pop("addr_full")


### PR DESCRIPTION
It's just not running from `US` as well as from `IN`, facing `403`. Utilized  `user_agent` to avoid this blockage.

```
{'atp/brand/ICICI Bank': 17732,
 'atp/brand_wikidata/Q1653258': 17732,
 'atp/category/amenity/atm': 9411,
 'atp/category/amenity/bank': 8321,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/city': 164,
 'atp/clean_strings/lat': 40,
 'atp/clean_strings/lon': 39,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/ref': 3,
 'atp/clean_strings/state': 116,
 'atp/clean_strings/street_address': 675,
 'atp/country/IN': 17732,
 'atp/field/country/from_spider_name': 17732,
 'atp/field/email/missing': 17732,
 'atp/field/image/missing': 17732,
 'atp/field/lat/invalid': 5,
 'atp/field/lat/missing': 15,
 'atp/field/lon/invalid': 1,
 'atp/field/lon/missing': 15,
 'atp/field/name/missing': 9411,
 'atp/field/opening_hours/missing': 15249,
 'atp/field/operator/missing': 8321,
 'atp/field/operator_wikidata/missing': 8321,
 'atp/field/phone/missing': 17732,
 'atp/field/postcode/missing': 26,
 'atp/field/street_address/missing': 10,
 'atp/field/twitter/missing': 17732,
 'atp/item_scraped_host_count/maps.icicibank.com': 17732,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 17732,
 'atp/operator/ICICI Bank': 9411,
 'atp/operator_wikidata/Q1653258': 9411,
 'downloader/request_bytes': 564,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1940673,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 25.986549,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 9, 12, 54, 15, 443929, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17424687,
 'httpcompression/response_count': 2,
 'item_scraped_count': 17732,
 'items_per_minute': None,
 'log_count/DEBUG': 17985,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 9, 12, 53, 49, 457380, tzinfo=datetime.timezone.utc)}
```