### PR TITLE
[Ben And Jerry] Fix Spider

### DIFF
--- a/locations/spiders/ben_and_jerrys.py
+++ b/locations/spiders/ben_and_jerrys.py
@@ -15,13 +15,14 @@ class BenAndJerrysSpider(Where2GetItSpider):
     custom_settings = {"DOWNLOAD_TIMEOUT": 60}
 
     def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        # Appears to be an indicator for suppliers (not actual shops), even after api_filter above
-        if location.get("jsonshopinfo") is None:  # May be equivalent to "jsonshop"
-            return
         item["lat"] = location["latitude"]
         item["lon"] = location["longitude"]
-
         item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
+        if website := item.get("website"):
+            if "facebook" in website:
+                item.pop("website")
+            elif "kojote" in website:
+                item["website"] = "https://www." + item["website"]
         apply_category(Categories.ICE_CREAM, item)
 
         apply_yes_no(Extras.DELIVERY, item, location["offersdelivery"] == "1")


### PR DESCRIPTION
```python
{"atp/brand/Ben & Jerry's": 2503,
 'atp/brand_wikidata/Q816412': 2503,
 'atp/category/missing': 2503,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/street_address': 10,
 'atp/country/AN': 1,
 'atp/country/AU': 23,
 'atp/country/AW': 3,
 'atp/country/BS': 1,
 'atp/country/CA': 3,
 'atp/country/DE': 4,
 'atp/country/DK': 18,
 'atp/country/ES': 22,
 'atp/country/FR': 18,
 'atp/country/GB': 14,
 'atp/country/IE': 2,
 'atp/country/MT': 2,
 'atp/country/MX': 3,
 'atp/country/NL': 13,
 'atp/country/NO': 2,
 'atp/country/NZ': 6,
 'atp/country/PT': 2153,
 'atp/country/SE': 12,
 'atp/country/SG': 1,
 'atp/country/US': 202,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 2503,
 'atp/field/geometry/missing': 2503,
 'atp/field/image/missing': 2503,
 'atp/field/name/missing': 2503,
 'atp/field/opening_hours/missing': 2276,
 'atp/field/operator/missing': 2503,
 'atp/field/operator_wikidata/missing': 2503,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 2280,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 2222,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2503,
 'atp/field/website/invalid': 7,
 'atp/field/website/missing': 2257,
 'atp/item_scraped_host_count/hosted.where2getit.com': 2503,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 2503,
 'downloader/request_bytes': 884,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 4125709,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 20.796349,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 29, 8, 12, 10, 878427, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 35861331,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2503,
 'items_per_minute': 7509.0,
 'log_count/DEBUG': 2546,
 'log_count/INFO': 3,
 'log_count/WARNING': 8,
 'response_received_count': 2,
 'responses_per_minute': 6.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 1, 29, 8, 11, 50, 82078, tzinfo=datetime.timezone.utc)}
```