### PR TITLE
[Tmobile US] Fix spider

### DIFF
--- a/locations/spiders/tmobile_us.py
+++ b/locations/spiders/tmobile_us.py
@@ -10,7 +10,7 @@ class TmobileUSSpider(SitemapSpider, StructuredDataSpider):
     name = "tmobile_us"
     item_attributes = {"brand": "T-Mobile", "brand_wikidata": "Q3511885"}
     sitemap_urls = ["https://www.t-mobile.com/stores/sitemap.xml"]
-    sitemap_rules = [(r"/stores/[a-z]{2}/t-mobile-", "parse_sd")]
+    sitemap_rules = [(r"/stores/[a-z]{2}/t-mobile-[-\w]+/?$", "parse_sd")]
     allowed_domains = ["www.t-mobile.com"]
     drop_attributes = {"facebook", "twitter"}
     custom_settings = {"ROBOTSTXT_OBEY": False, "CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 3}


### PR DESCRIPTION
```python
{'atp/brand/T-Mobile': 6648,
 'atp/brand_wikidata/Q3511885': 6648,
 'atp/category/shop/mobile_phone': 6648,
 'atp/clean_strings/branch': 4018,
 'atp/clean_strings/street_address': 1,
 'atp/country/US': 6648,
 'atp/field/email/missing': 6648,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 6648,
 'atp/field/operator_wikidata/missing': 6648,
 'atp/field/twitter/missing': 6648,
 'atp/item_scraped_host_count/www.t-mobile.com': 6648,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 6648,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 11039601,
 'downloader/request_count': 6696,
 'downloader/request_method_count/GET': 6696,
 'downloader/response_bytes': 347741333,
 'downloader/response_count': 6695,
 'downloader/response_status_count/200': 6695,
 'elapsed_time_seconds': 24575.602423,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 17, 20, 49, 12, 144587, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2829901273,
 'httpcompression/response_count': 6695,
 'item_scraped_count': 6648,
 'items_per_minute': 16.231129196337744,
 'log_count/DEBUG': 13347,
 'log_count/INFO': 418,
 'request_depth_max': 2,
 'response_received_count': 6695,
 'responses_per_minute': 16.345879959308242,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'scheduler/dequeued': 6696,
 'scheduler/dequeued/memory': 6696,
 'scheduler/enqueued': 6696,
 'scheduler/enqueued/memory': 6696,
 'start_time': datetime.datetime(2025, 12, 17, 13, 59, 36, 542164, tzinfo=datetime.timezone.utc)}
```