### PR TITLE
[SMBC Bank JP] create spider (1380 locations)

### DIFF
--- a/locations/spiders/smbc_jp.py
+++ b/locations/spiders/smbc_jp.py
@@ -6,7 +6,6 @@ from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
 from locations.geo import country_iseadgg_centroids
-from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 MAX_ITEMS = 1640  # determined experimentally
@@ -63,7 +62,7 @@ class SmbcJPSpider(Spider):
                 item["branch"] = row[6]
                 item["extras"]["branch:ja-Hira"] = row[7]
                 item["extras"]["branch:en"] = row[17]
-            
+
             item["addr_full"] = row[10]
 
             yield item


### PR DESCRIPTION
{'atp/brand/三井住友銀行': 1380,
 'atp/brand_wikidata/Q2660418': 1380,
 'atp/category/amenity/atm': 716,
 'atp/category/amenity/bank': 664,
 'atp/clean_strings/addr_full': 10,
 'atp/country/JP': 1380,
 'atp/duplicate_count': 967,
 'atp/field/branch/missing': 716,
 'atp/field/city/missing': 1380,
 'atp/field/country/from_spider_name': 1380,
 'atp/field/email/missing': 1380,
 'atp/field/image/missing': 1380,
 'atp/field/opening_hours/missing': 1380,
 'atp/field/operator/missing': 664,
 'atp/field/operator_wikidata/missing': 664,
 'atp/field/phone/missing': 1380,
 'atp/field/postcode/missing': 1380,
 'atp/field/state/missing': 1380,
 'atp/field/street_address/missing': 1380,
 'atp/field/twitter/missing': 1380,
 'atp/item_scraped_host_count/www.e-map.ne.jp': 2347,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1380,
 'atp/operator/三井住友銀行': 716,
 'atp/operator_wikidata/Q2660418': 716,
 'downloader/request_bytes': 320039,
 'downloader/request_count': 564,
 'downloader/request_method_count/GET': 564,
 'downloader/response_bytes': 1288811,
 'downloader/response_count': 564,
 'downloader/response_status_count/200': 564,
 'dupefilter/filtered': 375,
 'elapsed_time_seconds': 687.891808,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 20, 14, 24, 7, 702697, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 967,
 'item_dropped_reasons_count/DropItem': 967,
 'item_scraped_count': 1380,
 'items_per_minute': 120.52401746724891,
 'log_count/DEBUG': 2912,
 'log_count/INFO': 17,
 'request_depth_max': 1,
 'response_received_count': 564,
 'responses_per_minute': 49.257641921397386,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 563,
 'scheduler/dequeued/memory': 563,
 'scheduler/enqueued': 563,
 'scheduler/enqueued/memory': 563,
 'start_time': datetime.datetime(2026, 3, 20, 14, 12, 39, 810889, tzinfo=datetime.timezone.utc)}