### PR TITLE
[Change Group] Fix spider

### DIFF
--- a/locations/spiders/change_group.py
+++ b/locations/spiders/change_group.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 from scrapy.http import TextResponse
 
+from locations.categories import Extras, apply_yes_no
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -27,6 +28,7 @@ class ChangeGroupSpider(JSONBlobSpider):
             except:
                 self.logger.error("Failed to parse opening hours {}".format(hours))
 
+        apply_yes_no(Extras.ATM, item, feature.get("Servicios", {}).get("ATM"))
         yield item
 
     def parse_opening_hours(self, rules: dict) -> OpeningHours:


### PR DESCRIPTION
```python
{'atp/brand/Change Group': 181,
 'atp/brand_wikidata/Q5071758': 181,
 'atp/category/amenity/bureau_de_change': 181,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/phone': 1,
 'atp/country/AU': 25,
 'atp/country/CY': 4,
 'atp/country/DE': 5,
 'atp/country/DK': 4,
 'atp/country/ES': 19,
 'atp/country/FI': 7,
 'atp/country/FR': 21,
 'atp/country/GB': 48,
 'atp/country/IS': 3,
 'atp/country/NZ': 6,
 'atp/country/SE': 26,
 'atp/country/SG': 13,
 'atp/field/branch/missing': 181,
 'atp/field/email/missing': 152,
 'atp/field/image/missing': 181,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 181,
 'atp/field/operator_wikidata/missing': 181,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 95,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 181,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 181,
 'atp/field/website/missing': 181,
 'atp/item_scraped_host_count/uk.changegroup.com': 181,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 181,
 'downloader/request_bytes': 877,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28353,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.574322,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 11, 14, 0, 3, 151912, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 321264,
 'httpcompression/response_count': 1,
 'item_scraped_count': 181,
 'items_per_minute': 3620.0,
 'log_count/DEBUG': 183,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 11, 13, 59, 59, 577590, tzinfo=datetime.timezone.utc)}
```