### PR TITLE
[A1 MK] Fix Spider

### DIFF
--- a/locations/spiders/a1_mk.py
+++ b/locations/spiders/a1_mk.py
@@ -11,14 +11,11 @@ class A1MKSpider(Spider):
 
     def parse(self, response):
         for location in response.json():
-            if not location.get("isOpen"):
-                continue
-            item = DictParser.parse(location)
-            item["branch"] = location["nameMK"]
-
             if location["shopType"]["shopGroup"]["metadata"] != "centers":
                 # Ignore partner stores.
                 continue
+            item = DictParser.parse(location)
+            item["branch"] = location["nameMK"]
             if location.get("code"):
                 item["ref"] = location["code"]
             item["name"] = location.get("nameMK")


### PR DESCRIPTION
**_Fixes :  removed if condition to fix spider_**

```python
{'atp/brand/A1': 28,
 'atp/brand_wikidata/Q24589907': 28,
 'atp/category/shop/telecommunication': 28,
 'atp/country/MK': 28,
 'atp/field/country/from_reverse_geocoding': 28,
 'atp/field/email/missing': 28,
 'atp/field/image/missing': 28,
 'atp/field/operator/missing': 28,
 'atp/field/operator_wikidata/missing': 28,
 'atp/field/phone/missing': 28,
 'atp/field/postcode/missing': 28,
 'atp/field/twitter/missing': 28,
 'atp/field/website/missing': 28,
 'atp/item_scraped_host_count/www.a1.mk': 28,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 28,
 'downloader/request_bytes': 931,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 9168,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.298286,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 25, 6, 22, 23, 74078, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 55735,
 'httpcompression/response_count': 2,
 'item_scraped_count': 28,
 'items_per_minute': 420.0,
 'log_count/DEBUG': 43,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 25, 6, 22, 18, 775792, tzinfo=datetime.timezone.utc)}
```