### PR TITLE
[run_all_spiders] fix counting insights stats twice

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -86,9 +86,6 @@ fi
 OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson | wc -l | tr -d ' ')
 (>&2 echo "Generated ${OUTPUT_LINECOUNT} lines")
 
-uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPIDER_RUN_DIR}/stats/_insights.json"
-(>&2 echo "Done comparing against Name Suggestion Index and OpenStreetMap")
-
 tippecanoe --cluster-distance=25 \
            --drop-rate=1 \
            --maximum-zoom=15 \
@@ -123,6 +120,9 @@ fi
 rm "${SPIDER_RUN_DIR}"/output/*.ndgeojson
 
 (>&2 echo "Done creating parquet file")
+
+uv run scrapy insights --atp-nsi-osm "${SPIDER_RUN_DIR}/output" --outfile "${SPIDER_RUN_DIR}/stats/_insights.json"
+(>&2 echo "Done comparing against Name Suggestion Index and OpenStreetMap")
 
 (>&2 echo "Writing out summary JSON")
 echo "{\"count\": ${SPIDER_COUNT}, \"results\": []}" >> "${SPIDER_RUN_DIR}/stats/_results.json"


### PR DESCRIPTION
#14793 make insights counting stats twice, on geojson and ndgeojson files together. I moved launch of insights command later in the process, after deletion of ndgeojson files. Hope it will resolve the issue.