### PR TITLE
[Steers ZA] Fix Spider

### DIFF
--- a/locations/spiders/steers_za.py
+++ b/locations/spiders/steers_za.py
@@ -4,7 +4,6 @@ from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
 from locations.storefinders.go_review_api import GoReviewApiSpider
 
 
@@ -15,35 +14,21 @@ class SteersZASpider(GoReviewApiSpider):
     domain = "locations.steers.co.za"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request]:
-        yield Request(
-            url=item["website"],
-            meta={"item": item, "attributes": feature.get("attributes")},
-            callback=self.parse_location_ld,
-        )
-
-    def parse_location_ld(self, response) -> Iterable[Feature]:
-        ld_item = LinkedDataParser.parse(response, "Restaurant")
-
-        ld_item["ref"] = response.meta["item"]["ref"]
-        ld_item["branch"] = ld_item.pop("name").removeprefix("Steers ")
-
-        ld_item.pop("image")
-
-        if response.meta["attributes"] is not None:
-            attributes = [attribute["value"] for attribute in response.meta["attributes"]]
-
-            apply_yes_no(Extras.DELIVERY, ld_item, "Delivery" in attributes)
-            apply_yes_no(PaymentMethods.CARDS, ld_item, "Card" in attributes)
-            apply_yes_no(PaymentMethods.DEBIT_CARDS, ld_item, "Debit cards" in attributes)
-            apply_yes_no(PaymentMethods.CREDIT_CARDS, ld_item, "Credit cards" in attributes)
-            apply_yes_no(Extras.DRIVE_THROUGH, ld_item, "Drive-through" in attributes)
-            apply_yes_no(Extras.DRIVE_THROUGH, ld_item, "Drive Thru" in attributes)
-            apply_yes_no(Extras.BREAKFAST, ld_item, "Breakfast" in attributes)
-            apply_yes_no(Extras.BRUNCH, ld_item, "Brunch" in attributes)
+        item["branch"] = item.pop("name").removeprefix("Steers ")
+        if feature.get("attributes") is not None:
+            attributes = [attribute["value"] for attribute in feature["attributes"]]
+            apply_yes_no(Extras.DELIVERY, item, "Delivery" in attributes)
+            apply_yes_no(PaymentMethods.CARDS, item, "Card" in attributes)
+            apply_yes_no(PaymentMethods.DEBIT_CARDS, item, "Debit cards" in attributes)
+            apply_yes_no(PaymentMethods.CREDIT_CARDS, item, "Credit cards" in attributes)
+            apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive-through" in attributes)
+            apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive Thru" in attributes)
+            apply_yes_no(Extras.BREAKFAST, item, "Breakfast" in attributes)
+            apply_yes_no(Extras.BRUNCH, item, "Brunch" in attributes)
 
             for attribute in attributes:
                 self.crawler.stats.inc_value(f"atp/{self.name}/attribute/{attribute}")
 
-        apply_category(Categories.FAST_FOOD, ld_item)
+        apply_category(Categories.FAST_FOOD, item)
 
-        yield ld_item
+        yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Steers': 666,
 'atp/brand_wikidata/Q3056765': 666,
 'atp/category/amenity/fast_food': 666,
 'atp/country/ZA': 666,
 'atp/field/city/missing': 666,
 'atp/field/email/missing': 666,
 'atp/field/image/missing': 666,
 'atp/field/opening_hours/missing': 666,
 'atp/field/operator/missing': 666,
 'atp/field/operator_wikidata/missing': 666,
 'atp/field/phone/invalid': 6,
 'atp/field/postcode/missing': 666,
 'atp/field/state/missing': 666,
 'atp/field/street_address/missing': 666,
 'atp/item_scraped_host_count/admin.goreview.co.za': 666,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 666,
 'atp/steers_za/attribute/24 Hours': 60,
 'atp/steers_za/attribute/Breakfast': 601,
 'atp/steers_za/attribute/Brunch': 658,
 'atp/steers_za/attribute/Call & Collect': 580,
 'atp/steers_za/attribute/Card': 658,
 'atp/steers_za/attribute/Click & Collect': 464,
 'atp/steers_za/attribute/Comfort food': 15,
 'atp/steers_za/attribute/Contactless Payments': 658,
 'atp/steers_za/attribute/Counter service': 658,
 'atp/steers_za/attribute/Credit cards': 500,
 'atp/steers_za/attribute/Debit cards': 658,
 'atp/steers_za/attribute/Delivery': 555,
 'atp/steers_za/attribute/Dessert': 267,
 'atp/steers_za/attribute/Dinner': 150,
 'atp/steers_za/attribute/Drive Thru': 1,
 'atp/steers_za/attribute/Drive-through': 1,
 'atp/steers_za/attribute/English': 54,
 'atp/steers_za/attribute/Family-friendly': 24,
 'atp/steers_za/attribute/Generator': 1,
 'atp/steers_za/attribute/Good for kids': 17,
 'downloader/request_bytes': 555,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1035856,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 9.066144,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 30, 5, 9, 8, 931089, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 666,
 'items_per_minute': 4440.0,
 'log_count/DEBUG': 680,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 6.666666666666667,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 30, 5, 8, 59, 864945, tzinfo=datetime.timezone.utc),}

```