### PR TITLE
[Grand Optical] Fix Spider

### DIFF
--- a/locations/spiders/grand_optical.py
+++ b/locations/spiders/grand_optical.py
@@ -17,6 +17,7 @@ class GrandOpticalSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["website"] = response.url
+        item["branch"] = item.pop("name").replace("GRANDOPTICAL", "").replace("Opticien", "")
 
         data = json.loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
         store = data["props"]["initialProps"]["pageProps"]["storeData"]


### PR DESCRIPTION
**_Fixes : updated grand_optical to use sitemap to fix spider_**

```python
{'atp/brand/GrandOptical': 189,
 'atp/brand_wikidata/Q3113677': 189,
 'atp/category/shop/optician': 189,
 'atp/cdn/cloudflare/response_count': 191,
 'atp/cdn/cloudflare/response_status_count/200': 191,
 'atp/country/FR': 177,
 'atp/country/GF': 1,
 'atp/country/GP': 1,
 'atp/country/LU': 9,
 'atp/country/MQ': 1,
 'atp/field/branch/missing': 189,
 'atp/field/image/dropped': 7,
 'atp/field/image/missing': 7,
 'atp/field/lat/missing': 189,
 'atp/field/lon/missing': 189,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 189,
 'atp/field/operator_wikidata/missing': 189,
 'atp/field/state/missing': 189,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/invalid': 189,
 'atp/field/website/invalid': 15,
 'atp/item_scraped_host_count/www.grandoptical.com': 189,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 189,
 'downloader/request_bytes': 76534,
 'downloader/request_count': 191,
 'downloader/request_method_count/GET': 191,
 'downloader/response_bytes': 15501454,
 'downloader/response_count': 191,
 'downloader/response_status_count/200': 191,
 'elapsed_time_seconds': 236.547536,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2025, 12, 30, 8, 40, 13, 337451, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 87001350,
 'httpcompression/response_count': 191,
 'item_scraped_count': 189,
 'items_per_minute': 48.05084745762712,
 'log_count/DEBUG': 383,
 'log_count/INFO': 12,
 'log_count/WARNING': 15,
 'request_depth_max': 1,
 'response_received_count': 191,
 'responses_per_minute': 48.559322033898304,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 190,
 'scheduler/dequeued/memory': 190,
 'scheduler/enqueued': 190,
 'scheduler/enqueued/memory': 190,
 'start_time': datetime.datetime(2025, 12, 30, 8, 36, 16, 789915, tzinfo=datetime.timezone.utc)}
```