### PR TITLE
[Go Ape GB] Fix Spider

### DIFF
--- a/locations/spiders/go_ape_gb.py
+++ b/locations/spiders/go_ape_gb.py
@@ -10,7 +10,7 @@ class GoApeGBSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"https:\/\/goape\.co\.uk\/locations\/([-\w]+)/$", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["addr_full"] = item.pop("street_address").removeprefix("Go Ape ")):
+        item["addr_full"] = item.pop("street_address").removeprefix("Go Ape ")
         item["branch"] = item.pop("name").removeprefix("Go Ape ")
         item["ref"] = response.url
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Go Ape': 37,
 'atp/brand_wikidata/Q5574692': 37,
 'atp/category/leisure/sports_centre': 37,
 'atp/cdn/cloudflare/response_count': 40,
 'atp/cdn/cloudflare/response_status_count/200': 40,
 'atp/country/GB': 37,
 'atp/field/branch/missing': 37,
 'atp/field/email/missing': 37,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 37,
 'atp/field/operator_wikidata/missing': 37,
 'atp/field/phone/missing': 37,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 37,
 'atp/field/street_address/missing': 37,
 'atp/item_scraped_host_count/goape.co.uk': 37,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 37,
 'atp/structured_data/unmapped/amenity_features': 36,
 'downloader/request_bytes': 15299,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 1745106,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 40,
 'elapsed_time_seconds': 48.08791,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 3, 5, 52, 33, 722450, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9467755,
 'httpcompression/response_count': 40,
 'item_scraped_count': 37,
 'items_per_minute': 46.25,
 'log_count/DEBUG': 116,
 'log_count/INFO': 45,
 'memusage/max': 290131968,
 'memusage/startup': 290131968,
 'request_depth_max': 2,
 'response_received_count': 40,
 'responses_per_minute': 50.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2025, 12, 3, 5, 51, 45, 634540, tzinfo=datetime.timezone.utc)}
```