### PR TITLE
[Banca Sella IT] Fix Spider

### DIFF
--- a/locations/spiders/banca_sella_it.py
+++ b/locations/spiders/banca_sella_it.py
@@ -1,18 +1,35 @@
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.json_blob_spider import JSONBlobSpider
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
-class BancaSellaITSpider(JSONBlobSpider):
+class BancaSellaITSpider(scrapy.Spider):
     name = "banca_sella_it"
     item_attributes = {"brand": "Banca Sella", "brand_wikidata": "Q3633749"}
-    start_urls = ["https://www.sella.it/banca-online/store-locator/store-list.jsp"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    locations_key = "stores"
-    no_refs = True
+    start_urls = ["https://www.sella.it/SSRLocatorBranch?bankAbi=03268"]
 
-    def post_process_item(self, item, response, location):
-        item["city"] = location.get("citta")
-        item["postcode"] = location.get("cap")
-        apply_category(Categories.BANK, item)
-        apply_yes_no(Extras.ATM, item, bool(location["atm"]))
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["ref"] = location["subjectId"]
+            item["street_address"] = item.pop("addr_full")
+            item["lat"] = location["yCoordinate"]
+            item["lon"] = location["xCoordinate"]
+            apply_category(Categories.BANK, item)
+            apply_yes_no(Extras.ATM, item, bool(location["evoluedATM"]))
+            oh = OpeningHours()
+            for day, time in location["openingHours"].items():
+                if time["composed"] == "  ":
+                    oh.set_closed(day)
+                else:
+                    for open_close_time in time["composed"].strip().split("  "):
+                        open_time, close_time = open_close_time.split("-")
+                        oh.add_range(day=day, open_time=open_time, close_time=close_time)
+            item["opening_hours"] = oh
+
+            yield item


### PR DESCRIPTION
**_Fixes : code refactored to fix spider_**

```python
{'atp/brand/Banca Sella': 278,
 'atp/brand_wikidata/Q3633749': 278,
 'atp/category/amenity/bank': 278,
 'atp/country/IT': 278,
 'atp/field/branch/missing': 278,
 'atp/field/country/from_spider_name': 278,
 'atp/field/email/missing': 278,
 'atp/field/image/missing': 278,
 'atp/field/operator/missing': 278,
 'atp/field/operator_wikidata/missing': 278,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 3,
 'atp/field/twitter/missing': 278,
 'atp/field/website/missing': 278,
 'atp/item_scraped_host_count/www.sella.it': 278,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 278,
 'downloader/request_bytes': 680,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1296697,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.954034,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 17, 5, 3, 59, 606498, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 278,
 'items_per_minute': 3336.0,
 'log_count/DEBUG': 283,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 17, 5, 3, 53, 652464, tzinfo=datetime.timezone.utc)}
```