### PR TITLE
[saba] Add Spider (492 locations)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,h11,h2,ijson,json5,lxml,openpyxl,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_zyte_api,shapely,tldextract,unidecode,w3lib,xmltodict
+known_third_party = babel,boto3,botocore,chompjs,cryptography,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_zyte_api,shapely,tldextract,unidecode,w3lib,xmltodict


### PR DESCRIPTION
```
{'atp/brand/Saba': 492,
 'atp/brand_wikidata/Q67808022': 492,
 'atp/category/amenity/parking': 492,
 'atp/clean_strings/city': 25,
 'atp/clean_strings/name': 16,
 'atp/clean_strings/street': 90,
 'atp/country/CL': 41,
 'atp/country/CZ': 19,
 'atp/country/DE': 32,
 'atp/country/GB': 293,
 'atp/country/IT': 43,
 'atp/country/PT': 48,
 'atp/country/SK': 14,
 'atp/country/VA': 1,
 'atp/duplicate_count': 3,
 'atp/field/branch/missing': 492,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 198,
 'atp/field/country/from_website_url': 293,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 492,
 'atp/field/image/missing': 492,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 492,
 'atp/field/operator/missing': 492,
 'atp/field/operator_wikidata/missing': 492,
 'atp/field/phone/missing': 492,
 'atp/field/postcode/missing': 492,
 'atp/field/state/missing': 295,
 'atp/field/street_address/missing': 492,
 'atp/field/twitter/missing': 492,
 'atp/field/website/missing': 199,
 'atp/item_scraped_host_count/www.sabaparking.co.uk': 495,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 492,
 'downloader/request_bytes': 889,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 257947,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.822565,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 30, 14, 12, 49, 898273, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 3,
 'item_dropped_reasons_count/DropItem': 3,
 'item_scraped_count': 492,
 'items_per_minute': 7380.0,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 278421504,
 'memusage/startup': 278421504,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 9, 30, 14, 12, 45, 75708, tzinfo=datetime.timezone.utc)}
```