### PR TITLE
[Lenta RU] Fix spider

### DIFF
--- a/locations/spiders/lenta_ru.py
+++ b/locations/spiders/lenta_ru.py
@@ -1,35 +1,69 @@
-import scrapy
-from scrapy.http import JsonRequest
+import json
+import uuid
+from typing import Any, AsyncIterator
 
-from locations.categories import Categories, apply_category
+from scrapy import FormRequest, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
 
-class LentaRUSpider(scrapy.Spider):
+class LentaRUSpider(Spider):
     name = "lenta_ru"
     item_attributes = {"brand": "Лента", "brand_wikidata": "Q4258608"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
     allowed_domains = ["lenta.com"]
+    device_id = str(uuid.uuid4())
 
-    def start_requests(self):
-        yield JsonRequest("https://lenta.com/api/v2/stores")
+    async def start(self) -> AsyncIterator[Any]:
+        yield FormRequest(
+            url="https://lenta.com/api/rest/sessionGet",
+            headers={"x-retail-brand": "lo"},
+            formdata={
+                "request": json.dumps(
+                    {
+                        "Head": {
+                            "MarketingPartnerKey": "mp300-b1de0bac2c257f3257bf5ef2eea4ecbc",
+                            "Method": "sessionGet",
+                            "DeviceId": self.device_id,
+                        },
+                        "Body": {},
+                    }
+                ),
+            },
+        )
 
-    def parse(self, response):
-        for poi in response.json():
-            item = DictParser.parse(poi)
-            item["street_address"] = poi.get("address")
-            item["addr_full"] = None
-            self.parse_hours(item, poi)
-            # A few stores are marked as pet shops
-            if poi.get("type") == "zoo":
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            url="https://lenta.com/api-gateway/v1/stores/pickup/search",
+            headers={
+                "deviceid": self.device_id,
+                "sessiontoken": response.json()["Body"]["SessionToken"],
+                "x-retail-brand": "lo",
+                "x-platform": "omniweb",
+            },
+            data={},
+            callback=self.parse_locations,
+        )
+
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["items"]:
+            item = DictParser.parse(location)
+            item.pop("name")
+            item["addr_full"] = location["addressFull"]
+            item["opening_hours"] = self.parse_opening_hours(location["storeWorkingHours"])
+
+            if location.get("marketType") == "ZO":
                 apply_category(Categories.SHOP_PET, item)
+            else:
+                apply_category(Categories.SHOP_SUPERMARKET, item)
+
+            apply_yes_no(Extras.TAKEAWAY, item, "PICKUP" in location["features"])
             yield item
 
-    def parse_hours(self, item, poi):
-        if poi.get("is24hStore"):
-            item["opening_hours"] = "24/7"
-        else:
-            oh = OpeningHours()
-            oh.add_days_range(DAYS, poi.get("opensAt"), poi.get("closesAt"))
-            item["opening_hours"] = oh.as_opening_hours()
+    def parse_opening_hours(self, opening_hours: dict) -> OpeningHours:
+        oh = OpeningHours()
+        oh.add_days_range(DAYS, opening_hours.get("open"), opening_hours.get("close"))
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Лента': 797,
 'atp/brand_wikidata/Q4258608': 797,
 'atp/category/shop/pet': 132,
 'atp/category/shop/supermarket': 665,
 'atp/clean_strings/addr_full': 65,
 'atp/country/RU': 797,
 'atp/field/branch/missing': 797,
 'atp/field/city/missing': 797,
 'atp/field/country/from_spider_name': 797,
 'atp/field/email/missing': 797,
 'atp/field/image/missing': 797,
 'atp/field/operator/missing': 797,
 'atp/field/operator_wikidata/missing': 797,
 'atp/field/phone/missing': 797,
 'atp/field/postcode/missing': 797,
 'atp/field/state/missing': 797,
 'atp/field/street_address/missing': 797,
 'atp/field/twitter/missing': 797,
 'atp/field/website/missing': 797,
 'atp/item_scraped_host_count/lenta.com': 797,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 797,
 'downloader/request_bytes': 1371,
 'downloader/request_count': 2,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 64442,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 14.971251,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 16, 14, 40, 26, 53514, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 406510,
 'httpcompression/response_count': 2,
 'item_scraped_count': 797,
 'items_per_minute': 3415.714285714286,
 'log_count/DEBUG': 812,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 8.571428571428571,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 10, 16, 14, 40, 11, 82263, tzinfo=datetime.timezone.utc)}
```