### PR TITLE
[Salvos AU] Fix Spider

### DIFF
--- a/locations/spiders/salvos_au.py
+++ b/locations/spiders/salvos_au.py
@@ -1,32 +1,31 @@
-import re
+import json
 
-from scrapy import Spider
+from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
-class SalvosAUSpider(Spider):
+class SalvosAUSpider(SitemapSpider):
     name = "salvos_au"
     item_attributes = {"brand": "Salvos", "brand_wikidata": "Q120646407"}
-    allowed_domains = ["www.salvosstores.com.au"]
-    start_urls = ["https://www.salvosstores.com.au/api/uplister/store-list"]
+    sitemap_urls = ["https://www.salvosstores.com.au/sitemap.xml"]
+    sitemap_rules = [("/stores/", "parse")]
 
     def parse(self, response):
-        for location in response.json().values():
-            if location.get("isPermanentlyClosed") or location.get("isOpeningSoon"):
-                continue
-            item = DictParser.parse(location)
-            item["addr_full"] = re.sub(r"\s+", " ", location["FullAddress"].replace("<br>", ", ")).strip()
-            item["housenumber"] = location["Number"]
-            item["street"] = " ".join(filter(None, [location["StreetName"], location["StreetType"]]))
-            item["city"] = location["SuburbName"]
-            item["website"] = location["URL"].replace("uplister.com.au", "www.salvosstores.com.au/stores")
-            item["opening_hours"] = OpeningHours()
-            for day_name, day_hours in location["OpeningHours"].items():
-                if day_hours == "Close":
-                    continue
-                item["opening_hours"].add_range(day_name, day_hours["Opening"], day_hours["Closing"], "%H:%M:%S")
-            apply_category(Categories.SHOP_CHARITY, item)
+        store_data = json.loads(response.xpath('//*[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"]["store"]
+        if store_data.get("StoreID"):
+            item = DictParser.parse(store_data)
+            item["website"] = response.url
+            item["branch"] = item.pop("name")
+            oh = OpeningHours()
+            for day, time in store_data["OpeningHours"].items():
+                day = day
+                if time == "Close":
+                    oh.set_closed(day)
+                else:
+                    open_time = time["Opening"]
+                    close_time = time["Closing"]
+                    oh.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M:%S")
+            item["opening_hours"] = oh
             yield item


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/brand/Salvos': 344,
 'atp/brand_wikidata/Q120646407': 344,
 'atp/category/shop/charity': 344,
 'atp/cdn/cloudfront/response_count': 388,
 'atp/cdn/cloudfront/response_status_count/200': 388,
 'atp/clean_strings/addr_full': 9,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/phone': 4,
 'atp/clean_strings/street': 18,
 'atp/country/AU': 344,
 'atp/duplicate_count': 3,
 'atp/field/city/missing': 344,
 'atp/field/country/from_spider_name': 344,
 'atp/field/email/missing': 344,
 'atp/field/image/missing': 344,
 'atp/field/lat/missing': 6,
 'atp/field/lon/missing': 6,
 'atp/field/operator/missing': 344,
 'atp/field/operator_wikidata/missing': 344,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 1,
 'atp/field/street_address/missing': 344,
 'atp/field/twitter/missing': 344,
 'atp/item_scraped_host_count/www.salvosstores.com.au': 347,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 344,
 'atp/tt_locate/fail': 6,
 'downloader/request_bytes': 189771,
 'downloader/request_count': 416,
 'downloader/request_method_count/GET': 416,
 'downloader/response_bytes': 14517860,
 'downloader/response_count': 416,
 'downloader/response_status_count/200': 389,
 'downloader/response_status_count/307': 27,
 'dupefilter/filtered': 27,
 'elapsed_time_seconds': 515.293286,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 7, 9, 16, 40, 735943, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 67245868,
 'httpcompression/response_count': 387,
 'item_dropped_count': 3,
 'item_dropped_reasons_count/DropItem': 3,
 'item_scraped_count': 344,
 'items_per_minute': 40.07766990291262,
 'log_count/DEBUG': 777,
 'log_count/ERROR': 1,
 'log_count/INFO': 18,
 'log_count/WARNING': 6,
 'request_depth_max': 2,
 'response_received_count': 389,
 'responses_per_minute': 45.32038834951456,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'spider_exceptions/KeyError': 1,
 'spider_exceptions/count': 1,
 'start_time': datetime.datetime(2025, 10, 7, 9, 8, 5, 442657, tzinfo=datetime.timezone.utc)}
```