### PR TITLE
Correct website URLs in tortilla_gb.py

### DIFF
--- a/locations/spiders/tortilla_gb.py
+++ b/locations/spiders/tortilla_gb.py
@@ -22,7 +22,7 @@ class TortillaGBSpider(JSONBlobSpider):
             item["ref"] = item["branch"].replace(" ", "")
             if item["phone"]:
                 item["phone"].replace(" ", "")
-            item["website"] = "https://www.tortilla.co.uk/" + location["full_slug"]
+            item["website"] = "https://www.tortilla.co.uk/" + location["full_slug"].removeprefix('uk/')
 
             apply_category(Categories.FAST_FOOD, item)
 


### PR DESCRIPTION
The full_slug field contains a 'uk/' prefix that is not present in the live URLs for the outlets.

For example, the full slug is `uk/restaurants/birmingham`, but https://www.tortilla.co.uk/uk/restaurants/birmingham gives a 404 error. The actual page for that outlet is https://www.tortilla.co.uk/uk/restaurants/birmingham .