### PR TITLE
[Aeon Bank JP] create spider (8,665 locations)

### DIFF
--- a/locations/spiders/aeon_bank_jp.py
+++ b/locations/spiders/aeon_bank_jp.py
@@ -1,19 +1,14 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import Request, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
 class AeonBankJPSpider(Spider):
     name = "aeon_bank_jp"
-
-    item_attributes = {
-        "extras": {
-            "amenity": "atm",
-        },
-    }
 
     async def start(self) -> AsyncIterator[Request]:
         yield self.get_page(0)
@@ -24,7 +19,7 @@ class AeonBankJPSpider(Spider):
             meta={"offset": n},
         )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
         stores = data["items"]
 
@@ -50,6 +45,9 @@ class AeonBankJPSpider(Spider):
             item["addr_full"] = store["address_name"]
             item["postcode"] = store.get("postal_code")
             item["website"] = f"https://map.aeonbank.co.jp/aeonbank/spot/detail?code={store['code']}"
+
+            apply_category(Categories.ATM, item)
+
             yield item
 
         if data["count"]["limit"] == len(data["items"]):


### PR DESCRIPTION
{'atp/brand/みずほ銀行': 1696,
 'atp/brand/イオン銀行': 6969,
 'atp/brand_wikidata/Q11286327': 6969,
 'atp/brand_wikidata/Q2882956': 1696,
 'atp/category/amenity/atm': 8665,
 'atp/country/JP': 8665,
 'atp/field/city/missing': 8665,
 'atp/field/country/from_spider_name': 8665,
 'atp/field/email/missing': 8665,
 'atp/field/image/missing': 8665,
 'atp/field/opening_hours/missing': 8665,
 'atp/field/phone/missing': 8638,
 'atp/field/state/missing': 8665,
 'atp/field/street_address/missing': 8665,
 'atp/field/twitter/missing': 8665,
 'atp/item_scraped_host_count/map.aeonbank.co.jp': 8665,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 8665,
 'atp/operator/みずほ銀行': 1696,
 'atp/operator/イオン銀行': 6969,
 'atp/operator_wikidata/Q11286327': 6969,
 'atp/operator_wikidata/Q2882956': 1696,
 'downloader/request_bytes': 10475,
 'downloader/request_count': 19,
 'downloader/request_method_count/GET': 19,
 'downloader/response_bytes': 636216,
 'downloader/response_count': 19,
 'downloader/response_status_count/200': 19,
 'elapsed_time_seconds': 29.884913,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 15, 11, 31, 17, 387460, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5408127,
 'httpcompression/response_count': 19,
 'item_scraped_count': 8665,
 'items_per_minute': 17927.58620689655,
 'log_count/DEBUG': 8684,
 'log_count/INFO': 3,
 'request_depth_max': 17,
 'response_received_count': 19,
 'responses_per_minute': 39.310344827586206,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 18,
 'scheduler/dequeued/memory': 18,
 'scheduler/enqueued': 18,
 'scheduler/enqueued/memory': 18,
 'start_time': datetime.datetime(2026, 3, 15, 11, 30, 47, 502547, tzinfo=datetime.timezone.utc)}