### PR TITLE
[GSF Car Parts GB] Add spider

### DIFF
--- a/locations/spiders/gsf_car_parts_gb.py
+++ b/locations/spiders/gsf_car_parts_gb.py
@@ -1,0 +1,48 @@
+import re
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class GsfCarPartsGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "gsf_car_parts_gb"
+    item_attributes = {"brand": "GSF Car Parts", "brand_wikidata": "Q80963064"}
+    sitemap_urls = ["https://www.gsfcarparts.com/robots.txt"]
+    sitemap_follow = ["branch-sitemap"]
+    sitemap_rules = [(r"/branches/(\w+)$", "parse")]
+    wanted_types = ["Organization"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("GSF Car Parts - ")
+        item["city"] = item.pop("state")
+        item["facebook"] = None
+
+        item["opening_hours"] = self.parse_opening_hours(response)
+
+        if m := re.search(r"\\\"center\\\":\{\\\"lat\\\":(-?\d+\.\d+),\\\"lng\\\":(-?\d+\.\d+)}", response.text):
+            item["lat"], item["lon"] = m.groups()
+
+        apply_category(Categories.SHOP_CAR_PARTS, item)
+
+        yield item
+
+    def parse_opening_hours(self, response: TextResponse) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in response.xpath('//div[@class="store-timings"]/ul/li'):
+            day = rule.xpath('./span[@class="day"]/text()').get()
+            if rule.xpath('./span[contains(@class, "timings")][contains(text(), "Closed")]'):
+                oh.set_closed(day)
+            else:
+                oh.add_range(
+                    day,
+                    rule.xpath('./div[contains(@class, "timings")]/span[1]/text()').get(),
+                    rule.xpath('./div[contains(@class, "timings")]/span[2]/text()').get(),
+                    time_format="%I:%M%p",
+                )
+        return oh


### PR DESCRIPTION
Rel: https://community.openstreetmap.org/t/organised-editing-gsf-car-parts-uk/142037

```python
{'atp/brand/GSF Car Parts': 157,
 'atp/brand_wikidata/Q80963064': 157,
 'atp/category/shop/car_parts': 157,
 'atp/cdn/cloudflare/response_count': 161,
 'atp/cdn/cloudflare/response_status_count/200': 161,
 'atp/country/GB': 157,
 'atp/field/image/invalid': 10,
 'atp/field/operator/missing': 157,
 'atp/field/operator_wikidata/missing': 157,
 'atp/field/state/missing': 157,
 'atp/field/twitter/missing': 157,
 'atp/item_scraped_host_count/www.gsfcarparts.com': 157,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 157,
 'downloader/request_bytes': 68807,
 'downloader/request_count': 161,
 'downloader/request_method_count/GET': 161,
 'downloader/response_bytes': 8512654,
 'downloader/response_count': 161,
 'downloader/response_status_count/200': 161,
 'elapsed_time_seconds': 3.115927,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 10, 58, 36, 419044, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 161,
 'httpcompression/response_bytes': 59636387,
 'httpcompression/response_count': 161,
 'item_scraped_count': 157,
 'items_per_minute': 3140.0,
 'log_count/INFO': 3,
 'log_count/WARNING': 11,
 'memusage/max': 330563584,
 'memusage/startup': 330563584,
 'request_depth_max': 3,
 'response_received_count': 161,
 'responses_per_minute': 3220.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 160,
 'scheduler/dequeued/memory': 160,
 'scheduler/enqueued': 160,
 'scheduler/enqueued/memory': 160,
 'start_time': datetime.datetime(2026, 3, 5, 10, 58, 33, 303117, tzinfo=datetime.timezone.utc)}
```