### PR TITLE
Remove requires_proxy from famous_footwear spider

### DIFF
--- a/locations/spiders/famous_footwear.py
+++ b/locations/spiders/famous_footwear.py
@@ -11,7 +11,6 @@ class FamousFootwearSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://ecomprdsharedstorage.blob.core.windows.net/sitemaps/20000/stores-sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     wanted_types = ["Store"]
-    requires_proxy = "US"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         matches = re.search(r'location: \["(.*)", "(.*)"\],', response.text)


### PR DESCRIPTION
## Summary

- Zyte API stats for March 2026 show famousfootwear.com had 8,774 requests with only a 27.4% success rate through the proxy
- 73% of proxied requests are failing, wasting ~$0.76/month
- The spider uses a sitemap from Azure CDN and extracts structured data, which should work without proxy