### PR TITLE
[PPG Paints] Fix Spider

### DIFF
--- a/locations/spiders/ppg_paints.py
+++ b/locations/spiders/ppg_paints.py
@@ -1,44 +1,34 @@
-import re
-import urllib
+from typing import Any, Iterable
 
 import scrapy
+from scrapy.http import JsonRequest
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class PpgPaintsSpider(scrapy.Spider):
     name = "ppg_paints"
     item_attributes = {"brand": "PPG Paints", "brand_wikidata": "Q83891559"}
-    allowed_domains = ["www.ppgpaints.com"]
-    start_urls = [
-        "https://www.ppgpaints.com/store-locator/us",
-        "https://www.ppgpaints.com/store-locator/ca",
-        "https://www.ppgpaints.com/store-locator/mx",
-    ]
+
+    async def start(self) -> Iterable[Any]:
+        for country in ["CA", "US", "MX"]:
+            yield JsonRequest(
+                url="https://app-brandstorelocatoruscprd-001.azurewebsites.net/api/location/GetFilteredLocations",
+                data={
+                    "latitude": 0,
+                    "longitude": 0,
+                    "maxNumberOfResults": 5000,
+                    "filters": [
+                        {"locationType": ["Dealer"], "countryCode": [country], "brand": ["PPG Paints"]},
+                        {"locationType": ["PPC Store"], "countryCode": [country], "brand": ["PPG Paints"]},
+                    ],
+                },
+            )
 
     def parse(self, response):
-        for href in response.xpath('//*[@class="store-locations-item"]//@href').extract():
-            url = response.urljoin(href)
-            yield scrapy.Request(url)
-        for href in response.xpath('//*[@id="store-table"]//@href').extract():
-            url = response.urljoin(href)
-            yield scrapy.Request(url, callback=self.parse_store)
-
-    def parse_store(self, response):
-        map_url = re.search(r"url\('(.*)'\);", response.css(".store-staticmap").attrib["style"]).group(1)
-        [latlng] = urllib.parse.parse_qs(urllib.parse.urlparse(map_url).query)["center"]
-        lat, lon = map(float, latlng.split(","))
-        properties = {
-            "ref": response.xpath('//*[@itemprop="name"]/@href').get(),
-            "lat": lat,
-            "lon": lon,
-            "website": response.url,
-            "name": response.xpath('//*[@itemprop="name"]/text()').get(),
-            "street_address": response.xpath('//*[@itemprop="streetAddress"]/text()').get(),
-            "city": response.xpath('//*[@itemprop="addressLocality"]/text()').get(),
-            "state": response.xpath('//*[@itemprop="addressRegion"]/text()').get(),
-            "postcode": response.xpath('//*[@itemprop="postalCode"]/text()').get(),
-            "phone": response.xpath('//*[@itemprop="telephone"]/text()').get(),
-            "country": response.url.split("/")[4].upper(),
-        }
-        return Feature(**properties)
+        for location in response.json():
+            location.update(location.pop("location"))
+            item = DictParser.parse(location)
+            item["street_address"] = merge_address_lines([location])
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/PPG Paints': 2029,
 'atp/brand_wikidata/Q83891559': 2029,
 'atp/category/shop/paint': 2029,
 'atp/country/CA': 313,
 'atp/country/MX': 1,
 'atp/country/US': 1715,
 'atp/field/branch/missing': 2029,
 'atp/field/email/invalid': 2,
 'atp/field/email/missing': 1125,
 'atp/field/image/missing': 2029,
 'atp/field/opening_hours/missing': 2029,
 'atp/field/operator/missing': 2029,
 'atp/field/operator_wikidata/missing': 2029,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 66,
 'atp/field/street_address/missing': 2029,
 'atp/field/twitter/missing': 2029,
 'atp/field/website/missing': 2029,
 'atp/item_scraped_host_count/app-brandstorelocatoruscprd-001.azurewebsites.net': 2029,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2029,
 'downloader/request_bytes': 2278,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 3,
 'downloader/response_bytes': 958066,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 14.14089,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 27, 9, 38, 32, 682465, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2029,
 'items_per_minute': 8695.714285714286,
 'log_count/DEBUG': 2033,
 'log_count/INFO': 3,
 'log_count/WARNING': 2,
 'response_received_count': 4,
 'responses_per_minute': 17.142857142857142,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 3, 27, 9, 38, 18, 541575, tzinfo=datetime.timezone.utc)}
```