### PR TITLE
[Fastned] Fix Spider

### DIFF
--- a/locations/spiders/fastned.py
+++ b/locations/spiders/fastned.py
@@ -21,6 +21,7 @@ class FastnedSpider(Spider):
     def parse_feature(self, response: Response):
         feature = response.json()["location"]
         item = DictParser.parse(feature)
+        item["branch"] = item.pop("name")
         item["street_address"] = item.pop("addr_full")
         item["lat"] = response.meta["lat"]
         item["lon"] = response.meta["lon"]


### PR DESCRIPTION
```python
{'atp/brand/Fastned': 410,
 'atp/brand_wikidata/Q19935749': 410,
 'atp/category/amenity/charging_station': 410,
 'atp/cdn/cloudflare/response_count': 412,
 'atp/cdn/cloudflare/response_status_count/200': 412,
 'atp/clean_strings/street_address': 9,
 'atp/country/BE': 52,
 'atp/country/CH': 14,
 'atp/country/DE': 54,
 'atp/country/DK': 7,
 'atp/country/ES': 2,
 'atp/country/FR': 59,
 'atp/country/GB': 37,
 'atp/country/IT': 1,
 'atp/country/NL': 184,
 'atp/field/branch/missing': 410,
 'atp/field/email/missing': 410,
 'atp/field/image/missing': 410,
 'atp/field/opening_hours/missing': 410,
 'atp/field/phone/missing': 410,
 'atp/field/postcode/missing': 410,
 'atp/field/state/missing': 410,
 'atp/field/twitter/missing': 410,
 'atp/field/website/missing': 410,
 'atp/item_scraped_host_count/www.fastnedcharging.com': 410,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 410,
 'atp/operator/Fastned': 410,
 'atp/operator_wikidata/Q19935749': 410,
 'downloader/request_bytes': 165512,
 'downloader/request_count': 412,
 'downloader/request_method_count/GET': 412,
 'downloader/response_bytes': 1843614,
 'downloader/response_count': 412,
 'downloader/response_status_count/200': 412,
 'elapsed_time_seconds': 509.009136,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 19, 11, 24, 33, 674612, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 159086,
 'httpcompression/response_count': 412,
 'item_scraped_count': 410,
 'items_per_minute': 48.33005893909627,
 'log_count/DEBUG': 822,
 'log_count/INFO': 15,
 'request_depth_max': 1,
 'response_received_count': 412,
 'responses_per_minute': 48.56581532416504,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 411,
 'scheduler/dequeued/memory': 411,
 'scheduler/enqueued': 411,
 'scheduler/enqueued/memory': 411,
 'start_time': datetime.datetime(2026, 2, 19, 11, 16, 4, 665476, tzinfo=datetime.timezone.utc)}
```