### PR TITLE
[Pizza Hut FR] Fix low scraped count for spider

### DIFF
--- a/locations/spiders/pizza_hut_fr.py
+++ b/locations/spiders/pizza_hut_fr.py
@@ -1,25 +1,7 @@
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
-
-from locations.categories import Categories, apply_category
-from locations.items import Feature, set_closed
-from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.spiders.pizza_hut_gb import PizzaHutGBSpider
 
 
-class PizzaHutFRSpider(SitemapSpider, StructuredDataSpider):
+class PizzaHutFRSpider(PizzaHutGBSpider):
     name = "pizza_hut_fr"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
-    sitemap_urls = ["https://www.pizzahut.fr/sitemap.xml"]
-    sitemap_rules = [(r"https:\/\/www\.pizzahut\.fr\/huts\/[-\w]+\/([-.\w]+)\/$", "parse_sd")]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        if not item["opening_hours"]:
-            set_closed(item)
-
-        item["branch"] = item.pop("name").removeprefix("Pizza Hut ")
-
-        apply_category(Categories.RESTAURANT, item)
-
-        yield item
+    start_urls = ["https://api.pizzahut.io/v1/huts/?sector=fr-1"]

--- a/locations/spiders/pizza_hut_fr.py
+++ b/locations/spiders/pizza_hut_fr.py
@@ -1,3 +1,9 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.spiders.pizza_hut_gb import PizzaHutGBSpider
 
 
@@ -5,3 +11,10 @@ class PizzaHutFRSpider(PizzaHutGBSpider):
     name = "pizza_hut_fr"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
     start_urls = ["https://api.pizzahut.io/v1/huts/?sector=fr-1"]
+
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs) -> Iterable[Feature]:
+        if location["type"] == "restaurant":
+            apply_category(Categories.RESTAURANT, item)
+        elif location["type"] == "delivery":
+            apply_category(Categories.FAST_FOOD, item)
+        yield item

--- a/locations/spiders/pizza_hut_gb.py
+++ b/locations/spiders/pizza_hut_gb.py
@@ -32,7 +32,7 @@ class PizzaHutGBSpider(Spider):
                 item.update(PIZZA_HUT_DELIVERY)
                 apply_category(Categories.FAST_FOOD, item)
 
-            apply_yes_no(Extras.DELIVERY, item, location["allowedDisposition"]["delivery"])
-            apply_yes_no(Extras.TAKEAWAY, item, location["allowedDisposition"]["collection"])
+            apply_yes_no(Extras.DELIVERY, item, location.get("allowedDisposition", {}).get("delivery"))
+            apply_yes_no(Extras.TAKEAWAY, item, location.get("allowedDisposition", {}).get("collection"))
 
             yield item

--- a/locations/spiders/pizza_hut_gb.py
+++ b/locations/spiders/pizza_hut_gb.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Iterable
 
 from scrapy.http import Response
 from scrapy.spiders import Spider
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
-from locations.items import set_closed
+from locations.items import Feature, set_closed
 from locations.pipelines.address_clean_up import merge_address_lines
 
 PIZZA_HUT = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
@@ -25,14 +25,16 @@ class PizzaHutGBSpider(Spider):
             if location["closed"] is True:
                 set_closed(item)
 
-            if location["type"] == "restaurant":
-                item.update(PIZZA_HUT)
-                apply_category(Categories.RESTAURANT, item)
-            elif location["type"] == "delivery":
-                item.update(PIZZA_HUT_DELIVERY)
-                apply_category(Categories.FAST_FOOD, item)
+            yield from self.post_process_item(item, response, location) or []
 
-            apply_yes_no(Extras.DELIVERY, item, location.get("allowedDisposition", {}).get("delivery"))
-            apply_yes_no(Extras.TAKEAWAY, item, location.get("allowedDisposition", {}).get("collection"))
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs) -> Iterable[Feature]:
+        if location["type"] == "restaurant":
+            item.update(PIZZA_HUT)
+            apply_category(Categories.RESTAURANT, item)
+        elif location["type"] == "delivery":
+            item.update(PIZZA_HUT_DELIVERY)
+            apply_category(Categories.FAST_FOOD, item)
 
-            yield item
+        apply_yes_no(Extras.DELIVERY, item, location.get("allowedDisposition", {}).get("delivery"))
+        apply_yes_no(Extras.TAKEAWAY, item, location.get("allowedDisposition", {}).get("collection"))
+        yield item

--- a/locations/spiders/pizza_hut_in.py
+++ b/locations/spiders/pizza_hut_in.py
@@ -1,3 +1,9 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.spiders.pizza_hut_gb import PizzaHutGBSpider
 
 
@@ -5,3 +11,10 @@ class PizzaHutINSpider(PizzaHutGBSpider):
     name = "pizza_hut_in"
     item_attributes = {"brand": "Pizza Hut", "brand_wikidata": "Q191615"}
     start_urls = ["https://api.pizzahut.io/v1/huts?sectors=in-1"]
+
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs) -> Iterable[Feature]:
+        if location["type"] == "restaurant":
+            apply_category(Categories.RESTAURANT, item)
+        elif location["type"] == "delivery":
+            apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
For some the locations, it fails to decode `SD`, was resulting lower count. Hence refactor to fix it.

```python
{'atp/brand/Pizza Hut': 117,
 'atp/brand_wikidata/Q191615': 117,
 'atp/category/amenity/fast_food': 117,
 'atp/country/FR': 117,
 'atp/field/city/missing': 117,
 'atp/field/country/from_spider_name': 117,
 'atp/field/email/missing': 117,
 'atp/field/image/missing': 117,
 'atp/field/opening_hours/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/state/missing': 117,
 'atp/field/twitter/missing': 117,
 'atp/field/website/missing': 117,
 'atp/item_scraped_host_count/api.pizzahut.io': 117,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 117,
 'downloader/request_bytes': 676,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 11111,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.822632,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 16, 8, 29, 42, 262075, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 78877,
 'httpcompression/response_count': 1,
 'item_scraped_count': 117,
 'items_per_minute': 3510.0,
 'log_count/DEBUG': 132,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 16, 8, 29, 39, 439443, tzinfo=datetime.timezone.utc)}
```