### PR TITLE
[Aldi  Sud IE] Fix Spider

### DIFF
--- a/locations/spiders/aldi_sud_ie.py
+++ b/locations/spiders/aldi_sud_ie.py
@@ -1,21 +1,13 @@
-from scrapy.spiders import SitemapSpider
-
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.storefinders.uberall import UberallSpider
 
 
-class AldiSudIESpider(SitemapSpider, StructuredDataSpider):
+class AldiSudIESpider(UberallSpider):
     name = "aldi_sud_ie"
-    item_attributes = {"brand": "Aldi", "brand_wikidata": "Q41171672", "country": "IE"}
-    allowed_domains = ["aldi.ie"]
-    sitemap_urls = ["https://stores.aldi.ie/sitemap.xml"]
-    sitemap_rules = [(r"https://stores\.aldi\.ie/[^/]+/[^/]+/[^/]+$", "parse")]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    item_attributes = {"brand": "Aldi", "brand_wikidata": "Q41171672"}
+    key = "lS2g9eY7aREuErMGkEiNnvTRoO6jQM"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("ALDI ")
-
+        item["name"] = item["phone"] = None
         apply_category(Categories.SHOP_SUPERMARKET, item)
-
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Aldi': 165,
 'atp/brand_wikidata/Q41171672': 165,
 'atp/category/shop/supermarket': 165,
 'atp/country/IE': 165,
 'atp/field/branch/missing': 165,
 'atp/field/email/missing': 165,
 'atp/field/image/missing': 165,
 'atp/field/operator/missing': 165,
 'atp/field/operator_wikidata/missing': 165,
 'atp/field/phone/missing': 165,
 'atp/field/twitter/missing': 165,
 'atp/field/website/missing': 165,
 'atp/item_scraped_host_count/uberall.com': 165,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 165,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 13178,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.685545,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 4, 9, 53, 2, 454988, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 131532,
 'httpcompression/response_count': 2,
 'item_scraped_count': 165,
 'items_per_minute': 3300.0,
 'log_count/DEBUG': 167,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 4, 9, 52, 58, 769443, tzinfo=datetime.timezone.utc)}
```