### PR TITLE
[E-net ATM JP] create spider (24,492 locations)

### DIFF
--- a/locations/spiders/enet_jp.py
+++ b/locations/spiders/enet_jp.py
@@ -1,0 +1,45 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class EnetJPSpider(Spider):
+    name = "enet_jp"
+    item_attributes = {"brand": "イーネット", "brand_wikidata": "Q135317450"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield self.get_page(0)
+
+    def get_page(self, n):
+        return Request(
+            f"https://pkg.navitime.co.jp/enet/api/proxy2/shop/list?datum=wgs84&limit=500&offset={n}",
+            meta={"offset": n},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = response.json()
+        stores = data["items"]
+
+        for store in stores:
+            item = DictParser.parse(store)
+            item["name"] = "イーネット"
+            item["extras"]["name:en"] = "E-net"
+            item["branch"] = store["name"].removesuffix("　共同出張所")
+            item["ref"] = store["code"]
+            item["lat"] = store["coord"]["lat"]
+            item["lon"] = store["coord"]["lon"]
+            item["extras"]["branch:ja-Hira"] = store["ruby"]
+            item["addr_full"] = store["address_name"]
+            item["postcode"] = store["postal_code"]
+            item["website"] = f"https://pkg.navitime.co.jp/enet/spot/detail?code={store['code']}"
+
+            apply_category(Categories.ATM, item)
+
+            yield item
+
+        if data["count"]["limit"] == len(data["items"]):
+            yield self.get_page(data["count"]["limit"] + response.meta["offset"])


### PR DESCRIPTION
{'atp/brand/イーネット': 24492,
 'atp/brand_wikidata/Q135317450': 24492,
 'atp/category/amenity/atm': 24492,
 'atp/country/JP': 24492,
 'atp/field/city/missing': 24492,
 'atp/field/country/from_spider_name': 24492,
 'atp/field/email/missing': 24492,
 'atp/field/image/missing': 24492,
 'atp/field/opening_hours/missing': 24492,
 'atp/field/operator/missing': 24492,
 'atp/field/operator_wikidata/missing': 24492,
 'atp/field/phone/missing': 24492,
 'atp/field/state/missing': 24492,
 'atp/field/street_address/missing': 24492,
 'atp/field/twitter/missing': 24492,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 24492,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 24492,
 'downloader/request_bytes': 27842,
 'downloader/request_count': 50,
 'downloader/request_method_count/GET': 50,
 'downloader/response_bytes': 1712467,
 'downloader/response_count': 50,
 'downloader/response_status_count/200': 50,
 'elapsed_time_seconds': 121.849637,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 19, 10, 44, 34, 838344, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9374447,
 'httpcompression/response_count': 50,
 'item_scraped_count': 24492,
 'items_per_minute': 12144.793388429753,
 'log_count/DEBUG': 24542,
 'log_count/INFO': 5,
 'request_depth_max': 48,
 'response_received_count': 50,
 'responses_per_minute': 24.793388429752067,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 49,
 'scheduler/dequeued/memory': 49,
 'scheduler/enqueued': 49,
 'scheduler/enqueued/memory': 49,
 'start_time': datetime.datetime(2026, 3, 19, 10, 42, 32, 988707, tzinfo=datetime.timezone.utc)}