### PR TITLE
[Arbys US] Fix spider

### DIFF
--- a/locations/spiders/arbys_us.py
+++ b/locations/spiders/arbys_us.py
@@ -14,19 +14,18 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class ArbysUSSpider(Spider):
     name = "arbys_us"
     item_attributes = {"brand": "Arby's", "brand_wikidata": "Q630866"}
-    headers = {"x-channel": "WEBOA", "x-session-id": uuid.uuid4().hex}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             url="https://api.arbys.com/arb/digital-exp-api/v1/locations/regions?countryCode=US",
-            headers=self.headers,
+            headers={"x-channel": "WEBOA", "x-session-id": uuid.uuid4().hex},
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for region in response.json()["locations"][0]["regions"]:
             yield JsonRequest(
                 url=f'https://api.arbys.com/arb/digital-exp-api/v1/locations/regions?countryCode=US&regionCode={region["code"]}',
-                headers=self.headers,
+                headers={"x-channel": "WEBOA", "x-session-id": uuid.uuid4().hex},
                 callback=self.parse_locations,
             )
 
@@ -70,8 +69,7 @@ class ArbysUSSpider(Spider):
         oh = OpeningHours()
         for rule in rules:
             if rule.get("isTwentyFourHourService"):
-                open_time, close_time = ("00:00", "23:59")
+                oh.add_range(rule["dayOfWeek"], "00:00", "23:59")
             else:
-                open_time, close_time = rule.get("startTime"), rule.get("endTime")
-            oh.add_range(rule["dayOfWeek"], open_time, close_time)
+                oh.add_range(rule["dayOfWeek"], rule.get("startTime"), rule.get("endTime"))
         return oh


### PR DESCRIPTION
```python
{"atp/brand/Arby's": 3251,
 'atp/brand_wikidata/Q630866': 3251,
 'atp/category/amenity/fast_food': 3251,
 'atp/cdn/cloudflare/response_count': 50,
 'atp/cdn/cloudflare/response_status_count/200': 49,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/phone': 3,
 'atp/closed_poi': 3,
 'atp/country/US': 3251,
 'atp/field/branch/missing': 3251,
 'atp/field/email/missing': 3251,
 'atp/field/image/missing': 3251,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 3251,
 'atp/field/operator_wikidata/missing': 3251,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 3251,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/api.arbys.com': 3251,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3251,
 'downloader/request_bytes': 27620,
 'downloader/request_count': 50,
 'downloader/request_method_count/GET': 50,
 'downloader/response_bytes': 860402,
 'downloader/response_count': 50,
 'downloader/response_status_count/200': 49,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 11.466001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 9, 8, 39, 6, 373954, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 50,
 'httpcompression/response_bytes': 37254417,
 'httpcompression/response_count': 50,
 'item_scraped_count': 3251,
 'items_per_minute': 17732.727272727276,
 'log_count/DEBUG': 3303,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 50,
 'responses_per_minute': 272.72727272727275,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 49,
 'scheduler/dequeued/memory': 49,
 'scheduler/enqueued': 49,
 'scheduler/enqueued/memory': 49,
 'start_time': datetime.datetime(2026, 3, 9, 8, 38, 54, 907953, tzinfo=datetime.timezone.utc)}
```