### PR TITLE
[Ford Dealers US] Fix Spider

### DIFF
--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -41,7 +41,7 @@ class FordDealersUSSpider(scrapy.Spider):
             )
 
     def parse_details(self, response):
-        if data := json.loads(response.xpath("//pre/text()").get()).get("Response").get("Dealer")   :
+        if data := json.loads(response.xpath("//pre/text()").get()).get("Response").get("Dealer"):
             for dealer in data:
                 item = DictParser.parse(dealer)
                 item["ref"] = dealer.get("PACode")


### PR DESCRIPTION
```python
{'atp/brand/Ford': 2823,
 'atp/brand_wikidata/Q44294': 2823,
 'atp/category/shop/car': 2823,
 'atp/country/US': 2823,
 'atp/field/branch/missing': 2823,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1197,
 'atp/field/image/missing': 2823,
 'atp/field/opening_hours/missing': 57,
 'atp/field/operator/missing': 2823,
 'atp/field/operator_wikidata/missing': 2823,
 'atp/field/phone/missing': 13,
 'atp/field/twitter/missing': 2823,
 'atp/field/website/missing': 52,
 'atp/item_scraped_host_count/www.ford.com': 2823,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 2823,
 'downloader/request_bytes': 34773,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 15950394,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 54,
 'elapsed_time_seconds': 93.342499,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 9, 39, 44, 164454, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2823,
 'items_per_minute': 1821.2903225806451,
 'log_count/DEBUG': 3193,
 'log_count/INFO': 8,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 54,
 'playwright/page_count/closed': 54,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 130,
 'playwright/request_count/aborted': 76,
 'playwright/request_count/method/GET': 130,
 'playwright/request_count/navigation': 54,
 'playwright/request_count/resource_type/document': 54,
 'playwright/request_count/resource_type/font': 8,
 'playwright/request_count/resource_type/image': 4,
 'playwright/request_count/resource_type/script': 52,
 'playwright/request_count/resource_type/stylesheet': 12,
 'playwright/response_count': 54,
 'playwright/response_count/method/GET': 54,
 'playwright/response_count/resource_type/document': 54,
 'request_depth_max': 2,
 'response_received_count': 54,
 'responses_per_minute': 34.83870967741935,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 53,
 'scheduler/dequeued/memory': 53,
 'scheduler/enqueued': 53,
 'scheduler/enqueued/memory': 53,
 'start_time': datetime.datetime(2026, 2, 23, 9, 38, 10, 821955, tzinfo=datetime.timezone.utc)}
```