### PR TITLE
[SushiDaily] Fix error in country lookup

### DIFF
--- a/locations/country_utils.py
+++ b/locations/country_utils.py
@@ -22,6 +22,7 @@ class CountryUtils:
         "scotland": "GB",
         "wales": "GB",
         "northern ireland": "GB",
+        "netherlands": "NL",
         "uk": "GB",
         "norge": "NO",
         "united states of america": "US",


### PR DESCRIPTION
This error:
2025-10-30 23:21:25 [sushi_daily] ERROR: Invalid value "NETHERLANDS" for attribute "country".

caused by gc having this for Netherlands so the pipeline code does not find the country:

{'geonameid': 2750405, 'name': 'The Netherlands', 'iso': 'NL', 'iso3': 'NLD', 'isonumeric': 528, 'fips': 'NL', 'continentcode': 'EU', 'capital': 'Amsterdam', 'areakm2': 41526, 'population': 17231017, 'tld': '.nl', 'currencycode': 'EUR', 'currencyname': 'Euro', 'phone': '31', 'postalcoderegex': '^(\\d{4}\\s?[a-zA-Z]{2})$', 'languages': 'nl-NL,fy-NL', 'neighbours': 'DE,BE'}