### PR TITLE
[Route Inn JP] create spider (367 locations)

### DIFF
--- a/locations/spiders/routeinn_jp.py
+++ b/locations/spiders/routeinn_jp.py
@@ -23,7 +23,7 @@ class RouteinnJPSpider(Spider):
         for store in response.json()["items"]:
 
             item = DictParser.parse(store)
-            
+
             item["website"] = store["extra_fields"]["詳細ページへのリンク"]
             item["extras"]["website:booking"] = store["extra_fields"]["予約ページURL（PC）"]
             item["postcode"] = store["extra_fields"]["postal_code"]


### PR DESCRIPTION
No NSI but will make PR.

{'atp/brand/ホテルルートイン': 367,
 'atp/brand_wikidata/Q11337912': 367,
 'atp/category/tourism/hotel': 367,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/phone': 24,
 'atp/clean_strings/postcode': 3,
 'atp/country/JP': 367,
 'atp/field/city/missing': 367,
 'atp/field/country/from_spider_name': 367,
 'atp/field/email/missing': 367,
 'atp/field/image/missing': 367,
 'atp/field/opening_hours/missing': 367,
 'atp/field/operator/missing': 367,
 'atp/field/operator_wikidata/missing': 367,
 'atp/field/state/missing': 367,
 'atp/field/street_address/missing': 367,
 'atp/field/twitter/missing': 367,
 'atp/field/website/missing': 1,
 'atp/item_scraped_host_count/route-inn.storelocator.jp': 367,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 367,
 'downloader/request_bytes': 1423,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 625413,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 3.901421,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 21, 12, 22, 23, 981262, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 367,
 'items_per_minute': 7340.0,
 'log_count/DEBUG': 371,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 80.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 3, 21, 12, 22, 20, 79841, tzinfo=datetime.timezone.utc)}