### PR TITLE
[Agata Meble PL] Fix Spider

### DIFF
--- a/locations/spiders/agata_meble_pl.py
+++ b/locations/spiders/agata_meble_pl.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+import json
 
 import scrapy
 
@@ -8,21 +8,57 @@ from locations.dict_parser import DictParser
 class AgataMeblePLSpider(scrapy.Spider):
     name = "agata_meble_pl"
     item_attributes = {"brand": "Agata Meble", "brand_wikidata": "Q9141928"}
-    start_urls = ["https://www.agatameble.pl/api/v1/pos/pos/poses.json"]
+
+    def start_requests(self):
+        url = "https://www.agatameble.pl/graphql"
+        query = """
+        query PickupLocations($deviceType: Int!) {
+          pickupLocations(pageSize: 1000) {
+            total_count
+            items {
+              city
+              latitude
+              longitude
+              name
+              phone
+              pickup_location_code
+              postcode
+              street
+              is_megabox_location_active
+              url_key
+              opening_hours {
+                monday_friday_hours
+                saturday_hours
+                sunday_hours
+              }
+              salon_data {
+                salon_code
+                salon_id
+                salon_name
+              }
+            }
+          }
+          getStoresBanners(input: {
+            type: $deviceType
+            source_code: ""
+            listing: true
+          }) {
+            top_banner {
+              image
+              url
+            }
+          }
+        }
+        """
+
+        payload = {"query": query, "operationName": "PickupLocations", "variables": {"deviceType": 1}}
+
+        headers = {"Content-Type": "application/json"}
+
+        yield scrapy.Request(url=url, method="POST", body=json.dumps(payload), headers=headers, callback=self.parse)
 
     def parse(self, response):
-        for poi in response.json()["results"]:
-            # Skip disabled results
-            if poi["Enabled"] is False:
-                continue
-
-            item = DictParser.parse(poi)
-            item.pop("name", None)
-            item["website"] = urljoin("https://www.agatameble.pl/salon/", poi["Slug"])
-
-            # Make a request to the website so that we filter out closed stores that 404
-            yield scrapy.Request(item["website"], self.parse_store, meta={"item": item})
-
-    def parse_store(self, response, **kwargs):
-        item = response.meta["item"]
-        yield item
+        for location in response.json()["data"]["pickupLocations"]["items"]:
+            item = DictParser.parse(location)
+            item["website"] = item["ref"] = "https://www.agatameble.pl/sklep/" + location["url_key"]
+            yield item


### PR DESCRIPTION
**_Fixes : code updated to use graphql to fix spider_**

```python
{'atp/brand/Agata Meble': 36,
 'atp/brand_wikidata/Q9141928': 36,
 'atp/category/shop/furniture': 36,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/street': 5,
 'atp/country/PL': 36,
 'atp/field/branch/missing': 36,
 'atp/field/country/from_spider_name': 36,
 'atp/field/email/missing': 36,
 'atp/field/image/missing': 36,
 'atp/field/opening_hours/missing': 36,
 'atp/field/operator/missing': 36,
 'atp/field/operator_wikidata/missing': 36,
 'atp/field/state/missing': 36,
 'atp/field/street_address/missing': 36,
 'atp/field/twitter/missing': 36,
 'atp/item_scraped_host_count/www.agatameble.pl': 36,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 36,
 'downloader/request_bytes': 1740,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 9558,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.091919,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 30, 9, 54, 9, 293557, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17639,
 'httpcompression/response_count': 2,
 'item_scraped_count': 36,
 'items_per_minute': 540.0,
 'log_count/DEBUG': 51,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 30, 9, 54, 5, 201638, tzinfo=datetime.timezone.utc)}
```