### PR TITLE
[Kutxabank ES] Fix Spider

### DIFF
--- a/locations/spiders/kutxabank_es.py
+++ b/locations/spiders/kutxabank_es.py
@@ -5,6 +5,7 @@ from requests import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class KutxabankESSpider(scrapy.Spider):
@@ -14,7 +15,7 @@ class KutxabankESSpider(scrapy.Spider):
         "https://portal.kutxabank.es/cs/jsp/oficinascajeros/buscaroficinascajeros.jsp?idioma=03&entidad=2095&tipo=2&longMax=180&longMin=-180&latMax=90&latMin=-90&zoom=13",
         "https://portal.kutxabank.es/cs/jsp/oficinascajeros/buscaroficinascajeros.jsp?idioma=03&entidad=2095&tipo=1&servicios=todos&longMax=180&longMin=-180&latMax=90&latMin=-90&zoom=14",
     ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
     no_refs = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
```python
{'atp/brand/Kutxabank': 1675,
 'atp/brand_wikidata/Q5139377': 1675,
 'atp/category/amenity/atm': 1256,
 'atp/category/amenity/bank': 419,
 'atp/country/ES': 1675,
 'atp/field/country/from_spider_name': 1675,
 'atp/field/email/missing': 1675,
 'atp/field/image/missing': 1675,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/name/missing': 1256,
 'atp/field/opening_hours/missing': 1675,
 'atp/field/operator/missing': 419,
 'atp/field/operator_wikidata/missing': 419,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 160,
 'atp/field/twitter/missing': 1675,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/portal.kutxabank.es': 1675,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1675,
 'atp/operator/Kutxabank': 1256,
 'atp/operator_wikidata/Q5139377': 1256,
 'downloader/request_bytes': 798,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 101333,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 14.156318,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 22, 9, 34, 50, 722819, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 637943,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1675,
 'items_per_minute': 7178.571428571428,
 'log_count/DEBUG': 1680,
 'log_count/INFO': 9,
 'response_received_count': 2,
 'responses_per_minute': 8.571428571428571,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2025, 12, 22, 9, 34, 36, 566501, tzinfo=datetime.timezone.utc)}
```