### PR TITLE
[Paradis DK] Fix Spider

### DIFF
--- a/locations/spiders/paradis_dk.py
+++ b/locations/spiders/paradis_dk.py
@@ -2,29 +2,26 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class ParadisDKSpider(SitemapSpider):
     name = "paradis_dk"
     item_attributes = {"brand": "Paradis", "brand_wikidata": "Q12330951"}
-    sitemap_urls = ["https://paradis-is.dk/wp-sitemap.xml"]
+    sitemap_urls = ["https://paradis-is.dk/isbutik-sitemap.xml"]
     sitemap_follow = ["butikker"]
-    sitemap_rules = [(r"", "parse")]
+    sitemap_rules = [(r"/isbutik/[^/]+", "parse")]
 
     def parse(self, response, **kwargs):
         item = Feature()
         item["ref"] = item["website"] = response.url
-        item["name"] = response.xpath("//title/text()").get()
-        if address := response.xpath('//*[contains(text(),"adresse")]/following-sibling::p[1]/text()').getall():
-            item["addr_full"] = merge_address_lines(address)
-        else:
-            item["addr_full"] = merge_address_lines(
-                response.xpath('//*[contains(@class,"title-info")]/p[1]/text()').getall()
-            )
-        item["email"] = (
-            response.xpath('//a[contains(@href, "mailto")]/@href').get().replace("mailto:", "") or "info@paradis-is.dk"
+        item["name"] = (
+            response.xpath("//title/text()").get().replace(" – din lokale isbutik med frisklavet is fra Paradis", "")
         )
+        item["addr_full"] = response.xpath('//*[@id="main-content"]//p/text()').get()
+        item["email"] = (
+            response.xpath('//*[@id="main-content"]//*[contains(text(), "Email:")]//text()').get().replace("Email:", "")
+        )
+        item["phone"] = response.xpath("//*[contains(@href,'tel:')]/text()").get()
         apply_category(Categories.ICE_CREAM, item)
 
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Paradis': 19,
 'atp/brand_wikidata/Q12330951': 19,
 'atp/category/amenity/ice_cream': 19,
 'atp/clean_strings/email': 19,
 'atp/country/DK': 19,
 'atp/field/branch/missing': 19,
 'atp/field/city/missing': 19,
 'atp/field/country/from_spider_name': 19,
 'atp/field/image/missing': 19,
 'atp/field/lat/missing': 19,
 'atp/field/lon/missing': 19,
 'atp/field/opening_hours/missing': 19,
 'atp/field/operator/missing': 19,
 'atp/field/operator_wikidata/missing': 19,
 'atp/field/postcode/missing': 19,
 'atp/field/state/missing': 19,
 'atp/field/street_address/missing': 19,
 'atp/field/twitter/missing': 19,
 'atp/item_scraped_host_count/paradis-is.dk': 19,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 19,
 'downloader/request_bytes': 8136,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 21,
 'downloader/response_bytes': 662354,
 'downloader/response_count': 21,
 'downloader/response_status_count/200': 21,
 'elapsed_time_seconds': 28.204522,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 4, 12, 9, 33, 21722, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4297917,
 'httpcompression/response_count': 20,
 'item_scraped_count': 19,
 'items_per_minute': 40.714285714285715,
 'log_count/DEBUG': 43,
 'log_count/INFO': 9,
 'memusage/max': 289845248,
 'memusage/startup': 289845248,
 'request_depth_max': 1,
 'response_received_count': 21,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 20,
 'scheduler/dequeued/memory': 20,
 'scheduler/enqueued': 20,
 'scheduler/enqueued/memory': 20,
 'start_time': datetime.datetime(2025, 12, 4, 12, 9, 4, 817200, tzinfo=datetime.timezone.utc)}
```