### PR TITLE
[Ford Dealers US] Fix Spider

### DIFF
--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -1,4 +1,3 @@
-import ast
 import json
 import re
 
@@ -25,14 +24,15 @@ class FordDealersUSSpider(scrapy.Spider):
 
     def parse(self, response: Response, **kwargs):
         client_id = re.search(r"clientId\":\"([0-9-a-z-]+)\"", response.text).group(1)
+        js_path = response.xpath('//*[@id="baseBrand-5c0f3b34d2"]/script[10]/@src').get()
         yield scrapy.Request(
-            url="https://www.ford.com/etc/designs/brand_ford/brand/skin/ford.min.js",
+            url="https://www.ford.com" + js_path,
             callback=self.parse_state,
             cb_kwargs={"token": client_id},
         )
 
     def parse_state(self, response, **kwargs):
-        state_list = ast.literal_eval(re.search(r"fullStateNames\s*=\s*(\[.*\]);", response.text).group(1))
+        state_list = (re.search(r"var\s*u\s*=\s*\"(.+)\"\.split\(\";\"\),", response.text).group(1)).split(";")
         for state in state_list:
             yield JsonRequest(
                 url="https://www.ford.com/cxservices/dealer/Dealers.json?make=Ford&state={}".format(state),


### PR DESCRIPTION
```python
{'atp/brand/Ford': 2821,
 'atp/brand_wikidata/Q44294': 2821,
 'atp/category/shop/car': 2821,
 'atp/country/US': 2821,
 'atp/field/branch/missing': 2821,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1197,
 'atp/field/image/missing': 2821,
 'atp/field/opening_hours/missing': 58,
 'atp/field/operator/missing': 2821,
 'atp/field/operator_wikidata/missing': 2821,
 'atp/field/phone/missing': 14,
 'atp/field/twitter/missing': 2821,
 'atp/field/website/missing': 51,
 'atp/item_scraped_host_count/www.ford.com': 2821,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 2821,
 'downloader/request_bytes': 38601,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 11099339,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 54,
 'elapsed_time_seconds': 86.131123,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 9, 10, 5, 36, 819470, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2821,
 'items_per_minute': 1968.139534883721,
 'log_count/DEBUG': 3191,
 'log_count/INFO': 8,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 54,
 'playwright/page_count/closed': 54,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 130,
 'playwright/request_count/aborted': 76,
 'playwright/request_count/method/GET': 130,
 'playwright/request_count/navigation': 54,
 'playwright/request_count/resource_type/document': 54,
 'playwright/request_count/resource_type/font': 8,
 'playwright/request_count/resource_type/image': 4,
 'playwright/request_count/resource_type/script': 52,
 'playwright/request_count/resource_type/stylesheet': 12,
 'playwright/response_count': 54,
 'playwright/response_count/method/GET': 54,
 'playwright/response_count/resource_type/document': 54,
 'request_depth_max': 2,
 'response_received_count': 54,
 'responses_per_minute': 37.674418604651166,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 53,
 'scheduler/dequeued/memory': 53,
 'scheduler/enqueued': 53,
 'scheduler/enqueued/memory': 53,
 'start_time': datetime.datetime(2026, 3, 9, 10, 4, 10, 688347, tzinfo=datetime.timezone.utc)}
```