### PR TITLE
[Hyundai NZ] Fix Spider

### DIFF
--- a/locations/spiders/hyundai_nz.py
+++ b/locations/spiders/hyundai_nz.py
@@ -38,7 +38,7 @@ class HyundaiNZSpider(JSONBlobSpider):
                 service_feature["ref"] = service_feature["ref"] + "_Service"
                 yield item
                 yield service_feature
-            elif feature["Type"][0] == "Service only agents" or "Service only":
+            elif feature["Type"][0] in ["Service only agents", "Service only"]:
                 apply_category(Categories.SHOP_CAR_REPAIR, item)
                 item["ref"] = item["ref"] + "_Service"
                 yield item
@@ -55,7 +55,7 @@ class HyundaiNZSpider(JSONBlobSpider):
                 apply_category({"boat:repair": "yes"}, item)
                 apply_category({"boat:parts": "yes"}, item)
                 yield item
-            elif feature["Type"][0] == "Sales":
+            elif feature["Type"][0] in ["Sales", "Sales only"]:
                 apply_category(Categories.SHOP_CAR, item)
                 item["ref"] = item["ref"] + "_Sales"
                 yield item


### PR DESCRIPTION
```python
{'atp/brand/Hyundai': 93,
 'atp/brand_wikidata/Q55931': 93,
 'atp/category/shop/car': 26,
 'atp/category/shop/car_repair': 67,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/phone': 5,
 'atp/country/NZ': 93,
 'atp/field/city/missing': 93,
 'atp/field/country/from_spider_name': 93,
 'atp/field/email/missing': 93,
 'atp/field/geometry/missing': 1,
 'atp/field/image/missing': 93,
 'atp/field/opening_hours/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/postcode/missing': 93,
 'atp/field/state/missing': 93,
 'atp/field/street_address/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/field/website/missing': 7,
 'atp/item_scraped_host_count/www.hyundai.co.nz': 93,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 93,
 'downloader/request_bytes': 677,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 6982,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.093927,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 31, 4, 57, 59, 23919, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25899,
 'httpcompression/response_count': 1,
 'item_scraped_count': 93,
 'items_per_minute': 1860.0,
 'log_count/DEBUG': 95,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 31, 4, 57, 55, 929992, tzinfo=datetime.timezone.utc)}
```