### PR TITLE
[Core] Load nsi files relative to package directory

### DIFF
--- a/locations/name_suggestion_index.py
+++ b/locations/name_suggestion_index.py
@@ -1,5 +1,6 @@
 import json
 import re
+from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse
 
@@ -10,8 +11,9 @@ from unidecode import unidecode
 
 from locations.user_agents import BOT_USER_AGENT_REQUESTS
 
-NSI_FILE_PATH = "locations/data/nsi.json"
-WIKIDATA_FILE_PATH = "locations/data/nsi-wikidata.json"
+_DATA_DIR = Path(__file__).resolve().parent / "data"
+NSI_FILE_PATH = _DATA_DIR / "nsi.json"
+WIKIDATA_FILE_PATH = _DATA_DIR / "nsi-wikidata.json"
 
 
 class Singleton(type):


### PR DESCRIPTION
#14527 added some JSON data files to the repository which were previously downloaded. The files are simply loaded with a relative path like `locations/data/nsi.json`.

I would like to propose to load the files relative to the package instead. This allows to run the scrapers from a different working directory than the project root.

I’ve packaged AllThePlaces locally and am using it as dependency in other projects. This way AllThePlaces gets installed into a virtual environment `.venv/...`. Running scrapers works in principle, but loading the data files fails because they are not directly below `locations`.

Not sure if `Path(__file__).resolve().parent` is the best pattern for all situations. Please advise if there’s a better way.