### PR TITLE
Replace deprecated start_requests function in 'o' spiders

### DIFF
--- a/locations/spiders/o_tacos.py
+++ b/locations/spiders/o_tacos.py
@@ -1,8 +1,8 @@
-import string
-from typing import Any, Iterable
+from string import capwords
+from typing import Any, AsyncIterator
 
-from scrapy import FormRequest, Request, Spider
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import FormRequest, Response
 
 from locations.dict_parser import DictParser
 
@@ -11,7 +11,7 @@ class OTacosSpider(Spider):
     name = "o_tacos"
     item_attributes = {"brand": "O'Tacos", "brand_wikidata": "Q28494040"}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[FormRequest]:
         yield FormRequest(
             "https://www.o-tacos.fr/ajax",
             formdata={"action": "store_wpress_listener", "method": "display_map", "nb_display": "5000"},
@@ -20,6 +20,6 @@ class OTacosSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["locations"]:
             item = DictParser.parse(location)
-            item["branch"] = string.capwords(item.pop("name"))
+            item["branch"] = capwords(item.pop("name"))
 
             yield item

--- a/locations/spiders/ocean_basket_1.py
+++ b/locations/spiders/ocean_basket_1.py
@@ -1,4 +1,6 @@
-from scrapy import Request
+from typing import AsyncIterator
+
+from scrapy.http import Request
 from scrapy.linkextractors import LinkExtractor
 
 from locations.storefinders.go_review import GoReviewSpider
@@ -27,7 +29,7 @@ class OceanBasket1Spider(GoReviewSpider):
         "https://obmt.goreview.co.za/store-locator/goreview/default",
     ]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         for url in self.start_urls:
             yield Request(url=url, callback=self.fetch_store)
 

--- a/locations/spiders/ok_foods.py
+++ b/locations/spiders/ok_foods.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
@@ -42,7 +44,7 @@ class OkFoodsSpider(Spider):
         "SOUTH AFRICA": "https://www.okfoods.co.za/find-a-store.html",
     }
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url, callback=self.parse)
 

