### PR TITLE
[GB Addresses] Add Borough Council of King's Lynn & West Norfolk data

### DIFF
--- a/locations/spiders/addresses/gb/README.md
+++ b/locations/spiders/addresses/gb/README.md
@@ -107,6 +107,7 @@ Owen and published. Others are helping.
 | Aberdeenshire Council                  | https://www.owenboswarva.com/blog/post-addr47.htm                                                                                     |
 | Barnet Council                         | https://www.owenboswarva.com/blog/post-addr23.htm                                                                                     |
 | Birmingham City Council                | https://www.owenboswarva.com/blog/post-addr11.htm                                                                                     |
+| Borough Council of King's Lynn & West Norfolk | https://www.owenboswarva.com/blog/post-addr66.htm                                                                              |
 | Bradford Council                       | https://www.owenboswarva.com/blog/post-addr29.htm                                                                                     |
 | Brent Council                          | https://www.owenboswarva.com/blog/post-addr49.htm                                                                                     |
 | Brighton & Hove City Council           | https://www.owenboswarva.com/blog/post-addr26.htm                                                                                     |

--- a/locations/spiders/addresses/gb/gb_kings_lynn.py
+++ b/locations/spiders/addresses/gb/gb_kings_lynn.py
@@ -1,0 +1,135 @@
+import csv
+import re
+from io import BytesIO, TextIOWrapper
+from typing import Any
+from zipfile import ZipFile
+
+from scrapy.http import Response
+
+from locations.address_spider import AddressSpider
+from locations.items import Feature
+from locations.licenses import Licenses
+
+
+class GbDoncasterSpider(AddressSpider):
+    name = "gb_kings_lynn"
+    dataset_attributes = Licenses.GB_OGLv3.value | {
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0."  # address strings
+        + " Contains OS data © Crown copyright and database right 2025."  # OS Open UPRN, coords
+        + " Contains Royal Mail data © Royal Mail copyright and Database right."  # Postcodes
+        + " Contains GeoPlace data © Local Government Information House Limited copyright and database right."
+        + " Office for National Statistics licensed under the Open Government Licence v.3.0."
+    }
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 60 * 5}
+    no_refs = True
+    start_urls = [
+        "https://drive.usercontent.google.com/download?id=1EX1qK63HievHPfIfNEzf9hc2Im8F0gMQ&export=download&confirm=t"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        _re = re.compile(
+            r"^(.+?)(?:, ({}))?(?:, ({}))?$".format(
+                "|".join(
+                    [
+                        # "suburbs"
+                        "Heacham",
+                        "Dersingham",
+                        "South Wootton",
+                        "Terrington St Clement",
+                        "Snettisham",
+                        "Emneth",
+                        "Feltwell",
+                        "West Winch",
+                        "Watlington",
+                        "Upwell",
+                        "Outwell",
+                        "North Wootton",
+                        "Clenchwarton",
+                        "West Lynn",
+                        "Gayton",
+                        "Gaywood",
+                        "Docking",
+                        "Walsoken",
+                        "Burnham Market",
+                        "Upper Marham",
+                        "Southery",
+                        "Marshland St James",
+                        "Methwold",
+                        "Tilney St Lawrence",
+                        "West Walton",
+                        "Stoke Ferry",
+                        "Pott Row",
+                        "Middleton",
+                        "Castle Acre",
+                        "Great Massingham",
+                        "Hilgay",
+                        "Northwold",
+                        "Walpole St Andrew",
+                        "Denver",
+                        "Wiggenhall St Germans",
+                        "Terrington St John",
+                        "Grimston",
+                        "Brancaster",
+                        "Marham",
+                        "Ingoldisthorpe",
+                        "Walpole St Peter",
+                        "Thornham",
+                        "Walpole Highway",
+                        "Old Hunstanton",
+                        "Stow Bridge",
+                        "Wimbotsham",
+                        "East Winch",
+                        "South Creake",
+                        "Wereham",
+                        "Brancaster Staithe",
+                        "Sedgeford",
+                        "Pentney",
+                        "Tilney All Saints",
+                        "Wiggenhall St Mary Magdalen",
+                        "Hockwold cum Wilton",
+                        "Syderstone",
+                        "Shouldham",
+                        "East Rudham",
+                        "Walton Highway",
+                        "Fincham",
+                        "Runcton Holme",
+                        "Welney",
+                        "North Creake",
+                        "Holme Next The Sea",
+                        "Barroway Drove",
+                        "Nordelph",
+                        "Ringstead",
+                    ]
+                ),
+                "|".join(
+                    [
+                        # cities
+                        "King'?s Lynn",
+                        "Downham Market",
+                        "Wisbech",
+                        "Hunstanton",
+                        "Thetford",
+                        "Fakenham",
+                        "Sandringham",
+                        "Ely",
+                        "Snettisham",
+                    ]
+                ),
+            )
+        )
+
+        with ZipFile(BytesIO(response.body)) as zip_file:
+            for addr in csv.DictReader(TextIOWrapper(zip_file.open("KLWN_CTBANDS_OSOU_202602.csv"), encoding="utf-8")):
+                item = Feature()
+                item["ref"] = addr["PROPREF"]
+                item["extras"]["ref:GB:uprn"] = addr["UPRN"]
+                item["lat"] = addr["LAT"]
+                item["lon"] = addr["LNG"]
+                item["postcode"] = addr["POSTCODE"]
+
+                if m := _re.match(addr["ADDR"].removesuffix("Norfolk").removesuffix("Cambridgeshire").strip(", ")):
+                    item["street_address"], item["extras"]["addr:suburb"], item["city"] = m.groups()
+
+                item["country"] = "GB"
+
+                yield item


### PR DESCRIPTION
```python
{'atp/country/GB': 76737,
 'atp/field/branch/missing': 76737,
 'atp/field/brand/missing': 76737,
 'atp/field/brand_wikidata/missing': 76737,
 'atp/field/city/missing': 281,
 'atp/field/email/missing': 76737,
 'atp/field/geometry/invalid': 270,
 'atp/field/image/missing': 76737,
 'atp/field/name/missing': 76737,
 'atp/field/opening_hours/missing': 76737,
 'atp/field/operator/missing': 76737,
 'atp/field/operator_wikidata/missing': 76737,
 'atp/field/phone/missing': 76737,
 'atp/field/postcode/missing': 1173,
 'atp/field/state/missing': 76737,
 'atp/field/twitter/missing': 76737,
 'atp/field/website/missing': 76737,
 'atp/item_scraped_host_count/drive.usercontent.google.com': 76737,
 'atp/lineage': 'S_ATP_ADDRESSES',
 'downloader/request_bytes': 407,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 7879440,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 18.781202,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 1, 15, 1, 1, 762802, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1,
 'item_scraped_count': 76737,
 'items_per_minute': 255790.0,
 'log_count/INFO': 2,
 'log_count/WARNING': 1,
 'memusage/max': 331345920,
 'memusage/startup': 331345920,
 'response_received_count': 1,
 'responses_per_minute': 3.3333333333333335,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 1, 15, 0, 42, 981600, tzinfo=datetime.timezone.utc)}
```