### PR TITLE
Don't let shell expand the *.parquet arg

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -108,7 +108,7 @@ fi
 
 uv run python ci/concatenate_parquet.py \
     --output "${SPIDER_RUN_DIR}/output.parquet" \
-    "${SPIDER_RUN_DIR}"/output/*.parquet
+    "${SPIDER_RUN_DIR}/output/*.parquet"
 retval=$?
 if [ ! $retval -eq 0 ]; then
     (>&2 echo "Couldn't concatenate parquet files, won't include in output")


### PR DESCRIPTION
For #14341 

I think one of the reasons the parquet output was missing is that the shell would expand this glob for us instead of passing it into the script as a string. The quotes here should stop that. The script will handle the glob expansion for us.