### PR TITLE
[Walmart US] Increase download delay to avoid request failure for the spider

### DIFF
--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -20,7 +20,7 @@ class WalmartUSSpider(Spider):
     custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
-        "DOWNLOAD_DELAY": 5,
+        "DOWNLOAD_DELAY": 7,
         "ROBOTSTXT_OBEY": False,
     }
     base_url = "https://www.walmart.com/orchestra/home/graphql/nearByNodes"


### PR DESCRIPTION
[Last run](https://alltheplaces-data.openaddresses.io/runs/2025-09-20-13-32-33/stats/walmart_us.json) resulted just `220` POIs.
Increased download delay to avoid request failure.

```
{'atp/brand/Walmart': 4357,
 'atp/brand_wikidata/Q483551': 4357,
 'atp/category/amenity/pharmacy': 2,
 'atp/category/multiple': 2,
 'atp/category/shop/department_store': 332,
 'atp/category/shop/supermarket': 4023,
 'atp/country/US': 4357,
 'atp/duplicate_count': 79018,
 'atp/field/email/missing': 4357,
 'atp/field/image/missing': 4357,
 'atp/field/operator/missing': 4357,
 'atp/field/operator_wikidata/missing': 4357,
 'atp/field/phone/missing': 4357,
 'atp/field/twitter/missing': 4357,
 'atp/item_scraped_host_count/www.walmart.com': 83375,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4357,
 'downloader/exception_count': 3,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 3,
 'downloader/request_bytes': 10721146,
 'downloader/request_count': 3275,
 'downloader/request_method_count/GET': 3275,
 'downloader/response_bytes': 24933256,
 'downloader/response_count': 3272,
 'downloader/response_status_count/200': 1800,
 'downloader/response_status_count/412': 1472,
 'elapsed_time_seconds': 27995.201629,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 22, 19, 46, 43, 105196, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 122523626,
 'httpcompression/response_count': 1800,
 'httperror/response_ignored_count': 1472,
 'httperror/response_ignored_status_count/412': 1472,
 'item_dropped_count': 79018,
 'item_dropped_reasons_count/DropItem': 79018,
 'item_scraped_count': 4357,
 'items_per_minute': 9.338096088587248,
 'log_count/DEBUG': 86663,
 'log_count/INFO': 1947,
 'log_count/WARNING': 1,
 'response_received_count': 3272,
 'responses_per_minute': 7.012680835863548,
 'retry/count': 3,
 'retry/reason_count/twisted.internet.error.TimeoutError': 3,
 'scheduler/dequeued': 3275,
 'scheduler/dequeued/memory': 3275,
 'scheduler/enqueued': 3275,
 'scheduler/enqueued/memory': 3275,
 'start_time': datetime.datetime(2025, 9, 22, 12, 0, 7, 903567, tzinfo=datetime.timezone.utc)}
```