### PR TITLE
[Pal Closet] Collect more regions

### DIFF
--- a/locations/spiders/palcloset.py
+++ b/locations/spiders/palcloset.py
@@ -15,7 +15,7 @@ class PalclosetSpider(Spider):
         for points in [
             "w",
             "x",
-            "z",            
+            "z",
         ]:
             yield JsonRequest(url=f"https://palcloset.storelocator.jp/api/point/{points}/")
 


### PR DESCRIPTION
also, rename spider to reflect that it is not just a Japan brand.

{'atp/brand/-goocy-': 6,
 'atp/brand/3COINS': 380,
 'atp/brand/BEARDSLEY': 20,
 'atp/brand/BIRTHDAY BAR': 26,
 "atp/brand/CAPRICIEUX LE'MAGE": 7,
 'atp/brand/CIAOPANIC': 8,
 'atp/brand/CIAOPANIC TYPY': 63,
 'atp/brand/COLLAGE GALLARDAGALANTE': 13,
 'atp/brand/COLONY 2139': 10,
 'atp/brand/Chico': 30,
 'atp/brand/DISCOAT': 49,
 'atp/brand/DOUDOU': 5,
 'atp/brand/Drawing Numbers': 2,
 'atp/brand/FREDY & GLOSTER': 11,
 'atp/brand/GALLARDAGALANTE': 18,
 'atp/brand/GALLARDAGALANTE OUTLET': 15,
 'atp/brand/IACUCCI': 6,
 'atp/brand/KITO FOREST MARKET SHIMOICHI': 1,
 'atp/brand/Kastane': 34,
 'atp/brand/LARUTA': 3,
 'atp/brand/LOCUST': 43,
 'atp/brand/LOUNGEDRESS': 9,
 'atp/brand/La boutique BonBon': 3,
 'atp/brand/Lattice': 42,
 "atp/brand/Lui's": 10,
 'atp/brand/NICE CLAUP / OLIVE des OLIVE OUTLET': 38,
 "atp/brand/NOLLEY'S": 28,
 'atp/brand/OLIVE des OLIVE': 9,
 'atp/brand/OUTLET': 47,
 'atp/brand/Omekashi': 1,
 'atp/brand/PUAL CE CIN': 7,
 'atp/brand/RAY CASSIN': 3,
 'atp/brand/RIVE DROITE': 9,
 'atp/brand/Remind me and forever': 2,
 'atp/brand/SHENERY': 7,
 'atp/brand/Seemi.by NICE CLAUP': 2,
 'atp/brand/WHO’S WHO gallery': 7,
 'atp/brand/Whim Gazette': 13,
 'atp/brand/allegory GALLARDAGALANTE': 1,
 'atp/brand/baseyard tokyo': 8,
 'atp/brand/ear PAPILLONNER': 26,
 'atp/brand/earthy_': 4,
 'atp/brand/mline': 3,
 'atp/brand/mystic': 29,
 'atp/brand/natural couture': 15,
 'atp/brand/one after another NICE CLAUP': 24,
 'atp/brand/russet': 36,
 'atp/brand/russet OUTLET': 4,
 'atp/brand/salut!': 12,
 'atp/brand/w closet': 9,
 'atp/brand_wikidata/Q60997353': 380,
 'atp/category/shop/clothes': 778,
 'atp/category/shop/variety_store': 380,
 'atp/clean_strings/addr_full': 7,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/phone': 2,
 'atp/country/HK': 2,
 'atp/country/JP': 1155,
 'atp/country/MY': 1,
 'atp/field/brand_wikidata/missing': 778,
 'atp/field/city/missing': 1158,
 'atp/field/country/from_reverse_geocoding': 1158,
 'atp/field/email/missing': 1158,
 'atp/field/image/missing': 1158,
 'atp/field/name/missing': 778,
 'atp/field/opening_hours/missing': 1158,
 'atp/field/operator/missing': 1158,
 'atp/field/operator_wikidata/missing': 1158,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 379,
 'atp/field/postcode/missing': 3,
 'atp/field/street_address/missing': 1158,
 'atp/field/twitter/missing': 1158,
 'atp/item_scraped_host_count/palcloset.storelocator.jp': 1158,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 380,
 'downloader/request_bytes': 1423,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 2135402,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 4.570106,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 26, 12, 9, 17, 809372, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1158,
 'items_per_minute': 17370.0,
 'log_count/DEBUG': 1162,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 2, 26, 12, 9, 13, 239266, tzinfo=datetime.timezone.utc)}