### PR TITLE
[Rotten Robbie US] Fix Spider

### DIFF
--- a/locations/spiders/rotten_robbie_us.py
+++ b/locations/spiders/rotten_robbie_us.py
@@ -1,8 +1,19 @@
+import chompjs
+import scrapy
+from scrapy.http import Response
+
 from locations.categories import Categories
-from locations.storefinders.wp_go_maps import WpGoMapsSpider
+from locations.dict_parser import DictParser
 
 
-class RottenRobbieUSSpider(WpGoMapsSpider):
+class RottenRobbieUSSpider(scrapy.Spider):
     name = "rotten_robbie_us"
     item_attributes = {"brand": "Rotten Robbie", "brand_wikidata": "Q87378070", "extras": Categories.FUEL_STATION.value}
-    allowed_domains = ["www.rottenrobbie.com"]
+    start_urls = ["https://rottenrobbie.com/locations"]
+
+    def parse(self, response: Response, **kwargs):
+        for store in chompjs.parse_js_object(response.xpath('//*[@type="application/ld+json"]/text()').get())["@graph"]:
+            item = DictParser.parse(store)
+            item["ref"] = store["@id"]
+            item["branch"] = item.pop("name")
+            yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Rotten Robbie': 39,
 'atp/brand_wikidata/Q87378070': 39,
 'atp/category/amenity/fuel': 39,
 'atp/clean_strings/city': 36,
 'atp/clean_strings/phone': 36,
 'atp/clean_strings/postcode': 36,
 'atp/clean_strings/state': 36,
 'atp/clean_strings/street_address': 36,
 'atp/country/US': 39,
 'atp/field/email/missing': 39,
 'atp/field/image/missing': 39,
 'atp/field/lat/missing': 39,
 'atp/field/lon/missing': 39,
 'atp/field/opening_hours/missing': 39,
 'atp/field/operator/missing': 39,
 'atp/field/operator_wikidata/missing': 39,
 'atp/field/twitter/missing': 39,
 'atp/item_scraped_host_count/rottenrobbie.com': 39,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 39,
 'downloader/request_bytes': 667,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 10917,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.419929,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 11, 8, 44, 2, 412177, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 124743,
 'httpcompression/response_count': 1,
 'item_scraped_count': 39,
 'items_per_minute': None,
 'log_count/DEBUG': 52,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 11, 8, 43, 57, 992248, tzinfo=datetime.timezone.utc)}
```