### PR TITLE
[Maison de la Literie FR] Fix Spider

### DIFF
--- a/locations/spiders/maison_de_la_literie_fr.py
+++ b/locations/spiders/maison_de_la_literie_fr.py
@@ -1,5 +1,8 @@
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -8,3 +11,10 @@ class MaisonDeLaLiterieFRSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Maison de la Literie", "brand_wikidata": "Q80955776"}
     sitemap_urls = ["https://magasins.maisondelaliterie.fr/sitemap_pois.xml"]
     sitemap_rules = [(r".+/details$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Maison de la Literie - ")
+
+        apply_category(Categories.SHOP_BED, item)
+
+        yield item


### PR DESCRIPTION
**_Fixes : code refactored to use sitemap to fix spider_**

```python
{'atp/brand/Maison de la Literie': 127,
 'atp/brand_wikidata/Q80955776': 127,
 'atp/category/shop/bed': 127,
 'atp/country/FR': 127,
 'atp/field/branch/missing': 127,
 'atp/field/operator/missing': 127,
 'atp/field/operator_wikidata/missing': 127,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 127,
 'atp/field/twitter/missing': 127,
 'atp/item_scraped_host_count/magasins.maisondelaliterie.fr': 127,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 127,
 'downloader/request_bytes': 59344,
 'downloader/request_count': 129,
 'downloader/request_method_count/GET': 129,
 'downloader/response_bytes': 2293662,
 'downloader/response_count': 129,
 'downloader/response_status_count/200': 129,
 'elapsed_time_seconds': 157.451924,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 4, 5, 25, 38, 94660, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17200081,
 'httpcompression/response_count': 129,
 'item_scraped_count': 127,
 'items_per_minute': 48.53503184713376,
 'log_count/DEBUG': 259,
 'log_count/INFO': 11,
 'memusage/max': 414138368,
 'memusage/startup': 290045952,
 'request_depth_max': 1,
 'response_received_count': 129,
 'responses_per_minute': 49.29936305732484,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 128,
 'scheduler/dequeued/memory': 128,
 'scheduler/enqueued': 128,
 'scheduler/enqueued/memory': 128,
 'start_time': datetime.datetime(2025, 12, 4, 5, 23, 0, 642736, tzinfo=datetime.timezone.utc)}
```