### PR TITLE
[Bed Bath N Table] Fix Spider

### DIFF
--- a/locations/storefinders/amasty_store_locator.py
+++ b/locations/storefinders/amasty_store_locator.py
@@ -48,12 +48,13 @@ class AmastyStoreLocatorSpider(Spider):
         pagination_attribute = ""
         if self.pagination_mode:
             pagination_attribute = "?p=1"
-        if len(self.start_urls) == 0 and len(self.allowed_domains) == 1:
-            yield Request(
-                url=f"https://{self.allowed_domains[0]}/amlocator/index/ajax/{pagination_attribute}",
-                headers=headers,
-                method="POST",
-            )
+        if len(self.start_urls) == 0 and len(self.allowed_domains) >= 1:
+            for domain in self.allowed_domains:
+                yield Request(
+                    url=f"https://{domain}/amlocator/index/ajax/{pagination_attribute}",
+                    headers=headers,
+                    method="POST",
+                )
         elif len(self.start_urls) == 1:
             yield Request(url=urljoin(self.start_urls[0], pagination_attribute), headers=headers, method="POST")
         else:


### PR DESCRIPTION
**_Fixes : updated start_request condition of amasty_store_locator to fix spider_**

```python
{"atp/brand/Bed Bath N' Table": 184,
 'atp/brand_wikidata/Q118551276': 184,
 'atp/category/shop/houseware': 184,
 'atp/clean_strings/name': 11,
 'atp/country/AU': 170,
 'atp/country/NZ': 14,
 'atp/field/branch/missing': 184,
 'atp/field/city/missing': 184,
 'atp/field/country/from_website_url': 184,
 'atp/field/email/missing': 184,
 'atp/field/image/missing': 184,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 184,
 'atp/field/operator_wikidata/missing': 184,
 'atp/field/postcode/missing': 184,
 'atp/field/state/missing': 184,
 'atp/field/twitter/missing': 184,
 'atp/item_scraped_host_count/www.bedbathntable.co.nz': 14,
 'atp/item_scraped_host_count/www.bedbathntable.com.au': 170,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 184,
 'downloader/exception_count': 9,
 'downloader/exception_type_count/twisted.web._newclient.ResponseNeverReceived': 9,
 'downloader/request_bytes': 5592,
 'downloader/request_count': 15,
 'downloader/request_method_count/GET': 10,
 'downloader/request_method_count/POST': 5,
 'downloader/response_bytes': 1144467,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 10.59041,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 28, 6, 42, 13, 599879, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2094998,
 'httpcompression/response_count': 4,
 'item_scraped_count': 184,
 'items_per_minute': 1104.0,
 'log_count/DEBUG': 197,
 'log_count/ERROR': 6,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 6,
 'responses_per_minute': 36.0,
 'retry/count': 6,
 'retry/max_reached': 3,
 'retry/reason_count/twisted.web._newclient.ResponseNeverReceived': 6,
 "robotstxt/exception_count/<class 'twisted.web._newclient.ResponseNeverReceived'>": 1,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2026, 1, 28, 6, 42, 3, 9469, tzinfo=datetime.timezone.utc)}
```