### PR TITLE
[discover.swiss] Fix spider

### DIFF
--- a/locations/spiders/aggregators/discover_swiss.py
+++ b/locations/spiders/aggregators/discover_swiss.py
@@ -17,6 +17,10 @@ from locations.items import Feature
 class DiscoverSwissSpider(Spider):
     name = "discover_swiss"
     allowed_domains = ["api.discover.swiss"]
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "URLLENGTH_LIMIT": 4096,
+    }
     dataset_attributes = {
         # Mandatory attribution as per CC-BY 4.0, waived for OpenStreetMap
         # via standard template. Negotiations took place in January 2025


### PR DESCRIPTION
The Swiss OpenStreetMap organization has an agreement with Hotellerie
Suisse (who owns and runs the discover.swiss platform) that we’re
allowed to read this feed for keeping OSM up to date.
    
The site uses URLs with continuation tokens that are longer than
Scrapy’s default limit of 2083 characters.
