### PR TITLE
[Nandos QA] Fix spider with code clean up

### DIFF
--- a/locations/spiders/nandos_qa.py
+++ b/locations/spiders/nandos_qa.py
@@ -1,9 +1,8 @@
-from locations.spiders.nandos_za import NandosZASpider
+from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
+from locations.storefinders.location_bank import LocationBankSpider
 
 
-class NandosQASpider(NandosZASpider):
+class NandosQASpider(LocationBankSpider):
     name = "nandos_qa"
-    start_urls = [
-        "https://api.locationbank.net/storelocator/StoreLocatorAPI?clientId=4204d252-cd2d-4dc3-a548-133bd26a9b2e"
-    ]
-    web_root = "https://store.nandos.qa/details/"
+    item_attributes = NANDOS_SHARED_ATTRIBUTES
+    client_id = "4204d252-cd2d-4dc3-a548-133bd26a9b2e"

--- a/locations/spiders/nandos_za.py
+++ b/locations/spiders/nandos_za.py
@@ -1,36 +1,19 @@
 from typing import Iterable
-from urllib.parse import urljoin
 
 from scrapy.http import TextResponse
 
 from locations.categories import Extras, apply_yes_no
-from locations.hours import OpeningHours, sanitise_day
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
+from locations.storefinders.location_bank import LocationBankSpider
 
 
-class NandosZASpider(JSONBlobSpider):
+class NandosZASpider(LocationBankSpider):
     name = "nandos_za"
     item_attributes = NANDOS_SHARED_ATTRIBUTES
-    allowed_domains = ["api.locationbank.net"]
-    start_urls = [
-        "https://api.locationbank.net/storelocator/StoreLocatorAPI?clientId=67b9c5e4-6ddf-4856-b3c0-cf27cfe53255"
-    ]
-    web_root = "https://store.nandos.co.za/details/"
-    locations_key = "locations"
+    client_id = "67b9c5e4-6ddf-4856-b3c0-cf27cfe53255"
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
-        item["phone"] = item["phone"] = "; ".join(
-            filter(None, [feature.get("primaryPhone"), feature.get("additionalPhone1")])
-        )
-        item["state"] = feature.get("administrativeArea")
-        item["website"] = urljoin(self.web_root, feature.get("storeLocatorDetailsShortURL"))
-        item["street_address"] = merge_address_lines([feature.get("addressLine1"), feature.get("addressLine2")])
-        item["branch"] = item.pop("name").replace(self.item_attributes["brand"], "").strip()
-        item["opening_hours"] = self.parse_opening_hours(feature.get("regularHours", []))
-
         apply_yes_no(Extras.BACKUP_GENERATOR, item, "Generator" in feature["slAttributes"])
         apply_yes_no(Extras.DELIVERY, item, "Delivery" in feature["slAttributes"])
         apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive Thru" in feature["slAttributes"])
@@ -41,10 +24,3 @@ class NandosZASpider(JSONBlobSpider):
         # Unhandled: "Alcohol License", "Dine In"
 
         yield item
-
-    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
-        opening_hours = OpeningHours()
-        for rule in rules:
-            if day := sanitise_day(rule["openDay"]):
-                opening_hours.add_range(day, rule["openTime"], rule["closeTime"])
-        return opening_hours

--- a/locations/storefinders/location_bank.py
+++ b/locations/storefinders/location_bank.py
@@ -5,7 +5,7 @@ from scrapy import Spider
 from scrapy.http import JsonRequest, TextResponse
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, sanitise_day
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
@@ -71,11 +71,12 @@ class LocationBankSpider(Spider):
             )
 
             item["opening_hours"] = OpeningHours()
-            for day in location["regularHours"]:
-                if day["isOpen"]:
-                    item["opening_hours"].add_range(day["openDay"], day["openTime"], day["closeTime"])
-                else:
-                    item["opening_hours"].set_closed(day["openDay"])
+            for rule in location["regularHours"]:
+                if day := sanitise_day(rule["openDay"]):
+                    if rule["isOpen"]:
+                        item["opening_hours"].add_range(day, rule["openTime"], rule["closeTime"])
+                    else:
+                        item["opening_hours"].set_closed(day)
 
             if self.include_images:
                 image_root = "https://api.locationbank.net/storelocator/StoreLocatorAPI/locationImage"


### PR DESCRIPTION
`Nandos QA` was failing because of the [ValueError](https://alltheplaces-data.openaddresses.io/runs/2026-02-28-13-32-34/logs/nandos_qa.txt) resulted from inherited `Nandos ZA` Spider code. Now both `QA` & `ZA` spiders converted to `LocationBankSpider`.

`QA`:
```python
{"atp/brand/Nando's": 12,
 'atp/brand_wikidata/Q3472954': 12,
 'atp/category/amenity/restaurant': 12,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/QA': 12,
 'atp/field/email/missing': 12,
 'atp/field/image/missing': 12,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 12,
 'atp/field/operator_wikidata/missing': 12,
 'atp/field/postcode/missing': 12,
 'atp/field/twitter/missing': 12,
 'atp/item_scraped_host_count/api.locationbank.net': 12,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 12,
 'downloader/request_bytes': 755,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 6420,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.787397,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 9, 0, 34, 517141, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 74645,
 'httpcompression/response_count': 1,
 'item_scraped_count': 12,
 'items_per_minute': 360.0,
 'log_count/DEBUG': 14,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 5, 9, 0, 31, 729744, tzinfo=datetime.timezone.utc)}
```

`ZA`:
```python
{"atp/brand/Nando's": 294,
 'atp/brand_wikidata/Q3472954': 294,
 'atp/category/amenity/restaurant': 294,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/SZ': 5,
 'atp/country/ZA': 289,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 5,
 'atp/field/image/missing': 294,
 'atp/field/operator/missing': 294,
 'atp/field/operator_wikidata/missing': 294,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 294,
 'atp/item_scraped_host_count/api.locationbank.net': 294,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 294,
 'downloader/request_bytes': 755,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 105556,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.411191,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 9, 0, 34, 285928, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1942671,
 'httpcompression/response_count': 1,
 'item_scraped_count': 294,
 'items_per_minute': 4410.0,
 'log_count/DEBUG': 296,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 5, 9, 0, 29, 874737, tzinfo=datetime.timezone.utc)}
```