### PR TITLE
[Seven Bank JP] Create spider (26,589 locations)

### DIFF
--- a/locations/spiders/seven_bank_jp.py
+++ b/locations/spiders/seven_bank_jp.py
@@ -1,21 +1,15 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import Request, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class SevenBankJPSpider(Spider):
     name = "seven_bank_jp"
-
-    item_attributes = {
-        "brand": "セブン銀行",
-        "brand_wikidata": "Q7457182",
-        "extras": {
-            "amenity": "atm",
-        },
-    }
+    item_attributes = {"brand": "セブン銀行", "brand_wikidata": "Q7457182"}
 
     async def start(self) -> AsyncIterator[Request]:
         yield self.get_page(0)
@@ -26,7 +20,7 @@ class SevenBankJPSpider(Spider):
             meta={"offset": n},
         )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
         stores = data["items"]
 
@@ -41,6 +35,9 @@ class SevenBankJPSpider(Spider):
             item["addr_full"] = store["address_name"]
             item["postcode"] = store["postal_code"]
             item["website"] = f"https://location.sevenbank.co.jp/sevenbank/spot/detail?code={store['code']}"
+
+            apply_category(Categories.ATM, item)
+
             yield item
 
         if data["count"]["limit"] == len(data["items"]):


### PR DESCRIPTION
{'atp/brand/セブン銀行': 26589,
 'atp/brand_wikidata/Q7457182': 26589,
 'atp/category/amenity/atm': 26589,
 'atp/clean_strings/branch': 6,
 'atp/country/JP': 26589,
 'atp/field/city/missing': 26589,
 'atp/field/country/from_spider_name': 26589,
 'atp/field/email/missing': 26589,
 'atp/field/image/missing': 26589,
 'atp/field/opening_hours/missing': 26589,
 'atp/field/operator/missing': 26589,
 'atp/field/operator_wikidata/missing': 26589,
 'atp/field/phone/missing': 26589,
 'atp/field/state/missing': 26589,
 'atp/field/street_address/missing': 26589,
 'atp/field/twitter/missing': 26589,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/location.sevenbank.co.jp': 26589,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 26589,
 'downloader/request_bytes': 31961,
 'downloader/request_count': 55,
 'downloader/request_method_count/GET': 55,
 'downloader/response_bytes': 3315707,
 'downloader/response_count': 55,
 'downloader/response_status_count/200': 55,
 'elapsed_time_seconds': 93.540445,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 15, 10, 50, 48, 911290, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18826396,
 'httpcompression/response_count': 55,
 'item_scraped_count': 26589,
 'items_per_minute': 17154.193548387095,
 'log_count/DEBUG': 26644,
 'log_count/INFO': 63,
 'request_depth_max': 53,
 'response_received_count': 55,
 'responses_per_minute': 35.483870967741936,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 54,
 'scheduler/dequeued/memory': 54,
 'scheduler/enqueued': 54,
 'scheduler/enqueued/memory': 54,
 'start_time': datetime.datetime(2026, 3, 15, 10, 49, 15, 370845, tzinfo=datetime.timezone.utc)}