### PR TITLE
[easyfitness_de] Fix spider

### DIFF
--- a/locations/spiders/easyfitness_de.py
+++ b/locations/spiders/easyfitness_de.py
@@ -1,29 +1,40 @@
-from typing import AsyncIterator, Iterable
+from typing import Iterable
 
-from scrapy import Spider
+from scrapy import Request
 from scrapy.http import FormRequest, Response
+from scrapy.spiders import SitemapSpider
 
 from locations.dict_parser import DictParser
-from locations.geo import point_locations
 from locations.items import Feature
 
 
-class EasyfitnessDESpider(Spider):
+class EasyfitnessDESpider(SitemapSpider):
     name = "easyfitness_de"
     item_attributes = {"brand": "EasyFitness", "brand_wikidata": "Q106166703"}
+    sitemap_urls = ["https://easyfitness.club/robots.txt"]
+    sitemap_rules = [
+        (r"/studio/", "parse"),
+    ]
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        point_files = "eu_centroids_20km_radius_country.csv"
-        for lat, lng in point_locations(point_files, ["DE"]):
-            yield FormRequest(
-                "https://easyfitness.club/wp-admin/admin-ajax.php",
-                formdata={
-                    "action": "search_nearby_studios",
-                    "lat": str(lat),
-                    "lng": str(lng),
-                    "addaction": "start",
-                },
-            )
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
+        # Intercept the requests that result from parsing the sitemap. Instead of actually performing them, only look at
+        # their URLs.
+        for request in super()._parse_sitemap(response):
+            if "/studio/" in request.url:
+                slug = request.url.removesuffix("/").rsplit("/", maxsplit=1)[1]
+                search_term = slug.removeprefix("easyfitness-").replace("-", " ").title()
+                # The search API expects a search term like a city name or an address. Use the sitemap to get the names
+                # of all gyms, then search for each of them.
+                yield FormRequest(
+                    "https://easyfitness.club/wp-admin/admin-ajax.php",
+                    formdata={
+                        "action": "search_nearby_studios",
+                        "search_term": search_term,
+                        "addaction": "start",
+                    },
+                )
+            else:
+                yield request
 
     def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
         for data in response.json()["list"]:


### PR DESCRIPTION
The search API seems to longer accept latitude/longitude and instead wants a search term like a city name or an address. Use the sitemap to get the cities where Easyfitness is present and use those as search terms.