### PR TITLE
[Berel MX] Fix spider

### DIFF
--- a/locations/spiders/berel_mx.py
+++ b/locations/spiders/berel_mx.py
@@ -1,10 +1,13 @@
-from typing import AsyncIterator, Iterable
+from typing import Iterable
 
-from scrapy.http import JsonRequest, Response
+import chompjs
+from scrapy.http import Response, TextResponse
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.react_server_components import parse_rsc
 
 
 class BerelMXSpider(JSONBlobSpider):
@@ -13,12 +16,13 @@ class BerelMXSpider(JSONBlobSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     no_refs = True
     locations_key = ["bloques", 0, "sucursales"]
+    start_urls = ["https://berel.com/ubica-tienda"]
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield JsonRequest(
-            url="https://berel-web-cms.playfuldemo.com/rest/basicpage",
-            data={"id": "ubica-tienda"},
-        )
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        scripts = response.xpath('//script[contains(text(), "sucursales")]/text()').getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        return DictParser.get_nested_key(dict(parse_rsc(rsc)), "sucursales")
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["addr_full"] = feature["direccion"]


### PR DESCRIPTION
```python
{'atp/brand/Berel': 1436,
 'atp/brand_wikidata/Q108669250': 1436,
 'atp/category/shop/paint': 1436,
 'atp/clean_strings/addr_full': 26,
 'atp/clean_strings/name': 3,
 'atp/clean_strings/phone': 4,
 'atp/country/MX': 1436,
 'atp/field/branch/missing': 1436,
 'atp/field/city/missing': 1436,
 'atp/field/country/from_spider_name': 1436,
 'atp/field/email/missing': 1436,
 'atp/field/image/missing': 1436,
 'atp/field/opening_hours/missing': 1436,
 'atp/field/operator/missing': 1436,
 'atp/field/operator_wikidata/missing': 1436,
 'atp/field/phone/invalid': 25,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 4,
 'atp/field/street_address/missing': 1436,
 'atp/field/twitter/missing': 1436,
 'atp/field/website/missing': 1436,
 'atp/item_scraped_host_count/berel.com': 1436,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1436,
 'downloader/request_bytes': 329,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 110416,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 6.804791,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 7, 13, 50, 52, 116539, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 594468,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1436,
 'items_per_minute': 14360.0,
 'log_count/DEBUG': 1440,
 'log_count/INFO': 9,
 'response_received_count': 1,
 'responses_per_minute': 10.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 1, 7, 13, 50, 45, 311748, tzinfo=datetime.timezone.utc)}

```