### PR TITLE
Blink: De-prioritize secondary requests

### DIFF
--- a/locations/spiders/blink.py
+++ b/locations/spiders/blink.py
@@ -79,6 +79,7 @@ class BlinkSpider(Spider):
                 f"https://apigw.blinknetwork.com/v3/locations/{location['locationId']}",
                 callback=self.parse_points,
                 cb_kwargs={"parent": item},
+                priority=-1,
             )
 
     def parse_points(self, response: Response, parent: Feature) -> Iterable[Feature]:


### PR DESCRIPTION
Getting more stations is more important than getting the details of each individual charger. This especially affects the weekly run, since that has a timeout and this is a very slow spider.