### PR TITLE
[Mos Burger JP] create spider (1334 locations)

### DIFF
--- a/locations/spiders/mos_burger_jp.py
+++ b/locations/spiders/mos_burger_jp.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from scrapy import Spider
 from scrapy.http import Response
+
 from locations.dict_parser import DictParser
 
 
@@ -12,7 +13,6 @@ class MosBurgerJPSpider(Spider):
         "brand_wikidata": "Q1204169",
     }
     start_urls = ["https://www.mos.jp/data/shop/shop.json"]
-    
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["shops"]:


### PR DESCRIPTION
{'atp/brand/モスバーガー': 1334,
 'atp/brand_wikidata/Q1204169': 1334,
 'atp/category/amenity/fast_food': 1334,
 'atp/country/JP': 1334,
 'atp/field/country/from_spider_name': 1334,
 'atp/field/email/missing': 1334,
 'atp/field/image/missing': 1334,
 'atp/field/opening_hours/missing': 1334,
 'atp/field/operator/missing': 1334,
 'atp/field/operator_wikidata/missing': 1334,
 'atp/field/phone/invalid': 16,
 'atp/field/state/missing': 1334,
 'atp/field/street_address/missing': 1334,
 'atp/field/twitter/missing': 1334,
 'atp/item_scraped_host_count/www.mos.jp': 1334,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1334,
 'downloader/request_bytes': 665,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4009359,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 6.619779,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 20, 10, 10, 40, 399122, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1334,
 'items_per_minute': 13340.0,
 'log_count/DEBUG': 1349,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 20, 10, 10, 33, 779343, tzinfo=datetime.timezone.utc)}