### PR TITLE
[Chipotle] Fix Spider

### DIFF
--- a/locations/spiders/chipotle.py
+++ b/locations/spiders/chipotle.py
@@ -1,110 +1,34 @@
 import re
-from typing import AsyncIterator
+from urllib.parse import unquote
 
-from scrapy import Spider
-from scrapy.http import Request
+from requests import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
-from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ChipotleSpider(Spider):
+class ChipotleSpider(CrawlSpider, StructuredDataSpider):
     name = "chipotle"
     item_attributes = {"brand": "Chipotle", "brand_wikidata": "Q465751"}
-    allowed_domains = ["chipotle.com", "chipotle.ca", "chipotle.co.uk"]
 
-    async def start(self) -> AsyncIterator[Request]:
-        urls = [
-            "https://locations.chipotle.com/",
-            "https://locations.chipotle.ca/",
-            "https://locations.chipotle.co.uk/london",
-        ]
+    start_urls = [
+        "https://locations.chipotle.com/",
+        "https://locations.chipotle.ca/",
+        "https://locations.chipotle.co.uk/",
+        "https://locations.chipotle.fr/",
+        "https://locations.chipotle.de/",
+    ]
+    rules = [
+        Rule(LinkExtractor(restrict_xpaths="//*[@class='mb-4']")),
+        Rule(LinkExtractor(allow=r"\w+/[a-z0-9-]+$", restrict_xpaths="//*[@class='mb-4']")),
+        Rule(LinkExtractor(allow=r"../[^/]+/[^/]+/[a-z-0-9]+"), callback="parse_sd"),
+    ]
 
