### PR TITLE
[Elkjøp NO] Add spider

### DIFF
--- a/locations/spiders/elkjop_no.py
+++ b/locations/spiders/elkjop_no.py
@@ -1,0 +1,18 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ElkjopNOSpider(SitemapSpider, StructuredDataSpider):
+    name = "elkjop_no"
+    item_attributes = {"name": "Elkjøp", "brand": "Elkjøp", "brand_wikidata": "Q1771628"}
+    sitemap_urls = ["https://www.elkjop.no/robots.txt"]
+    sitemap_rules = [("/store/elkjop-", "parse")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Elkjøp ")
+        apply_category(Categories.SHOP_ELECTRONICS, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Elkjøp': 136,
 'atp/brand_wikidata/Q1771628': 136,
 'atp/category/shop/electronics': 136,
 'atp/country/NO': 136,
 'atp/field/email/missing': 136,
 'atp/field/image/dropped': 136,
 'atp/field/image/missing': 136,
 'atp/field/operator/missing': 136,
 'atp/field/operator_wikidata/missing': 136,
 'atp/field/phone/missing': 136,
 'atp/field/state/missing': 136,
 'atp/field/twitter/missing': 136,
 'atp/item_scraped_host_count/www.elkjop.no': 136,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 136,
 'downloader/request_bytes': 74207,
 'downloader/request_count': 174,
 'downloader/request_method_count/GET': 174,
 'downloader/response_bytes': 25239085,
 'downloader/response_count': 174,
 'downloader/response_status_count/200': 174,
 'elapsed_time_seconds': 7.764282,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 14, 14, 21, 15, 416020, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 174,
 'httpcompression/response_bytes': 311908216,
 'httpcompression/response_count': 174,
 'item_scraped_count': 136,
 'items_per_minute': 1165.7142857142858,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 288759808,
 'memusage/startup': 288759808,
 'request_depth_max': 3,
 'response_received_count': 174,
 'responses_per_minute': 1491.4285714285713,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 173,
 'scheduler/dequeued/memory': 173,
 'scheduler/enqueued': 173,
 'scheduler/enqueued/memory': 173,
 'start_time': datetime.datetime(2025, 10, 14, 14, 21, 7, 651738, tzinfo=datetime.timezone.utc)}
```

I learnt about this brand in https://github.com/OvertureMaps/data/issues/428