### PR TITLE
Fix spider runner to skip non-.py files and avoid empty PR comments

### DIFF
--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -124,9 +124,14 @@ if [ ! $retval -eq 0 ]; then
 fi
 (>&2 echo "Changed files: ${changed_filenames}")
 
-spiders=$(echo "${changed_filenames}" | grep "^locations/spiders/")
+spiders=$(echo "${changed_filenames}" | grep "^locations/spiders/.*\.py$")
 
-spider_count=$(echo "${spiders}" | wc -l)
+if [ -z "${spiders}" ]; then
+    spider_count=0
+else
+    spider_count=$(echo "${spiders}" | wc -l)
+fi
+
 if [ "${spider_count}" -gt 15 ]; then
     (>&2 echo "refusing to run on more than 15 spiders")
     exit 1
@@ -349,9 +354,9 @@ do
     (>&2 echo "${spider} done")
 done
 
-if [[ ! "$(ls ${RUN_DIR})" ]]; then
+if [[ ! "$(ls ${RUN_DIR} 2>/dev/null)" ]]; then
     echo "Nothing ran. Exiting."
-    echo $EXIT_CODE
+    exit $EXIT_CODE
 fi
 
 if [ "${HAD_TIMEOUT}" = true ]; then


### PR DESCRIPTION
## Summary
- Filter changed files to only `.py` files so non-spider files like `README.md` under `locations/spiders/` aren't run (seen in #15670)
- Fix empty spider count detection — `echo "" | wc -l` returns 1 not 0, so an empty grep result bypassed the "no spiders modified" exit path, leading to empty comments being posted (seen in #15739)
- Fix "nothing ran" code path to actually `exit` instead of just `echo`ing the exit code, which let the script fall through to post an empty comment