### PR TITLE
[Castorama FR] Clean up spider

### DIFF
--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -1,26 +1,27 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class CastoramaFRSpider(SitemapSpider, StructuredDataSpider):
     name = "castorama_fr"
     item_attributes = {"brand": "Castorama", "brand_wikidata": "Q966971"}
-    sitemap_urls = ["https://www.castorama.fr/static/sitemap.xml"]
+    sitemap_urls = ["https://www.castorama.fr/robots.txt"]
+    sitemap_follow = ["sitemap-magasins.xml"]
     sitemap_rules = [(r"/store/\d+", "parse_sd")]
-    drop_attributes = {"image"}
+    time_format = "%H:%M:%S Europe/Paris"
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        oh = OpeningHours()
-        for opening_hour in ld_data["openingHoursSpecification"]:
-            if "opens" in opening_hour:
-                oh.add_range(
-                    DAYS_EN[opening_hour["dayOfWeek"]],
-                    opening_hour["opens"][0:5],
-                    opening_hour["closes"][0:5],
-                )
-                item["opening_hours"] = oh
-        apply_category(Categories.SHOP_HARDWARE, item)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["image"] = None
+        if item["name"].startswith("Castorama "):
+            item["branch"] = item.pop("name").removeprefix("Castorama ")
+            item["name"] = "Castorama"
+        elif item["name"].startswith("Casto "):
+            item["branch"] = item.pop("name").removeprefix("Casto ")
+            item["name"] = "Casto"
+
+        apply_category(Categories.SHOP_DOITYOURSELF, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Castorama': 92,
 'atp/brand_wikidata/Q966971': 92,
 'atp/category/shop/doityourself': 92,
 'atp/cdn/cloudfront/response_count': 2,
 'atp/cdn/cloudfront/response_status_count/200': 2,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/street_address': 2,
 'atp/country/FR': 92,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 92,
 'atp/field/image/missing': 92,
 'atp/field/name/missing': 92,
 'atp/field/operator/missing': 92,
 'atp/field/operator_wikidata/missing': 92,
 'atp/field/state/missing': 92,
 'atp/field/twitter/missing': 92,
 'atp/item_scraped_host_count/www.castorama.fr': 92,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_failed': 92,
 'downloader/request_bytes': 40047,
 'downloader/request_count': 96,
 'downloader/request_method_count/GET': 96,
 'downloader/response_bytes': 17691347,
 'downloader/response_count': 96,
 'downloader/response_status_count/200': 96,
 'elapsed_time_seconds': 3.144067,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 11, 28, 11, 35, 2, 29218, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 96,
 'httpcompression/response_bytes': 65007816,
 'httpcompression/response_count': 96,
 'item_scraped_count': 92,
 'items_per_minute': 1840.0,
 'log_count/DEBUG': 192,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 283430912,
 'memusage/startup': 283430912,
 'request_depth_max': 3,
 'response_received_count': 96,
 'responses_per_minute': 1920.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 95,
 'scheduler/dequeued/memory': 95,
 'scheduler/enqueued': 95,
 'scheduler/enqueued/memory': 95,
 'start_time': datetime.datetime(2025, 11, 28, 11, 34, 58, 885151, tzinfo=datetime.timezone.utc)}
```