### PR TITLE
Fixed sams_club spider (1131 locations)

### DIFF
--- a/locations/spiders/sams_club.py
+++ b/locations/spiders/sams_club.py
@@ -11,6 +11,7 @@ class SamsClubSpider(Spider):
     start_urls = [
         "https://www.samsclub.com/api/node/vivaldi/browse/v2/clubfinder/list?singleLineAddr=USA&distance=50000&nbrOfStores=1000"
     ]
+    requires_proxy = True
 
     def parse(self, response):
         for store in response.json():


### PR DESCRIPTION
The Sam's Club spider works on my computer but hasn't worked for a long time on the weekly runs.
This PR is just to test if the automatic bot message will find any locations if I add requires_proxy = True. If it doesn't work I will close the PR.
