### PR TITLE
[Godfathers Pizza] Fix Spider

### DIFF
--- a/locations/spiders/godfathers_pizza.py
+++ b/locations/spiders/godfathers_pizza.py
@@ -10,10 +10,19 @@ from locations.dict_parser import DictParser
 class GodfathersPizzaSpider(scrapy.Spider):
     name = "godfathers_pizza"
     item_attributes = {"brand": "Godfather's Pizza", "brand_wikidata": "Q5576353"}
-    start_urls = ["https://godfathers.orderexperience.net/_nuxt/dbf11b2.js"]
+    # start_urls = ["https://godfathers.orderexperience.net/_nuxt/dbf11b2.js"]
+    start_urls = [
+        "https://godfathers.orderexperience.net/locations?_gl=1*wnu5aw*_gcl_au*MjAzNTAxNDc1OC4xNzYxODMwODU1*_ga*MjEwODI5ODM0My4xNzYxODMwODU1*_ga_TG5PXZSCYT*czE3NjE4MzA4NTUkbzEkZzEkdDE3NjE4MzA4NTgkajU3JGwwJGgw"
+    ]
     requires_proxy = True
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
+    def parse(self, response):
+        yield scrapy.Request(
+            url="https://godfathers.orderexperience.net" + response.xpath("/html/body/script[4]/@src").get(),
+            callback=self.parse_token,
+        )
+
+    def parse_token(self, response: Response, **kwargs: Any) -> Any:
         key = re.search(r"apiKey:\s*\"(\w+)\"", response.text).group(1)
         yield JsonRequest(
             url="https://oxb.pxsweb.com/api/v1/apps/restaurants/66abfd6ce1b9d093ee0ab75d?key={}".format(key),
@@ -26,5 +35,6 @@ class GodfathersPizzaSpider(scrapy.Spider):
             if store["loc"]:
                 item["lat"] = store["loc"][0]
                 item["lon"] = store["loc"][1]
-            item["street_address"] = item.pop("addr_full")
+            if item.get("addr_full"):
+                item["street_address"] = item.pop("addr_full")
             yield item


### PR DESCRIPTION
**_Fixes : updated start_url to fetch api_key to fix spider_**

```python
{"atp/brand/Godfather's Pizza": 645,
 'atp/brand_wikidata/Q5576353': 645,
 'atp/category/amenity/restaurant': 645,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/street_address': 2,
 'atp/closed_check': 1,
 'atp/country/US': 643,
 'atp/field/branch/missing': 645,
 'atp/field/city/missing': 1,
 'atp/field/country/missing': 2,
 'atp/field/email/missing': 645,
 'atp/field/image/missing': 645,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 645,
 'atp/field/operator/missing': 645,
 'atp/field/operator_wikidata/missing': 645,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 26,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 645,
 'atp/field/website/missing': 633,
 'atp/item_scraped_host_count/oxb.pxsweb.com': 645,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 645,
 'downloader/request_bytes': 1530,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 3359283,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 19.500858,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 9, 10, 6, 31, 454995, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3891718,
 'httpcompression/response_count': 1,
 'item_scraped_count': 645,
 'items_per_minute': 2036.842105263158,
 'log_count/DEBUG': 662,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': 12.631578947368421,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'spider_exceptions/KeyError': 1,
 'spider_exceptions/count': 1,
 'start_time': datetime.datetime(2025, 10, 9, 10, 6, 11, 954137, tzinfo=datetime.timezone.utc)}
```