### PR TITLE
[Avia PL] Fix Spider

### DIFF
--- a/locations/spiders/avia_pl.py
+++ b/locations/spiders/avia_pl.py
@@ -65,7 +65,8 @@ class AviaPLSpider(Spider):
                 for tag, value in station["features"][key].items():
                     if not isinstance(value, bool):
                         continue
-                    apply_yes_no(FUELS_AND_SERVICES_MAPPING[tag], item, True if value else False)
+                    if fuel_and_services := FUELS_AND_SERVICES_MAPPING.get(tag):
+                        apply_yes_no(fuel_and_services, item, True if value else False)
 
             yield item
 


### PR DESCRIPTION
**_Fixes : added if condition to avoid key error to fix spider_**

```python
{'atp/brand/Avia': 142,
 'atp/brand_wikidata/Q300147': 142,
 'atp/category/amenity/fuel': 142,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/street': 4,
 'atp/country/PL': 142,
 'atp/field/country/from_spider_name': 142,
 'atp/field/email/missing': 142,
 'atp/field/image/missing': 142,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/operator/missing': 142,
 'atp/field/operator_wikidata/missing': 142,
 'atp/field/phone/missing': 20,
 'atp/field/state/missing': 142,
 'atp/field/street_address/missing': 142,
 'atp/field/twitter/missing': 142,
 'atp/item_scraped_host_count/mapa.aviastacjapaliw.pl': 142,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 142,
 'downloader/request_bytes': 2413,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 99306,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 5,
 'elapsed_time_seconds': 2.985145,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 6, 8, 47, 18, 537889, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 5,
 'httpcompression/response_bytes': 550700,
 'httpcompression/response_count': 5,
 'item_scraped_count': 142,
 'items_per_minute': 4260.0,
 'log_count/DEBUG': 161,
 'log_count/INFO': 9,
 'request_depth_max': 2,
 'response_received_count': 5,
 'responses_per_minute': 150.0,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2025, 11, 6, 8, 47, 15, 552744, tzinfo=datetime.timezone.utc)}
```