### PR TITLE
Add subway_us spider using locator API for better data quality

### DIFF
--- a/locations/spiders/subway.py
+++ b/locations/spiders/subway.py
@@ -7,7 +7,10 @@ from locations.structured_data_spider import StructuredDataSpider
 
 
 class SubwaySpider(SitemapSpider, StructuredDataSpider):
-    """Also see SubwayWorldwideSpider for API-based spider."""
+    """
+    Sitemap-based spider for Subway locations outside the US.
+    US locations are handled by SubwayUSSpider which uses the API for better data quality.
+    """
 
     name = "subway"
     item_attributes = {"brand": "Subway", "brand_wikidata": "Q244457"}
@@ -15,6 +18,12 @@ class SubwaySpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://restaurants.subway.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     drop_attributes = {"image"}
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            # Skip US locations - handled by subway_us spider with better data quality
+            if "/united-states/" not in entry["loc"]:
+                yield entry
 
     def pre_process_data(self, ld_data, **kwargs):
         if isinstance(ld_data["name"], list):

--- a/locations/spiders/subway_us.py
+++ b/locations/spiders/subway_us.py
@@ -1,0 +1,5 @@
+from locations.spiders.subway_th import SubwayWorldwideSpider
+
+
+class SubwayUSSpider(SubwayWorldwideSpider):
+    name = "subway_us"


### PR DESCRIPTION
The sitemap-based spider extracts structured data from pages, but the source data has "City County" format (e.g., "Birmingham Jefferson" instead of "Birmingham").

This adds a new subway_us spider using the locator API (same approach as subway_th, subway_kw, subway_qa) which provides clean city names and reliable coordinates.

Changes:
- Add subway_us.py using SubwayWorldwideSpider base class
- Update subway.py sitemap_filter to skip US URLs (handled by subway_us)

Tested: Returns locations with clean city names (e.g., "Birmingham" not "Birmingham Jefferson") and proper coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)