### PR TITLE
[Verizon US] Fix spider

### DIFF
--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -1,19 +1,27 @@
-import datetime
-import json
 import re
+from typing import Any, Iterable
 
-from scrapy.spiders import SitemapSpider
+import chompjs
+from scrapy.http import Response, TextResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class VerizonUSSpider(SitemapSpider):
+class VerizonUSSpider(CrawlSpider, StructuredDataSpider):
     name = "verizon_us"
     item_attributes = {"brand": "Verizon", "brand_wikidata": "Q919641"}
-    sitemap_urls = ["https://www.verizon.com/robots.txt"]
-    sitemap_rules = [(r"https://www.verizon.com/stores/city/[^/]+/[^/]+/$", "parse_store")]
+    start_urls = ["https://www.verizon.com/nextgendigital/nos/storelocator"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"/storelocator/[-\w]+$"),
+        ),
+        Rule(LinkExtractor(allow=r"/storelocator/[-\w]+/[-\w]+$"), callback="parse"),
+    ]
 
     OPERATORS = {
         "Asurion FSL": {"operator": "Asurion FSL"},
@@ -33,44 +41,36 @@ class VerizonUSSpider(SitemapSpider):
         "Your Wireless": {"operator": "Your Wireless"},
     }
 
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store_url in re.findall(r'\\"storeUrl\\":\\"(.+?)\\"', response.text):
+            if "/details/" not in store_url:
+                store_url = store_url.replace("/stores/", "/stores/details/")
+            yield response.follow(url=store_url, callback=self.parse_sd)
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["ref"] = item["website"] = response.url
+        store_data = chompjs.parse_js_object(response.xpath('//script[contains(text(), "storeJSON")]/text()').get())
+        item["name"] = store_data["storeName"]
+
+        if "Authorized Retailer" in store_data["typeOfStore"]:
+            for operator, tags in self.OPERATORS.items():
+                if item["name"].startswith(operator):
+                    item["branch"] = item.pop("name").removeprefix(operator).strip(" -")
+                    item.update(tags)
+                    break
+        else:
+            item["branch"] = item.pop("name")
+            item["operator"] = self.item_attributes["brand"]
+            item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
+
+        #  ld_data hours don't match with Google Maps data, hence skipped.
+        item["opening_hours"] = self.parse_hours(store_data.get("StoreHours"))
+
+        apply_category(Categories.SHOP_MOBILE_PHONE, item)
+        yield item
+
     def parse_hours(self, store_hours: dict) -> OpeningHours:
         opening_hours = OpeningHours()
-
-        for day, time in store_hours.items():
-            if time == "Closed Closed":
-                opening_hours.set_closed(day)
-            elif m := re.match(r"(\d\d:\d\d [AP]M) (\d\d:\d\d [AP]M)", time):
-                opening_hours.add_range(day, *m.groups(), "%I:%M %p")
-
+        for day in DAYS_3_LETTERS:
+            opening_hours.add_range(day, store_hours.get(f"{day}Open"), store_hours.get(f"{day}Close"), "%I:%M %p")
         return opening_hours
-
-    def parse_store(self, response):
-        script = response.xpath('//script[contains(text(), "cityJSON")]/text()').extract_first()
-        if not script:
-            return
-
-        for store_data in json.loads(re.search(r"var cityJSON = (.*);", script).group(1))["stores"]:
-            item = DictParser.parse(store_data)
-            item["street_address"] = item.pop("addr_full")
-            item["state"] = store_data["stateAbbr"]
-            item["website"] = response.urljoin(store_data["storeUrl"])
-            item["extras"]["start_date"] = datetime.datetime.strptime(store_data["openingDate"], "%d-%b-%y").strftime(
-                "%Y-%m-%d"
-            )
-
-            if "Authorized Retailer" in store_data["typeOfStore"]:
-                for operator, tags in self.OPERATORS.items():
-                    if item["name"].startswith(operator):
-                        item["branch"] = item.pop("name").removeprefix(operator).strip(" -")
-                        item.update(tags)
-                        break
-            else:
-                item["branch"] = item.pop("name")
-                item["operator"] = self.item_attributes["brand"]
-                item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
-
-            item["opening_hours"] = self.parse_hours(store_data.get("openingHours"))
-
-            apply_category(Categories.SHOP_MOBILE_PHONE, item)
-
-            yield item

