### PR TITLE
[Tchibo] Fix Spider

### DIFF
--- a/locations/spiders/tchibo.py
+++ b/locations/spiders/tchibo.py
@@ -27,6 +27,7 @@ class TchiboSpider(Spider):
             [store.update(store.pop(key)) for key in ["locationGeographicDto", "addressDto"]]
             item = DictParser.parse(store)
             item["branch"] = item.pop("name")
+            item["street_address"] = item.pop("street")
 
             try:
                 item["opening_hours"] = self.parse_hours(store["daysDto"])


### PR DESCRIPTION
```python
{'atp/brand/Tchibo': 774,
 'atp/brand_wikidata/Q564213': 774,
 'atp/category/shop/coffee': 774,
 'atp/country/AT': 114,
 'atp/country/CH': 30,
 'atp/country/CZ': 43,
 'atp/country/DE': 465,
 'atp/country/HU': 9,
 'atp/country/PL': 42,
 'atp/country/SK': 18,
 'atp/country/TR': 53,
 'atp/field/branch/missing': 444,
 'atp/field/email/missing': 774,
 'atp/field/image/missing': 774,
 'atp/field/operator/missing': 774,
 'atp/field/operator_wikidata/missing': 774,
 'atp/field/phone/missing': 21,
 'atp/field/state/missing': 774,
 'atp/field/street_address/missing': 774,
 'atp/field/twitter/missing': 774,
 'atp/field/website/missing': 774,
 'atp/item_scraped_host_count/www.tchibo.de': 774,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 774,
 'downloader/request_bytes': 12849,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 163075,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 11.960884,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 1, 6, 52, 47, 73654, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1013552,
 'httpcompression/response_count': 9,
 'item_scraped_count': 774,
 'items_per_minute': 4221.818181818182,
 'log_count/DEBUG': 783,
 'log_count/INFO': 3,
 'request_depth_max': 8,
 'response_received_count': 9,
 'responses_per_minute': 49.09090909090909,
 'scheduler/dequeued': 9,
 'scheduler/dequeued/memory': 9,
 'scheduler/enqueued': 9,
 'scheduler/enqueued/memory': 9,
 'start_time': datetime.datetime(2026, 4, 1, 6, 52, 35, 112770, tzinfo=datetime.timezone.utc)}
```