### PR TITLE
[Superdrug] Fix spider

### DIFF
--- a/locations/spiders/superdrug.py
+++ b/locations/spiders/superdrug.py
@@ -47,20 +47,25 @@ class SuperdrugSpider(PlaywrightSpider):
             item["website"] = urljoin("https://www.superdrug.com/", location["url"])
             item["phone"] = location["address"].get("phone")
 
-            item["opening_hours"] = OpeningHours()
-            for rule in location["openingHours"]["weekDayOpeningList"]:
-                if (
-                    rule["closed"] is True
-                    or rule["openingTime"]["formattedHour"] == rule["closingTime"]["formattedHour"] == "00:00"
-                ):
-                    item["opening_hours"].set_closed(rule["weekDay"])
-                else:
-                    item["opening_hours"].add_range(
-                        rule["weekDay"], rule["openingTime"]["formattedHour"], rule["closingTime"]["formattedHour"]
-                    )
+            item["opening_hours"] = self.parse_opening_hours(location["openingHours"]["weekDayOpeningList"])
+
             apply_category(Categories.SHOP_CHEMIST, item)
             yield item
 
         pagination = results["pagination"]
         if pagination["currentPage"] < pagination["totalPages"]:
             yield self.make_request(pagination["currentPage"] + 1)
+
+    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for rule in rules:
+            if (
+                rule["closed"] is True
+                or rule["openingTime"]["formattedHour"] == rule["closingTime"]["formattedHour"] == "00:00"
+            ):
+                opening_hours.set_closed(rule["weekDay"])
+            else:
+                opening_hours.add_range(
+                    rule["weekDay"], rule["openingTime"]["formattedHour"], rule["closingTime"]["formattedHour"]
+                )
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/Superdrug': 864,
 'atp/brand_wikidata/Q7643261': 864,
 'atp/category/shop/chemist': 864,
 'atp/country/GB': 755,
 'atp/country/IE': 11,
 'atp/field/country/from_reverse_geocoding': 4,
 'atp/field/country/missing': 98,
 'atp/field/email/missing': 864,
 'atp/field/geometry/missing': 98,
 'atp/field/image/missing': 864,
 'atp/field/operator/missing': 864,
 'atp/field/operator_wikidata/missing': 864,
 'atp/field/phone/invalid': 79,
 'atp/field/phone/missing': 22,
 'atp/field/state/missing': 131,
 'atp/field/twitter/missing': 864,
 'atp/item_scraped_host_count/api.superdrug.com': 864,
 'atp/lineage': 'S_?',
 'atp/nsi/category_match': 98,
 'atp/nsi/cc_match': 766,
 'downloader/request_bytes': 7372,
 'downloader/request_count': 11,
 'downloader/request_method_count/GET': 11,
 'downloader/response_bytes': 2822965,
 'downloader/response_count': 11,
 'downloader/response_status_count/200': 11,
 'elapsed_time_seconds': 19.845462,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 2, 10, 23, 58, 299746, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 864,
 'items_per_minute': 2728.421052631579,
 'log_count/DEBUG': 910,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 11,
 'playwright/page_count/closed': 11,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 11,
 'playwright/request_count/method/GET': 11,
 'playwright/request_count/navigation': 11,
 'playwright/request_count/resource_type/document': 11,
 'playwright/response_count': 11,
 'playwright/response_count/method/GET': 11,
 'playwright/response_count/resource_type/document': 11,
 'request_depth_max': 9,
 'response_received_count': 11,
 'responses_per_minute': 34.73684210526316,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 10,
 'scheduler/dequeued/memory': 10,
 'scheduler/enqueued': 10,
 'scheduler/enqueued/memory': 10,
 'start_time': datetime.datetime(2026, 3, 2, 10, 23, 38, 454284, tzinfo=datetime.timezone.utc)}
```