### PR TITLE
[Crust AU] Fix Spider

### DIFF
--- a/locations/spiders/crust_au.py
+++ b/locations/spiders/crust_au.py
@@ -13,13 +13,12 @@ class CrustAUSpider(Spider):
     name = "crust_au"
     item_attributes = {"brand": "Crust", "brand_wikidata": "Q100792715"}
     allowed_domains = ["www.crust.com.au"]
-
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield scrapy.Request(url="https://www.crust.com.au/stores/stores_for_map_markers.json?catering_active=null")
+    start_urls = ["https://www.crust.com.au/stores/stores_for_map_markers.json?catering_active=null"]
 
     def parse(self, response):
         for location in response.json():
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
             item["lat"], item["lon"] = location["location"].split(",", 1)
             item.pop("addr_full", None)
             item["street_address"] = clean_address([location["address"], location["address2"]])


### PR DESCRIPTION
```python
{'atp/brand/Crust': 142,
 'atp/brand_wikidata/Q100792715': 142,
 'atp/category/amenity/fast_food': 142,
 'atp/clean_strings/city': 6,
 'atp/country/AU': 142,
 'atp/field/branch/missing': 142,
 'atp/field/city/missing': 2,
 'atp/field/country/from_spider_name': 142,
 'atp/field/image/missing': 142,
 'atp/field/operator/missing': 142,
 'atp/field/operator_wikidata/missing': 142,
 'atp/field/phone/missing': 2,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 142,
 'atp/item_scraped_host_count/www.crust.com.au': 142,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 142,
 'downloader/request_bytes': 140289,
 'downloader/request_count': 144,
 'downloader/request_method_count/GET': 144,
 'downloader/response_bytes': 512090,
 'downloader/response_count': 144,
 'downloader/response_status_count/200': 144,
 'elapsed_time_seconds': 175.921349,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 16, 5, 10, 55, 855395, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 243302,
 'httpcompression/response_count': 144,
 'item_scraped_count': 142,
 'items_per_minute': 48.68571428571429,
 'log_count/DEBUG': 286,
 'log_count/INFO': 44,
 'request_depth_max': 1,
 'response_received_count': 144,
 'responses_per_minute': 49.371428571428574,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 143,
 'scheduler/dequeued/memory': 143,
 'scheduler/enqueued': 143,
 'scheduler/enqueued/memory': 143,
 'start_time': datetime.datetime(2026, 3, 16, 5, 7, 59, 934046, tzinfo=datetime.timezone.utc)}
```