### PR TITLE
[Office Depot] Fix Spider

### DIFF
--- a/locations/spiders/office_depot.py
+++ b/locations/spiders/office_depot.py
@@ -16,6 +16,7 @@ class OfficeDepotSpider(SitemapSpider, StructuredDataSpider):
     requires_proxy = "US"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["name"] = None
         item["website"] = response.url
         if item.get("image") == "http://www.example.com/LocationImageURL":
             item["image"] = None


### PR DESCRIPTION
**_Fixes : updated code to fix spider_**

```python
{'atp/brand/Office Depot': 744,
 'atp/brand_wikidata/Q1337797': 744,
 'atp/category/shop/stationery': 744,
 'atp/country/US': 744,
 'atp/field/branch/missing': 744,
 'atp/field/email/missing': 744,
 'atp/field/image/dropped': 744,
 'atp/field/image/missing': 744,
 'atp/field/operator/missing': 744,
 'atp/field/operator_wikidata/missing': 744,
 'atp/item_scraped_host_count/www.officedepot.com': 744,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 744,
 'downloader/request_bytes': 2467197,
 'downloader/request_count': 860,
 'downloader/request_method_count/GET': 860,
 'downloader/response_bytes': 113783852,
 'downloader/response_count': 860,
 'downloader/response_status_count/200': 860,
 'elapsed_time_seconds': 1047.244693,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 20, 10, 51, 56, 68438, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1364053665,
 'httpcompression/response_count': 860,
 'item_scraped_count': 744,
 'items_per_minute': 42.636103151862464,
 'log_count/DEBUG': 1607,
 'log_count/INFO': 26,
 'request_depth_max': 1,
 'response_received_count': 860,
 'responses_per_minute': 49.28366762177651,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 859,
 'scheduler/dequeued/memory': 859,
 'scheduler/enqueued': 859,
 'scheduler/enqueued/memory': 859,
 'start_time': datetime.datetime(2025, 11, 20, 10, 34, 28, 823745, tzinfo=datetime.timezone.utc)}
```