### PR TITLE
[Big Lots US] Fix Spider

### DIFF
--- a/locations/spiders/big_lots_us.py
+++ b/locations/spiders/big_lots_us.py
@@ -21,12 +21,10 @@ class BigLotsUSSpider(Spider):
             location.update(location.pop("place"))
             item = DictParser.parse(location)
             item["website"] = item["name"] = None
-
-            item["image"] = location["photo"]["url"]
+            if location["photo"]:
+                item["image"] = location["photo"]["url"]
             item["extras"]["ref:google:place_id"] = location["placeId"]
-
             item["opening_hours"] = self.parse_opening_hours(location)
-
             yield item
 
     def parse_opening_hours(self, location: dict) -> OpeningHours:


### PR DESCRIPTION
```python
{'atp/brand/Big Lots': 218,
 'atp/brand_wikidata/Q4905973': 218,
 'atp/category/shop/department_store': 218,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/US': 218,
 'atp/field/branch/missing': 218,
 'atp/field/city/missing': 218,
 'atp/field/country/from_spider_name': 218,
 'atp/field/email/missing': 218,
 'atp/field/image/missing': 1,
 'atp/field/operator/missing': 218,
 'atp/field/operator_wikidata/missing': 218,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 218,
 'atp/field/state/from_reverse_geocoding': 218,
 'atp/field/street_address/missing': 218,
 'atp/field/twitter/missing': 218,
 'atp/field/website/missing': 218,
 'atp/item_scraped_host_count/core.service.elfsight.com': 218,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 218,
 'downloader/request_bytes': 772,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 53725,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.3748,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 25, 5, 33, 41, 763453, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 316828,
 'httpcompression/response_count': 2,
 'item_scraped_count': 218,
 'items_per_minute': 2616.0,
 'log_count/DEBUG': 220,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 25, 5, 33, 36, 388653, tzinfo=datetime.timezone.utc)}
```