### PR TITLE
[Energie Fitness GB IE] Fix Spider

### DIFF
--- a/locations/spiders/energie_fitness_gb_ie.py
+++ b/locations/spiders/energie_fitness_gb_ie.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
@@ -8,11 +8,10 @@ from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class EnergieFitnessGBIESpider(scrapy.Spider):
+class EnergieFitnessGBIESpider(Spider):
     name = "energie_fitness_gb_ie"
     item_attributes = {"brand": "énergie Fitness", "brand_wikidata": "Q109855553"}
     start_urls = ["https://www.energiefitness.com/api/locations"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["items"]:


### PR DESCRIPTION
```python
{'atp/brand/énergie Fitness': 67,
 'atp/brand_wikidata/Q109855553': 67,
 'atp/category/leisure/fitness_centre': 67,
 'atp/clean_strings/email': 8,
 'atp/clean_strings/phone': 1,
 'atp/country/GB': 51,
 'atp/country/IE': 16,
 'atp/field/city/missing': 6,
 'atp/field/country/from_reverse_geocoding': 2,
 'atp/field/image/missing': 67,
 'atp/field/opening_hours/missing': 67,
 'atp/field/operator/missing': 67,
 'atp/field/operator_wikidata/missing': 67,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/street_address/missing': 67,
 'atp/field/twitter/missing': 67,
 'atp/item_scraped_host_count/www.energiefitness.com': 67,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 67,
 'downloader/request_bytes': 343,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 83370,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.2184,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 5, 17, 34, 161529, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 566164,
 'httpcompression/response_count': 1,
 'item_scraped_count': 67,
 'items_per_minute': 1340.0,
 'log_count/DEBUG': 68,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 20.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 5, 5, 17, 30, 943129, tzinfo=datetime.timezone.utc)}
```