### PR TITLE
[Columbia US] Switch to YextAnswersSpider

### DIFF
--- a/locations/spiders/columbia_us.py
+++ b/locations/spiders/columbia_us.py
@@ -1,12 +1,15 @@
-from locations.storefinders.locally import LocallySpider
+from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class ColumbiaUSSpider(LocallySpider):
+class ColumbiaUSSpider(YextAnswersSpider):
     name = "columbia_us"
     item_attributes = {"brand": "Columbia", "brand_wikidata": "Q1112588"}
-    allowed_domains = ["www.columbia.com"]
-    start_urls = [
-        "https://columbia.locally.com/stores/conversion_data?has_data=true&company_id=67&store_mode=&style=&color=&upc=&category=Brand&inline=1&show_links_in_list=&parent_domain=&map_ne_lat=48.60220231134477&map_ne_lng=-92.18225182145208&map_sw_lat=20.342279879097987&map_sw_lng=-135.99572838395235&map_center_lat=34.47224109522138&map_center_lng=-114.08899010270221&map_distance_diag=3000&sort_by=proximity&no_variants=0&only_retailer_id=&dealers_company_id=67&only_store_id=false&uses_alt_coords=false&q=false&zoom_level=4&lang=en-us&currency=USD",
-        "https://columbia.locally.com/stores/conversion_data?has_data=true&company_id=67&store_mode=&style=&color=&upc=&category=Factory&inline=1&show_links_in_list=&parent_domain=&map_ne_lat=48.60220231134477&map_ne_lng=-92.18225182145208&map_sw_lat=20.342279879097987&map_sw_lng=-135.99572838395235&map_center_lat=34.47224109522138&map_center_lng=-114.08899010270221&map_distance_diag=3000&sort_by=proximity&no_variants=0&only_retailer_id=&dealers_company_id=67&only_store_id=false&uses_alt_coords=false&q=false&zoom_level=4&lang=en-us&currency=USD",
-        "https://columbia.locally.com/stores/conversion_data?has_data=true&company_id=67&store_mode=&style=&color=&upc=&category=clearancestore&inline=1&show_links_in_list=&parent_domain=&map_ne_lat=48.60220231134477&map_ne_lng=-92.18225182145208&map_sw_lat=20.342279879097987&map_sw_lng=-135.99572838395235&map_center_lat=34.47224109522138&map_center_lng=-114.08899010270221&map_distance_diag=3000&sort_by=proximity&no_variants=0&only_retailer_id=&dealers_company_id=67&only_store_id=false&uses_alt_coords=false&q=false&zoom_level=4&lang=en-us&currency=USD",
-    ]
+    api_key = "3e0457d17939280a4ed5eef2e99daf8b"
+    experience_key = "pages-locator"
+    facet_filters = {
+        "$or": [
+            {"c_storeType": {"$eq": "Brand Store"}},
+            {"c_storeType": {"$eq": "Factory Store"}},
+            {"c_storeType": {"$eq": "Clearance Store"}},
+        ]
+    }


### PR DESCRIPTION
Storefinder at https://www.columbia.com/stores now uses YextAnswersSpider. More locations returned than the previous LocallySpider version of this storefinder.