### PR TITLE
[Batteries Plus Bulbs PR US] Fix Spider

### DIFF
--- a/locations/spiders/batteries_plus_bulbs_pr_us.py
+++ b/locations/spiders/batteries_plus_bulbs_pr_us.py
@@ -21,4 +21,6 @@ class BatteriesPlusBulbsPRUSSpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name").replace("Check us out in ", "")
+        item["image"] = None
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Batteries Plus Bulbs': 687,
 'atp/brand_wikidata/Q17005157': 687,
 'atp/category/shop/electronics': 687,
 'atp/cdn/cloudflare/response_count': 1360,
 'atp/cdn/cloudflare/response_status_count/200': 1360,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 1,
 'atp/country/PR': 6,
 'atp/country/US': 681,
 'atp/field/country/from_reverse_geocoding': 687,
 'atp/field/email/missing': 687,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 687,
 'atp/field/operator_wikidata/missing': 687,
 'atp/field/phone/missing': 1,
 'atp/item_scraped_host_count/www.batteriesplus.com': 687,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 687,
 'downloader/request_bytes': 1373548,
 'downloader/request_count': 1360,
 'downloader/request_method_count/GET': 1360,
 'downloader/response_bytes': 34068686,
 'downloader/response_count': 1360,
 'downloader/response_status_count/200': 1360,
 'dupefilter/filtered': 1294,
 'elapsed_time_seconds': 1669.910881,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 17, 8, 28, 33, 433242, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 246423385,
 'httpcompression/response_count': 1360,
 'item_scraped_count': 687,
 'items_per_minute': 24.69742360695027,
 'log_count/DEBUG': 2048,
 'log_count/INFO': 139,
 'request_depth_max': 3,
 'response_received_count': 1360,
 'responses_per_minute': 48.89155182744158,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1359,
 'scheduler/dequeued/memory': 1359,
 'scheduler/enqueued': 1359,
 'scheduler/enqueued/memory': 1359,
 'start_time': datetime.datetime(2026, 2, 17, 8, 0, 43, 522361, tzinfo=datetime.timezone.utc)}
```