### PR TITLE
[Liquor City ZA] Fix Spider

### DIFF
--- a/locations/spiders/liquor_city_za.py
+++ b/locations/spiders/liquor_city_za.py
@@ -1,28 +1,27 @@
 import scrapy
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
 class LiquorCityZASpider(scrapy.Spider):
     name = "liquor_city_za"
-    item_attributes = {
-        "brand": "Liquor City",
-        "brand_wikidata": "Q116620538",
-    }
+    item_attributes = {"brand": "Liquor City", "brand_wikidata": "Q116620538"}
     start_urls = [
-        "https://shop.liquorcity.co.za/api/marketplace/marketplace_get_city_storefronts_v3?domain_name=shop.liquorcity.co.za&post_to_get=1&marketplace_reference_id=01c838877c7b7c7d9f15b8f40d3d2980&marketplace_user_id=742314&latitude=-30.559482&longitude=22.937506&search_text=&filters=undefined&skip=0&limit=5000&self_pickup=1&source=0&dual_user_key=0&language=en"
+        "https://lets-trade-client-prod.letstrade.global/v2/client/branches?client_id=689053976a0872f147baef68"
     ]
 
     def parse(self, response):
-        for location in response.json()["data"]:
-
-            properties = {
-                "ref": location["storefront_user_id"],
-                "addr_full": location["address"],
-                "phone": location["phone"],
-                "email": location["email"],
-                "lat": location["latitude"],
-                "lon": location["longitude"],
-                "city": location["display_address"],
-            }
-            yield Feature(**properties)
+        for location in response.json()["content"]["branch_list"]:
+            location.update(location.pop("address"))
+            item = DictParser.parse(location)
+            item["ref"] = location["_id"]
+            oh = OpeningHours()
+            for day_time in location["working_hours"]:
+                day = day_time["day"]
+                if day != "Public Holidays":
+                    open_time = day_time["from"]
+                    close_time = day_time["to"]
+                    oh.add_range(day=day, open_time=open_time, close_time=close_time)
+            item["opening_hours"] = oh
+            yield item


### PR DESCRIPTION
**_Fixes : updated url and code to fix spider_**

```python
{'atp/brand/Liquor City': 82,
 'atp/brand_wikidata/Q116620538': 82,
 'atp/category/shop/alcohol': 82,
 'atp/country/ZA': 82,
 'atp/field/branch/missing': 82,
 'atp/field/country/from_spider_name': 82,
 'atp/field/image/missing': 82,
 'atp/field/operator/missing': 82,
 'atp/field/operator_wikidata/missing': 82,
 'atp/field/street_address/missing': 82,
 'atp/field/twitter/missing': 82,
 'atp/field/website/missing': 82,
 'atp/item_scraped_host_count/lets-trade-client-prod.letstrade.global': 82,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 82,
 'downloader/request_bytes': 757,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 178029,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.195418,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 11, 5, 49, 34, 849474, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 82,
 'items_per_minute': None,
 'log_count/DEBUG': 96,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 11, 5, 49, 29, 654056, tzinfo=datetime.timezone.utc)}
```