### PR TITLE
[clai_it] Add Spider (972 locations)

### DIFF
--- a/locations/spiders/crai_it.py
+++ b/locations/spiders/crai_it.py
@@ -4,12 +4,10 @@ from locations.hours import DAYS_IT, sanitise_day
 from locations.structured_data_spider import StructuredDataSpider
 
 
-
-class CraiITSpider(SitemapSpider,StructuredDataSpider):
+class CraiITSpider(SitemapSpider, StructuredDataSpider):
     name = "crai_it"
     item_attributes = {"brand": "Crai", "brand_wikidata": "Q3696429"}
     sitemap_urls = ["https://crai.it/negozi-e-volantini/sitemap.xml"]
-
 
     def pre_process_data(self, ld_data, **kwargs):
         opening_hours = ld_data.get("openingHoursSpecification")
@@ -18,12 +16,7 @@ class CraiITSpider(SitemapSpider,StructuredDataSpider):
             if all(all(key in rule for key in ["dayOfWeek", "opens", "closes"]) for rule in opening_hours):
                 for rule in opening_hours:
                     rule["dayOfWeek"] = sanitise_day(rule["dayOfWeek"], DAYS_IT)
-                    if '/' in rule["closes"]:
-                        rule["closes"] = rule["closes"].split('/')[1]
+                    if "/" in rule["closes"]:
+                        rule["closes"] = rule["closes"].split("/")[1]
             else:
                 ld_data["openingHoursSpecification"] = None
-
-
-            
-
-   


### PR DESCRIPTION
```
{'atp/brand/Crai': 972,
 'atp/brand_wikidata/Q3696429': 972,
 'atp/category/shop/supermarket': 972,
 'atp/country/IT': 972,
 'atp/field/branch/missing': 972,
 'atp/field/city/missing': 2,
 'atp/field/email/missing': 972,
 'atp/field/image/missing': 972,
 'atp/field/lat/missing': 72,
 'atp/field/lon/missing': 72,
 'atp/field/opening_hours/missing': 507,
 'atp/field/operator/missing': 972,
 'atp/field/operator_wikidata/missing': 972,
 'atp/field/phone/invalid': 61,
 'atp/field/phone/missing': 27,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 2,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 972,
 'atp/item_scraped_host_count/crai.it': 972,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 972,
 'downloader/request_bytes': 410668,
 'downloader/request_count': 984,
 'downloader/request_method_count/GET': 984,
 'downloader/response_bytes': 42184407,
 'downloader/response_count': 984,
 'downloader/response_status_count/200': 975,
 'downloader/response_status_count/500': 9,
 'elapsed_time_seconds': 1208.822752,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 5, 16, 36, 7, 325476, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 238905472,
 'httpcompression/response_count': 982,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/500': 3,
 'item_scraped_count': 972,
 'items_per_minute': 48.27814569536424,
 'log_count/ERROR': 3,
 'log_count/INFO': 32,
 'memusage/max': 479666176,
 'memusage/startup': 280166400,
 'request_depth_max': 1,
 'response_received_count': 978,
 'responses_per_minute': 48.57615894039735,
 'retry/count': 6,
 'retry/max_reached': 3,
 'retry/reason_count/500 Internal Server Error': 6,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 983,
 'scheduler/dequeued/memory': 983,
 'scheduler/enqueued': 983,
 'scheduler/enqueued/memory': 983,
 'start_time': datetime.datetime(2025, 12, 5, 16, 15, 58, 502724, tzinfo=datetime.timezone.utc)}
```