### PR TITLE
 [AutoNation US] Fix spider

### DIFF
--- a/locations/spiders/auto_nation_us.py
+++ b/locations/spiders/auto_nation_us.py
@@ -18,7 +18,7 @@ class AutoNationUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.autonation.com/robots.txt"]
     sitemap_rules = [(r"https://www.autonation.com/dealers/[^/]+$", "parse")]
     is_playwright_spider = True
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         store_data = json.loads(response.xpath('//script[@id="store-detail-state"]/text()').get())


### PR DESCRIPTION
``` python
{'atp/brand/AutoNation': 248,
 'atp/brand_wikidata/Q784804': 248,
 'atp/category/shop/car': 246,
 'atp/category/shop/car_repair': 2,
 'atp/country/US': 248,
 'atp/field/branch/missing': 248,
 'atp/field/email/missing': 248,
 'atp/field/operator/missing': 248,
 'atp/field/operator_wikidata/missing': 248,
 'atp/item_scraped_host_count/www.autonation.com': 248,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 248,
 'downloader/request_bytes': 187470,
 'downloader/request_count': 279,
 'downloader/request_method_count/GET': 279,
 'downloader/response_bytes': 149073173,
 'downloader/response_count': 279,
 'downloader/response_status_count/200': 271,
 'downloader/response_status_count/404': 2,
 'downloader/response_status_count/500': 6,
 'elapsed_time_seconds': 481.745963,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 6, 9, 26, 21, 426677, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 4,
 'httperror/response_ignored_status_count/404': 2,
 'httperror/response_ignored_status_count/500': 2,
 'item_scraped_count': 248,
 'items_per_minute': 30.935550935550932,
 'log_count/DEBUG': 44068,
 'log_count/ERROR': 2,
 'log_count/INFO': 22,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 279,
 'playwright/page_count/closed': 279,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 21630,
 'playwright/request_count/aborted': 21347,
 'playwright/request_count/method/GET': 21381,
 'playwright/request_count/method/POST': 249,
 'playwright/request_count/navigation': 282,
 'playwright/request_count/resource_type/document': 282,
 'playwright/request_count/resource_type/fetch': 250,
 'playwright/request_count/resource_type/font': 250,
 'playwright/request_count/resource_type/image': 8536,
 'playwright/request_count/resource_type/script': 9952,
 'playwright/request_count/resource_type/stylesheet': 2360,
 'playwright/response_count': 282,
 'playwright/response_count/method/GET': 282,
 'playwright/response_count/resource_type/document': 282,
 'request_depth_max': 2,
 'response_received_count': 275,
 'responses_per_minute': 34.3035343035343,
 'retry/count': 4,
 'retry/max_reached': 2,
 'retry/reason_count/500 Internal Server Error': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 278,
 'scheduler/dequeued/memory': 278,
 'scheduler/enqueued': 278,
 'scheduler/enqueued/memory': 278,
 'start_time': datetime.datetime(2026, 4, 6, 9, 18, 19, 680714, tzinfo=datetime.timezone.utc)}
```