### PR TITLE
[Valero] Fix Spider

### DIFF
--- a/locations/spiders/valero.py
+++ b/locations/spiders/valero.py
@@ -11,6 +11,7 @@ class ValeroSpider(scrapy.Spider):
     usa_bbox = [-125, 24, -65, 51]
     xstep = 5
     ystep = 3
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def make_search(self, xmin, ymin, xmax, ymax):
         return scrapy.FormRequest(


### PR DESCRIPTION
**_Fixes : Flag robotstxt_obey as False to fix spider_**

```python
{'atp/brand/Valero': 4701,
 'atp/brand_wikidata/Q1283291': 4701,
 'atp/category/amenity/fuel': 4701,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/name': 3,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/street_address': 6,
 'atp/country/US': 4701,
 'atp/field/branch/missing': 4701,
 'atp/field/email/missing': 4701,
 'atp/field/image/missing': 4701,
 'atp/field/opening_hours/missing': 1524,
 'atp/field/operator/missing': 4701,
 'atp/field/operator_wikidata/missing': 4701,
 'atp/field/phone/invalid': 102,
 'atp/field/phone/missing': 396,
 'atp/field/twitter/missing': 4701,
 'atp/item_scraped_host_count/locations.valero.com': 4701,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4701,
 'downloader/request_bytes': 75119,
 'downloader/request_count': 108,
 'downloader/request_method_count/POST': 108,
 'downloader/response_bytes': 9601949,
 'downloader/response_count': 108,
 'downloader/response_status_count/200': 108,
 'elapsed_time_seconds': 131.854359,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 29, 9, 36, 20, 377797, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 4701,
 'items_per_minute': 2153.1297709923665,
 'log_count/DEBUG': 4823,
 'log_count/INFO': 11,
 'log_count/WARNING': 1,
 'response_received_count': 108,
 'responses_per_minute': 49.465648854961835,
 'scheduler/dequeued': 108,
 'scheduler/dequeued/memory': 108,
 'scheduler/enqueued': 108,
 'scheduler/enqueued/memory': 108,
 'start_time': datetime.datetime(2025, 9, 29, 9, 34, 8, 523438, tzinfo=datetime.timezone.utc)}
```