### PR TITLE
[Jumbo CH] Fix Spider

### DIFF
--- a/locations/spiders/jumbo_ch.py
+++ b/locations/spiders/jumbo_ch.py
@@ -5,9 +5,9 @@ from scrapy.spiders import SitemapSpider
 
 from locations.hours import DAYS_DE, OpeningHours
 from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
 class JumboCHSpider(SitemapSpider, StructuredDataSpider):
@@ -21,7 +21,7 @@ class JumboCHSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.jumbo.ch/sitemap.xml"]
     sitemap_follow = ["/sitemap/STORE-de-"]
     sitemap_rules = [(r"_POS$", "parse_sd")]
-    custom_settings =  DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
     is_playwright_spider = True
     requires_proxy = True
 


### PR DESCRIPTION
```python
{'atp/brand/Jumbo': 119,
 'atp/brand_wikidata/Q1713190': 119,
 'atp/category/shop/doityourself': 119,
 'atp/clean_strings/addr_full': 119,
 'atp/clean_strings/street_address': 6,
 'atp/country/CH': 119,
 'atp/field/branch/missing': 119,
 'atp/field/city/missing': 119,
 'atp/field/email/missing': 119,
 'atp/field/image/missing': 119,
 'atp/field/operator/missing': 119,
 'atp/field/operator_wikidata/missing': 119,
 'atp/field/postcode/missing': 119,
 'atp/field/state/missing': 119,
 'atp/field/twitter/missing': 119,
 'atp/item_scraped_host_count/www.jumbo.ch': 119,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 119,
 'downloader/request_bytes': 236891,
 'downloader/request_count': 156,
 'downloader/request_method_count/GET': 156,
 'downloader/response_bytes': 3868115,
 'downloader/response_count': 156,
 'downloader/response_status_count/200': 121,
 'downloader/response_status_count/302': 17,
 'downloader/response_status_count/404': 15,
 'downloader/response_status_count/410': 3,
 'dupefilter/filtered': 15,
 'elapsed_time_seconds': 188.618808,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 23, 11, 43, 46, 365361, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18080372,
 'httpcompression/response_count': 139,
 'httperror/response_ignored_count': 18,
 'httperror/response_ignored_status_count/404': 15,
 'httperror/response_ignored_status_count/410': 3,
 'item_scraped_count': 119,
 'items_per_minute': 37.97872340425532,
 'log_count/DEBUG': 277,
 'log_count/INFO': 24,
 'offsite/domains': 1,
 'offsite/filtered': 1,
 'request_depth_max': 2,
 'response_received_count': 139,
 'responses_per_minute': 44.361702127659576,
 'scheduler/dequeued': 156,
 'scheduler/dequeued/memory': 156,
 'scheduler/enqueued': 156,
 'scheduler/enqueued/memory': 156,
 'start_time': datetime.datetime(2026, 1, 23, 11, 40, 37, 746553, tzinfo=datetime.timezone.utc)}
```