### PR TITLE
[ben_and_jerrys] Fix spider 

### DIFF
--- a/locations/spiders/ben_and_jerrys.py
+++ b/locations/spiders/ben_and_jerrys.py
@@ -15,26 +15,27 @@ class BenAndJerrysSpider(Where2GetItSpider):
     custom_settings = {"DOWNLOAD_TIMEOUT": 60}
 
     def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
-        if location.get("jsonshopinfo"):
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-            item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
-            if website := item.get("website"):
-                if "facebook" in website:
-                    item.pop("website")
-                elif "kojote" in website:
-                    item["website"] = "https://www." + item["website"]
-            apply_category(Categories.ICE_CREAM, item)
+        if not location.get("jsonshopinfo"):
+            return
+        item["lat"] = location["latitude"]
+        item["lon"] = location["longitude"]
+        item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
+        if website := item.get("website"):
+            if "facebook" in website:
+                item.pop("website")
+            elif "kojote" in website:
+                item["website"] = "https://www." + item["website"]
+        apply_category(Categories.ICE_CREAM, item)
 
-            apply_yes_no(Extras.DELIVERY, item, location["offersdelivery"] == "1")
+        apply_yes_no(Extras.DELIVERY, item, location["offersdelivery"] == "1")
 
-            item["opening_hours"] = OpeningHours()
-            for day in DAYS_FULL:
-                if location.get(day.lower()) in [None, ""]:
-                    continue
-                if "closed" in location.get(day.lower()):
-                    item["opening_hours"].set_closed(day)
-                else:
-                    item["opening_hours"].add_ranges_from_string(day + " " + location.get(day.lower()))
+        item["opening_hours"] = OpeningHours()
+        for day in DAYS_FULL:
+            if location.get(day.lower()) in [None, ""]:
+                continue
+            if "closed" in location.get(day.lower()):
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_ranges_from_string(day + " " + location.get(day.lower()))
 
-            yield item
+        yield item


### PR DESCRIPTION
Returning several locations that do not exist as per reality.  Specifically 2153 ivalid locations Portugal.  Need to filter for jsonshopinfo -- these are branded shop locations.  Those without this data are not, likely resellers/ suppliers.  

```
{"atp/brand/Ben & Jerry's": 262,
 'atp/brand_wikidata/Q816412': 262,
 'atp/category/amenity/ice_cream': 262,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/city': 5,
 'atp/clean_strings/street_address': 10,
 'atp/country/AU': 21,
 'atp/country/CA': 3,
 'atp/country/DE': 2,
 'atp/country/ES': 20,
 'atp/country/GB': 8,
 'atp/country/NZ': 6,
 'atp/country/SG': 1,
 'atp/country/US': 201,
 'atp/field/email/missing': 262,
 'atp/field/image/missing': 262,
 'atp/field/opening_hours/missing': 37,
 'atp/field/operator/missing': 262,
 'atp/field/operator_wikidata/missing': 262,
 'atp/field/phone/invalid': 22,
 'atp/field/phone/missing': 33,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 262,
 'atp/field/website/invalid': 1,
 'atp/field/website/missing': 154,
 'atp/item_scraped_host_count/hosted.where2getit.com': 262,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 262,
 'downloader/request_bytes': 884,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 4126498,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 6.783883,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 3, 15, 45, 24, 274711, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 35896387,
 'httpcompression/response_count': 2,
 'item_scraped_count': 262,
 'items_per_minute': 2620.0,
 'log_count/DEBUG': 278,
 'log_count/INFO': 3,
 'log_count/WARNING': 2,
 'memusage/max': 281538560,
 'memusage/startup': 281538560,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 3, 15, 45, 17, 490828, tzinfo=datetime.timezone.utc)}
```