### PR TITLE
[Starbucks SG] Fix spider

### DIFF
--- a/locations/spiders/starbucks_sg.py
+++ b/locations/spiders/starbucks_sg.py
@@ -55,25 +55,29 @@ class StarbucksSGSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
         item["addr_full"] = feature["address"]["html"]
-        item["opening_hours"] = OpeningHours()
-        for rule in feature["openingHours"]["contentItems"]:
-            if "Closed" in rule["times"]:
-                continue
+        item["opening_hours"] = self.parse_opening_hours(feature["openingHours"]["contentItems"])
+
+        apply_category(Categories.COFFEE_SHOP, item)
+        if any(service["displayText"] == "Free Wifi" for service in feature["storeAmenities"]["termContentItems"]):
+            item["extras"]["internet_access"] = "wlan"
+            item["extras"]["internet_access:fee"] = "no"
+        yield item
+
+    def parse_opening_hours(self, opening_hours: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours:
             if m := re.match(r"(\w+)[\s-]*(\w+)?", rule["day"]):
                 start_day = sanitise_day(m.group(1))
                 end_day = sanitise_day(m.group(2)) or start_day
                 if start_day:
+                    if "Closed" in rule["times"]:
+                        oh.set_closed(day_range(start_day, end_day))
+                        continue
                     timing = rule["times"].replace("00:00", "12:00").replace("24 Hours", "12:00 AM to 11:59 PM")
                     for start_time, start_am_pm, end_time, end_am_pm in re.findall(
                         r"(\d+:\d+)\s*(AM|PM)\s*to\s*(\d+:\d+)\s*(AM|PM)", timing
                     ):
                         open_time = f"{start_time} {start_am_pm}"
                         close_time = f"{end_time} {end_am_pm}"
-                        item["opening_hours"].add_days_range(
-                            day_range(start_day, end_day), open_time, close_time, time_format="%I:%M %p"
-                        )
-        apply_category(Categories.COFFEE_SHOP, item)
-        if any(service["displayText"] == "Free Wifi" for service in feature["storeAmenities"]["termContentItems"]):
-            item["extras"]["internet_access"] = "wlan"
-            item["extras"]["internet_access:fee"] = "no"
-        yield item
+                        oh.add_days_range(day_range(start_day, end_day), open_time, close_time, time_format="%I:%M %p")
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Starbucks': 135,
 'atp/brand_wikidata/Q37158': 135,
 'atp/category/amenity/cafe': 135,
 'atp/clean_strings/addr_full': 3,
 'atp/clean_strings/branch': 11,
 'atp/clean_strings/lat': 2,
 'atp/clean_strings/phone': 2,
 'atp/country/SG': 135,
 'atp/field/city/missing': 135,
 'atp/field/country/from_spider_name': 135,
 'atp/field/email/missing': 135,
 'atp/field/image/missing': 135,
 'atp/field/operator/missing': 135,
 'atp/field/operator_wikidata/missing': 135,
 'atp/field/postcode/missing': 135,
 'atp/field/state/missing': 135,
 'atp/field/street_address/missing': 135,
 'atp/field/twitter/missing': 135,
 'atp/field/website/missing': 135,
 'atp/item_scraped_host_count/www.starbucks.com.sg': 135,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 135,
 'downloader/request_bytes': 1346,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 108144,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.526308,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 10, 8, 56, 34, 276096, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 135,
 'items_per_minute': 8100.0,
 'log_count/DEBUG': 139,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': 60.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 10, 8, 56, 32, 749788, tzinfo=datetime.timezone.utc)}
```