### PR TITLE
Fix salvation_army_gb.py

### DIFF
--- a/locations/spiders/salvation_army_gb.py
+++ b/locations/spiders/salvation_army_gb.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 class SalvationArmyGBSpider(SitemapSpider):
     name = "salvation_army_gb"
     item_attributes = {"brand": "The Salvation Army", "brand_wikidata": "Q188307"}
-    sitemap_urls = ["https://www.salvationarmy.org.uk/sitemap.xml?page=3"]
+    sitemap_urls = ["https://www.salvationarmy.org.uk/sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/www\.salvationarmy\.org\.uk\/[^/]+-charity-shop(?:-\d+)?$", "parse")]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 


### PR DESCRIPTION
Not all of the shops are (currently) on page=3 of the sitemap; about half are on page=2. The different pages are all linked from the main sitemap.xml file, so to future-proof things, we can just start the spider there.