### PR TITLE
[Super Hotel JP] Specify datum to fix location

### DIFF
--- a/locations/spiders/super_hotel_jp.py
+++ b/locations/spiders/super_hotel_jp.py
@@ -14,7 +14,7 @@ class SuperHotelJPSpider(Spider):
 
     def make_request(self, offset: int, count: int = 100) -> JsonRequest:
         return JsonRequest(
-            "https://pkg.navitime.co.jp/superhotel-map/api/proxy2/shop/list?offset={}&limit={}".format(offset, count)
+            "https://pkg.navitime.co.jp/superhotel-map/api/proxy2/shop/list?datum=wgs84&offset={}&limit={}".format(offset, count)
         )
 
     async def start(self) -> AsyncIterator[JsonRequest]:

--- a/locations/spiders/super_hotel_jp.py
+++ b/locations/spiders/super_hotel_jp.py
@@ -14,7 +14,9 @@ class SuperHotelJPSpider(Spider):
 
     def make_request(self, offset: int, count: int = 100) -> JsonRequest:
         return JsonRequest(
-            "https://pkg.navitime.co.jp/superhotel-map/api/proxy2/shop/list?datum=wgs84&offset={}&limit={}".format(offset, count)
+            "https://pkg.navitime.co.jp/superhotel-map/api/proxy2/shop/list?datum=wgs84&offset={}&limit={}".format(
+                offset, count
+            )
         )
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
This fixes the location.

{'atp/brand/Super Hotel': 181,
 'atp/brand_wikidata/Q11313858': 181,
 'atp/category/tourism/hotel': 181,
 'atp/clean_strings/branch': 1,
 'atp/country/JP': 181,
 'atp/field/city/missing': 181,
 'atp/field/country/from_spider_name': 181,
 'atp/field/email/missing': 181,
 'atp/field/image/missing': 181,
 'atp/field/opening_hours/missing': 181,
 'atp/field/operator/missing': 181,
 'atp/field/operator_wikidata/missing': 181,
 'atp/field/phone/missing': 27,
 'atp/field/state/missing': 181,
 'atp/field/twitter/missing': 181,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 181,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 181,
 'downloader/request_bytes': 1004,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16504,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 1.972796,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 15, 1, 13, 15, 745216, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 73696,
 'httpcompression/response_count': 2,
 'item_scraped_count': 181,
 'items_per_minute': 10860.0,
 'log_count/DEBUG': 183,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 120.0,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 3, 15, 1, 13, 13, 772420, tzinfo=datetime.timezone.utc)}