### PR TITLE
[Target US] Fix spider

### DIFF
--- a/locations/spiders/target_us.py
+++ b/locations/spiders/target_us.py
@@ -6,6 +6,7 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
 class TargetUSSpider(SitemapSpider):
@@ -40,8 +41,22 @@ class TargetUSSpider(SitemapSpider):
                 elif contact_info.get("telephone_type") == "FAX":
                     item["extras"]["fax"] = contact_info.get("telephone_number")
 
+            opening_hours_info = store.get("rolling_operating_hours", {}).get("main_hours", {}).get("days") or []
+            item["opening_hours"] = self.parse_opening_hours(opening_hours_info)
+
             if store.get("physical_specifications", {}).get("format") == "SuperTarget":
                 apply_category(Categories.SHOP_SUPERMARKET, item)
             else:
                 apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
             yield item
+
+    def parse_opening_hours(self, rules: list) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in rules[:7]:
+            day = rule.get("day_name")
+            if rule.get("is_open") is False:
+                oh.set_closed(day)
+                continue
+            for shift in rule.get("hours", []):
+                oh.add_range(day, shift["begin_time"], shift["end_time"], "%H:%M:%S")
+        return oh


### PR DESCRIPTION
`Structured Data` is not consistently served, hence to fix this, code refactored using `API`.

```python
{'atp/brand/Target': 1995,
 'atp/brand_wikidata/Q1046951': 1995,
 'atp/category/shop/department_store': 1774,
 'atp/category/shop/supermarket': 221,
 'atp/country/US': 1995,
 'atp/field/email/missing': 1995,
 'atp/field/image/missing': 1995,
 'atp/field/operator/missing': 1995,
 'atp/field/operator_wikidata/missing': 1995,
 'atp/field/twitter/missing': 1995,
 'atp/item_scraped_host_count/redsky.target.com': 1995,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1995,
 'downloader/request_bytes': 2215303,
 'downloader/request_count': 1998,
 'downloader/request_method_count/GET': 1998,
 'downloader/response_bytes': 4596449,
 'downloader/response_count': 1998,
 'downloader/response_status_count/200': 1997,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 22.311377,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 6, 13, 18, 16, 894706, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1998,
 'httpcompression/response_bytes': 43832598,
 'httpcompression/response_count': 1997,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 1995,
 'items_per_minute': 5440.909090909091,
 'log_count/DEBUG': 3997,
 'log_count/INFO': 11,
 'request_depth_max': 2,
 'response_received_count': 1998,
 'responses_per_minute': 5449.09090909091,
 'scheduler/dequeued': 1998,
 'scheduler/dequeued/memory': 1998,
 'scheduler/enqueued': 1998,
 'scheduler/enqueued/memory': 1998,
 'start_time': datetime.datetime(2026, 1, 6, 13, 17, 54, 583329, tzinfo=datetime.timezone.utc)}
```