### PR TITLE
Add missing websites to bhf_gb.py spider output

### DIFF
--- a/locations/spiders/bhf_gb.py
+++ b/locations/spiders/bhf_gb.py
@@ -40,6 +40,7 @@ class BhfGBSpider(SitemapSpider, StructuredDataSpider):
         if "item" not in locals():
             item = Feature()
             item["ref"] = response.url
+            item["website"] = response.url
             item["name"] = "British Heart Foundation"
             item["branch"] = response.xpath("//h1/text()").get()
             if "permanently closed" in item["branch"]:


### PR DESCRIPTION
Manually parsed store pages are missing the "website" property. But since each entry comes from an individual web page, we know what the website should be.