### PR TITLE
Fix Fragrance Shop Spider

### DIFF
--- a/locations/spiders/the_fragrance_shop_gb.py
+++ b/locations/spiders/the_fragrance_shop_gb.py
@@ -1,5 +1,4 @@
 import re
-
 from typing import Any
 
 from scrapy.http import Response
@@ -39,7 +38,7 @@ class TheFragranceShopGBSpider(Spider):
         if "openingHours" in location:
             times = location.get("openingHours")
             oh = OpeningHours()
-            hours = re.split(r',\s*',times)
+            hours = re.split(r",\s*", times)
             if hours[-1] == "":
                 hours.pop()
             i = 1


### PR DESCRIPTION
Currently, issues with the openingHours field causes the spider to halt before its parsed all ~219 of the entries from https://www.thefragranceshop.co.uk/api/stores/all . Issues include  openingHours days being separated by ", " rather than just ",", an additional "," at the end of openingHours, and openingHours not existing at all. This PR works around these issues to ensure all entries are returned.