### PR TITLE
[KFC DE] Fix Spider

### DIFF
--- a/locations/spiders/kfc_de.py
+++ b/locations/spiders/kfc_de.py
@@ -59,5 +59,5 @@ class KfcDESpider(Spider):
         oh = OpeningHours()
         for rule in rules:
             if rule["disposition"] == mode:
-                oh.add_range(DAYS[rule["dayOfWeek"]], rule["start"], rule["end"])
+                oh.add_range(DAYS[rule["dayOfWeek"] - 1], rule["start"], rule["end"])
         return oh


### PR DESCRIPTION
```python
{'atp/brand/KFC': 218,
 'atp/brand_wikidata/Q524757': 218,
 'atp/category/amenity/fast_food': 218,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/street_address': 6,
 'atp/country/DE': 218,
 'atp/field/branch/missing': 218,
 'atp/field/country/from_spider_name': 218,
 'atp/field/email/missing': 218,
 'atp/field/image/missing': 218,
 'atp/field/opening_hours/invalid': 5,
 'atp/field/operator/missing': 218,
 'atp/field/operator_wikidata/missing': 218,
 'atp/field/phone/missing': 218,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 218,
 'atp/field/twitter/missing': 218,
 'atp/item_scraped_host_count/api.kfc.de': 218,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 218,
 'downloader/request_bytes': 274,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 41350,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.911016,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 19, 7, 51, 45, 684414, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 605257,
 'httpcompression/response_count': 1,
 'item_scraped_count': 218,
 'items_per_minute': 6540.0,
 'log_count/DEBUG': 219,
 'log_count/INFO': 3,
 'log_count/WARNING': 384,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 19, 7, 51, 42, 773398, tzinfo=datetime.timezone.utc)}
```