### PR TITLE
[Franprix FR] Brand Marché d'à Côté locations

### DIFF
--- a/locations/spiders/franprix_fr.py
+++ b/locations/spiders/franprix_fr.py
@@ -3,16 +3,24 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
+FRANPRIX = {"brand": "Franprix", "brand_wikidata": "Q2420096"}
+MARCHE = {"brand_wikidata": "Q130165186"}
+
 
 class FranprixFRSpider(SitemapSpider, StructuredDataSpider):
     name = "franprix_fr"
-    item_attributes = {"brand": "Franprix", "brand_wikidata": "Q2420096"}
     sitemap_urls = ["https://www.franprix.fr/sitemap.xml"]
     sitemap_rules = [(r"/magasins/\d+$", "parse_sd")]
     requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        if item["name"].lower().startswith("franprix "):
+            item["branch"] = item.pop("name").split(" ", 1)[1]
+            item.update(FRANPRIX)
+        elif item["name"].startswith("Marché d'à Côté "):
+            item["branch"] = item.pop("name").removeprefix("Marché d'à Côté ")
+            item.update(MARCHE)
+
         item["ref"] = response.url.split("/")[-1]
-        item["branch"] = item.pop("name")
         apply_category(Categories.SHOP_CONVENIENCE, item)
         yield item


### PR DESCRIPTION
Rel: https://github.com/alltheplaces/alltheplaces/pull/15458#issuecomment-4037832210

```python
{'atp/brand/Franprix': 734,
 "atp/brand/le marché d'à côté": 116,
 'atp/brand_wikidata/Q130165186': 116,
 'atp/brand_wikidata/Q2420096': 734,
 'atp/category/shop/convenience': 852,
 'atp/clean_strings/branch': 5,
 'atp/country/FR': 852,
 'atp/field/branch/missing': 2,
 'atp/field/brand/missing': 2,
 'atp/field/brand_wikidata/missing': 2,
 'atp/field/email/missing': 852,
 'atp/field/opening_hours/missing': 55,
 'atp/field/operator/missing': 852,
 'atp/field/operator_wikidata/missing': 852,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 78,
 'atp/field/state/missing': 852,
 'atp/field/twitter/missing': 852,
 'atp/item_scraped_host_count/www.franprix.fr': 852,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 734,
 'atp/nsi/perfect_match': 116,
 'downloader/request_bytes': 535907,
 'downloader/request_count': 961,
 'downloader/request_method_count/GET': 961,
 'downloader/response_bytes': 96788059,
 'downloader/response_count': 961,
 'downloader/response_status_count/200': 854,
 'downloader/response_status_count/404': 104,
 'downloader/response_status_count/500': 3,
 'elapsed_time_seconds': 14.467511,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 16, 15, 10, 3, 511277, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 961,
 'httpcompression/response_bytes': 459416676,
 'httpcompression/response_count': 957,
 'httperror/response_ignored_count': 105,
 'httperror/response_ignored_status_count/404': 104,
 'httperror/response_ignored_status_count/500': 1,
 'item_scraped_count': 852,
 'items_per_minute': 3651.4285714285716,
 'log_count/ERROR': 1,
 'log_count/INFO': 108,
 'log_count/WARNING': 56,
 'memusage/max': 345096192,
 'memusage/startup': 345096192,
 'request_depth_max': 1,
 'response_received_count': 959,
 'responses_per_minute': 4110.0,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/500 Internal Server Error': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 960,
 'scheduler/dequeued/memory': 960,
 'scheduler/enqueued': 960,
 'scheduler/enqueued/memory': 960,
 'start_time': datetime.datetime(2026, 3, 16, 15, 9, 49, 43766, tzinfo=datetime.timezone.utc)}
```