### PR TITLE
[Rural King US] Fix shop category

### DIFF
--- a/locations/spiders/rural_king_us.py
+++ b/locations/spiders/rural_king_us.py
@@ -134,7 +134,7 @@ class RuralKingUSSpider(scrapy.Spider):
             apply_yes_no(Fuel.PROPANE, item, True)
 
         if "RKGuns" in services:
-            extras["shop"] = "guns"
+            extras["shop"] = "weapons"
 
         if "In-Store Pickup" in services:
             extras["pickup"] = "yes"


### PR DESCRIPTION
`shop=guns` isn't a thing, `shop=gun` is a tiny thing. `shop=weapons` is a more real thing.