### PR TITLE
[Baskin Robbins JP] add spider

### DIFF
--- a/locations/spiders/baskin_robbins_jp.py
+++ b/locations/spiders/baskin_robbins_jp.py
@@ -1,6 +1,5 @@
 from typing import Iterable
 
-from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.location_cloud import LocationCloudSpider
 
@@ -14,5 +13,5 @@ class BaskinRobbinsJPSpider(LocationCloudSpider):
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
 
         item["branch"] = source_feature.get("name").removeprefix("サーティワンアイスクリーム　")
-        
+
         yield item


### PR DESCRIPTION
{'atp/brand/バスキン・ロビンス': 1078,
 'atp/brand_wikidata/Q584601': 1078,
 'atp/category/amenity/ice_cream': 1078,
 'atp/clean_strings/addr_full': 1,
 'atp/country/JP': 1078,
 'atp/field/city/missing': 1078,
 'atp/field/country/from_spider_name': 1078,
 'atp/field/email/missing': 1078,
 'atp/field/image/missing': 1078,
 'atp/field/opening_hours/missing': 1078,
 'atp/field/operator/missing': 1078,
 'atp/field/operator_wikidata/missing': 1078,
 'atp/field/phone/missing': 1078,
 'atp/field/state/missing': 1078,
 'atp/field/street_address/missing': 1078,
 'atp/field/twitter/missing': 1078,
 'atp/item_scraped_host_count/store.br31.jp': 1078,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1078,
 'downloader/request_bytes': 1815,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 88892,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 5.624681,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 4, 11, 13, 39, 475684, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 643857,
 'httpcompression/response_count': 4,
 'item_scraped_count': 1078,
 'items_per_minute': 12936.0,
 'log_count/DEBUG': 1082,
 'log_count/INFO': 3,
 'request_depth_max': 2,
 'response_received_count': 4,
 'responses_per_minute': 48.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 4, 4, 11, 13, 33, 851003, tzinfo=datetime.timezone.utc)}