### PR TITLE
[Petrol] Fix Spider

### DIFF
--- a/locations/spiders/petrol.py
+++ b/locations/spiders/petrol.py
@@ -1,9 +1,10 @@
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from typing import Any, AsyncIterator
 
-from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 
 
 class PetrolSpider(Spider):
@@ -12,38 +13,74 @@ class PetrolSpider(Spider):
     PETROL = {"brand": "Petrol", "brand_wikidata": "Q174824"}
     item_attributes = PETROL
 
-    @staticmethod
-    def make_request(offset):
-        return JsonRequest(
-            f"https://www.petrol.eu/restservices/sales-service/filterStores?offset={offset}", meta={"offset": offset}
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(
+            url="https://www.petrol.eu/restservices/graphql/eshop/sales-locations",
+            data={
+                "query": """
+              query GetSalesLocations(
+                $filterType: SalesLocationFilterType!
+                $filterValue: SalesLocationFilterValue!
+                $locale: String!
+              ) {
+                salesLocations(filterType: $filterType, filterValue: $filterValue, locale: $locale) {
+                  items {
+                    id
+                    originId
+                    status
+                    name
+                    croduxBrand
+                    hidden
+                    operatingSchedules {
+                      date
+                      openingHours {
+                        from
+                        to
+                        crew
+                      }
+                    }
+                    geolocation {
+                      longitude
+                      latitude
+                    }
+                    address {
+                      country {
+                        code
+                        numericCode
+                      }
+                      street {
+                        name
+                        number
+                      }
+                    }
+                    groupCharacteristics {
+                      handle
+                      name
+                      characteristics {
+                        handle
+                        name
+                        value
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+                "variables": {"filterType": "TYPE", "filterValue": {"type": "GAS_STATION"}, "locale": "sl"},
+            },
+            callback=self.parse,
         )
 
-    def start_requests(self):
-        yield self.make_request(0)
-
-    def parse(self, response, **kwargs):
-        for location in response.json():
-            if location["status"] != "ACTIVE":
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for station in response.json()["data"]["salesLocations"]["items"]:
+            if station["geolocation"]["longitude"] == "0":
                 continue
-            location["location"] = location["location"]["coordinates"][0]
-
-            item = DictParser.parse(location)
-
-            item["opening_hours"] = OpeningHours()
-            for day, times in location["activeOpeningHours"]["times"].items():
-                for time_range in times:
-                    item["opening_hours"].add_range(day, time_range["open"], time_range["close"])
-
-            for cat in location["storeCharacteristics"]:
-                if cat["characteristic"]["key"] == "28":
-                    item.update(self.CRODUX)
-                elif cat["characteristic"]["key"] == "160":
-                    apply_yes_no(Fuel.DIESEL, item, True)
-                elif cat["characteristic"]["key"] == "191":
-                    apply_yes_no(Extras.WIFI, item, True)
-
+            item = DictParser.parse(station)
+            item["street"] = item["street"]["name"]
+            item["street_address"] = ",".join([station["address"]["street"]["number"], item["street"]])
             apply_category(Categories.FUEL_STATION, item)
+            if station["croduxBrand"]:
+                item.update(self.CRODUX)
+            else:
+                item.update(self.PETROL)
             yield item
-
-        if len(response.json()) == 100:
-            yield self.make_request(response.meta["offset"] + 100)


### PR DESCRIPTION
```python
{'atp/brand/Crodux': 28,
 'atp/brand/Petrol': 617,
 'atp/brand_wikidata/Q174824': 617,
 'atp/brand_wikidata/Q62274622': 28,
 'atp/category/amenity/fuel': 645,
 'atp/country/AT': 1,
 'atp/country/BA': 46,
 'atp/country/HR': 212,
 'atp/country/IT': 1,
 'atp/country/ME': 15,
 'atp/country/RS': 22,
 'atp/country/SI': 337,
 'atp/country/XK': 11,
 'atp/field/branch/missing': 645,
 'atp/field/city/missing': 645,
 'atp/field/country/from_reverse_geocoding': 645,
 'atp/field/email/missing': 645,
 'atp/field/image/missing': 645,
 'atp/field/opening_hours/missing': 645,
 'atp/field/operator/missing': 645,
 'atp/field/operator_wikidata/missing': 645,
 'atp/field/phone/missing': 645,
 'atp/field/postcode/missing': 645,
 'atp/field/state/missing': 7,
 'atp/field/twitter/missing': 645,
 'atp/field/website/missing': 645,
 'atp/item_scraped_host_count/www.petrol.eu': 645,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 632,
 'atp/nsi/match_failed': 13,
 'downloader/request_bytes': 2505,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 132707,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.70277,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 27, 8, 41, 41, 604687, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3555060,
 'httpcompression/response_count': 2,
 'item_scraped_count': 645,
 'items_per_minute': 6450.0,
 'log_count/DEBUG': 650,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 11, 27, 8, 41, 34, 901917, tzinfo=datetime.timezone.utc)}
```