### PR TITLE
Fix my_dentist_gb spider

### DIFF
--- a/locations/spiders/my_dentist_gb.py
+++ b/locations/spiders/my_dentist_gb.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from scrapy import FormRequest
-from scrapy.exceptions import CloseSpider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category


### PR DESCRIPTION
Currently the spider is unstable returning different numbers of branches on each run. There should be just over 500 branches, but typically only 120-200 are returned, so a lot are missing.

I think the cause is that when the condition on len(self.seen_refs) is met, it terminates the spider before it has had a chance to fetch all the queued relevant pages. (I see something like `'scheduler/enqueued': 725` but `'scheduler/dequeued': 429` in the output when it stops.)

This change safeguards the check against an additional branch appearing after the first check (which could result in len(self.seen_refs) > self.total_count without len(self.seen_refs) == self.total_count occurring in the check), and also removes the explicit CloseSpider() call. Instead, we just don't fetch any more pages of search results when enough refs have been found.

I've run it locally, and it has given me 510 results, which seems about right.