### PR TITLE
[PNC Bank US] Fix Spider

### DIFF
--- a/locations/spiders/pnc_bank_us.py
+++ b/locations/spiders/pnc_bank_us.py
@@ -15,6 +15,7 @@ class PncBankUSSpider(Spider):
     item_attributes = {"brand": "PNC Bank", "brand_wikidata": "Q38928"}
     start_urls = ["https://apps.pnc.com/locator/bundle/bundle.js"]
     allowed_domains = ["apps.pnc.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[Request]:
         yield Request(url=self.start_urls[0], callback=self.parse_app_key)


### PR DESCRIPTION
```python
{'atp/brand/PNC Bank': 2260,
 'atp/brand_wikidata/Q38928': 2260,
 'atp/category/amenity/bank': 2260,
 'atp/country/US': 2260,
 'atp/field/branch/missing': 2260,
 'atp/field/country/from_spider_name': 2260,
 'atp/field/email/missing': 2260,
 'atp/field/image/missing': 2260,
 'atp/field/opening_hours/missing': 33,
 'atp/field/operator/missing': 2260,
 'atp/field/operator_wikidata/missing': 2260,
 'atp/field/twitter/missing': 2260,
 'atp/item_scraped_host_count/apps.pnc.com': 2260,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2260,
 'downloader/request_bytes': 4661017,
 'downloader/request_count': 2263,
 'downloader/request_method_count/GET': 2262,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 14040944,
 'downloader/response_count': 2263,
 'downloader/response_status_count/200': 2263,
 'elapsed_time_seconds': 2756.52921,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 5, 10, 7, 49, 767777, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 51720097,
 'httpcompression/response_count': 2262,
 'item_scraped_count': 2260,
 'items_per_minute': 49.20174165457185,
 'log_count/DEBUG': 4526,
 'log_count/INFO': 54,
 'memusage/max': 429920256,
 'memusage/startup': 290557952,
 'request_depth_max': 3,
 'response_received_count': 2263,
 'responses_per_minute': 49.26705370101597,
 'scheduler/dequeued': 2263,
 'scheduler/dequeued/memory': 2263,
 'scheduler/enqueued': 2263,
 'scheduler/enqueued/memory': 2263,
 'start_time': datetime.datetime(2025, 12, 5, 9, 21, 53, 238567, tzinfo=datetime.timezone.utc)}
```