### PR TITLE
[PUDO Station JP] fix request URLs

### DIFF
--- a/locations/spiders/pudostation_jp.py
+++ b/locations/spiders/pudostation_jp.py
@@ -1,26 +1,24 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 
 
 class PudostationJPSpider(Spider):
     name = "pudostation_jp"
+    item_attributes = {"brand_wikidata": "Q86738066"}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for points in ["w", "x", "z"]:
             yield JsonRequest(url=f"https://map.pudo.jp/api/points/{points}")
 
-    item_attributes = {
-        "brand_wikidata": "Q86738066",
-    }
-
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["items"]:
 
             item = DictParser.parse(store)
+            item["branch"] = item.pop("name")
             item["ref"] = store["key"]
             item["website"] = f"https://map.pudo.jp/points/{store['key']}"
             item["postcode"] = store["extra_fields"]["Zip code"]


### PR DESCRIPTION
added URLs for all of Japan.

{'atp/brand/プドー': 7290,
 'atp/brand_wikidata/Q86738066': 7290,
 'atp/category/amenity/parcel_locker': 7290,
 'atp/clean_strings/addr_full': 3,
 'atp/clean_strings/name': 2,
 'atp/country/JP': 7290,
 'atp/field/branch/missing': 7290,
 'atp/field/city/missing': 7290,
 'atp/field/country/from_spider_name': 7290,
 'atp/field/email/missing': 7290,
 'atp/field/image/missing': 7290,
 'atp/field/opening_hours/missing': 2645,
 'atp/field/operator/missing': 7290,
 'atp/field/operator_wikidata/missing': 7290,
 'atp/field/phone/missing': 7290,
 'atp/field/state/missing': 7290,
 'atp/field/street_address/missing': 7290,
 'atp/field/twitter/missing': 7290,
 'atp/item_scraped_host_count/map.pudo.jp': 7290,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 7290,
 'downloader/request_bytes': 1367,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 374280,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 18.730581,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 3, 52, 18, 197651, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3693004,
 'httpcompression/response_count': 3,
 'item_scraped_count': 7290,
 'items_per_minute': 24300.0,
 'log_count/DEBUG': 7294,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 23, 3, 51, 59, 467070, tzinfo=datetime.timezone.utc)}