### PR TITLE
[Wendy's] Collect corporate code

### DIFF
--- a/locations/spiders/wendys.py
+++ b/locations/spiders/wendys.py
@@ -1,8 +1,11 @@
 import json
 
+from scrapy import Selector
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Extras, apply_yes_no
 from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -16,6 +19,7 @@ class WendysSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["website"] = ld_data.get("url")
+        item["extras"]["ref:wendys"] = response.xpath("//@data-corporatecode").get()
 
         # Opening hours for the drive-through seem to get included with regular hours, so clean that up
         opening_hours_divs = response.xpath('//div[@class="c-location-hours-details-wrapper js-location-hours"]')
@@ -30,6 +34,11 @@ class WendysSpider(SitemapSpider, StructuredDataSpider):
             item["extras"]["breakfast"] = self.clean_hours(breakfast_hours_divs[0])
 
         yield item
+
+    def extract_amenity_features(self, item: Feature | dict, selector: Selector, ld_item: dict) -> None:
+        if not ld_item.get("amenityFeature"):
+            return
+        apply_yes_no(Extras.WIFI, item, "Wi-Fi" in ld_item["amenityFeature"])
 
     @staticmethod
     def clean_hours(hours_div):


### PR DESCRIPTION
Partial run:
```python
{"atp/brand/Wendy's": 2159,
 'atp/brand_wikidata/Q550258': 2159,
 'atp/category/amenity/fast_food': 2159,
 'atp/cdn/cloudflare/response_count': 2163,
 'atp/cdn/cloudflare/response_status_count/200': 2163,
 'atp/country/US': 2159,
 'atp/field/email/missing': 2159,
 'atp/field/image/missing': 2159,
 'atp/field/opening_hours/invalid': 3,
 'atp/field/operator/missing': 2159,
 'atp/field/operator_wikidata/missing': 2159,
 'atp/item_scraped_host_count/locations.wendys.com': 2159,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2159,
 'downloader/request_bytes': 1045234,
 'downloader/request_count': 2163,
 'downloader/request_method_count/GET': 2163,
 'downloader/response_bytes': 42702970,
 'downloader/response_count': 2163,
 'downloader/response_status_count/200': 2163,
 'elapsed_time_seconds': 287.111036,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'shutdown',
 'finish_time': datetime.datetime(2026, 3, 13, 13, 55, 33, 355010, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 213,
 'httpcache/hit': 1950,
 'httpcache/miss': 213,
 'httpcache/store': 213,
 'httpcompression/response_bytes': 271431740,
 'httpcompression/response_count': 2163,
 'item_scraped_count': 2159,
 'items_per_minute': 451.35888501742164,
 'log_count/INFO': 8,
 'log_count/WARNING': 74,
 'memusage/max': 694861824,
 'memusage/startup': 340496384,
 'request_depth_max': 1,
 'response_received_count': 2163,
 'responses_per_minute': 452.1951219512195,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2162,
 'scheduler/dequeued/memory': 2162,
 'scheduler/enqueued': 6268,
 'scheduler/enqueued/memory': 6268,
 'start_time': datetime.datetime(2026, 3, 13, 13, 50, 46, 243974, tzinfo=datetime.timezone.utc)}
```