### PR TITLE
[GB Addresses] Add Arun District Council

### DIFF
--- a/locations/spiders/addresses/gb/README.md
+++ b/locations/spiders/addresses/gb/README.md
@@ -105,6 +105,7 @@ Owen and published. Others are helping.
 | Local Authority                        | Links                                                                                                                                 |
 |----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Aberdeenshire Council                  | https://www.owenboswarva.com/blog/post-addr47.htm                                                                                     |
+| Arun District Council                  | https://www.owenboswarva.com/blog/post-addr67.htm                                                                                     |
 | Barnet Council                         | https://www.owenboswarva.com/blog/post-addr23.htm                                                                                     |
 | Birmingham City Council                | https://www.owenboswarva.com/blog/post-addr11.htm                                                                                     |
 | Bradford Council                       | https://www.owenboswarva.com/blog/post-addr29.htm                                                                                     |

--- a/locations/spiders/addresses/gb/gb_arun.py
+++ b/locations/spiders/addresses/gb/gb_arun.py
@@ -1,0 +1,96 @@
+import csv
+import re
+from io import BytesIO, TextIOWrapper
+from typing import Any
+from zipfile import ZipFile
+
+from scrapy.http import Response
+
+from locations.address_spider import AddressSpider
+from locations.items import Feature
+from locations.licenses import Licenses
+
+
+class GbArunSpider(AddressSpider):
+    name = "gb_arun"
+    dataset_attributes = Licenses.GB_OGLv3.value | {
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0."  # address strings
+        + " Contains OS data © Crown copyright and database right 2025."  # OS Open UPRN, coords
+        + " Contains Royal Mail data © Royal Mail copyright and Database right."  # Postcodes
+        + " Contains GeoPlace data © Local Government Information House Limited copyright and database right."
+        + " Office for National Statistics licensed under the Open Government Licence v.3.0."
+    }
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 60 * 5}
+    no_refs = True
+    start_urls = [
+        "https://drive.usercontent.google.com/download?id=1030scDO9gFByATcXGQK5Ao7m9pTYW5Xs&export=download&confirm=t"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        _re = re.compile(
+            r"^(.+?)(?:, ({}))?(?:, ({}))?(?:,? West Sussex)?$".format(
+                "|".join(
+                    [
+                        # "suburbs"
+                        "Pagham",
+                        "Bersted",
+                        "Rustington",
+                        "East Preston",
+                        "Angmering",
+                        "Wick",
+                        "Yapton",
+                        "Middleton-On-Sea",
+                        "Barnham",
+                        "Felpham",
+                        "Eastergate",
+                        "Findon",
+                        "Walberton",
+                        "Westergate",
+                        "Fontwell",
+                        "Ferring",
+                        "Climping",
+                        "Aldingbourne",
+                        "Tortington",
+                        "Middleton On Sea",
+                        "Clapham",
+                        "Slindon",
+                        "Slindon Common",
+                        "Patching",
+                        "Poling",
+                        "Burpham",
+                        "Ford",
+                        "Aldwick",
+                        "Woodgate",
+                    ]
+                ),
+                "|".join(
+                    [
+                        # cities
+                        "Arundel",
+                        "Barnham",
+                        "Bognor Regis",
+                        "Chichester",
+                        "Littlehampton",
+                        "Nr Bognor Regis",
+                        "Worthing",
+                        "Madehurst",
+                    ]
+                ),
+            )
+        )
+
+        with ZipFile(BytesIO(response.body)) as zip_file:
+            for addr in csv.DictReader(TextIOWrapper(zip_file.open("ARUN_CTBANDS_OSOU_202602.csv"), encoding="utf-8")):
+                item = Feature()
+                item["ref"] = addr["PROPREF"]
+                item["extras"]["ref:GB:uprn"] = addr["UPRN"]
+                item["lat"] = addr["LAT"]
+                item["lon"] = addr["LNG"]
+                item["postcode"] = addr["POSTCODE"]
+
+                if m := _re.match(addr["ADDR"]):
+                    item["street_address"], item["extras"]["addr:suburb"], item["city"] = m.groups()
+
+                item["country"] = "GB"
+
+                yield item


### PR DESCRIPTION
```python
{'atp/clean_strings/street_address': 98,
 'atp/country/GB': 81465,
 'atp/field/branch/missing': 81465,
 'atp/field/brand/missing': 81465,
 'atp/field/brand_wikidata/missing': 81465,
 'atp/field/city/missing': 851,
 'atp/field/email/missing': 81465,
 'atp/field/geometry/invalid': 37,
 'atp/field/image/missing': 81465,
 'atp/field/name/missing': 81465,
 'atp/field/opening_hours/missing': 81465,
 'atp/field/operator/missing': 81465,
 'atp/field/operator_wikidata/missing': 81465,
 'atp/field/phone/missing': 81465,
 'atp/field/postcode/missing': 680,
 'atp/field/state/missing': 81465,
 'atp/field/twitter/missing': 81465,
 'atp/field/website/missing': 81465,
 'atp/item_scraped_host_count/drive.usercontent.google.com': 81465,
 'atp/lineage': 'S_ATP_ADDRESSES',
 'downloader/request_bytes': 407,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 7344588,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 22.189391,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 2, 16, 18, 2, 812730, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1,
 'item_scraped_count': 81465,
 'items_per_minute': 222177.27272727274,
 'log_count/INFO': 2,
 'log_count/WARNING': 1,
 'memusage/max': 319533056,
 'memusage/startup': 319533056,
 'response_received_count': 1,
 'responses_per_minute': 2.7272727272727275,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 2, 16, 17, 40, 623339, tzinfo=datetime.timezone.utc)}
```