### PR TITLE
[Banque Populaire] banque_populaire_fr: add ATM detection and yield separate ATM items

### DIFF
--- a/locations/spiders/banque_populaire_fr.py
+++ b/locations/spiders/banque_populaire_fr.py
@@ -1,4 +1,3 @@
-
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
@@ -13,7 +12,8 @@ class BanquePopulaireFRSpider(SitemapSpider, StructuredDataSpider):
     drop_attributes = {"image"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = response.url
+        item["branch"] = item.pop("name")
+        item["website"] = response.url  # Bad url in linked data+
 
         apply_category(Categories.BANK, item)
         apply_yes_no(Extras.ATM, item, bool(response.xpath('//*[contains(@class, "em-details__services-dab")]')))


### PR DESCRIPTION
Spider now detects ATM service on branch pages by checking for the 
`em-details__services-dab` CSS class in the services section.

Changes:
- For branches with ATM: yields both a bank item (amenity=bank, atm=yes) 
  and a separate ATM item (amenity=atm, ref=XXXX-ATM)
- For branches without ATM: yields bank item only (amenity=bank)
- Uses deepcopy to avoid shared state between items