### PR TITLE
[porsche] Remove branch to become name

### DIFF
--- a/locations/spiders/porsche.py
+++ b/locations/spiders/porsche.py
@@ -28,7 +28,6 @@ class PorscheSpider(Spider):
             shop_info = dealer.get("dealer", {})
             item = DictParser.parse(shop_info)
             item["country"] = country
-            item["branch"] = item.pop("name")
             item["street_address"] = item.pop("street")
             item["phone"] = shop_info.get("contactDetails", {}).get("phoneNumber")
             item["email"] = shop_info.get("contactDetails", {}).get("emailAddress")


### PR DESCRIPTION
All of the currently attributed branch include the brand name Porsche (below examples).   Is more aligned with definition of 'name' rather than 'branch'. 
Examples:
Porsche Service Centre Dubai
Porsche Centre Sharjah
Porsche Service Centre Fujairah
Porsche Centre Al Ain
Porsche Centre Mussafah