-        for url in urls:
-            if url == "https://locations.chipotle.co.uk/london":
-                yield Request(
-                    url=url,
-                    callback=self.parse_same_city,
-                    meta={"url": "https://locations.chipotle.co.uk/"},
-                )
-            else:
-                yield Request(url=url, callback=self.parse_state, meta={"url": url})
-
-    def parse_state(self, response):
-        states = response.xpath('//*[@class="Directory-listLink"]/@href').extract()
-        count = response.xpath('//*[@class="Directory-listLink"]/@data-count').extract()
-
-        base_url = response.meta.get("url")
-
-        for c, state in zip(count, states):
-            url = base_url + state
-            if c == "(1)":
-                yield Request(url=url, callback=self.parse_store)
-            elif state == "dc/washington" or state == "nd/fargo":
-                yield Request(url=url, callback=self.parse_same_city, meta={"url": base_url})
-            else:
-                yield Request(url=url, callback=self.parse_city, meta={"url": base_url})
-
-    def parse_city(self, response):
-        city_count = response.xpath('//*[@class="Directory-listLink"]/@data-count').extract()
-        cities = response.xpath('//*[@class="Directory-listLink"]/@href').extract()
-
-        base_url = response.meta.get("url")
-
-        for count, city in zip(city_count, cities):
-            url = base_url + city
-            if count == "(1)":
-                yield Request(url=url, callback=self.parse_store)
-            else:
-                yield Request(url=url, callback=self.parse_same_city, meta={"url": base_url})
-
-    def parse_same_city(self, response):
-        stores = response.xpath('//*[@class="Teaser-titleLink"]/@href').extract()
-        base_url = response.meta.get("url")
-
-        for store in stores:
-            if "london" in store:
-                pass
-            else:
-                store = store[2:]
-            url = base_url + store
-
-            yield Request(url=url, callback=self.parse_store)
-
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        hours = list(dict.fromkeys(hours))
-
-        for hour in hours:
-            hour = hour.split(" ")
-            day = hour[0]
-            open_time, close_time = hour[1].split("-")
-
-            opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M")
-
-        return opening_hours.as_opening_hours()
-
-    def parse_store(self, response):
-        properties = {
-            "ref": "_".join(re.search(r".+/(.+?)/(.+?)/(.+?)/?(?:\.html|$)", response.url).groups()),
-            "name": response.xpath('//*[@itemprop="name"]/text()').extract_first().strip(),
-            "street_address": response.xpath('//*[@class="c-address-street-1"]/text()').extract_first(),
-            "city": response.xpath('//*[@class="c-address-city"]/text()').extract_first(),
-            "state": response.xpath('//*[@itemprop="addressRegion"]/text()').extract_first(),
-            "postcode": response.xpath('//*[@itemprop="postalCode"]/text()').extract_first(),
-            "country": response.xpath('//*[@itemprop="addressCountry"]/text()').extract_first(),
-            "lat": response.xpath('//*[@itemprop="latitude"]/@content').extract_first(),
-            "lon": response.xpath('//*[@itemprop="longitude"]/@content').extract_first(),
-            "phone": response.xpath('//*[@itemprop="telephone"]/text()').extract_first(),
-            "website": response.url,
-        }
-
-        try:
-            hours = self.parse_hours(response.xpath('//*[@itemprop="openingHours"]/@content').extract())
-
-            if hours:
-                properties["opening_hours"] = hours
-        except:
-            pass
-
-        yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["lat"], item["lon"] = re.search(
+            r"latitude\":(-?\d+\.\d+),\"longitude\":(-?\d+\.\d+)",
+            unquote(response.xpath('//*[contains(text(),"latitude")]/text()').get()),
+        ).groups()
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Chipotle': 4053,
 'atp/brand_wikidata/Q465751': 4053,
 'atp/category/amenity/fast_food': 4053,
 'atp/cdn/cloudflare/response_count': 6374,
 'atp/cdn/cloudflare/response_status_count/200': 6374,
 'atp/closed_check': 19,
 'atp/country/CA': 74,
 'atp/country/DE': 2,
 'atp/country/FR': 6,
 'atp/country/GB': 20,
 'atp/country/US': 3951,
 'atp/field/branch/missing': 4053,
 'atp/field/email/missing': 4053,
 'atp/field/opening_hours/missing': 13,
 'atp/field/operator/missing': 4053,
 'atp/field/operator_wikidata/missing': 4053,
 'atp/field/phone/missing': 11,
 'atp/field/state/missing': 13,
 'atp/field/twitter/missing': 82,
 'atp/item_scraped_host_count/locations.chipotle.ca': 74,
 'atp/item_scraped_host_count/locations.chipotle.co.uk': 20,
 'atp/item_scraped_host_count/locations.chipotle.com': 3951,
 'atp/item_scraped_host_count/locations.chipotle.de': 2,
 'atp/item_scraped_host_count/locations.chipotle.fr': 6,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 4053,
 'downloader/request_bytes': 4040011,
 'downloader/request_count': 6386,
 'downloader/request_method_count/GET': 6386,
 'downloader/response_bytes': 81034046,
 'downloader/response_count': 6386,
 'downloader/response_status_count/200': 6376,
 'downloader/response_status_count/301': 4,
 'downloader/response_status_count/302': 2,
 'downloader/response_status_count/404': 4,
 'dupefilter/filtered': 35,
 'elapsed_time_seconds': 7132.877029,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 27, 9, 26, 12, 120064, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 5879,
 'httpcache/hit': 507,
 'httpcache/miss': 5879,
 'httpcache/store': 5879,
 'httpcompression/response_bytes': 392375806,
 'httpcompression/response_count': 6380,
 'item_scraped_count': 4053,
 'items_per_minute': 34.097027481772294,
 'log_count/DEBUG': 10638,
 'log_count/INFO': 127,
 'log_count/WARNING': 19,
 'request_depth_max': 3,
 'response_received_count': 6380,
 'responses_per_minute': 53.67358384744812,
 'robotstxt/request_count': 9,
 'robotstxt/response_count': 9,
 'robotstxt/response_status_count/200': 5,
 'robotstxt/response_status_count/404': 4,
 'scheduler/dequeued': 6375,
 'scheduler/dequeued/memory': 6375,
 'scheduler/enqueued': 6375,
 'scheduler/enqueued/memory': 6375,
 'start_time': datetime.datetime(2026, 1, 27, 7, 27, 19, 243035, tzinfo=datetime.timezone.utc)}
```