### PR TITLE
[Halfords GB] Fix Spider

### DIFF
--- a/locations/spiders/halfords_gb.py
+++ b/locations/spiders/halfords_gb.py
@@ -10,7 +10,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class HalfordsGBSpider(CrawlSpider, StructuredDataSpider):
     name = "halfords_gb"
     start_urls = ["https://www.halfords.com/locations"]
-    rules = [Rule(LinkExtractor(r"/locations/([^/]+)/$"), "parse")]
+    rules = [Rule(LinkExtractor(r"/locations/([^/]+)$"), "parse_sd")]
     wanted_types = ["AutomotiveBusiness", "LocalBusiness"]
     search_for_facebook = False
     search_for_twitter = False


### PR DESCRIPTION
**_Fixes : updated rules to fix spider_**
```python
{'atp/brand/Halfords': 428,
 'atp/brand/Halfords Autocentre': 298,
 'atp/brand/National Tyres and Autocare': 140,
 'atp/brand_wikidata/Q3398786': 356,
 'atp/brand_wikidata/Q5641894': 298,
 'atp/brand_wikidata/Q6979055': 140,
 'atp/category/missing': 6,
 'atp/category/shop/car_parts': 356,
 'atp/category/shop/car_repair': 510,
 'atp/clean_strings/branch': 31,
 'atp/country/GB': 872,
 'atp/field/branch/missing': 6,
 'atp/field/brand/missing': 6,
 'atp/field/brand_wikidata/missing': 78,
 'atp/field/email/missing': 872,
 'atp/field/image/missing': 516,
 'atp/field/operator/missing': 872,
 'atp/field/operator_wikidata/missing': 872,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 872,
 'atp/field/twitter/missing': 434,
 'atp/item_scraped_host_count/www.halfords.com': 872,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 794,
 'downloader/request_bytes': 686736,
 'downloader/request_count': 874,
 'downloader/request_method_count/GET': 874,
 'downloader/response_bytes': 110766556,
 'downloader/response_count': 874,
 'downloader/response_status_count/200': 874,
 'elapsed_time_seconds': 1067.584773,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 15, 12, 59, 51, 139046, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1550250299,
 'httpcompression/response_count': 874,
 'item_scraped_count': 872,
 'items_per_minute': 49.03467666354264,
 'log_count/DEBUG': 1781,
 'log_count/INFO': 26,
 'request_depth_max': 1,
 'response_received_count': 874,
 'responses_per_minute': 49.14714151827553,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 873,
 'scheduler/dequeued/memory': 873,
 'scheduler/enqueued': 873,
 'scheduler/enqueued/memory': 873,
 'start_time': datetime.datetime(2025, 9, 15, 12, 42, 3, 554273, tzinfo=datetime.timezone.utc),
 'tt_requires_proxy': False}
 
```