### PR TITLE
Connected Kerb: Add spider (6917 locations)

### DIFF
--- a/locations/spiders/connected_kerb_gb.py
+++ b/locations/spiders/connected_kerb_gb.py
@@ -1,0 +1,52 @@
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+SOCKET_TYPES = {
+    "CHAdeMO": "chademo",
+    "IEC_62196_T2_COMBO": "type2_combo",
+    "Type 2": "type2",
+}
+
+
+class ConnectedKerbGBSpider(JSONBlobSpider):
+    name = "connected_kerb_gb"
+    item_attributes = {
+        "operator": "Connected Kerb",
+        "operator_wikidata": "Q113579669",
+    }
+    start_urls = ["https://connectedkerb.com/umbraco/api/maps/data/en-GB"]
+
+    def post_process_item(self, station_item, response, station_location):
+        station_item["street_address"] = station_item.pop("addr_full")
+        station_item["website"] = station_location["yextLink"]["href"]
+
+        for connector_type in (
+            station_location["connectorType"].removeprefix("Plug type: ").removeprefix("Plug types: ").split(", ")
+        ):
+            if connector_type in SOCKET_TYPES:
+                socket_type = SOCKET_TYPES[connector_type]
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_socket_type/{connector_type}")
+                socket_type = "unknown"
+            apply_yes_no(f"socket:{socket_type}", station_item, True)
+            station_item["extras"][f"socket:{socket_type}:output"] = station_location["maxSpeed"].removeprefix(
+                "Max speed: "
+            )
+
+        apply_category(Categories.CHARGING_STATION, station_item)
+        yield station_item
+
+        for i, point_location in enumerate(station_location["chargingPoints"]):
+            point_item = Feature(lat=station_item["lat"], lon=station_item["lon"])
+            point_item["ref"] = point_location.get("socketId", f"{station_item['ref']}:{i}")
+            if point_location["type"] in SOCKET_TYPES:
+                socket_type = SOCKET_TYPES[point_location["type"]]
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_socket_type/{point_location['type']}")
+                socket_type = "unknown"
+            apply_yes_no(f"socket:{socket_type}", point_item, True)
+            point_item["extras"][f"socket:{socket_type}:output"] = point_location["maxPower"]
+
+            apply_category({"man_made": "charge_point"}, point_item)
+            yield point_item


### PR DESCRIPTION
```py
{'atp/category/amenity/charging_station': 1372,
 'atp/category/man_made/charge_point': 5544,
 'atp/clean_strings/website': 1372,
 'atp/country/GB': 6916,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 6916,
 'atp/field/brand/missing': 6916,
 'atp/field/brand_wikidata/missing': 6916,
 'atp/field/city/missing': 6916,
 'atp/field/country/from_spider_name': 5544,
 'atp/field/email/missing': 6916,
 'atp/field/image/missing': 6916,
 'atp/field/name/missing': 5544,
 'atp/field/opening_hours/missing': 6916,
 'atp/field/phone/missing': 6916,
 'atp/field/postcode/missing': 6916,
 'atp/field/state/missing': 6916,
 'atp/field/street_address/missing': 5544,
 'atp/field/twitter/missing': 6916,
 'atp/field/website/missing': 5544,
 'atp/item_scraped_host_count/connectedkerb.com': 6917,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 6916,
 'atp/operator/Connected Kerb': 6916,
 'atp/operator_wikidata/Q113579669': 6916,
 'downloader/request_bytes': 687,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1167043,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.77169,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 31, 19, 1, 25, 852917, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 6916,
 'items_per_minute': 51870.0,
 'log_count/INFO': 3,
 'memusage/max': 285777920,
 'memusage/startup': 285777920,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 3, 31, 19, 1, 17, 81227, tzinfo=datetime.timezone.utc)}
```