### PR TITLE
[Kuroneko Yamato JP] add spider (~36k locations)

### DIFF
--- a/locations/spiders/kuroneko_jp.py
+++ b/locations/spiders/kuroneko_jp.py
@@ -37,9 +37,9 @@ class KuronekoJPSpider(Spider):
         for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):
             yield self.make_request(lat, lon, radius_m)
         for city in city_locations("JP", 50000):
-            yield self.make_request(city['latitude'], city['longitude'], 5500)
+            yield self.make_request(city["latitude"], city["longitude"], 5500)
         for city in city_locations("JP"):
-            yield self.make_request(city['latitude'], city['longitude'], 10000)
+            yield self.make_request(city["latitude"], city["longitude"], 10000)
 
     def parse(self, response, lat, lon, offset):
         # response is an EUC-encoded JS file that looks like
@@ -59,13 +59,13 @@ class KuronekoJPSpider(Spider):
         if rec_count >= hit_count:
             yield self.make_request(lat, lon, offset + rec_count)
         for row in reader:
-            if row[3] == "001": #skip FamilyMart
+            if row[3] == "001":  # skip FamilyMart
                 continue
             item = Feature()
             item["ref"] = row[0]
             item["website"] = f"https://www.e-map.ne.jp/p/{MAP_ID}/dtl/{row[0]}/"
             item["lat"] = row[1]
-            item["lon"] = row[2]            
+            item["lon"] = row[2]
             if row[3] == "YTC":
                 apply_category(Categories.POST_OFFICE, item)
                 item["branch"] = row[6]
@@ -80,14 +80,13 @@ class KuronekoJPSpider(Spider):
                         item["name"] = None
                     except:
                         item["branch"] = row[6]
-                        pass
                 else:
                     item["name"] = row[6]
                 apply_category(Categories.POST_PARTNER, item)
                 item["extras"]["post_office:service_provider"] = "ヤマト運輸"
 
             item["brand"], item["brand_wikidata"] = BRANDS.get(row[3], (None, None))
-                        
+
             item["addr_full"] = row[7]
             item["phone"] = row[16]
 


### PR DESCRIPTION
Got the search area working.

{'atp/brand/NewDays': 43,
 'atp/brand/セブン-イレブン': 19920,
 'atp/brand/デイリーヤマザキ': 1008,
 'atp/brand/ポプラ': 111,
 'atp/brand/ヤマト運輸': 5589,
 'atp/brand_wikidata/Q11234763': 43,
 'atp/brand_wikidata/Q259340': 19920,
 'atp/brand_wikidata/Q5209392': 1008,
 'atp/brand_wikidata/Q6584353': 5589,
 'atp/brand_wikidata/Q7229380': 111,
 'atp/category/amenity/parcel_locker': 7163,
 'atp/category/amenity/post_office': 5589,
 'atp/category/missing': 2100,
 'atp/category/shop/convenience': 21082,
 'atp/clean_strings/name': 4755,
 'atp/country/JP': 35934,
 'atp/duplicate_count': 210847,
 'atp/field/branch/missing': 9475,
 'atp/field/brand/missing': 9263,
 'atp/field/brand_wikidata/missing': 9263,
 'atp/field/city/missing': 35934,
 'atp/field/country/from_spider_name': 35934,
 'atp/field/email/missing': 35934,
 'atp/field/image/missing': 35934,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 7219,
 'atp/field/operator/missing': 30345,
 'atp/field/operator_wikidata/missing': 30345,
 'atp/field/phone/invalid': 22,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 35934,
 'atp/field/state/missing': 35934,
 'atp/field/street_address/missing': 35934,
 'atp/field/twitter/missing': 35934,
 'atp/item_scraped_host_count/www.e-map.ne.jp': 246781,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 19920,
 'atp/nsi/perfect_match': 6751,
 'atp/operator/ヤマト運輸': 5589,
 'atp/operator_wikidata/Q6584353': 5589,
 'downloader/request_bytes': 4271783,
 'downloader/request_count': 6373,
 'downloader/request_method_count/GET': 6373,
 'downloader/response_bytes': 144314239,
 'downloader/response_count': 6373,
 'downloader/response_status_count/200': 6373,
 'dupefilter/filtered': 2147,
 'elapsed_time_seconds': 7799.320849,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 14, 26, 42, 536694, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 210847,
 'item_dropped_reasons_count/DropItem': 210847,
 'item_scraped_count': 35934,
 'items_per_minute': 276.45082702910634,
 'log_count/DEBUG': 253155,
 'log_count/ERROR': 122,
 'log_count/INFO': 344,
 'request_depth_max': 5,
 'response_received_count': 6373,
 'responses_per_minute': 49.02936273881267,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6372,
 'scheduler/dequeued/memory': 6372,
 'scheduler/enqueued': 6372,
 'scheduler/enqueued/memory': 6372,
 'spider_exceptions/ValueError': 122,
 'spider_exceptions/count': 122,
 'start_time': datetime.datetime(2026, 3, 5, 12, 16, 43, 215845, tzinfo=datetime.timezone.utc)}