### PR TITLE
[Edible Arrangements] Fix Spider

### DIFF
--- a/locations/spiders/edible_arrangements.py
+++ b/locations/spiders/edible_arrangements.py
@@ -57,8 +57,8 @@ class EdibleArrangementsSpider(scrapy.Spider):
                 )
 
                 from_time, to_time = h["Timing"].split("-")
-                from_t = datetime.strptime(from_time, "%I:%M %p").strftime("%H:%M")
-                to_t = datetime.strptime(to_time, "%I:%M %p").strftime("%H:%M")
+                from_t = datetime.strptime(from_time.strip(), "%I:%M %p").strftime("%H:%M")
+                to_t = datetime.strptime(to_time.strip(), "%I:%M %p").strftime("%H:%M")
 
                 oh.append(f"{days} {from_t}-{to_t}")
 

--- a/locations/spiders/edible_arrangements.py
+++ b/locations/spiders/edible_arrangements.py
@@ -1,9 +1,9 @@
 import json
-from datetime import datetime
 
 import scrapy
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, day_range
 
 
 class EdibleArrangementsSpider(scrapy.Spider):
@@ -29,40 +29,22 @@ class EdibleArrangementsSpider(scrapy.Spider):
 
     def parse(self, response):
         d = json.loads(response.json()["d"])
-        for s in d["_Data"]:
-            properties = {
-                "lat": s["Latitude"],
-                "lon": s["Longitude"],
-                "phone": s["PhoneNumber"],
-                "ref": s["ID"],
-                "addr_full": s["MapAddress"],
-                "name": s["FormalName"],
-                "website": response.urljoin("/stores/" + s["PageFriendlyURL"]),
-            }
-
-            oh = []
-            for h in s["TimingsShort"]:
-                if h["Timing"] == "Closed":
-                    continue
-
-                days = (
-                    h["Days"]
-                    .replace("Monday", "Mo")
-                    .replace("Tuesday", "Tu")
-                    .replace("Wednesday", "We")
-                    .replace("Thursday", "Th")
-                    .replace("Friday", "Fr")
-                    .replace("Saturday", "Sa")
-                    .replace("Sunday", "Su")
-                )
-
-                from_time, to_time = h["Timing"].split("-")
-                from_t = datetime.strptime(from_time.strip(), "%I:%M %p").strftime("%H:%M")
-                to_t = datetime.strptime(to_time.strip(), "%I:%M %p").strftime("%H:%M")
-
-                oh.append(f"{days} {from_t}-{to_t}")
-
-            if oh:
-                properties["opening_hours"] = "; ".join(oh)
-
-            yield Feature(**properties)
+        for shop in d["_Data"]:
+            item = DictParser.parse(shop)
+            oh = OpeningHours()
+            for day_time in shop["TimingsShort"]:
+                day = day_time["Days"]
+                time = day_time["Timing"]
+                if time == "Closed":
+                    oh.set_closed(day)
+                else:
+                    start_day, end_day = day.split("-") if "-" in day else (day, day)
+                    open_time, close_time = time.split("-")
+                    oh.add_days_range(
+                        day_range(start_day, end_day),
+                        open_time=open_time.strip(),
+                        close_time=close_time.strip(),
+                        time_format="%I:%M %p",
+                    )
+                item["opening_hours"] = oh
+            yield item


### PR DESCRIPTION
**_Fixes : strip time to fix spider_**

```python
{'atp/brand/Edible Arrangements': 620,
 'atp/brand_wikidata/Q5337996': 620,
 'atp/category/shop/gift': 620,
 'atp/clean_strings/addr_full': 19,
 'atp/country/PR': 2,
 'atp/country/US': 618,
 'atp/field/branch/missing': 620,
 'atp/field/city/missing': 620,
 'atp/field/country/from_reverse_geocoding': 620,
 'atp/field/email/missing': 620,
 'atp/field/image/missing': 620,
 'atp/field/operator/missing': 620,
 'atp/field/operator_wikidata/missing': 620,
 'atp/field/postcode/missing': 620,
 'atp/field/street_address/missing': 620,
 'atp/field/twitter/missing': 620,
 'atp/item_scraped_host_count/www.ediblearrangements.com': 620,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 620,
 'downloader/request_bytes': 1187,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 457470,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 9.624857,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 16, 9, 11, 26, 924422, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6984,
 'httpcompression/response_count': 1,
 'item_scraped_count': 620,
 'items_per_minute': 4133.333333333334,
 'log_count/DEBUG': 635,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 16, 9, 11, 17, 299565, tzinfo=datetime.timezone.utc)}
```