### PR TITLE
[mcdonalds_rs] Split McCafe POIs

### DIFF
--- a/locations/spiders/mcdonalds_rs.py
+++ b/locations/spiders/mcdonalds_rs.py
@@ -5,9 +5,9 @@ import scrapy
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_RS, OpeningHours
 from locations.spiders.mcdonalds import McdonaldsSpider
 from locations.spiders.mcdonalds_cz import Categories, apply_category
-from locations.hours import OpeningHours, DAYS_RS
 
 SERVICES_MAPPING = {
     "drive": Extras.DRIVE_THROUGH,
@@ -27,7 +27,7 @@ class McdonaldsRSSpider(scrapy.Spider):
         data = response.xpath('//script[contains(., "restaurantMarkers")]/text()').get()
         match = re.search(r"var restaurantMarkers = (\[.*?\]);", data, re.DOTALL)
         pois = json.loads(match.group(1))
-        
+
         for poi in pois:
             poi["street-address"] = poi.pop("address")
             item = DictParser.parse(poi)
@@ -36,7 +36,7 @@ class McdonaldsRSSpider(scrapy.Spider):
                 if match := SERVICES_MAPPING.get(category):
                     apply_yes_no(match, item, True)
 
-            opening_hours = (re.sub(r'h<br />|H<br />|h|H', '', poi["restaurant_worktime"]))
+            opening_hours = re.sub(r"h<br />|H<br />|h|H", "", poi["restaurant_worktime"])
             oh = OpeningHours()
             oh.add_ranges_from_string(opening_hours, DAYS_RS)
             item["opening_hours"] = oh


### PR DESCRIPTION
```
{'atp/brand/McCafé': 22,
 "atp/brand/McDonald's": 40,
 'atp/brand_wikidata/Q3114287': 22,
 'atp/brand_wikidata/Q38076': 40,
 'atp/category/amenity/cafe': 22,
 'atp/category/amenity/fast_food': 40,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/street_address': 2,
 'atp/country/RS': 62,
 'atp/field/branch/missing': 62,
 'atp/field/city/missing': 5,
 'atp/field/country/from_spider_name': 62,
 'atp/field/email/missing': 62,
 'atp/field/image/missing': 62,
 'atp/field/lat/missing': 1,
 'atp/field/lon/missing': 1,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 62,
 'atp/field/operator_wikidata/missing': 62,
 'atp/field/phone/missing': 22,
 'atp/field/postcode/missing': 62,
 'atp/field/state/missing': 62,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 62,
 'atp/field/website/missing': 62,
 'atp/item_scraped_host_count/www.mcdonalds.rs': 62,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 40,
 'atp/nsi/perfect_match': 22,
 'downloader/request_bytes': 668,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 44497,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.976821,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 6, 20, 23, 50, 500563, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 235471,
 'httpcompression/response_count': 2,
 'item_scraped_count': 62,
 'items_per_minute': 1860.0,
 'log_count/INFO': 9,
 'memusage/max': 282411008,
 'memusage/startup': 282411008,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 1, 6, 20, 23, 47, 523742, tzinfo=datetime.timezone.utc)}
```