### PR TITLE
[Oshkosh US] Remove Spider

### DIFF
--- a/locations/spiders/carters_us.py
+++ b/locations/spiders/carters_us.py
@@ -11,29 +11,25 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class CartersUSSpider(SitemapSpider, StructuredDataSpider):
     name = "carters_us"
-    BRANDS = {
-        "carter": {"brand": "Carter's", "brand_wikidata": "Q5047083"},
-        "oshkosh": {"brand": "OshKosh B'gosh", "brand_wikidata": "Q1417347"},
-    }
+    item_attributes = {"brand": "Carter's", "brand_wikidata": "Q5047083"}
     allowed_domains = ["www.carters.com"]
     sitemap_urls = ["https://www.carters.com/sitemap_index.xml"]
     sitemap_follow = ["store-page"]
     sitemap_rules = [(r"^https://www.carters.com/l/\w\w/[^/]+/[^/]+$", "parse_sd")]
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        if "oshkosh" in response.url:
+        if item["name"].startswith("Oshkosh "):
             item["branch"] = item.pop("name").removeprefix("Oshkosh ").removesuffix(" OshKosh")
             item["name"] = "Carter's OshKosh"
-            item.update(self.BRANDS["oshkosh"])
-        else:
+        elif item["name"].startswith("Carter’s "):
             item["branch"] = item.pop("name").removeprefix("Carter’s ").removesuffix(" Carters")
             item["name"] = "Carter's"
-            item.update(self.BRANDS["carter"])
 
         oh = OpeningHours()
         for day_time in ld_data["openingHours"]:
             oh.add_ranges_from_string(day_time)
         item["opening_hours"] = oh
+
         apply_category(Categories.SHOP_CLOTHES, item)
 
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Carter's": 778,
 "atp/brand/OshKosh B'gosh": 440,
 'atp/brand_wikidata/Q1417347': 440,
 'atp/brand_wikidata/Q5047083': 778,
 'atp/category/shop/clothes': 1218,
 'atp/cdn/cloudflare/response_count': 1228,
 'atp/cdn/cloudflare/response_status_count/200': 1228,
 'atp/country/US': 1218,
 'atp/field/branch/missing': 1218,
 'atp/field/email/missing': 1218,
 'atp/field/image/missing': 1218,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 1218,
 'atp/field/operator_wikidata/missing': 1218,
 'atp/item_scraped_host_count/www.carters.com': 1218,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1218,
 'downloader/request_bytes': 3947468,
 'downloader/request_count': 1228,
 'downloader/request_method_count/GET': 1228,
 'downloader/response_bytes': 78648667,
 'downloader/response_count': 1228,
 'downloader/response_status_count/200': 1228,
 'elapsed_time_seconds': 1504.234068,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 18, 13, 12, 26, 876050, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 485310981,
 'httpcompression/response_count': 1228,
 'item_scraped_count': 1218,
 'items_per_minute': 48.590425531914896,
 'log_count/DEBUG': 2446,
 'log_count/INFO': 38,
 'log_count/WARNING': 2,
 'request_depth_max': 2,
 'response_received_count': 1228,
 'responses_per_minute': 48.98936170212766,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1227,
 'scheduler/dequeued/memory': 1227,
 'scheduler/enqueued': 1227,
 'scheduler/enqueued/memory': 1227,
 'start_time': datetime.datetime(2026, 2, 18, 12, 47, 22, 641982, tzinfo=datetime.timezone.utc)}

```