### PR TITLE
Replace deprecated start_requests function in 'd' spiders

### DIFF
--- a/locations/spiders/da_nl.py
+++ b/locations/spiders/da_nl.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -12,7 +14,7 @@ class DaNLSpider(Spider):
     allowed_domains = ["www.da.nl"]
     item_attributes = {"brand": "DA", "brand_wikidata": "Q4899756", "extras": Categories.SHOP_CHEMIST.value}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         graphql_query = """query GetRetailStores($storeId: Int = 3) {
     retailStores(pageSize: 5000, storeId: $storeId) {
         id

--- a/locations/spiders/dairy_queen_us.py
+++ b/locations/spiders/dairy_queen_us.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin
 
 from scrapy import Spider
@@ -17,7 +17,7 @@ class DairyQueenUSSpider(Spider):
     start_urls = ["https://prod-dairyqueen.dotcmscloud.com/api/es/search"]
     item_attributes = {"nsi_id": "N/A"}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url=self.start_urls[0],
             method="POST",

--- a/locations/spiders/daiso_us.py
+++ b/locations/spiders/daiso_us.py
@@ -1,4 +1,5 @@
 from json import loads
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -15,7 +16,7 @@ class DaisoUSSpider(Spider):
     # Also appears to be rebadged as "ProMap Store Locator by AMAI" (https://help.amai.com/en/collections/3274749-promap-store-locator)
     start_urls = ["https://daisous.com/cdn/shop/t/68/assets/sca.storelocatordata.json"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url)
 

--- a/locations/spiders/dats_24_be.py
+++ b/locations/spiders/dats_24_be.py
@@ -1,4 +1,7 @@
-from scrapy import Request, Spider
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.categories import Categories, Extras, Fuel, apply_yes_no
 from locations.dict_parser import DictParser
@@ -11,7 +14,7 @@ class Dats24BESpider(Spider):
     start_urls = ["https://dats24.be/api/service_point_locator"]
     allowed_domains = ["dats24.be"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         query = '{"latitude":0,"longitude":0,"searchRadius":1000000000,"filterCriteria":{"serviceDeliveryPointType":["FUEL"],"serviceDeliveryPointAvailability":[],"chargingConnectorType":[],"chargingConnectorPowerType":[],"chargingLocationOperatorName":["ALL"],"fuelProductType":[]}}'
         yield Request(
             url=self.start_urls[0],

--- a/locations/spiders/dave_and_busters.py
+++ b/locations/spiders/dave_and_busters.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from chompjs import parse_js_object
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -12,7 +14,7 @@ class DaveAndBustersSpider(Spider):
     allowed_domains = ["www.daveandbusters.com"]
     start_urls = ["https://www.daveandbusters.com/content/dnb-request/datadetails.json?mode=location"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url)
 

--- a/locations/spiders/davita_us.py
+++ b/locations/spiders/davita_us.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
 from geonamescache import GeonamesCache
 from scrapy import Spider
@@ -13,7 +13,7 @@ class DavitaUSSpider(Spider):
     item_attributes = {"operator": "DaVita Dialysis", "operator_wikidata": "Q5207184", "country": "US"}
     allowed_domains = ["davita.com"]
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for state in GeonamesCache().get_us_states():
             yield JsonRequest(
                 url=f"https://davita.com/wp-json/davita/v1/find-a-center?location={state}&p=1&lat=32.3182314&lng=-86.902298"

--- a/locations/spiders/dealz_pl.py
+++ b/locations/spiders/dealz_pl.py
@@ -1,8 +1,8 @@
 from json import loads
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
-from scrapy import Request, Spider
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import Request, Response
 
 from locations.geo import country_iseadgg_centroids
 from locations.hours import DAYS_PL, OpeningHours
@@ -14,7 +14,7 @@ class DealzPLSpider(Spider):
     item_attributes = {"brand": "Dealz", "brand_wikidata": "Q16942585"}
     allowed_domains = ["www.dealz.pl"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         # Fifty closest shops are returned no matter their distance from the
         # supplied centroid. Small search radius (24km) required to find the
         # maximum number of features.

--- a/locations/spiders/decathlon_au.py
+++ b/locations/spiders/decathlon_au.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -13,7 +15,7 @@ class DecathlonAUSpider(Spider):
     allowed_domains = ["decathlon.com.au"]
     start_urls = ["https://www.decathlon.com.au/api/store-setting?countryCode=AU"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url)
 

--- a/locations/spiders/delikatesy_centrum_pl.py
+++ b/locations/spiders/delikatesy_centrum_pl.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -12,7 +14,7 @@ class DelikatesyCentrumPLSpider(Spider):
     start_urls = ["https://www.delikatesy.pl"]
     allowed_domains = ["www.delikatesy.pl"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url=self.start_urls[0])
 
     def parse(self, response):

--- a/locations/spiders/deloitte.py
+++ b/locations/spiders/deloitte.py
@@ -1,18 +1,20 @@
 import json
 import re
+from typing import AsyncIterator
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 
-class DeloitteSpider(scrapy.Spider):
+class DeloitteSpider(Spider):
     name = "deloitte"
     item_attributes = {"brand": "Deloitte", "brand_wikidata": "Q491748"}
     allowed_domains = ["deloitte.com"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         start_urls = (
             (
                 "https://www2.deloitte.com/us/en/footerlinks/office-locator.html",
@@ -25,7 +27,7 @@ class DeloitteSpider(scrapy.Spider):
         )
 
         for url, callback in start_urls:
-            yield scrapy.Request(url, callback=callback)
+            yield Request(url, callback=callback)
 
     def parse(self, response):
         """First scrape the data from the location list page.  If there is a link to the details page, then
