### PR TITLE
[Weekend Max Mara] Add spider

### DIFF
--- a/locations/spiders/weekend_max_mara.py
+++ b/locations/spiders/weekend_max_mara.py
@@ -1,0 +1,18 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WeekendMaxMaraSpider(SitemapSpider, StructuredDataSpider):
+    name = "weekend_max_mara"
+    item_attributes = {"brand": "Weekend Max Mara", "brand_wikidata": "Q136159038"}
+    sitemap_urls = ["https://store.weekendmaxmara.com/robots.txt"]
+    sitemap_rules = [(r"https://store\.weekendmaxmara\.com/en/[^/]+/[^/]+/weekend-max-mara-[^/]+$", "parse")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Weekend Max Mara ")
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Weekend Max Mara': 284,
 'atp/brand_wikidata/Q136159038': 284,
 'atp/category/shop/clothes': 284,
 'atp/cdn/cloudflare/response_count': 288,
 'atp/cdn/cloudflare/response_status_count/200': 288,
 'atp/clean_strings/branch': 15,
 'atp/clean_strings/street_address': 7,
 'atp/country/AD': 1,
 'atp/country/AE': 3,
 'atp/country/AL': 1,
 'atp/country/AT': 2,
 'atp/country/AU': 6,
 'atp/country/AZ': 1,
 'atp/country/BE': 4,
 'atp/country/BY': 1,
 'atp/country/CA': 5,
 'atp/country/CH': 3,
 'atp/country/CO': 1,
 'atp/country/CY': 1,
 'atp/country/CZ': 3,
 'atp/country/DE': 3,
 'atp/country/DK': 2,
 'atp/country/EE': 1,
 'atp/country/ES': 24,
 'atp/country/FR': 18,
 'atp/country/GB': 6,
 'atp/country/GE': 1,
 'atp/country/GR': 2,
 'atp/country/HK': 5,
 'atp/country/HR': 5,
 'atp/country/HU': 1,
 'atp/country/ID': 1,
 'atp/country/IS': 1,
 'atp/country/IT': 59,
 'atp/country/JO': 1,
 'atp/country/JP': 20,
 'atp/country/KG': 1,
 'atp/country/KW': 2,
 'atp/country/KZ': 2,
 'atp/country/LT': 4,
 'atp/country/LU': 1,
 'atp/country/LV': 3,
 'atp/country/MA': 2,
 'atp/country/ME': 1,
 'atp/country/MK': 1,
 'atp/country/MT': 1,
 'atp/country/MX': 1,
 'atp/country/NL': 3,
 'atp/country/NZ': 1,
 'atp/country/PL': 10,
 'atp/country/PT': 3,
 'atp/country/PY': 1,
 'atp/country/RO': 1,
 'atp/country/RS': 1,
 'atp/country/RU': 25,
 'atp/country/SA': 1,
 'atp/country/SE': 1,
 'atp/country/SG': 1,
 'atp/country/SI': 1,
 'atp/country/SK': 1,
 'atp/country/TH': 1,
 'atp/country/TR': 4,
 'atp/country/UA': 6,
 'atp/country/US': 19,
 'atp/country/VN': 3,
 'atp/field/country/from_reverse_geocoding': 8,
 'atp/field/email/missing': 284,
 'atp/field/image/missing': 284,
 'atp/field/name/missing': 284,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 284,
 'atp/field/operator_wikidata/missing': 284,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 8,
 'atp/field/state/missing': 26,
 'atp/field/twitter/missing': 284,
 'atp/item_scraped_host_count/store.weekendmaxmara.com': 284,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 284,
 'downloader/request_bytes': 127761,
 'downloader/request_count': 288,
 'downloader/request_method_count/GET': 288,
 'downloader/response_bytes': 3975467,
 'downloader/response_count': 288,
 'downloader/response_status_count/200': 288,
 'elapsed_time_seconds': 3.204464,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 6, 10, 52, 15, 361166, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 288,
 'httpcompression/response_bytes': 17359032,
 'httpcompression/response_count': 288,
 'item_scraped_count': 284,
 'items_per_minute': 5680.0,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 290885632,
 'memusage/startup': 290885632,
 'request_depth_max': 3,
 'response_received_count': 288,
 'responses_per_minute': 5760.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 287,
 'scheduler/dequeued/memory': 287,
 'scheduler/enqueued': 287,
 'scheduler/enqueued/memory': 287,
 'start_time': datetime.datetime(2025, 11, 6, 10, 52, 12, 156702, tzinfo=datetime.timezone.utc)}
```