### PR TITLE
[Acom JP] specify datum to fix location

### DIFF
--- a/locations/spiders/acom_jp.py
+++ b/locations/spiders/acom_jp.py
@@ -1,22 +1,15 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import Request, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class AcomJPSpider(Spider):
     name = "acom_jp"
-
-    item_attributes = {
-        "brand": "アコム",
-        "brand_wikidata": "Q4674469",
-        "extras": {
-            "brand:en": "Acom",
-            "shop": "money_lender",
-        },
-    }
+    item_attributes = {"brand": "アコム", "brand_wikidata": "Q4674469"}
 
     async def start(self) -> AsyncIterator[Request]:
         yield self.get_page(0)
@@ -27,7 +20,7 @@ class AcomJPSpider(Spider):
             meta={"offset": n},
         )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
         stores = data["items"]
 
@@ -41,6 +34,9 @@ class AcomJPSpider(Spider):
             item["extras"]["branch:ja-Hira"] = store["ruby"]
             item["addr_full"] = store["address_name"]
             item["website"] = f"https://store.acom.co.jp/acomnavi/spot/detail?code={store['code']}"
+
+            apply_category(Categories.SHOP_MONEY_LENDER, item)
+
             yield item
 
         if data["count"]["limit"] == len(data["items"]):


### PR DESCRIPTION
{'atp/brand/アコム': 501,
 'atp/brand_wikidata/Q4674469': 501,
 'atp/category/shop/money_lender': 501,
 'atp/country/JP': 501,
 'atp/field/city/missing': 501,
 'atp/field/country/from_spider_name': 501,
 'atp/field/email/missing': 501,
 'atp/field/image/missing': 501,
 'atp/field/opening_hours/missing': 501,
 'atp/field/operator/missing': 501,
 'atp/field/operator_wikidata/missing': 501,
 'atp/field/phone/missing': 501,
 'atp/field/state/missing': 501,
 'atp/field/street_address/missing': 501,
 'atp/field/twitter/missing': 501,
 'atp/item_scraped_host_count/store.acom.co.jp': 501,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 501,
 'downloader/request_bytes': 1282,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 46328,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.033447,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 15, 2, 21, 14, 379326, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 317795,
 'httpcompression/response_count': 3,
 'item_scraped_count': 501,
 'items_per_minute': 7515.0,
 'log_count/DEBUG': 504,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 3, 15, 2, 21, 10, 345879, tzinfo=datetime.timezone.utc)}