### PR TITLE
[Jumbo CH] Fix Spider

### DIFF
--- a/locations/spiders/jumbo_ch.py
+++ b/locations/spiders/jumbo_ch.py
@@ -19,7 +19,7 @@ class JumboCHSpider(SitemapSpider):
     sitemap_urls = ["https://www.jumbo.ch/sitemap.xml"]
     sitemap_follow = ["/sitemap/STORE-de-"]
     sitemap_rules = [(r"_POS$", "parse_store")]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT,"ROBOTSTXT_OBEY":False}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
     requires_proxy = True
 
     def parse_store(self, response):


### PR DESCRIPTION
**_Fixes : added user_agent to fix spider_**

```python
{'atp/brand/Jumbo': 109,
 'atp/brand_wikidata/Q1713190': 109,
 'atp/category/shop/doityourself': 109,
 'atp/country/CH': 109,
 'atp/field/email/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/state/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/item_scraped_host_count/www.jumbo.ch': 109,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 109,
 'downloader/request_bytes': 178342,
 'downloader/request_count': 155,
 'downloader/request_method_count/GET': 155,
 'downloader/response_bytes': 3588876,
 'downloader/response_count': 155,
 'downloader/response_status_count/200': 112,
 'downloader/response_status_count/302': 17,
 'downloader/response_status_count/404': 16,
 'downloader/response_status_count/410': 10,
 'dupefilter/filtered': 15,
 'elapsed_time_seconds': 194.732923,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 29, 5, 11, 14, 399665, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14512433,
 'httpcompression/response_count': 138,
 'httperror/response_ignored_count': 26,
 'httperror/response_ignored_status_count/404': 16,
 'httperror/response_ignored_status_count/410': 10,
 'item_scraped_count': 109,
 'items_per_minute': 33.71134020618557,
 'log_count/DEBUG': 279,
 'log_count/INFO': 38,
 'offsite/domains': 1,
 'offsite/filtered': 1,
 'request_depth_max': 2,
 'response_received_count': 138,
 'responses_per_minute': 42.68041237113402,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 154,
 'scheduler/dequeued/memory': 154,
 'scheduler/enqueued': 154,
 'scheduler/enqueued/memory': 154,
 'start_time': datetime.datetime(2025, 10, 29, 5, 7, 59, 666742, tzinfo=datetime.timezone.utc)}
```