### PR TITLE
brockport_village_board_trees_us: delete spider

### DIFF
--- a/locations/spiders/infrastructure/brockport_village_board_trees_us.py
+++ b/locations/spiders/infrastructure/brockport_village_board_trees_us.py
@@ -1,8 +1,0 @@
-from locations.storefinders.treeplotter import TreePlotterSpider
-
-
-class BrockportVillageBoardTreesUSSpider(TreePlotterSpider):
-    name = "brockport_village_board_trees_us"
-    item_attributes = {"operator": "Brockport Village Board", "operator_wikidata": "Q132178943", "state": "NY"}
-    folder = "brockportny"
-    layer_name = "trees"


### PR DESCRIPTION
Village no longer appears to be using TreePlotter and does not appear to be using an alternative street tree map/storefinder.

Split from PR #14996.