### PR TITLE
[Me Group JP] add spider (8594 locations)

### DIFF
--- a/locations/spiders/megroup_jp.py
+++ b/locations/spiders/megroup_jp.py
@@ -45,6 +45,5 @@ class MegroupJPSpider(Spider):
                 elif loc["MachineType"] == "N":
                     item["name"] = "NAMES ステッカー"
                     item["extras"]["vending"] = "stickers"
-                
-            
+
             yield item


### PR DESCRIPTION
{'atp/category/amenity/photo_booth': 8312,
 'atp/category/amenity/vending_machine': 282,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 7,
 'atp/clean_strings/phone': 2942,
 'atp/clean_strings/ref': 7,
 'atp/clean_strings/street_address': 1,
 'atp/country/JP': 8594,
 'atp/duplicate_count': 9006,
 'atp/field/branch/missing': 282,
 'atp/field/brand/missing': 8594,
 'atp/field/brand_wikidata/missing': 8594,
 'atp/field/city/missing': 8594,
 'atp/field/country/from_spider_name': 8594,
 'atp/field/email/missing': 8594,
 'atp/field/image/missing': 8594,
 'atp/field/opening_hours/missing': 8594,
 'atp/field/phone/invalid': 20,
 'atp/field/phone/missing': 1270,
 'atp/field/postcode/missing': 8594,
 'atp/field/state/missing': 8594,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 8594,
 'atp/field/website/missing': 8594,
 'atp/item_scraped_host_count/locator.me-group.jp': 17600,
 'atp/lineage': 'S_?',
 'atp/nsi/operator_missing': 8594,
 'atp/operator/ME Group Japan': 8594,
 'atp/operator_wikidata/Q124004072': 8594,
 'downloader/request_bytes': 703491,
 'downloader/request_count': 1762,
 'downloader/request_method_count/GET': 1762,
 'downloader/response_bytes': 6212053,
 'downloader/response_count': 1762,
 'downloader/response_status_count/200': 1760,
 'downloader/response_status_count/302': 1,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 2173.665897,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 21, 4, 59, 50, 532391, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 9006,
 'item_dropped_reasons_count/DropItem': 9006,
 'item_scraped_count': 8594,
 'items_per_minute': 237.29406350667279,
 'log_count/DEBUG': 19396,
 'log_count/INFO': 102,
 'response_received_count': 1761,
 'responses_per_minute': 48.624022089277496,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1760,
 'scheduler/dequeued/memory': 1760,
 'scheduler/enqueued': 1760,
 'scheduler/enqueued/memory': 1760,
 'start_time': datetime.datetime(2026, 3, 21, 4, 23, 36, 866494, tzinfo=datetime.timezone.utc)}