### PR TITLE
[Auchan RO] Sync brand and category with NSI

### DIFF
--- a/locations/spiders/auchan_ro.py
+++ b/locations/spiders/auchan_ro.py
@@ -1,19 +1,22 @@
 import re
+from typing import Any, AsyncIterator
 
-import scrapy
-from scrapy.http import JsonRequest
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, sanitise_day
+from locations.spiders.auchan_lu import MY_AUCHAN
 from locations.spiders.auchan_pl import AuchanPLSpider
 
 
-class AuchanROSpider(scrapy.Spider):
+class AuchanROSpider(Spider):
     name = "auchan_ro"
     item_attributes = AuchanPLSpider.item_attributes
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Any]:
         yield JsonRequest(
             url="https://www.auchan.ro/api/dataentities/PU/search?_fields=address,city,clickAndCollectDrive,clickAndCollectStore,county,deliveryWithin24h,email,expressDelivery,fridaySchedule,holidaySchedule,latitude,longitude,mondaySchedule,myAuchanPetrom,phoneNumber,pickupFromDrive,saturdaySchedule,sellerId,storeName,sundaySchedule,thursdaySchedule,tuesdaySchedule,wednesdaySchedule,zipcode,id",
             headers={
@@ -21,7 +24,7 @@ class AuchanROSpider(scrapy.Spider):
             },
         )
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
             store["street-address"] = store.pop("address", "")
             item = DictParser.parse(store)
@@ -34,4 +37,19 @@ class AuchanROSpider(scrapy.Spider):
                         for open_time, close_time in re.findall(r"(\d+:\d+)[-\s]+(\d+:\d+)", store[key]):
                             item["opening_hours"].add_range(day, open_time, close_time)
             item["website"] = f'https://www.auchan.ro/magazin/{store["id"]}'
+
+            if item["name"].startswith("MyAuchan"):
+                item["branch"] = item.pop("name").removeprefix("MyAuchan")
+                item.update(MY_AUCHAN)
+                apply_category(Categories.SHOP_CONVENIENCE, item)
+            elif item["name"].startswith("ATAC HIPER DISCOUNT ") or item["name"].startswith("ATAC Hiper Discount "):
+                item["branch"] = (
+                    item.pop("name").removeprefix("ATAC HIPER DISCOUNT ").removeprefix("ATAC Hiper Discount ")
+                )
+                item["name"] = "ATAC"
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+            elif item["name"].startswith("Auchan "):
+                item["branch"] = item.pop("name").removeprefix("Auchan ")
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+
             yield item


### PR DESCRIPTION
https://github.com/osmlab/name-suggestion-index/pull/11376

```python
{'atp/brand/Auchan': 43,
 'atp/brand/My Auchan': 394,
 'atp/brand_wikidata/Q115800307': 394,
 'atp/brand_wikidata/Q758603': 43,
 'atp/category/shop/convenience': 394,
 'atp/category/shop/supermarket': 43,
 'atp/clean_strings/branch': 1,
 'atp/country/RO': 437,
 'atp/field/branch/missing': 393,
 'atp/field/country/from_spider_name': 437,
 'atp/field/email/missing': 22,
 'atp/field/image/missing': 437,
 'atp/field/operator/missing': 437,
 'atp/field/operator_wikidata/missing': 437,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 437,
 'atp/item_scraped_host_count/www.auchan.ro': 437,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 43,
 'atp/nsi/perfect_match': 394,
 'downloader/request_bytes': 722,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 34060,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 0.850582,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 12, 12, 20, 14, 581370, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1,
 'httpcompression/response_bytes': 301484,
 'httpcompression/response_count': 1,
 'item_scraped_count': 437,
 'items_per_minute': None,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 289525760,
 'memusage/startup': 289525760,
 'response_received_count': 1,
 'responses_per_minute': None,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 12, 12, 20, 13, 730788, tzinfo=datetime.timezone.utc)}
```