### PR TITLE
[Valley Bank US] Add spider

### DIFF
--- a/locations/spiders/valley_bank_us.py
+++ b/locations/spiders/valley_bank_us.py
@@ -1,0 +1,26 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ValleyBankUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "valley_bank_us"
+    item_attributes = {"brand": "Valley Bank", "brand_wikidata": "Q7912152"}
+    sitemap_urls = ["https://locations.valley.com/robots.txt"]
+    sitemap_rules = [(r"/valley\-bank\-(\d+a?)\.html$", "parse")]
+    wanted_types = ["BankorCreditUnion"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = None
+        item["facebook"] = None
+        if response.url.endswith("a.html"):
+            apply_category(Categories.ATM, item)
+        else:
+            item["branch"] = response.xpath('//a[@class="current--page"]/text()').get()
+            apply_category(Categories.BANK, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Valley Bank': 464,
 'atp/brand_wikidata/Q7912152': 464,
 'atp/category/amenity/atm': 238,
 'atp/category/amenity/bank': 226,
 'atp/country/US': 464,
 'atp/field/branch/missing': 238,
 'atp/field/country/from_spider_name': 464,
 'atp/field/email/missing': 453,
 'atp/field/image/dropped': 464,
 'atp/field/image/missing': 464,
 'atp/field/name/missing': 238,
 'atp/field/opening_hours/missing': 221,
 'atp/field/operator/missing': 226,
 'atp/field/operator_wikidata/missing': 226,
 'atp/field/phone/missing': 236,
 'atp/field/twitter/missing': 464,
 'atp/item_scraped_host_count/locations.valley.com': 464,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 464,
 'atp/operator/Valley Bank': 238,
 'atp/operator_wikidata/Q7912152': 238,
 'downloader/request_bytes': 192789,
 'downloader/request_count': 468,
 'downloader/request_method_count/GET': 468,
 'downloader/response_bytes': 27845332,
 'downloader/response_count': 468,
 'downloader/response_status_count/200': 467,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 9.851736,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 24, 12, 45, 37, 841790, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 468,
 'httpcompression/response_bytes': 344286752,
 'httpcompression/response_count': 467,
 'item_scraped_count': 464,
 'items_per_minute': 3093.3333333333335,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 330522624,
 'memusage/startup': 330522624,
 'request_depth_max': 2,
 'response_received_count': 467,
 'responses_per_minute': 3113.3333333333335,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 467,
 'scheduler/dequeued/memory': 467,
 'scheduler/enqueued': 467,
 'scheduler/enqueued/memory': 467,
 'start_time': datetime.datetime(2026, 3, 24, 12, 45, 27, 990054, tzinfo=datetime.timezone.utc)}
```