### PR TITLE
[FLO] Add spider (8404 locations)

### DIFF
--- a/locations/spiders/flo_ca_us.py
+++ b/locations/spiders/flo_ca_us.py
@@ -1,0 +1,94 @@
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.geo import make_subdivisions
+from locations.items import Feature
+
+SOCKET_TYPES = {
+    "CHADEMO": "chademo",
+    "IEC_62196_T1": "type1",
+    "IEC_62196_T1_COMBO": "type1_combo",
+    "IEC_62196_T2": "type2",
+    "IEC_62196_T2_COMBO": "type2_combo",
+    "J3400": "nacs",
+    "TESLA_S": "nacs",
+}
+
+
+class FloCAUSSpider(Spider):
+    name = "flo_ca_us"
+    item_attributes = {
+        "brand": "FLO",
+        "brand_wikidata": "Q64971203",
+        "operator": "FLO",
+        "operator_wikidata": "Q64971203",
+    }
+
+    def make_request(self, zoom_level: int, bounds: tuple[float, float, float, float]) -> JsonRequest:
+        return JsonRequest(
+            "https://emobility.flo.ca/v3.0/map/markers/search",
+            data={
+                "bounds": {
+                    "SouthWest": {"Latitude": bounds[1], "Longitude": bounds[0]},
+                    "NorthEast": {"Latitude": bounds[3], "Longitude": bounds[2]},
+                },
+                "filter": {"networkIds": [1, 6]},
+                "zoomLevel": zoom_level,
+            },
+            cb_kwargs={"zoom_level": zoom_level, "bounds": bounds},
+        )
+
+    async def start(self):
+        yield self.make_request(zoom_level=0, bounds=(-180, -85, 180, 85))
+
+    def parse(self, response, zoom_level, bounds):
+        for park in response.json()["parks"]:
+            station = self.parse_station(park)
+            yield station
+            for point in park["stations"]:
+                yield self.parse_charge_point(station, point)
+
+        clusters = response.json()["clusters"]
+        for subdivision in make_subdivisions(bounds, 2):
+            xmin, ymin, xmax, ymax = subdivision
+            if (
+                any(
+                    xmin <= cluster["geoCoordinates"]["longitude"] < xmax
+                    and ymin <= cluster["geoCoordinates"]["latitude"] < ymax
+                    for cluster in clusters
+                )
+                > 0
+            ):
+                yield self.make_request(zoom_level=zoom_level + 1, bounds=subdivision)
+
+    def parse_station(self, location) -> Feature:
+        item = Feature(
+            ref=location["id"],
+            name=location["name"],
+            lat=location["geoCoordinates"]["latitude"],
+            lon=location["geoCoordinates"]["longitude"],
+        )
+        apply_category(Categories.CHARGING_STATION, item)
+        return item
+
+    def parse_charge_point(self, parent: Feature, location: dict) -> Feature:
+        item = Feature(
+            lat=parent["lat"],
+            lon=parent["lon"],
+            ref=f"{parent['ref']}:{location['id']}",
+            name=location["name"],
+        )
+        apply_yes_no(Extras.FEE, item, not location.get("freeOfCharge", False), "freeOfCharge" not in location)
+
+        for connector in location["connectors"]:
+            if connector in SOCKET_TYPES:
+                socket_type = SOCKET_TYPES[connector]
+            else:
+                self.crawler.stats.inc_value(f"atp/{self.name}/unhandled_socket_type/{connector}")
+                socket_type = "unknown"
+            apply_yes_no(f"socket:{socket_type}", item, True)
+            item["extras"][f"socket:{socket_type}:output"] = f"{location['chargingSpeed']} kW"
+
+        apply_category({"man_made": "charge_point"}, item)
+        return item


### PR DESCRIPTION
```py
{'atp/brand/FLO': 7446,
 'atp/brand_wikidata/Q64971203': 7446,
 'atp/category/amenity/charging_station': 1985,
 'atp/category/man_made/charge_point': 5461,
 'atp/clean_strings/name': 19,
 'atp/country/CA': 7089,
 'atp/country/GH': 11,
 'atp/country/US': 346,
 'atp/duplicate_count': 958,
 'atp/field/branch/missing': 7446,
 'atp/field/city/missing': 7446,
 'atp/field/country/from_reverse_geocoding': 7446,
 'atp/field/email/missing': 7446,
 'atp/field/image/missing': 7446,
 'atp/field/opening_hours/missing': 7446,
 'atp/field/phone/missing': 7446,
 'atp/field/postcode/missing': 7446,
 'atp/field/street_address/missing': 7446,
 'atp/field/twitter/missing': 7446,
 'atp/field/website/missing': 7446,
 'atp/flo_ca_us/unhandled_socket_type/J3400': 2,
 'atp/geometry/null_island': 11,
 'atp/item_scraped_host_count/emobility.flo.ca': 8404,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 7435,
 'atp/nsi/match_failed': 11,
 'atp/operator/FLO': 7446,
 'atp/operator_wikidata/Q64971203': 7446,
 'downloader/request_bytes': 1635578,
 'downloader/request_count': 2628,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 2627,
 'downloader/response_bytes': 2547225,
 'downloader/response_count': 2628,
 'downloader/response_status_count/200': 2627,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3207.151496,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 3, 31, 23, 27, 31, 161670, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 958,
 'item_dropped_reasons_count/DropItem': 958,
 'item_scraped_count': 7446,
 'items_per_minute': 139.30776426566885,
 'log_count/INFO': 56,
 'memusage/max': 510730240,
 'memusage/startup': 285814784,
 'request_depth_max': 15,
 'response_received_count': 2628,
 'responses_per_minute': 49.16744621141253,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2627,
 'scheduler/dequeued/memory': 2627,
 'scheduler/enqueued': 2627,
 'scheduler/enqueued/memory': 2627,
 'start_time': datetime.datetime(2026, 3, 31, 22, 34, 4, 10174, tzinfo=datetime.timezone.utc)}
```