### PR TITLE
[Skylark JP] fix start_urls

### DIFF
--- a/locations/spiders/skylark_jp.py
+++ b/locations/spiders/skylark_jp.py
@@ -10,10 +10,11 @@ from locations.dict_parser import DictParser
 
 class SkylarkJPSpider(Spider):
     name = "skylark_jp"
+
     async def start(self) -> AsyncIterator[JsonRequest]:
         for points in ["w", "xj", "xn", "xp", "z"]:
             yield JsonRequest(url=f"https://store-info.skylark.co.jp/api/point/{points}/")
-    
+
     def parse(self, response):
         for store in response.json()["items"]:
 


### PR DESCRIPTION
Didn't initially know the meaning behind the characters after the point/ in the URL. Now I know it is a geohash, so I have updated them to include all of Japan.

{'atp/brand/chawan': 30,
 'atp/brand/くし葉': 1,
 'atp/brand/しゃぶ葉': 328,
 'atp/brand/じゅうじゅうカルビ': 44,
 'atp/brand/とんから亭': 27,
 'atp/brand/むさしの森珈琲': 83,
 'atp/brand/ゆめあん食堂': 2,
 'atp/brand/ガスト': 1229,
 'atp/brand/グラッチェガーデンズ': 11,
 'atp/brand/グランブッフェ': 11,
 'atp/brand/ジョナサン': 157,
 'atp/brand/ステーキガスト': 70,
 'atp/brand/トマト＆オニオン': 47,
 'atp/brand/バーミヤン': 370,
 'atp/brand/フェスタガーデン': 3,
 'atp/brand/フロプレステージュ': 120,
 'atp/brand/ペルティカ': 6,
 'atp/brand/ラ・オハナ': 22,
 'atp/brand/三〇三': 1,
 'atp/brand/八郎そば': 3,
 'atp/brand/包包點心': 3,
 'atp/brand/夢庵': 173,
 'atp/brand/桃菜': 3,
 'atp/brand/藍屋': 31,
 'atp/brand/資さんうどん': 101,
 'atp/brand/魚屋路': 22,
 'atp/brand/點心甜心': 1,
 'atp/brand_wikidata/Q11253593': 173,
 'atp/brand_wikidata/Q11310628': 157,
 'atp/brand_wikidata/Q11321395': 47,
 'atp/brand_wikidata/Q11328598': 370,
 'atp/brand_wikidata/Q11634979': 101,
 'atp/brand_wikidata/Q116758676': 83,
 'atp/brand_wikidata/Q120500825': 11,
 'atp/brand_wikidata/Q67710247': 328,
 'atp/brand_wikidata/Q87724117': 1229,
 'atp/brand_wikidata/Q92599119': 70,
 'atp/brand_wikidata/Q98798383': 44,
 'atp/category/amenity/cafe': 83,
 'atp/category/amenity/restaurant': 2779,
 'atp/category/shop/confectionery': 120,
 'atp/clean_strings/addr_full': 2408,
 'atp/country/JP': 2982,
 'atp/field/brand/missing': 83,
 'atp/field/brand_wikidata/missing': 369,
 'atp/field/city/missing': 2982,
 'atp/field/country/from_spider_name': 2982,
 'atp/field/email/missing': 2982,
 'atp/field/image/missing': 2982,
 'atp/field/name/missing': 525,
 'atp/field/opening_hours/missing': 2928,
 'atp/field/operator/missing': 2982,
 'atp/field/operator_wikidata/missing': 2982,
 'atp/field/phone/invalid': 17,
 'atp/field/postcode/missing': 2982,
 'atp/field/state/missing': 2982,
 'atp/field/street_address/missing': 2982,
 'atp/field/twitter/missing': 2982,
 'atp/item_scraped_host_count/store-info.skylark.co.jp': 2982,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 156,
 'atp/nsi/cc_match': 328,
 'atp/nsi/perfect_match': 2129,
 'downloader/request_bytes': 2065,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 309142,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 11.079736,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 22, 14, 49, 53, 452430, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10548121,
 'httpcompression/response_count': 4,
 'item_scraped_count': 2982,
 'items_per_minute': 16265.454545454546,
 'log_count/DEBUG': 2988,
 'log_count/INFO': 3,
 'response_received_count': 6,
 'responses_per_minute': 32.72727272727273,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2026, 2, 22, 14, 49, 42, 372694, tzinfo=datetime.timezone.utc)}