### PR TITLE
[Mol] add brand mapping for Shell

### DIFF
--- a/locations/spiders/mol.py
+++ b/locations/spiders/mol.py
@@ -49,7 +49,7 @@ BRANDS_MAPPING = {
     "EX-OMV": ("MOL", "Q549181"),
     "TIFON": ("Tifon", None),
     "ENERGOPETROL": ("Energopetrol", "Q120433"),
-    "SHELL": ("Shell", "Q110716465")
+    "SHELL": ("Shell", "Q110716465"),
 }
 
 FUEL_MAPPING = {


### PR DESCRIPTION
Mol also returns 456 Shell petrol stations that were not mapped.