### PR TITLE
[Activ Fitness CH] Fix Spider

### DIFF
--- a/locations/spiders/activ_fitness_ch.py
+++ b/locations/spiders/activ_fitness_ch.py
@@ -1,34 +1,25 @@
-from typing import Any, AsyncIterator
+import json
+import re
+from typing import Any
 
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Response
 from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class ActivFitnessCHSpider(Spider):
     name = "activ_fitness_ch"
     item_attributes = {"brand": "Activ Fitness", "brand_wikidata": "Q123747318"}
-
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield JsonRequest(
-            "https://web-api.migros.ch/widgets/stores?aggregation_options%5Bempty_buckets%5D=true&filters%5Bmarkets%5D%5B0%5D%5B0%5D=activ_fitness&verbosity=store&offset=0&limit=5000&key=9e74726846ff4e91a515edd24618d463ae26c89e7ea907fe30db2901da3691ba",
-            headers={"Origin": "https://www.activfitness.ch"},
-        )
+    start_urls = ["https://www.activfitness.ch/en/map/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["stores"]:
-            location.update(location.pop("location"))
-            location["street_address"] = merge_address_lines([location.pop("address"), location.pop("address2")])
+        raw_data = re.search(
+            r"filialfinderData\s*=\s*(\[.*\]);\s* ",
+            response.xpath('//*[contains(text(),"filialfinderData")]/text()').get(),
+        ).group(1)
+        for location in json.loads(raw_data):
             item = DictParser.parse(location)
-            item["branch"] = item.pop("name").removeprefix("ACTIV FITNESS ")
-
-            item["website"] = item["extras"]["website:de"] = "https://www.activfitness.ch/studios/{}/".format(
-                location["slug"]
-            )
-            item["extras"]["website:fr"] = "https://www.activfitness.ch/fr/{}/".format(location["slug"])
-            item["extras"]["website:it"] = "https://www.activfitness.ch/it/{}/".format(location["slug"])
-            item["extras"]["website:en"] = "https://www.activfitness.ch/en/{}/".format(location["slug"])
-
+            item["street_address"] = item.pop("addr_full")
+            item["branch"] = item.pop("name").removeprefix("Activ Fitness ")
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Activ Fitness': 128,
 'atp/brand_wikidata/Q123747318': 128,
 'atp/category/leisure/fitness_centre': 128,
 'atp/country/CH': 128,
 'atp/field/country/from_spider_name': 128,
 'atp/field/image/missing': 128,
 'atp/field/opening_hours/missing': 128,
 'atp/field/operator/missing': 128,
 'atp/field/operator_wikidata/missing': 128,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 128,
 'atp/field/twitter/missing': 128,
 'atp/item_scraped_host_count/www.activfitness.ch': 128,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 128,
 'downloader/request_bytes': 671,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 30620,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.390433,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 11, 5, 17, 6, 143144, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 197884,
 'httpcompression/response_count': 2,
 'item_scraped_count': 128,
 'items_per_minute': 2560.0,
 'log_count/DEBUG': 130,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 11, 5, 17, 2, 752711, tzinfo=datetime.timezone.utc)}
```