### PR TITLE
[Sam's Club]: fix spider (600 stores, 531 fuel stations)

### DIFF
--- a/locations/spiders/sams_club.py
+++ b/locations/spiders/sams_club.py
@@ -11,6 +11,7 @@ class SamsClubSpider(Spider):
     start_urls = [
         "https://www.samsclub.com/api/node/vivaldi/browse/v2/clubfinder/list?singleLineAddr=USA&distance=50000&nbrOfStores=1000"
     ]
+    custom_settings = {"DOWNLOAD_HANDLERS": {"https": "scrapy.core.downloader.handlers.http.HTTPDownloadHandler"}}
 
     def parse(self, response):
         for store in response.json():


### PR DESCRIPTION
Circumvent the bot detection by directly using the API. I'm setting the HTTP Handlers as well, since using ZYTE also is blocked by the site.

Produce petrol stations and additional services in the process.