### PR TITLE
Fix empty output.parquet, broken R2 redirects, and noisy tippecanoe logs

### DIFF
--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -26,8 +26,9 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             con.load_extension("spatial")
 
             con.execute(f"SET temp_directory='{temp_dir}'")
-            con.execute("SET memory_limit='1GB'")
+            con.execute("SET memory_limit='8GB'")
             con.execute("SET threads=2")
+            con.execute("SET preserve_insertion_order=false")
 
             con.execute(f"""
             CREATE TABLE geojson_data AS

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -95,8 +95,9 @@ tippecanoe --cluster-distance=25 \
            --read-parallel \
            --attribution="<a href=\"https://www.alltheplaces.xyz/\">All the Places</a> ${RUN_TIMESTAMP}" \
            -o "${SPIDER_RUN_DIR}/output.pmtiles" \
-           "${SPIDER_RUN_DIR}"/output/*.geojson
-retval=$?
+           "${SPIDER_RUN_DIR}"/output/*.geojson \
+           2>&1 | grep -v -E '^\s*[0-9]+\.[0-9]+%\s|^Reordering geometry:\s*[0-9]|^Read [0-9]+\.[0-9]+ million features|^Sorting\.\.\.' >&2
+retval=${PIPESTATUS[0]}
 if [ ! $retval -eq 0 ]; then
     (>&2 echo "Couldn't generate pmtiles, won't include in output")
     include_pmtiles=false
@@ -409,7 +410,7 @@ do
         --endpoint-url="${R2_ENDPOINT_URL}" \
         cp \
         --only-show-errors \
-        --website-redirect"${RUN_URL_PREFIX}/output/${spider}.geojson" \
+        --website-redirect="${RUN_URL_PREFIX}/output/${spider}.geojson" \
         "${SPIDER_RUN_DIR}/latest_placeholder.txt" \
         "s3://${R2_BUCKET}/runs/latest/output/${spider}.geojson"
 


### PR DESCRIPTION
## Summary

Fixes three issues found in the 2026-03-28 run (seen in alltheplaces/alltheplaces.xyz#90):

- **Empty `output.parquet`**: DuckDB ran out of temp disk space (64 GiB) during Hilbert sort of ~28M features. Increased `memory_limit` from 1GB to 8GB and enabled `preserve_insertion_order=false` to reduce spill pressure.
- **Broken R2 redirects**: Missing `=` in `--website-redirect` flag caused every per-spider R2 redirect to fail with `Unknown options`.
- **Noisy tippecanoe logs**: Filtered progress lines (tile percentages, reordering geometry, feature read counts, sorting) from CloudWatch logs while preserving useful warnings. Uses `PIPESTATUS[0]` to keep tippecanoe's exit code.