### PR TITLE
[Batteries Plus Bulbs US] Fix Spider

### DIFF
--- a/locations/spiders/batteries_plus_bulbs_pr_us.py
+++ b/locations/spiders/batteries_plus_bulbs_pr_us.py
@@ -11,6 +11,7 @@ class BatteriesPlusBulbsPRUSSpider(Where2GetItSpider):
     item_attributes = {"brand": "Batteries Plus Bulbs", "brand_wikidata": "Q17005157"}
     api_key = "EC1E5D98-07CF-11EF-89F1-68CFC87EF9CB"
     api_filter = {"opening_status": {"ne": "permanently_closed"}}
+    api_brand_name = "batteriesplusbulbs"
 
     def parse_item(self, item, location):
         item["branch"] = item.pop("name")


### PR DESCRIPTION
```python
{'atp/brand/Batteries Plus Bulbs': 715,
 'atp/brand_wikidata/Q17005157': 715,
 'atp/category/shop/electronics': 715,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/country/PR': 1,
 'atp/country/US': 714,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 715,
 'atp/field/opening_hours/missing': 14,
 'atp/field/operator/missing': 715,
 'atp/field/operator_wikidata/missing': 715,
 'atp/field/phone/missing': 2,
 'atp/field/twitter/missing': 715,
 'atp/item_scraped_host_count/hosted.where2getit.com': 715,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 715,
 'downloader/request_bytes': 570,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 22093761,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 11.930614,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 22, 7, 16, 5, 895492, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 715,
 'items_per_minute': 3900.0000000000005,
 'log_count/DEBUG': 716,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 5.454545454545455,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 1, 22, 7, 15, 53, 964878, tzinfo=datetime.timezone.utc)}
```