### PR TITLE
[CoCo Ichibanya] Collect more regions

### DIFF
--- a/locations/spiders/coco_ichibanya.py
+++ b/locations/spiders/coco_ichibanya.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncIterator
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 
@@ -11,11 +11,7 @@ from locations.hours import DAYS, OpeningHours
 class CocoIchibanyaSpider(Spider):
     name = "coco_ichibanya"
     skip_auto_cc_domain = True
-    item_attributes = {
-        "brand": "CoCo Ichibanya",
-        "brand_wikidata": "Q5986105",
-        "extras": Categories.RESTAURANT.value,
-    }
+    item_attributes = {"brand": "CoCo Ichibanya", "brand_wikidata": "Q5986105"}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for points in ["g", "t", "q", "w", "x", "8", "9"]:
@@ -25,7 +21,7 @@ class CocoIchibanyaSpider(Spider):
         for store in response.json()["items"]:
 
             item = DictParser.parse(store)
-            item["branch"] = store["name"].replace("店", "")
+            item["branch"] = item.pop("name").replace("店", "")
             item["ref"] = store["key"]
             try:
                 item["opening_hours"] = OpeningHours()
@@ -36,5 +32,7 @@ class CocoIchibanyaSpider(Spider):
                 )
             except:
                 pass
-            item["name"] = None
+
+            apply_category(Categories.RESTAURANT, item)
+
             yield item


### PR DESCRIPTION
expand locations and add opening_hours and other info.

{'atp/brand/CoCo Ichibanya': 216,
 'atp/brand_wikidata/Q5986105': 216,
 'atp/category/amenity/restaurant': 215,
 'atp/category/missing': 1,
 'atp/clean_strings/addr_full': 5,
 'atp/country/CN': 26,
 'atp/country/GB': 2,
 'atp/country/GU': 1,
 'atp/country/HK': 9,
 'atp/country/ID': 11,
 'atp/country/IN': 2,
 'atp/country/KR': 40,
 'atp/country/PH': 18,
 'atp/country/SG': 5,
 'atp/country/TH': 45,
 'atp/country/TW': 41,
 'atp/country/US': 11,
 'atp/country/VN': 5,
 'atp/field/city/missing': 216,
 'atp/field/country/from_reverse_geocoding': 216,
 'atp/field/email/missing': 216,
 'atp/field/image/missing': 216,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 54,
 'atp/field/operator/missing': 175,
 'atp/field/operator_wikidata/missing': 216,
 'atp/field/phone/missing': 216,
 'atp/field/postcode/missing': 216,
 'atp/field/state/missing': 7,
 'atp/field/street_address/missing': 216,
 'atp/field/twitter/missing': 216,
 'atp/field/website/missing': 216,
 'atp/item_scraped_host_count/worldwide.ichibanya.co.jp': 216,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 215,
 'atp/nsi/match_failed': 1,
 'atp/operator/壹番屋股份有限公司': 41,
 'downloader/request_bytes': 2863,
 'downloader/request_count': 8,
 'downloader/request_method_count/GET': 8,
 'downloader/response_bytes': 154111,
 'downloader/response_count': 8,
 'downloader/response_status_count/200': 8,
 'elapsed_time_seconds': 8.671586,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 2, 28, 0, 57, 48, 73689, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 216,
 'items_per_minute': 1620.0,
 'log_count/DEBUG': 224,
 'log_count/INFO': 3,
 'response_received_count': 8,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2026, 2, 28, 0, 57, 39, 402103, tzinfo=datetime.timezone.utc)}