### PR TITLE
[Casper US] Fix Spider

### DIFF
--- a/locations/spiders/casper_us.py
+++ b/locations/spiders/casper_us.py
@@ -2,12 +2,13 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class CasperUSSpider(SitemapSpider, StructuredDataSpider):
     name = "casper_us"
     item_attributes = {"brand": "Casper", "brand_wikidata": "Q20539294", "extras": Categories.SHOP_BED.value}
     sitemap_urls = ["https://stores.casper.com/sitemap.xml"]
-    sitemap_rules = [(r"stores\.casper\.com\/casper\-.*$", "parse_sd")]
-    wanted_types = ["HomeGoodsStore"]
+    sitemap_rules = [(r"stores\.casper\.com\/[^/]+/[^/]+/.*html$", "parse_sd")]
     drop_attributes = {"image"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
**_Fixes : updated sitemap rules to fix spider_**

```python
{'atp/brand/Casper': 826,
 'atp/brand_wikidata/Q20539294': 826,
 'atp/category/shop/bed': 826,
 'atp/country/US': 826,
 'atp/field/branch/missing': 826,
 'atp/field/country/from_spider_name': 826,
 'atp/field/image/missing': 826,
 'atp/field/operator/missing': 826,
 'atp/field/operator_wikidata/missing': 826,
 'atp/field/phone/missing': 190,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 826,
 'atp/item_scraped_host_count/stores.casper.com': 826,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 826,
 'downloader/request_bytes': 295467,
 'downloader/request_count': 828,
 'downloader/request_method_count/GET': 828,
 'downloader/response_bytes': 34495261,
 'downloader/response_count': 828,
 'downloader/response_status_count/200': 828,
 'elapsed_time_seconds': 1018.029162,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 7, 10, 22, 31, 201041, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 306343219,
 'httpcompression/response_count': 828,
 'item_scraped_count': 826,
 'items_per_minute': 48.683693516699414,
 'log_count/DEBUG': 1675,
 'log_count/INFO': 25,
 'request_depth_max': 1,
 'response_received_count': 828,
 'responses_per_minute': 48.8015717092338,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 827,
 'scheduler/dequeued/memory': 827,
 'scheduler/enqueued': 827,
 'scheduler/enqueued/memory': 827,
 'start_time': datetime.datetime(2025, 11, 7, 10, 5, 33, 171879, tzinfo=datetime.timezone.utc)}
```