### PR TITLE
[American Mattress US] Fix Spider

### DIFF
--- a/locations/spiders/american_mattress_us.py
+++ b/locations/spiders/american_mattress_us.py
@@ -8,14 +8,13 @@ from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AmericanMattressUSSpider(
-    SitemapSpider,
-):
+class AmericanMattressUSSpider(SitemapSpider):
     name = "american_mattress_us"
     sitemap_urls = ["https://cdn.avbportal.com/magento-media/sitemaps/bs0085/sitemap.xml"]
     item_attributes = {"brand": "American Mattress", "brand_wikidata": "Q126896153"}
     sitemap_rules = [("/locations/", "parse")]
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    requires_proxy = True
 
     def parse(self, response):
         item = Feature()


### PR DESCRIPTION
```python
{'atp/brand/American Mattress': 70,
 'atp/brand_wikidata/Q126896153': 70,
 'atp/category/shop/bed': 70,
 'atp/clean_strings/branch': 70,
 'atp/clean_strings/street_address': 70,
 'atp/country/US': 70,
 'atp/field/city/missing': 70,
 'atp/field/country/from_spider_name': 70,
 'atp/field/email/missing': 70,
 'atp/field/image/missing': 70,
 'atp/field/opening_hours/missing': 70,
 'atp/field/operator/missing': 70,
 'atp/field/operator_wikidata/missing': 70,
 'atp/field/postcode/missing': 70,
 'atp/field/state/from_reverse_geocoding': 70,
 'atp/field/twitter/missing': 70,
 'atp/item_scraped_host_count/www.americanmattress.com': 70,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 70,
 'downloader/request_bytes': 31955,
 'downloader/request_count': 71,
 'downloader/request_method_count/GET': 71,
 'downloader/response_bytes': 24443667,
 'downloader/response_count': 71,
 'downloader/response_status_count/200': 71,
 'elapsed_time_seconds': 83.697873,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 1, 9, 52, 36, 578166, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 62181645,
 'httpcompression/response_count': 71,
 'item_scraped_count': 70,
 'items_per_minute': 50.60240963855422,
 'log_count/DEBUG': 144,
 'log_count/INFO': 10,
 'memusage/max': 566910976,
 'memusage/startup': 288976896,
 'request_depth_max': 1,
 'response_received_count': 71,
 'responses_per_minute': 51.325301204819276,
 'scheduler/dequeued': 71,
 'scheduler/dequeued/memory': 71,
 'scheduler/enqueued': 71,
 'scheduler/enqueued/memory': 71,
 'start_time': datetime.datetime(2025, 12, 1, 9, 51, 12, 880293, tzinfo=datetime.timezone.utc)}
```