### PR TITLE
[Nisa GB] Drop invalid twitter profiles

### DIFF
--- a/locations/spiders/nisalocal_gb.py
+++ b/locations/spiders/nisalocal_gb.py
@@ -11,7 +11,14 @@ class NisalocalGBSpider(CrawlSpider, StructuredDataSpider):
     allowed_domains = ["nisalocally.co.uk"]
     start_urls = ["https://www.nisalocally.co.uk/stores/index.html"]
     rules = [Rule(LinkExtractor(allow=".*/stores/.*"), callback="parse_sd", follow=True)]
+    search_for_twitter = False
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        apply_category(Categories.SHOP_CONVENIENCE, item)
+        if item["name"].startswith("Test "):
+            return
+        elif "Nisa Extra" in item["name"]:
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+        else:
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Nisa': 1102,
 'atp/brand_wikidata/Q16999069': 1102,
 'atp/category/shop/convenience': 1085,
 'atp/category/shop/supermarket': 17,
 'atp/country/GB': 1101,
 'atp/country/JE': 1,
 'atp/field/branch/missing': 1102,
 'atp/field/email/missing': 1102,
 'atp/field/image/dropped': 1102,
 'atp/field/image/missing': 1102,
 'atp/field/opening_hours/missing': 45,
 'atp/field/operator/missing': 1102,
 'atp/field/operator_wikidata/missing': 1102,
 'atp/field/phone/missing': 222,
 'atp/field/state/missing': 1102,
 'atp/field/twitter/missing': 1102,
 'atp/item_scraped_host_count/www.nisalocally.co.uk': 1102,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 17,
 'atp/nsi/match_failed': 1085,
 'atp/structured_data/unmapped/payment_accepted/applePay': 1,
 'downloader/request_bytes': 1081676,
 'downloader/request_count': 1779,
 'downloader/request_method_count/GET': 1779,
 'downloader/response_bytes': 59803358,
 'downloader/response_count': 1779,
 'downloader/response_status_count/200': 1774,
 'downloader/response_status_count/404': 5,
 'dupefilter/filtered': 9998,
 'elapsed_time_seconds': 1036.836465,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 26, 10, 33, 47, 686313, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 844,
 'httpcache/hit': 935,
 'httpcache/miss': 844,
 'httpcache/store': 844,
 'httpcompression/response_bytes': 396531828,
 'httpcompression/response_count': 1779,
 'item_scraped_count': 1102,
 'items_per_minute': 63.82239382239383,
 'log_count/INFO': 21,
 'log_count/WARNING': 1,
 'memusage/max': 665477120,
 'memusage/startup': 334024704,
 'offsite/domains': 2,
 'offsite/filtered': 25,
 'request_depth_max': 4,
 'response_received_count': 1779,
 'responses_per_minute': 103.03088803088804,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1778,
 'scheduler/dequeued/memory': 1778,
 'scheduler/enqueued': 1778,
 'scheduler/enqueued/memory': 1778,
 'start_time': datetime.datetime(2026, 2, 26, 10, 16, 30, 849848, tzinfo=datetime.timezone.utc)}
```