### PR TITLE
[globus_de] Add spider (267 locations)

### DIFF
--- a/locations/spiders/globus_de.py
+++ b/locations/spiders/globus_de.py
@@ -1,0 +1,48 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy import Request
+from scrapy.http import FormRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class GlobusDESpider(JSONBlobSpider):
+    name = "globus_de"
+    item_attributes = {"brand": "Globus", "brand_wikidata": "Q457503"}
+    allowed_domains = ["globus.de"]
+    locations_key = "data"
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield FormRequest("https://www.globus.de/api/open", formdata={"type": "maerkte"})
+
+    def pre_process_data(self, feature: dict) -> None:
+        rename = {
+            "laengengrad": "longitude",
+            "breitengrad": "latitude",
+            "marktName": "name",
+            "strasse": "street_address",
+            "plz": "postcode",
+            "stadt": "city",
+            "telefon": "phone",
+            "marktUrl": "website",
+            "bundesland": "state",
+        }
+        del feature["region"]
+        for de, en in rename.items():
+            feature[en] = feature.pop(de)
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        categories = {
+            "ARC": Categories.SHOP_WHOLESALE,
+            "GC": Categories.SHOP_BEVERAGES,
+            "RES": Categories.RESTAURANT,
+            "SBW": Categories.SHOP_SUPERMARKET,
+            "TS": Categories.FUEL_STATION,
+            "WS": Categories.CAR_WASH,
+        }
+        apply_category(categories[feature["betriebsstaette"]], item)
+        item["extras"]["contact:maps"] = feature["googleUrl"]
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
Add spider for [globus.de](https://www.globus.de/), which is mainly a supermarket, but also has beverage shops, gas stations, car wash and restaurants.

```
{'atp/brand/Globus': 267,
 'atp/brand_wikidata/Q457503': 267,
 'atp/category/amenity/car_wash': 37,
 'atp/category/amenity/fuel': 50,
 'atp/category/amenity/restaurant': 56,
 'atp/category/shop/beverages': 62,
 'atp/category/shop/supermarket': 61,
 'atp/category/shop/wholesale': 1,
 'atp/country/DE': 267,
 'atp/field/country/from_spider_name': 267,
 'atp/field/email/invalid': 203,
 'atp/field/email/missing': 206,
 'atp/field/geometry/missing': 4,
 'atp/field/image/missing': 267,
 'atp/field/name/missing': 119,
 'atp/field/opening_hours/missing': 267,
 'atp/field/operator/missing': 267,
 'atp/field/operator_wikidata/missing': 267,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 8,
 'atp/field/twitter/missing': 267,
 'atp/field/website/missing': 185,
 'atp/item_scraped_host_count/www.globus.de': 267,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 148,
 'atp/nsi/match_failed': 119,
```