### PR TITLE
[Drummond Golf AU] Fix coord extraction

### DIFF
--- a/locations/spiders/drummond_golf_au.py
+++ b/locations/spiders/drummond_golf_au.py
@@ -20,6 +20,7 @@ class DrummondGolfAUSpider(SitemapSpider, StructuredDataSpider):
         if item.get("street_address"):
             if coords := re.search(r"\"(-?\d+\.\d+),\s?(-?\d+\.\d+)\"", response.xpath("//@data-markers").get("")):
                 item["lat"], item["lon"] = coords.groups()
+            item["phone"] = None
             item["branch"] = response.xpath("//title/text()").get().removesuffix(" Drummond Golf")
             item["website"] = response.url
             apply_category(Categories.SHOP_SPORTS, item)


### PR DESCRIPTION
```python
{'atp/brand/Drummond Golf': 52,
 'atp/brand_wikidata/Q124065894': 52,
 'atp/category/shop/sports': 52,
 'atp/cdn/cloudflare/response_count': 59,
 'atp/cdn/cloudflare/response_status_count/200': 59,
 'atp/country/AU': 52,
 'atp/field/image/missing': 52,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 52,
 'atp/field/operator_wikidata/missing': 52,
 'atp/item_scraped_host_count/drummondgolf.com.au': 52,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_missing': 52,
 'downloader/request_bytes': 60209,
 'downloader/request_count': 59,
 'downloader/request_method_count/GET': 59,
 'downloader/response_bytes': 2891077,
 'downloader/response_count': 59,
 'downloader/response_status_count/200': 59,
 'elapsed_time_seconds': 1.273119,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 19, 13, 13, 50, 560080, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 59,
 'httpcompression/response_bytes': 12763149,
 'httpcompression/response_count': 59,
 'item_scraped_count': 52,
 'items_per_minute': 3120.0,
 'log_count/DEBUG': 112,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 336437248,
 'memusage/startup': 336437248,
 'request_depth_max': 2,
 'response_received_count': 59,
 'responses_per_minute': 3540.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 58,
 'scheduler/dequeued/memory': 58,
 'scheduler/enqueued': 58,
 'scheduler/enqueued/memory': 58,
 'start_time': datetime.datetime(2026, 3, 19, 13, 13, 49, 286961, tzinfo=datetime.timezone.utc)}
```

I wasn't paying attention #15522