### PR TITLE
[Seven Eleven MX] Fix spider

### DIFF
--- a/locations/spiders/seven_eleven_mx.py
+++ b/locations/spiders/seven_eleven_mx.py
@@ -11,7 +11,7 @@ from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
 class SevenElevenMXSpider(Spider):
     name = "seven_eleven_mx"
     item_attributes = SEVEN_ELEVEN_SHARED_ATTRIBUTES
-    start_urls = ["https://www.7-eleven.com.mx/buscador-de-tiendas/fetch_data.php"]
+    start_urls = ["https://7-eleven.com.mx/buscador-de-tiendas/fetch_data.php"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         store_keys = [key.removesuffix("_tienda") for key in response.json()["values"][0]]


### PR DESCRIPTION
```python
{'atp/brand/7-Eleven': 2076,
 'atp/brand_wikidata/Q259340': 2076,
 'atp/category/shop/convenience': 2076,
 'atp/clean_strings/branch': 1,
 'atp/country/MX': 2076,
 'atp/field/branch/missing': 1,
 'atp/field/country/from_spider_name': 2076,
 'atp/field/email/missing': 2076,
 'atp/field/geometry/invalid': 6,
 'atp/field/image/missing': 2076,
 'atp/field/opening_hours/missing': 2076,
 'atp/field/operator/missing': 2076,
 'atp/field/operator_wikidata/missing': 2076,
 'atp/field/phone/missing': 2076,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 2076,
 'atp/field/twitter/missing': 2076,
 'atp/field/website/missing': 2076,
 'atp/item_scraped_host_count/7-eleven.com.mx': 2076,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2076,
 'downloader/request_bytes': 690,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 150406,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 33.065884,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 17, 14, 10, 17, 949155, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 612535,
 'httpcompression/response_count': 1,
 'item_scraped_count': 2076,
 'items_per_minute': 3774.545454545454,
 'log_count/DEBUG': 2078,
 'log_count/INFO': 3,
 'memusage/max': 282718208,
 'memusage/startup': 282718208,
 'response_received_count': 2,
 'responses_per_minute': 3.6363636363636362,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 17, 14, 9, 44, 883271, tzinfo=datetime.timezone.utc)}
```