### PR TITLE
[Intersport GR] Fix spider

### DIFF
--- a/locations/spiders/intersport_gr.py
+++ b/locations/spiders/intersport_gr.py
@@ -21,10 +21,11 @@ class IntersportGRSpider(PlaywrightSpider):
             item = LinkedDataParser.parse_ld(
                 json.loads(store.xpath('.//script[@type="application/ld+json"]/text()').get())
             )
+            item["name"] = item["email"] = item["phone"] = None
             item["lat"] = store.xpath(".//@data-latitude").get()
             item["lon"] = store.xpath(".//@data-longitude").get()
             item["ref"] = item["website"] = response.urljoin(
-                store.xpath('.//a[contains(text(),"Περισσότερα")]/@href').get()
+                store.xpath('.//a[contains(text(), "Περισσότερα")]/@href').get()
             )
             item["branch"] = store.xpath('.//li[@class="name"]/text()').get()
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Intersport': 66,
 'atp/brand_wikidata/Q666888': 66,
 'atp/category/shop/sports': 66,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/street_address': 13,
 'atp/country/GR': 66,
 'atp/duplicate_count': 66,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 66,
 'atp/field/image/missing': 66,
 'atp/field/opening_hours/missing': 66,
 'atp/field/operator/missing': 66,
 'atp/field/operator_wikidata/missing': 66,
 'atp/field/twitter/missing': 66,
 'atp/item_scraped_host_count/www.intersport.gr': 132,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 66,
 'downloader/request_bytes': 547,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1639064,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.636747,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 2, 7, 18, 25, 818604, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 66,
 'item_dropped_reasons_count/DropItem': 66,
 'item_scraped_count': 66,
 'items_per_minute': 990.0,
 'log_count/DEBUG': 250,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 56,
 'playwright/request_count/aborted': 54,
 'playwright/request_count/method/GET': 56,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/image': 14,
 'playwright/request_count/resource_type/script': 33,
 'playwright/request_count/resource_type/stylesheet': 7,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 2, 7, 18, 21, 181857, tzinfo=datetime.timezone.utc)}
```