### PR TITLE
[Topps Tiles GB] Fix Spider

### DIFF
--- a/locations/spiders/topps_tiles_gb.py
+++ b/locations/spiders/topps_tiles_gb.py
@@ -10,6 +10,7 @@ class ToppsTilesGBSpider(Spider):
     name = "topps_tiles_gb"
     item_attributes = {"brand": "Topps Tiles", "brand_wikidata": "Q17026595"}
     start_urls = ["https://www.toppstiles.co.uk/api/n/find?type=store"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["catalog"]:


### PR DESCRIPTION
```python
{'atp/brand/Topps Tiles': 300,
 'atp/brand_wikidata/Q17026595': 300,
 'atp/category/shop/tiles': 300,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/email': 1,
 'atp/clean_strings/phone': 2,
 'atp/clean_strings/street_address': 1,
 'atp/country/GB': 300,
 'atp/field/email/missing': 3,
 'atp/field/image/missing': 300,
 'atp/field/lat/missing': 3,
 'atp/field/lon/missing': 3,
 'atp/field/opening_hours/missing': 300,
 'atp/field/operator/missing': 300,
 'atp/field/operator_wikidata/missing': 300,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/wrong_type': 1,
 'atp/field/state/missing': 288,
 'atp/field/twitter/missing': 300,
 'atp/item_scraped_host_count/www.toppstiles.co.uk': 300,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 300,
 'downloader/request_bytes': 349,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 72715,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.370149,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 21, 7, 47, 45, 978174, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5074885,
 'httpcompression/response_count': 1,
 'item_scraped_count': 300,
 'items_per_minute': 4500.0,
 'log_count/DEBUG': 304,
 'log_count/ERROR': 1,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': 15.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 21, 7, 47, 41, 608025, tzinfo=datetime.timezone.utc)}
```