### PR TITLE
[BP]: extend brand mapping

### DIFF
--- a/locations/spiders/bp.py
+++ b/locations/spiders/bp.py
@@ -22,10 +22,17 @@ class BpSpider(GeoMeSpider):
         "aral": {"brand": "Aral", "brand_wikidata": "Q565734"},
         "amoco": {"brand": "Amoco", "brand_wikidata": "Q465952"},
         "aral_pulse": {"brand": "Aral pulse", "operator": "Aral", "operator_wikidata": "Q565734"},
+        "esso": {"brand": "Esso", "brand_wikidata": "Q867662"},
+        "petro": {"brand": "Petro", "brand_wikidata": "Q64051305"},
+        "ta": {"brand": "TA", "brand_wikidata": "Q7835892"},
+        "ta_express": {"brand": "TA Express", "brand_wikidata": "Q7835892"},
+        "thorntons": {"brand": "Thorntons", "brand_wikidata": "Q7796584"},
     }
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
-        if brand := self.brands.get(location["site_brand"]):
+        if location.get("name", "").upper().startswith("ESSO"):
+            item.update(self.brands["esso"])
+        elif brand := self.brands.get(location["site_brand"]):
             item.update(brand)
         else:
             item.update(self.brands["bp"])


### PR DESCRIPTION
Also, the spider returns petrol stations with "Esso" in the name, but `site_brand` as BP. Street imagery suggests the brand should indeed be Esso.