### PR TITLE
[Hilton] Fix spider

### DIFF
--- a/locations/spiders/hilton.py
+++ b/locations/spiders/hilton.py
@@ -167,7 +167,7 @@ class HiltonSpider(Spider):
 
     def get_hotels(self, quadrant_id):
         # TODO: we should use JsonRequest here, but it doesn't work with this endpoint for some reason!
-        url = "https://www.hilton.com/graphql/customer?appName=dx_shop_search_app&operationName=hotelSummaryOptions&originalOpName=hotelSummaryOptions&bl=en"
+        url = "https://www.hilton.com/graphql/customer?appName=dx_shop_search_app&operationName=hotelSummaryOptions_geocodePage&originalOpName=hotelSummaryOptions_geocodePage&bl=en"
         data = {
             "operationName": "hotelSummaryOptions",
             "query": """


### PR DESCRIPTION
```python
{'atp/brand/AutoCamp': 8,
 'atp/brand/Canopy': 51,
 'atp/brand/Conrad': 54,
 'atp/brand/Curio Collection': 215,
 'atp/brand/DoubleTree': 738,
 'atp/brand/Embassy Suites': 270,
 'atp/brand/Graduate': 35,
 'atp/brand/Hampton': 3249,
 'atp/brand/Hilton': 637,
 'atp/brand/Hilton Garden Inn': 1190,
 'atp/brand/Hilton Grand Vacations': 96,
 'atp/brand/Home2 Suites': 919,
 'atp/brand/Homewood Suites': 564,
 'atp/brand/LXR': 19,
 'atp/brand/Motto': 12,
 'atp/brand/NoMad': 1,
 'atp/brand/Signia': 6,
 'atp/brand/Small Luxury Hotels of the World': 507,
 'atp/brand/Spark by Hilton': 269,
 'atp/brand/Tapestry Collection': 214,
 'atp/brand/Tempo': 10,
 'atp/brand/Tru': 357,
 'atp/brand/Waldorf Astoria': 43,
 'atp/brand_wikidata/Q109275422': 214,
 'atp/brand_wikidata/Q112144335': 6,
 'atp/brand_wikidata/Q112144350': 12,
 'atp/brand_wikidata/Q112144357': 10,
 'atp/brand_wikidata/Q1162859': 1190,
 'atp/brand_wikidata/Q13636126': 96,
 'atp/brand_wikidata/Q19903229': 215,
 'atp/brand_wikidata/Q24907770': 357,
 'atp/brand_wikidata/Q2504643': 738,
 'atp/brand_wikidata/Q30632909': 51,
 'atp/brand_wikidata/Q3239392': 43,
 'atp/brand_wikidata/Q5369524': 270,
 'atp/brand_wikidata/Q5646230': 3249,
 'atp/brand_wikidata/Q5887912': 919,
 'atp/brand_wikidata/Q5890701': 564,
 'atp/brand_wikidata/Q598884': 637,
 'atp/brand_wikidata/Q64605184': 19,
 'atp/brand_wikidata/Q855525': 54,
 'atp/brand_wikidata/Q85846030': 35,
 'atp/category/tourism/hotel': 9469,
 'atp/country/AD': 1,
 'atp/country/AE': 37,
 'atp/country/AG': 3,
 'atp/country/AI': 2,
 'atp/country/AL': 1,
 'atp/country/AM': 2,
 'atp/country/AR': 11,
 'atp/country/AT': 20,
 'atp/country/AU': 25,
 'atp/country/AW': 3,
 'atp/country/AZ': 3,
 'atp/country/BB': 2,
 'atp/country/BE': 9,
 'atp/country/BG': 3,
 'atp/country/BH': 4,
 'atp/country/BO': 1,
 'atp/country/BQ': 1,
 'atp/country/BR': 29,
 'atp/country/BS': 1,
 'atp/country/BT': 2,
 'atp/country/BW': 1,
 'atp/country/BY': 5,
 'atp/country/BZ': 5,
 'atp/country/CA': 212,
 'atp/country/CD': 1,
 'atp/country/CG': 2,
 'atp/country/CH': 17,
 'atp/country/CL': 9,
 'atp/country/CM': 1,
 'atp/country/CN': 1094,
 'atp/country/CO': 28,
 'atp/country/CR': 21,
 'atp/country/CV': 1,
 'atp/country/CW': 2,
 'atp/country/CY': 4,
 'atp/country/CZ': 3,
 'atp/country/DE': 56,
 'atp/country/DK': 2,
 'atp/country/DO': 10,
 'atp/country/EC': 5,
 'atp/country/EE': 4,
 'atp/country/EG': 15,
 'atp/country/ES': 52,
 'atp/country/ET': 2,
 'atp/country/FI': 4,
 'atp/country/FJ': 5,
 'atp/country/FO': 1,
 'atp/country/FR': 68,
 'atp/country/GB': 205,
 'atp/country/GE': 4,
 'atp/country/GH': 1,
 'atp/country/GR': 55,
 'atp/country/GT': 3,
 'atp/country/GU': 1,
 'atp/country/HK': 4,
 'atp/country/HN': 3,
 'atp/country/HR': 13,
 'atp/country/HU': 6,
 'atp/country/ID': 18,
 'atp/country/IE': 17,
 'atp/country/IL': 4,
 'atp/country/IN': 46,
 'atp/country/IS': 6,
 'atp/country/IT': 111,
 'atp/country/JE': 1,
 'atp/country/JM': 5,
 'atp/country/JO': 6,
 'atp/country/JP': 51,
 'atp/country/KE': 4,
 'atp/country/KH': 1,
 'atp/country/KN': 2,
 'atp/country/KR': 7,
 'atp/country/KW': 3,
 'atp/country/KY': 1,
 'atp/country/KZ': 6,
 'atp/country/LA': 2,
 'atp/country/LB': 2,
 'atp/country/LC': 1,
 'atp/country/LK': 11,
 'atp/country/LT': 3,
 'atp/country/LU': 1,
 'atp/country/LV': 3,
 'atp/country/MA': 13,
 'atp/country/MC': 1,
 'atp/country/ME': 1,
 'atp/country/MK': 1,
 'atp/country/MM': 3,
 'atp/country/MO': 1,
 'atp/country/MT': 3,
 'atp/country/MU': 2,
 'atp/country/MV': 9,
 'atp/country/MX': 118,
 'atp/country/MY': 28,
 'atp/country/NA': 2,
 'atp/country/NC': 2,
 'atp/country/NG': 2,
 'atp/country/NI': 4,
 'atp/country/NL': 19,
 'atp/country/NO': 2,
 'atp/country/NP': 1,
 'atp/country/NZ': 10,
 'atp/country/OM': 6,
 'atp/country/PA': 6,
 'atp/country/PE': 12,
 'atp/country/PF': 3,
 'atp/country/PG': 1,
 'atp/country/PH': 3,
 'atp/country/PK': 1,
 'atp/country/PL': 35,
 'atp/country/PR': 12,
 'atp/country/PT': 33,
 'atp/country/PY': 2,
 'atp/country/QA': 15,
 'atp/country/RO': 12,
 'atp/country/RS': 2,
 'atp/country/RU': 24,
 'atp/country/RW': 1,
 'atp/country/SA': 28,
 'atp/country/SC': 7,
 'atp/country/SE': 5,
 'atp/country/SG': 4,
 'atp/country/SI': 2,
 'atp/country/SK': 2,
 'atp/country/ST': 1,
 'atp/country/SV': 1,
 'atp/country/SX': 2,
 'atp/country/SZ': 1,
 'atp/country/TC': 3,
 'atp/country/TH': 35,
 'atp/country/TJ': 1,
 'atp/country/TN': 2,
 'atp/country/TR': 99,
 'atp/country/TT': 1,
 'atp/country/TW': 7,
 'atp/country/TZ': 2,
 'atp/country/UA': 1,
 'atp/country/UG': 1,
 'atp/country/US': 6428,
 'atp/country/UY': 3,
 'atp/country/UZ': 9,
 'atp/country/VC': 2,
 'atp/country/VI': 1,
 'atp/country/VN': 23,
 'atp/country/XK': 1,
 'atp/country/ZA': 9,
 'atp/country/ZM': 1,
 'atp/field/branch/missing': 9469,
 'atp/field/brand/missing': 5,
 'atp/field/brand_wikidata/missing': 790,
 'atp/field/email/missing': 9469,
 'atp/field/image/missing': 9469,
 'atp/field/opening_hours/missing': 9469,
 'atp/field/operator/missing': 9469,
 'atp/field/operator_wikidata/missing': 9469,
 'atp/field/phone/invalid': 38,
 'atp/field/phone/missing': 41,
 'atp/field/postcode/missing': 9469,
 'atp/field/state/missing': 2527,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 9469,
 'atp/hilton/unknown_brand/EY': 3,
 'atp/hilton/unknown_brand/ID': 2,
 'atp/hilton/unknown_service/adjoiningRooms': 6722,
 'atp/hilton/unknown_service/adventureStays': 8,
 'atp/hilton/unknown_service/airportShuttle': 918,
 'atp/hilton/unknown_service/allInclusive': 11,
 'atp/hilton/unknown_service/beach': 294,
 'atp/hilton/unknown_service/boutique': 529,
 'atp/hilton/unknown_service/businessCenter': 4501,
 'atp/hilton/unknown_service/casino': 26,
 'atp/hilton/unknown_service/childcare': 375,
 'atp/hilton/unknown_service/concierge': 1873,
 'atp/hilton/unknown_service/cribs': 8049,
 'atp/hilton/unknown_service/digitalKey': 7166,
 'atp/hilton/unknown_service/dining': 4645,
 'atp/hilton/unknown_service/evCharging': 2635,
 'atp/hilton/unknown_service/eveningReception': 269,
 'atp/hilton/unknown_service/executiveLounge': 405,
 'atp/hilton/unknown_service/extendedStay': 1489,
 'atp/hilton/unknown_service/fitnessCenter': 9050,
 'atp/hilton/unknown_service/freeBreakfast': 5612,
 'atp/hilton/unknown_service/freeParking': 6450,
 'atp/hilton/unknown_service/golf': 70,
 'atp/hilton/unknown_service/hotelResidence': 147,
 'atp/hilton/unknown_service/inRoomKitchen': 1485,
 'atp/hilton/unknown_service/luxury': 630,
 'atp/hilton/unknown_service/meetingRooms': 6421,
 'atp/hilton/unknown_service/newHotel': 397,
 'atp/hilton/unknown_service/outdoorPool': 3414,
 'atp/hilton/unknown_service/petsAllowed': 7150,
 'atp/hilton/unknown_service/petsNotAllowed': 2319,
 'atp/hilton/unknown_service/playground': 269,
 'atp/hilton/unknown_service/resort': 361,
 'atp/hilton/unknown_service/roomService': 2951,
 'atp/hilton/unknown_service/ski': 77,
 'atp/hilton/unknown_service/spa': 756,
 'atp/hilton/unknown_service/streamingTv': 4244,
 'atp/hilton/unknown_service/tennisCourt': 208,
 'atp/item_scraped_host_count/www.hilton.com': 9469,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 3249,
 'atp/nsi/perfect_match': 5430,
 'downloader/request_bytes': 5048,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 513031,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 302.916933,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 3, 7, 48, 9, 521819, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9469,
 'items_per_minute': 1881.2582781456954,
 'log_count/DEBUG': 11603,
 'log_count/INFO': 12,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 3,
 'playwright/page_count/closed': 3,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 50,
 'playwright/request_count/aborted': 47,
 'playwright/request_count/method/GET': 50,
 'playwright/request_count/navigation': 3,
 'playwright/request_count/resource_type/document': 3,
 'playwright/request_count/resource_type/image': 5,
 'playwright/request_count/resource_type/script': 35,
 'playwright/request_count/resource_type/stylesheet': 7,
 'playwright/response_count': 3,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/method/POST': 2,
 'playwright/response_count/resource_type/document': 3,
 'request_depth_max': 2,
 'response_received_count': 3,
 'responses_per_minute': 0.5960264900662252,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 3, 7, 43, 6, 604886, tzinfo=datetime.timezone.utc)}
```