### PR TITLE
[HSBC UK GB] Fix Spider

### DIFF
--- a/locations/spiders/hsbc_uk_gb.py
+++ b/locations/spiders/hsbc_uk_gb.py
@@ -13,7 +13,7 @@ class HsbcUkGBSpider(CrawlSpider, StructuredDataSpider):
     name = "hsbc_uk_gb"
     item_attributes = {"brand": "HSBC UK", "brand_wikidata": "Q64767453"}
     start_urls = ["https://www.hsbc.co.uk/branch-list/"]
-    rules = [Rule(LinkExtractor(allow="/branch-list//"), callback="parse_sd")]
+    rules = [Rule(LinkExtractor(allow="/branch-list/"), callback="parse_sd")]
 
     def iter_linked_data(self, response: Response) -> Iterable[dict]:
         for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):


### PR DESCRIPTION
**_Fixes : updated link extractor rule to fix spider_**

```python
{'atp/brand/HSBC UK': 552,
 'atp/brand_wikidata/Q64767453': 552,
 'atp/category/amenity/bank': 552,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/street_address': 2,
 'atp/closed_check': 1,
 'atp/country/GB': 552,
 'atp/field/branch/missing': 552,
 'atp/field/email/missing': 552,
 'atp/field/image/missing': 552,
 'atp/field/opening_hours/missing': 9,
 'atp/field/operator/missing': 552,
 'atp/field/operator_wikidata/missing': 552,
 'atp/field/phone/missing': 552,
 'atp/field/state/missing': 552,
 'atp/item_scraped_host_count/www.hsbc.co.uk': 552,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 552,
 'downloader/request_bytes': 267298,
 'downloader/request_count': 555,
 'downloader/request_method_count/GET': 555,
 'downloader/response_bytes': 15372661,
 'downloader/response_count': 555,
 'downloader/response_status_count/200': 555,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 677.45624,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 30, 6, 43, 21, 987235, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 106225239,
 'httpcompression/response_count': 555,
 'item_scraped_count': 552,
 'items_per_minute': 48.921713441654354,
 'log_count/DEBUG': 1124,
 'log_count/INFO': 20,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 555,
 'responses_per_minute': 49.18759231905465,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 554,
 'scheduler/dequeued/memory': 554,
 'scheduler/enqueued': 554,
 'scheduler/enqueued/memory': 554,
 'start_time': datetime.datetime(2025, 12, 30, 6, 32, 4, 530995, tzinfo=datetime.timezone.utc)}
```