### PR TITLE
[Fastsigns] New spider (797 locations)

### DIFF
--- a/locations/spiders/fastsigns.py
+++ b/locations/spiders/fastsigns.py
@@ -31,5 +31,6 @@ class FastsignsSpider(JSONBlobSpider):
 
         if location["Country"] == "AUS":
             item["name"] = item["brand"] = "Signwave"
+            item["brand_wikidata"] = "Q136850122"
 
         yield item


### PR DESCRIPTION
```py
{'atp/brand/Fastsigns': 779,
 'atp/brand/Signwave': 18,
 'atp/brand_wikidata/Q5437127': 797,
 'atp/category/craft/signmaker': 797,
 'atp/country/AU': 18,
 'atp/country/CA': 39,
 'atp/country/CL': 2,
 'atp/country/GB': 22,
 'atp/country/US': 716,
 'atp/field/email/missing': 797,
 'atp/field/image/missing': 167,
 'atp/field/opening_hours/missing': 797,
 'atp/field/operator/missing': 797,
 'atp/field/operator_wikidata/missing': 797,
 'atp/field/state/missing': 14,
 'atp/field/twitter/missing': 797,
 'atp/item_scraped_host_count/www.fastsigns.cl': 2,
 'atp/item_scraped_host_count/www.fastsigns.co.uk': 22,
 'atp/item_scraped_host_count/www.fastsigns.com': 755,
 'atp/item_scraped_host_count/www.signwave.com.au': 18,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 797,
 'downloader/request_bytes': 2772,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 1777054,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 4.087002,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 19, 20, 15, 25, 902330, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 797,
 'items_per_minute': 11955.0,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 282533888,
 'memusage/startup': 282533888,
 'response_received_count': 8,
 'responses_per_minute': 120.0,
 'robotstxt/request_count': 4,
 'robotstxt/response_count': 4,
 'robotstxt/response_status_count/200': 4,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2025, 11, 19, 20, 15, 21, 815328, tzinfo=datetime.timezone.utc)}
```