### PR TITLE
[Aldi Sud US] Fix Spider

### DIFF
--- a/locations/spiders/aldi_sud_us.py
+++ b/locations/spiders/aldi_sud_us.py
@@ -8,7 +8,7 @@ class AldiSudUSSpider(UberallSpider):
     key = "LETA2YVm6txbe0b9lS297XdxDX4qVQ"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["name"] = None
+        item["name"] = item["phone"] = None
 
         apply_category(Categories.SHOP_SUPERMARKET, item)
 


### PR DESCRIPTION
```python
{'atp/brand/Aldi': 2642,
 'atp/brand_wikidata/Q41171672': 2642,
 'atp/category/shop/supermarket': 2642,
 'atp/country/US': 2642,
 'atp/field/branch/missing': 2642,
 'atp/field/email/missing': 2642,
 'atp/field/image/missing': 2642,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 2642,
 'atp/field/operator_wikidata/missing': 2642,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 2642,
 'atp/field/website/missing': 2642,
 'atp/item_scraped_host_count/uberall.com': 2642,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 2642,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 220979,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 14.82386,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 1, 30, 11, 32, 30, 223703, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2299595,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2642,
 'items_per_minute': 11322.857142857143,
 'log_count/DEBUG': 2644,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 8.571428571428571,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 1, 30, 11, 32, 15, 399843, tzinfo=datetime.timezone.utc)}
```