### PR TITLE
[Transport Department, HK] add new spider (993 locations)

### DIFF
--- a/locations/spiders/infrastructure/transport_department_traffic_cameras_hk.py
+++ b/locations/spiders/infrastructure/transport_department_traffic_cameras_hk.py
@@ -1,0 +1,37 @@
+import re
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
+
+
+class TransportDepartmentTrafficCamerasHKSpider(ArcGISFeatureServerSpider):
+    dataset_attributes = {
+        "attribution": "required",
+        "attribution:name": "Transport Department/Government of Hong Kong via CSDI Portal",
+        "attribution:website": "https://portal.csdi.gov.hk/geoportal/?lang=en&datasetId=td_rcd_1638952287148_39267",
+        "license": "Terms and Conditions of Use of the CSDI Portal",
+        "license:website": "https://portal.csdi.gov.hk/csdi-webpage/doc/TNC",
+        "use:commercial": "permit",
+    }
+    name = "transport_department_traffic_cameras_hk"
+    item_attributes = {"operator": "運輸署 Transport Department", "operator_wikidata": "Q2355889"}
+    host = "portal.csdi.gov.hk"
+    context_path = "server"
+    service_id = "common/td_rcd_1638952287148_39267"
+    layer_id = "0"
+    cam_name_regex = re.compile(r"(^.*)(?: \[.*].*$)")
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        apply_category(Categories.SURVEILLANCE_CAMERA, item)
+        name = self.cam_name_regex.match(feature["description"])
+        if name is None:
+            self.logger.warning("Name not found for camera: {}".format(feature["key_"]))
+        else:
+            item["name"] = name.group(1)
+        item["ref"] = feature["key_"]
+        item["extras"]["contact:webcam"] = feature["url"]
+        yield item


### PR DESCRIPTION
first time writing a spider, this one covers all the traffic cameras owned by the Transport Department of Hong Kong

```python
{'atp/category/man_made/surveillance': 993,
 'atp/clean_strings/name': 2,
 'atp/country/HK': 993,
 'atp/field/branch/missing': 993,
 'atp/field/brand/missing': 993,
 'atp/field/brand_wikidata/missing': 993,
 'atp/field/city/missing': 993,
 'atp/field/country/from_spider_name': 993,
 'atp/field/email/missing': 993,
 'atp/field/image/missing': 993,
 'atp/field/opening_hours/missing': 993,
 'atp/field/phone/missing': 993,
 'atp/field/postcode/missing': 993,
 'atp/field/street_address/missing': 993,
 'atp/field/twitter/missing': 993,
 'atp/item_scraped_host_count/portal.csdi.gov.hk': 993,
 'atp/lineage': 'S_ATP_INFRASTRUCTURE',
 'atp/nsi/match_failed': 993,
 'atp/operator/Transport Department': 993,
 'atp/operator_wikidata/Q2355889': 993,
 'downloader/request_bytes': 1079,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 52520,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.510479,
 'feedexport/success_count/FileFeedStorage': 2,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 2, 5, 22, 5, 799289, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 341176,
 'httpcompression/response_count': 2,
 'item_scraped_count': 993,
 'items_per_minute': 11916.0,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'memusage/max': 292880384,
 'memusage/startup': 292880384,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 1, 2, 5, 22, 0, 288810, tzinfo=datetime.timezone.utc)}
```