### PR TITLE
[Shell AU] Fix dropped count because of null ref value

### DIFF
--- a/locations/spiders/shell_au.py
+++ b/locations/spiders/shell_au.py
@@ -11,9 +11,19 @@ from locations.spiders.tesco_gb import set_located_in
 from locations.storefinders.mapdata_services import MapDataServicesSpider
 
 SHOP_BRANDS = {
+    "Dunnings": {"brand": "Dunnings"},
+    "Eagle Group": None,
+    "Maranos": None,
+    "NightOwl": None,
+    "NorthCoast": None,
+    "OTR": OtrAUSpider.item_attributes,
+    "OilsPlus": None,
+    "Perrys": None,
     "Reddy Express": {"brand": "Reddy Express", "brand_wikidata": "Q5144653"},
-    "Coles Express": {},
-    "Otr": OtrAUSpider.item_attributes,
+    "Store24": None,
+    "Sunraysia": None,
+    "TAS Petroleum": None,
+    "Urbanista": None,
 }
 FUEL_BRANDS = {
     "Advantage": None,
@@ -47,12 +57,8 @@ class ShellAUSpider(MapDataServicesSpider):
 
             apply_category(Categories.SHOP_CONVENIENCE, shop)
 
-            name = shop.pop("name").removeprefix(feature["forecourt_brand"]).strip()
-            for shop_brand in SHOP_BRANDS.keys():
-                if name.startswith(shop_brand):
-                    shop["branch"] = name.removeprefix(shop_brand).strip()
-                    shop.update(SHOP_BRANDS[shop_brand])
-                    break
+            if brand := SHOP_BRANDS.get(feature["shop_brand"]):
+                shop.update(brand)
 
             yield shop
 


### PR DESCRIPTION
```python
{'atp/brand/Shell': 1152,
 'atp/brand_wikidata/Q110716465': 1152,
 'atp/category/amenity/fuel': 1152,
 'atp/category/shop/convenience': 1092,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 2,
 'atp/country/AU': 2244,
 'atp/field/branch/missing': 2244,
 'atp/field/brand/missing': 1092,
 'atp/field/brand_wikidata/missing': 1092,
 'atp/field/email/missing': 2244,
 'atp/field/image/missing': 2244,
 'atp/field/name/missing': 1092,
 'atp/field/opening_hours/missing': 2244,
 'atp/field/operator/missing': 2244,
 'atp/field/operator_wikidata/missing': 2244,
 'atp/field/phone/missing': 7,
 'atp/field/twitter/missing': 2244,
 'atp/field/website/missing': 2244,
 'atp/item_scraped_host_count/data.nowwhere.com.au': 2244,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1152,
 'downloader/request_bytes': 612,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 2531455,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 10.478921,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 18, 13, 59, 15, 32919, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2244,
 'items_per_minute': 13464.0,
 'log_count/DEBUG': 2248,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 6.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 18, 13, 59, 4, 553998, tzinfo=datetime.timezone.utc)}
```