### PR TITLE
[Denny's JP] replace Seven and i foodsystems spider 

### DIFF
--- a/locations/spiders/dennys_jp.py
+++ b/locations/spiders/dennys_jp.py
@@ -3,7 +3,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.categories import Categories, apply_category, apply_yes_no
+from locations.categories import Categories, apply_yes_no
 from locations.dict_parser import DictParser
 
 
@@ -18,7 +18,7 @@ class DennysJPSpider(Spider):
         for store in response.json()["items"]:
 
             item = DictParser.parse(store)
-                       
+
             if store["extra_fields"]["24時間営業"] == "1":
                 item["opening_hours"] = "24/7"
             item["website"] = f"https://shop.dennys.co.jp/map/{store['key']}/"


### PR DESCRIPTION
Seven and I food systems is now just Denny's only, looks like all the stores opened under the other brands have closed.

{'atp/brand/デニーズ': 316,
 'atp/brand_wikidata/Q11320661': 316,
 'atp/category/amenity/restaurant': 316,
 'atp/clean_strings/name': 245,
 'atp/country/JP': 316,
 'atp/field/branch/missing': 316,
 'atp/field/city/missing': 316,
 'atp/field/country/from_spider_name': 316,
 'atp/field/email/missing': 316,
 'atp/field/image/missing': 316,
 'atp/field/opening_hours/missing': 316,
 'atp/field/operator/missing': 316,
 'atp/field/operator_wikidata/missing': 316,
 'atp/field/state/missing': 316,
 'atp/field/street_address/missing': 316,
 'atp/field/twitter/missing': 316,
 'atp/item_scraped_host_count/shop.dennys.co.jp': 316,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 316,
 'downloader/request_bytes': 673,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 85246,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.913023,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 20, 23, 55, 57, 618053, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 864513,
 'httpcompression/response_count': 1,
 'item_scraped_count': 316,
 'items_per_minute': 9480.0,
 'log_count/DEBUG': 318,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 20, 23, 55, 54, 705030, tzinfo=datetime.timezone.utc)}