### PR TITLE
[Schnucks US] Fix Spider

### DIFF
--- a/locations/spiders/schnucks_us.py
+++ b/locations/spiders/schnucks_us.py
@@ -1,38 +1,16 @@
-import json
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
-import scrapy
-
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_FULL, OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class SchnucksUSSpider(scrapy.Spider):
+class SchnucksUSSpider(SitemapSpider, StructuredDataSpider):
     name = "schnucks_us"
     item_attributes = {"brand": "Schnucks", "brand_wikidata": "Q7431920"}
-    allowed_domains = ["locations.schnucks.com"]
-    start_urls = ["https://locations.schnucks.com/"]
+    sitemap_urls = ["https://schnucks.com/locations.sitemap.xml"]
+    sitemap_rules = [("/locations/", "parse_sd")]
 
-    def parse(self, response):
-        data_raw = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
-        locations = json.loads(data_raw)["props"]["pageProps"]["locations"]
-        for location in locations:
-            item = DictParser.parse(location)
-            item["ref"] = location["storeCode"]
-            item["name"] = location["businessName"]
-            item["street_address"] = location["addressLines"][0]
-            item["phone"] = location["phoneNumbers"][0]
-            item["website"] = location["websiteURL"]
-            item["image"] = (
-                "https://storage.googleapis.com/schnucks-digital-assets/storefront-image/" + item["ref"] + ".jpg"
-            )
-            if len(location["businessHours"]) == 7:
-                oh = OpeningHours()
-                for day_index in range(0, 7, 1):
-                    oh.add_range(
-                        DAYS_FULL[day_index],
-                        location["businessHours"][day_index][0],
-                        location["businessHours"][day_index][1],
-                        "%H:%M",
-                    )
-                item["opening_hours"] = oh.as_opening_hours()
-            yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
**_Fixes : code updated to use sitemap and structured data to fix spider_**

```python
{'atp/brand/Schnucks': 114,
 'atp/brand_wikidata/Q7431920': 114,
 'atp/category/shop/supermarket': 114,
 'atp/country/US': 114,
 'atp/field/email/missing': 114,
 'atp/field/operator/missing': 114,
 'atp/field/operator_wikidata/missing': 114,
 'atp/item_scraped_host_count/schnucks.com': 114,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 114,
 'downloader/request_bytes': 76712,
 'downloader/request_count': 116,
 'downloader/request_method_count/GET': 116,
 'downloader/response_bytes': 5727099,
 'downloader/response_count': 116,
 'downloader/response_status_count/200': 116,
 'elapsed_time_seconds': 140.610003,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 11, 9, 36, 5, 942083, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 28029157,
 'httpcompression/response_count': 116,
 'item_scraped_count': 114,
 'items_per_minute': None,
 'log_count/DEBUG': 241,
 'log_count/INFO': 11,
 'request_depth_max': 1,
 'response_received_count': 116,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 115,
 'scheduler/dequeued/memory': 115,
 'scheduler/enqueued': 115,
 'scheduler/enqueued/memory': 115,
 'start_time': datetime.datetime(2025, 9, 11, 9, 33, 45, 332080, tzinfo=datetime.timezone.utc)}

```