### PR TITLE
[Electric Circuit CA] Add spider

### DIFF
--- a/locations/spiders/electric_circuit_ca.py
+++ b/locations/spiders/electric_circuit_ca.py
@@ -1,0 +1,47 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class ElectricCircuitCASpider(Spider):
+    name = "electric_circuit_ca"
+    item_attributes = {"brand_wikidata": "Q24934590"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(
+            "https://api.lecircuitelectrique.com/public/v1/configs",
+            headers={
+                "Authorization": "Basic SHl1alRsUWpTSkN0YzZNaEtIRDZJQzEzTDNXS3JJcm46QTlLdzhoZVlMMmZxVFRWRlRnZnVYdFF1YlVxOU14R1Y=",
+                "Origin": "https://sites-map.lecircuitelectrique.com",
+            },
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            "https://api.lecircuitelectrique.com/public/v1/sites/all?hidePartnerNetworkIds={}".format(
+                ",".join(p["id"] for p in response.json()["site"]["partnerNetworks"])
+            ),
+            headers={
+                "Authorization": "Basic SHl1alRsUWpTSkN0YzZNaEtIRDZJQzEzTDNXS3JJcm46QTlLdzhoZVlMMmZxVFRWRlRnZnVYdFF1YlVxOU14R1Y=",
+                "Origin": "https://sites-map.lecircuitelectrique.com",
+            },
+            callback=self.parse_locations,
+        )
+
+    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            if location.get("isVisible") is not True:
+                continue
+
+            item = Feature()
+            item["ref"] = location["id"]
+            item["lat"] = location["address"]["location"]["lat"]
+            item["lon"] = location["address"]["location"]["lng"]
+
+            apply_category(Categories.CHARGING_STATION, item)
+
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Circuit électrique': 2858,
 'atp/brand_wikidata/Q24934590': 2858,
 'atp/category/amenity/charging_station': 2858,
 'atp/country/CA': 2858,
 'atp/field/branch/missing': 2858,
 'atp/field/city/missing': 2858,
 'atp/field/country/from_spider_name': 2858,
 'atp/field/email/missing': 2858,
 'atp/field/image/missing': 2858,
 'atp/field/opening_hours/missing': 2858,
 'atp/field/phone/missing': 2858,
 'atp/field/postcode/missing': 2858,
 'atp/field/state/from_reverse_geocoding': 2858,
 'atp/field/state/missing': 16,
 'atp/field/street_address/missing': 2858,
 'atp/field/twitter/missing': 2858,
 'atp/field/website/missing': 2858,
 'atp/item_scraped_host_count/api.lecircuitelectrique.com': 2858,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2858,
 'atp/operator/Circuit électrique': 2858,
 'atp/operator_wikidata/Q24934590': 2858,
 'downloader/request_bytes': 1877,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 70670,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 6.643784,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 9, 12, 10, 28, 752562, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 3,
 'httpcache/miss': 3,
 'httpcache/store': 3,
 'httpcompression/response_bytes': 586957,
 'httpcompression/response_count': 2,
 'item_scraped_count': 2858,
 'items_per_minute': 28580.0,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 329064448,
 'memusage/startup': 329064448,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 3, 9, 12, 10, 22, 108778, tzinfo=datetime.timezone.utc)}
```