### PR TITLE
feat: add Norwegian after school care [1911]

### DIFF
--- a/locations/spiders/government/nfr_skolefritidsordningen_no.py
+++ b/locations/spiders/government/nfr_skolefritidsordningen_no.py
@@ -97,9 +97,8 @@ class NfrSkolefritidsordningenNOSpider(Spider):
         # Operator information
         for relasjon in data.get("ForeldreRelasjoner") or []:
             relasjonstype = relasjon.get("Relasjonstype") or {}
-            if (
-                relasjonstype.get("Id") == "51"
-            ):  #  51 (Eierstruktur) = ownership structure, i.e. who owns/operates the SFO
+            # 51 (Eierstruktur) = ownership structure, i.e. who owns/operates the SFO
+            if relasjonstype.get("Id") == "51":
                 if enhet := relasjon.get("Enhet"):
                     if navn := enhet.get("Navn"):
                         item["operator"] = navn


### PR DESCRIPTION
Add SFO ([After School Offering](https://en.wikipedia.org/wiki/After-school_activity)) from open government data https://data.norge.no/data-services/73ee2f17-e21a-38fc-9d20-a8c7caaa747c and docs at https://data-nfr.udir.no/swagger/index.html

```js
{
 'atp/category/amenity/childcare': 1911,
 'atp/country/NO': 1911,
 'atp/field/branch/missing': 1911,
 'atp/field/brand/missing': 1911,
 'atp/field/brand_wikidata/missing': 1911,
 'atp/field/city/missing': 17,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 1911,
 'atp/field/geometry/missing': 493,
 'atp/field/image/missing': 1911,
 'atp/field/opening_hours/missing': 1911,
 'atp/field/operator/missing': 1911,
 'atp/field/operator_wikidata/missing': 1911,
 'atp/field/phone/missing': 1911,
 'atp/field/postcode/missing': 1,
 'atp/field/street_address/missing': 801,
 'atp/field/twitter/missing': 1911,
 'atp/field/website/missing': 1894,
 'atp/item_scraped_host_count/data-nfr.udir.no': 1911,
 'atp/lineage': 'S_ATP_GOVERNMENTS',
 'downloader/request_bytes': 1162126,
 'downloader/request_count': 1915,
 'downloader/request_method_count/GET': 1915,
 'downloader/response_bytes': 2693805,
 'downloader/response_count': 1915,
 'downloader/response_status_count/200': 1914,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2347.139445,
 'finish_reason': 'finished',
 'httpcompression/response_bytes': 4774878,
 'httpcompression/response_count': 1914,
 'item_scraped_count': 1911,
 'items_per_minute': 48.85385598636557,
 'log_count/DEBUG': 3829,
 'log_count/INFO': 48,
 'memusage/max': 283672576,
 'memusage/startup': 266321920,
 'request_depth_max': 2,
 'response_received_count': 1915,
 'responses_per_minute': 48.95611418832552,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1914,
 'scheduler/dequeued/memory': 1914,
 'scheduler/enqueued': 1914,
 'scheduler/enqueued/memory': 1914,
}
```