### PR TITLE
[Arb 4x4 Accessories] Fix spider

### DIFF
--- a/locations/spiders/arb_4x4_accessories.py
+++ b/locations/spiders/arb_4x4_accessories.py
@@ -3,6 +3,7 @@ from typing import AsyncIterator, Iterable
 from scrapy.http import JsonRequest, TextResponse
 
 from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -57,5 +58,14 @@ class Arb4x4AccessoriesSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("ARB ").removeprefix("Accessories ").removeprefix("4x4 ")
         item["website"] = f'https://www.arb.com.au/arb-stores/{feature["name"]}'.lower().replace(" ", "-")
+        item["opening_hours"] = self.parse_opening_hours(feature["attributes"])
         apply_category(Categories.SHOP_CAR_PARTS, item)
         yield item
+
+    def parse_opening_hours(self, location_attributes: list[dict]) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for attribute in location_attributes:
+            if "_schedule" in attribute["attribute_code"]:
+                days = attribute["attribute_code"].split("_schedule")[0].replace("weekday", "Monday-Friday")
+                opening_hours.add_ranges_from_string(f'{days} {attribute["value"]}')
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/ARB 4×4 Accessories': 83,
 'atp/brand_wikidata/Q126166453': 83,
 'atp/category/shop/car_parts': 83,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street_address': 7,
 'atp/country/AU': 79,
 'atp/country/NZ': 3,
 'atp/country/TH': 1,
 'atp/field/city/missing': 83,
 'atp/field/email/missing': 83,
 'atp/field/image/missing': 83,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 83,
 'atp/field/operator_wikidata/missing': 83,
 'atp/field/phone/missing': 83,
 'atp/field/state/missing': 83,
 'atp/field/twitter/missing': 83,
 'atp/item_scraped_host_count/mcprod.arb.com.au': 83,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 83,
 'downloader/request_bytes': 1579,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 127187,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.754883,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 2, 14, 0, 53, 60966, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 83,
 'items_per_minute': 4980.0,
 'log_count/DEBUG': 84,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 60.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 2, 14, 0, 51, 306083, tzinfo=datetime.timezone.utc)}
```