### PR TITLE
Remove some more unwanted Iceland stores

### DIFF
--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -35,11 +35,9 @@ class IcelandFoodsSpider(Spider):
 
             item["branch"] = item.pop("name")
             if (
-                "FWH" in item["branch"]
-                or "fwh" in item["branch"]
-                or "Food War" in item["branch"]
-                or "FOOD WAR" in item["branch"]
-                or "TEST2" in item["branch"]
+                "FWH" in item["branch"].upper()
+                or "FOOD WAR" in item["branch"].upper()
+                or "TEST2" in item["branch"].upper()
             ):
                 # The Food Warehouse, obtained via its own spider
                 # The name usually ends with FWH or has Food Warehouse, sometime truncated.


### PR DESCRIPTION
The current returns from the spider include some Food Warehouse stores with "fwh" in lowercase, and (truncated "FOOD WAREHOUSE" in uppercase. There's also one with "TEST2", which presumably isn't a real store. (The entry duplicates another with the same address.)