### PR TITLE
[American Golf GB] Fix Spider

### DIFF
--- a/locations/spiders/american_golf_gb.py
+++ b/locations/spiders/american_golf_gb.py
@@ -20,7 +20,7 @@ class AmericanGolfGBSpider(JSONBlobSpider):
     def extract_json(self, response: Response, **kwargs: Any) -> Any:
         raw_data = json.loads(
             re.search(
-                r"channel\":(\[.*\])}},\"content",
+                r"channel\":(\[.*\]),\"p1BadgeData",
                 response.xpath('//*[contains(text(),"address1")]/text()').get().replace("\\", ""),
             ).group(1)
         )


### PR DESCRIPTION
**_Fixes : updated regex to fix spider_**

```python
{'atp/brand/American Golf': 82,
 'atp/brand_wikidata/Q62657494': 82,
 'atp/category/shop/sports': 82,
 'atp/country/GB': 80,
 'atp/country/IE': 2,
 'atp/field/email/missing': 71,
 'atp/field/image/missing': 82,
 'atp/field/opening_hours/missing': 82,
 'atp/field/operator/missing': 82,
 'atp/field/operator_wikidata/missing': 82,
 'atp/field/state/missing': 82,
 'atp/field/twitter/missing': 82,
 'atp/field/website/missing': 82,
 'atp/item_scraped_host_count/www.americangolf.co.uk': 82,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 82,
 'downloader/request_bytes': 345,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 80135,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 6.181472,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 29, 8, 15, 3, 67609, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 632796,
 'httpcompression/response_count': 1,
 'item_scraped_count': 82,
 'items_per_minute': 820.0,
 'log_count/DEBUG': 96,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 10.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 10, 29, 8, 14, 56, 886137, tzinfo=datetime.timezone.utc)}
```