### PR TITLE
[Sonic Drivein] Fix spider

### DIFF
--- a/locations/spiders/sonic_drivein.py
+++ b/locations/spiders/sonic_drivein.py
@@ -12,6 +12,7 @@ from locations.pipelines.address_clean_up import merge_address_lines
 
 class SonicDriveinSpider(Spider):
     name = "sonic_drivein"
+    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
     item_attributes = {"brand": "Sonic", "brand_wikidata": "Q7561808"}
 
     def make_request(self, page: int, limit: int = 500) -> JsonRequest:


### PR DESCRIPTION
```python
{'atp/brand/Sonic': 3410,
 'atp/brand_wikidata/Q7561808': 3410,
 'atp/category/amenity/fast_food': 3410,
 'atp/cdn/cloudflare/response_count': 8,
 'atp/cdn/cloudflare/response_status_count/200': 7,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/phone': 10,
 'atp/closed_poi': 10,
 'atp/country/US': 3410,
 'atp/field/branch/missing': 3410,
 'atp/field/email/missing': 3410,
 'atp/field/image/missing': 3410,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 3410,
 'atp/field/operator_wikidata/missing': 3410,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 10,
 'atp/field/state/from_reverse_geocoding': 3410,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 3410,
 'atp/item_scraped_host_count/api-idp.sonicdrivein.com': 3410,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3410,
 'downloader/request_bytes': 4882,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 778958,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 7,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 37.503129,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 23, 12, 28, 34, 740239, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 21517338,
 'httpcompression/response_count': 8,
 'item_scraped_count': 3410,
 'items_per_minute': 5529.729729729729,
 'log_count/DEBUG': 3419,
 'log_count/INFO': 3,
 'request_depth_max': 6,
 'response_received_count': 8,
 'responses_per_minute': 12.972972972972972,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2026, 1, 23, 12, 27, 57, 237110, tzinfo=datetime.timezone.utc)}

```