### PR TITLE
[Ember Inns GB] Fix Spider

### DIFF
--- a/locations/spiders/ember_inns_gb.py
+++ b/locations/spiders/ember_inns_gb.py
@@ -1,10 +1,26 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.storefinders.woosmap import WoosmapSpider
 
 
-class EmberInnsGBSpider(SitemapSpider, StructuredDataSpider):
+class EmberInnsGBSpider(WoosmapSpider):
     name = "ember_inns_gb"
     item_attributes = {"brand": "Ember Inns", "brand_wikidata": "Q116272278"}
-    sitemap_urls = ["https://www.emberinns.co.uk/robots.txt"]
-    sitemap_rules = [(r"/nationalsearch/\w+/[-\w]+$", "parse_sd")]
+    key = "woos-63fb5127-b80c-3aa9-b672-bee33a31a43d"
+    origin = "https://www.emberinns.co.uk"
+
+    def parse_item(self, item: Feature, feature: dict) -> Iterable[Feature]:
+        item["website"] = feature.get("properties").get("user_properties").get("primaryWebsiteUrl")
+        oh = OpeningHours()
+        try:
+            for day_time in feature["properties"]["user_properties"].get("tradingHours"):
+                day = day_time["day"]
+                open_time = day_time["openTime"]
+                close_time = day_time["closeTime"]
+                oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        except:
+            pass
+        item["opening_hours"] = oh
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to use woosmap spider to fix spider_**

```python
{'atp/brand/Ember Inns': 150,
 'atp/brand_wikidata/Q116272278': 150,
 'atp/category/amenity/pub': 150,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/GB': 150,
 'atp/field/branch/missing': 150,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 150,
 'atp/field/image/missing': 150,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 150,
 'atp/field/operator_wikidata/missing': 150,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 150,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 150,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/api.woosmap.com': 150,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 150,
 'downloader/request_bytes': 786,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 70041,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.249953,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 17, 5, 12, 53, 31021, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 787785,
 'httpcompression/response_count': 2,
 'item_scraped_count': 150,
 'items_per_minute': 3000.0,
 'log_count/DEBUG': 165,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 10, 17, 5, 12, 49, 781068, tzinfo=datetime.timezone.utc)}
```