### PR TITLE
[Jumbo NL] Fix Spider

### DIFF
--- a/locations/spiders/jumbo_nl.py
+++ b/locations/spiders/jumbo_nl.py
@@ -23,6 +23,11 @@ class JumboNLSpider(Spider):
     def make_request(self, page: int, size: int = 30) -> JsonRequest:
         return JsonRequest(
             url="https://www.jumbo.com/api/graphql",
+            headers={
+                "apollographql-client-name": "JUMBO_WEB-store",
+                "apollographql-client-version": "master-v22.12.1-web",
+                "content-type": "application/json",
+            },
             data={
                 "operationName": "GetStoreList",
                 "variables": {


### PR DESCRIPTION
```python
{'atp/brand/Jumbo': 755,
 'atp/brand_wikidata/Q2262314': 755,
 'atp/category/shop/supermarket': 755,
 'atp/country/NL': 755,
 'atp/field/country/from_spider_name': 755,
 'atp/field/email/missing': 755,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 755,
 'atp/field/operator_wikidata/missing': 755,
 'atp/field/phone/missing': 755,
 'atp/field/state/missing': 755,
 'atp/field/street_address/missing': 755,
 'atp/item_scraped_host_count/www.jumbo.com': 755,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 755,
 'downloader/request_bytes': 114631,
 'downloader/request_count': 26,
 'downloader/request_method_count/POST': 26,
 'downloader/response_bytes': 79296,
 'downloader/response_count': 26,
 'downloader/response_status_count/200': 26,
 'elapsed_time_seconds': 32.615652,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 27, 5, 56, 29, 741733, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 726299,
 'httpcompression/response_count': 26,
 'item_scraped_count': 755,
 'items_per_minute': 1415.625,
 'log_count/DEBUG': 794,
 'log_count/INFO': 9,
 'request_depth_max': 25,
 'response_received_count': 26,
 'responses_per_minute': 48.75,
 'scheduler/dequeued': 26,
 'scheduler/dequeued/memory': 26,
 'scheduler/enqueued': 26,
 'scheduler/enqueued/memory': 26,
 'start_time': datetime.datetime(2025, 11, 27, 5, 55, 57, 126081, tzinfo=datetime.timezone.utc)}
```