### PR TITLE
[Benchmarx GB] Fix Spider

### DIFF
--- a/locations/spiders/benchmarx_gb.py
+++ b/locations/spiders/benchmarx_gb.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
+import chompjs
 from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -11,10 +12,17 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class BenchmarxGBSpider(Spider):
     name = "benchmarx_gb"
     item_attributes = {"brand": "Benchmarx", "brand_wikidata": "Q102181127"}
-    start_urls = ["https://api.live.benchmarxkitchens.co.uk/locations?locationPageStatus=active"]
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(
+            url="https://www.benchmarxkitchens.co.uk/branches",
+            body="[]",
+            method="POST",
+            headers={"next-action": "c9ba5010b454e57b7be8e7636bed638268d6b777"},
+        )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["hydra:member"]:
+        for location in list(chompjs.parse_js_objects(response.text))[1]:
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
             item["street_address"] = merge_address_lines(
@@ -28,6 +36,3 @@ class BenchmarxGBSpider(Spider):
                 item["opening_hours"].add_range(day, times["opening"], times["closing"])
 
             yield item
-
-        if next_page := response.json()["hydra:view"].get("hydra:next"):
-            yield response.follow(next_page)


### PR DESCRIPTION
```python
{'atp/brand/Benchmarx': 132,
 'atp/brand_wikidata/Q102181127': 132,
 'atp/category/shop/kitchen': 132,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/GB': 132,
 'atp/field/image/missing': 132,
 'atp/field/operator/missing': 132,
 'atp/field/operator_wikidata/missing': 132,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 132,
 'atp/item_scraped_host_count/www.benchmarxkitchens.co.uk': 132,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 132,
 'downloader/request_bytes': 761,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 28801,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.399988,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 9, 11, 21, 30, 555216, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 282525,
 'httpcompression/response_count': 2,
 'item_scraped_count': 132,
 'items_per_minute': 1980.0,
 'log_count/DEBUG': 134,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 9, 11, 21, 26, 155228, tzinfo=datetime.timezone.utc)}
```