### PR TITLE
[Hofer SI] Fix spider

### DIFF
--- a/locations/spiders/hofer_si.py
+++ b/locations/spiders/hofer_si.py
@@ -1,36 +1,21 @@
-import scrapy
+from typing import Iterable
 
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_SI, OpeningHours, sanitise_day
+from scrapy.http import TextResponse
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class HoferSISpider(scrapy.Spider):  # Aldi Sud
+class HoferSISpider(JSONBlobSpider):  # Aldi Sud
     name = "hofer_si"
     item_attributes = {"brand": "Hofer", "brand_wikidata": "Q15815751"}
-    start_urls = [
-        "https://www.hofer.si/si/sl/.get-stores-in-radius.json?latitude=46.23974949999999&longitude=15.2677063&radius=2500000"
-    ]
+    start_urls = ["https://api.hofer.si/v2/service-points?limit=1000"]
+    locations_key = ["data"]
 
-    def parse(self, response):
-        for store in response.json()["stores"]:
-            item = DictParser.parse(store)
-            if store["storeType"] == "N":
-                continue
-            if item["country"] != "SI":
-                continue
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("address"))
 
-            item["website"] = store.get("url")
-
-            oh = OpeningHours()
-            for rule in store["openUntilSorted"]["openingHours"]:
-                day = sanitise_day(rule["day"].replace(".", ""), DAYS_SI)
-                if not rule.get("closed", False):
-                    oh.add_range(
-                        day,
-                        rule["openFormatted"],
-                        rule["closeFormatted"],
-                        time_format="%H.%M",
-                    )
-            item["opening_hours"] = oh.as_opening_hours()
-
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["name"] = None
+        item["phone"] = feature.get("publicPhoneNumber")
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Hofer': 93,
 'atp/brand_wikidata/Q15815751': 93,
 'atp/category/shop/supermarket': 93,
 'atp/country/SI': 93,
 'atp/field/branch/missing': 93,
 'atp/field/email/missing': 93,
 'atp/field/image/missing': 93,
 'atp/field/opening_hours/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/state/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/field/website/missing': 93,
 'atp/item_scraped_host_count/api.hofer.si': 93,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 678,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 6055,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 1.862279,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 4, 10, 22, 5, 379880, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 53495,
 'httpcompression/response_count': 1,
 'item_scraped_count': 93,
 'items_per_minute': 5580.0,
 'log_count/DEBUG': 95,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 120.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 4, 10, 22, 3, 517601, tzinfo=datetime.timezone.utc)}
```