### PR TITLE
Migrate amigo_pr spider from AgileStoreLocator to Elfsight

### DIFF
--- a/locations/spiders/amigo_pr.py
+++ b/locations/spiders/amigo_pr.py
@@ -1,12 +1,18 @@
-from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+from locations.categories import Categories
+from locations.storefinders.elfsight import ElfsightSpider
 
 
-class AmigoPRSpider(AgileStoreLocatorSpider):
+class AmigoPRSpider(ElfsightSpider):
     name = "amigo_pr"
     item_attributes = {
-        "brand_wikidata": "Q4746234",
         "brand": "Amigo",
+        "brand_wikidata": "Q4746234",
+        "extras": Categories.SHOP_SUPERMARKET.value,
     }
-    allowed_domains = [
-        "amigo.com",
-    ]
+    host = "core.service.elfsight.com"
+    api_key = "5ffee2a7-32be-4ca7-8809-cec5d0a2e06f"
+
+    def pre_process_data(self, feature: dict) -> None:
+        if coordinates := feature.get("coordinates"):
+            feature["coordinates"] = str(coordinates).replace(" ", ", ", 1)
+        super().pre_process_data(feature)


### PR DESCRIPTION
## Summary
- Amigo's website was rebuilt (no longer WordPress-based) and the old AgileStoreLocator endpoint returns `999 No Hacking`
- The store locator has moved to `virtual.amigo.com/tiendas/` and now uses an Elfsight Google Maps widget
- Rewrote spider to use `ElfsightSpider` with the Elfsight cloud API, matching the approach used by the sibling brand `pueblo_pr`
- Overrides `pre_process_data` to normalize space-separated coordinates to the comma-separated format the storefinder expects
- Spider now returns 11 locations in Puerto Rico

Seen in #15777