### PR TITLE
[Shahs Halal Food CA] Fix spider

### DIFF
--- a/locations/spiders/shahs_halal_food_ca.py
+++ b/locations/spiders/shahs_halal_food_ca.py
@@ -3,6 +3,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -19,6 +20,7 @@ class ShahsHalalFoodCASpider(JSONBlobSpider):
         item["street_address"] = item.pop("street")
         item["branch"] = item.pop("name").split(",")[0]
         item["opening_hours"] = self.parse_opening_hours(json.loads(feature["open_hours"]))
+        apply_category(Categories.FAST_FOOD, item)
         yield item
 
     def parse_opening_hours(self, opening_hours: dict) -> OpeningHours:


### PR DESCRIPTION
```python
{"atp/brand/Shah's Halal Food": 2,
 'atp/brand_wikidata/Q135009954': 2,
 'atp/category/amenity/fast_food': 2,
 'atp/country/CA': 2,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 2,
 'atp/field/name/missing': 2,
 'atp/field/operator/missing': 2,
 'atp/field/operator_wikidata/missing': 2,
 'atp/field/twitter/missing': 2,
 'atp/item_scraped_host_count/www.shahshalalfood.ca': 2,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 2,
 'downloader/request_bytes': 714,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1552,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.46488,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 15, 14, 34, 42, 52446, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1861,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2,
 'items_per_minute': 30.0,
 'log_count/DEBUG': 17,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 10, 15, 14, 34, 37, 587566, tzinfo=datetime.timezone.utc)}
```