### PR TITLE
Tommy Bahama: use store-finder to include restaurants

### DIFF
--- a/locations/spiders/tommy_bahama.py
+++ b/locations/spiders/tommy_bahama.py
@@ -1,25 +1,55 @@
 from typing import Iterable
 
+import chompjs
+from scrapy import Request
 from scrapy.http import TextResponse
-from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class TommyBahamaSpider(SitemapSpider, StructuredDataSpider):
+class TommyBahamaSpider(StructuredDataSpider):
     name = "tommy_bahama"
     item_attributes = {"brand": "Tommy Bahama", "brand_wikidata": "Q3531299"}
-    sitemap_urls = ["https://www.tommybahama.com/en/sitemap.xml"]
-    sitemap_rules = [("/en/store/", "parse_sd")]
+    start_urls = ["https://www.tommybahama.com/store-finder"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
     wanted_types = ["ClothingStore"]
     search_for_twitter = False
     search_for_facebook = False
     search_for_email = False
+
+    def parse(self, response: TextResponse, **kwargs):
+        # The sitemap does not include the restaurants, so use this JS list instead
+        script = response.xpath("//script[contains(text(), 'window.allStoresData = ')]/text()").get()
+        all_stores_data = chompjs.parse_js_object(script)
+        for store in all_stores_data:
+            yield Request(
+                response.urljoin(store["url"]),
+                callback=self.parse_island if store.get("restaurantUrl", False) else self.parse_sd,
+            )
+
+    def parse_island(self, response: TextResponse):
+        item = Feature()
+        item["website"] = item["ref"] = response.url
+        item["lat"] = response.xpath("//@location-latitude").get()
+        item["lon"] = response.xpath("//@location-longitude").get()
+        item["branch"] = response.xpath("//@location-name").get()
+        item["street_address"] = response.xpath("//@location-address").get()
+        item["addr_full"] = merge_address_lines(
+            [item["street_address"], response.xpath("//@location-city-state-zip").get()]
+        )
+
+        oh = OpeningHours()
+        for row in response.css(".hours tr"):
+            oh.add_ranges_from_string(" ".join(row.xpath("*/text()").getall()))
+        item["opening_hours"] = oh
+
+        apply_category(Categories.RESTAURANT, item)
+        yield item
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["ref"] = item["website"] = response.url
@@ -35,10 +65,7 @@ class TommyBahamaSpider(SitemapSpider, StructuredDataSpider):
             item["name"] = "Tommy Bahama"
             item["branch"] = branch
 
-        try:
-            item["opening_hours"] = self.parse_hours(response)
-        except:
-            pass
+        item["opening_hours"] = self.parse_hours(response)
 
         apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
## Summary
- Switch from sitemap-based discovery back to the store-finder JS list, which includes both stores and restaurants
- Add `parse_island` method to scrape Tommy Bahama restaurant/island locations (~18 locations)
- Keep the name-splitting logic and custom hours parsing from #15719
- Remove `requires_proxy` and broad exception handler

As pointed out in #15654, the sitemap doesn't include Tommy Bahama's restaurant ("Island") locations. This reverts to the store-finder approach from that PR while preserving the attribute improvements from #15719.