### PR TITLE
[Best Western] Fix brand

### DIFF
--- a/locations/spiders/best_western.py
+++ b/locations/spiders/best_western.py
@@ -27,7 +27,7 @@ class BestWesternSpider(scrapy.spiders.SitemapSpider):
         "SSSC": ("SureStay Collection", "Q135246644"),
         "SSPL": ("SureStay Plus", "Q135246640"),
         "SSES": ("SureStay Studio", "Q135246687"),
-        "SUH": ("Sure Hotel", "Q135246620"),
+        "SUH": ("Sure Hotel", "Q135246628"),
         "SUPL": ("Sure Hotel", "Q135246628"),  # Sure Hotel Plus
         "SUSC": ("Sure Hotel Collection", "Q135246644"),
         "SUES": ("Sure Hotel Studio", "Q135246687"),


### PR DESCRIPTION
The wikidata Q135246620 isn't a Best Western brand and Sure Stay and Sure Hotel seem to both be the same wikidata so I've replace it with Q135246628