### PR TITLE
[Optic2000] Fix Spider

### DIFF
--- a/locations/spiders/optic2000.py
+++ b/locations/spiders/optic2000.py
@@ -1,13 +1,9 @@
-from locations.categories import Categories, apply_category
-from locations.items import Feature
-from locations.storefinders.uberall import UberallSpider
+from locations.spiders.safeway_ca import SitemapSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class Optic2000Spider(UberallSpider):
+class Optic2000Spider(SitemapSpider, StructuredDataSpider):
     name = "optic2000"
     item_attributes = {"brand": "Optic 2000", "brand_wikidata": "Q3354445"}
-    key = "cnOakpSgwYPnQbwwv6ZpHtfy0PMjaK"
-
-    def post_process_item(self, item: Feature, response, location: dict, **kwargs):
-        apply_category(Categories.SHOP_OPTICIAN, item)
-        yield item
+    sitemap_urls = ["https://opticien.optic2000.com/sitemap.xml"]
+    sitemap_rules = [(r"https://opticien.optic2000.com/[^/]+/[^/]+/[^/]+/[^/]+$", "parse_sd")]


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap_**

```python
{'atp/brand/Optic 2000': 1216,
 'atp/brand_wikidata/Q3354445': 1216,
 'atp/category/shop/optician': 1216,
 'atp/country/FR': 1209,
 'atp/country/GP': 4,
 'atp/country/RE': 3,
 'atp/field/branch/missing': 1216,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 1216,
 'atp/field/image/dropped': 56,
 'atp/field/image/missing': 421,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1216,
 'atp/field/operator_wikidata/missing': 1216,
 'atp/field/phone/invalid': 5,
 'atp/field/state/missing': 1216,
 'atp/item_scraped_host_count/opticien.optic2000.com': 1216,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 1216,
 'downloader/request_bytes': 562952,
 'downloader/request_count': 1218,
 'downloader/request_method_count/GET': 1218,
 'downloader/response_bytes': 30446787,
 'downloader/response_count': 1218,
 'downloader/response_status_count/200': 1218,
 'elapsed_time_seconds': 1480.495551,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 12, 7, 52, 37, 706866, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 230728020,
 'httpcompression/response_count': 1218,
 'item_scraped_count': 1216,
 'items_per_minute': None,
 'log_count/DEBUG': 2445,
 'log_count/INFO': 33,
 'memusage/max': 522711040,
 'memusage/startup': 289488896,
 'request_depth_max': 1,
 'response_received_count': 1218,
 'responses_per_minute': None,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1217,
 'scheduler/dequeued/memory': 1217,
 'scheduler/enqueued': 1217,
 'scheduler/enqueued/memory': 1217,
 'start_time': datetime.datetime(2025, 9, 12, 7, 27, 57, 211315, tzinfo=datetime.timezone.utc)}
```