### PR TITLE
[Skechers] Fix Spider

### DIFF
--- a/locations/spiders/skechers.py
+++ b/locations/spiders/skechers.py
@@ -20,4 +20,6 @@ class SkechersSpider(Where2GetItSpider):
     def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
         item["lat"] = location["latitude"]
         item["lon"] = location["longitude"]
+        if item["website"] == "/":
+            item.pop("website")
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Skechers': 6149,
 'atp/brand_wikidata/Q2945643': 6149,
 'atp/category/shop/shoes': 6149,
 'atp/cdn/cloudflare/response_count': 109,
 'atp/cdn/cloudflare/response_status_count/200': 109,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/name': 5,
 'atp/clean_strings/street_address': 30,
 'atp/country/AD': 2,
 'atp/country/AE': 40,
 'atp/country/AF': 3,
 'atp/country/AL': 1,
 'atp/country/AM': 3,
 'atp/country/AO': 2,
 'atp/country/AR': 1,
 'atp/country/AT': 7,
 'atp/country/AU': 171,
 'atp/country/AW': 1,
 'atp/country/AZ': 5,
 'atp/country/BA': 1,
 'atp/country/BB': 1,
 'atp/country/BD': 4,
 'atp/country/BE': 11,
 'atp/country/BG': 5,
 'atp/country/BH': 8,
 'atp/country/BN': 10,
 'atp/country/BO': 2,
 'atp/country/BR': 15,
 'atp/country/BT': 2,
 'atp/country/CA': 67,
 'atp/country/CI': 1,
 'atp/country/CL': 57,
 'atp/country/CN': 3199,
 'atp/country/CO': 46,
 'atp/country/CR': 7,
 'atp/country/CW': 1,
 'atp/country/CY': 3,
 'atp/country/CZ': 10,
 'atp/country/DE': 34,
 'atp/country/DK': 1,
 'atp/country/DO': 4,
 'atp/country/DZ': 15,
 'atp/country/EC': 15,
 'atp/country/EE': 6,
 'atp/country/EG': 17,
 'atp/country/ES': 27,
 'atp/country/FI': 1,
 'atp/country/FR': 27,
 'atp/country/GB': 102,
 'atp/country/GE': 2,
 'atp/country/GH': 3,
 'atp/country/GR': 12,
 'atp/country/GT': 25,
 'atp/country/GU': 1,
 'atp/country/HK': 51,
 'atp/country/HN': 8,
 'atp/country/HR': 14,
 'atp/country/HU': 13,
 'atp/country/ID': 182,
 'atp/country/IE': 1,
 'atp/country/IL': 26,
 'atp/country/IN': 32,
 'atp/country/IQ': 24,
 'atp/country/IS': 1,
 'atp/country/IT': 23,
 'atp/country/JO': 5,
 'atp/country/JP': 58,
 'atp/country/KE': 5,
 'atp/country/KG': 2,
 'atp/country/KH': 7,
 'atp/country/KR': 83,
 'atp/country/KW': 10,
 'atp/country/LB': 5,
 'atp/country/LK': 3,
 'atp/country/LT': 6,
 'atp/country/LV': 7,
 'atp/country/LY': 6,
 'atp/country/MA': 9,
 'atp/country/MM': 4,
 'atp/country/MN': 1,
 'atp/country/MO': 7,
 'atp/country/MT': 3,
 'atp/country/MU': 3,
 'atp/country/MX': 128,
 'atp/country/MY': 109,
 'atp/country/NG': 9,
 'atp/country/NL': 6,
 'atp/country/NP': 5,
 'atp/country/NZ': 37,
 'atp/country/OM': 6,
 'atp/country/PA': 6,
 'atp/country/PE': 33,
 'atp/country/PH': 5,
 'atp/country/PK': 20,
 'atp/country/PL': 5,
 'atp/country/PT': 1,
 'atp/country/PY': 5,
 'atp/country/QA': 13,
 'atp/country/SA': 92,
 'atp/country/SG': 38,
 'atp/country/SL': 1,
 'atp/country/SV': 11,
 'atp/country/TH': 67,
 'atp/country/TJ': 2,
 'atp/country/TM': 1,
 'atp/country/TR': 82,
 'atp/country/TW': 107,
 'atp/country/TZ': 2,
 'atp/country/UA': 25,
 'atp/country/UG': 1,
 'atp/country/US': 673,
 'atp/country/UY': 3,
 'atp/country/UZ': 7,
 'atp/country/VN': 50,
 'atp/country/ZA': 21,
 'atp/country/ZW': 1,
 'atp/field/branch/missing': 6149,
 'atp/field/city/missing': 72,
 'atp/field/email/missing': 5884,
 'atp/field/image/missing': 6149,
 'atp/field/opening_hours/missing': 6149,
 'atp/field/operator/missing': 6149,
 'atp/field/operator_wikidata/missing': 6149,
 'atp/field/phone/missing': 4851,
 'atp/field/postcode/missing': 3022,
 'atp/field/state/from_reverse_geocoding': 738,
 'atp/field/state/missing': 117,
 'atp/field/street_address/missing': 20,
 'atp/field/twitter/invalid': 5373,
 'atp/field/twitter/missing': 1,
 'atp/field/website/invalid': 1,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/hosted.where2getit.com': 6149,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 6149,
 'downloader/request_bytes': 64306,
 'downloader/request_count': 109,
 'downloader/request_method_count/POST': 109,
 'downloader/response_bytes': 2570032,
 'downloader/response_count': 109,
 'downloader/response_status_count/200': 109,
 'elapsed_time_seconds': 138.217133,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 21, 7, 5, 1, 502737, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 109,
 'httpcache/miss': 109,
 'httpcache/store': 109,
 'httpcompression/response_bytes': 55357213,
 'httpcompression/response_count': 109,
 'item_scraped_count': 6149,
 'items_per_minute': 2673.4782608695655,
 'log_count/DEBUG': 6259,
 'log_count/INFO': 5,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 109,
 'responses_per_minute': 47.39130434782609,
 'scheduler/dequeued': 109,
 'scheduler/dequeued/memory': 109,
 'scheduler/enqueued': 109,
 'scheduler/enqueued/memory': 109,
 'start_time': datetime.datetime(2026, 1, 21, 7, 2, 43, 285604, tzinfo=datetime.timezone.utc)}
```