### PR TITLE
[Cookies by Design] New spider (24 locations)

### DIFF
--- a/locations/spiders/cookies_by_design_us.py
+++ b/locations/spiders/cookies_by_design_us.py
@@ -1,0 +1,35 @@
+import json
+from urllib.parse import urljoin
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class CookiesByDesignUSSpider(JSONBlobSpider):
+    name = "cookies_by_design_us"
+    item_attributes = {
+        "brand": "Cookies by Design",
+        "brand_wikidata": "Q5167112",
+    }
+    start_urls = [
+        "https://sl.storeify.app/js/stores/cookiesbydesignprod.myshopify.com/storeifyapps-storelocator-geojson.js"
+    ]
+
+    def extract_json(self, response):
+        return json.loads(response.text.removeprefix("eqfeed_callback(").removesuffix(")"))["features"]
+
+    def pre_process_data(self, feature):
+        feature.update(feature.pop("properties"))
+
+    def post_process_item(self, item, response, location):
+        item["branch"] = item.pop("name").split(" - ")[0]
+        item["website"] = urljoin("https://www.cookiesbydesign.com", item["website"])
+
+        oh = OpeningHours()
+        oh.add_ranges_from_string(location["schedule_text"])
+        item["opening_hours"] = oh
+
+        apply_category(Categories.SHOP_PASTRY, item)
+
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Cookies by Design': 24,
 'atp/brand_wikidata/Q5167112': 24,
 'atp/category/craft/bakery': 24,
 'atp/category/multiple': 24,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/US': 24,
 'atp/field/image/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/postcode/missing': 24,
 'atp/field/street_address/missing': 24,
 'atp/field/twitter/missing': 24,
 'atp/item_scraped_host_count/sl.storeify.app': 24,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 24,
 'downloader/request_bytes': 736,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 6474,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.83854,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 5, 23, 48, 8, 323564, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 44137,
 'httpcompression/response_count': 2,
 'item_scraped_count': 24,
 'items_per_minute': 1440.0,
 'log_count/DEBUG': 42,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 284045312,
 'memusage/startup': 284045312,
 'response_received_count': 2,
 'responses_per_minute': 120.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 5, 23, 48, 6, 485024, tzinfo=datetime.timezone.utc)}
```