### PR TITLE
[Apcoa] Fix Spider

### DIFF
--- a/locations/spiders/apcoa.py
+++ b/locations/spiders/apcoa.py
@@ -1,12 +1,12 @@
+from scrapy.http import TextResponse
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
 
 
-class ApcoaSpider(CrawlSpider, StructuredDataSpider):
+class ApcoaSpider(CrawlSpider):
     name = "apcoa"
     item_attributes = {"operator": "APCOA Parking", "operator_wikidata": "Q296108"}
     allowed_domains = [
@@ -23,43 +23,58 @@ class ApcoaSpider(CrawlSpider, StructuredDataSpider):
         "www.apcoa.ch",
     ]
     start_urls = [
-        "https://www.apcoa.at/standorte/staedte/alle-staedte/",  # Austria
-        "https://www.apcoa.dk/alle-lokationer/",  # Denmark
-        "https://www.apcoa.de/standorte/alle-standorte/",  # Germany
-        "https://www.apcoa.ie/locations/all-locations/",  # Ireland
-        "https://www.apcoa.it/parcheggi/",  # Italy
-        "https://www.apcoa.nl/alle-locaties/",  # Netherlands
+        "https://www.apcoa.at/kurzparken/staedte-a-z",  # Austria
+        "https://www.apcoa.dk/find-en-p-plads/find-en-parkeringsplads/find-en-p-plads",  # Denmark
+        "https://www.apcoa.de/einmal-parken/parkplatzsuche",  # Germany
+        "https://www.apcoa.ie/location-overview/location-overview/search-for-parking",  # Ireland
+        "https://www.apcoa.it/sosta-breve/trovare-un-parcheggio/trova-un-parcheggio",  # Italy
+        "https://www.apcoa.nl/kort-parkeren/parkeerplaats-vinden/parkeerplaats-zoeken",  # Netherlands
         "https://www.apcoa.no/finnparkering/parkering/",  # Norway
-        "https://www.apcoa.se/alla-staeder/",  # Sweden
-        "https://www.apcoa.co.uk/parking-locations/all-locations/",  # UK
-        "https://www.apcoa.pl/en/parking-locations/all-locations/",  # Poland
-        "https://www.apcoa.ch/en/parking-locations/cities/all-cities/",  # Switzerland
+        "https://www.apcoa.se/hitta-parkering/hitta-en-parkeringsplats/hitta-din-parkeringsplats",  # Sweden
+        "https://www.apcoa.co.uk/find-parking/find-parking/search-for-parking-spaces",  # UK
+        "https://www.apcoa.pl/en/short-term-parking/find-a-car-park/looking-for-a-parking-space",  # Poland
+        "https://www.apcoa.ch/en/short-stay-parking/find-a-car-park/car-park-search",  # Switzerland
     ]
     rules = [
         Rule(
             LinkExtractor(
                 allow=[
-                    ".*/parken/.*",  # Austria, Germany
-                    ".*/parkings-per-stad/.*",  # Belgium
-                    ".*/all-locations-by-city/.*",  # Denmark
-                    ".*/parking/.*",  # Ireland
-                    ".*/parcheggi-in/.*",  # Italy
-                    ".*/parkeerplaats/.*",  # Netherlands
-                    ".*/finn-parkering/.*",  # Norway
-                    ".*/parkering-i/.*",  # Sweden
-                    ".*/parking-in/.*",  # UK
+                    r"/kurzparken|einmal-parken/standorte/[a-z-]+$",  # Austria, Germany
+                    r"/find-en-p-plads/lokationer/[a-z-]+$",  # Denmark
+                    r"/location-overview/location/[a-z-]+$",  # Ireland
+                    r"/sosta-breve/sedi/[a-z-]+$",  # Italy
+                    r"/kort-parkeren/locaties/[a-z-]+$",  # Netherland
+                    "/finn-parkering/lokasjoner/[a-z-]+$",  # Norway
+                    "/hitta-parkering/parkering/[a-z-]+$",  # Sweden
+                    "/find-parking/locations/[a-z-]+$",  # UK
+                    "/en/short-term-parking|short-stay-parking/locations/[a-z-]+$",  # Poland, Switzerland
+                ]
+            )
+        ),
+        Rule(
+            LinkExtractor(
+                allow=[
+                    r"/kurzparken|einmal-parken/standorte/[a-z-]+/[a-z-0-9]+$",  # Austria, Germany
+                    r"/find-en-p-plads/lokationer/[a-z-]+/[a-z-0-9]+$",  # Denmark
+                    r"/location-overview/location/[a-z-]+/[a-z-0-9]+$",  # Ireland
+                    r"/kort-parkeren/locaties/[a-z-]+/[a-z-0-9]+$",  # Netherland
+                    r"/sosta-breve/sedi/[a-z-]+/[a-z-0-9]+$",  # Italy
+                    r"/finn-parkering/lokasjoner/[a-z-]+/[a-z-0-9]+$",  # Norway
+                    r"/hitta-parkering/parkering/[a-z-]+/[a-z-0-9]+$",  # Sweden
+                    r"/find-parking/locations/[a-z-]+/[a-z-0-9]+$",  # UK
+                    r"/en/short-term-parking|short-stay-parking/locations/[a-z-]+/[a-z-0-9]+$",
                 ]
             ),
-            callback="parse_sd",
-            follow=True,
-        )
+            callback="parse",
+        ),
     ]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = response.url
