### PR TITLE
[Hunkemöller] Clean up parsing

### DIFF
--- a/locations/spiders/hunkemoller.py
+++ b/locations/spiders/hunkemoller.py
@@ -1,40 +1,35 @@
 import json
-import re
+from typing import Any
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_NL, OpeningHours, sanitise_day
+from locations.hours import DAYS, OpeningHours
 
 
 class HunkemollerSpider(SitemapSpider):
     name = "hunkemoller"
     item_attributes = {"brand": "Hunkemöller", "brand_wikidata": "Q2604175"}
     sitemap_urls = ["https://www.hunkemoller.be/nl/sitemap-stores.xml"]
-    sitemap_rules = [
-        (
-            r"https://www.hunkemoller.be/nl/winkel/.+/.+$",
-            "parse",
-        ),
-    ]
+    sitemap_rules = [(r"https://www.hunkemoller.be/nl/winkel/[^/]+/[^/]+\-(\d+)$", "parse")]
 
-    def parse(self, response, **kwargs):
-        script_text = json.loads(
-            re.search(
-                r"data\"s*:\s*\[({\"address1\".*})\],\s*\"total",
-                response.xpath('//*[contains(text(), "latitude")]/text()').get(),
-            ).group(1)
-        )
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = json.loads(response.xpath('//script[@id="mobify-data"]/text()').get())
+        for q in data["__PRELOADED_STATE__"]["__reactQuery"]["queries"]:
+            if "\u002fstores" in q["queryKey"]:
+                poi = q["state"]["data"]["data"][0]
+                break
 
-        item = DictParser.parse(script_text)
+        item = DictParser.parse(poi)
+        item["branch"] = item.pop("name")
         item["website"] = response.url
 
-        oh = OpeningHours()
-        for day_time in script_text.get("c_openingHours") or []:
-            day = sanitise_day(day_time["dayOfWeek"], DAYS_NL)
-            open_time = day_time["open"]
-            close_time = day_time["close"]
-            oh.add_range(day=day, open_time=open_time, close_time=close_time)
-        item["opening_hours"] = oh
+        item["opening_hours"] = OpeningHours()
+        for day, rule in (poi.get("c_hoursObj") or {}).items():
+            item["opening_hours"].add_range(DAYS[int(day) - 2], rule["open"], rule["close"])
+
+        apply_category(Categories.SHOP_CLOTHES, item)
 
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Hunkemöller': 709,
 'atp/brand_wikidata/Q2604175': 709,
 'atp/category/shop/clothes': 709,
 'atp/cdn/cloudflare/response_count': 711,
 'atp/cdn/cloudflare/response_status_count/200': 711,
 'atp/country/AT': 34,
 'atp/country/BE': 77,
 'atp/country/BY': 5,
 'atp/country/CH': 10,
 'atp/country/DE': 337,
 'atp/country/DK': 19,
 'atp/country/ES': 18,
 'atp/country/FR': 8,
 'atp/country/GR': 3,
 'atp/country/IN': 14,
 'atp/country/LU': 6,
 'atp/country/MA': 6,
 'atp/country/NL': 140,
 'atp/country/NO': 8,
 'atp/country/SE': 23,
 'atp/country/VE': 1,
 'atp/field/email/missing': 709,
 'atp/field/image/missing': 709,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 709,
 'atp/field/operator_wikidata/missing': 709,
 'atp/field/phone/invalid': 20,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 709,
 'atp/field/twitter/missing': 709,
 'atp/item_scraped_host_count/www.hunkemoller.be': 709,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 709,
 'downloader/request_bytes': 686296,
 'downloader/request_count': 711,
 'downloader/request_method_count/GET': 711,
 'downloader/response_bytes': 58767439,
 'downloader/response_count': 711,
 'downloader/response_status_count/200': 711,
 'elapsed_time_seconds': 16.402496,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 3, 13, 11, 34, 474201, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 711,
 'httpcompression/response_bytes': 392149480,
 'httpcompression/response_count': 711,
 'item_scraped_count': 709,
 'items_per_minute': 2658.75,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 346247168,
 'memusage/startup': 346247168,
 'request_depth_max': 1,
 'response_received_count': 711,
 'responses_per_minute': 2666.25,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 710,
 'scheduler/dequeued/memory': 710,
 'scheduler/enqueued': 710,
 'scheduler/enqueued/memory': 710,
 'start_time': datetime.datetime(2026, 3, 3, 13, 11, 18, 71705, tzinfo=datetime.timezone.utc)}
```