### PR TITLE
[Metro US] Fix Spider

### DIFF
--- a/locations/spiders/metro_us.py
+++ b/locations/spiders/metro_us.py
@@ -14,9 +14,6 @@ class MetroUSSpider(CrawlSpider, StructuredDataSpider):
     ]
     wanted_types = ["Store"]
 
-    def pre_process_data(self, ld_data, **kwargs):
-        ld_data["openingHours"] = ld_data.pop("openingHoursSpecification")
-
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Metro by T-Mobile ")
         item["street_address"] = (


### PR DESCRIPTION
**_Fixes : removed pre_process_item to fix spider_**

```python
{'atp/brand/Metro by T-Mobile': 5968,
'atp/brand_wikidata/Q1925685': 5968,
'atp/category/shop/mobile_phone': 5968,
'atp/clean_strings/branch': 1,
'atp/clean_strings/street_address': 6,
'atp/country/US': 5968,
'atp/field/email/missing': 5968,
'atp/field/image/missing': 5968,
'atp/field/opening_hours/missing': 116,
'atp/field/operator/missing': 5968,
'atp/field/operator_wikidata/missing': 5968,
'atp/field/phone/missing': 1,
'atp/field/twitter/missing': 5968,
'atp/item_scraped_host_count/www.metrobyt-mobile.com': 5968,
'atp/lineage': 'S_?',
'atp/nsi/perfect_match': 5968,
'downloader/request_bytes': 10286013,
'downloader/request_count': 6018,
'downloader/request_method_count/GET': 6018,
'downloader/response_bytes': 265134836,
'downloader/response_count': 6018,
'downloader/response_status_count/200': 6018,
'elapsed_time_seconds': 7603.335626,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2025, 10, 9, 9, 33, 53, 294291, tzinfo=datetime.timezone.utc),
'httpcompression/response_bytes': 1614514542,
'httpcompression/response_count': 6018,
'item_scraped_count': 5968,
'items_per_minute': 47.097198474286465,
'log_count/DEBUG': 12003,
'log_count/INFO': 136,
'request_depth_max': 2,
'response_received_count': 6018,
'responses_per_minute': 47.491779560699726,
'robotstxt/request_count': 1,
'robotstxt/response_count': 1,
'robotstxt/response_status_count/200': 1,
'scheduler/dequeued': 6017,
'scheduler/dequeued/memory': 6017,
'scheduler/enqueued': 6017,
'scheduler/enqueued/memory': 6017,
'start_time': datetime.datetime(2025, 10, 9, 7, 27, 9, 958665, tzinfo=datetime.timezone.utc),
'tt/dissolved/brand/wikidata/Q1925685': 5968,
'tt/dissolved/brand/wikidata/total_count': 5968,
'tt/dissolved/wikidata/item_count': 5968}
```