### PR TITLE
[Brico BE LU] Fix Spider

### DIFF
--- a/locations/spiders/brico_be_lu.py
+++ b/locations/spiders/brico_be_lu.py
@@ -28,7 +28,6 @@ class BricoBELUSpider(SitemapSpider):
             item["street_address"] = merge_address_lines([raw_data["address"]["line2"], raw_data["address"]["line1"]])
             oh = OpeningHours()
             for day_time in raw_data["openingHours"]["weekDayOpeningList"]:
-                print(day_time)
                 day = sanitise_day(day_time["weekDay"], DAYS_FR)
                 if day_time["closed"]:
                     oh.set_closed(day)


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Brico': 136,
 'atp/brand_wikidata/Q2510786': 136,
 'atp/category/shop/doityourself': 136,
 'atp/clean_strings/housenumber': 1,
 'atp/country/BE': 134,
 'atp/country/LU': 2,
 'atp/field/email/missing': 136,
 'atp/field/image/missing': 136,
 'atp/field/operator/missing': 136,
 'atp/field/operator_wikidata/missing': 136,
 'atp/field/phone/missing': 136,
 'atp/field/state/missing': 136,
 'atp/field/twitter/missing': 136,
 'atp/item_scraped_host_count/www.brico.be': 136,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 136,
 'downloader/request_bytes': 78364,
 'downloader/request_count': 161,
 'downloader/request_method_count/GET': 161,
 'downloader/response_bytes': 23072033,
 'downloader/response_count': 161,
 'downloader/response_status_count/200': 154,
 'downloader/response_status_count/301': 7,
 'elapsed_time_seconds': 199.367092,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 14, 7, 56, 57, 777982, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 141125581,
 'httpcompression/response_count': 154,
 'item_scraped_count': 136,
 'items_per_minute': 41.00502512562814,
 'log_count/DEBUG': 300,
 'log_count/INFO': 12,
 'request_depth_max': 1,
 'response_received_count': 154,
 'responses_per_minute': 46.4321608040201,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 160,
 'scheduler/dequeued/memory': 160,
 'scheduler/enqueued': 160,
 'scheduler/enqueued/memory': 160,
 'start_time': datetime.datetime(2025, 11, 14, 7, 53, 38, 410890, tzinfo=datetime.timezone.utc)}
```