### PR TITLE
[Tmobile CZ] Fix Spider

### DIFF
--- a/locations/spiders/tmobile_cz.py
+++ b/locations/spiders/tmobile_cz.py
@@ -2,7 +2,6 @@ import json
 import re
 
 from locations.categories import Categories
-from locations.hours import DAYS_CZ, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -30,10 +29,3 @@ class TmobileCZSpider(JSONBlobSpider):
         del feature["address"]
         feature["city"] = feature["a_city"]
         feature["postcode"] = feature["a_psc"]
-
-    def post_process_item(self, item, response, feature: dict):
-        oh = OpeningHours()
-        for hrs in feature["openinghrs"]:
-            oh.add_ranges_from_string(hrs, DAYS_CZ)
-        item["opening_hours"] = oh
-        yield item


### PR DESCRIPTION

```python
{'atp/brand/T-Mobile': 99,
 'atp/brand_wikidata/Q327634': 99,
 'atp/category/shop/mobile_phone': 99,
 'atp/country/CZ': 99,
 'atp/field/branch/missing': 99,
 'atp/field/country/from_spider_name': 99,
 'atp/field/image/missing': 99,
 'atp/field/opening_hours/missing': 98,
 'atp/field/operator/missing': 99,
 'atp/field/operator_wikidata/missing': 99,
 'atp/field/phone/missing': 78,
 'atp/field/state/missing': 99,
 'atp/field/twitter/missing': 99,
 'atp/field/website/missing': 99,
 'atp/item_scraped_host_count/coveragemap-tmcz.position.cz': 99,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 99,
 'downloader/request_bytes': 737,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16707,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.534752,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 5, 8, 34, 49, 557586, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 210626,
 'httpcompression/response_count': 1,
 'item_scraped_count': 99,
 'items_per_minute': 2970.0,
 'log_count/DEBUG': 104,
 'log_count/INFO': 9,
 'log_count/WARNING': 1,
 'memusage/max': 290865152,
 'memusage/startup': 290865152,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 5, 8, 34, 47, 22834, tzinfo=datetime.timezone.utc)}
```