### PR TITLE
Always do one spider at a time for requires_proxy check

### DIFF
--- a/.github/workflows/remove-requires-proxy.yml
+++ b/.github/workflows/remove-requires-proxy.yml
@@ -5,12 +5,6 @@ on:
     # Run at 2 AM UTC every other day (Monday, Wednesday, Friday)
     - cron: '0 2 * * 1,3,5'
   workflow_dispatch:
-    inputs:
-      num_spiders:
-        description: 'Number of random spiders to test'
-        required: false
-        default: '2'
-        type: string
 
 jobs:
   remove-requires-proxy:
@@ -43,7 +37,6 @@ jobs:
       - name: Run remove_requires_proxy script
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUM_SPIDERS: ${{ github.event.inputs.num_spiders || '2' }}
         run: |
           cd ci
           uv run python remove_requires_proxy.py


### PR DESCRIPTION
Extension of #14463 

When one of the spiders that was randomly chosen still needs the flag, it's cumbersome to fix that, so we'll just do one at a time and close the PR if it is needed.