### PR TITLE
[Ford Dealers US] Fix Spider

### DIFF
--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -32,7 +32,7 @@ class FordDealersUSSpider(scrapy.Spider):
         )
 
     def parse_state(self, response, **kwargs):
-        state_list = (re.search(r"var\s*u\s*=\s*\"(.+)\"\.split\(\";\"\),", response.text).group(1)).split(";")
+        state_list = (re.search(r"var\s*\w+\s*=\s*\"(.+)\"\.split\(\";\"\),", response.text).group(1)).split(";")
         for state in state_list:
             yield JsonRequest(
                 url="https://www.ford.com/cxservices/dealer/Dealers.json?make=Ford&state={}".format(state),


### PR DESCRIPTION
```python
{'atp/brand/Ford': 2819,
 'atp/brand_wikidata/Q44294': 2819,
 'atp/category/shop/car': 2819,
 'atp/country/US': 2819,
 'atp/field/branch/missing': 2819,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 1196,
 'atp/field/image/missing': 2819,
 'atp/field/opening_hours/missing': 57,
 'atp/field/operator/missing': 2819,
 'atp/field/operator_wikidata/missing': 2819,
 'atp/field/phone/missing': 15,
 'atp/field/twitter/missing': 2819,
 'atp/field/website/missing': 50,
 'atp/item_scraped_host_count/www.ford.com': 2819,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 2819,
 'downloader/request_bytes': 37945,
 'downloader/request_count': 54,
 'downloader/request_method_count/GET': 54,
 'downloader/response_bytes': 11088215,
 'downloader/response_count': 54,
 'downloader/response_status_count/200': 54,
 'elapsed_time_seconds': 98.141363,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 30, 8, 55, 31, 939290, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2819,
 'items_per_minute': 1725.9183673469388,
 'log_count/DEBUG': 3197,
 'log_count/INFO': 8,
 'memusage/max': 435355648,
 'memusage/startup': 293801984,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 54,
 'playwright/page_count/closed': 54,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 134,
 'playwright/request_count/aborted': 80,
 'playwright/request_count/method/GET': 134,
 'playwright/request_count/navigation': 54,
 'playwright/request_count/resource_type/document': 54,
 'playwright/request_count/resource_type/font': 8,
 'playwright/request_count/resource_type/image': 4,
 'playwright/request_count/resource_type/script': 55,
 'playwright/request_count/resource_type/stylesheet': 13,
 'playwright/response_count': 54,
 'playwright/response_count/method/GET': 54,
 'playwright/response_count/resource_type/document': 54,
 'request_depth_max': 2,
 'response_received_count': 54,
 'responses_per_minute': 33.06122448979592,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 53,
 'scheduler/dequeued/memory': 53,
 'scheduler/enqueued': 53,
 'scheduler/enqueued/memory': 53,
 'start_time': datetime.datetime(2026, 3, 30, 8, 53, 53, 797927, tzinfo=datetime.timezone.utc)}
```