### PR TITLE
[Carters US] Fix Spider

### DIFF
--- a/locations/spiders/carters_us.py
+++ b/locations/spiders/carters_us.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
@@ -13,14 +14,22 @@ class CartersUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Carter's", "brand_wikidata": "Q5047083"}
     allowed_domains = ["www.carters.com"]
     sitemap_urls = ["https://www.carters.com/sitemap_index.xml"]
-    sitemap_rules = [
-        (r"https://www.carters.com/l/.*/.*/.*", "parse_sd"),
-    ]
-    time_format = "%I:%M%p"
+    sitemap_follow = ["store-page"]
+    sitemap_rules = [(r"^https://www.carters.com/l/\w\w/[^/]+/[^/]+$", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item["name"].startswith("Oshkosh "):
+            item["branch"] = item.pop("name").removeprefix("Oshkosh ").removesuffix(" OshKosh")
+            item["name"] = "Carter's OshKosh"
+        elif item["name"].startswith("Carter’s "):
+            item["branch"] = item.pop("name").removeprefix("Carter’s ").removesuffix(" Carters")
+            item["name"] = "Carter's"
+
         oh = OpeningHours()
         for day_time in ld_data["openingHours"]:
             oh.add_ranges_from_string(day_time)
         item["opening_hours"] = oh
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Carter's": 950,
 'atp/brand_wikidata/Q5047083': 950,
 'atp/category/shop/clothes': 950,
 'atp/cdn/cloudflare/response_count': 1228,
 'atp/cdn/cloudflare/response_status_count/200': 960,
 'atp/cdn/cloudflare/response_status_count/403': 268,
 'atp/country/US': 950,
 'atp/field/branch/missing': 950,
 'atp/field/email/missing': 950,
 'atp/field/image/missing': 950,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 950,
 'atp/field/operator_wikidata/missing': 950,
 'atp/item_scraped_host_count/www.carters.com': 950,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 950,
 'downloader/request_bytes': 3947468,
 'downloader/request_count': 1228,
 'downloader/request_method_count/GET': 1228,
 'downloader/response_bytes': 62151286,
 'downloader/response_count': 1228,
 'downloader/response_status_count/200': 960,
 'downloader/response_status_count/403': 268,
 'elapsed_time_seconds': 1493.459512,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 18, 7, 52, 57, 24532, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 380615714,
 'httpcompression/response_count': 1228,
 'httperror/response_ignored_count': 268,
 'httperror/response_ignored_status_count/403': 268,
 'item_scraped_count': 950,
 'items_per_minute': 38.17816476892163,
 'log_count/DEBUG': 2178,
 'log_count/INFO': 496,
 'log_count/WARNING': 1,
 'request_depth_max': 2,
 'response_received_count': 1228,
 'responses_per_minute': 49.350301406563965,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1227,
 'scheduler/dequeued/memory': 1227,
 'scheduler/enqueued': 1227,
 'scheduler/enqueued/memory': 1227,
 'start_time': datetime.datetime(2026, 2, 18, 7, 28, 3, 565020, tzinfo=datetime.timezone.utc)}
```