### PR TITLE
[Starbucks IN] Fix spider

### DIFF
--- a/locations/spiders/starbucks_in.py
+++ b/locations/spiders/starbucks_in.py
@@ -1,22 +1,84 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+import json
+import time
+import uuid
+from typing import Any, AsyncIterable
 
-from locations.categories import Categories, apply_category
+from scrapy.http import JsonRequest, Response
+from scrapy.spiders import Spider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.hours import DAYS, OpeningHours
 from locations.spiders.starbucks_us import STARBUCKS_SHARED_ATTRIBUTES
-from locations.structured_data_spider import StructuredDataSpider
 
 
-class StarbucksINSpider(CrawlSpider, StructuredDataSpider):
+class StarbucksINSpider(Spider):
     name = "starbucks_in"
     item_attributes = STARBUCKS_SHARED_ATTRIBUTES
-    start_urls = ["https://tsb-stores.starbucksindia.net/"]
-    rules = [
-        Rule(LinkExtractor(allow=r"/Home$"), "parse_sd"),
-        Rule(LinkExtractor(allow=r"page=", restrict_xpaths='//*[contains(text(),"Next")]')),
-    ]
-    wanted_types = ["Restaurant"]
-    time_format = "%I:%M %p"
+    guest_token = ""
+    device_id = str(uuid.uuid4())
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "CONCURRENT_REQUESTS": 1,
+        "DEFAULT_REQUEST_HEADERS": {
+            "Content-Type": "application/json",
+            "Device-Meta-Info": json.dumps(
+                {
+                    "appVersion": "v1.0.0",
+                    "deviceCountry": "India",
+                    "deviceCity": "",
+                    "deviceId": device_id,
+                    "deviceModel": "",
+                    "platform": "WEB",
+                    "deviceOSVersion": "",
+                }
+            ),
+        },
+    }
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        apply_category(Categories.COFFEE_SHOP, item)
-        yield item
+    async def start(self) -> AsyncIterable[JsonRequest]:
+        yield JsonRequest(
+            url="https://tsb-mbaas.starbucksindia.net/api/unsec/user/guest/v2/token",
+            data={"deviceToken": None},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        self.guest_token = response.json()["response"]["guestToken"]
+        for city in city_locations("IN", 15000):
+            yield JsonRequest(
+                url="https://tsb-mbaas.starbucksindia.net/api/unsec/store/v3/get",
+                data={
+                    "lat": city["latitude"],
+                    "lng": city["longitude"],
+                    "searchId": f"{self.device_id}_{int(time.time() * 1000)}",
+                    "pageNumber": 1,
+                    "pageSize": 100,
+                },
+                headers={"GuestToken": self.guest_token},
+                callback=self.parse_locations,
+            )
+
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
+        locations = response.json().get("response") or []
+        for location in locations:
+            item = DictParser.parse(location)
+            item["branch"] = location["shopName"]
+            item["addr_full"] = location["shopAddress"]
+            item["phone"] = "; ".join(filter(None, [location["storeContactPhone1"], location["storeContactPhone2"]]))
+            opening_hours = location.get("workingHours") or {}
+            item["opening_hours"] = self.parse_opening_hours(
+                opening_hours.get("mop-pickup") or opening_hours.get("mop-delivery")
+            )
+            services = [service.get("title") for service in location.get("amenities")]
+            apply_yes_no(Extras.INDOOR_SEATING, item, "Dine In" in services)
+            apply_yes_no(Extras.WIFI, item, "Wifi" in services)
+            apply_category(Categories.COFFEE_SHOP, item)
+            yield item
+
+    def parse_opening_hours(self, opening_hours: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours:
+            for slot in rule.get("slots", []):
+                oh.add_range(DAYS[int(rule["day"]) - 1], slot["from"], slot["to"].replace("00:01", "23:59"))
+        return oh


### PR DESCRIPTION
Not sure about the current `count` , since in past spider was yielding [497](https://alltheplaces-data.openaddresses.io/runs/2025-10-25-13-32-36/stats/starbucks_in.json).

```python
{'atp/brand/Starbucks': 218,
 'atp/brand_wikidata/Q37158': 218,
 'atp/category/amenity/cafe': 218,
 'atp/country/IN': 218,
 'atp/duplicate_count': 11559,
 'atp/field/city/missing': 218,
 'atp/field/country/from_spider_name': 218,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 218,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 218,
 'atp/field/operator_wikidata/missing': 218,
 'atp/field/phone/missing': 51,
 'atp/field/postcode/missing': 218,
 'atp/field/state/missing': 218,
 'atp/field/street_address/missing': 218,
 'atp/field/twitter/missing': 218,
 'atp/field/website/missing': 218,
 'atp/item_scraped_host_count/tsb-mbaas.starbucksindia.net': 11777,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 218,
 'downloader/request_bytes': 4726821,
 'downloader/request_count': 3768,
 'downloader/request_method_count/POST': 3768,
 'downloader/response_bytes': 21536983,
 'downloader/response_count': 3768,
 'downloader/response_status_count/200': 3768,
 'elapsed_time_seconds': 4700.13097,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 18, 6, 23, 56, 336078, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 11559,
 'item_dropped_reasons_count/DropItem': 11559,
 'item_scraped_count': 218,
 'items_per_minute': 2.7829787234042556,
 'log_count/DEBUG': 15548,
 'log_count/INFO': 87,
 'request_depth_max': 1,
 'response_received_count': 3768,
 'responses_per_minute': 48.10212765957447,
 'scheduler/dequeued': 3768,
 'scheduler/dequeued/memory': 3768,
 'scheduler/enqueued': 3768,
 'scheduler/enqueued/memory': 3768,
 'start_time': datetime.datetime(2025, 11, 18, 5, 5, 36, 205108, tzinfo=datetime.timezone.utc)}
```