### PR TITLE
[Lawson JP] fix tagging, prep for storefinder

### DIFF
--- a/locations/spiders/lawson_jp.py
+++ b/locations/spiders/lawson_jp.py
@@ -4,7 +4,7 @@ from io import StringIO
 from chompjs import parse_js_object
 from scrapy import Request, Spider
 
-from locations.categories import Categories, Extras, Fuel, PaymentMethods, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.geo import country_iseadgg_centroids
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
@@ -16,7 +16,7 @@ BRANDS = {
 }
 MAX_ITEMS = 1640  # determined experimentally
 RADIUS_KM = 24
-MAP_ID = "lawson" # for storefinder
+MAP_ID = "lawson"  # for storefinder
 
 
 class LawsonJPSpider(Spider):


### PR DESCRIPTION
Fix to match meaning of tags on website and proper tagging for post_partner. Add MAP_ID constant for ease of integrating with possible storefinder.

{'atp/brand/LAWSON': 13668,
 'atp/brand/LAWSON STORE 100': 585,
 'atp/brand/NATURAL LAWSON': 82,
 'atp/brand_wikidata/Q11323850': 82,
 'atp/brand_wikidata/Q11350960': 585,
 'atp/brand_wikidata/Q1557223': 13668,
 'atp/category/shop/convenience': 14335,
 'atp/country/JP': 14335,
 'atp/duplicate_count': 7039,
 'atp/field/city/missing': 14335,
 'atp/field/country/from_spider_name': 14335,
 'atp/field/email/missing': 14335,
 'atp/field/image/missing': 14335,
 'atp/field/operator/missing': 14335,
 'atp/field/operator_wikidata/missing': 14335,
 'atp/field/phone/missing': 15,
 'atp/field/postcode/missing': 14335,
 'atp/field/state/missing': 14335,
 'atp/field/street_address/missing': 14335,
 'atp/field/twitter/missing': 14335,
 'atp/item_scraped_host_count/www.e-map.ne.jp': 21374,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 13668,
 'atp/nsi/perfect_match': 667,
 'downloader/request_bytes': 519724,
 'downloader/request_count': 830,
 'downloader/request_method_count/GET': 830,
 'downloader/response_bytes': 5650626,
 'downloader/response_count': 830,
 'downloader/response_status_count/200': 830,
 'dupefilter/filtered': 105,
 'elapsed_time_seconds': 1029.551219,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 21, 6, 23, 51, 685320, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 7039,
 'item_dropped_reasons_count/DropItem': 7039,
 'item_scraped_count': 14335,
 'items_per_minute': 835.860058309038,
 'log_count/DEBUG': 22205,
 'log_count/INFO': 137,
 'log_count/WARNING': 2,
 'request_depth_max': 1,
 'response_received_count': 830,
 'responses_per_minute': 48.396501457725954,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 829,
 'scheduler/dequeued/memory': 829,
 'scheduler/enqueued': 829,
 'scheduler/enqueued/memory': 829,
 'start_time': datetime.datetime(2026, 2, 21, 6, 6, 42, 134101, tzinfo=datetime.timezone.utc)}