### PR TITLE
Replace deprecated start_requests function in 'e' spiders

### DIFF
--- a/locations/spiders/easyfitness_de.py
+++ b/locations/spiders/easyfitness_de.py
@@ -1,21 +1,21 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
-import scrapy
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import FormRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.geo import point_locations
 from locations.items import Feature
 
 
-class EasyfitnessDESpider(scrapy.Spider):
+class EasyfitnessDESpider(Spider):
     name = "easyfitness_de"
     item_attributes = {"brand": "EasyFitness", "brand_wikidata": "Q106166703"}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[FormRequest]:
         point_files = "eu_centroids_20km_radius_country.csv"
         for lat, lng in point_locations(point_files, ["DE"]):
-            yield scrapy.FormRequest(
+            yield FormRequest(
                 "https://easyfitness.club/wp-admin/admin-ajax.php",
                 formdata={
                     "action": "search_nearby_studios",

--- a/locations/spiders/ecars.py
+++ b/locations/spiders/ecars.py
@@ -1,4 +1,5 @@
 import logging
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -12,7 +13,7 @@ class EcarsSpider(Spider):
     item_attributes = {"brand": "ESB ecars", "brand_wikidata": "Q134882112"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://myaccount.esbecars.com/stationFacade/findSitesInBounds",
             data={

--- a/locations/spiders/echte_bakker_nl.py
+++ b/locations/spiders/echte_bakker_nl.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
@@ -14,7 +14,7 @@ class EchteBakkerNLSpider(Spider):
     def make_request(self, page: int) -> JsonRequest:
         return JsonRequest(url="https://echtebakker.nl/api/fetch-dealers?page={}".format(page), meta={"page": page})
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield self.make_request(1)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/ecopack_bg.py
+++ b/locations/spiders/ecopack_bg.py
@@ -1,23 +1,25 @@
 import json
+from typing import AsyncIterator
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.items import Feature
 
 
-class EcopackBGSpider(scrapy.Spider):
+class EcopackBGSpider(Spider):
     name = "ecopack_bg"
     item_attributes = {"operator": "Екопак", "operator_wikidata": "Q116687081", "country": "BG"}
     allowed_domains = ["ecopack.bg"]
     start_urls = ["https://www.ecopack.bg/bg/containers_xhr/?method=pins"]
     no_refs = True
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         headers = {
             "X-Requested-With": "XMLHttpRequest",
         }
         for url in self.start_urls:
-            yield scrapy.Request(url, headers=headers)
+            yield Request(url, headers=headers)
 
     def parse(self, response):
         data = json.loads(response.text)

--- a/locations/spiders/edible_arrangements.py
+++ b/locations/spiders/edible_arrangements.py
@@ -1,18 +1,20 @@
 import json
+from typing import AsyncIterator
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import FormRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, day_range
 
 
-class EdibleArrangementsSpider(scrapy.Spider):
+class EdibleArrangementsSpider(Spider):
     name = "edible_arrangements"
     item_attributes = {"brand": "Edible Arrangements", "brand_wikidata": "Q5337996"}
     allowed_domains = ["www.ediblearrangements.com"]
 
-    def start_requests(self):
-        yield scrapy.FormRequest(
+    async def start(self) -> AsyncIterator[FormRequest]:
+        yield FormRequest(
             "https://www.ediblearrangements.com/stores/store-locator.aspx/GetStoresByCurrentLocation",
             method="POST",
             headers={

--- a/locations/spiders/eg_america_us.py
+++ b/locations/spiders/eg_america_us.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
@@ -32,7 +32,7 @@ class EgAmericaUSSpider(Spider):
         20: {"brand": "Sprint", "brand_wikidata": "Q123012447"},
     }
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url=self.start_urls[0], callback=self.parse)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/el_pollo_loco.py
+++ b/locations/spiders/el_pollo_loco.py
@@ -1,16 +1,18 @@
-import scrapy
+from typing import AsyncIterator
+
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.items import Feature
 
 
-class ElPolloLocoSpider(scrapy.Spider):
+class ElPolloLocoSpider(Spider):
     name = "el_pollo_loco"
     item_attributes = {"brand": "El Pollo Loco", "brand_wikidata": "Q2353849"}
     allowed_domains = ["www.elpolloloco.com"]
     start_urls = ["https://www.elpolloloco.com/locations/locations_json"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url="https://www.elpolloloco.com/locations/locations_json")
 
     def parse(self, response):

--- a/locations/spiders/elements_massage_ca_us.py
+++ b/locations/spiders/elements_massage_ca_us.py
@@ -1,6 +1,7 @@
 import json
+from typing import AsyncIterator
 
-from scrapy import Request
+from scrapy.http import Request
 
 from locations.hours import OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
@@ -16,7 +17,7 @@ class ElementsMassageCAUSSpider(JSONBlobSpider):
     }
     locations_key = "locations"
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         for country, states in STATES.items():
             for state in states:
                 yield Request(f"https://elementsmassage.com/locator?q={state}%2C%20{country}&lat=0&lng=0")

--- a/locations/spiders/empik_pl.py
+++ b/locations/spiders/empik_pl.py
@@ -1,8 +1,8 @@
 import json
-from typing import Iterable
+from typing import AsyncIterator
 
-from scrapy import Request, Spider
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import Request, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -14,7 +14,7 @@ class EmpikPLSpider(Spider):
     item_attributes = {"brand": "Empik", "brand_wikidata": "Q3045978"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         yield Request(
             method="POST",
             url="https://www.empik.com/ajax/delivery-point/empik?query=",

--- a/locations/spiders/empres_us.py
+++ b/locations/spiders/empres_us.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import FormRequest
 
@@ -13,7 +15,7 @@ class EmpresUSSpider(Spider):
     start_urls = ["https://www.empres.com/wp-admin/admin-ajax.php"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[FormRequest]:
         formdata = {
             "within": "200",
             "state": "",

--- a/locations/spiders/engbers.py
+++ b/locations/spiders/engbers.py
@@ -1,6 +1,5 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
-from scrapy import Request
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
@@ -14,7 +13,7 @@ class EngbersSpider(JSONBlobSpider):
     item_attributes = {"brand": "engbers", "brand_wikidata": "Q1290088"}
     EMILIO_ADANI = {"brand": "emilio adani", "brand_wikidata": "Q123022474"}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://engbersos-engbers.frontastic.live/frontastic/action/stores/getStoresByLocation",
             data={"type": "storeFinder"},

--- a/locations/spiders/engel_and_volkers.py
+++ b/locations/spiders/engel_and_volkers.py
@@ -1,4 +1,5 @@
 import re
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -44,7 +45,7 @@ class EngelAndVolkersSpider(Spider):
         "ZA",
     ]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for country_code in self.country_codes:
             yield JsonRequest(url=self.search_url_template.format(country_code=country_code))
 

--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 import geonamescache
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -12,7 +14,7 @@ class EnterpriseSpider(Spider):
     item_attributes = {"brand": "Enterprise", "brand_wikidata": "Q17085454"}
     allowed_domains = ["prd.location.enterprise.com", "int1.location.enterprise.com"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         gc = geonamescache.GeonamesCache()
         countries = gc.get_countries()
         for country_code in countries.keys():

--- a/locations/spiders/equinox.py
+++ b/locations/spiders/equinox.py
@@ -1,14 +1,14 @@
-from typing import Any
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin
 
-import scrapy
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import Request, Response
 
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class EquinoxSpider(scrapy.Spider):
+class EquinoxSpider(Spider):
     name = "equinox"
     item_attributes = {"brand": "Equinox", "brand_wikidata": "Q5384535"}
     allowed_domains = ["cdn.contentful.com"]
@@ -21,8 +21,8 @@ class EquinoxSpider(scrapy.Spider):
         "Origin": "https://www.equinox.com",
     }
 
-    def start_requests(self):
-        yield scrapy.Request(self.start_url, callback=self.parse, headers=self.headers, meta={"skip": 0})
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(self.start_url, callback=self.parse, headers=self.headers, meta={"skip": 0})
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
@@ -41,7 +41,7 @@ class EquinoxSpider(scrapy.Spider):
             )
         records_read = data["skip"] + data["limit"]
         if records_read < data["total"]:
-            yield scrapy.Request(
+            yield Request(
                 f"{self.start_url}&skip={records_read}",
                 callback=self.parse,
                 headers=self.headers,

--- a/locations/spiders/ernstings_family.py
+++ b/locations/spiders/ernstings_family.py
@@ -1,6 +1,7 @@
-from typing import Iterable
+from typing import AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.dict_parser import DictParser
 from locations.geo import point_locations
@@ -11,7 +12,7 @@ class ErnstingsFamilySpider(Spider):
     name = "ernstings_family"
     item_attributes = {"brand": "Ernsting's family", "brand_wikidata": "Q1361016"}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         for lat, lon in point_locations("eu_centroids_120km_radius_country.csv", ["DE", "AT"]):
             yield Request(f"https://filialen.ernstings-family.de/api/stores/nearby/{lat}/{lon}/120/3000")
 

--- a/locations/spiders/esb_energy_gb.py
+++ b/locations/spiders/esb_energy_gb.py
@@ -1,4 +1,5 @@
 import logging
+from typing import AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest
@@ -12,7 +13,7 @@ class EsbEnergyGBSpider(Spider):
     item_attributes = {"operator": "ESB Energy", "operator_wikidata": "Q118261834"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://myevaccount.esbenergy.co.uk/stationFacade/findSitesInBounds",
             data={

--- a/locations/spiders/evereve_us.py
+++ b/locations/spiders/evereve_us.py
@@ -1,19 +1,18 @@
 import json
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
-import scrapy
-from scrapy import Request
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.items import Feature
 
 
-class EvereveUSSpider(scrapy.Spider):
+class EvereveUSSpider(Spider):
     name = "evereve_us"
     item_attributes = {"brand": "Evereve", "brand_wikidata": "Q69891997"}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://evereve-prod.labs.wesupply.xyz/searchForStores", method="POST", callback=self.parse
         )


### PR DESCRIPTION
For all spiders with a name commencing 'e' that use the now-deprecated start_requests(...) function, replace it with Scrapy's async start function.