### PR TITLE
[Mitsui Repark] create spider (14622 locations)

### DIFF
--- a/locations/spiders/repark_jp.py
+++ b/locations/spiders/repark_jp.py
@@ -1,22 +1,20 @@
-from typing import Any, AsyncIterator
+from typing import Any
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.geo import city_locations, country_iseadgg_centroids
 
 RADIUS_KM = 24
+
 
 class ReparkJPSpider(Spider):
     name = "repark_jp"
     item_attributes = {"brand_wikidata": "Q55521368"}
 
     def make_request(self, lat, lon):
-        return JsonRequest(
-            f"https://www.repark.jp/ajax/time_markers.json?range=C{lat},{lon}N90W0S0E180"
-        )
+        return JsonRequest(f"https://www.repark.jp/ajax/time_markers.json?range=C{lat},{lon}N90W0S0E180")
 
     async def start(self):
         for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):

--- a/locations/spiders/repark_jp.py
+++ b/locations/spiders/repark_jp.py
@@ -1,0 +1,39 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import city_locations, country_iseadgg_centroids
+
+RADIUS_KM = 24
+
+class ReparkJPSpider(Spider):
+    name = "repark_jp"
+    item_attributes = {"brand_wikidata": "Q55521368"}
+
+    def make_request(self, lat, lon):
+        return JsonRequest(
+            f"https://www.repark.jp/ajax/time_markers.json?range=C{lat},{lon}N90W0S0E180"
+        )
+
+    async def start(self):
+        for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):
+            yield self.make_request(lat, lon)
+        for city in city_locations("JP"):
+            yield self.make_request(city["latitude"], city["longitude"])
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for loc in response.json():
+            item = DictParser.parse(loc)
+            item["ref"] = loc["park_code"]
+            item["name"] = loc["park_name"]
+            item["extras"]["capacity"] = loc["capacity"]
+            item["extras"]["maxheight"] = loc["height_limit"]
+            item["extras"]["maxwidth"] = loc["width_limit"]
+            item["extras"]["maxlength"] = loc["length_limit"]
+            item["extras"]["maxweight"] = loc["weight_limit"]
+            item["website"] = f"https://www.repark.jp/parking_user/time/result/detail/?park={loc['park_code']}"
+
+            yield item


### PR DESCRIPTION
{'atp/brand/三井のリパーク': 14622,
 'atp/brand_wikidata/Q55521368': 14622,
 'atp/category/amenity/parking': 14622,
 'atp/country/JP': 14622,
 'atp/duplicate_count': 337378,
 'atp/field/branch/missing': 14622,
 'atp/field/city/missing': 14622,
 'atp/field/country/from_spider_name': 14622,
 'atp/field/email/missing': 14622,
 'atp/field/image/missing': 14622,
 'atp/field/opening_hours/missing': 14622,
 'atp/field/phone/missing': 14622,
 'atp/field/postcode/missing': 14622,
 'atp/field/state/missing': 14622,
 'atp/field/street_address/missing': 14622,
 'atp/field/twitter/missing': 14622,
 'atp/item_scraped_host_count/www.repark.jp': 352000,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 14622,
 'atp/operator/三井不動産リアルティ': 14622,
 'atp/operator_wikidata/Q11354218': 14622,
 'downloader/request_bytes': 1251604,
 'downloader/request_count': 1761,
 'downloader/request_method_count/GET': 1761,
 'downloader/response_bytes': 1003874110,
 'downloader/response_count': 1761,
 'downloader/response_status_count/200': 1761,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 2136.26339,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 20, 5, 46, 42, 637994, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 360,
 'httpcompression/response_count': 1,
 'item_dropped_count': 337378,
 'item_dropped_reasons_count/DropItem': 337378,
 'item_scraped_count': 14622,
 'items_per_minute': 410.73033707865164,
 'log_count/DEBUG': 353762,
 'log_count/INFO': 608,
 'response_received_count': 1761,
 'responses_per_minute': 49.466292134831455,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1760,
 'scheduler/dequeued/memory': 1760,
 'scheduler/enqueued': 1760,
 'scheduler/enqueued/memory': 1760,
 'start_time': datetime.datetime(2026, 3, 20, 5, 11, 6, 374604, tzinfo=datetime.timezone.utc)}