### PR TITLE
[WPStoreLocatorSpider] fix for loops inside async start

### DIFF
--- a/locations/storefinders/wp_store_locator.py
+++ b/locations/storefinders/wp_store_locator.py
@@ -84,13 +84,13 @@ class WPStoreLocatorSpider(Spider):
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         if len(self.iseadgg_countries_list) > 0 and self.search_radius != 0 and self.max_results != 0:
-            async for request in self.start_requests_geo_search_iseadgg_method():
+            for request in self.start_requests_geo_search_iseadgg_method():
                 yield request
         elif len(self.searchable_points_files) > 0 and self.search_radius != 0 and self.max_results != 0:
-            async for request in self.start_requests_geo_search_manual_method():
+            for request in self.start_requests_geo_search_manual_method():
                 yield request
         else:
-            async for request in self.start_requests_all_at_once_method():
+            for request in self.start_requests_all_at_once_method():
                 yield request
 
     def start_requests_all_at_once_method(self) -> Iterable[JsonRequest]:


### PR DESCRIPTION
This was causing an error: 
```
TypeError: 'async for' requires an object with __aiter__ method, got generator
```