### PR TITLE
[Can Do JP] create spider (1341 locations)

### DIFF
--- a/locations/spiders/can_do_jp.py
+++ b/locations/spiders/can_do_jp.py
@@ -23,7 +23,7 @@ class CanDOJPSpider(Spider):
             item["website"] = f"https://shopinfo.cando-web.co.jp/detail/{store['storeCode']}/"
             if store["phoneNumber"] is not None:
                 item["phone"] = f"+81 {store['phoneNumber']}"
-            item["branch"] = store["nameKanji"].removeprefix("Can★Do").removeprefix("Can★Doセレクト")
+            item["branch"] = store["nameKanji"].removeprefix("Can★Doセレクト").removeprefix("Can★Do")
             item["extras"]["branch:ja-Hira"] = store["nameKana"]
             item["postcode"] = store["postalCode"]
             item["addr_full"] = store["address"]


### PR DESCRIPTION
{'atp/brand/キャンドゥ': 1341,
 'atp/brand_wikidata/Q11297367': 1341,
 'atp/category/shop/variety_store': 1341,
 'atp/clean_strings/branch': 1270,
 'atp/country/JP': 1341,
 'atp/field/city/missing': 1341,
 'atp/field/country/from_website_url': 1341,
 'atp/field/email/missing': 1341,
 'atp/field/image/missing': 1341,
 'atp/field/opening_hours/missing': 1341,
 'atp/field/operator/missing': 1341,
 'atp/field/operator_wikidata/missing': 1341,
 'atp/field/phone/missing': 338,
 'atp/field/state/missing': 1341,
 'atp/field/street_address/missing': 1341,
 'atp/field/twitter/missing': 1341,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 1341,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1341,
 'downloader/request_bytes': 710,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 264082,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 9.602738,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 21, 0, 24, 40, 621164, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6180825,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1341,
 'items_per_minute': 8940.0,
 'log_count/DEBUG': 1344,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 21, 0, 24, 31, 18426, tzinfo=datetime.timezone.utc)}