### PR TITLE
[Metro Cash And Carry] Fix spider

### DIFF
--- a/locations/spiders/metro_cash_and_carry.py
+++ b/locations/spiders/metro_cash_and_carry.py
@@ -26,6 +26,7 @@ class MetroCashAndCarrySpider(Spider):
     # API query params default values
     s = "0F3B38A3-7330-4544-B95B-81FC80A6BB6F"
     v = "D5BC0757-6F6D-4BDB-BFBD-065D34D0B4A3"
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         # Check for updated values


### PR DESCRIPTION
```python
{'atp/brand/Makro': 106,
 'atp/brand/Metro': 422,
 'atp/brand_wikidata/Q13610282': 422,
 'atp/brand_wikidata/Q704606': 106,
 'atp/category/shop/wholesale': 528,
 'atp/clean_strings/email': 45,
 'atp/clean_strings/phone': 24,
 'atp/country/AT': 16,
 'atp/country/BG': 11,
 'atp/country/CZ': 13,
 'atp/country/DE': 102,
 'atp/country/ES': 37,
 'atp/country/FR': 99,
 'atp/country/HR': 10,
 'atp/country/HU': 13,
 'atp/country/IT': 46,
 'atp/country/KZ': 6,
 'atp/country/MD': 3,
 'atp/country/NL': 17,
 'atp/country/PK': 10,
 'atp/country/PL': 29,
 'atp/country/PT': 10,
 'atp/country/RO': 30,
 'atp/country/RS': 9,
 'atp/country/SK': 6,
 'atp/country/TR': 35,
 'atp/country/UA': 26,
 'atp/field/branch/missing': 4,
 'atp/field/city/missing': 528,
 'atp/field/country/from_reverse_geocoding': 41,
 'atp/field/country/from_website_url': 487,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 82,
 'atp/field/image/missing': 528,
 'atp/field/opening_hours/missing': 528,
 'atp/field/operator/missing': 528,
 'atp/field/operator_wikidata/missing': 528,
 'atp/field/phone/invalid': 12,
 'atp/field/postcode/missing': 528,
 'atp/field/state/missing': 487,
 'atp/field/street_address/missing': 528,
 'atp/field/twitter/missing': 528,
 'atp/item_scraped_host_count/www.makro.cz': 13,
 'atp/item_scraped_host_count/www.makro.es': 37,
 'atp/item_scraped_host_count/www.makro.nl': 17,
 'atp/item_scraped_host_count/www.makro.pl': 29,
 'atp/item_scraped_host_count/www.makro.pt': 10,
 'atp/item_scraped_host_count/www.metro-cc.hr': 10,
 'atp/item_scraped_host_count/www.metro-kz.com': 6,
 'atp/item_scraped_host_count/www.metro-tr.com': 35,
 'atp/item_scraped_host_count/www.metro.at': 16,
 'atp/item_scraped_host_count/www.metro.bg': 11,
 'atp/item_scraped_host_count/www.metro.de': 102,
 'atp/item_scraped_host_count/www.metro.fr': 99,
 'atp/item_scraped_host_count/www.metro.hu': 13,
 'atp/item_scraped_host_count/www.metro.it': 46,
 'atp/item_scraped_host_count/www.metro.md': 3,
 'atp/item_scraped_host_count/www.metro.pk': 10,
 'atp/item_scraped_host_count/www.metro.ro': 30,
 'atp/item_scraped_host_count/www.metro.rs': 9,
 'atp/item_scraped_host_count/www.metro.sk': 6,
 'atp/item_scraped_host_count/www.metro.ua': 26,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 426,
 'atp/nsi/match_failed': 102,
 'downloader/request_bytes': 11056,
 'downloader/request_count': 26,
 'downloader/request_method_count/GET': 26,
 'downloader/response_bytes': 407920,
 'downloader/response_count': 26,
 'downloader/response_status_count/200': 22,
 'downloader/response_status_count/301': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 33.720403,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 5, 12, 22, 39, 288417, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3720444,
 'httpcompression/response_count': 23,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 528,
 'items_per_minute': 959.9999999999999,
 'log_count/DEBUG': 567,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'request_depth_max': 2,
 'response_received_count': 23,
 'responses_per_minute': 41.81818181818181,
 'scheduler/dequeued': 26,
 'scheduler/dequeued/memory': 26,
 'scheduler/enqueued': 26,
 'scheduler/enqueued/memory': 26,
 'start_time': datetime.datetime(2025, 11, 5, 12, 22, 5, 568014, tzinfo=datetime.timezone.utc)}
```