### PR TITLE
[Denny's JP] Collect more regions

### DIFF
--- a/locations/spiders/dennys_jp.py
+++ b/locations/spiders/dennys_jp.py
@@ -15,7 +15,7 @@ class DennysJPSpider(Spider):
         for points in [
             "w",
             "x",
-            "z",            
+            "z",
         ]:
             yield JsonRequest(url=f"https://shop.dennys.co.jp/api/point/{points}/")
 


### PR DESCRIPTION
expand URLs to cover all of Japan

{'atp/brand/デニーズ': 316,
 'atp/brand_wikidata/Q11320661': 316,
 'atp/category/amenity/restaurant': 316,
 'atp/clean_strings/name': 245,
 'atp/country/JP': 316,
 'atp/field/branch/missing': 316,
 'atp/field/city/missing': 316,
 'atp/field/country/from_spider_name': 316,
 'atp/field/email/missing': 316,
 'atp/field/image/missing': 316,
 'atp/field/opening_hours/missing': 316,
 'atp/field/operator/missing': 316,
 'atp/field/operator_wikidata/missing': 316,
 'atp/field/state/missing': 316,
 'atp/field/street_address/missing': 316,
 'atp/field/twitter/missing': 316,
 'atp/item_scraped_host_count/shop.dennys.co.jp': 316,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 316,
 'downloader/request_bytes': 1391,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 86031,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 5.636788,
 'feedexport/success_count/FileFeedStorage': 2,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 26, 11, 39, 54, 923192, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 864513,
 'httpcompression/response_count': 1,
 'item_scraped_count': 316,
 'items_per_minute': 3792.0,
 'log_count/INFO': 3,
 'memusage/max': 218710016,
 'memusage/startup': 218710016,
 'response_received_count': 4,
 'responses_per_minute': 48.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 26, 11, 39, 49, 286404, tzinfo=datetime.timezone.utc)}