### PR TITLE
Convert JSONBlobSpiders to use async start

### DIFF
--- a/locations/spiders/47_street_ar.py
+++ b/locations/spiders/47_street_ar.py
@@ -13,7 +13,7 @@ class FortysevenStreetARSpider(JSONBlobSpider):
     item_attributes = {"brand": "47 Street", "brand_wikidata": "Q4638513"}
     locations_key = ["data", "getStores", "items"]
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest(
             url="https://www.47street.com.ar/_v/private/graphql/v1",
             data={

--- a/locations/spiders/frasers_gb.py
+++ b/locations/spiders/frasers_gb.py
@@ -14,7 +14,7 @@ class FrasersGBSpider(JSONBlobSpider):
         "ROBOTSTXT_OBEY": False,
     }
 
-    def start_requests(self):
+    async def start(self):
         headers = {"content-type": "application/json"}
         url = "https://api-fras.prd.frasersgroup.services/graphql?op=getStoresByLocation"
         formdata = {

--- a/locations/spiders/infrastructure/banyule_city_council_au.py
+++ b/locations/spiders/infrastructure/banyule_city_council_au.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -14,7 +14,7 @@ class BanyuleCityCouncilAUSpider(JSONBlobSpider):
     start_urls = ["https://www.banyule.vic.gov.au/ocmaps/layer"]
     locations_key = ["layerItems"]
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         data = {
             "Bounds": "-90,-180,90,180",
             "IdList": [

--- a/locations/spiders/infrastructure/euro_argo_eric_floats.py
+++ b/locations/spiders/infrastructure/euro_argo_eric_floats.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -17,7 +17,7 @@ class EuroArgoEricFloatsSpider(JSONBlobSpider):
     skip_auto_cc_geocoder = True
     skip_auto_cc_domain = True
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         data = [
             {
                 "nested": "false",

--- a/locations/spiders/infrastructure/federal_aviation_administration_weathercams_ca_us.py
+++ b/locations/spiders/infrastructure/federal_aviation_administration_weathercams_ca_us.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -14,7 +14,7 @@ class FederalAviationAdministrationWeathercamsCAUSSpider(JSONBlobSpider):
     start_urls = ["https://weathercams.faa.gov/api/sites"]
     locations_key = "payload"
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url=self.start_urls[0], headers={"Referer": "https://weathercams.faa.gov"})
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:

--- a/locations/spiders/infrastructure/melbourne_city_council_parking_spaces_au.py
+++ b/locations/spiders/infrastructure/melbourne_city_council_parking_spaces_au.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -18,7 +18,7 @@ class MelbourneCityCouncilParkingSpacesAUSpider(JSONBlobSpider):
     ]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://data.melbourne.vic.gov.au/api/explore/v2.1/catalog/datasets/sign-plates-located-in-each-parking-zone/exports/json?lang=en&timezone=Australia%2FSydney",
             callback=self.parse_parking_restrictions,

--- a/locations/spiders/infrastructure/mississippi_department_of_transportation_us.py
+++ b/locations/spiders/infrastructure/mississippi_department_of_transportation_us.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import Request, Response
 
@@ -20,7 +20,7 @@ class MississippiDepartmentOfTransportationUSSpider(JSONBlobSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     locations_key = "value"
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         yield Request(url=self.start_urls[0], headers={"Client-Id": "01072004-0bce-4b91-b9e1-adfa6f7260d4"})
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:

--- a/locations/spiders/infrastructure/oklahoma_department_of_transportation_us.py
+++ b/locations/spiders/infrastructure/oklahoma_department_of_transportation_us.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -13,11 +13,11 @@ class OklahomaDepartmentOfTransportationUSSpider(JSONBlobSpider):
     allowed_domains = ["oktraffic.org"]
     start_urls = ["https://oktraffic.org/api/CameraPoles"]
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             self.start_urls[0],
             headers={
-                "filter": '{"include":[{"relation":"mapCameras","scope":{"include":"streamDictionary","where":{"status":{"neq":"Out Of Service"},"type":"Web","blockAtis":{"neq":"1"}}}},{"relation":"cameraLocationLinks","scope":{"include":["linkedCameraPole","cameraPole"]}}]}'
+                "filter": '{"include":[{"relation":"mapCameras","scope":{"include":"streamDictionary","where":{"status":{"neq":"Out Of Service"},"type":"Web","blockAtis":{"neq":"1"}}}}, {"relation":"cameraLocationLinks","scope":{"include":["linkedCameraPole","cameraPole"]}}]}'
             },
         )
 

--- a/locations/spiders/infrastructure/travel_midwest_us.py
+++ b/locations/spiders/infrastructure/travel_midwest_us.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -14,7 +14,7 @@ class TravelMidwestUSSpider(JSONBlobSpider):
     start_urls = ["https://travelmidwest.com/lmiga/cameraMap.json"]
     locations_key = "features"
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         data = {"bbox": [-90, -180, 90, 180]}
         yield JsonRequest(url=self.start_urls[0], data=data, method="POST")
 

--- a/locations/spiders/q8.py
+++ b/locations/spiders/q8.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -20,7 +20,7 @@ class Q8Spider(JSONBlobSpider):
     }
     locations_key = "results"
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://www.q8.be/api/poi/locations",
             data={

--- a/locations/spiders/quarterra_us.py
+++ b/locations/spiders/quarterra_us.py
@@ -37,7 +37,7 @@ class QuarterraUSSpider(JSONBlobSpider):
     }
     locations_key = ["data", "locations"]
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest("https://quarterra.com/api", data={"query": QUERY})
 
     def post_process_item(self, item, response, feature):

--- a/locations/spiders/rage_za.py
+++ b/locations/spiders/rage_za.py
@@ -1,5 +1,5 @@
 import html
-from typing import Any, Iterable
+from typing import Any, AsyncIterator
 
 from scrapy import Request
 from scrapy.http import JsonRequest, Response
@@ -22,7 +22,7 @@ class RageZASpider(JSONBlobSpider):
             meta={"page": page},
         )
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         yield self.make_request(1)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/raleys_us.py
+++ b/locations/spiders/raleys_us.py
@@ -20,7 +20,7 @@ class RaleysUSSpider(JSONBlobSpider):
     locations_key = ["data"]
     allowed_domains = ["www.raleys.com"]
 
-    def start_requests(self):
+    async def start(self):
         for domain in self.allowed_domains:
             yield Request(f"https://{domain}/stores", callback=self.start_api_request)
 

--- a/locations/spiders/rocomamas.py
+++ b/locations/spiders/rocomamas.py
@@ -37,7 +37,7 @@ class RocomamasSpider(JSONBlobSpider):
     countries = ROCOMAMAS_COUNTRIES
     brands = ROCOMAMAS_BRANDS
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             for country in self.countries:
                 yield JsonRequest(

--- a/locations/spiders/royal_bank_of_canada_ca.py
+++ b/locations/spiders/royal_bank_of_canada_ca.py
@@ -14,7 +14,7 @@ class RoyalBankOfCanadaCASpider(JSONBlobSpider):
     item_attributes = {"brand_wikidata": "Q735261"}
     locations_key = "locations"
 
-    def start_requests(self):
+    async def start(self):
         for city in city_locations("CA", min_population=20000):
             yield scrapy.Request(
                 url=f'https://maps.rbcroyalbank.com/api/?q={city["name"]}',

--- a/locations/spiders/salmoiraghi_and_vigano_it.py
+++ b/locations/spiders/salmoiraghi_and_vigano_it.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 import scrapy
 from scrapy.http import JsonRequest, Request, Response
@@ -14,7 +14,7 @@ class SalmoiraghiAndViganoITSpider(JSONBlobSpider):
     item_attributes = {"brand": "Salmoiraghi & Viganò", "brand_wikidata": "Q21272314"}
     locations_key = "records"
 
-    def start_requests(self) -> Iterable[JsonRequest | Request]:
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
         for lat, lng in point_locations("eu_centroids_120km_radius_country.csv", "IT"):
             yield scrapy.Request(
                 url=f"https://api-tab.luxottica.com/tl-store-locator/api/v1/SV/offices?latitude={lat}&longitude={lng}&radius=100&limit=1000&offset=0&officeTypes=BOUTIQUE"

--- a/locations/spiders/save_mart_us.py
+++ b/locations/spiders/save_mart_us.py
@@ -23,7 +23,7 @@ class SaveMartUSSpider(JSONBlobSpider):
     name = "save_mart_us"
     locations_key = ["data", "stores", "all"]
 
-    def start_requests(self):
+    async def start(self):
         for brand in ["fm", "lu", "sm"]:
             yield JsonRequest(
                 f"https://{brand}.swiftlyapi.net/graphql",

--- a/locations/spiders/scouts_za.py
+++ b/locations/spiders/scouts_za.py
@@ -16,7 +16,7 @@ class ScoutsZASpider(JSONBlobSpider):
     start_urls = ["https://www.scouts.org.za/scouts-near-you/"]
     allowed_domains = ["scouts.org.za"]
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield Request(url=url, callback=self.parse_province)
 

--- a/locations/spiders/seven_eleven_ph.py
+++ b/locations/spiders/seven_eleven_ph.py
@@ -14,7 +14,7 @@ class SevenElevenPHSpider(WPStoreLocatorSpider):
     item_attributes = SEVEN_ELEVEN_SHARED_ATTRIBUTES
     days = DAYS_EN
 
-    def start_requests(self):
+    async def start(self):
         for city in city_locations("PH"):
             lat = city.get("latitude")
             lon = city.get("longitude")

--- a/locations/spiders/shoe_show_mega_us.py
+++ b/locations/spiders/shoe_show_mega_us.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 import scrapy
 from scrapy.http import JsonRequest, Request, Response
@@ -25,7 +25,7 @@ class ShoeShowMegaUSSpider(JSONBlobSpider):
     custom_settings = {"ROBOTSTXT_OBEY": "False"}
     locations_key = "stores"
 
-    def start_requests(self) -> Iterable[JsonRequest | Request]:
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
         for index, record in enumerate(postal_regions("US")):
             if index % 100 == 0:
                 yield scrapy.Request(

--- a/locations/spiders/sigma_it.py
+++ b/locations/spiders/sigma_it.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import FormRequest, Request, Response
 
@@ -16,7 +16,7 @@ class SigmaITSpider(JSONBlobSpider):
     start_urls = ["https://www.supersigma.com/wp-admin/admin-ajax.php"]
     locations_key = ["map_args", "locations"]
 
-    def start_requests(self) -> Iterable[FormRequest]:
+    async def start(self) -> AsyncIterator[FormRequest]:
         formdata = {
             "action": "gmw_form_ajax_submission",
             "submitted": "true",

--- a/locations/spiders/spar_bw_mz_na_sz_za.py
+++ b/locations/spiders/spar_bw_mz_na_sz_za.py
@@ -24,7 +24,7 @@ class SparBWMZNASZZASpider(JSONBlobSpider):
     skip_auto_cc_domain = True
     custom_settings = {"DOWNLOAD_TIMEOUT": 30}
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest(
             url="https://www.spar.co.za/api/stores/search",
             data={"Types": ["SPAR", "SUPERSPAR", "KWIKSPAR", "SPAR Express", "Savemor", "Pharmacy"]},

--- a/locations/spiders/sprinter.py
+++ b/locations/spiders/sprinter.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy import Request
 from scrapy.http import JsonRequest, Response
@@ -15,7 +15,7 @@ class SprinterSpider(JSONBlobSpider):
     locations_key = "stores"
     custom_settings = {"USER_AGENT": FIREFOX_LATEST}
 
-    def start_requests(self) -> Iterable[JsonRequest | Request]:
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
         yield JsonRequest(
             url="https://www.sprintersports.com/api/store/by_points",
             method="POST",

--- a/locations/spiders/starbucks_cn.py
+++ b/locations/spiders/starbucks_cn.py
@@ -27,7 +27,7 @@ class StarbucksCNSpider(JSONBlobSpider):
     locations_key = "data"
     custom_settings = {"DOWNLOAD_TIMEOUT": 30}
 
-    def start_requests(self):
+    async def start(self):
         for lat, lon in country_iseadgg_centroids(["CN"], 79):
             yield JsonRequest(
                 url=f"https://www.starbucks.com.cn/api/stores/nearby?lat={lat}&lon={lon}&limit=1000&locale=EN&features=&radius=100000",

--- a/locations/spiders/starbucks_jp.py
+++ b/locations/spiders/starbucks_jp.py
@@ -12,7 +12,7 @@ class StarbucksJPSpider(JSONBlobSpider):
     start_urls = ["https://store.starbucks.co.jp/store_vue/js/store.js"]
     locations_key = ["hits", "hit"]
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield Request(
                 url=url,

--- a/locations/spiders/starbucks_mena.py
+++ b/locations/spiders/starbucks_mena.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator, Iterable
 
 from scrapy import Request
 from scrapy.http import JsonRequest, Response
@@ -15,7 +15,7 @@ class StarbucksMenaSpider(YextSearchSpider):
     item_attributes = {"brand": "ستاربكس", "brand_wikidata": "Q37158"}
     stored_items = {}
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         offset = 0
         yield JsonRequest(
             url=f"https://locations.starbucks.eg/index.html?search&r=250000&per={self.page_size}&offset={offset}"

--- a/locations/spiders/starbucks_za.py
+++ b/locations/spiders/starbucks_za.py
@@ -12,7 +12,7 @@ class StarbucksZASpider(JSONBlobSpider):
     locations_key = "data"
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def start_requests(self):
+    async def start(self):
         for lat, lon in country_iseadgg_centroids("ZA", 158):
             yield JsonRequest(
                 url=f"https://www.starbucks.co.za/api/v2/stores/?filter%5Bcoordinates%5D%5Blatitude%5D={lat}&filter%5Bcoordinates%5D%5Blongitude%5D={lon}&filter%5Bradius%5D=158"

--- a/locations/spiders/ster_kinekor.py
+++ b/locations/spiders/ster_kinekor.py
@@ -9,7 +9,7 @@ class SterKinekorSpider(JSONBlobSpider):
     item_attributes = {"brand": "Ster-Kinekor", "brand_wikidata": "Q130179"}
     start_urls = ["https://www.sterkinekor.com/middleware/api/v2/regions"]
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield JsonRequest(
                 url=url,

--- a/locations/spiders/storcash_no.py
+++ b/locations/spiders/storcash_no.py
@@ -19,7 +19,7 @@ class StorcashNOSpider(SylinderSpider):
         "5090",  # Bodø Storcash
     ]
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest(url="https://api.ngdata.no/sylinder/stores/v1/extended-info")
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/subway_kr.py
+++ b/locations/spiders/subway_kr.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy import FormRequest
 from scrapy.http import Response
@@ -19,7 +19,7 @@ class SubwayKRSpider(JSONBlobSpider):
     }
     locations_key = "searchResult"
 
-    def start_requests(self) -> Iterable[FormRequest]:
+    async def start(self) -> AsyncIterator[FormRequest]:
         yield FormRequest(
             url="https://www.subway.co.kr/ajaxStoreSearch",
             formdata={

--- a/locations/spiders/sunglass_hut_in.py
+++ b/locations/spiders/sunglass_hut_in.py
@@ -10,7 +10,7 @@ class SunglassHutINSpider(JSONBlobSpider):
     start_urls = ["https://sunglasshut.in/api/service/application/catalog/v1.0/locations/?page_size=100000"]
     locations_key = "items"
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield JsonRequest(
                 url=url,

--- a/locations/spiders/tango.py
+++ b/locations/spiders/tango.py
@@ -13,7 +13,7 @@ class TangoSpider(JSONBlobSpider):
     item_attributes = {"brand": "Tango", "brand_wikidata": "Q125867683"}
     locations_key = "results"
 
-    def start_requests(self) -> Iterable[JsonRequest]:
+    async def start(self) -> Iterable[JsonRequest]:
         yield JsonRequest(
             url="https://www.tango.nl/api/poi/locations",
             data={

--- a/locations/spiders/timpson_group.py
+++ b/locations/spiders/timpson_group.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import FormRequest, Response
 
@@ -94,7 +94,7 @@ class TimpsonGroupSpider(JSONBlobSpider):
         },
     }
 
-    def start_requests(self) -> Iterable[FormRequest]:
+    async def start(self) -> AsyncIterator[FormRequest]:
         formdata = {"start": "50000"}
         headers = {"X-Requested-With": "XMLHttpRequest"}
         yield FormRequest(url=self.start_urls[0], formdata=formdata, headers=headers, method="POST")

--- a/locations/spiders/toyota_eu.py
+++ b/locations/spiders/toyota_eu.py
@@ -60,7 +60,7 @@ class ToyotaEUSpider(JSONBlobSpider):
         "zw",  # toyota_africa
     ]
 
-    def start_requests(self):
+    async def start(self):
         available_countries = [c for c in self.all_countries if c not in self.exclude_countries]
         for brand in ["toyota", "lexus"]:
             for country in available_countries:

--- a/locations/spiders/toyota_us.py
+++ b/locations/spiders/toyota_us.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import timedelta
-from typing import Any, Iterable
+from typing import Any, AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Request, Response
 
@@ -17,7 +17,7 @@ class ToyotaUSSpider(JSONBlobSpider):
     locations_key = "dealers"
     requires_proxy = True
 
-    def start_requests(self) -> Iterable[JsonRequest | Request]:
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
         # API can not handle huge radius coverage, therefore
         # I decicded to use zipcodes from:
         # Alaska(99775), Florida(33040), California(91932), Washington(98221), Kansas(66952), Maine(04619)

--- a/locations/spiders/uniqlo.py
+++ b/locations/spiders/uniqlo.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, Response
 
@@ -13,7 +13,7 @@ class UniqloSpider(JSONBlobSpider):
     locations_key = ["result", "stores"]
     offset = 0
 
-    def start_requests(self):
+    async def start(self) -> AsyncIterator[JsonRequest]:
         for country in [
             "uk",
             "jp",
@@ -28,9 +28,10 @@ class UniqloSpider(JSONBlobSpider):
             "eu-lu",
             "eu-pl",
         ]:
-            yield from self.request_page(country, 0)
+            for request in self.request_page(country, 0):
+                yield request
 
-    def request_page(self, country, offset):
+    def request_page(self, country, offset) -> Iterable[JsonRequest]:
         yield JsonRequest(
             url=f"https://map.uniqlo.com/{country}/api/storelocator/v1/en/stores?limit=100&RESET=true&offset={offset}&r=storelocator",
             meta={

--- a/locations/spiders/vodacom_cd.py
+++ b/locations/spiders/vodacom_cd.py
@@ -13,7 +13,7 @@ class VodacomCDSpider(JSONBlobSpider):
     }
     locations_key = ["response", "stores"]
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest(
             url="https://www.vodacom.cd/integration/drcportal/store_locator/portal",
             data={"method": "findNearestStore", "longitude": 0, "latitude": 0, "source": "portal"},

--- a/locations/spiders/vodacom_mz.py
+++ b/locations/spiders/vodacom_mz.py
@@ -16,7 +16,7 @@ class VodacomMZSpider(JSONBlobSpider):
     start_urls = ["https://www.vm.co.mz/lojas"]
     locations_key = "data"
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield Request(url=url, callback=self.parse_provinces)
 

--- a/locations/spiders/vodacom_tz.py
+++ b/locations/spiders/vodacom_tz.py
@@ -13,7 +13,7 @@ class VodacomTZSpider(JSONBlobSpider):
     }
     start_urls = ["https://myvodacom.vodacom.co.tz/app/myvodacom/web/vodacom/shop/get-region"]
 
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield JsonRequest(url=url, callback=self.parse_regions)
 

--- a/locations/spiders/volkswagen.py
+++ b/locations/spiders/volkswagen.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import Any, Iterable
+from typing import Any, AsyncIterator, Iterable
 
 import reverse_geocoder
 from geonamescache import GeonamesCache
@@ -65,7 +65,7 @@ class VolkswagenSpider(JSONBlobSpider):
     countries.pop("BW")  # included in ZA
     countries.pop("NA")  # included in ZA
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         for url in self.start_urls:
             yield JsonRequest(url=url, callback=self.fetch_json)
 

--- a/locations/spiders/whistles_gb.py
+++ b/locations/spiders/whistles_gb.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator
 
 from scrapy import Request
 
@@ -14,7 +14,7 @@ class WhistlesGBSpider(JSONBlobSpider):
     item_attributes = {"brand": "Whistles", "brand_wikidata": "Q7994069"}
     locations_key = "stores"
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         for lat, lon in country_iseadgg_centroids(["gb"], 94):
             yield Request(
                 f"https://www.whistles.com/on/demandware.store/Sites-WH-UK-Site/en/Stores-FindStores?standaloneStore=on&lat={lat}&long={lon}&dwfrm_address_country=GB"

--- a/locations/spiders/wienerschnitzel_us_ec.py
+++ b/locations/spiders/wienerschnitzel_us_ec.py
@@ -29,7 +29,7 @@ class WienerschnitzelUSECSpider(StoreLocatorPlusSelfSpider):
     max_results = 10000
     search_radius = 30000
 
-    def start_requests(self):
+    async def start(self):
         url = f"https://{self.allowed_domains[0]}/wp-admin/admin-ajax.php"
         formdata = {
             "action": "csl_ajax_onload",

--- a/locations/spiders/woolworths_za.py
+++ b/locations/spiders/woolworths_za.py
@@ -12,7 +12,7 @@ class WoolworthsZASpider(JSONBlobSpider):
     item_attributes = {"brand": "Woolworths", "brand_wikidata": "Q8033997"}
     locations_key = "stores"
 
-    def start_requests(self):
+    async def start(self):
         yield JsonRequest(
             url="https://www.woolworths.co.za/server/storelocatorByArea?suburbId=3041&distance=100000",
             headers={"Referer": "https://www.woolworths.co.za/storelocator"},

--- a/locations/spiders/worldcat.py
+++ b/locations/spiders/worldcat.py
@@ -1,3 +1,5 @@
+from typing import AsyncIterator
+
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
@@ -17,8 +19,9 @@ class WorldcatSpider(JSONBlobSpider):
             meta={"offset": next_offset},
         )
 
-    def start_requests(self):
-        yield from self.request_page(1)
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for request in self.request_page(1):
+            yield request
 
     def parse(self, response):
         features = self.extract_json(response)

--- a/locations/storefinders/go_review_api.py
+++ b/locations/storefinders/go_review_api.py
@@ -21,7 +21,7 @@ class GoReviewApiSpider(JSONBlobSpider):
     domain = None
     domain_list = None
 
-    def start_requests(self):
+    async def start(self):
         if self.domain is not None:
             self.domain_list = [self.domain]
         if self.domain_list is not None:

--- a/locations/storefinders/storeify.py
+++ b/locations/storefinders/storeify.py
@@ -19,7 +19,7 @@ class StoreifySpider(JSONBlobSpider):
 
     # TODO: Autodetection
 
-    def start_requests(self):
+    async def start(self):
         yield Request(url=f"https://sl.storeify.app/js/stores/{self.api_key}/storeifyapps-storelocator-geojson.js")
 
     # API returns a geojson feature collection

--- a/locations/storefinders/yith.py
+++ b/locations/storefinders/yith.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import AsyncIterator
 
 from scrapy import Request, Selector
 
@@ -22,7 +22,7 @@ class YithSpider(JSONBlobSpider):
         # )
     ]
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Request]:
         yield Request(
             f"https://{self.allowed_domains[0]}/wp-admin/admin-ajax.php?action=yith_sl_get_results&context=frontend&filters[radius][]=500"
         )


### PR DESCRIPTION
**Issue:** `start_requests()` is ignored if parent store finder uses `start()`

**Fix:** converted spiders to use `start()` where applicable. Tested a few, works as expected.

**Scope:** 47 spiders, majority are JSONBlobSpider, but there are few others.
```
grep -r -l 'JSONBlobSpider\|GoReviewApiSpider\|StoreifySpider\|YithSpider\|YextSearchSpider\|WPStoreLocatorSpider\|SylinderSpider\|StoreLocatorPlusSelfSpider\|StockistSpider' locations --include='*.py' | xargs grep -l 'def start_requests'
```
<details><summary>Spiders</summary>

```
locations/storefinders/storeify.py
locations/storefinders/wp_store_locator.py
locations/storefinders/go_review_api.py
locations/storefinders/yith.py
locations/spiders/volkswagen.py
locations/spiders/starbucks_mena.py
locations/spiders/save_mart_us.py
locations/spiders/timpson_group.py
locations/spiders/royal_bank_of_canada_ca.py
locations/spiders/rocomamas.py
locations/spiders/starbucks_za.py
locations/spiders/scouts_za.py
locations/spiders/shoe_show_mega_us.py
locations/spiders/toyota_us.py
locations/spiders/47_street_ar.py
locations/spiders/ster_kinekor.py
locations/spiders/vodacom_cd.py
locations/spiders/tango.py
locations/spiders/raleys_us.py
locations/spiders/seven_eleven_ph.py
locations/spiders/sigma_it.py
locations/spiders/woolworths_za.py
locations/spiders/rage_za.py
locations/spiders/vodacom_mz.py
locations/spiders/sprinter.py
locations/spiders/storcash_no.py
locations/spiders/vodacom_tz.py
locations/spiders/starbucks_cn.py
locations/spiders/salmoiraghi_and_vigano_it.py
locations/spiders/spar_bw_mz_na_sz_za.py
locations/spiders/frasers_gb.py
locations/spiders/starbucks_jp.py
locations/spiders/whistles_gb.py
locations/spiders/q8.py
locations/spiders/quarterra_us.py
locations/spiders/sunglass_hut_in.py
locations/spiders/toyota_eu.py
locations/spiders/wienerschnitzel_us_ec.py
locations/spiders/infrastructure/melbourne_city_council_parking_spaces_au.py
locations/spiders/infrastructure/mississippi_department_of_transportation_us.py
locations/spiders/infrastructure/federal_aviation_administration_weathercams_ca_us.py
locations/spiders/infrastructure/euro_argo_eric_floats.py
locations/spiders/infrastructure/travel_midwest_us.py
locations/spiders/infrastructure/oklahoma_department_of_transportation_us.py
locations/spiders/infrastructure/banyule_city_council_au.py
locations/spiders/subway_kr.py
locations/spiders/worldcat.py
locations/spiders/uniqlo.py
```
</details>





 