### PR TITLE
[NSI] Pin NSI v6

### DIFF
--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -34,7 +34,9 @@ class NSI(metaclass=Singleton):
     @staticmethod
     def _request_file(file: str) -> dict:
         resp = requests.get(
-            "https://cdn.jsdelivr.net/npm/name-suggestion-index@6/{}".format(file),
+            "https://raw.githubusercontent.com/osmlab/name-suggestion-index/f98dfe538b8afca9b2c3f42608f67b666e7d8017/{}".format(
+                file
+            ),
             headers={"User-Agent": BOT_USER_AGENT_REQUESTS},
         )
         if not resp.status_code == 200:


### PR DESCRIPTION
NSI is in the process of migrating to v7, we can't (and shouldn’t) be reading HEAD. Once v7 is out, we should migrate to it.