### PR TITLE
[TwentyFourHourFitnessUS] Fix Spider

### DIFF
--- a/locations/spiders/twenty_four_hour_fitness_us.py
+++ b/locations/spiders/twenty_four_hour_fitness_us.py
@@ -14,6 +14,16 @@ class TwentyFourHourFitnessUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/gyms/[^/]+/[^/]+", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        if item["name"].endswith(" Super-Sport"):
+            item["branch"] = item.pop("name").removeprefix("24 Hour Fitness ").removesuffix(" Super-Sport")
+            item["name"] = "24 Hour Fitness Super Sport"
+        elif item["name"].endswith(" Sport"):
+            item["branch"] = item.pop("name").removeprefix("24 Hour Fitness ").removesuffix(" Sport")
+            item["name"] = "24 Hour Fitness Sport"
+        elif item["name"].endswith(" Active"):
+            item["branch"] = item.pop("name").removeprefix("24 Hour Fitness ").removesuffix(" Active")
+            item["name"] = "24 Hour Fitness"
+
         oh = OpeningHours()
         if response.xpath('//*[@id="gym-info-hours"]//li'):
             for day_time in response.xpath('//*[@id="gym-info-hours"]//li'):
@@ -30,5 +40,7 @@ class TwentyFourHourFitnessUSSpider(SitemapSpider, StructuredDataSpider):
             if time_string == "OPEN 24/7":
                 oh = "24/7"
         item["opening_hours"] = oh
+
         apply_category(Categories.GYM, item)
+
         yield item


### PR DESCRIPTION
`_Fixes : code updated to use sitemap to fix spider_`

```python
{'atp/brand/24 Hour Fitness': 241,
 'atp/brand_wikidata/Q4631849': 241,
 'atp/category/leisure/fitness_centre': 241,
 'atp/clean_strings/name': 1,
 'atp/country/US': 241,
 'atp/field/branch/missing': 241,
 'atp/field/operator/missing': 241,
 'atp/field/operator_wikidata/missing': 241,
 'atp/item_scraped_host_count/www.24hourfitness.com': 241,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 241,
 'downloader/request_bytes': 402668,
 'downloader/request_count': 280,
 'downloader/request_method_count/GET': 280,
 'downloader/response_bytes': 12165766,
 'downloader/response_count': 280,
 'downloader/response_status_count/200': 246,
 'downloader/response_status_count/302': 34,
 'dupefilter/filtered': 32,
 'elapsed_time_seconds': 332.411942,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 12, 6, 52, 9, 293274, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39614934,
 'httpcompression/response_count': 245,
 'item_scraped_count': 241,
 'items_per_minute': 43.55421686746988,
 'log_count/DEBUG': 525,
 'log_count/INFO': 14,
 'request_depth_max': 1,
 'response_received_count': 246,
 'responses_per_minute': 44.45783132530121,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 279,
 'scheduler/dequeued/memory': 279,
 'scheduler/enqueued': 279,
 'scheduler/enqueued/memory': 279,
 'start_time': datetime.datetime(2025, 12, 12, 6, 46, 36, 881332, tzinfo=datetime.timezone.utc)}
```