-        item["image"] = None
+    def parse(self, response: TextResponse, **kwargs):
+        item = Feature()
+        item["branch"] = (
+            response.xpath('//*[@class="text-h3 inline"]').xpath("normalize-space()").get().replace("| APCOA", "")
+        )
+        item["addr_full"] = response.xpath('//*[@class="main"]//span[2]/text()').get()
+        item["ref"] = item["website"] = response.url
         extract_google_position(item, response)
-
-        apply_category(Categories.PARKING, item)
-
         yield item


### PR DESCRIPTION
```python
{'atp/category/amenity/parking': 4945,
'atp/clean_strings/branch': 165,
'atp/country/AT': 172,
'atp/country/CH': 14,
'atp/country/DE': 272,
'atp/country/DK': 493,
'atp/country/GB': 1156,
'atp/country/IE': 236,
'atp/country/IT': 124,
'atp/country/NL': 42,
'atp/country/NO': 1127,
'atp/country/SE': 1309,
'atp/field/brand/missing': 4945,
'atp/field/brand_wikidata/missing': 4945,
'atp/field/city/missing': 4945,
'atp/field/country/from_website_url': 4945,
'atp/field/email/missing': 4945,
'atp/field/image/missing': 4945,
'atp/field/name/missing': 4945,
'atp/field/opening_hours/missing': 4945,
'atp/field/phone/missing': 4945,
'atp/field/postcode/missing': 3763,
'atp/field/state/missing': 4945,
'atp/field/street_address/missing': 4945,
'atp/field/twitter/missing': 4945,
'atp/item_scraped_host_count/www.apcoa.at': 172,
'atp/item_scraped_host_count/www.apcoa.ch': 14,
'atp/item_scraped_host_count/www.apcoa.co.uk': 1156,
'atp/item_scraped_host_count/www.apcoa.de': 272,
'atp/item_scraped_host_count/www.apcoa.dk': 493,
'atp/item_scraped_host_count/www.apcoa.ie': 236,
'atp/item_scraped_host_count/www.apcoa.it': 124,
'atp/item_scraped_host_count/www.apcoa.nl': 42,
'atp/item_scraped_host_count/www.apcoa.no': 1127,
'atp/item_scraped_host_count/www.apcoa.se': 1309,
'atp/lineage': 'S_?',
'atp/nsi/cc_match': 4945,
'atp/operator/APCOA Parking': 4945,
'atp/operator_wikidata/Q296108': 4945,
'downloader/exception_count': 8,
'downloader/exception_type_count/twisted.internet.error.TimeoutError': 8,
'downloader/request_bytes': 3755124,
'downloader/request_count': 6573,
'downloader/request_method_count/GET': 6573,
'downloader/response_bytes': 317847164,
'downloader/response_count': 6565,
'downloader/response_status_count/200': 6412,
'downloader/response_status_count/307': 1,
'downloader/response_status_count/404': 11,
'downloader/response_status_count/500': 141,
'dupefilter/filtered': 3735,
'elapsed_time_seconds': 2475.456823,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2026, 1, 29, 7, 25, 17, 888631, tzinfo=datetime.timezone.utc),
'httpcache/firsthand': 4775,
'httpcache/hit': 1790,
'httpcache/miss': 4783,
'httpcache/store': 4775,
'httpcompression/response_bytes': 2343029036,
'httpcompression/response_count': 6412,
'item_scraped_count': 4945,
'items_per_minute': 119.87878787878788,
'log_count/DEBUG': 16002,
'log_count/ERROR': 49,
'log_count/INFO': 186,
'request_depth_max': 6,
'response_received_count': 6470,
'responses_per_minute': 156.84848484848484,
'retry/count': 101,
'retry/max_reached': 48,
'retry/reason_count/500 Internal Server Error': 94,
'retry/reason_count/twisted.internet.error.TimeoutError': 7,
'robotstxt/request_count': 11,
'robotstxt/response_count': 11,
'robotstxt/response_status_count/404': 11,
'scheduler/dequeued': 6562,
'scheduler/dequeued/memory': 6562,
'scheduler/enqueued': 6562,
'scheduler/enqueued/memory': 6562,
'start_time': datetime.datetime(2026, 1, 29, 6, 44, 2, 431808, tzinfo=datetime.timezone.utc)}
```