### PR TITLE
[Taco Bell GB] Fix Spider

### DIFF
--- a/locations/spiders/taco_bell_gb.py
+++ b/locations/spiders/taco_bell_gb.py
@@ -1,12 +1,24 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
 
+from scrapy.http import TextResponse
+
+from locations.items import Feature
 from locations.spiders.taco_bell_us import TACO_BELL_SHARED_ATTRIBUTES
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.uberall import UberallSpider
 
 
-class TacoBellGBSpider(SitemapSpider, StructuredDataSpider):
+class TacoBellGBSpider(UberallSpider):
     name = "taco_bell_gb"
     item_attributes = TACO_BELL_SHARED_ATTRIBUTES
-    sitemap_urls = ["https://locations.tacobell.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"uk/[^/]+/[^/]+\.html$", "parse")]
-    drop_attributes = {"image", "name"}
+    key = "oeY9DoIkFdLIquGvE5IQNv9wW53kHs"
+
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
+        item["website"] = "/".join(
+            [
+                "https://www.tacobell.co.uk/locations/l",
+                item["city"].lower().replace(" ", "-"),
+                location["streetAndNumber"].lower().replace(" ", "-"),
+                str(location["id"]),
+            ]
+        )
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Taco Bell': 160,
 'atp/brand_wikidata/Q752941': 160,
 'atp/category/amenity/fast_food': 160,
 'atp/country/GB': 160,
 'atp/field/branch/missing': 160,
 'atp/field/email/missing': 160,
 'atp/field/image/missing': 34,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 160,
 'atp/field/operator_wikidata/missing': 160,
 'atp/field/phone/missing': 23,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 160,
 'atp/item_scraped_host_count/uberall.com': 160,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 160,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 22350,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.911608,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 31, 5, 47, 45, 841927, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 165507,
 'httpcompression/response_count': 2,
 'item_scraped_count': 160,
 'items_per_minute': 3200.0,
 'log_count/DEBUG': 162,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 31, 5, 47, 41, 930319, tzinfo=datetime.timezone.utc)}
```