### PR TITLE
[Ray White AU NZ] Fix Spider

### DIFF
--- a/locations/spiders/ray_white_au_nz.py
+++ b/locations/spiders/ray_white_au_nz.py
@@ -1,3 +1,4 @@
+import re
 from typing import AsyncIterator
 
 from scrapy import Spider
@@ -57,7 +58,10 @@ class RayWhiteAUNZSpider(Spider):
             item = DictParser.parse(location["value"])
             item["lat"] = location["value"]["address"]["location"]["lat"]
             item["lon"] = location["value"]["address"]["location"]["lon"]
-            item["website"] = location["value"]["webSite"]
+            if website := re.sub(r"^(?:https?://)+", "", location["value"]["webSite"], flags=re.IGNORECASE):
+                if "http" not in website:
+                    item["website"] = f"https://{website}" if website else None
+
             for phone_number in location["value"].get("phones", []):
                 if phone_number["typeCode"] == "FIX":  # Fixed phone number
                     item["phone"] = phone_number["internationalizedNumber"]


### PR DESCRIPTION
```python
{'atp/brand/Ray White': 838,
 'atp/brand_wikidata/Q81077729': 838,
 'atp/category/office/estate_agent': 838,
 'atp/clean_strings/city': 5,
 'atp/clean_strings/housenumber': 34,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/phone': 5,
 'atp/clean_strings/street': 10,
 'atp/clean_strings/website': 4,
 'atp/country/AU': 641,
 'atp/country/NZ': 197,
 'atp/field/branch/missing': 838,
 'atp/field/image/missing': 560,
 'atp/field/opening_hours/missing': 838,
 'atp/field/operator/missing': 838,
 'atp/field/operator_wikidata/missing': 838,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 24,
 'atp/field/state/missing': 6,
 'atp/field/street_address/missing': 838,
 'atp/field/twitter/invalid': 1,
 'atp/field/twitter/missing': 792,
 'atp/field/website/invalid': 134,
 'atp/item_scraped_host_count/raywhiteapi.ep.dynamics.net': 838,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 838,
 'downloader/request_bytes': 714,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1059859,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 8.191203,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 6, 11, 22, 48, 739891, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8388656,
 'httpcompression/response_count': 1,
 'item_scraped_count': 838,
 'items_per_minute': 6285.0,
 'log_count/DEBUG': 839,
 'log_count/INFO': 3,
 'log_count/WARNING': 134,
 'response_received_count': 1,
 'responses_per_minute': 7.5,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 6, 11, 22, 40, 548688, tzinfo=datetime.timezone.utc)}
```