### PR TITLE
[P.F. Chang's] Move to RioSeoSpider to fix spider

### DIFF
--- a/locations/spiders/pf_changs.py
+++ b/locations/spiders/pf_changs.py
@@ -1,11 +1,12 @@
-from locations.storefinders.yext_answers import YextAnswersSpider
+from locations.storefinders.rio_seo import RioSeoSpider
 
 
-class PfChangsSpider(YextAnswersSpider):
+class PfChangsSpider(RioSeoSpider):
     name = "pf_changs"
     item_attributes = {"brand": "P.F. Chang's", "brand_wikidata": "Q5360181"}
-    endpoint = "https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query"
-    api_key = "74fc62da2a16bf5d87424b94f3bfddcc"
-    experience_key = "locator"
-    feature_type = "restaurants"
-    drop_attributes = {"contact:instagram", "twitter"}
+    end_point = "https://maps.locations.pfchangs.com"
+    template = "search"
+
+    def post_process_feature(self, feature, location):
+        feature["branch"] = feature.pop("name")
+        yield feature

--- a/locations/storefinders/rio_seo.py
+++ b/locations/storefinders/rio_seo.py
@@ -31,8 +31,11 @@ class RioSeoSpider(Spider):
     radius: int = 20038
     template: str = "domain"
 
-    def start_requests(self) -> Iterable[Request]:
-        yield JsonRequest(f"{self.end_point}/api/getAutocompleteData", callback=self.parse_autocomplete)
+    async def start(self) -> Iterable[Request]:
+        yield JsonRequest(
+            f"{self.end_point}/api/getAutocompleteData?template={self.template}&level={self.template}",
+            callback=self.parse_autocomplete,
+        )
 
     def parse_autocomplete(self, response: Response, **kwargs: Any) -> Any:
         yield JsonRequest(


### PR DESCRIPTION
```py
{"atp/brand/P.F. Chang's": 207,
 'atp/brand_wikidata/Q5360181': 207,
 'atp/category/amenity/restaurant': 207,
 'atp/country/US': 207,
 'atp/field/email/missing': 207,
 'atp/field/image/missing': 207,
 'atp/field/operator/missing': 207,
 'atp/field/operator_wikidata/missing': 207,
 'atp/field/twitter/missing': 207,
 'atp/item_scraped_host_count/maps.locations.pfchangs.com': 207,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 207,
 'downloader/request_bytes': 1296,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 67387,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.395658,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 9, 30, 18, 42, 30, 53676, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1397869,
 'httpcompression/response_count': 3,
 'item_scraped_count': 207,
 'items_per_minute': 4140.0,
 'log_count/INFO': 9,
 'memusage/max': 280330240,
 'memusage/startup': 280330240,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 9, 30, 18, 42, 26, 658018, tzinfo=datetime.timezone.utc)}
```