### PR TITLE
[Mcdonalds AT] Fix ValueError for opening hours

### DIFF
--- a/locations/spiders/mcdonalds_at.py
+++ b/locations/spiders/mcdonalds_at.py
@@ -19,7 +19,8 @@ class McdonaldsATSpider(SitemapSpider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
-        item["website"] = item["ref"] = response.url
+        item["website"] = response.url
+        item["ref"] = response.xpath("//@data-id").get()
         item["lat"] = response.xpath("//@data-marker-icon-lat").get()
         item["lon"] = response.xpath("//@data-marker-icon-lng").get()
         item["addr_full"] = response.xpath('//meta[@property="og:title"]/@content').get().removesuffix(" - McDonald’s")


### PR DESCRIPTION
```python
{'atp/brand/McCafé': 204,
 "atp/brand/McDonald's": 211,
 'atp/brand_wikidata/Q3114287': 204,
 'atp/brand_wikidata/Q38076': 211,
 'atp/category/amenity/cafe': 204,
 'atp/category/amenity/fast_food': 211,
 'atp/country/AT': 415,
 'atp/field/branch/missing': 415,
 'atp/field/city/missing': 415,
 'atp/field/country/from_spider_name': 415,
 'atp/field/email/missing': 415,
 'atp/field/image/missing': 415,
 'atp/field/opening_hours/missing': 211,
 'atp/field/operator/missing': 415,
 'atp/field/operator_wikidata/missing': 415,
 'atp/field/phone/missing': 415,
 'atp/field/postcode/missing': 415,
 'atp/field/state/missing': 415,
 'atp/field/street_address/missing': 415,
 'atp/field/twitter/missing': 415,
 'atp/item_scraped_host_count/www.mcdonalds.at': 415,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 211,
 'atp/nsi/perfect_match': 204,
 'downloader/request_bytes': 102068,
 'downloader/request_count': 213,
 'downloader/request_method_count/GET': 213,
 'downloader/response_bytes': 45247055,
 'downloader/response_count': 213,
 'downloader/response_status_count/200': 213,
 'elapsed_time_seconds': 12.940305,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 22, 6, 55, 14, 118409, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 213,
 'httpcompression/response_bytes': 301544503,
 'httpcompression/response_count': 213,
 'item_scraped_count': 415,
 'items_per_minute': 2075.0,
 'log_count/DEBUG': 642,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 213,
 'responses_per_minute': 1065.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 212,
 'scheduler/dequeued/memory': 212,
 'scheduler/enqueued': 212,
 'scheduler/enqueued/memory': 212,
 'start_time': datetime.datetime(2025, 9, 22, 6, 55, 1, 178104, tzinfo=datetime.timezone.utc)}
```