@@ -77,7 +79,7 @@ class DeloitteSpider(scrapy.Spider):
 
             details_url = office.xpath(".//h3/a/@href").extract_first()
             if details_url:
-                yield scrapy.Request(
+                yield Request(
                     response.urljoin(details_url),
                     callback=self.parse_location,
                     meta={"properties": properties},
@@ -94,7 +96,7 @@ class DeloitteSpider(scrapy.Spider):
                 url = en_links[0]
             else:
                 url = links[0]
-            yield scrapy.Request(response.urljoin(url), callback=self.parse)
+            yield Request(response.urljoin(url), callback=self.parse)
 
     def parse_location(self, response):
         properties = response.meta["properties"]

--- a/locations/spiders/denner_ch.py
+++ b/locations/spiders/denner_ch.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
 from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
@@ -18,7 +18,7 @@ class DennerCHSpider(Spider):
             cb_kwargs={"current_page": page},
         )
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield self.make_request(1)
 
     def parse(self, response: Response, current_page: int) -> Any:

--- a/locations/spiders/deutsche_bank_de.py
+++ b/locations/spiders/deutsche_bank_de.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
 from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
@@ -15,7 +15,7 @@ class DeutscheBankDESpider(Spider):
     SPARDA_BANK = {"brand": "Sparda-Bank", "brand_wikidata": "Q2307136"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         base_url = "https://www.deutsche-bank.de/cip/rest/api/url/pfb/content/gdata/Presentation/DbFinder/Home/IndexJson?label={type}&searchTerm={searchBy}&country=D"
 
         for city in city_locations("DE", 15000):

--- a/locations/spiders/deutsche_post_de.py
+++ b/locations/spiders/deutsche_post_de.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -31,7 +33,7 @@ class DeutschePostDESpider(Spider):
         "POSTSTATION": None,
     }
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for lat, lon in point_locations("germany_grid_15km.csv"):
             yield JsonRequest(
                 f"https://www.deutschepost.de/int-postfinder/webservice/rest/v1/nearbySearch?address={lat},{lon}",

--- a/locations/spiders/deutsche_telekom_de.py
+++ b/locations/spiders/deutsche_telekom_de.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories
@@ -21,7 +21,7 @@ class DeutscheTelekomDESpider(Spider):
     def make_request(self, page: int) -> JsonRequest:
         return JsonRequest(url="https://shopseite.telekom.de/api/shops?_page={}".format(page))
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield self.make_request(1)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/dhl_express_es.py
+++ b/locations/spiders/dhl_express_es.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
@@ -17,7 +17,7 @@ class DhlExpressESSpider(Spider):
     allowed_domains = ["wsbexpress.dhl.com"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         # Fifty closest shops are returned no matter their distance from the
         # supplied centroid. Small search radius (48km) required to find the
         # maximum number of features.

--- a/locations/spiders/dhl_express_fr.py
+++ b/locations/spiders/dhl_express_fr.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
@@ -17,7 +17,7 @@ class DhlExpressFRSpider(Spider):
     allowed_domains = ["wsbexpress.dhl.com"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         # Fifty closest shops are returned no matter their distance from the
         # supplied centroid. Small search radius (24km) required to find the
         # maximum number of features.

--- a/locations/spiders/dhl_express_gb.py
+++ b/locations/spiders/dhl_express_gb.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
@@ -9,12 +9,12 @@ from locations.items import Feature
 from locations.spiders.dhl_express_de import DHL_EXPRESS_SHARED_ATTRIBUTES
 
 
-class DhlExpressGBSpider(scrapy.Spider):
+class DhlExpressGBSpider(Spider):
     name = "dhl_express_gb"
     item_attributes = DHL_EXPRESS_SHARED_ATTRIBUTES
     allowed_domains = ["dhlparcel.co.uk"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url="https://track.dhlparcel.co.uk/UKMail/Handlers/DepotData", method="POST")
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/di.py
+++ b/locations/spiders/di.py
@@ -1,11 +1,13 @@
-import scrapy
+from typing import AsyncIterator
+
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
-class DiSpider(scrapy.Spider):
+class DiSpider(Spider):
     name = "di"
     item_attributes = {
         "brand": "Di",
@@ -19,7 +21,7 @@ class DiSpider(scrapy.Spider):
         },
     }
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://www.di.be/ajax.V1.php/fr_FR/Rbs/Storelocator/Store/",
             data={

--- a/locations/spiders/dierbergs.py
+++ b/locations/spiders/dierbergs.py
@@ -1,16 +1,18 @@
-import scrapy
+from typing import AsyncIterator
+
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
 
-class DierbergsSpider(scrapy.Spider):
+class DierbergsSpider(Spider):
     name = "dierbergs"
     item_attributes = {"brand": "Dierbergs", "brand_wikidata": "Q5274978"}
     allowed_domains = ["api.dierbergs.com"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://api.dierbergs.com/graphql/",
             data={

--- a/locations/spiders/dirck_iii_nl.py
+++ b/locations/spiders/dirck_iii_nl.py
@@ -1,4 +1,5 @@
 import json
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -15,7 +16,7 @@ class DirckIiiNLSpider(Spider):
     allowed_domains = ["www.dirckiii.nl"]
     start_urls = ["https://www.dirckiii.nl/storelocator/index/ajax/"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url)
 

--- a/locations/spiders/disco_argentina.py
+++ b/locations/spiders/disco_argentina.py
@@ -1,4 +1,7 @@
-from scrapy import Request, Spider
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
@@ -13,7 +16,7 @@ class DiscoArgentinaSpider(Spider):
     ]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         yield Request(url=self.start_urls[0], headers={"Accept": "application/json", "Rest-Range": "resources=0-999"})
 
     def parse(self, response):

--- a/locations/spiders/dish.py
+++ b/locations/spiders/dish.py
@@ -1,4 +1,7 @@
-import scrapy
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import FormRequest
 
 from locations.items import Feature
 
@@ -57,16 +60,16 @@ POSTALS = [
 ]
 
 
-class DishSpider(scrapy.Spider):
+class DishSpider(Spider):
     name = "dish"
     item_attributes = {"brand": "DISH", "brand_wikidata": "Q1199757"}
     allowed_domains = ["webapps.dish.com"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[FormRequest]:
         for postal in POSTALS:
             url = "https://webapps.dish.com/find-retailer/getretailershandler.ashx?Zip=" + postal + "&Miles=1000"
 
-            yield scrapy.http.FormRequest(
+            yield FormRequest(
                 url,
                 self.parse_store,
                 method="GET",

--- a/locations/spiders/dodo_pizza.py
+++ b/locations/spiders/dodo_pizza.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -14,7 +16,7 @@ class DodoPizzaSpider(Spider):
     # TODO: update list of countries in 2024
     countries = ["RU", "BY", "GB", "VN", "DE", "KZ", "CN", "KG", "LT", "NG", "PL", "RO", "SI", "TJ", "UZ", "EE", "US"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for country in self.countries:
             yield JsonRequest(
                 url=f"https://publicapi.dodois.io/{country}/api/v1/unitinfo/all",

--- a/locations/spiders/dollarama.py
+++ b/locations/spiders/dollarama.py
@@ -1,18 +1,20 @@
+from typing import AsyncIterator
 from urllib.parse import urlencode
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.searchable_points import open_searchable_points
 
 
-class DollaramaSpider(scrapy.Spider):
+class DollaramaSpider(Spider):
     name = "dollarama"
     item_attributes = {"brand": "Dollarama", "brand_wikidata": "Q3033947"}
     allowed_domains = ["dollarama.com"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         base_url = "https://www.dollarama.com/en-CA/locations/GetDataByCoordinates?"
 
         params = {"distance": "100", "units": "miles"}
@@ -22,7 +24,7 @@ class DollaramaSpider(scrapy.Spider):
             for point in points:
                 _, lat, lon = point.strip().split(",")
                 params |= {"latitude": lat, "longitude": lon}
-                yield scrapy.Request(url=base_url + urlencode(params), method="POST")
+                yield Request(url=base_url + urlencode(params), method="POST")
 
     def parse_hours(self, hours):
         hrs = hours.split("|")

--- a/locations/spiders/dominos_pizza_au.py
+++ b/locations/spiders/dominos_pizza_au.py
@@ -1,6 +1,5 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
-from scrapy import Request
 from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
 
@@ -15,7 +14,7 @@ class DominosPizzaAUSpider(Spider):
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     custom_settings = {"DOWNLOAD_TIMEOUT": 180, "USER_AGENT": BROWSER_DEFAULT}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for lat, lon in point_locations("au_centroids_20km_radius.csv"):
             # The API does not support a custom radius parameter and returns up to 10 records per request.
             yield JsonRequest(

--- a/locations/spiders/dominos_pizza_fr.py
+++ b/locations/spiders/dominos_pizza_fr.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
 
@@ -11,7 +11,7 @@ class DominosPizzaFRSpider(DominosPizzaAUSpider):
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
     allowed_domains = ["dominos.fr"]
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for city in city_locations("FR", 15000):
             yield JsonRequest(
                 url=f"https://www.dominos.fr/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}",

--- a/locations/spiders/dominos_pizza_jp.py
+++ b/locations/spiders/dominos_pizza_jp.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
 
@@ -10,7 +10,7 @@ class DominosPizzaJPSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_jp"
     item_attributes = {"brand_wikidata": "Q839466"}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for city in city_locations("JP", 10000):
             yield JsonRequest(
                 url=f"https://www.dominos.jp/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}"

--- a/locations/spiders/dominos_pizza_nl.py
+++ b/locations/spiders/dominos_pizza_nl.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
 
@@ -10,7 +10,7 @@ class DominosPizzaNLSpider(DominosPizzaAUSpider):
     name = "dominos_pizza_nl"
     item_attributes = {"brand": "Domino's", "brand_wikidata": "Q839466"}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for city in city_locations("NL", 15000):
             yield JsonRequest(
                 url=f"https://www.dominos.nl/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}",

--- a/locations/spiders/dominos_pizza_tw.py
+++ b/locations/spiders/dominos_pizza_tw.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
@@ -8,12 +8,12 @@ from locations.geo import city_locations
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class DominosPizzaTWSpider(scrapy.Spider):
+class DominosPizzaTWSpider(Spider):
     name = "dominos_pizza_tw"
     item_attributes = {"brand_wikidata": "Q839466"}
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for city in city_locations("TW", 16000):
             yield JsonRequest(
                 url=f"https://www.dominos.com.tw/dynamicstoresearchapi/getstoresfromquery?lon={city['longitude']}&lat={city['latitude']}&count=100000"

--- a/locations/spiders/dr_max.py
+++ b/locations/spiders/dr_max.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin
 from zoneinfo import ZoneInfo
 
-import scrapy
-from scrapy import Request
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
@@ -13,7 +12,7 @@ from locations.hours import OpeningHours
 from locations.items import set_closed
 
 
-class DrMaxSpider(scrapy.Spider):
+class DrMaxSpider(Spider):
     name = "dr_max"
     item_attributes = {"brand": "Dr. Max", "brand_wikidata": "Q56317371"}
     store_locators = {
@@ -24,7 +23,7 @@ class DrMaxSpider(scrapy.Spider):
         "ro": "https://www.drmax.ro/farmacii/",
     }
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for country in self.store_locators:
             yield JsonRequest(
                 url=f"https://pharmacy.drmax.{country}/api/v1/public/pharmacies",

--- a/locations/spiders/duffys.py
+++ b/locations/spiders/duffys.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
@@ -12,7 +12,7 @@ class DuffysSpider(Spider):
     item_attributes = {"name": "Duffy's", "brand": "Duffy's"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://api.duffysmvp.com/api/app/nearByLocations",
             data={"latitude": "26.6289791", "longitude": "-80.0724384"},

--- a/locations/spiders/dulux_decorator_centre_gb.py
+++ b/locations/spiders/dulux_decorator_centre_gb.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Selector, Spider
 from scrapy.http import JsonRequest
 
@@ -18,7 +20,7 @@ class DuluxDecoratorCentreGBSpider(Spider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     requires_proxy = True
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url)
 

--- a/locations/spiders/dunkin_sa.py
+++ b/locations/spiders/dunkin_sa.py
@@ -1,4 +1,5 @@
 import json
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -10,7 +11,7 @@ class DunkinSASpider(Spider):
     name = "dunkin_sa"
     item_attributes = {"brand_wikidata": "Q847743"}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://www.dunkinksa.com/asmx/WebMethods.asmx/getMapStoresList",
             data={"searchVal": "", "latitude": "24.7136", "longitude": "46.6753", "allowString": ""},


### PR DESCRIPTION
For all spiders with a name commencing 'd' that use the now-deprecated start_requests(...) function, replace it with Scrapy's async start function.