--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -26,6 +26,7 @@ class VerizonUSSpider(CrawlSpider, StructuredDataSpider):
     OPERATORS = {
         "Asurion FSL": {"operator": "Asurion FSL"},
         "BeMobile": {"operator": "BeMobile"},
+        "Best Buy": {"operator": "Best Buy", "operator_wikidata": "Q533415"},
         "Best Wireless": {"operator": "Best Wireless"},
         "Cellular Plus": {"operator": "Cellular Plus"},
         "Cellular Sales": {"operator": "Cellular Sales", "operator_wikidata": "Q5058345"},
@@ -48,8 +49,9 @@ class VerizonUSSpider(CrawlSpider, StructuredDataSpider):
             yield response.follow(url=store_url, callback=self.parse_sd)
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["ref"] = item["website"] = response.url
+        item["website"] = response.url
         store_data = chompjs.parse_js_object(response.xpath('//script[contains(text(), "storeJSON")]/text()').get())
+        item["ref"] = store_data["storeNumber"]
         item["name"] = store_data["storeName"]
 
         if "Authorized Retailer" in store_data["typeOfStore"]:
@@ -62,6 +64,9 @@ class VerizonUSSpider(CrawlSpider, StructuredDataSpider):
             item["branch"] = item.pop("name")
             item["operator"] = self.item_attributes["brand"]
             item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
+
+        if item.get("branch") and "#" in item["branch"]:
+            item["branch"] = item["branch"].split("#")[1].split(" ", 1)[-1]
 
         #  ld_data hours don't match with Google Maps data, hence skipped.
         item["opening_hours"] = self.parse_hours(store_data.get("StoreHours"))


### PR DESCRIPTION
```python
{'atp/brand/Verizon': 6982,
 'atp/brand_wikidata/Q919641': 6982,
 'atp/category/shop/mobile_phone': 6982,
 'atp/country/US': 6982,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 276,
 'atp/field/email/missing': 6982,
 'atp/field/geometry/missing': 19,
 'atp/field/opening_hours/missing': 107,
 'atp/field/operator/missing': 276,
 'atp/field/operator_wikidata/missing': 973,
 'atp/field/phone/invalid': 1,
 'atp/item_scraped_host_count/www.verizon.com': 6983,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 6982,
 'atp/operator/Asurion FSL': 86,
 'atp/operator/BeMobile': 111,
 'atp/operator/Best Buy': 503,
 'atp/operator/Cellular Plus': 59,
 'atp/operator/Cellular Sales': 819,
 'atp/operator/Mobile Generation': 43,
 'atp/operator/R Wireless': 26,
 'atp/operator/Russell Cellular': 694,
 'atp/operator/Team Wireless': 85,
 'atp/operator/The Cellular Connection': 522,
 'atp/operator/Verizon': 1267,
 'atp/operator/Victra': 1489,
 'atp/operator/Wireless Plus': 34,
 'atp/operator/Wireless World': 59,
 'atp/operator/Wireless Zone': 715,
 'atp/operator/Your Wireless': 194,
 'atp/operator_wikidata/Q118402656': 1489,
 'atp/operator_wikidata/Q121336519': 522,
 'atp/operator_wikidata/Q122517436': 715,
 'atp/operator_wikidata/Q125523800': 694,
 'atp/operator_wikidata/Q5058345': 819,
 'atp/operator_wikidata/Q533415': 503,
 'atp/operator_wikidata/Q919641': 1267,
 'downloader/request_bytes': 36173371,
 'downloader/request_count': 11069,
 'downloader/request_method_count/GET': 11069,
 'downloader/response_bytes': 225592935,
 'downloader/response_count': 11069,
 'downloader/response_status_count/200': 11033,
 'downloader/response_status_count/500': 36,
 'dupefilter/filtered': 2736,
 'elapsed_time_seconds': 301.47961,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 13, 17, 25, 51, 412007, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 11069,
 'httpcompression/response_bytes': 927064658,
 'httpcompression/response_count': 11069,
 'httperror/response_ignored_count': 12,
 'httperror/response_ignored_status_count/500': 12,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 6982,
 'items_per_minute': 1391.7607973421927,
 'log_count/DEBUG': 18054,
 'log_count/ERROR': 12,
 'log_count/INFO': 20,
 'request_depth_max': 3,
 'response_received_count': 11045,
 'responses_per_minute': 2201.6611295681064,
 'retry/count': 24,
 'retry/max_reached': 12,
 'retry/reason_count/500 Internal Server Error': 24,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 11068,
 'scheduler/dequeued/memory': 11068,
 'scheduler/enqueued': 11068,
 'scheduler/enqueued/memory': 11068,
 'start_time': datetime.datetime(2026, 3, 13, 17, 20, 49, 932397, tzinfo=datetime.timezone.utc)}
```