### PR TITLE
[Nordea SE] Fix Spider

### DIFF
--- a/locations/spiders/nordea_se.py
+++ b/locations/spiders/nordea_se.py
@@ -1,41 +1,35 @@
-import re
+from typing import Any, Iterable
 
 import scrapy
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_SE, OpeningHours, sanitise_day
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class NordeaSESpider(scrapy.Spider):
     name = "nordea_se"
     item_attributes = {"brand": "Nordea", "brand_wikidata": "Q1123823"}
-    start_urls = [
-        "https://bank.nordea.se/wemapp/api/bl2/markersdesktop?language=sv&country=se&type=all&swlat=48.62106214708822&swlng=-64.9736865&nelat=68.88121906615748&nelng=102.2606885&clat=60.12816&clng=18.64350&category=all&_=1677934421045"
-    ]
 
-    def parse(self, response):
-        for bank in response.json().get("listItems"):
-            oh = OpeningHours()
-            for row in bank.get("openingHoursRegular").split("<br />"):
-                hours = re.findall(r": [0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}|: Stängt", row)[0]
-                days = row.replace(hours, "")
-                for day in days.split(", "):
-                    if (hours := hours.replace(": ", "")) == "Stängt":
-                        continue
-                    oh.add_range(
-                        day=sanitise_day(day, {**DAYS_SE}),
-                        open_time=hours.split("-")[0],
-                        close_time=hours.split("-")[1],
-                    )
-            item = Feature()
-            item["ref"] = bank.get("id")
-            item["street_address"] = bank.get("address", {}).get("street_address")
-            item["state"] = bank.get("address", {}).get("region")
-            item["postcode"] = bank.get("address", {}).get("postal_code")
-            item["lat"] = bank.get("lat")
-            item["lon"] = bank.get("lng")
-            item["opening_hours"] = oh.as_opening_hours()
+    def start_requests(self) -> Iterable[Any]:
+        yield JsonRequest(
+            url="https://public-api.nordea.com/api/dbf/ca/nordea-locations-v1/branches-and-atms",
+            data={
+                "country": "se",
+                "coordinate1": "",
+                "coordinate2": "",
+                "category": "ALL",
+                "services": [],
+                "currencies": [],
+            },
+            method="POST",
+            callback=self.parse,
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for bank in response.json()["collection_of_atms_and_branches"]:
+            item = DictParser.parse(bank)
+            item["lat"] = bank["coordinate1"]
+            item["lon"] = bank["coordinate2"]
             apply_category(Categories.BANK, item)
-
             yield item


### PR DESCRIPTION
**_Fixes : code updated to fix spider_**

```python
{'atp/brand/Nordea': 209,
 'atp/brand_wikidata/Q1123823': 209,
 'atp/category/amenity/bank': 209,
 'atp/clean_strings/postcode': 4,
 'atp/country/SE': 209,
 'atp/field/branch/missing': 209,
 'atp/field/city/missing': 209,
 'atp/field/email/missing': 209,
 'atp/field/image/missing': 209,
 'atp/field/opening_hours/missing': 209,
 'atp/field/operator/missing': 209,
 'atp/field/operator_wikidata/missing': 209,
 'atp/field/phone/missing': 209,
 'atp/field/postcode/missing': 8,
 'atp/field/state/missing': 7,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 209,
 'atp/field/website/missing': 209,
 'atp/item_scraped_host_count/public-api.nordea.com': 209,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 209,
 'downloader/request_bytes': 1518,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 3,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 13755,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/503': 3,
 'elapsed_time_seconds': 6.15678,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 7, 7, 6, 40, 582501, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 131146,
 'httpcompression/response_count': 1,
 'item_scraped_count': 209,
 'items_per_minute': 2090.0,
 'log_count/DEBUG': 226,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/503 Service Unavailable': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/503': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 10, 7, 7, 6, 34, 425721, tzinfo=datetime.timezone.utc)}
```