### PR TITLE
[Seims JP] fix source URLs

### DIFF
--- a/locations/spiders/seims_jp.py
+++ b/locations/spiders/seims_jp.py
@@ -59,7 +59,7 @@ class SeimsJPSpider(Spider):
 
             apply_yes_no("drinking_water:refill", item, store["extra_fields"]["給水器"] == "1")
             apply_yes_no("drive_through", item, store["extra_fields"]["【調剤】調剤ドライブスルー"] == "1")
-            
+
             apply_yes_no("sells:rice", item, store["extra_fields"]["【取扱】米"] == "1")
             apply_yes_no("sells:meat", item, store["extra_fields"]["【取扱】精肉"] == "1")
             apply_yes_no("sells:pet_supplies", item, store["extra_fields"]["【取扱】ペット用品"] == "1")
@@ -69,17 +69,17 @@ class SeimsJPSpider(Spider):
             apply_yes_no("sells:alcohol", item, store["extra_fields"]["【取扱】酒類"] == "1")
             apply_yes_no("sells:contact_lenses", item, store["extra_fields"]["【取扱】コンタクトレンズ"] == "1")
             apply_yes_no("sells:baby_goods", item, store["extra_fields"]["【取扱】ベビー用品"] == "1")
-            
+
             apply_yes_no(PaymentMethods.CREDIT_CARDS, item, store["extra_fields"]["【支払】ｸﾚｼﾞｯﾄ"] == "1")
             apply_yes_no(PaymentMethods.CONTACTLESS, item, store["extra_fields"]["【支払】ｸﾚｼﾞｯﾄ(タッチ決済)"] == "1")
-            
+
             if str("".join(filter(str.isdigit, str(store["extra_fields"]["駐車場台数"])))) in ("", "0"):
                 pass
             else:
                 item["extras"]["parking:capacity:standard"] = str(
                     "".join(filter(str.isdigit, str(store["extra_fields"]["駐車場台数"])))
                 )
-            
+
             item["website"] = f"https://store.seims.co.jp/map/{store['key']}/"
             item["extras"]["website:booking"] = store["extra_fields"]["【調剤】処方せんネット受付URL"]
             item["ref"] = store["key"]


### PR DESCRIPTION
This fix gets locations from all of Japan rather than just a subset.

```python
{'atp/brand/アメリカンドラッグ': 91,
 'atp/brand/オストジャパン': 17,
 'atp/brand/スーパードラッグキリン': 12,
 'atp/brand/ドラッグストアエース': 4,
 'atp/brand/ドラッグストアスマイル': 6,
 'atp/brand/ドラッグセイムス': 923,
 'atp/brand/ドラッグユタカ': 228,
 'atp/brand/救命堂': 5,
 'atp/brand_wikidata/Q11456137': 1286,
 'atp/category/amenity/pharmacy': 599,
 'atp/category/multiple': 599,
 'atp/category/shop/chemist': 687,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/postcode': 1,
 'atp/country/JP': 1286,
 'atp/field/branch/missing': 1286,
 'atp/field/city/missing': 1286,
 'atp/field/country/from_spider_name': 1286,
 'atp/field/email/missing': 1286,
 'atp/field/image/missing': 1286,
 'atp/field/opening_hours/missing': 1286,
 'atp/field/operator/missing': 1286,
 'atp/field/operator_wikidata/missing': 1286,
 'atp/field/state/missing': 1286,
 'atp/field/street_address/missing': 1286,
 'atp/field/twitter/missing': 1286,
 'atp/item_scraped_host_count/store.seims.co.jp': 1286,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1286,
 'downloader/request_bytes': 1391,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 173791,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 6.145914,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 11, 42, 47, 744950, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4947357,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1286,
 'items_per_minute': 12860.0,
 'log_count/DEBUG': 1290,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 23, 11, 42, 41, 599036, tzinfo=datetime.timezone.utc)}
```