### PR TITLE
[Mondadori IT ] Fix Spider

### DIFF
--- a/locations/spiders/mondadori_it.py
+++ b/locations/spiders/mondadori_it.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_IT, OpeningHours, sanitise_day
@@ -15,12 +15,10 @@ class MondadoriITSpider(JSONBlobSpider):
         "Rizzoli": ("Rizzoli", "Q1327389"),
         "Mondolibri": ("Mondolibri", "Q119942453"),
     }
+    start_urls = [
+        "https://www.mondadoristore.it/occ/v2/mondadorisite-b2c/stores?pageSize=1000&currentPage=0&province=&latitude=45.4642&longitude=9.19&fields=FULL&lang=it&curr=EUR"
+    ]
     locations_key = "results"
-
-    def start_requests(self):
-        yield JsonRequest(
-            url="https://www.mondadoristore.it/occ/v2/mondadorisite-b2c/stores?pageSize=1000&currentPage=0&province=&latitude=45.4642&longitude=9.19&fields=FULL&lang=it&curr=EUR"
-        )
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))

--- a/locations/spiders/mondadori_it.py
+++ b/locations/spiders/mondadori_it.py
@@ -19,6 +19,7 @@ class MondadoriITSpider(JSONBlobSpider):
         "https://www.mondadoristore.it/occ/v2/mondadorisite-b2c/stores?pageSize=1000&currentPage=0&province=&latitude=45.4642&longitude=9.19&fields=FULL&lang=it&curr=EUR"
     ]
     locations_key = "results"
+    needs_json_request = True
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))

--- a/locations/spiders/mondadori_it.py
+++ b/locations/spiders/mondadori_it.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_IT, OpeningHours, sanitise_day
@@ -15,10 +15,12 @@ class MondadoriITSpider(JSONBlobSpider):
         "Rizzoli": ("Rizzoli", "Q1327389"),
         "Mondolibri": ("Mondolibri", "Q119942453"),
     }
-    start_urls = [
-        "https://www.mondadoristore.it/occ/v2/mondadorisite-b2c/stores?pageSize=1000&currentPage=0&province=&latitude=45.4642&longitude=9.19&fields=FULL&lang=it&curr=EUR"
-    ]
     locations_key = "results"
+
+    def start_requests(self):
+        yield JsonRequest(
+            url="https://www.mondadoristore.it/occ/v2/mondadorisite-b2c/stores?pageSize=1000&currentPage=0&province=&latitude=45.4642&longitude=9.19&fields=FULL&lang=it&curr=EUR"
+        )
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))


### PR DESCRIPTION
**_Fixes : added start request to avoid xml response_**

```python
{'atp/brand/Mondadori': 518,
 'atp/brand/Mondolibri': 42,
 'atp/brand/Rizzoli': 1,
 'atp/brand_wikidata/Q119942453': 42,
 'atp/brand_wikidata/Q1327389': 1,
 'atp/brand_wikidata/Q85355': 518,
 'atp/category/shop/books': 453,
 'atp/category/shop/newsagent': 108,
 'atp/country/IT': 561,
 'atp/field/image/missing': 561,
 'atp/field/name/missing': 43,
 'atp/field/operator/missing': 561,
 'atp/field/operator_wikidata/missing': 561,
 'atp/field/phone/missing': 11,
 'atp/field/twitter/missing': 561,
 'atp/item_scraped_host_count/www.mondadoristore.it': 561,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 43,
 'atp/nsi/perfect_match': 518,
 'downloader/request_bytes': 813,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1116888,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.56244,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 16, 6, 32, 0, 744445, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10089425,
 'httpcompression/response_count': 2,
 'item_scraped_count': 561,
 'items_per_minute': 6732.0,
 'log_count/DEBUG': 576,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 16, 6, 31, 55, 182005, tzinfo=datetime.timezone.utc)}
```