### PR TITLE
[Mtexx BG] Fix Spider

### DIFF
--- a/locations/spiders/mtexx_bg.py
+++ b/locations/spiders/mtexx_bg.py
@@ -1,29 +1,26 @@
-import re
+from typing import Any
 
 import chompjs
-from scrapy import Request, Spider
+import scrapy
+from scrapy.http import Response
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.react_server_components import parse_rsc
 
 
-class MtexxBGSpider(Spider):
+class MtexxBGSpider(scrapy.Spider):
     name = "mtexx_bg"
     item_attributes = {"operator": "M-Texx", "operator_wikidata": "Q122947768"}
-    allowed_domains = ["m-texx.com"]
     start_urls = ["https://m-texx.com/locations"]
-    no_refs = True
 
-    def parse(self, response, **kwargs):
-        url = re.search(r"(static/chunks/app/\(website\)/locations/page-\w+\.js)", response.text)
-        yield Request("https://m-texx.com/_next/" + url.group(1), callback=self.parse_locations)
-
-    def parse_locations(self, response, **kwargs):
-        locations = chompjs.parse_js_objects(re.search(r"exports=\[({city:.+}])}", response.text).group(1))
-        for location in locations:
-            properties = {
-                "city": location["city"],
-                "addr_full": location["popUp"],
-                "lat": location["geocode"][0],
-                "lon": location["geocode"][1],
-            }
-            yield Feature(**properties)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        scripts = response.xpath('//*[contains(text(),"coordinates")]/text()').getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        raw_data = DictParser.get_nested_key(dict(parse_rsc(rsc)), "initialCities")
+        for location in raw_data:
+            for local in location["locations"]:
+                item = DictParser.parse(local)
+                item["name"] = item["name"].split(" - ")[0]
+                item["lat"], item["lon"] = local["coordinates"]
+                yield item


### PR DESCRIPTION
```python
{'atp/category/amenity/recycling': 440,
 'atp/country/BG': 440,
 'atp/field/branch/missing': 440,
 'atp/field/brand/missing': 440,
 'atp/field/brand_wikidata/missing': 440,
 'atp/field/country/from_spider_name': 440,
 'atp/field/email/missing': 440,
 'atp/field/image/missing': 440,
 'atp/field/opening_hours/missing': 440,
 'atp/field/phone/missing': 440,
 'atp/field/postcode/missing': 440,
 'atp/field/state/missing': 440,
 'atp/field/street_address/missing': 440,
 'atp/field/twitter/missing': 440,
 'atp/field/website/missing': 440,
 'atp/item_scraped_host_count/m-texx.com': 440,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 440,
 'atp/operator/M-Texx': 440,
 'atp/operator_wikidata/Q122947768': 440,
 'downloader/request_bytes': 655,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 31538,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.56245,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 8, 33, 16, 993542, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 317814,
 'httpcompression/response_count': 1,
 'item_scraped_count': 440,
 'items_per_minute': 6600.0,
 'log_count/DEBUG': 442,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 5, 8, 33, 12, 431092, tzinfo=datetime.timezone.utc)}
```