### PR TITLE
[Vets4Pets GB] Trim requests

### DIFF
--- a/locations/spiders/kfc_gb.py
+++ b/locations/spiders/kfc_gb.py
@@ -7,7 +7,7 @@ from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.spiders.asda_gb import AsdaGBSpider
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
-from locations.spiders.vets4pets_gb import set_located_in
+from locations.spiders.tesco_gb import set_located_in
 from locations.user_agents import FIREFOX_LATEST
 
 
@@ -46,7 +46,7 @@ class KfcGBSpider(Spider):
             apply_yes_no(Extras.WIFI, item, "Free Wifi" in facilities)
 
             if "ASDA" in item["name"].upper():
-                set_located_in(item, AsdaGBSpider.item_attributes)
+                set_located_in(AsdaGBSpider.item_attributes, item)
 
             item["branch"] = item.pop("name")
 

--- a/locations/spiders/vets4pets_gb.py
+++ b/locations/spiders/vets4pets_gb.py
@@ -2,29 +2,24 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.google_url import url_to_coords
+from locations.google_url import extract_google_position
 from locations.items import Feature
 from locations.spiders.pets_at_home_gb import PetsAtHomeGBSpider
+from locations.spiders.tesco_gb import set_located_in
 from locations.structured_data_spider import StructuredDataSpider
-
-
-def extract_google_position(item, response):
-    for link in response.xpath("//iframe/@src").extract():
-        if "google.com" in link:
-            item["lat"], item["lon"] = url_to_coords(link)
-            return
-
-
-def set_located_in(item, location):
-    item["located_in"] = location["brand"]
-    item["located_in_wikidata"] = location["brand_wikidata"]
 
 
 class Vets4petsGBSpider(CrawlSpider, StructuredDataSpider):
     name = "vets4pets_gb"
     item_attributes = {"brand": "Vets4Pets", "brand_wikidata": "Q16960196"}
     start_urls = ["https://www.vets4pets.com/practices/"]
-    rules = [Rule(LinkExtractor(allow="/practices/"), callback="parse_sd", follow=True)]
+    rules = [
+        Rule(LinkExtractor(allow=r"/practices/\?page=\d+")),
+        Rule(
+            LinkExtractor(allow="/practices/", restrict_xpaths="//a[contains(@class, 'listingBlock')]"),
+            callback="parse_sd",
+        ),
+    ]
     allowed_domains = ["vets4pets.com"]
     drop_attributes = {"image"}
     wanted_types = ["VeterinaryCare"]
@@ -33,5 +28,5 @@ class Vets4petsGBSpider(CrawlSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         extract_google_position(item, response)
         if "petsathome" in item["street_address"].lower().replace(" ", ""):
-            set_located_in(item, PetsAtHomeGBSpider.item_attributes)
+            set_located_in(PetsAtHomeGBSpider.item_attributes, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Vets4Pets': 426,
 'atp/brand_wikidata/Q16960196': 426,
 'atp/category/amenity/veterinary': 426,
 'atp/cdn/cloudflare/response_count': 471,
 'atp/cdn/cloudflare/response_status_count/200': 471,
 'atp/clean_strings/postcode': 1,
 'atp/country/GB': 426,
 'atp/field/branch/missing': 426,
 'atp/field/city/missing': 8,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 426,
 'atp/field/opening_hours/missing': 84,
 'atp/field/operator/missing': 426,
 'atp/field/operator_wikidata/missing': 426,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 30,
 'atp/field/twitter/invalid': 426,
 'atp/item_scraped_host_count/www.vets4pets.com': 426,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 426,
 'downloader/request_bytes': 286664,
 'downloader/request_count': 471,
 'downloader/request_method_count/GET': 471,
 'downloader/response_bytes': 14915374,
 'downloader/response_count': 471,
 'downloader/response_status_count/200': 471,
 'dupefilter/filtered': 268,
 'elapsed_time_seconds': 562.007595,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 9, 14, 10, 33, 100509, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 458,
 'httpcache/hit': 13,
 'httpcache/miss': 458,
 'httpcache/store': 458,
 'httpcompression/response_bytes': 65263685,
 'httpcompression/response_count': 471,
 'item_scraped_count': 426,
 'items_per_minute': None,
 'log_count/DEBUG': 910,
 'log_count/INFO': 18,
 'log_count/WARNING': 5,
 'memusage/max': 483823616,
 'memusage/startup': 293175296,
 'request_depth_max': 16,
 'response_received_count': 471,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 470,
 'scheduler/dequeued/memory': 470,
 'scheduler/enqueued': 470,
 'scheduler/enqueued/memory': 470,
 'start_time': datetime.datetime(2025, 9, 9, 14, 1, 11, 92914, tzinfo=datetime.timezone.utc)}
```