### PR TITLE
[MediaMarkt TR] Add spider

### DIFF
--- a/locations/spiders/mediamarkt_tr.py
+++ b/locations/spiders/mediamarkt_tr.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.mediamarkt import MEDIAMARKT
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MediamarktTRSpider(SitemapSpider, StructuredDataSpider):
+    name = "mediamarkt_tr"
+    item_attributes = MEDIAMARKT
+    sitemap_urls = ["https://www.mediamarkt.com.tr/sitemaps/sitemap-marketpages.xml"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("MediaMarkt ")
+        item["phone"] = None
+
+        apply_category(Categories.SHOP_ELECTRONICS, item)
+
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/MediaMarkt': 104,
 'atp/brand_wikidata/Q2381223': 104,
 'atp/category/shop/electronics': 104,
 'atp/cdn/cloudflare/response_count': 107,
 'atp/cdn/cloudflare/response_status_count/200': 107,
 'atp/country/TR': 104,
 'atp/field/email/missing': 104,
 'atp/field/image/missing': 104,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 100,
 'atp/item_scraped_host_count/www.mediamarkt.com.tr': 104,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 104,
 'downloader/request_bytes': 80002,
 'downloader/request_count': 107,
 'downloader/request_method_count/GET': 107,
 'downloader/response_bytes': 15586427,
 'downloader/response_count': 107,
 'downloader/response_status_count/200': 107,
 'elapsed_time_seconds': 2.595056,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 10, 12, 20, 39, 4875, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 107,
 'httpcompression/response_bytes': 90300598,
 'httpcompression/response_count': 107,
 'item_scraped_count': 104,
 'items_per_minute': 3120.0,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 294006784,
 'memusage/startup': 294006784,
 'request_depth_max': 1,
 'response_received_count': 107,
 'responses_per_minute': 3210.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 106,
 'scheduler/dequeued/memory': 106,
 'scheduler/enqueued': 106,
 'scheduler/enqueued/memory': 106,
 'start_time': datetime.datetime(2026, 2, 10, 12, 20, 36, 409819, tzinfo=datetime.timezone.utc)}
```