### PR TITLE
[Vintage Inns GB] Fix Spider

### DIFF
--- a/locations/spiders/vintage_inns_gb.py
+++ b/locations/spiders/vintage_inns_gb.py
@@ -1,11 +1,26 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.storefinders.woosmap import WoosmapSpider
 
 
-class VintageInnsGBSpider(SitemapSpider, StructuredDataSpider):
+class VintageInnsGBSpider(WoosmapSpider):
     name = "vintage_inns_gb"
     item_attributes = {"brand": "Vintage Inns", "brand_wikidata": "Q87067899"}
-    sitemap_urls = ["https://www.vintageinn.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"/restaurants/[a-z-]+/[a-z-]+$", "parse_sd")]
-    search_for_twitter = False
+    key = "woos-f6518149-ce6e-365c-b912-12ae5d6c8b2f"
+    origin = "https://www.vintageinn.co.uk"
+
+    def parse_item(self, item: Feature, feature: dict) -> Iterable[Feature]:
+        item["website"] = feature.get("properties").get("user_properties").get("primaryWebsiteUrl")
+        oh = OpeningHours()
+        try:
+            for day_time in feature["properties"]["user_properties"].get("tradingHours"):
+                day = day_time["day"]
+                open_time = day_time["openTime"]
+                close_time = day_time["closeTime"]
+                oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        except:
+            pass
+        item["opening_hours"] = oh
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to use woosmap to fix spider_**

```python
{'atp/brand/Vintage Inns': 176,
 'atp/brand_wikidata/Q87067899': 176,
 'atp/category/amenity/pub': 176,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/GB': 176,
 'atp/field/branch/missing': 176,
 'atp/field/city/missing': 3,
 'atp/field/country/from_spider_name': 3,
 'atp/field/email/missing': 176,
 'atp/field/image/missing': 176,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 176,
 'atp/field/operator_wikidata/missing': 176,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 3,
 'atp/field/state/missing': 176,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 176,
 'atp/field/website/missing': 5,
 'atp/item_scraped_host_count/api.woosmap.com': 176,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 176,
 'downloader/request_bytes': 787,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 108200,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.439118,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 16, 9, 25, 19, 673220, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 989756,
 'httpcompression/response_count': 2,
 'item_scraped_count': 176,
 'items_per_minute': 2640.0,
 'log_count/DEBUG': 191,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 10, 16, 9, 25, 15, 234102, tzinfo=datetime.timezone.utc)}
```