### PR TITLE
[Burger King TR] Fix spider

### DIFF
--- a/locations/spiders/burger_king_tr.py
+++ b/locations/spiders/burger_king_tr.py
@@ -17,7 +17,7 @@ class BurgerKingTRSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["ref"] = item["website"] = response.url
-        item["name"] = None
+        item["name"] = item["phone"] = None
         item["branch"] = response.xpath('//*[@class="current-page-name"]/text()').get("").strip()
         apply_category(Categories.FAST_FOOD, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Burger King': 807,
 'atp/brand_wikidata/Q177054': 807,
 'atp/category/amenity/fast_food': 807,
 'atp/clean_strings/street_address': 204,
 'atp/country/TR': 807,
 'atp/field/email/missing': 807,
 'atp/field/geometry/missing': 1,
 'atp/field/image/dropped': 807,
 'atp/field/image/missing': 807,
 'atp/field/opening_hours/missing': 72,
 'atp/field/operator/missing': 807,
 'atp/field/operator_wikidata/missing': 807,
 'atp/field/postcode/missing': 807,
 'atp/field/street_address/missing': 1,
 'atp/item_scraped_host_count/www.burgerking.com.tr': 807,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 807,
 'downloader/request_bytes': 428570,
 'downloader/request_count': 809,
 'downloader/request_method_count/GET': 809,
 'downloader/response_bytes': 13323883,
 'downloader/response_count': 809,
 'downloader/response_status_count/200': 809,
 'elapsed_time_seconds': 13.498048,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 25, 10, 0, 30, 371665, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 809,
 'httpcompression/response_bytes': 58770381,
 'httpcompression/response_count': 809,
 'item_scraped_count': 807,
 'items_per_minute': 3724.6153846153843,
 'log_count/DEBUG': 1617,
 'log_count/INFO': 3,
 'log_count/WARNING': 19,
 'request_depth_max': 1,
 'response_received_count': 809,
 'responses_per_minute': 3733.846153846154,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 808,
 'scheduler/dequeued/memory': 808,
 'scheduler/enqueued': 808,
 'scheduler/enqueued/memory': 808,
 'start_time': datetime.datetime(2026, 2, 25, 10, 0, 16, 873617, tzinfo=datetime.timezone.utc)}
```