### PR TITLE
[Woolworths AU] Fix Spider

### DIFF
--- a/locations/spiders/woolworths_au.py
+++ b/locations/spiders/woolworths_au.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -17,7 +18,8 @@ class WoolworthsAUSpider(scrapy.Spider):
     start_urls = [
         "https://www.woolworths.com.au/apis/ui/StoreLocator/Stores?Max=10000&Division=SUPERMARKETS&Facility=&postcode=*"
     ]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["Stores"]:


### PR DESCRIPTION
```python
{'atp/brand/Woolworths': 1032,
 'atp/brand/Woolworths Metro': 101,
 'atp/brand_wikidata/Q111772555': 101,
 'atp/brand_wikidata/Q3249145': 1032,
 'atp/category/shop/supermarket': 1133,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/phone': 1,
 'atp/country/AU': 1133,
 'atp/field/country/from_spider_name': 1133,
 'atp/field/email/missing': 1133,
 'atp/field/image/missing': 1133,
 'atp/field/opening_hours/missing': 1133,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 1133,
 'atp/item_scraped_host_count/www.woolworths.com.au': 1133,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 101,
 'atp/nsi/perfect_match': 1032,
 'atp/operator/Woolworths Group': 1133,
 'atp/operator_wikidata/Q607272': 1133,
 'downloader/request_bytes': 612,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1380003,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 37.626057,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 18, 10, 19, 3, 144850, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1133,
 'items_per_minute': 1837.2972972972973,
 'log_count/DEBUG': 1145,
 'log_count/INFO': 13,
 'memusage/max': 291155968,
 'memusage/startup': 291155968,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 3.243243243243243,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 18, 10, 18, 25, 518793, tzinfo=datetime.timezone.utc)}
```