### PR TITLE
[Seijo Ishii JP] create spider (231 locations)

### DIFF
--- a/locations/spiders/seijoishii_jp.py
+++ b/locations/spiders/seijoishii_jp.py
@@ -1,47 +1,24 @@
-from typing import Any, AsyncIterator
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import Request, Response
-
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
 
 
-class SeijoishiiJPSpider(Spider):
+class SeijoishiiJPSpider(LocationCloudSpider):
     name = "seijoishii_jp"
     item_attributes = {"brand": "成城石井", "brand_wikidata": "Q11495410"}
+    api_endpoint = "https://shop.seijoishii.com/seijoishii/api/proxy2/shop/list"
+    website_formatter = "https://shop.seijoishii.com/seijoishii/spot/detail?code={}"
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield self.get_page(0)
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if source_feature["categories"][0]["code"] != "03":
+            return  # skip other types
 
-    def get_page(self, n):
-        return Request(
-            f"https://shop.seijoishii.com/seijoishii/api/proxy2/shop/list?datum=wgs84&limit=500&offset={n}",
-            meta={"offset": n},
-        )
+        item["branch"] = source_feature["name"]
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+        item["phone"] = f"+81 {source_feature['phone']}"
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = response.json()
-        stores = data["items"]
+        apply_category(Categories.SHOP_SUPERMARKET, item)
 
-        for store in stores:
-            item = Feature()
-            match store["categories"][0]["code"]:
-                case "03":
-                    pass
-                case _:
-                    continue  # skip other types
-
-            item["branch"] = store["name"]
-            item["extras"]["branch:ja-Hira"] = store.get("ruby")
-            item["website"] = f"https://shop.seijoishii.com/seijoishii/spot/detail?code={store['code']}"
-            item["ref"] = store["code"]
-            item["phone"] = f"+81 {store['phone']}"
-            item["lat"] = store["coord"]["lat"]
-            item["lon"] = store["coord"]["lon"]
-            item["addr_full"] = store["address_name"]
-            item["postcode"] = store["postal_code"]
-
-            yield item
-
-        if data["count"]["offset"] + data["count"]["limit"] < data["count"]["total"]:
-            yield self.get_page(data["count"]["limit"] + response.meta["offset"])
+        yield item

--- a/locations/storefinders/location_cloud.py
+++ b/locations/storefinders/location_cloud.py
@@ -1,0 +1,46 @@
+from typing import Any, AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.items import Feature
+
+# https://location-cloud.navitime.co.jp/
+
+
+class LocationCloudSpider(Spider):
+    dataset_attributes: dict = {"source": "api"}
+
+    api_endpoint: str
+    website_formatter: str = ""
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield self._get_page(0)
+
+    def _get_page(self, offset: int):
+        return Request(
+            "{}?datum=wgs84&limit=500&offset={}".format(self.api_endpoint, offset),
+            meta={"offset": offset},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = response.json()
+
+        for location in data["items"]:
+            item = Feature()
+            if self.website_formatter:
+                item["website"] = self.website_formatter.format(location["code"])
+            item["ref"] = location["code"]
+            item["lat"] = location["coord"]["lat"]
+            item["lon"] = location["coord"]["lon"]
+            item["addr_full"] = location["address_name"]
+            item["postcode"] = location["postal_code"]
+            item["phone"] = location["phone"]
+
+            yield from self.post_process_feature(item, location)
+
+        if data["count"]["offset"] + data["count"]["limit"] < data["count"]["total"]:
+            yield self._get_page(data["count"]["limit"] + response.meta["offset"])
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        yield item


### PR DESCRIPTION
{'atp/brand/成城石井': 231,
 'atp/brand_wikidata/Q11495410': 231,
 'atp/category/shop/supermarket': 231,
 'atp/country/JP': 231,
 'atp/field/city/missing': 231,
 'atp/field/country/from_spider_name': 231,
 'atp/field/email/missing': 231,
 'atp/field/image/missing': 231,
 'atp/field/opening_hours/missing': 231,
 'atp/field/operator/missing': 231,
 'atp/field/operator_wikidata/missing': 231,
 'atp/field/state/missing': 231,
 'atp/field/street_address/missing': 231,
 'atp/field/twitter/missing': 231,
 'atp/item_scraped_host_count/shop.seijoishii.com': 231,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 231,
 'downloader/request_bytes': 726,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23445,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.968109,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 23, 12, 0, 31, 30484, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 154691,
 'httpcompression/response_count': 2,
 'item_scraped_count': 231,
 'items_per_minute': 6930.0,
 'log_count/DEBUG': 233,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 23, 12, 0, 28, 62375, tzinfo=datetime.timezone.utc)}