### PR TITLE
[Starbucks TW] Fix Spider

### DIFF
--- a/locations/spiders/starbucks_tw.py
+++ b/locations/spiders/starbucks_tw.py
@@ -8,42 +8,20 @@ from locations.items import Feature
 class StarbucksTWSpider(Spider):
     name = "starbucks_tw"
     item_attributes = {"brand": "星巴克", "brand_wikidata": "Q37158"}
-    start_urls = ["https://www.starbucks.com.tw/stores/storesearch.jspx"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response, **kwargs):
+    async def start(self):
         yield FormRequest(
-            "https://www.starbucks.com.tw/stores/storesearch.jspx",
+            "https://www.starbucks.com.tw/stores/ajax/json_storesearch.aspx",
             formdata={
-                "AJAXREQUEST": "j_id_jsp_139507100_0",
-                "javax.faces.ViewState": response.xpath('//input[@id="javax.faces.ViewState"]/@value').get(),
-                "sbForm:useGeolocation": "0",
-                "sbForm:fetchGeolocation": "1",
-                "sbForm:lon": "0",
-                "sbForm:lat": "0",
-                "sbForm:reserve": "",
-                "sbForm:pour": "",
-                "sbForm:nitro": "",
-                "sbForm:drive": "",
-                "sbForm:fizzio": "",
-                "sbForm:baked": "",
-                "sbForm:wifi": "",
-                "sbForm:mobileOrder": "",
-                "sbForm:mobileOrderInStore": "",
-                "sbForm:mobileOrderOutStore": "",
-                "sbForm:mobileOrderRoadSide": "",
-                "sbForm:coffeeVoucher": "",
-                "sbForm:borrowCup": "",
-                "sbForm:returnCup": "",
-                "sbForm:showUnusualBusinessInfo": "",
-                "storeName": "",
-                "sbForm_SUBMIT": "1",
-                "sbForm:doFindByName": "sbForm:doFindByName",
+                "lat": "0",
+                "lon": "0",
             },
-            callback=self.parse_locations,
+            callback=self.parse,
         )
 
-    def parse_locations(self, response, **kwargs):
-        selector = Selector(text=response.xpath(".").get())
+    def parse(self, response, **kwargs):
+        selector = Selector(text=response.json()["renderElements"][0]["elementHTML"])
         for location in selector.xpath('//li[@class="store_data"]'):
             item = Feature()
             item["ref"], item["lat"], item["lon"] = re.match(


### PR DESCRIPTION
```python
{'atp/brand/星巴克': 605,
 'atp/brand_wikidata/Q37158': 605,
 'atp/category/amenity/cafe': 605,
 'atp/clean_strings/addr_full': 60,
 'atp/clean_strings/branch': 1,
 'atp/country/TW': 605,
 'atp/field/city/missing': 605,
 'atp/field/country/from_spider_name': 605,
 'atp/field/email/missing': 605,
 'atp/field/image/missing': 605,
 'atp/field/opening_hours/missing': 605,
 'atp/field/operator_wikidata/missing': 605,
 'atp/field/phone/missing': 605,
 'atp/field/postcode/missing': 605,
 'atp/field/state/missing': 605,
 'atp/field/street_address/missing': 605,
 'atp/field/twitter/missing': 605,
 'atp/item_scraped_host_count/www.starbucks.com.tw': 605,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 605,
 'atp/operator/悠旅生活事業股份有限公司': 605,
 'downloader/request_bytes': 422,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 878804,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.759286,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 4, 9, 5, 42, 385852, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 605,
 'items_per_minute': 7260.0,
 'log_count/DEBUG': 606,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 12.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 4, 9, 5, 36, 626566, tzinfo=datetime.timezone.utc)}

```