### PR TITLE
[Halfords GB] Fix Spider

### DIFF
--- a/locations/spiders/halfords_gb.py
+++ b/locations/spiders/halfords_gb.py
@@ -20,33 +20,42 @@ class HalfordsGBSpider(scrapy.Spider):
         ]["queries"]
         for location in raw_data:
             data = location.get("state").get("data")
-            if isinstance(data, dict) and data.get("stores"):
-                for data in data.get("stores"):
-                    if data.get("coordinates").get("latitude") == 0:
-                        continue
-                    item = DictParser.parse(data)
-                    item["street_address"] = merge_address_lines([item.pop("street_address"), data.get("address2")])
-                    item["website"] = "https://www.halfords.com/locations/" + data["storeDetailsLink"]
-                    oh = OpeningHours()
-                    for day_time in data["storeHours"]["workingHours"]:
-                        for day, time in day_time.items():
-                            for open_close_time in time:
-                                if open_close_time in [{}, {"isToday": True}]:
-                                    continue
-                                open_time = open_close_time.get("Start").strip()
-                                close_time = open_close_time.get("Finish").strip()
-                                oh.add_range(day=day, open_time=open_time, close_time=close_time)
-                    item["opening_hours"] = oh
 
-                    if data["storePrefix"] == "Halfords Autocentre":
-                        item["brand_wikidata"] = "Q5641894"
-                    elif data["storePrefix"] == "Halfords Garage Services":
-                        item["brand"] = "Halfords"
-                        apply_category(Categories.SHOP_CAR_REPAIR, item)
-                    elif data["storePrefix"] == "National Tyres and Autocare":
-                        item["brand_wikidata"] = "Q6979055"
-                    elif data["storePrefix"] == "Halfords Store":
-                        item["brand_wikidata"] = "Q3398786"
-                    else:
-                        item["brand_wikidata"] = "Q5641894"
-                    yield item
+            if not isinstance(data, dict):
+                continue
+
+            store_data = data.get("stores")
+            if not store_data:
+                continue
+
+            for data in store_data:
+                if data.get("coordinates").get("latitude") == 0:
+                    continue
+
+                item = DictParser.parse(data)
+                item["street_address"] = merge_address_lines([item.pop("street_address"), data.get("address2")])
+                item["website"] = "https://www.halfords.com/locations/" + data["storeDetailsLink"]
+
+                oh = OpeningHours()
+                for day_time in data["storeHours"]["workingHours"]:
+                    for day, time in day_time.items():
+                        for open_close_time in time:
+                            if open_close_time in [{}, {"isToday": True}]:
+                                continue
+                            open_time = open_close_time.get("Start").strip()
+                            close_time = open_close_time.get("Finish").strip()
+                            oh.add_range(day=day, open_time=open_time, close_time=close_time)
+                item["opening_hours"] = oh
+
+                if data["storePrefix"] == "Halfords Autocentre":
+                    item["brand_wikidata"] = "Q5641894"
+                elif data["storePrefix"] == "Halfords Garage Services":
+                    item["brand"] = "Halfords"
+                    apply_category(Categories.SHOP_CAR_REPAIR, item)
+                elif data["storePrefix"] == "National Tyres and Autocare":
+                    item["brand_wikidata"] = "Q6979055"
+                elif data["storePrefix"] == "Halfords Store":
+                    item["brand_wikidata"] = "Q3398786"
+                else:
+                    item["brand_wikidata"] = "Q5641894"
+                yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Halfords': 439,
'atp/brand/Halfords Autocentre': 294,
'atp/brand/National Tyres and Autocare': 132,
'atp/brand_wikidata/Q3398786': 356,
'atp/brand_wikidata/Q5641894': 294,
'atp/brand_wikidata/Q6979055': 132,
'atp/category/missing': 8,
'atp/category/shop/car_parts': 356,
'atp/category/shop/car_repair': 509,
'atp/clean_strings/city': 1,
'atp/clean_strings/name': 32,
'atp/clean_strings/postcode': 1,
'atp/country/GB': 873,
'atp/field/branch/missing': 873,
'atp/field/brand/missing': 8,
'atp/field/brand_wikidata/missing': 91,
'atp/field/country/from_spider_name': 873,
'atp/field/email/missing': 873,
'atp/field/image/missing': 517,
'atp/field/opening_hours/missing': 13,
'atp/field/operator/missing': 873,
'atp/field/operator_wikidata/missing': 873,
'atp/field/phone/invalid': 2,
'atp/field/phone/missing': 8,
'atp/field/state/missing': 873,
'atp/field/twitter/missing': 447,
'atp/item_scraped_host_count/www.halfords.com': 873,
'atp/lineage': 'S_?',
'atp/nsi/perfect_match': 782,
'downloader/request_bytes': 798,
'downloader/request_count': 2,
'downloader/request_method_count/GET': 2,
'downloader/response_bytes': 252963,
'downloader/response_count': 2,
'downloader/response_status_count/200': 2,
'elapsed_time_seconds': 13.339993,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2025, 10, 30, 5, 35, 50, 403906, tzinfo=datetime.timezone.utc),
'httpcompression/response_bytes': 3103208,
'httpcompression/response_count': 2,
'item_scraped_count': 873,
'items_per_minute': 4029.230769230769,
'log_count/DEBUG': 898,
'log_count/INFO': 9,
'log_count/WARNING': 2,
'response_received_count': 2,
'responses_per_minute': 9.23076923076923,
'robotstxt/request_count': 1,
'robotstxt/response_count': 1,
'robotstxt/response_status_count/200': 1,
'scheduler/dequeued': 1,
'scheduler/dequeued/memory': 1,
'scheduler/enqueued': 1,
'scheduler/enqueued/memory': 1,
'start_time': datetime.datetime(2025, 10, 30, 5, 35, 37, 63913, tzinfo=datetime.timezone.utc)}
```