### PR TITLE
[Mazda JP] Fix Spider

### DIFF
--- a/locations/spiders/mazda_jp.py
+++ b/locations/spiders/mazda_jp.py
@@ -14,7 +14,7 @@ MAZDA_SHARED_ATTRIBUTES = {"brand": "Mazda", "brand_wikidata": "Q35996"}
 class MazdaJPSpider(JSONBlobSpider):
     name = "mazda_jp"
     item_attributes = MAZDA_SHARED_ATTRIBUTES
-    allowed_domains = ["ssl.mazda.co.jp"]
+    allowed_domains = ["www.mazda.co.jp", "ssl.mazda.co.jp", "www2.mazda.co.jp"]
     locations_key = ["Shops"]
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
```python
{'atp/brand/Mazda': 96,
 'atp/brand_wikidata/Q35996': 96,
 'atp/category/shop/car': 48,
 'atp/category/shop/car_repair': 48,
 'atp/country/JP': 96,
 'atp/duplicate_count': 8404,
 'atp/field/branch/missing': 96,
 'atp/field/country/from_spider_name': 96,
 'atp/field/email/missing': 96,
 'atp/field/image/missing': 96,
 'atp/field/opening_hours/missing': 96,
 'atp/field/operator/missing': 96,
 'atp/field/operator_wikidata/missing': 96,
 'atp/field/twitter/missing': 96,
 'atp/field/website/missing': 4,
 'atp/item_scraped_host_count/www2.mazda.co.jp': 8500,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 96,
 'downloader/request_bytes': 82583,
 'downloader/request_count': 173,
 'downloader/request_method_count/GET': 173,
 'downloader/response_bytes': 1213377,
 'downloader/response_count': 173,
 'downloader/response_status_count/200': 87,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/307': 85,
 'elapsed_time_seconds': 210.486159,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 23, 12, 9, 3, 569639, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 13488009,
 'httpcompression/response_count': 87,
 'item_dropped_count': 8404,
 'item_dropped_reasons_count/DropItem': 8404,
 'item_scraped_count': 96,
 'items_per_minute': 27.428571428571427,
 'log_count/DEBUG': 8673,
 'log_count/INFO': 6,
 'response_received_count': 87,
 'responses_per_minute': 24.857142857142858,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 170,
 'scheduler/dequeued/memory': 170,
 'scheduler/enqueued': 170,
 'scheduler/enqueued/memory': 170,
 'start_time': datetime.datetime(2026, 2, 23, 12, 5, 33, 83480, tzinfo=datetime.timezone.utc)}

```