### PR TITLE
[ATT US] Fix Spider

### DIFF
--- a/locations/spiders/att_us.py
+++ b/locations/spiders/att_us.py
@@ -1,32 +1,29 @@
 import re
 
-from locations.hours import DAYS_3_LETTERS_FROM_SUNDAY, OpeningHours
-from locations.pipelines.address_clean_up import clean_address
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.storefinders.where2getit import Where2GetItSpider
-from locations.structured_data_spider import clean_facebook
 
 
 class AttUSSpider(Where2GetItSpider):
     name = "att_us"
     item_attributes = {"brand": "AT&T", "brand_wikidata": "Q298594"}
     api_endpoint = "https://www.att.com/stores/rest/getlist"
-    api_key = "2F8B3130-66C5-11ED-9608-26F2C42605F6"
+    api_key = "A62B99DD-E92C-4936-B286-553804D8013F"
     api_filter_admin_level = 2
+    api_brand_name = "att"
 
     def parse_item(self, item, location):
         if not location.get("company_owned_stores"):
             return
         item["ref"] = location["clientkey"]
         item["name"] = re.sub(r" - \d+$", "", item["name"])
-        if location.get("address1") == "123 Main Street":
-            item.pop("street_address", None)
-        else:
-            item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
-        item["facebook"] = clean_facebook(location.get("facebook_url"))
-        if location.get("bho") and len(location.get("bho")) == 7:
-            item["opening_hours"] = OpeningHours()
-            for index, day in enumerate(DAYS_3_LETTERS_FROM_SUNDAY):
-                if location["bho"][index][0] == "9999" or location["bho"][index][1] == "9999":
-                    continue
-                item["opening_hours"].add_range(day, location["bho"][index][0], location["bho"][index][1], "%H%M")
+        item["lat"] = location["latitude"]
+        item["lon"] = location["longitude"]
+        oh = OpeningHours()
+        for day in DAYS_FULL:
+            open_time = location.get(f"{day.lower()}_open")
+            close_time = location.get(f"{day.lower()}_close")
+            if open_time:
+                oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        item["opening_hours"] = oh
         yield item


### PR DESCRIPTION
```python
{'atp/brand/AT&T': 1388,
 'atp/brand_wikidata/Q298594': 1388,
 'atp/category/shop/mobile_phone': 1388,
 'atp/cdn/cloudflare/response_count': 58,
 'atp/cdn/cloudflare/response_status_count/200': 58,
 'atp/country/US': 1388,
 'atp/field/branch/missing': 1388,
 'atp/field/email/missing': 1388,
 'atp/field/image/missing': 1388,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1388,
 'atp/field/operator_wikidata/missing': 1388,
 'atp/field/twitter/missing': 1388,
 'atp/item_scraped_host_count/www.att.com': 1388,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1388,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/twisted.internet.error.TimeoutError': 1,
 'downloader/request_bytes': 89379,
 'downloader/request_count': 59,
 'downloader/request_method_count/POST': 59,
 'downloader/response_bytes': 246973614,
 'downloader/response_count': 58,
 'downloader/response_status_count/200': 58,
 'elapsed_time_seconds': 97.154896,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 21, 12, 20, 42, 448608, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2014829497,
 'httpcompression/response_count': 58,
 'item_scraped_count': 1388,
 'items_per_minute': 858.5567010309278,
 'log_count/DEBUG': 1447,
 'log_count/INFO': 4,
 'log_count/WARNING': 21,
 'request_depth_max': 1,
 'response_received_count': 58,
 'responses_per_minute': 35.876288659793815,
 'retry/count': 1,
 'retry/reason_count/twisted.internet.error.TimeoutError': 1,
 'scheduler/dequeued': 59,
 'scheduler/dequeued/memory': 59,
 'scheduler/enqueued': 59,
 'scheduler/enqueued/memory': 59,
 'start_time': datetime.datetime(2026, 1, 21, 12, 19, 5, 293712, tzinfo=datetime.timezone.utc)}
```