--- a/locations/spiders/old_chicago_us.py
+++ b/locations/spiders/old_chicago_us.py
@@ -1,15 +1,17 @@
-import scrapy
+from typing import AsyncIterator
+
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, day_range, sanitise_day
 
 
-class OldChicagoUSSpider(scrapy.Spider):
+class OldChicagoUSSpider(Spider):
     name = "old_chicago_us"
     item_attributes = {"brand": "Old Chicago", "brand_wikidata": "Q64411347"}
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://oc-api-prod.azurewebsites.net/graphql",
             data={

--- a/locations/spiders/old_mutual_za.py
+++ b/locations/spiders/old_mutual_za.py
@@ -1,5 +1,7 @@
+from typing import AsyncIterator
+
 from chompjs import parse_js_object
-from scrapy import Request
+from scrapy.http import Request
 
 from locations.categories import Categories
 from locations.hours import DAYS_FULL, OpeningHours
@@ -26,7 +28,7 @@ class OldMutualZASpider(JSONBlobSpider):
     start_urls = ["https://www.oldmutual.co.za/about/branch-locator/"]
     no_refs = True
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         for url in self.start_urls:
             yield Request(url=url, callback=self.fetch_js)
 

--- a/locations/spiders/ollies_bargain_outlet.py
+++ b/locations/spiders/ollies_bargain_outlet.py
@@ -1,18 +1,20 @@
-import scrapy
-from scrapy import FormRequest
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import FormRequest
 
 from locations.dict_parser import DictParser
 from locations.linked_data_parser import LinkedDataParser
 
 
-class OlliesBargainOutletSpider(scrapy.Spider):
+class OlliesBargainOutletSpider(Spider):
     name = "ollies_bargain_outlet"
     allowed_domains = ["ollies.us"]
     item_attributes = {"brand": "Ollie's Bargain Outlet", "brand_wikidata": "Q7088304"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
     requires_proxy = "US"
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[FormRequest]:
         formdata = {
             "Page": "0",
             "PageSize": "1",

--- a/locations/spiders/opentransportdata_swiss.py
+++ b/locations/spiders/opentransportdata_swiss.py
@@ -4,9 +4,11 @@ import io
 import re
 import zipfile
 from collections import namedtuple
+from typing import AsyncIterator
 from urllib.parse import urlencode
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.items import Feature
 from locations.user_agents import BOT_USER_AGENT_SCRAPY
@@ -16,7 +18,7 @@ from locations.user_agents import BOT_USER_AGENT_SCRAPY
 Station = namedtuple("Station", "name operator operator_wikidata city country means")
 
 
-class OpentransportdataSwissSpider(scrapy.Spider):
+class OpentransportdataSwissSpider(Spider):
     name = "opentransportdata_swiss"
     allowed_domains = [
         "opentransportdata.swiss",
@@ -37,8 +39,8 @@ class OpentransportdataSwissSpider(scrapy.Spider):
     dataset_pattern = "https://data.opentransportdata.swiss/en/dataset/%s/permalink"
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
-        yield scrapy.Request(
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
             "https://query.wikidata.org/sparql?{}".format(
                 urlencode({"query": "SELECT ?item ?sboid WHERE {?item p:P13221 ?s. ?s ps:P13221 ?sboid.}"})
             ),
@@ -52,12 +54,12 @@ class OpentransportdataSwissSpider(scrapy.Spider):
             if m := re.search(r"(Q\d+)", row["item"]):
                 self.operators[row["sboid"].lower().strip()] = m.group(1)
         url = "https://data.opentransportdata.swiss/de/dataset/bfr-rollstuhl"
-        yield scrapy.Request(url, callback=self.handle_wheelchair_overview)
+        yield Request(url, callback=self.handle_wheelchair_overview)
 
     def handle_wheelchair_overview(self, response):
         # The download URL changes daily with every database dump.
         link = next(href for href in response.xpath("//a/@href").getall() if href.endswith("bfr_haltestellendaten.csv"))
-        yield scrapy.Request(link, callback=self.handle_wheelchair_data)
+        yield Request(link, callback=self.handle_wheelchair_data)
 
     def handle_wheelchair_data(self, response):
         # The data feed supplies seperate properties for railbound
@@ -100,7 +102,7 @@ class OpentransportdataSwissSpider(scrapy.Spider):
             )
         # Next, fetch data file for wheelchair-accessible toilets.
         url = self.dataset_pattern % "prm-toilet-actual-date"
-        yield scrapy.Request(url, callback=self.handle_wheelchair_toilets)
+        yield Request(url, callback=self.handle_wheelchair_toilets)
 
     def handle_wheelchair_toilets(self, response):
         self.toilets_wheelchair = {}  # "ch:1:sloid:2213" -> "yes"
@@ -119,7 +121,7 @@ class OpentransportdataSwissSpider(scrapy.Spider):
         )
         # Next, fetch data file for "service points" (stations/stop areas).
         url = self.dataset_pattern % "service-points-actual-date"
-        yield scrapy.Request(url, callback=self.handle_service_points)
+        yield Request(url, callback=self.handle_service_points)
 
     def handle_service_points(self, response):
         self.stations = {}
@@ -178,7 +180,7 @@ class OpentransportdataSwissSpider(scrapy.Spider):
 
         # Next, fetch data for "traffic points" (platforms).
         url = self.dataset_pattern % "traffic-points-actual-date"
-        yield scrapy.Request(url, callback=self.handle_traffic_points)
+        yield Request(url, callback=self.handle_traffic_points)
 
     def handle_traffic_points(self, response):
         for row in self.read_csv("actual_date-world-traffic_point", response):

--- a/locations/spiders/orange_fr.py
+++ b/locations/spiders/orange_fr.py
@@ -1,7 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin
 
-from scrapy import Request
 from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
 
@@ -16,13 +15,13 @@ class OrangeFRSpider(Spider):
     skip_auto_cc_domain = True
     skip_auto_cc_spider_name = True
 
-    def make_request(self, page: int, page_size: int = 100) -> Request:
+    def make_request(self, page: int, page_size: int = 100) -> JsonRequest:
         return JsonRequest(
             url="https://7jl9sk5vbq-dsn.algolia.net/1/indexes/stores_locator_ofr/query?x-algolia-application-id=7JL9SK5VBQ&x-algolia-api-key=409fd5e4ef65efe7dacf57d93698910c",
             data={"params": "hitsPerPage={}&page={}".format(page_size, page)},
         )
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield self.make_request(0)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/orlen_paczka_pl.py
+++ b/locations/spiders/orlen_paczka_pl.py
@@ -1,4 +1,7 @@
-from scrapy import Request, Spider
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_PL, OpeningHours
@@ -11,7 +14,7 @@ class OrlenPaczkaPLSpider(Spider):
     start_urls = ["https://ruch-osm.sysadvisors.pl/api.php"]
     allowed_domains = ["ruch-osm.sysadvisors.pl"]
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[Request]:
         for url in self.start_urls:
             yield Request(
                 url=url,

--- a/locations/spiders/osterreichische_post_at.py
+++ b/locations/spiders/osterreichische_post_at.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category, apply_yes_no
@@ -14,7 +14,7 @@ class OsterreichischePostATSpider(Spider):
     name = "osterreichische_post_at"
     custom_settings = {"DOWNLOAD_TIMEOUT": 180}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://api.post.at/branchservice/core/graphql",
             data={

--- a/locations/spiders/otpbank_hu.py
+++ b/locations/spiders/otpbank_hu.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
@@ -12,7 +12,7 @@ class OtpbankHUSpider(Spider):
     item_attributes = {"brand_wikidata": "Q912778"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://www.otpbank.hu/apps2/branch-atm-locator/atm/list",
             data={"enclosingRectangle": [{"latitude": 90, "longitude": 180}, {"latitude": -90, "longitude": -180}]},

--- a/locations/spiders/outdoor_supply_hardware_us.py
+++ b/locations/spiders/outdoor_supply_hardware_us.py
@@ -1,8 +1,8 @@
-import json
-from typing import Any, Iterable
+from json import loads
+from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import Request, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -25,7 +25,7 @@ class OutdoorSupplyHardwareUSSpider(Spider):
     }
     requires_proxy = True
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         yield Request(
             url="https://www.outdoorsupplyhardware.com/Locations",
             headers={
@@ -42,7 +42,7 @@ class OutdoorSupplyHardwareUSSpider(Spider):
         for el in root:
             el.text = decode_email(el.get("data-cfemail"))
 
-        for location in json.loads(root.text_content()):
+        for location in loads(root.text_content()):
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
             item["street_address"] = item.pop("street", None)


### PR DESCRIPTION
For all spiders with a name commencing 'o' that use the now-deprecated start_requests(...) function, replace it with Scrapy's async start function.