### PR TITLE
Add requires_proxy to autobarn_au spider

### DIFF
--- a/locations/spiders/autobarn_au.py
+++ b/locations/spiders/autobarn_au.py
@@ -14,6 +14,7 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class AutobarnAUSpider(SitemapSpider):
     name = "autobarn_au"
     item_attributes = {"brand": "Autobarn", "brand_wikidata": "Q105831666"}
+    requires_proxy = True
     allowed_domains = ["autobarn.com.au"]
     sitemap_urls = ["https://autobarn.com.au/ab/sitemap/store/store-sitemap.xml"]
     sitemap_rules = [(r"^https:\/\/autobarn\.com\.au\/ab\/store\/[A-Z][a-zA-Z\s\-]*$", "parse")]


### PR DESCRIPTION
## Summary
- Add `requires_proxy = True` to `autobarn_au` spider to fix 403 bot protection blocks

Seen in #15779