### PR TITLE
[Roadhouse IT] Fix Spider

### DIFF
--- a/locations/spiders/roadhouse_it.py
+++ b/locations/spiders/roadhouse_it.py
@@ -13,6 +13,13 @@ class RoadhouseITSpider(UberallSpider):
 
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
         item["ref"] = location["id"]
+        item["branch"] = (
+            item.pop("name")
+            .removeprefix("ROADHOUSE RESTAURANT ")
+            .removeprefix("Roadhouse Restaurant ")
+            .removeprefix("Roadhouse ")
+            .strip(" -")
+        )
         item["website"] = "/".join(
             [
                 "https://www.roadhouse.it/store-locator/#!/l",


### PR DESCRIPTION
**_Fixes : code refactored to use uberall to fix spider_**

```python
{'atp/brand/Roadhouse': 182,
 'atp/brand_wikidata/Q7339591': 182,
 'atp/category/amenity/restaurant': 182,
 'atp/country/IT': 182,
 'atp/field/branch/missing': 182,
 'atp/field/email/missing': 182,
 'atp/field/image/missing': 181,
 'atp/field/operator/missing': 182,
 'atp/field/operator_wikidata/missing': 182,
 'atp/field/twitter/missing': 182,
 'atp/field/website/invalid': 44,
 'atp/item_scraped_host_count/uberall.com': 182,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 182,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23921,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.271698,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 21, 11, 26, 14, 950317, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 186833,
 'httpcompression/response_count': 2,
 'item_scraped_count': 182,
 'items_per_minute': 2730.0,
 'log_count/DEBUG': 187,
 'log_count/INFO': 9,
 'log_count/WARNING': 45,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 21, 11, 26, 10, 678619, tzinfo=datetime.timezone.utc)}
```