### PR TITLE
[Lindt] New spider (216 locations)

### DIFF
--- a/locations/spiders/lindt.py
+++ b/locations/spiders/lindt.py
@@ -1,0 +1,36 @@
+import json
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class LindtSpider(JSONBlobSpider):
+    name = "lindt"
+    item_attributes = {
+        "brand": "Lindt",
+        "brand_wikidata": "Q152822",
+    }
+    start_urls = ["https://www.lindt-spruengli.com/stores/"]
+
+    def extract_json(self, response):
+        return DictParser.get_nested_key(
+            json.loads(response.xpath('//script[contains(text(), "locationItems")]/text()').get()), "locationItems"
+        )
+
+    def post_process_item(self, item, response, location):
+        item["street_address"] = item.pop("street")
+
+        oh = OpeningHours()
+        for day in DAYS_FULL:
+            day_hours = location[f"opening_hours_{day.lower()}"]
+            oh.add_ranges_from_string(f"{day} {day_hours}")
+        item["opening_hours"] = oh
+
+        if "ghirardelli" in item["name"].casefold():
+            item["brand"] = "Ghirardelli"
+            item["brand_wikidata"] = "Q1134349"
+
+        apply_category(Categories.SHOP_CHOCOLATE, item)
+        yield item


### PR DESCRIPTION
```py
{'atp/brand/Ghirardelli': 21,
 'atp/brand/Lindt': 195,
 'atp/brand_wikidata/Q1134349': 21,
 'atp/brand_wikidata/Q152822': 195,
 'atp/category/shop/chocolate': 216,
 'atp/clean_strings/city': 9,
 'atp/clean_strings/name': 13,
 'atp/clean_strings/street_address': 9,
 'atp/country/BG': 4,
 'atp/country/BR': 58,
 'atp/country/CA': 1,
 'atp/country/DE': 1,
 'atp/country/ES': 22,
 'atp/country/FR': 27,
 'atp/country/GB': 7,
 'atp/country/IT': 33,
 'atp/country/PT': 2,
 'atp/country/US': 47,
 'atp/country/ZA': 14,
 'atp/field/branch/missing': 216,
 'atp/field/email/missing': 216,
 'atp/field/image/missing': 216,
 'atp/field/lat/missing': 4,
 'atp/field/lon/missing': 4,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 216,
 'atp/field/operator_wikidata/missing': 216,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 10,
 'atp/field/postcode/missing': 3,
 'atp/field/state/from_reverse_geocoding': 10,
 'atp/field/state/missing': 49,
 'atp/field/twitter/missing': 216,
 'atp/field/website/missing': 215,
 'atp/geometry/null_island': 4,
 'atp/item_scraped_host_count/www.lindt-spruengli.com': 216,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 21,
 'atp/nsi/perfect_match': 195,
 'downloader/request_bytes': 679,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 269476,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.614635,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 8, 3, 4, 9, 511033, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 984127,
 'httpcompression/response_count': 2,
 'item_scraped_count': 216,
 'items_per_minute': 2160.0,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 286986240,
 'memusage/startup': 286986240,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 8, 3, 4, 2, 896398, tzinfo=datetime.timezone.utc)}
```