### PR TITLE
[bmw_group] Updating qcode for Rolls-Royce

### DIFF
--- a/locations/spiders/bmw_group.py
+++ b/locations/spiders/bmw_group.py
@@ -34,9 +34,7 @@ class BmwGroupSpider(Spider):
     BMW_MOTORBIKE = "BMW_MOTORBIKE"
     BRAND_MAPPING = {
         "BMW": {"brand": "BMW", "brand_wikidata": "Q26678"},
-        "BMW_I": {"brand": "BMW i", "brand_wikidata": "Q796784"},
-        "ROLLS_ROYCE": {"brand": "Rolls-Royce", "brand_wikidata": "Q243278"},
-        "BMW_M": {"brand": "BMW M", "brand_wikidata": "Q173339"},
+        "ROLLS_ROYCE": {"brand": "Rolls-Royce", "brand_wikidata": "Q234803"},
         "MINI": {"brand": "Mini", "brand_wikidata": "Q116232"},
         BMW_MOTORBIKE: {"brand": "BMW Motorrad", "brand_wikidata": "Q249173"},
     }


### PR DESCRIPTION
Removed BMW i and BMW M as they are not present in the data
```
{
 "atp/brand/BMW": 6891,
 "atp/brand/BMW Motorrad": 2464,
 "atp/brand/Mini": 4564,
 "atp/brand/Rolls-Royce": 215,
 "atp/brand_wikidata/Q116232": 4564,
 "atp/brand_wikidata/Q234803": 215,
 "atp/brand_wikidata/Q249173": 2464,
 "atp/brand_wikidata/Q26678": 6891,
 "atp/category/shop/car": 5035,
 "atp/category/shop/car_repair": 6635,
 "atp/category/shop/motorcycle": 1180,
 "atp/category/shop/motorcycle_repair": 1284,
 "atp/clean_strings/postcode": 6,
 "atp/clean_strings/street_address": 1,
 "atp/closed_check": 2,
 "atp/country/AE": 60,
 "atp/country/AG": 2,
 "atp/country/AL": 5,
 "atp/country/AM": 5,
 "atp/country/AR": 66,
 "atp/country/AT": 249,
 "atp/country/AU": 256,
 "atp/country/AW": 4,
 "atp/country/AZ": 6,
 "atp/country/BA": 16,
 "atp/country/BB": 4,
 "atp/country/BD": 2,
 "atp/country/BE": 311,
 "atp/country/BG": 27,
 "atp/country/BH": 8,
 "atp/country/BJ": 1,
 "atp/country/BL": 2,
 "atp/country/BM": 4,
 "atp/country/BN": 6,
 "atp/country/BO": 15,
 "atp/country/BR": 284,
 "atp/country/BS": 4,
 "atp/country/BY": 6,
 "atp/country/CA": 224,
 "atp/country/CH": 327,
 "atp/country/CL": 37,
 "atp/country/CO": 70,
 "atp/country/CR": 13,
 "atp/country/CW": 4,
 "atp/country/CY": 19,
 "atp/country/CZ": 79,
 "atp/country/DE": 2326,
 "atp/country/DK": 87,
 "atp/country/DO": 14,
 "atp/country/DZ": 2,
 "atp/country/EC": 17,
 "atp/country/EE": 20,
 "atp/country/EG": 4,
 "atp/country/ES": 625,
 "atp/country/FI": 80,
 "atp/country/FR": 850,
 "atp/country/GB": 652,
 "atp/country/GE": 6,
 "atp/country/GF": 4,
 "atp/country/GH": 6,
 "atp/country/GP": 4,
 "atp/country/GR": 74,
 "atp/country/GT": 12,
 "atp/country/GU": 3,
 "atp/country/HN": 6,
 "atp/country/HR": 37,
 "atp/country/HT": 2,
 "atp/country/HU": 61,
 "atp/country/ID": 92,
 "atp/country/IE": 53,
 "atp/country/IL": 26,
 "atp/country/IN": 214,
 "atp/country/IQ": 16,
 "atp/country/IS": 6,
 "atp/country/IT": 822,
 "atp/country/JM": 7,
 "atp/country/JO": 6,
 "atp/country/JP": 916,
 "atp/country/KE": 5,
 "atp/country/KG": 3,
 "atp/country/KH": 6,
 "atp/country/KR": 271,
 "atp/country/KW": 9,
 "atp/country/KY": 4,
 "atp/country/KZ": 32,
 "atp/country/LA": 3,
 "atp/country/LB": 10,
 "atp/country/LC": 4,
 "atp/country/LK": 5,
 "atp/country/LT": 14,
 "atp/country/LU": 14,
 "atp/country/LV": 7,
 "atp/country/LY": 5,
 "atp/country/MA": 37,
 "atp/country/MD": 6,
 "atp/country/ME": 6,
 "atp/country/MF": 4,
 "atp/country/MG": 3,
 "atp/country/MK": 6,
 "atp/country/MM": 5,
 "atp/country/MQ": 4,
 "atp/country/MT": 6,
 "atp/country/MU": 5,
 "atp/country/MX": 291,
 "atp/country/MY": 120,
 "atp/country/NC": 4,
 "atp/country/NG": 34,
 "atp/country/NL": 248,
 "atp/country/NO": 130,
 "atp/country/NP": 2,
 "atp/country/NZ": 58,
 "atp/country/OM": 8,
 "atp/country/PA": 17,
 "atp/country/PE": 18,
 "atp/country/PF": 8,
 "atp/country/PH": 30,
 "atp/country/PK": 16,
 "atp/country/PL": 235,
 "atp/country/PS": 2,
 "atp/country/PT": 165,
 "atp/country/PY": 10,
 "atp/country/QA": 23,
 "atp/country/RE": 10,
 "atp/country/RO": 65,
 "atp/country/RS": 29,
 "atp/country/RU": 162,
 "atp/country/RW": 1,
 "atp/country/SA": 51,
 "atp/country/SC": 3,
 "atp/country/SE": 191,
 "atp/country/SG": 18,
 "atp/country/SI": 33,
 "atp/country/SK": 37,
 "atp/country/SR": 2,
 "atp/country/SV": 5,
 "atp/country/TH": 138,
 "atp/country/TM": 4,
 "atp/country/TN": 11,
 "atp/country/TR": 158,
 "atp/country/TT": 7,
 "atp/country/TW": 83,
 "atp/country/UA": 70,
 "atp/country/US": 1740,
 "atp/country/UY": 11,
 "atp/country/VN": 46,
 "atp/country/ZA": 199,
 "atp/country/ZM": 1,
 "atp/duplicate_count": 1,
 "atp/field/branch/missing": 14134,
 "atp/field/email/invalid": 12,
 "atp/field/email/missing": 1719,
 "atp/field/image/missing": 14134,
 "atp/field/lat/missing": 3,
 "atp/field/lon/missing": 3,
 "atp/field/opening_hours/missing": 14134,
 "atp/field/operator/missing": 14134,
 "atp/field/operator_wikidata/missing": 14134,
 "atp/field/phone/invalid": 224,
 "atp/field/phone/missing": 54,
 "atp/field/postcode/missing": 92,
 "atp/field/state/from_reverse_geocoding": 15,
 "atp/field/state/missing": 7701,
 "atp/field/twitter/missing": 14134,
 "atp/field/website/invalid": 27,
 "atp/field/website/missing": 936,
 "atp/item_scraped_host_count/c2b-services.bmw.com": 14135,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 11670,
 "atp/nsi/perfect_match": 2464,
 "downloader/request_bytes": 115502,
 "downloader/request_count": 253,
 "downloader/request_method_count/GET": 253,
 "downloader/response_bytes": 1621450,
 "downloader/response_count": 253,
 "downloader/response_status_count/200": 132,
 "downloader/response_status_count/204": 117,
 "downloader/response_status_count/400": 3,
 "downloader/response_status_count/403": 1,
 "elapsed_time_seconds": 55.781725,
 "finish_reason": "finished",
 "finish_time": "2025-10-24T13:13:55.108895+00:00",
 "httpcache/hit": 253,
 "httpcompression/response_bytes": 10856972,
 "httpcompression/response_count": 135,
 "httperror/response_ignored_count": 3,
 "httperror/response_ignored_status_count/400": 3,
 "item_dropped_count": 1,
 "item_dropped_reasons_count/DropItem": 1,
 "item_scraped_count": 14134,
 "items_per_minute": 15418.909090909092,
 "log_count/INFO": 129,
 "log_count/WARNING": 33,
 "response_received_count": 253,
 "responses_per_minute": 276.0,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/403": 1,
 "scheduler/dequeued": 252,
 "scheduler/dequeued/memory": 252,
 "scheduler/enqueued": 252,
 "scheduler/enqueued/memory": 252,
 "start_time": "2025-10-24T13:12:59.327170+00:00"
}
```