### PR TITLE
Add requires_proxy to baby_bunting_au_nz spider

### DIFF
--- a/locations/spiders/baby_bunting_au_nz.py
+++ b/locations/spiders/baby_bunting_au_nz.py
@@ -14,6 +14,7 @@ class BabyBuntingAUNZSpider(JSONBlobSpider):
         "brand": "Baby Bunting",
         "brand_wikidata": "Q109626935",
     }
+    requires_proxy = True
     allowed_domains = ["www.babybunting.com.au"]
     start_urls = ["https://www.babybunting.com.au/api/cnts/getAllFromType"]
 


### PR DESCRIPTION
## Summary
- Add `requires_proxy = True` to `baby_bunting_au_nz` spider to fix 403 bot protection blocks

Seen in #15780