### PR TITLE
[Asda GB] Add other POIs

### DIFF
--- a/locations/spiders/asda_gb.py
+++ b/locations/spiders/asda_gb.py
@@ -115,5 +115,3 @@ class AsdaGBSpider(VirtualEarthSpider):
     def create_petrol_station_poi(self, store_item):
         """Create separate POI for petrol station"""
         return self.create_department_poi(store_item, "fuel", "Petrol Station", Categories.FUEL_STATION)
-
-


### PR DESCRIPTION
I've added cafes, opticians, pharmacies and petrol stations. But there is not much information available in this data about these - on the storefinder on the website there is full information about opening hours, etc. So I'm not sure if it would be better to rewrite this to use the storefinder.