### PR TITLE
[Ninety Nine Bikes AU] Fix Spider

### DIFF
--- a/locations/spiders/99_bikes_au.py
+++ b/locations/spiders/99_bikes_au.py
@@ -10,5 +10,6 @@ class NinetynineBikesAUSpider(StockistSpider):
     key = "map_r3mjnyvq"
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("99 Bikes ").removesuffix(" ⚡")
         item["website"] = location["custom_fields"][0]["value"]
         yield item


### PR DESCRIPTION
```python
{'atp/brand/99 Bikes': 72,
 'atp/brand_wikidata/Q110288298': 72,
 'atp/category/shop/bicycle': 72,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AU': 72,
 'atp/field/branch/missing': 72,
 'atp/field/image/missing': 72,
 'atp/field/opening_hours/missing': 72,
 'atp/field/operator/missing': 72,
 'atp/field/operator_wikidata/missing': 72,
 'atp/field/twitter/missing': 72,
 'atp/item_scraped_host_count/stockist.co': 72,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 72,
 'downloader/request_bytes': 696,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7793,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.05963,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 5, 12, 36, 23, 1371, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 41205,
 'httpcompression/response_count': 2,
 'item_scraped_count': 72,
 'items_per_minute': 1440.0,
 'log_count/DEBUG': 74,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 5, 12, 36, 19, 941741, tzinfo=datetime.timezone.utc)}
```