### PR TITLE
[Japan Traffic Culture Association] create spider (497 public artworks)

### DIFF
--- a/locations/spiders/jptca.py
+++ b/locations/spiders/jptca.py
@@ -16,7 +16,7 @@ class JptcaSpider(SitemapSpider):
         if latlon := re.search(r"LatLng\(\s*(\d+\.\d+),(\d+\.\d+)\);", response.text):  # only get items with location
             item["lat"], item["lon"] = latlon.groups()
         else:
-            yield None
+            return
         item["ref"] = "".join(filter(str.isdigit, response.url))
         item["website"] = response.url
         item["extras"]["website:en"] = f"https://jptca.org/en/publicart{item['ref']}/"


### PR DESCRIPTION
{'atp/category/tourism/artwork': 567,
 'atp/clean_strings/name': 1,
 'atp/country/BE': 1,
 'atp/country/JP': 496,
 'atp/duplicate_count': 3,
 'atp/field/branch/missing': 567,
 'atp/field/brand/missing': 567,
 'atp/field/brand_wikidata/missing': 567,
 'atp/field/city/missing': 567,
 'atp/field/country/from_reverse_geocoding': 497,
 'atp/field/country/missing': 70,
 'atp/field/email/missing': 567,
 'atp/field/geometry/missing': 70,
 'atp/field/image/missing': 39,
 'atp/field/name/missing': 70,
 'atp/field/opening_hours/missing': 567,
 'atp/field/phone/missing': 567,
 'atp/field/postcode/missing': 567,
 'atp/field/state/missing': 70,
 'atp/field/street_address/missing': 567,
 'atp/field/twitter/missing': 567,
 'atp/item_scraped_host_count/jptca.org': 570,
 'atp/lineage': 'S_?',
 'atp/nsi/operator_missing': 567,
 'atp/operator/日本交通文化協会': 567,
 'atp/operator_wikidata/Q41698337': 567,
 'downloader/request_bytes': 214426,
 'downloader/request_count': 572,
 'downloader/request_method_count/GET': 572,
 'downloader/response_bytes': 13503676,
 'downloader/response_count': 572,
 'downloader/response_status_count/200': 572,
 'elapsed_time_seconds': 704.884451,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 22, 9, 2, 1, 874563, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 84817969,
 'httpcompression/response_count': 572,
 'item_dropped_count': 3,
 'item_dropped_reasons_count/DropItem': 3,
 'item_scraped_count': 567,
 'items_per_minute': 48.32386363636364,
 'log_count/DEBUG': 1142,
 'log_count/INFO': 161,
 'request_depth_max': 1,
 'response_received_count': 572,
 'responses_per_minute': 48.75,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 571,
 'scheduler/dequeued/memory': 571,
 'scheduler/enqueued': 571,
 'scheduler/enqueued/memory': 571,
 'start_time': datetime.datetime(2026, 3, 22, 8, 50, 16, 990112, tzinfo=datetime.timezone.utc)}