### PR TITLE
[Wagamama GB] Fix Spider

### DIFF
--- a/locations/spiders/wagamama_gb.py
+++ b/locations/spiders/wagamama_gb.py
@@ -1,31 +1,29 @@
-from typing import Any
+from typing import Iterable
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.http import TextResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
-from locations.structured_data_spider import extract_phone
-
-# 2024-02-20 - Site has microdata, but it is broken :(
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class WagamamaGBSpider(SitemapSpider):
+class WagamamaGBSpider(CrawlSpider, StructuredDataSpider):
     name = "wagamama_gb"
     item_attributes = {"brand": "Wagamama", "brand_wikidata": "Q503715"}
     allowed_domains = ["wagamama.com"]
-    sitemap_urls = ["https://www.wagamama.com/sitemap.xml"]
-    sitemap_rules = [("/restaurants/[^/]+/[^/]+$", "parse")]
+    start_urls = ["https://www.wagamama.com/restaurants"]
+    rules = [
+        Rule(
+            LinkExtractor(allow="/restaurants/", restrict_xpaths='//*[@class="_list_nzdug_20"]'),
+            callback="parse_sd",
+            follow=True,
+        ),
+        Rule(LinkExtractor(allow=r"/restaurants/[^/]+/[^/]+"), callback="parse_sd"),
+    ]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
-        item["ref"] = item["website"] = response.url
-
-        item["addr_full"] = merge_address_lines(response.xpath("//address//text()").getall())
-        item["street_address"] = response.xpath('//meta[@itemprop="streetAddress"]/@content').get()
-        item["city"] = response.xpath('//meta[@itemprop="addressLocality"]/@content').get()
-
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").replace("wagamama", "")
         extract_google_position(item, response)
-        extract_phone(item, response)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Wagamama': 169,
 'atp/brand_wikidata/Q503715': 169,
 'atp/category/amenity/restaurant': 169,
 'atp/clean_strings/branch': 169,
 'atp/country/GB': 169,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 169,
 'atp/field/operator_wikidata/missing': 169,
 'atp/field/state/missing': 169,
 'atp/item_scraped_host_count/www.wagamama.com': 169,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 169,
 'atp/structured_data/unmapped/amenity_features': 169,
 'downloader/request_bytes': 76361,
 'downloader/request_count': 188,
 'downloader/request_method_count/GET': 188,
 'downloader/response_bytes': 6691307,
 'downloader/response_count': 188,
 'downloader/response_status_count/200': 187,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 1819,
 'elapsed_time_seconds': 223.758982,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 2, 10, 33, 4, 334442, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 50244529,
 'httpcompression/response_count': 187,
 'item_scraped_count': 169,
 'items_per_minute': 45.47085201793722,
 'log_count/DEBUG': 530,
 'log_count/INFO': 175,
 'request_depth_max': 2,
 'response_received_count': 188,
 'responses_per_minute': 50.582959641255606,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 187,
 'scheduler/dequeued/memory': 187,
 'scheduler/enqueued': 187,
 'scheduler/enqueued/memory': 187,
 'start_time': datetime.datetime(2026, 4, 2, 10, 29, 20, 575460, tzinfo=datetime.timezone.utc)}
```