### PR TITLE
[Intersport ES] Avoid lost of POIs beacuse of ValueError for  the spider

### DIFF
--- a/locations/spiders/intersport_es.py
+++ b/locations/spiders/intersport_es.py
@@ -22,7 +22,10 @@ class IntersportESSpider(scrapy.Spider):
             store["website"] = "https://www.intersport.es/tiendas?idStore=" + str(store["ref"])
             item = DictParser.parse(store)
             if "business_hours" in store and store["business_hours"] is not None:
-                item["opening_hours"] = self.parse_opening_hours(store["business_hours"])
+                try:
+                    item["opening_hours"] = self.parse_opening_hours(store["business_hours"])
+                except:
+                    self.logger.error("Failed to parse opening hours: {}".format(store["business_hours"]))
             yield item
 
     def parse_opening_hours(self, hours_definition):


### PR DESCRIPTION
```python
{'atp/brand/Intersport': 124,
 'atp/brand_wikidata/Q666888': 124,
 'atp/category/shop/sports': 124,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/ES': 124,
 'atp/field/branch/missing': 124,
 'atp/field/email/missing': 75,
 'atp/field/image/missing': 124,
 'atp/field/opening_hours/missing': 29,
 'atp/field/operator/missing': 124,
 'atp/field/operator_wikidata/missing': 124,
 'atp/field/phone/missing': 4,
 'atp/field/state/missing': 124,
 'atp/field/twitter/missing': 124,
 'atp/item_scraped_host_count/www.intersport.es': 124,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 124,
 'downloader/request_bytes': 667,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 51889,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.699799,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 29, 7, 5, 24, 464316, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1213766,
 'httpcompression/response_count': 2,
 'item_scraped_count': 124,
 'items_per_minute': 2480.0,
 'log_count/DEBUG': 139,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 29, 7, 5, 20, 764517, tzinfo=datetime.timezone.utc)}
```