### PR TITLE
[Castorama FR] Fix Spider

### DIFF
--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -8,7 +8,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class CastoramaFRSpider(SitemapSpider, StructuredDataSpider):
     name = "castorama_fr"
     item_attributes = {"brand": "Castorama", "brand_wikidata": "Q966971"}
-    sitemap_urls = ["https://www.castorama.fr/static/sitemap.xml"]
+    sitemap_urls = ["https://www.castorama.fr/fstrz/sm/sitemap-magasins.xml"]
     sitemap_rules = [(r"/store/\d+", "parse_sd")]
     drop_attributes = {"image"}
 


### PR DESCRIPTION
```python
{'atp/brand/Castorama': 92,
 'atp/brand_wikidata/Q966971': 92,
 'atp/category/shop/hardware': 92,
 'atp/cdn/cloudfront/response_count': 1,
 'atp/cdn/cloudfront/response_status_count/200': 1,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 2,
 'atp/country/FR': 92,
 'atp/field/branch/missing': 92,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 92,
 'atp/field/operator/missing': 92,
 'atp/field/operator_wikidata/missing': 92,
 'atp/field/state/missing': 92,
 'atp/item_scraped_host_count/www.castorama.fr': 92,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 92,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 43644,
 'downloader/request_count': 95,
 'downloader/request_method_count/GET': 95,
 'downloader/response_bytes': 17422819,
 'downloader/response_count': 94,
 'downloader/response_status_count/200': 94,
 'elapsed_time_seconds': 118.492391,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 27, 10, 41, 20, 734576, tzinfo=datetime.timezone.utc),
 'httpcompression/response_count': 94,
 'item_scraped_count': 92,
 'items_per_minute': 46.779661016949156,
 'log_count/DEBUG': 204,
 'log_count/INFO': 10,
 'log_count/WARNING': 92,
 'request_depth_max': 1,
 'response_received_count': 94,
 'responses_per_minute': 47.79661016949153,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 94,
 'scheduler/dequeued/memory': 94,
 'scheduler/enqueued': 94,
 'scheduler/enqueued/memory': 94,
 'start_time': datetime.datetime(2025, 11, 27, 10, 39, 22, 242185, tzinfo=datetime.timezone.utc)}
 
```