### PR TITLE
[Bjs Wholesale] Fix spider

### DIFF
--- a/locations/spiders/bjs_wholesale.py
+++ b/locations/spiders/bjs_wholesale.py
@@ -1,6 +1,4 @@
 import json
-import re
-from datetime import datetime
 from typing import Any
 
 from scrapy.http import Response
@@ -10,8 +8,6 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
-DAY_MAPPING = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
-
 
 class BjsWholesaleSpider(SitemapSpider):
     name = "bjs_wholesale"
@@ -19,40 +15,6 @@ class BjsWholesaleSpider(SitemapSpider):
     allowed_domains = ["bjs.com"]
     sitemap_urls = ["https://www.bjs.com/bjs_ancillary_sitemap.xml"]
     sitemap_rules = [(r"/cl/[-\w]+/\d+", "parse_store")]
-
-    def parse_hours(self, hours: list):
-        opening_hours = OpeningHours()
-
-        if hours:
-            hours = hours[0].get("value").split("<br>") or []
-            for hour in hours:
-                try:
-                    day, open_time, close_time = re.search(r"(.*?):\s(.*?)\s-\s(.*?)$", hour).groups()
-                except AttributeError:  # closed
-                    continue
-                open_time = (
-                    datetime.strptime(open_time, "%I:%M %p")
-                    if ":" in open_time
-                    else datetime.strptime(open_time, "%I %p")
-                ).strftime("%H:%M")
-                close_time = (
-                    datetime.strptime(close_time, "%I:%M %p")
-                    if ":" in close_time
-                    else datetime.strptime(close_time, "%I %p")
-                ).strftime("%H:%M")
-
-                if "-" in day:
-                    start_day, end_day = day.split("-")
-                    start_day = start_day.strip()
-                    end_day = end_day.strip()
-                    for d in DAY_MAPPING[DAY_MAPPING.index(start_day[:2]) : DAY_MAPPING.index(end_day[:2]) + 1]:
-                        opening_hours.add_range(
-                            day=d,
-                            open_time=open_time,
-                            close_time=close_time,
-                            time_format="%H:%M",
-                        )
-        return opening_hours.as_opening_hours()
 
     def parse_store(self, response: Response) -> Any:
         store = {}
@@ -69,14 +31,34 @@ class BjsWholesaleSpider(SitemapSpider):
             if "club/search" in key:
                 store = json_blob[key]["Stores"]["PhysicalStore"][0]
                 break
+
         store["ref"] = store.pop("storeName")
         item = DictParser.parse(store)
         item["branch"] = store["Description"][0]["displayStoreName"]
         item["website"] = response.url
-        hours = self.parse_hours([attr for attr in store["Attribute"] if attr["name"] == "Hours of Operation"])
-        if hours:
-            store["opening_hours"] = hours
 
-        apply_category(Categories.SHOP_WHOLESALE, item)
+        operating_hours = ""
+        gas_hours = ""
+        store_type = ""
+        for attr in store["Attribute"]:
+            if attr["name"] == "Hours of Operation":
+                operating_hours = attr["value"]
+            elif attr["name"] == "StoreType":
+                store_type = attr["value"]
+            elif attr["name"] == "Gas Hours":
+                gas_hours = attr["value"]
+
+        if store_type.lower() == "club":
+            item["opening_hours"] = self.parse_hours(operating_hours)
+            apply_category(Categories.SHOP_WHOLESALE, item)
+        elif store_type.lower() == "gas":
+            item["branch"] = item["branch"].removesuffix(" Gas Station")
+            item["opening_hours"] = self.parse_hours(gas_hours)
+            apply_category(Categories.FUEL_STATION, item)
 
         yield item
+
+    def parse_hours(self, hours: str) -> OpeningHours:
+        opening_hours = OpeningHours()
+        opening_hours.add_ranges_from_string(hours.replace(".", ""))
+        return opening_hours


### PR DESCRIPTION
`API` even after updating versioning faces blockage during the run, also this uses `1 request per POI`, that's why switched to `Sitemap`, a better option here.

```python
{"atp/brand/BJ's Wholesale Club": 272,
 'atp/brand_wikidata/Q4835754': 272,
 'atp/category/amenity/fuel': 8,
 'atp/category/shop/wholesale': 264,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/phone': 272,
 'atp/country/US': 272,
 'atp/field/email/missing': 272,
 'atp/field/image/missing': 272,
 'atp/field/operator/missing': 272,
 'atp/field/operator_wikidata/missing': 272,
 'atp/field/state/from_reverse_geocoding': 272,
 'atp/field/twitter/missing': 272,
 'atp/item_scraped_host_count/www.bjs.com': 272,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 272,
 'downloader/request_bytes': 731426,
 'downloader/request_count': 274,
 'downloader/request_method_count/GET': 274,
 'downloader/response_bytes': 7344779,
 'downloader/response_count': 274,
 'downloader/response_status_count/200': 274,
 'elapsed_time_seconds': 4.140179,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 10, 14, 52, 41, 736181, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 274,
 'httpcompression/response_bytes': 24546134,
 'httpcompression/response_count': 273,
 'item_scraped_count': 272,
 'items_per_minute': 4080.0,
 'log_count/DEBUG': 547,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 274,
 'responses_per_minute': 4110.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 273,
 'scheduler/dequeued/memory': 273,
 'scheduler/enqueued': 273,
 'scheduler/enqueued/memory': 273,
 'start_time': datetime.datetime(2026, 3, 10, 14, 52, 37, 596002, tzinfo=datetime.timezone.utc)}
```