### PR TITLE
[AEDs (defibrillators) JP] add spider (70450 locations)

### DIFF
--- a/locations/spiders/aed_jp.py
+++ b/locations/spiders/aed_jp.py
@@ -26,7 +26,7 @@ class AedJPSpider(Spider):
         aeds = data["aeds"]
 
         for aed in aeds:
-            if aed["rank"] == "E": #removes AEDs older than 8 years.
+            if aed["rank"] == "E":  # removes AEDs older than 8 years.
                 continue
             item = DictParser.parse(aed)
             item["ref"] = aed["id"]


### PR DESCRIPTION
{'atp/category/emergency/defibrillator': 70450,
 'atp/clean_strings/name': 709,
 'atp/clean_strings/street_address': 254,
 'atp/country/JP': 70450,
 'atp/field/branch/missing': 70450,
 'atp/field/brand/missing': 70450,
 'atp/field/brand_wikidata/missing': 70450,
 'atp/field/city/missing': 70450,
 'atp/field/country/from_spider_name': 70450,
 'atp/field/email/missing': 70450,
 'atp/field/image/missing': 70450,
 'atp/field/opening_hours/missing': 70450,
 'atp/field/operator/missing': 70450,
 'atp/field/operator_wikidata/missing': 70450,
 'atp/field/phone/missing': 70450,
 'atp/field/postcode/missing': 70450,
 'atp/field/state/missing': 70450,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 70450,
 'atp/item_scraped_host_count/www.qqzaidanmap.jp': 70450,
 'atp/lineage': 'S_?',
 'downloader/request_bytes': 950684,
 'downloader/request_count': 1819,
 'downloader/request_method_count/GET': 1819,
 'downloader/response_bytes': 369629266,
 'downloader/response_count': 1819,
 'downloader/response_status_count/200': 1819,
 'elapsed_time_seconds': 18429.969576,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 20, 4, 46, 28, 491347, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 70450,
 'items_per_minute': 229.36675891258344,
 'log_count/DEBUG': 72269,
 'log_count/INFO': 1774,
 'request_depth_max': 1817,
 'response_received_count': 1819,
 'responses_per_minute': 5.92218785609637,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1818,
 'scheduler/dequeued/memory': 1818,
 'scheduler/enqueued': 1818,
 'scheduler/enqueued/memory': 1818,
 'start_time': datetime.datetime(2026, 3, 19, 23, 39, 18, 521771, tzinfo=datetime.timezone.utc)}