### PR TITLE
Change connector keys to socket in ionna_us.py

### DIFF
--- a/locations/spiders/ionna_us.py
+++ b/locations/spiders/ionna_us.py
@@ -72,8 +72,8 @@ class IonnaUSSpider(scrapy.Spider):
                 nacs_count = nacs_text.rstrip(" NACS")
                 ccs_count = ccs_text.rstrip(" CCS")
 
-                item["extras"]["connector:type1_combo"] = ccs_count
-                item["extras"]["connector:nacs"] = nacs_count
+                item["extras"]["socket:type1_combo"] = ccs_count
+                item["extras"]["socket:nacs"] = nacs_count
                 item["extras"]["capacity"] = str(int(ccs_count) + int(nacs_count))
             apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
[Charging Stations on the OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station) states stations should use the socket key. IONNA's page does use the term connector (and I like it better) but at this point it has a [snowballs chance in Hell](https://en.wikipedia.org/wiki/Wikipedia%3ASnowball_clause) of changing.