### PR TITLE
[Chick Fil A] Fix spider

### DIFF
--- a/locations/spiders/chick_fil_a.py
+++ b/locations/spiders/chick_fil_a.py
@@ -8,6 +8,7 @@ from locations.storefinders.yext_search import YextSearchSpider
 class ChickFilASpider(YextSearchSpider):
     name = "chick_fil_a"
     item_attributes = {"brand": "Chick-fil-A", "brand_wikidata": "Q491516"}
+    host = "https://locator.chick-fil-a.com.yext-cdn.com"
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         self.crawler.stats.inc_value("z/c_conceptCode/{}".format(location["profile"].get("c_conceptCode")))


### PR DESCRIPTION
```python
{'atp/brand/Chick-fil-A': 3362,
 'atp/brand_wikidata/Q491516': 3362,
 'atp/category/amenity/fast_food': 3362,
 'atp/cdn/cloudflare/response_count': 69,
 'atp/cdn/cloudflare/response_status_count/200': 69,
 'atp/closed_poi': 1,
 'atp/country/CA': 28,
 'atp/country/PR': 8,
 'atp/country/US': 3326,
 'atp/field/branch/missing': 3,
 'atp/field/email/missing': 455,
 'atp/field/image/missing': 3362,
 'atp/field/opening_hours/invalid': 67,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 3362,
 'atp/field/operator_wikidata/missing': 3362,
 'atp/field/phone/missing': 110,
 'atp/field/twitter/missing': 3362,
 'atp/field/website/missing': 3,
 'atp/item_scraped_host_count/locator.chick-fil-a.com.yext-cdn.com': 3362,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3362,
 'downloader/request_bytes': 45975,
 'downloader/request_count': 69,
 'downloader/request_method_count/GET': 69,
 'downloader/response_bytes': 10224613,
 'downloader/response_count': 69,
 'downloader/response_status_count/200': 69,
 'elapsed_time_seconds': 89.505783,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 22, 8, 37, 6, 718177, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 117733954,
 'httpcompression/response_count': 69,
 'item_scraped_count': 3362,
 'items_per_minute': 2266.516853932584,
 'log_count/DEBUG': 3431,
 'log_count/INFO': 4,
 'request_depth_max': 68,
 'response_received_count': 69,
 'responses_per_minute': 46.51685393258427,
 'scheduler/dequeued': 69,
 'scheduler/dequeued/memory': 69,
 'scheduler/enqueued': 69,
 'scheduler/enqueued/memory': 69,
 'start_time': datetime.datetime(2026, 1, 22, 8, 35, 37, 212394, tzinfo=datetime.timezone.utc),
 'z/c_conceptCode/CFA': 2961,
 'z/c_conceptCode/DWH': 18,
 'z/c_conceptCode/LIC': 425,
 'z/c_conceptCode/None': 3,
 'z/c_locationFormat/Food Court': 653,
 'z/c_locationFormat/In-Line': 103,
 'z/c_locationFormat/None': 7,
 'z/c_locationFormat/Stand Alone': 2644}
```