### PR TITLE
[Betfred GB] Add spider

### DIFF
--- a/locations/spiders/betfred_gb.py
+++ b/locations/spiders/betfred_gb.py
@@ -16,7 +16,6 @@ class BetfredGBSpider(JSONBlobSpider):
     allowed_domains = ["www.betfredgroup.com"]
     item_attributes = {"brand": "Betfred", "brand_wikidata": "Q4897425"}
     requires_proxy = True
-    seen = set()
 
     async def start(self) -> AsyncIterator[FormRequest]:
         for region in postal_regions("GB"):
@@ -31,9 +30,6 @@ class BetfredGBSpider(JSONBlobSpider):
         return []
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
-        if item["ref"] in self.seen:
-            return
-        self.seen.add(item["ref"])
         item["branch"] = item.pop("name")
         oh = OpeningHours()
         oh.add_ranges_from_string(feature.get("OpeningHoursDescription", ""))


### PR DESCRIPTION
Adds all ~1233 Betfred locations. Takes about an hours on my machine.

I've compared the output to the premises-license-register, there are some postcode mismatches but always close by, and some shops that have been closed since, even searching for the exact postcode doesn't come up with the branch.