### PR TITLE
[total_energies] Remove invalid website

### DIFF
--- a/locations/spiders/total_energies.py
+++ b/locations/spiders/total_energies.py
@@ -174,8 +174,6 @@ class TotalEnergiesSpider(WoosmapSpider):
             # Other types, possibly interesting
             return
 
-        item["website"] = f'https://store.totalenergies.fr/en_EN/{item["ref"]}'
-
         self.apply_services(item, feature)
 
         if brand := self.BRANDS.get(feature["properties"]["user_properties"]["brand"]):


### PR DESCRIPTION
mapping websites was incorrect.  lead to invalid sites.  
examples:
https://store.totalenergies.fr/en_EN/37236
https://store.totalenergies.fr/en_EN/37240
https://store.totalenergies.fr/en_EN/37241

