### PR TITLE
Fix gsf_car_parts_gb spider

### DIFF
--- a/locations/spiders/gsf_car_parts_gb.py
+++ b/locations/spiders/gsf_car_parts_gb.py
@@ -15,7 +15,7 @@ class GsfCarPartsGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "GSF Car Parts", "brand_wikidata": "Q80963064"}
     sitemap_urls = ["https://www.gsfcarparts.com/robots.txt"]
     sitemap_follow = ["branch-sitemap"]
-    sitemap_rules = [(r"/branches/(\w+)$", "parse")]
+    sitemap_rules = [(r"/branches/([-\w]+)$", "parse")]
     wanted_types = ["Organization"]
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:


### PR DESCRIPTION
The current `sitemap_rules` regex is too strict, and excludes a number of branches that have a hyphen in the URL slug, such as https://www.gsfcarparts.com/branches/high-wycombe . Running this revised version locally, I get 211 branches, as opposed to the 158 with the current version. The total number of URLs in the Branch Sitemap at https://www.gsfcarparts.com/branch-sitemap-1-1.xml is 211.