### PR TITLE
[PDQ US] Fix Spider

### DIFF
--- a/locations/spiders/pdq_us.py
+++ b/locations/spiders/pdq_us.py
@@ -1,66 +1,24 @@
-import chompjs
+import json
+from typing import Any
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class PdqUSSpider(SitemapSpider):
     name = "pdq_us"
     item_attributes = {"brand": "PDQ", "brand_wikidata": "Q87675367"}
     sitemap_urls = ["https://www.eatpdq.com/sitemap.xml"]
-    sitemap_rules = [(r"/locations/.*", "parse_store")]
+    sitemap_rules = [(r"/locations/(?!find-a-location).*", "parse")]
 
-    # The store pages here appear to be hand crafted HTML.
-    # So, we need to look at where the 'text' is in the structure for a given heading
-    def current_or_next_sibling_matching(self, label, styled_box):
-        # Scenario 1: It's in the same node. https://www.eatpdq.com/locations/bradenton is the main example
-        # Scenario 2: it's in the following node
-        store_location = styled_box.xpath("div/div/p/span/strong[contains(text(), '" + label + "')]")
-        if store_location.get():
-            if store_location.xpath("../../text()").get() is not None:
-                return store_location.xpath("../../text()").getall()
-            else:
-                return store_location.xpath("../../following-sibling::p[1]/text()").getall()
-
-    def parse_address(self, item, styled_box):
-        store_location = self.current_or_next_sibling_matching("Store Location", styled_box)
-        store_address = self.current_or_next_sibling_matching("Store Address", styled_box)
-
-        if store_location is not None and len(store_location) > 0:
-            item["street_address"] = " ".join(store_location)
-
-        if store_address is not None and len(store_address) > 0:
-            item["street_address"] = " ".join(store_address)
-
-    def parse_contact(self, item, styled_box):
-        store_contact = self.current_or_next_sibling_matching("Store Contact", styled_box)
-
-        if store_contact is not None and len(store_contact) > 0:
-            if len(store_contact) == 3:
-                item["phone"] = store_contact[2]
-                item["email"] = store_contact[1]
-
-    def parse_store(self, response):
-        if response.url == "https://www.eatpdq.com/locations/find-a-location":
-            return
-
-        styled_box = response.xpath('//div[@class="sqs-block html-block sqs-block-html"]')
-        if styled_box:
-            item = Feature()
-            name = styled_box.xpath("div/div//h1/text()").get()
-            if name:
-                item["name"] = name.strip()
-
-            self.parse_address(item, styled_box)
-            self.parse_contact(item, styled_box)
-
-            if location_map := response.xpath('//div[contains(@data-block-json, "markerLat")]').get():
-                json_data = chompjs.parse_js_object(location_map)["location"]
-
-                item["lat"] = json_data["markerLat"]
-                item["lon"] = json_data["markerLng"]
-
-            item["ref"] = response.url
-            item["website"] = response.url
-
-            yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location_data = json.loads(response.xpath("//@data-context").get())
+        item = DictParser.parse(location_data["location"])
+        item["lat"] = location_data["location"]["markerLat"]
+        item["lon"] = location_data["location"]["markerLng"]
+        item["addr_full"] = merge_address_lines([item["street_address"], location_data["location"]["addressLine2"]])
+        item["ref"] = item["website"] = response.url
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/PDQ': 29,
 'atp/brand_wikidata/Q87675367': 29,
 'atp/category/amenity/fast_food': 29,
 'atp/country/US': 29,
 'atp/field/branch/missing': 29,
 'atp/field/city/missing': 29,
 'atp/field/country/from_spider_name': 2,
 'atp/field/email/missing': 29,
 'atp/field/image/missing': 29,
 'atp/field/opening_hours/missing': 29,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/phone/missing': 29,
 'atp/field/postcode/missing': 29,
 'atp/field/state/from_reverse_geocoding': 29,
 'atp/field/twitter/missing': 29,
 'atp/item_scraped_host_count/www.eatpdq.com': 29,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 29,
 'downloader/request_bytes': 14001,
 'downloader/request_count': 31,
 'downloader/request_method_count/GET': 31,
 'downloader/response_bytes': 805935,
 'downloader/response_count': 31,
 'downloader/response_status_count/200': 31,
 'elapsed_time_seconds': 39.187628,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 11, 11, 48, 33, 725798, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5019423,
 'httpcompression/response_count': 31,
 'item_scraped_count': 29,
 'items_per_minute': 44.61538461538461,
 'log_count/DEBUG': 60,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 31,
 'responses_per_minute': 47.69230769230769,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 30,
 'scheduler/dequeued/memory': 30,
 'scheduler/enqueued': 30,
 'scheduler/enqueued/memory': 30,
 'start_time': datetime.datetime(2026, 3, 11, 11, 47, 54, 538170, tzinfo=datetime.timezone.utc)}
```