### PR TITLE
Fix classification of some Sainsbury's stores

### DIFF
--- a/locations/spiders/sainsburys.py
+++ b/locations/spiders/sainsburys.py
@@ -74,7 +74,9 @@ class SainsburysSpider(Spider):
             apply_yes_no(Extras.PARKING_WHEELCHAIR, item, any(f["id"] == 166 for f in store["facilities"]))
         apply_yes_no(PaymentMethods.CONTACTLESS, item, any(f["id"] == 104 for f in store["facilities"]))
 
-        if store["store_type"] == "local" or (store["store_type"] == "main" and store["additional_data"]["main_store_branded_as_local"]):
+        if store["store_type"] == "local" or (
+            store["store_type"] == "main" and store["additional_data"]["main_store_branded_as_local"]
+        ):
             item.update(self.SAINSBURYS_LOCAL)
             item["branch"] = item.pop("name").removesuffix(" Local")
             apply_category(Categories.SHOP_CONVENIENCE, item)


### PR DESCRIPTION
A small number of Sainbury's stores appear to officially have type=main, but in reality (at least according to OSM mapping) are branded as "Sainsbury's Local" stores. This "main_store_branded_as_local" type is recorded in the JSON file used by the spider, so we can leverage this to fix the classification.

Example of store this applies to: https://stores.sainsburys.co.uk/2107/buchanan-galleries which is mapped in OSM as https://www.openstreetmap.org/node/540630910 .