### PR TITLE
[Dunelm GB] Fix Spider

### DIFF
--- a/locations/spiders/dunelm_gb.py
+++ b/locations/spiders/dunelm_gb.py
@@ -1,19 +1,17 @@
 from typing import Any
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class DunelmGBSpider(scrapy.Spider):
+class DunelmGBSpider(Spider):
     name = "dunelm_gb"
-    item_attributes = {
-        "brand": "Dunelm",
-        "brand_wikidata": "Q5315020",
-    }
+    item_attributes = {"brand": "Dunelm", "brand_wikidata": "Q5315020"}
     start_urls = ["https://sloc-service.dunelm.com/api/v2/dunelm/stores/locations"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
@@ -23,5 +21,17 @@ class DunelmGBSpider(scrapy.Spider):
             item["ref"] = location["sapSiteId"]
             item["street_address"] = merge_address_lines([item["street_address"], location["localArea"]])
             item["website"] = "https://www.dunelm.com/stores/" + location["uri"]
+
+            item["opening_hours"] = self.parse_opening_hours(location["openingHours"])
             apply_category(Categories.SHOP_INTERIOR_DECORATION, item)
+
             yield item
+
+    def parse_opening_hours(self, openingHours: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in openingHours:
+            if rule["open"] == rule["close"] == "00:00":
+                oh.set_closed(rule["day"])
+            else:
+                oh.add_range(rule["day"], rule["open"], rule["close"])
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Dunelm': 194,
 'atp/brand_wikidata/Q5315020': 194,
 'atp/category/shop/interior_decoration': 194,
 'atp/clean_strings/name': 6,
 'atp/clean_strings/phone': 7,
 'atp/country/GB': 193,
 'atp/country/JE': 1,
 'atp/field/branch/missing': 194,
 'atp/field/email/missing': 2,
 'atp/field/image/missing': 194,
 'atp/field/opening_hours/missing': 194,
 'atp/field/operator/missing': 194,
 'atp/field/operator_wikidata/missing': 194,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 113,
 'atp/field/twitter/missing': 194,
 'atp/field/website/invalid': 22,
 'atp/item_scraped_host_count/sloc-service.dunelm.com': 194,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 193,
 'atp/nsi/match_failed': 1,
 'downloader/request_bytes': 722,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 710095,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 5.187454,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 18, 4, 45, 44, 303129, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1765648,
 'httpcompression/response_count': 1,
 'item_scraped_count': 194,
 'items_per_minute': 2328.0,
 'log_count/DEBUG': 197,
 'log_count/INFO': 3,
 'log_count/WARNING': 22,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 18, 4, 45, 39, 115675, tzinfo=datetime.timezone.utc)}
```