### PR TITLE
[Coinflip] Fix Spider

### DIFF
--- a/locations/spiders/coinflip.py
+++ b/locations/spiders/coinflip.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
@@ -15,6 +17,7 @@ class CoinflipSpider(SitemapSpider, StructuredDataSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_DELAY": 3, "CONCURRENT_REQUESTS": 1}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["lat"], item["lon"] = re.search(r"q=(-?\d+\.\d+),(-?\d+\.\d+)", ld_data["hasMap"]).groups()
         oh = OpeningHours()
         for day_time in ld_data["openingHoursSpecification"]:
             day = DAYS_FULL[int(day_time["dayOfWeek"][0])]


### PR DESCRIPTION
**_Fixes : updated code to use sitemap to fix spider_**

```python
{'atp/brand/CoinFlip': 1887,
 'atp/brand_wikidata/Q109850256': 1887,
 'atp/category/amenity/atm': 1887,
 'atp/cdn/cloudflare/response_count': 1944,
 'atp/cdn/cloudflare/response_status_count/200': 1909,
 'atp/cdn/cloudflare/response_status_count/404': 35,
 'atp/country/AU': 175,
 'atp/country/BR': 2,
 'atp/country/CA': 115,
 'atp/country/ES': 42,
 'atp/country/IT': 49,
 'atp/country/MX': 4,
 'atp/country/NZ': 20,
 'atp/country/PA': 2,
 'atp/country/US': 1464,
 'atp/country/ZA': 14,
 'atp/field/branch/missing': 1887,
 'atp/field/email/missing': 1887,
 'atp/field/operator/missing': 1887,
 'atp/field/operator_wikidata/missing': 1887,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 20,
 'atp/item_scraped_host_count/locations.coinflip.tech': 1887,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1887,
 'downloader/request_bytes': 1276458,
 'downloader/request_count': 2008,
 'downloader/request_method_count/GET': 2008,
 'downloader/response_bytes': 75242248,
 'downloader/response_count': 2008,
 'downloader/response_status_count/200': 1909,
 'downloader/response_status_count/307': 58,
 'downloader/response_status_count/308': 6,
 'downloader/response_status_count/404': 35,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 7358.973341,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 26, 12, 22, 51, 816621, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 440659315,
 'httpcompression/response_count': 1944,
 'httperror/response_ignored_count': 35,
 'httperror/response_ignored_status_count/404': 35,
 'item_scraped_count': 1887,
 'items_per_minute': 15.387333514541995,
 'log_count/DEBUG': 3909,
 'log_count/INFO': 166,
 'log_count/WARNING': 1887,
 'request_depth_max': 1,
 'response_received_count': 1944,
 'responses_per_minute': 15.852133731992389,
 'scheduler/dequeued': 2008,
 'scheduler/dequeued/memory': 2008,
 'scheduler/enqueued': 2008,
 'scheduler/enqueued/memory': 2008,
 'start_time': datetime.datetime(2025, 11, 26, 10, 20, 12, 843280, tzinfo=datetime.timezone.utc)}
```