### PR TITLE
[Harvester GB] Fix Spider

### DIFF
--- a/locations/spiders/harvester_gb.py
+++ b/locations/spiders/harvester_gb.py
@@ -9,3 +9,4 @@ class HarvesterGBSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "Harvester", "brand_wikidata": "Q5676915"}
     start_urls = ["https://www.harvester.co.uk/restaurants/"]
     rules = [Rule(LinkExtractor(allow="/restaurants/"), callback="parse_sd")]
+    requires_proxy = True


### PR DESCRIPTION
**_Fixes : Flag harvester_gb as requires proxy to fix spider_**

```python
{'atp/brand/Harvester': 139,
 'atp/brand_wikidata/Q5676915': 139,
 'atp/category/amenity/restaurant': 139,
 'atp/cdn/cloudflare/response_count': 157,
 'atp/cdn/cloudflare/response_status_count/200': 148,
 'atp/cdn/cloudflare/response_status_count/403': 9,
 'atp/country/GB': 139,
 'atp/field/branch/missing': 139,
 'atp/field/email/missing': 139,
 'atp/field/image/dropped': 138,
 'atp/field/image/missing': 138,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 139,
 'atp/field/operator_wikidata/missing': 139,
 'atp/field/state/missing': 3,
 'atp/item_scraped_host_count/www.browns-restaurants.co.uk': 1,
 'atp/item_scraped_host_count/www.harvester.co.uk': 138,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 139,
 'downloader/request_bytes': 103325,
 'downloader/request_count': 159,
 'downloader/request_method_count/GET': 159,
 'downloader/response_bytes': 3237525,
 'downloader/response_count': 159,
 'downloader/response_status_count/200': 148,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/403': 9,
 'elapsed_time_seconds': 190.711162,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 23, 6, 9, 25, 522428, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12356176,
 'httpcompression/response_count': 157,
 'item_scraped_count': 139,
 'items_per_minute': 43.89473684210527,
 'log_count/DEBUG': 318,
 'log_count/INFO': 12,
 'request_depth_max': 1,
 'response_received_count': 157,
 'responses_per_minute': 49.578947368421055,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/403': 3,
 'scheduler/dequeued': 156,
 'scheduler/dequeued/memory': 156,
 'scheduler/enqueued': 156,
 'scheduler/enqueued/memory': 156,
 'start_time': datetime.datetime(2025, 9, 23, 6, 6, 14, 811266, tzinfo=datetime.timezone.utc)}
 
```