### PR TITLE
[Dulux Decorator Centre GB] Fix spider

### DIFF
--- a/locations/spiders/dulux_decorator_centre_gb.py
+++ b/locations/spiders/dulux_decorator_centre_gb.py
@@ -1,9 +1,9 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Selector, Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -13,17 +13,14 @@ class DuluxDecoratorCentreGBSpider(Spider):
     item_attributes = {
         "brand": "Dulux Decorator Centre",
         "brand_wikidata": "Q115593557",
-        "extras": Categories.SHOP_PAINT.value,
     }
     allowed_domains = ["www.duluxdecoratorcentre.co.uk"]
-    start_urls = ["https://www.duluxdecoratorcentre.co.uk/store/getstores"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+        yield JsonRequest(url="https://www.duluxdecoratorcentre.co.uk/store/getstores", cookies={"BVBRANDID": ""})
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["Points"]:
             item = DictParser.parse(location)
             store_details = Selector(text=location["FormattedAddress"])
@@ -38,4 +35,5 @@ class DuluxDecoratorCentreGBSpider(Spider):
             hours_string = " ".join(store_details.xpath('//div[@class="store-days"]//text()').getall())
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(hours_string)
+            apply_category(Categories.SHOP_PAINT, item)
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Dulux Decorator Centre': 228,
 'atp/brand_wikidata/Q115593557': 228,
 'atp/category/shop/paint': 228,
 'atp/clean_strings/phone': 1,
 'atp/country/GB': 228,
 'atp/field/city/missing': 2,
 'atp/field/country/from_spider_name': 228,
 'atp/field/email/missing': 228,
 'atp/field/image/missing': 228,
 'atp/field/operator/missing': 228,
 'atp/field/operator_wikidata/missing': 228,
 'atp/field/state/missing': 40,
 'atp/field/twitter/missing': 228,
 'atp/item_scraped_host_count/www.duluxdecoratorcentre.co.uk': 228,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 228,
 'downloader/request_bytes': 388,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 747274,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.826137,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 11, 15, 9, 29, 180501, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 228,
 'items_per_minute': 2736.0,
 'log_count/DEBUG': 229,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 12.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 11, 15, 9, 23, 354364, tzinfo=datetime.timezone.utc)}
```