### PR TITLE
[Gadisa ES] Fix Spider

### DIFF
--- a/locations/spiders/gadisa_es.py
+++ b/locations/spiders/gadisa_es.py
@@ -22,6 +22,7 @@ class GadisaESSpider(Spider):
         "CLAUDIO": {"brand": "Claudio", "brand_wikidata": "Q123369953", "extras": Categories.SHOP_SUPERMARKET.value},
         "GADIS": {"brand": "Gadis", "brand_wikidata": "Q114398305", "extras": Categories.SHOP_SUPERMARKET.value},
     }
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:


### PR DESCRIPTION
**_Fixes : Flag robotstxt_obey as False to fix spider_**

```python
{'atp/brand/Casa Claudio': 2,
 'atp/brand/Cash IFA': 12,
 'atp/brand/Claudio': 246,
 'atp/brand/Gadis': 223,
 'atp/brand_wikidata/Q114398305': 223,
 'atp/brand_wikidata/Q123369953': 246,
 'atp/brand_wikidata/Q123369964': 12,
 'atp/brand_wikidata/Q123370107': 2,
 'atp/category/shop/deli': 2,
 'atp/category/shop/supermarket': 469,
 'atp/category/shop/wholesale': 12,
 'atp/clean_strings/city': 5,
 'atp/clean_strings/lat': 2,
 'atp/clean_strings/lon': 69,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/phone': 3,
 'atp/clean_strings/postcode': 7,
 'atp/clean_strings/state': 1,
 'atp/clean_strings/street_address': 8,
 'atp/country/ES': 483,
 'atp/field/branch/missing': 483,
 'atp/field/country/from_spider_name': 483,
 'atp/field/email/missing': 483,
 'atp/field/image/missing': 483,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 474,
 'atp/field/operator/missing': 483,
 'atp/field/operator_wikidata/missing': 483,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 483,
 'atp/field/website/missing': 483,
 'atp/item_scraped_host_count/www.gadisa.es': 483,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 14,
 'atp/nsi/perfect_match': 469,
 'downloader/request_bytes': 1075,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 37216,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 6.223703,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 29, 6, 54, 42, 144977, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 351089,
 'httpcompression/response_count': 3,
 'item_scraped_count': 483,
 'items_per_minute': 4830.0,
 'log_count/DEBUG': 499,
 'log_count/INFO': 9,
 'response_received_count': 3,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 10, 29, 6, 54, 35, 921274, tzinfo=datetime.timezone.utc)}
```