### PR TITLE
[Bouygues Telecom FR] Fix Spider

### DIFF
--- a/locations/spiders/bouygues_telecom_fr.py
+++ b/locations/spiders/bouygues_telecom_fr.py
@@ -1,23 +1,19 @@
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class BouyguesTelecomFRSpider(CrawlSpider, StructuredDataSpider):
+class BouyguesTelecomFRSpider(SitemapSpider, StructuredDataSpider):
     name = "bouygues_telecom_fr"
     item_attributes = {"brand": "Bouygues Telecom", "brand_wikidata": "Q581438"}
-    start_urls = ["https://boutiques.bouyguestelecom.fr/"]
-    rules = [
-        Rule(LinkExtractor(restrict_xpaths='//*[@id="module-all-cities"]')),
-        Rule(LinkExtractor(tags=["section"], attrs=["data-route-load-stores"])),
-        Rule(LinkExtractor(restrict_xpaths='//*[@data-tracking="storeLink"]'), callback="parse_sd"),
-    ]
+    sitemap_urls = ["https://boutiques.bouyguestelecom.fr/sitemap.xml"]
+    sitemap_rules = [("/shop/", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["branch"] = item.pop("name").removeprefix("BOUYGUES TELECOM ")
+        item["name"] = self.item_attributes["brand"]
         apply_category(Categories.SHOP_MOBILE_PHONE, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Bouygues Telecom': 501,
 'atp/brand_wikidata/Q581438': 501,
 'atp/category/shop/mobile_phone': 501,
 'atp/country/FR': 501,
 'atp/field/email/missing': 501,
 'atp/field/image/missing': 13,
 'atp/field/operator/missing': 501,
 'atp/field/operator_wikidata/missing': 501,
 'atp/field/state/missing': 501,
 'atp/field/twitter/missing': 501,
 'atp/item_scraped_host_count/boutiques.bouyguestelecom.fr': 501,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 501,
 'downloader/request_bytes': 267066,
 'downloader/request_count': 503,
 'downloader/request_method_count/GET': 503,
 'downloader/response_bytes': 19138749,
 'downloader/response_count': 503,
 'downloader/response_status_count/200': 503,
 'elapsed_time_seconds': 614.431339,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 30, 7, 3, 21, 832719, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 131279635,
 'httpcompression/response_count': 501,
 'item_scraped_count': 501,
 'items_per_minute': 48.95765472312704,
 'log_count/DEBUG': 1004,
 'log_count/INFO': 67,
 'request_depth_max': 1,
 'response_received_count': 503,
 'responses_per_minute': 49.15309446254072,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 502,
 'scheduler/dequeued/memory': 502,
 'scheduler/enqueued': 502,
 'scheduler/enqueued/memory': 502,
 'start_time': datetime.datetime(2026, 1, 30, 6, 53, 7, 401380, tzinfo=datetime.timezone.utc)}
```