### PR TITLE
[Ferguson Plarres Bakehouse AU] Fix spider

### DIFF
--- a/locations/spiders/ferguson_plarres_bakehouse_au.py
+++ b/locations/spiders/ferguson_plarres_bakehouse_au.py
@@ -1,8 +1,8 @@
 import re
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
@@ -20,15 +20,19 @@ class FergusonPlarresBakehouseAUSpider(Spider):
         for url in self.start_urls:
             yield JsonRequest(url=url, data=query, method="POST")
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["hits"]:
             item = DictParser.parse(location["_source"])
             item["branch"] = item.pop("name").removesuffix(" Bakery")
             item["addr_full"] = re.sub(r"\s*-\s*This store is located on.*", "", item["addr_full"])
             item["website"] = "https://www.fergusonplarre.com.au/" + location["_source"]["url_key"]
-            item["opening_hours"] = OpeningHours()
-            for day_name, day in location["_source"]["schedule"].items():
-                if not day["status"]:
-                    continue
-                item["opening_hours"].add_range(day_name.title(), day["from"], day["to"])
+            item["opening_hours"] = self.parse_opening_hours(location["_source"]["schedule"])
             yield item
+
+    def parse_opening_hours(self, rules: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day_name, day in rules.items():
+            if not day["status"]:
+                continue
+            opening_hours.add_range(day_name, day["from"], day["to"])
+        return opening_hours


### PR DESCRIPTION
```python
{"atp/brand/Ferguson Plarre's Bakehouse": 79,
 'atp/brand_wikidata/Q5444249': 79,
 'atp/category/shop/bakery': 79,
 'atp/clean_strings/addr_full': 17,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/phone': 1,
 'atp/country/AU': 79,
 'atp/field/image/missing': 79,
 'atp/field/operator/missing': 79,
 'atp/field/operator_wikidata/missing': 79,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 79,
 'atp/field/twitter/missing': 79,
 'atp/item_scraped_host_count/www.fergusonplarre.com.au': 79,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 79,
 'downloader/request_bytes': 458,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 263807,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.100358,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 4, 6, 48, 5, 37974, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 79,
 'items_per_minute': 2370.0,
 'log_count/DEBUG': 80,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 4, 6, 48, 2, 937616, tzinfo=datetime.timezone.utc)}
```