### PR TITLE
[Juut] New spider (fixes #657)

### DIFF
--- a/locations/spiders/juut_us.py
+++ b/locations/spiders/juut_us.py
@@ -1,0 +1,20 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class JuutUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "juut_us"
+    item_attributes = {"brand": "Juut"}
+    sitemap_urls = ["https://juut.com/locations-sitemap.xml"]
+    sitemap_rules = [
+        (r"https://juut.com/locations/[\w-]+/", "parse"),
+    ]
+    wanted_types = ["BeautySalon"]
+    search_for_facebook = False
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("JUUT ")
+        apply_category(Categories.SHOP_HAIRDRESSER, item)
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Juut': 6,
 'atp/category/shop/hairdresser': 6,
 'atp/cdn/cloudflare/response_count': 11,
 'atp/cdn/cloudflare/response_status_count/200': 11,
 'atp/country/US': 6,
 'atp/field/brand_wikidata/missing': 6,
 'atp/field/email/missing': 6,
 'atp/field/name/missing': 6,
 'atp/field/operator/missing': 6,
 'atp/field/operator_wikidata/missing': 6,
 'atp/field/twitter/missing': 6,
 'atp/item_scraped_host_count/juut.com': 6,
 'atp/lineage': 'S_ATP_BRANDS',
 'downloader/request_bytes': 6110,
 'downloader/request_count': 11,
 'downloader/request_method_count/GET': 11,
 'downloader/response_bytes': 221912,
 'downloader/response_count': 11,
 'downloader/response_status_count/200': 11,
 'elapsed_time_seconds': 12.757191,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 3, 23, 3, 26, 536987, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1156522,
 'httpcompression/response_count': 11,
 'item_scraped_count': 6,
 'items_per_minute': 30.0,
 'log_count/DEBUG': 20,
 'log_count/INFO': 10,
 'memusage/max': 283807744,
 'memusage/startup': 283807744,
 'request_depth_max': 1,
 'response_received_count': 11,
 'responses_per_minute': 55.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2025, 12, 3, 23, 3, 13, 779796, tzinfo=datetime.timezone.utc)}
```