### PR TITLE
[Mitsubishi BE LU] Fix Spider

### DIFF
--- a/locations/spiders/mitsubishi_be_lu.py
+++ b/locations/spiders/mitsubishi_be_lu.py
@@ -13,7 +13,7 @@ from locations.spiders.mitsubishi import MitsubishiSpider
 class MitsubishiBELUSpider(JSONBlobSpider):
     name = "mitsubishi_be_lu"
     item_attributes = MitsubishiSpider.item_attributes
-    start_urls = ["https://mitsubishi-motors.be/dealers.json"]
+    start_urls = ["https://service.mitsubishi-motors.be/dealers.json"]
     locations_key = "dealers"
     skip_auto_cc_spider_name = True
 


### PR DESCRIPTION
**_Fixes : updated start_urls to fix spider_**

```python
{'atp/brand/Mitsubishi': 60,
 'atp/brand_wikidata/Q36033': 60,
 'atp/category/shop/car_repair': 60,
 'atp/country/BE': 56,
 'atp/country/LU': 4,
 'atp/field/branch/missing': 60,
 'atp/field/city/missing': 60,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/country/from_website_url': 59,
 'atp/field/image/missing': 60,
 'atp/field/operator/missing': 60,
 'atp/field/operator_wikidata/missing': 60,
 'atp/field/state/missing': 59,
 'atp/field/street_address/missing': 60,
 'atp/field/twitter/missing': 60,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/service.mitsubishi-motors.be': 60,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 60,
 'downloader/request_bytes': 694,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12950,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.031684,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 15, 10, 27, 33, 75831, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 73243,
 'httpcompression/response_count': 2,
 'item_scraped_count': 60,
 'items_per_minute': 720.0,
 'log_count/DEBUG': 124,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 15, 10, 27, 28, 44147, tzinfo=datetime.timezone.utc)}
```