### PR TITLE
[Walmart CA] Fix spider

### DIFF
--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -23,8 +23,8 @@ class WalmartCASpider(scrapy.Spider):
         "DOWNLOAD_DELAY": 5,
         "ROBOTSTXT_OBEY": False,
     }
-    base_url = "https://www.walmart.ca/orchestra/graphql/nearByNodes"
-    hash = "383d44ac5962240870e513c4f53bb3d05a143fd7b19acb32e8a83e39f1ed266c"
+    base_url = "https://www.walmart.ca/orchestra/graphql/storeFinderNearbyNodesQuery"
+    hash = "d3236419dacf3a02137445459aeaeda81fd40630ddd2d3f218cf43f60e1ad16a"
 
     def start_requests(self) -> Iterable[JsonRequest]:
         # Tried raw GraphQL query, but it's blocked, hash appears to be stable and required for successful requests.
@@ -49,7 +49,7 @@ class WalmartCASpider(scrapy.Spider):
             yield JsonRequest(
                 url=f"{self.base_url}/{self.hash}?{urlencode({'variables': json.dumps(variables)})}",
                 headers={
-                    "x-apollo-operation-name": "nearByNodes",
+                    "x-apollo-operation-name": "storeFinderNearbyNodesQuery",
                     "x-o-bu": "WALMART-CA",
                     "x-o-segment": "oaoh",
                 },


### PR DESCRIPTION
```python
{'atp/brand/Walmart': 389,
 'atp/brand_wikidata/Q483551': 389,
 'atp/category/shop/department_store': 49,
 'atp/category/shop/supermarket': 340,
 'atp/country/CA': 389,
 'atp/duplicate_count': 14513,
 'atp/field/email/missing': 389,
 'atp/field/image/missing': 389,
 'atp/field/operator/missing': 389,
 'atp/field/operator_wikidata/missing': 389,
 'atp/field/twitter/missing': 389,
 'atp/field/website/missing': 389,
 'atp/item_scraped_host_count/www.walmart.ca': 14902,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 389,
 'downloader/request_bytes': 883191,
 'downloader/request_count': 415,
 'downloader/request_method_count/GET': 415,
 'downloader/response_bytes': 7212084,
 'downloader/response_count': 415,
 'downloader/response_status_count/200': 415,
 'elapsed_time_seconds': 2518.349631,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 10, 29, 10, 39, 16, 563031, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 48088729,
 'httpcompression/response_count': 415,
 'item_dropped_count': 14513,
 'item_dropped_reasons_count/DropItem': 14513,
 'item_scraped_count': 389,
 'items_per_minute': 9.269261318506752,
 'log_count/DEBUG': 15330,
 'log_count/INFO': 50,
 'log_count/WARNING': 1,
 'response_received_count': 415,
 'responses_per_minute': 9.88880063542494,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'start_time': datetime.datetime(2025, 10, 29, 9, 57, 18, 213400, tzinfo=datetime.timezone.utc)}
```