### PR TITLE
[Armaguard AU] Add protection against timeout error

### DIFF
--- a/locations/spiders/armaguard_au.py
+++ b/locations/spiders/armaguard_au.py
@@ -13,6 +13,7 @@ class ArmaguardAUSpider(scrapy.Spider):
     start_urls = [
         "https://app.ehoundplatform.com/api/1.3/proximity_search?output=json&lat=-33.867139&lon=151.207114&count=5000&priority_distance=undefined&priority_filters=undefined&priority_logic=undefined&log_type=web&create_log=true&api_key=a34dcb3a0c98793&custom_logic=undefined&user_selection=undefined&ch=7203"
     ]
+    download_timeout = 120
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for atm in response.json()["record_set"]:


### PR DESCRIPTION
```python
{'atp/brand/Armaguard': 1761,
 'atp/brand_wikidata/Q118898974': 1761,
 'atp/category/amenity/atm': 1761,
 'atp/clean_strings/branch': 49,
 'atp/clean_strings/city': 7,
 'atp/clean_strings/street_address': 17,
 'atp/country/AU': 1761,
 'atp/field/email/missing': 1761,
 'atp/field/image/missing': 1761,
 'atp/field/name/missing': 1761,
 'atp/field/opening_hours/missing': 965,
 'atp/field/operator/missing': 1761,
 'atp/field/operator_wikidata/missing': 1761,
 'atp/field/phone/missing': 1761,
 'atp/field/twitter/missing': 1761,
 'atp/field/website/missing': 1761,
 'atp/item_scraped_host_count/app.ehoundplatform.com': 1761,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1761,
 'downloader/request_bytes': 936,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 289648,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 9.068497,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 29, 12, 14, 20, 379740, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2605310,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1761,
 'items_per_minute': 11740.0,
 'log_count/DEBUG': 1777,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 29, 12, 14, 11, 311243, tzinfo=datetime.timezone.utc)}
```