### PR TITLE
[KFC FR] Fix Spider

### DIFF
--- a/locations/spiders/kfc_fr.py
+++ b/locations/spiders/kfc_fr.py
@@ -1,21 +1,20 @@
 import chompjs
+import scrapy
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import set_closed
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
 from locations.user_agents import FIREFOX_LATEST
 
 
-class KfcFRSpider(PlaywrightSpider):
+class KfcFRSpider(scrapy.Spider):
     name = "kfc_fr"
     item_attributes = KFC_SHARED_ATTRIBUTES
     start_urls = ["https://api.kfc.fr/stores/allStores"]
-    is_playwright_spider = True
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST} | DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST}
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         for location in chompjs.parse_js_object(response.text):


### PR DESCRIPTION
```python
{'atp/brand/KFC': 409,
 'atp/brand_wikidata/Q524757': 409,
 'atp/category/amenity/fast_food': 409,
 'atp/clean_strings/city': 1,
 'atp/closed_poi': 2,
 'atp/country/FR': 409,
 'atp/field/country/from_spider_name': 409,
 'atp/field/email/missing': 409,
 'atp/field/image/missing': 409,
 'atp/field/opening_hours/invalid': 1,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 409,
 'atp/field/operator_wikidata/missing': 409,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 6,
 'atp/field/state/missing': 409,
 'atp/field/street_address/missing': 409,
 'atp/field/twitter/missing': 409,
 'atp/item_scraped_host_count/api.kfc.fr': 409,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 409,
 'downloader/request_bytes': 266,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 79058,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.01486,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 19, 8, 57, 45, 944930, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 621348,
 'httpcompression/response_count': 1,
 'item_scraped_count': 409,
 'items_per_minute': 4908.0,
 'log_count/DEBUG': 410,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 12.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 19, 8, 57, 40, 930070, tzinfo=datetime.timezone.utc)}
```