### PR TITLE
[Walmart US] Use centroids based requests to optimize spider

### DIFF
--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -7,7 +7,7 @@ from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.geo import city_locations
+from locations.geo import country_iseadgg_centroids
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
@@ -27,14 +27,14 @@ class WalmartUSSpider(Spider):
     hash = "383d44ac5962240870e513c4f53bb3d05a143fd7b19acb32e8a83e39f1ed266c"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for city in city_locations("US", min_population=15000):
+        for lat, lon in country_iseadgg_centroids("US", 94):
             variables = {
                 "input": {
                     "postalCode": "",
                     "accessTypes": ["PICKUP_INSTORE", "PICKUP_CURBSIDE"],
                     "nodeTypes": ["STORE", "PICKUP_SPOKE", "PICKUP_POPUP"],
-                    "latitude": city["latitude"],
-                    "longitude": city["longitude"],
+                    "latitude": lat,
+                    "longitude": lon,
                     "radius": 100,
                 },
                 "checkItemAvailability": False,
@@ -55,7 +55,7 @@ class WalmartUSSpider(Spider):
                     "x-o-platform-version": "usweb-1.220.0-ada3f07b1e1f576f89fca794606c73b0cd2ce649-8211424r",
                     "x-o-segment": "oaoh",
                 },
-                cookies={"walmart.nearestLatLng": f'{city["latitude"]},{city["longitude"]}'},
+                cookies={"walmart.nearestLatLng": f"{lat},{lon}"},
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
`country_iseadgg_centroids("US", 94)` results `'item_scraped_count': 4172`
`country_iseadgg_centroids("US", 158)`  results `'item_scraped_count': 3133`

```python
{'atp/brand/Walmart': 4172,
 'atp/brand_wikidata/Q483551': 4172,
 'atp/category/amenity/pharmacy': 2,
 'atp/category/multiple': 2,
 'atp/category/shop/department_store': 307,
 'atp/category/shop/supermarket': 3863,
 'atp/country/US': 4172,
 'atp/duplicate_count': 3918,
 'atp/field/email/missing': 4172,
 'atp/field/image/missing': 4172,
 'atp/field/operator/missing': 4172,
 'atp/field/operator_wikidata/missing': 4172,
 'atp/field/phone/missing': 4172,
 'atp/field/twitter/missing': 4172,
 'atp/item_scraped_host_count/www.walmart.com': 8090,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4172,
 'downloader/request_bytes': 1193563,
 'downloader/request_count': 554,
 'downloader/request_method_count/GET': 554,
 'downloader/response_bytes': 3055069,
 'downloader/response_count': 554,
 'downloader/response_status_count/200': 407,
 'downloader/response_status_count/412': 147,
 'elapsed_time_seconds': 6835.445664,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 19, 9, 15, 36, 806088, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11965691,
 'httpcompression/response_count': 407,
 'httperror/response_ignored_count': 147,
 'httperror/response_ignored_status_count/412': 147,
 'item_dropped_count': 3918,
 'item_dropped_reasons_count/DropItem': 3918,
 'item_scraped_count': 4172,
 'items_per_minute': 36.62326261887345,
 'log_count/DEBUG': 8647,
 'log_count/INFO': 269,
 'response_received_count': 554,
 'responses_per_minute': 4.863204096561814,
 'scheduler/dequeued': 554,
 'scheduler/dequeued/memory': 554,
 'scheduler/enqueued': 554,
 'scheduler/enqueued/memory': 554,
 'start_time': datetime.datetime(2025, 11, 19, 7, 21, 41, 360424, tzinfo=datetime.timezone.utc)}
```