### PR TITLE
[Audi][Skoda] Add VN for Skoda and ignore test data for Audi

### DIFF
--- a/locations/spiders/skoda.py
+++ b/locations/spiders/skoda.py
@@ -35,6 +35,7 @@ class SkodaSpider(Spider):
         308: ("fr-ma", "MA"),
         318: ("en-dz", "DZ"),
         334: ("fr-TN", "TN"),
+        352: ("vi-VN", "VN"),
         411: ("lv-LV", "LV"),
         423: ("tr-tr", "TR"),
         428: ("en-sa", "SA"),


### PR DESCRIPTION
Test data comes mostly from A-ATA market, but there are some cases in other countries with fields containing default values such as Test, test.com, etc.