### PR TITLE
[KFC JP] add request URLs

### DIFF
--- a/locations/spiders/kfc_jp.py
+++ b/locations/spiders/kfc_jp.py
@@ -12,7 +12,7 @@ class KfcJPSpider(Spider):
     item_attributes = {"brand_wikidata": "Q524757"}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for points in ["x", "wv", "wy"]:
+        for points in ["x", "w", "z"]:
             yield JsonRequest(url=f"https://search.kfc.co.jp/api/points/{points}")
 
     def parse(self, response):


### PR DESCRIPTION
replace wv, wy with w to cover Okinawa as well as western Japan. add z for north Hokkaido. No stores yet up there but this is for future use just in case.

```python
{'atp/brand/ケンタッキーフライドチキン': 1340,
 'atp/brand_wikidata/Q524757': 1340,
 'atp/category/amenity/fast_food': 1340,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/phone': 11,
 'atp/clean_strings/postcode': 1,
 'atp/country/JP': 1340,
 'atp/field/country/from_spider_name': 1340,
 'atp/field/email/missing': 1340,
 'atp/field/image/missing': 1340,
 'atp/field/opening_hours/missing': 1340,
 'atp/field/operator/missing': 1340,
 'atp/field/operator_wikidata/missing': 1340,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 1340,
 'atp/item_scraped_host_count/search.kfc.co.jp': 1340,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1340,
 'downloader/request_bytes': 1387,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 195430,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 6.638869,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 4, 3, 25, 517740, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2104218,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1340,
 'items_per_minute': 13400.0,
 'log_count/DEBUG': 1344,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 23, 4, 3, 18, 878871, tzinfo=datetime.timezone.utc)}
```