### PR TITLE
[lukoil] Update Payment and Service Dictionaries

### DIFF
--- a/locations/spiders/lukoil.py
+++ b/locations/spiders/lukoil.py
@@ -55,16 +55,14 @@ PAYMENT_TYPES = {
     "UTA fuel card": FuelCards.UTA,
     "Vpay": PaymentMethods.V_PAY,
     "Карта AMEX": PaymentMethods.AMERICAN_EXPRESS,
-    
     # Russian language payment types
-    "Банковские карты": PaymentMethods.CARDS, # Bank Cards,
-    "Безналичный расчет": PaymentMethods.CARDS, # Cashless Non-cash payment methods
-    "Топливные карты ЛУКОЙЛ": FuelCards.LUKOIL, # LUKOIL fuel card
-    "Оплата баллами ЛУКОЙЛ": FuelCards.LUKOIL_LOYALTY_PROGRAM, # LUKOIL rewards card 
-    "СБП": PaymentMethods.SBP, # Fast payment system
-    "Бесконтактные платежи": PaymentMethods.CONTACTLESS, # Contactless Payments
-    "Топливные карты DKV": FuelCards.DKV, # DKV fuel card
-    
+    "Банковские карты": PaymentMethods.CARDS,  # Bank Cards,
+    "Безналичный расчет": PaymentMethods.CARDS,  # Cashless Non-cash payment methods
+    "Топливные карты ЛУКОЙЛ": FuelCards.LUKOIL,  # LUKOIL fuel card
+    "Оплата баллами ЛУКОЙЛ": FuelCards.LUKOIL_LOYALTY_PROGRAM,  # LUKOIL rewards card
+    "СБП": PaymentMethods.SBP,  # Fast payment system
+    "Бесконтактные платежи": PaymentMethods.CONTACTLESS,  # Contactless Payments
+    "Топливные карты DKV": FuelCards.DKV,  # DKV fuel card
     # TODO: find payment methods for the following
     '"Халва" cards': None,
     "Bancontact/mister cash": None,
@@ -86,15 +84,13 @@ SERVICES = {
     "handicap accessible restroom": Extras.TOILETS_WHEELCHAIR,
     "Oil Change": Extras.OIL_CHANGE,
     "Vacuum": Extras.VACUUM_CLEANER,
-
     # Russian language services
-    "Выдача наличных": Extras.ATM, # Cash withdrawal
-    "Туалет": Extras.TOILETS, # Restroom
-    "Подкачка шин": Extras.COMPRESSED_AIR, # Air tower
-    "Автомойка": Extras.CAR_WASH, # Car Wash
-    "Пылесос": Extras.VACUUM_CLEANER, # Vacuum
-    "Туалет для маломобильных групп населения": Extras.TOILETS_WHEELCHAIR, # Accessibility restroom
-
+    "Выдача наличных": Extras.ATM,  # Cash withdrawal
+    "Туалет": Extras.TOILETS,  # Restroom
+    "Подкачка шин": Extras.COMPRESSED_AIR,  # Air tower
+    "Автомойка": Extras.CAR_WASH,  # Car Wash
+    "Пылесос": Extras.VACUUM_CLEANER,  # Vacuum
+    "Туалет для маломобильных групп населения": Extras.TOILETS_WHEELCHAIR,  # Accessibility restroom
     # Values below are not mapped as they should exist as separate POIs,
     # or already mapped in other attributes, or not possible to map at all.
     "ASE": None,


### PR DESCRIPTION
The spider was fixed a couple of months ago in https://github.com/alltheplaces/alltheplaces/pull/14814. The API  changed and the payment type and service names are now in Russian. I’ve added the most common Russian terms to the dictionaries to preserve the majority of tags. The remaining English keys are being kept for now in case the API changes again.

```
{'atp/brand/Lukoil': 1396,
 'atp/brand/Лукойл': 2462,
 'atp/brand/ლუკოილი': 62,
 'atp/brand_wikidata/Q329347': 3922,
 'atp/category/amenity/fuel': 4670,
 'atp/clean_strings/addr_full': 15,
 'atp/clean_strings/city': 10,
 'atp/clean_strings/name': 102,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street': 50,
 'atp/country/AL': 1,
 'atp/country/AX': 1,
 'atp/country/AZ': 70,
 'atp/country/BE': 183,
 'atp/country/BG': 211,
 'atp/country/BY': 84,
 'atp/country/FI': 391,
 'atp/country/FR': 3,
 'atp/country/GE': 62,
 'atp/country/GR': 1,
 'atp/country/HR': 42,
 'atp/country/HU': 1,
 'atp/country/IR': 4,
 'atp/country/IT': 29,
 'atp/country/JO': 1,
 'atp/country/LT': 1,
 'atp/country/MD': 95,
 'atp/country/ME': 8,
 'atp/country/MK': 38,
 'atp/country/NL': 49,
 'atp/country/OM': 1,
 'atp/country/PK': 5,
 'atp/country/RO': 318,
 'atp/country/RS': 114,
 'atp/country/RU': 2361,
 'atp/country/SA': 12,
 'atp/country/SH': 1,
 'atp/country/SI': 2,
 'atp/country/SY': 1,
 'atp/country/TR': 397,
 'atp/country/UA': 5,
 'atp/country/US': 176,
 'atp/field/branch/missing': 4670,
 'atp/field/brand/missing': 750,
 'atp/field/brand_wikidata/missing': 748,
 'atp/field/city/missing': 927,
 'atp/field/country/from_reverse_geocoding': 4668,
 'atp/field/country/missing': 2,
 'atp/field/email/invalid': 107,
 'atp/field/email/missing': 3598,
 'atp/field/geometry/missing': 2,
 'atp/field/image/missing': 4137,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 4608,
 'atp/field/operator_wikidata/missing': 4670,
 'atp/field/phone/invalid': 95,
 'atp/field/phone/missing': 3664,
 'atp/field/postcode/missing': 1610,
 'atp/field/state/missing': 54,
 'atp/field/street_address/missing': 4670,
 'atp/field/twitter/missing': 4670,
 'atp/field/website/missing': 4670,
 'atp/item_scraped_host_count/auto.lukoil.ru': 4670,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/lukoil/brand/failed/"ЛИКАРД"': 194,
 'atp/lukoil/brand/failed/АО "Тебойл"': 402,
 'atp/lukoil/brand/failed/ЛУКОИЛ МАКЕДОНИJА ДООЕЛ Скопjе': 38,
 'atp/lukoil/brand/failed/ЛУКОИЛ СЕРБИА д.о.о. Београд': 113,
 'atp/lukoil/brand/failed/Неизвестный контрагент': 1,
 'atp/lukoil/fuel/failed/cno.png': 1,
 'atp/nsi/cc_match': 3920,
 'atp/nsi/match_failed': 2,
 'atp/operator/შპს ლუკოილ ჯორჯია': 62,
 'downloader/request_bytes': 2525872,
 'downloader/request_count': 4671,
 'downloader/request_method_count/GET': 4671,
 'downloader/response_bytes': 9136513,
 'downloader/response_count': 4671,
 'downloader/response_status_count/200': 4671,
 'elapsed_time_seconds': 5666.018295,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 20, 19, 59, 45, 85871, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18614765,
 'httpcompression/response_count': 4671,
 'item_scraped_count': 4670,
 'items_per_minute': 49.452876809036354,
 'log_count/INFO': 97,
 'log_count/WARNING': 766,
 'memusage/max': 528506880,
 'memusage/startup': 281096192,
 'request_depth_max': 1,
 'response_received_count': 4671,
 'responses_per_minute': 49.46346629015178,
 'scheduler/dequeued': 4671,
 'scheduler/dequeued/memory': 4671,
 'scheduler/enqueued': 4671,
 'scheduler/enqueued/memory': 4671,
 'start_time': datetime.datetime(2026, 2, 20, 18, 25, 19, 67576, tzinfo=datetime.timezone.utc)}
```