### PR TITLE
Correct webpage URLs in sweaty_betty.py

### DIFF
--- a/locations/spiders/sweaty_betty.py
+++ b/locations/spiders/sweaty_betty.py
@@ -22,7 +22,7 @@ class SweatyBettySpider(Spider):
                 item = DictParser.parse(location)
                 item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
                 s = location["name"]
-                slug = "".join(s.split()).lower() + "-" + location["storeId"]
+                slug = "-".join(s.split()).lower() + "-" + location["storeId"]
                 item["website"] = urljoin("https://www.sweatybetty.com/shop-details/", slug)
                 # if location.get("storeHours"):
                 #   item["opening_hours"] = OpeningHours()


### PR DESCRIPTION
While the current URLs returned by the spider do work, they don't match the URLs that the Sweaty Betty website itself links to in the case of shop names comprising multiple words. In those cases, e.g. https://www.sweatybetty.com/shop-details/east-dulwich-079 the words in the slug appear to be linked by hyphens.