### PR TITLE
[Truist US] Fix spider

### DIFF
--- a/locations/spiders/truist_us.py
+++ b/locations/spiders/truist_us.py
@@ -5,6 +5,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class TruistUSSpider(SitemapSpider, StructuredDataSpider):
@@ -23,6 +24,7 @@ class TruistUSSpider(SitemapSpider, StructuredDataSpider):
     wanted_types = ["FinancialService", "AutomatedTeller"]
     search_for_twitter = False
     drop_attributes = {"facebook"}
+    custom_settings = {"user_agent": BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         path = urlparse(response.url).path

--- a/locations/spiders/truist_us.py
+++ b/locations/spiders/truist_us.py
@@ -24,7 +24,7 @@ class TruistUSSpider(SitemapSpider, StructuredDataSpider):
     wanted_types = ["FinancialService", "AutomatedTeller"]
     search_for_twitter = False
     drop_attributes = {"facebook"}
-    custom_settings = {"user_agent": BROWSER_DEFAULT}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         path = urlparse(response.url).path

--- a/locations/spiders/truist_us.py
+++ b/locations/spiders/truist_us.py
@@ -64,6 +64,7 @@ class TruistUSSpider(SitemapSpider, StructuredDataSpider):
                 oh.add_ranges_from_string(line)
             item["opening_hours"] = oh
 
+        item["extras"]["fax"] = location_info.get("fax")
         yield item
 
     def extract_amenity_features(self, item, response, ld_item):


### PR DESCRIPTION
```python
{'atp/brand/Truist': 1979,
 'atp/brand_wikidata/Q795486': 1979,
 'atp/category/amenity/atm': 81,
 'atp/category/amenity/bank': 1898,
 'atp/country/US': 1979,
 'atp/duplicate_count': 238,
 'atp/field/email/missing': 1979,
 'atp/field/image/dropped': 1979,
 'atp/field/image/missing': 1979,
 'atp/field/name/missing': 81,
 'atp/field/operator/missing': 1898,
 'atp/field/operator_wikidata/missing': 1898,
 'atp/field/twitter/missing': 1979,
 'atp/item_scraped_host_count/www.truist.com': 2217,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1979,
 'atp/operator/Truist': 81,
 'atp/operator_wikidata/Q795486': 81,
 'downloader/exception_count': 75,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 75,
 'downloader/request_bytes': 2301818,
 'downloader/request_count': 3692,
 'downloader/request_method_count/GET': 3692,
 'downloader/response_bytes': 129227882,
 'downloader/response_count': 3617,
 'downloader/response_status_count/200': 3601,
 'downloader/response_status_count/302': 15,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 1751,
 'elapsed_time_seconds': 4625.139233,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 18, 20, 27, 58, 683111, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 657602758,
 'httpcompression/response_count': 3602,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_dropped_count': 238,
 'item_dropped_reasons_count/DropItem': 238,
 'item_scraped_count': 1979,
 'items_per_minute': 25.673513513513516,
 'log_count/DEBUG': 5914,
 'log_count/ERROR': 18,
 'log_count/INFO': 87,
 'request_depth_max': 1,
 'response_received_count': 3602,
 'responses_per_minute': 46.72864864864865,
 'retry/count': 66,
 'retry/max_reached': 9,
 'retry/reason_count/twisted.internet.error.TimeoutError': 66,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3691,
 'scheduler/dequeued/memory': 3691,
 'scheduler/enqueued': 3691,
 'scheduler/enqueued/memory': 3691,
 'start_time': datetime.datetime(2025, 9, 18, 19, 10, 53, 543878, tzinfo=datetime.timezone.utc)}
```