### PR TITLE
fix: partially fix redcross_gb spider

### DIFF
--- a/locations/spiders/redcross_gb.py
+++ b/locations/spiders/redcross_gb.py
@@ -10,7 +10,7 @@ from locations.google_url import extract_google_position
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
-from locations.structured_data_spider import extract_email, extract_phone, extract_facebook
+from locations.structured_data_spider import extract_email, extract_facebook, extract_phone
 
 
 class RedcrossGBSpider(SitemapSpider):


### PR DESCRIPTION
Due to a website refactor of the Red Cross page, it seems to have broken the Spider

However, due to the google iframe being removed, the lat/long extraction is not possible using extract_google_position.
If there is an another alternative please let me know
<img width="1543" height="40" alt="Screenshot 2026-01-10 at 00 17 34" src="https://github.com/user-attachments/assets/f071708d-c584-4ab4-bfdd-7dc80a06c3b8" />
