### PR TITLE
[Premierurgentcare] Fix spider

### DIFF
--- a/locations/spiders/premierurgentcare.py
+++ b/locations/spiders/premierurgentcare.py
@@ -16,6 +16,7 @@ class PremierurgentcareSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/locations/[\w-]+/$", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["addr_full"] = response.xpath('//a[contains(@href,"maps/search")]/span/text()').get()
         apply_category(Categories.CLINIC, item)
         apply_yes_no("emergency", item, True)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Premier Urgent Care': 7,
 'atp/category/amenity/clinic': 7,
 'atp/category/multiple': 7,
 'atp/country/US': 7,
 'atp/field/branch/missing': 7,
 'atp/field/brand_wikidata/missing': 7,
 'atp/field/city/missing': 7,
 'atp/field/country/from_reverse_geocoding': 7,
 'atp/field/email/missing': 7,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 7,
 'atp/field/operator_wikidata/missing': 7,
 'atp/field/postcode/missing': 7,
 'atp/field/street_address/missing': 7,
 'atp/field/twitter/missing': 7,
 'atp/item_scraped_host_count/www.premier.care': 7,
 'atp/lineage': 'S_?',
 'downloader/request_bytes': 3094,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 116949,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 9.657687,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 15, 13, 29, 46, 17877, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 526742,
 'httpcompression/response_count': 8,
 'item_scraped_count': 7,
 'items_per_minute': 46.66666666666667,
 'log_count/DEBUG': 18,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 8,
 'responses_per_minute': 53.333333333333336,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2025, 10, 15, 13, 29, 36, 360190, tzinfo=datetime.timezone.utc)}
```