### PR TITLE
[Toyota AU] Fix spider

### DIFF
--- a/locations/spiders/toyota_au.py
+++ b/locations/spiders/toyota_au.py
@@ -1,6 +1,7 @@
+import json
 from typing import Iterable
 
-from scrapy.http import Response
+from scrapy.http import Response, TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
@@ -27,7 +28,9 @@ class ToyotaAUSpider(JSONBlobSpider, PlaywrightSpider):
         "https://www.toyota.com.au/main/api/v1/toyotaforms/info/dealersbystate/WA?dealerOptIn=false",
     ]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS | {"USER_AGENT": BROWSER_DEFAULT}
-    locations_key = "results"
+
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        return json.loads(response.xpath("//pre/text()").get())["results"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["lat"] = feature["refY"]


### PR DESCRIPTION
```python
{'atp/brand/Toyota': 972,
 'atp/brand_wikidata/Q53268': 972,
 'atp/category/shop/car': 324,
 'atp/category/shop/car_parts': 324,
 'atp/category/shop/car_repair': 324,
 'atp/country/AU': 972,
 'atp/field/branch/missing': 972,
 'atp/field/country/from_spider_name': 972,
 'atp/field/email/missing': 144,
 'atp/field/image/missing': 972,
 'atp/field/opening_hours/missing': 972,
 'atp/field/operator/missing': 972,
 'atp/field/operator_wikidata/missing': 972,
 'atp/field/twitter/missing': 972,
 'atp/field/website/invalid': 12,
 'atp/field/website/missing': 141,
 'atp/item_scraped_host_count/www.toyota.com.au': 972,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 648,
 'atp/nsi/match_failed': 324,
 'downloader/request_bytes': 2840,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 217780,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 11.737085,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 18, 13, 17, 53, 896797, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 972,
 'items_per_minute': 5301.818181818182,
 'log_count/DEBUG': 1014,
 'log_count/INFO': 7,
 'log_count/WARNING': 12,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 9,
 'playwright/page_count/closed': 9,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 9,
 'playwright/request_count/method/GET': 9,
 'playwright/request_count/navigation': 9,
 'playwright/request_count/resource_type/document': 9,
 'playwright/response_count': 9,
 'playwright/response_count/method/GET': 9,
 'playwright/response_count/resource_type/document': 9,
 'response_received_count': 9,
 'responses_per_minute': 49.09090909090909,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2026, 2, 18, 13, 17, 42, 159712, tzinfo=datetime.timezone.utc)}
```