### PR TITLE
[Obriens IE] Fix Spider

### DIFF
--- a/locations/spiders/obriens_ie.py
+++ b/locations/spiders/obriens_ie.py
@@ -14,6 +14,7 @@ class ObriensIESpider(JSONBlobSpider):
     start_urls = ["https://adminob.iplanit.ie/api/getLocationsInventory"]
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
         item["street_address"] = merge_address_lines([feature["address1"], feature["address2"]])
         oh = OpeningHours()
         oh.add_ranges_from_string(feature["openingHours"])


### PR DESCRIPTION
```python
{"atp/brand/O'Briens": 36,
 'atp/brand_wikidata/Q113151266': 36,
 'atp/category/shop/alcohol': 36,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/IE': 36,
 'atp/field/branch/missing': 36,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 36,
 'atp/field/operator/missing': 36,
 'atp/field/operator_wikidata/missing': 36,
 'atp/field/twitter/missing': 36,
 'atp/field/website/missing': 36,
 'atp/item_scraped_host_count/adminob.iplanit.ie': 36,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 36,
 'downloader/request_bytes': 687,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4808,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.609781,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 18, 10, 47, 45, 464844, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18697,
 'httpcompression/response_count': 2,
 'item_scraped_count': 36,
 'items_per_minute': 720.0,
 'log_count/DEBUG': 38,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 18, 10, 47, 41, 855063, tzinfo=datetime.timezone.utc)}
```