### PR TITLE
[Kfc IN] Fix spider

### DIFF
--- a/locations/spiders/kfc_in.py
+++ b/locations/spiders/kfc_in.py
@@ -4,7 +4,7 @@ from scrapy import Selector
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
@@ -25,6 +25,7 @@ class KfcINSpider(SitemapSpider, StructuredDataSpider):
         item["addr_full"] = merge_address_lines(
             [item.pop("street_address"), item.pop("city"), item.pop("state"), item["postcode"]]
         )
+        apply_category(Categories.FAST_FOOD, item)
         yield item
 
     def extract_amenity_features(self, item: Feature | dict, selector: Selector, ld_item: dict) -> None:


### PR DESCRIPTION
```python
{'atp/brand/KFC': 1361,
 'atp/brand_wikidata/Q524757': 1361,
 'atp/category/amenity/fast_food': 1361,
 'atp/clean_strings/addr_full': 243,
 'atp/country/IN': 1361,
 'atp/field/branch/missing': 1361,
 'atp/field/city/missing': 1361,
 'atp/field/email/missing': 1361,
 'atp/field/image/missing': 1361,
 'atp/field/operator/missing': 1361,
 'atp/field/operator_wikidata/missing': 1361,
 'atp/field/state/missing': 1361,
 'atp/field/street_address/missing': 1361,
 'atp/field/twitter/missing': 1361,
 'atp/item_scraped_host_count/restaurants.kfc.co.in': 1361,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1361,
 'atp/structured_data/unmapped/payment_accepted/Online Payment': 563,
 'atp/structured_data/unmapped/payment_accepted/PayTM': 791,
 'downloader/request_bytes': 859047,
 'downloader/request_count': 1734,
 'downloader/request_method_count/GET': 1734,
 'downloader/response_bytes': 45811416,
 'downloader/response_count': 1734,
 'downloader/response_status_count/200': 1734,
 'dupefilter/filtered': 9,
 'elapsed_time_seconds': 1016.894246,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 17, 12, 58, 35, 843880, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 741,
 'httpcache/hit': 993,
 'httpcache/miss': 741,
 'httpcache/store': 741,
 'httpcompression/response_bytes': 414313960,
 'httpcompression/response_count': 1734,
 'item_scraped_count': 1361,
 'items_per_minute': 80.3740157480315,
 'log_count/DEBUG': 4451,
 'log_count/INFO': 1496,
 'request_depth_max': 3,
 'response_received_count': 1734,
 'responses_per_minute': 102.4015748031496,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1733,
 'scheduler/dequeued/memory': 1733,
 'scheduler/enqueued': 1733,
 'scheduler/enqueued/memory': 1733,
 'start_time': datetime.datetime(2026, 3, 17, 12, 41, 38, 949634, tzinfo=datetime.timezone.utc)}
```