### PR TITLE
[Bo Rent NL] Add Spider (82 locations)

### DIFF
--- a/locations/spiders/bo_rent_nl.py
+++ b/locations/spiders/bo_rent_nl.py
@@ -30,9 +30,7 @@ class BoRentNLSpider(CrawlSpider, StructuredDataSpider):
             callback="parse_tool_rental_locations",
         ),
         Rule(
-            LinkExtractor(
-                allow="//self-storage/filialen/[^/]+$", restrict_xpaths='//*[@class="col-xs-6 singlemarker"]'
-            ),
+            LinkExtractor(allow="/self-storage/filialen/", restrict_xpaths='//*[@class="stretched-link"]'),
             callback="parse_self_storage_locations",
         ),
     ]
@@ -44,6 +42,8 @@ class BoRentNLSpider(CrawlSpider, StructuredDataSpider):
         item["lon"] = re.search(
             r"lon\s*=\s*(\d+\.\d+),", response.xpath('//*[contains(text(),"markersArray")]/text()').get()
         ).group(1)
+        # TODO: remove below line when category is added to NSI for this brand
+        item["nsi_id"] = "N/A"
         apply_category(Categories.CAR_RENTAL, item)
         yield item
 


### PR DESCRIPTION
```python
{'atp/brand/Bo-rent': 12,
 'atp/brand_wikidata/Q126919301': 12,
 'atp/category/shop/storage_rental': 12,
 'atp/country/NL': 12,
 'atp/field/branch/missing': 12,
 'atp/field/country/from_spider_name': 12,
 'atp/field/image/missing': 12,
 'atp/field/operator/missing': 12,
 'atp/field/operator_wikidata/missing': 12,
 'atp/field/state/missing': 12,
 'atp/field/twitter/missing': 12,
 'atp/item_scraped_host_count/borent.nl': 12,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 12,
 'downloader/request_bytes': 5753,
 'downloader/request_count': 14,
 'downloader/request_method_count/GET': 14,
 'downloader/response_bytes': 583974,
 'downloader/response_count': 14,
 'downloader/response_status_count/200': 14,
 'elapsed_time_seconds': 18.124579,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 6, 10, 24, 15, 223383, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2036497,
 'httpcompression/response_count': 14,
 'item_scraped_count': 12,
 'items_per_minute': 40.0,
 'log_count/DEBUG': 39,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 14,
 'responses_per_minute': 46.66666666666667,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 13,
 'scheduler/dequeued/memory': 13,
 'scheduler/enqueued': 13,
 'scheduler/enqueued/memory': 13,
 'start_time': datetime.datetime(2025, 10, 6, 10, 23, 57, 98804, tzinfo=datetime.timezone.utc)}
```