### PR TITLE
[ATI Physical Therapy] Fix Spider

### DIFF
--- a/locations/spiders/ati_physical_therapy.py
+++ b/locations/spiders/ati_physical_therapy.py
@@ -1,12 +1,14 @@
-import json
+from typing import Iterable
 
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
 # Can't currently use StructuredDataSpider as there is no type in the source data
-class AtiPhysicalTherapySpider(SitemapSpider):
+class AtiPhysicalTherapySpider(SitemapSpider, StructuredDataSpider):
     name = "ati_physical_therapy"
     item_attributes = {
         "brand": "ATI Physical Therapy",
@@ -15,11 +17,9 @@ class AtiPhysicalTherapySpider(SitemapSpider):
     }
     allowed_domains = ["locations.atipt.com"]
     sitemap_urls = ["https://locations.atipt.com/sitemap.xml"]
-    sitemap_rules = [(r"\.com\/([-\w]{3,})$", "parse")]
+    sitemap_rules = [(r"\.com\/[^/]+/[^/]+/\d+-[a-z-]+/$", "parse_sd")]
+    time_format = "%H:%M:%S"
 
-    def parse(self, response, **kwargs):
-        if ld := response.xpath('//script[@type="application/ld+json"]//text()').get():
-            item = LinkedDataParser.parse_ld(json.loads(ld))
-            item["ref"] = response.url
-
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/ATI Physical Therapy': 712,
 'atp/brand_wikidata/Q50039703': 712,
 'atp/category/healthcare/physiotherapist': 712,
 'atp/country/US': 712,
 'atp/field/email/missing': 712,
 'atp/field/geometry/missing': 1,
 'atp/field/operator/missing': 712,
 'atp/field/operator_wikidata/missing': 712,
 'atp/field/twitter/missing': 712,
 'atp/item_scraped_host_count/locations.atipt.com': 712,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 712,
 'downloader/request_bytes': 312633,
 'downloader/request_count': 738,
 'downloader/request_method_count/GET': 738,
 'downloader/response_bytes': 30391788,
 'downloader/response_count': 738,
 'downloader/response_status_count/200': 738,
 'elapsed_time_seconds': 903.012287,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 12, 7, 55, 26, 819588, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 127297117,
 'httpcompression/response_count': 737,
 'item_scraped_count': 712,
 'items_per_minute': 47.308970099667775,
 'log_count/DEBUG': 1450,
 'log_count/INFO': 168,
 'request_depth_max': 2,
 'response_received_count': 738,
 'responses_per_minute': 49.03654485049834,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 737,
 'scheduler/dequeued/memory': 737,
 'scheduler/enqueued': 737,
 'scheduler/enqueued/memory': 737,
 'start_time': datetime.datetime(2026, 2, 12, 7, 40, 23, 807301, tzinfo=datetime.timezone.utc)}
```