### PR TITLE
[Lukoil] Fix spider

### DIFF
--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -1,7 +1,7 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Iterable
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -123,19 +123,21 @@ PROPERTIES = {
 class LukoilSpider(Spider):
     name = "lukoil"
     custom_settings = {"ROBOTSTXT_OBEY": False}
-    start_urls = ["https://lukoil.bg/api/cartography/GetCountryDependentSearchObjectData?form=gasStation"]
-    allowed_domains = ["lukoil.bg"]
+    start_urls = ["https://auto.lukoil.ru/api/cartography/GetCountryDependentSearchObjectData?form=gasStation"]
+    allowed_domains = ["lukoil.ru"]
     handle_httpstatus_list = [403]
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
             yield JsonRequest(url=url, callback=self.get_results)
 
-    def get_results(self, response):
+    def get_results(self, response: Response) -> Iterable[JsonRequest]:
         for station in response.json()["GasStations"]:
-            yield JsonRequest(f"https://lukoil.bg/api/cartography/GetObjects?ids=gasStation{station['GasStationId']}")
+            yield JsonRequest(
+                f"https://auto.lukoil.ru/api/cartography/GetObjects?ids=gasStation{station['GasStationId']}"
+            )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         if data := response.json()[0]:
             poi = data.get("GasStation")
             item = DictParser.parse(poi)
@@ -150,7 +152,7 @@ class LukoilSpider(Spider):
             apply_category(Categories.FUEL_STATION, item)
             yield item
 
-    def parse_brand(self, item: Feature, poi: dict):
+    def parse_brand(self, item: Feature, poi: dict) -> None:
         if company_name := poi.get("Company", {}).get("Name", ""):
             for brand, brand_tags in COMPANY_BRANDS.items():
                 if brand.lower() in company_name.lower():
@@ -160,7 +162,7 @@ class LukoilSpider(Spider):
                 self.logger.warning(f"Unknown brand: {company_name}")
                 self.crawler.stats.inc_value(f"atp/lukoil/brand/failed/{company_name}")
 
-    def parse_attribute(self, item: Feature, poi: dict, attribute_name: str, mapping: dict):
+    def parse_attribute(self, item: Feature, poi: dict, attribute_name: str, mapping: dict) -> None:
         for attribute_entity in poi.get(attribute_name, []):
             if tag := mapping.get(attribute_entity.get("Name")):
                 apply_yes_no(tag, item, True)
@@ -168,7 +170,7 @@ class LukoilSpider(Spider):
                 pass
                 # self.crawler.stats.inc_value(f"atp/lukoil/{attribute_name}/failed/{attribute_entity.get('Name')}")
 
-    def parse_hours(self, item: Feature, poi: dict):
+    def parse_hours(self, item: Feature, poi: dict) -> None:
         if poi.get("TwentyFourHour"):
             item["opening_hours"] = "24/7"
             return
@@ -184,7 +186,7 @@ class LukoilSpider(Spider):
         except:
             self.crawler.stats.inc_value("atp/lukoil/hours/failed")
 
-    def parse_fuel_types(self, item: Feature, data: dict):
+    def parse_fuel_types(self, item: Feature, data: dict) -> None:
         if fuels := data.get("Fuels"):
             for fuel_type in fuels:
                 # Use fuel icon to determine fuel type as fuel name is not always available


### PR DESCRIPTION
```python
{'atp/brand/Lukoil': 1396,
 'atp/brand/Лукойл': 2464,
 'atp/brand/ლუკოილი': 62,
 'atp/brand_wikidata/Q329347': 3924,
 'atp/category/amenity/fuel': 4681,
 'atp/clean_strings/addr_full': 16,
 'atp/clean_strings/city': 10,
 'atp/clean_strings/name': 102,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street': 48,
 'atp/country/AL': 1,
 'atp/country/AX': 1,
 'atp/country/AZ': 70,
 'atp/country/BE': 183,
 'atp/country/BG': 211,
 'atp/country/BY': 84,
 'atp/country/FI': 391,
 'atp/country/FR': 3,
 'atp/country/GE': 62,
 'atp/country/GR': 1,
 'atp/country/HR': 42,
 'atp/country/HU': 1,
 'atp/country/IR': 4,
 'atp/country/IT': 29,
 'atp/country/JO': 1,
 'atp/country/LT': 1,
 'atp/country/MD': 95,
 'atp/country/ME': 8,
 'atp/country/MK': 38,
 'atp/country/NL': 49,
 'atp/country/OM': 1,
 'atp/country/PK': 5,
 'atp/country/RO': 318,
 'atp/country/RS': 114,
 'atp/country/RU': 2372,
 'atp/country/SA': 12,
 'atp/country/SH': 1,
 'atp/country/SI': 2,
 'atp/country/SY': 1,
 'atp/country/TR': 397,
 'atp/country/UA': 5,
 'atp/country/US': 176,
 'atp/field/branch/missing': 4681,
 'atp/field/brand/missing': 759,
 'atp/field/brand_wikidata/missing': 757,
 'atp/field/city/missing': 932,
 'atp/field/country/from_reverse_geocoding': 4679,
 'atp/field/country/missing': 2,
 'atp/field/email/invalid': 107,
 'atp/field/email/missing': 3609,
 'atp/field/image/missing': 4148,
 'atp/field/lat/missing': 2,
 'atp/field/lon/missing': 2,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 4619,
 'atp/field/operator_wikidata/missing': 4681,
 'atp/field/phone/invalid': 95,
 'atp/field/phone/missing': 3675,
 'atp/field/postcode/missing': 1618,
 'atp/field/state/missing': 54,
 'atp/field/street_address/missing': 4681,
 'atp/field/twitter/missing': 4681,
 'atp/field/website/missing': 4681,
 'atp/item_scraped_host_count/auto.lukoil.ru': 4681,
 'atp/lineage': 'S_?',
 'atp/lukoil/brand/failed/"ЛИКАРД"': 203,
 'atp/lukoil/brand/failed/АО "Тебойл"': 402,
 'atp/lukoil/brand/failed/ЛУКОИЛ МАКЕДОНИJА ДООЕЛ Скопjе': 38,
 'atp/lukoil/brand/failed/ЛУКОИЛ СЕРБИА д.о.о. Београд': 113,
 'atp/lukoil/brand/failed/Неизвестный контрагент': 1,
 'atp/lukoil/fuel/failed/cno.png': 1,
 'atp/nsi/cc_match': 3922,
 'atp/nsi/match_failed': 2,
 'atp/operator/შპს ლუკოილ ჯორჯია': 62,
 'downloader/request_bytes': 2531832,
 'downloader/request_count': 4682,
 'downloader/request_method_count/GET': 4682,
 'downloader/response_bytes': 9159796,
 'downloader/response_count': 4682,
 'downloader/response_status_count/200': 4682,
 'elapsed_time_seconds': 5715.748095,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 24, 12, 58, 31, 180062, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 4682,
 'httpcache/miss': 4682,
 'httpcache/store': 4682,
 'httpcompression/response_bytes': 18671930,
 'httpcompression/response_count': 4682,
 'item_scraped_count': 4681,
 'items_per_minute': 49.14435695538058,
 'log_count/DEBUG': 9367,
 'log_count/INFO': 105,
 'log_count/WARNING': 775,
 'request_depth_max': 1,
 'response_received_count': 4682,
 'responses_per_minute': 49.15485564304462,
 'scheduler/dequeued': 4682,
 'scheduler/dequeued/memory': 4682,
 'scheduler/enqueued': 4682,
 'scheduler/enqueued/memory': 4682,
 'start_time': datetime.datetime(2025, 12, 24, 11, 23, 15, 431967, tzinfo=datetime.timezone.utc)}
```