### PR TITLE
[Handelsbanken SE] Fix Spider

### DIFF
--- a/locations/spiders/handelsbanken_se.py
+++ b/locations/spiders/handelsbanken_se.py
@@ -13,6 +13,7 @@ class HandelsbankenSESpider(scrapy.Spider):
     start_urls = [
         "https://locator.maptoweb.dk/handelsbanken.com/locator/points/where/CountryCode/eqi/se?callback=jQuery1820675693055071215_1676888222517&_=1676888222528"
     ]
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         stores_raw = response.text


### PR DESCRIPTION
**_Fixes : Flag handelsbanken_se as requires proxy to fix spider_**

```python
{'atp/brand/Handelsbanken': 1372,
 'atp/brand_wikidata/Q1421630': 1372,
 'atp/category/amenity/atm': 1166,
 'atp/category/amenity/bank': 206,
 'atp/country/SE': 1372,
 'atp/field/branch/missing': 1372,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 1166,
 'atp/field/image/missing': 1372,
 'atp/field/opening_hours/missing': 1168,
 'atp/field/operator/missing': 206,
 'atp/field/operator_wikidata/missing': 206,
 'atp/field/phone/missing': 1166,
 'atp/field/state/missing': 1372,
 'atp/field/twitter/missing': 1372,
 'atp/field/website/missing': 1166,
 'atp/item_scraped_host_count/locator.maptoweb.dk': 1372,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1372,
 'atp/operator/Handelsbanken': 1166,
 'atp/operator_wikidata/Q1421630': 1166,
 'downloader/request_bytes': 786,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 70476,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 11.343751,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 20, 5, 41, 2, 729894, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1036583,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1372,
 'items_per_minute': 7483.636363636364,
 'log_count/DEBUG': 1395,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 10.90909090909091,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 20, 5, 40, 51, 386143, tzinfo=datetime.timezone.utc)}
```