### PR TITLE
[Bipa HR] Fix Spider

### DIFF
--- a/locations/spiders/bipa_hr.py
+++ b/locations/spiders/bipa_hr.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from scrapy import Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_SR, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -8,27 +11,26 @@ from locations.pipelines.address_clean_up import merge_address_lines
 
 class BipaHRSpider(Spider):
     name = "bipa_hr"
-    item_attributes = {
-        "brand": "Bipa",
-        "brand_wikidata": "Q864933",
-    }
+    item_attributes = {"brand": "Bipa", "brand_wikidata": "Q864933"}
     start_urls = ["https://bipa.hr/poslovnice/"]
 
-    def parse(self, response: Response):
-        for store in response.xpath('//*[@class="entry-list__entries-col col-12 col-md-4 marker"]'):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.xpath("//div[contains(@class, 'marker')]"):
             item = Feature()
-            item["name"] = store.xpath(".//@data-name").get()
-            item["lat"] = store.xpath(".//@data-lat").get()
-            item["lon"] = store.xpath(".//@data-lng").get()
-            item["street_address"] = store.xpath(".//address//text()[1]").get()
-            item["addr_full"] = merge_address_lines(
-                [item["street_address"], store.xpath(".//address//text()[1]").get()]
-            )
-            item["ref"] = store.xpath(".//article/@class").get()
+            item["branch"] = store.xpath("@data-name").get()
+            item["lat"] = store.xpath("@data-lat").get()
+            item["lon"] = store.xpath("@data-lng").get()
+            item["street_address"] = store.xpath("./article/address/text()[1]").get()
+            item["addr_full"] = merge_address_lines(store.xpath("./article/address/text()").getall())
+            item["ref"] = store.xpath("./article/@class").get().split(" ", 1)[0]
+
             oh = OpeningHours()
 
             for day_time in store.xpath(".//ul//li"):
                 day_time_string = day_time.xpath("normalize-space()").get()
                 oh.add_ranges_from_string(day_time_string.strip(), days=DAYS_SR)
             item["opening_hours"] = oh
+
+            apply_category(Categories.SHOP_CHEMIST, item)
+
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Bipa': 147,
 'atp/brand_wikidata/Q864933': 147,
 'atp/category/shop/chemist': 147,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/street_address': 147,
 'atp/country/HR': 147,
 'atp/field/branch/missing': 147,
 'atp/field/city/missing': 147,
 'atp/field/country/from_spider_name': 147,
 'atp/field/email/missing': 147,
 'atp/field/image/missing': 147,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 147,
 'atp/field/operator_wikidata/missing': 147,
 'atp/field/phone/missing': 147,
 'atp/field/postcode/missing': 147,
 'atp/field/state/missing': 147,
 'atp/field/twitter/missing': 147,
 'atp/field/website/missing': 147,
 'atp/item_scraped_host_count/bipa.hr': 147,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 147,
 'downloader/request_bytes': 839,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 35882,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.108995,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 27, 9, 54, 29, 445187, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 207560,
 'httpcompression/response_count': 2,
 'item_scraped_count': 147,
 'items_per_minute': 2940.0,
 'log_count/DEBUG': 149,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 2, 27, 9, 54, 26, 336192, tzinfo=datetime.timezone.utc)}
```