### PR TITLE
[FamilyMart JP] add spider (16144 locations)

### DIFF
--- a/locations/spiders/familymart_jp.py
+++ b/locations/spiders/familymart_jp.py
@@ -80,10 +80,7 @@ class FamilymartJPSpider(Spider):
                     item.update({"brand": "ファミマ!!", "brand_wikidata": "Q115868189"})
                     apply_category(Categories.SHOP_CONVENIENCE, item)
                 case "3":
-                    item.update({"brand_wikidata": "Q11247682"})  # using familymart until tomony is accepted.
-                    # item.update({"brand_wikidata": "Q11249798"}) # no NSI for this one yet, pull request submitted 2026-Feb-22
-                    # item.update({"brand": "TOMONY"})
-                    # item["extras"]["brand:en"] = "TOMONY"
+                    item.update({"brand_wikidata": "Q11249798"})
                     apply_category(Categories.SHOP_CONVENIENCE, item)
                 case _:
                     item.update({"brand_wikidata": "Q11247682"})


### PR DESCRIPTION
Seems like one phone number is not working but the rest are okay? Not sure where the error is coming from.

```python
{'atp/brand/FamilyMart': 15126,
 'atp/brand/ファミマ!!': 45,
 'atp/brand_wikidata/Q11247682': 15126,
 'atp/brand_wikidata/Q115868189': 45,
 'atp/category/shop/convenience': 15171,
 'atp/country/JP': 15171,
 'atp/field/city/missing': 15171,
 'atp/field/country/from_spider_name': 15171,
 'atp/field/email/missing': 15171,
 'atp/field/image/missing': 15171,
 'atp/field/opening_hours/invalid': 1357,
 'atp/field/operator/missing': 15171,
 'atp/field/operator_wikidata/missing': 15171,
 'atp/field/phone/invalid': 3,
 'atp/field/state/missing': 15171,
 'atp/field/street_address/missing': 15171,
 'atp/field/twitter/missing': 15171,
 'atp/item_scraped_host_count/store.family.co.jp': 15171,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 15126,
 'atp/nsi/perfect_match': 45,
 'downloader/request_bytes': 18468,
 'downloader/request_count': 52,
 'downloader/request_method_count/GET': 52,
 'downloader/response_bytes': 1523090,
 'downloader/response_count': 52,
 'downloader/response_status_count/200': 52,
 'elapsed_time_seconds': 70.581792,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 1, 31, 44, 21420, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17278182,
 'httpcompression/response_count': 49,
 'item_scraped_count': 15171,
 'items_per_minute': 13003.714285714284,
 'log_count/DEBUG': 15223,
 'log_count/ERROR': 2,
 'log_count/INFO': 25,
 'response_received_count': 52,
 'responses_per_minute': 44.57142857142857,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 51,
 'scheduler/dequeued/memory': 51,
 'scheduler/enqueued': 51,
 'scheduler/enqueued/memory': 51,
 'spider_exceptions/KeyError': 2,
 'spider_exceptions/count': 2,
 'start_time': datetime.datetime(2026, 2, 23, 1, 30, 33, 439628, tzinfo=datetime.timezone.utc)}
```