### PR TITLE
[Bp] Fix KeyError to recover lost POIs

### DIFF
--- a/locations/spiders/bp.py
+++ b/locations/spiders/bp.py
@@ -24,11 +24,11 @@ class BpSpider(GeoMeSpider):
         "aral_pulse": {"brand": "Aral pulse", "operator": "Aral", "operator_wikidata": "Q565734"},
     }
 
-    def parse_item(self, item, location):
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
         if brand := self.brands.get(location["site_brand"]):
             item.update(brand)
         else:
-            item.update(self.brands["BP"])
+            item.update(self.brands["bp"])
             self.crawler.stats.inc_value("{}/unmapped_brand/{}".format(self.name, location["site_brand"]))
 
         products = location["products"]


### PR DESCRIPTION
```python
{'atp/brand/Amoco': 992,
 'atp/brand/Aral': 2374,
 'atp/brand/Aral pulse': 90,
 'atp/brand/BP': 13695,
 'atp/brand/BP Connect': 38,
 'atp/brand/REWE To Go': 900,
 'atp/brand/Wild Bean Cafe': 1532,
 'atp/brand_wikidata/Q130210067': 90,
 'atp/brand_wikidata/Q152057': 13733,
 'atp/brand_wikidata/Q465952': 992,
 'atp/brand_wikidata/Q565734': 2374,
 'atp/brand_wikidata/Q61804826': 1532,
 'atp/brand_wikidata/Q85224313': 900,
 'atp/category/amenity/cafe': 1532,
 'atp/category/amenity/charging_station': 90,
 'atp/category/amenity/fuel': 17017,
 'atp/category/shop/convenience': 982,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/postcode': 6,
 'atp/clean_strings/state': 3,
 'atp/clean_strings/street_address': 66,
 'atp/closed_check': 2,
 'atp/country/AT': 304,
 'atp/country/AU': 1731,
 'atp/country/CH': 342,
 'atp/country/DE': 3258,
 'atp/country/ES': 683,
 'atp/country/FR': 238,
 'atp/country/GB': 1493,
 'atp/country/GR': 704,
 'atp/country/ID': 73,
 'atp/country/LU': 113,
 'atp/country/MX': 399,
 'atp/country/NL': 331,
 'atp/country/NZ': 406,
 'atp/country/PL': 1063,
 'atp/country/PT': 493,
 'atp/country/US': 7990,
 'atp/duplicate_count': 20612,
 'atp/field/branch/missing': 19621,
 'atp/field/email/missing': 19621,
 'atp/field/image/missing': 19621,
 'atp/field/name/missing': 90,
 'atp/field/opening_hours/missing': 4622,
 'atp/field/operator/missing': 19265,
 'atp/field/operator_wikidata/missing': 19265,
 'atp/field/phone/invalid': 331,
 'atp/field/phone/missing': 344,
 'atp/field/postcode/missing': 406,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/state/missing': 9148,
 'atp/field/street_address/missing': 45,
 'atp/field/twitter/missing': 19621,
 'atp/field/website/missing': 16363,
 'atp/item_scraped_host_count/bpretaillocator.geoapp.me': 40233,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 17148,
 'atp/nsi/match_failed': 41,
 'atp/nsi/perfect_match': 2432,
 'atp/operator/Aral': 90,
 'atp/operator/BP': 266,
 'atp/operator_wikidata/Q152057': 266,
 'atp/operator_wikidata/Q565734': 90,
 'bp/unmapped_brand/petro': 149,
 'bp/unmapped_brand/ta': 358,
 'bp/unmapped_brand/ta_express': 137,
 'bp/unmapped_brand/thorntons': 42,
 'downloader/request_bytes': 775870,
 'downloader/request_count': 1377,
 'downloader/request_method_count/GET': 1377,
 'downloader/response_bytes': 5693033,
 'downloader/response_count': 1377,
 'downloader/response_status_count/200': 1376,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 1898.349952,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 17, 12, 52, 39, 616330, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1371,
 'httpcache/hit': 6,
 'httpcache/miss': 1371,
 'httpcache/store': 1371,
 'httpcompression/response_bytes': 34026059,
 'httpcompression/response_count': 1299,
 'item_dropped_count': 20612,
 'item_dropped_reasons_count/DropItem': 20612,
 'item_scraped_count': 19621,
 'items_per_minute': 620.2634351949421,
 'log_count/DEBUG': 41614,
 'log_count/INFO': 41,
 'log_count/WARNING': 2,
 'request_depth_max': 701,
 'response_received_count': 1377,
 'responses_per_minute': 43.5300316122234,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1376,
 'scheduler/dequeued/memory': 1376,
 'scheduler/enqueued': 1376,
 'scheduler/enqueued/memory': 1376,
 'start_time': datetime.datetime(2025, 12, 17, 12, 21, 1, 266378, tzinfo=datetime.timezone.utc)}
```