### PR TITLE
[Costco] Sync brand with NSI

### DIFF
--- a/locations/spiders/costco_ca_gb_us.py
+++ b/locations/spiders/costco_ca_gb_us.py
@@ -18,7 +18,7 @@ COSTCO_SHARED_ATTRIBUTES = {"brand_wikidata": "Q715583"}
 
 class CostcoCAGBUSSpider(JSONBlobSpider, CamoufoxSpider):
     name = "costco_ca_gb_us"
-    item_attributes = COSTCO_SHARED_ATTRIBUTES
+    item_attributes = {"brand": "Costco"} | COSTCO_SHARED_ATTRIBUTES
     allowed_domains = ["ecom-api.costco.com"]
     start_urls = [
         "https://ecom-api.costco.com/warehouseLocatorMobile/v1/warehouses.json?client_id=45823696-9189-482d-89c3-0c067e477ea1&latitude=0&longitude=0&limit=5000&distanceUnit=km"
@@ -55,6 +55,7 @@ class CostcoCAGBUSSpider(JSONBlobSpider, CamoufoxSpider):
             )
         else:
             # Costco allowing retail customers
+            item["name"] = "Costco"
             if item["country"] == "US":
                 item["website"] = "https://www.costco.com/warehouse-locations/{}-{}-{}.html".format(
                     slug_branch_name, slug_state_code, item["ref"]


### PR DESCRIPTION
```python
{'atp/brand/Costco': 782,
 'atp/brand_wikidata/Q715583': 782,
 'atp/category/shop/wholesale': 782,
 'atp/country/CA': 114,
 'atp/country/GB': 29,
 'atp/country/US': 639,
 'atp/field/email/missing': 782,
 'atp/field/image/missing': 782,
 'atp/field/name/missing': 717,
 'atp/field/operator/missing': 782,
 'atp/field/operator_wikidata/missing': 782,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 29,
 'atp/field/twitter/missing': 782,
 'atp/item_scraped_host_count/': 782,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 29,
 'atp/nsi/match_failed': 753,
 'downloader/request_bytes': 351,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 4709944,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.038879,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 18, 12, 55, 9, 407969, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 782,
 'items_per_minute': 23460.0,
 'log_count/INFO': 10,
 'log_count/WARNING': 1,
 'memusage/max': 290762752,
 'memusage/startup': 290762752,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2025, 12, 18, 12, 55, 7, 369090, tzinfo=datetime.timezone.utc)}
```