### PR TITLE
[Gratis TR] Fix Spider

### DIFF
--- a/locations/spiders/gratis_tr.py
+++ b/locations/spiders/gratis_tr.py
@@ -1,93 +1,25 @@
-import re
-
 import scrapy
 import scrapy.http
 
-from locations.categories import apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS, OpeningHours
-from locations.pipelines.address_clean_up import clean_address
+from locations.hours import DAYS_TR, OpeningHours, sanitise_day
 
 
 class GratisTRSpider(scrapy.Spider):
     name = "gratis_tr"
     start_urls = [
-        "https://api.cn94v1klbw-gratisicv1-p1-public.model-t.cc.commerce.ondemand.com/gratiscommercewebservices/v2/gratis/stores/country/TR?fields=DEFAULT&lang=tr&curr=TRY"
+        "https://api.gratis.retter.io/1oakekr4e/CALL/StoreManager/getStores/default?__culture=tr_TR&__platform=WEB"
     ]
     item_attributes = {"brand": "Gratis", "brand_wikidata": "Q28605813"}
 
-    def start_requests(self):
-        yield scrapy.Request(headers={"Accept": "application/json"}, url=self.start_urls[0], callback=self.parse)
-
     def parse(self, response):
-        for store in response.json()["pointOfServices"]:
+        for store in response.json()["storeList"]:
             item = DictParser.parse(store)
-            if item["lat"] is None or item["lon"] is None:
-                # SKIP: No coordinates means either the store is closed or this is an office
-                continue
-            item["ref"] = store["storeCode"]
-            item["city"] = get_loop(["address", "townInfo", "name"], store)
-            item["state"] = get_loop(["address", "cityInfo", "name"], store)
-            item["branch"] = store["displayName"]
-            street_address, addr_full = self.process_address(
-                get_loop(["address", "line1"], store), item["city"], item["state"]
-            )
-            item["addr_full"] = addr_full
-            item["street_address"] = street_address
-            item["name"] = "Gratis"
-            # Gratis has a default opening hours of 10:00 - 22:00
-            # For every store scraped with its own web page, the opening hours is the same
+            item["addr_full"] = store["addressText"]
             oh = OpeningHours()
-            oh.add_days_range(DAYS, "10:00", "22:00")
-            item["opening_hours"] = oh.as_opening_hours()
-            apply_category({"brand:website": "https://www.gratis.com"}, item)
-
-            if item["city"] is not None and item["state"] is not None:
-                apply_category({"website": self.get_page_url(item["branch"], item["city"], item["state"])}, item)
-            if store.get("phone") is not None and store.get("phone") != "-":
-                item["phone"] = store["phone"]
-
+            for day_time in store["workingHours"]:
+                day = sanitise_day(day_time["day"], DAYS_TR)
+                open_time, close_time = day_time["hours"].split(" - ")
+                oh.add_range(day=day, open_time=open_time, close_time=close_time)
+            item["opening_hours"] = oh
             yield item
-
-    # The only added information is opening hours but all stores have the same opening hours so this is not used
-    # For future reference, this is how the opening hours are scraped
-    def parse_page(self, response: scrapy.http.TextResponse):
-        time_re = re.compile("([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])")
-        time_str = response.css("span.store-times-content").get()
-        oh = OpeningHours()
-        if time_str is not None:
-            [opening, closing] = list(map(lambda e: f"{e[0]}:{e[1]}", time_re.findall(time_str)))
-            oh.add_days_range(DAYS, opening, closing)
-        item = response.meta["item"]
-        item["opening_hours"] = oh.as_opening_hours()
-        yield item
-
-    @staticmethod
-    def process_address(address: str, district: str | None = None, province: str | None = None) -> tuple[str, str]:
-        cleaned_street_adress = clean_address(address.strip().removesuffix(f"/{district}").strip())
-        cleaned_addr_full = clean_address([cleaned_street_adress, district, province])
-        return cleaned_street_adress, cleaned_addr_full
-
-    @staticmethod
-    def get_page_url(display_name: str, district: str, province: str) -> str:
-        display_name = "-".join(map(lambda e: GratisTRSpider.process_for_url(e.strip()), display_name.split(" ")))
-        district = "-".join(map(lambda e: GratisTRSpider.process_for_url(e.strip()), display_name.split(" ")))
-        province = GratisTRSpider.process_for_url(province)
-        url = "https://www.gratis.com/magazalarimiz/{province}/{district}/{display_name}"
-        return url.format(province=province, district=district, display_name=display_name)
-
-    @staticmethod
-    def process_for_url(s: str) -> str:
-        chars_dict = {"İ": "i", "Ğ": "g", "Ü": "u", "Ş": "s", "Ö": "o", "Ç": "c"}
-        for char, replacement in chars_dict.items():
-            s = s.replace(char, replacement)
-        return s.lower()
-
-
-def get_loop(keys: list[str], d: dict):
-    for key in keys:
-        d = d.get(key)
-        if d is None:
-            return None
-
-    return d


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Gratis': 789,
 'atp/brand_wikidata/Q28605813': 789,
 'atp/category/shop/cosmetics': 789,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/lon': 1,
 'atp/clean_strings/name': 5,
 'atp/clean_strings/street': 10,
 'atp/country/TR': 789,
 'atp/field/branch/missing': 789,
 'atp/field/country/from_spider_name': 789,
 'atp/field/email/missing': 789,
 'atp/field/image/missing': 789,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 789,
 'atp/field/operator_wikidata/missing': 789,
 'atp/field/phone/missing': 789,
 'atp/field/postcode/missing': 789,
 'atp/field/state/missing': 789,
 'atp/field/street_address/missing': 789,
 'atp/field/twitter/missing': 789,
 'atp/field/website/missing': 789,
 'atp/item_scraped_host_count/api.gratis.retter.io': 789,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 789,
 'downloader/request_bytes': 1418,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 57827,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/500': 3,
 'elapsed_time_seconds': 7.786448,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 30, 6, 41, 46, 513619, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 2,
 'httpcache/hit': 2,
 'httpcache/miss': 2,
 'httpcache/store': 2,
 'httpcompression/response_bytes': 575984,
 'httpcompression/response_count': 1,
 'item_scraped_count': 789,
 'items_per_minute': 6762.857142857143,
 'log_count/DEBUG': 808,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 17.142857142857142,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/500 Internal Server Error': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/500': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 30, 6, 41, 38, 727171, tzinfo=datetime.timezone.utc)}
```