### PR TITLE
Add requires_proxy to allstate_insurance_agents spider

### DIFF
--- a/locations/spiders/allstate_insurance_agents.py
+++ b/locations/spiders/allstate_insurance_agents.py
@@ -9,6 +9,7 @@ from locations.items import Feature
 class AllstateInsuranceAgentsSpider(scrapy.Spider):
     name = "allstate_insurance_agents"
     item_attributes = {"brand": "Allstate", "brand_wikidata": "Q2645636"}
+    requires_proxy = True
     allowed_domains = ["agents.allstate.com"]
     start_urls = ("https://agents.allstate.com/",)
 


### PR DESCRIPTION
## Summary
- Add `requires_proxy = True` to `allstate_insurance_agents` spider to fix 403 bot protection blocks

Seen in #15776