### PR TITLE
[CIC] cic_fr: add ATM detection and yield separate ATM items

### DIFF
--- a/locations/spiders/cic_fr.py
+++ b/locations/spiders/cic_fr.py
@@ -14,18 +14,10 @@ class CicFRSpider(CrawlSpider):
     start_urls = ["https://www.cic.fr/fr/agences-et-distributeurs/Regions.aspx"]
     allowed_domains = ["cic.fr"]
     rules = [
-        Rule(
-            LinkExtractor(allow=r"/Departements\.aspx\?regionId=")
-        ),
-        Rule(
-            LinkExtractor(allow=r"/Localites\.aspx\?regionId=")
-        ),
-        Rule(
-            LinkExtractor(allow=r"/ResultatsRechercheGeographique\.aspx\?inseeCode=")
-        ),
-        Rule(
-            LinkExtractor(allow=r"/fr/agence/"), callback="parse"
-        ),
+        Rule(LinkExtractor(allow=r"/Departements\.aspx\?regionId=")),
+        Rule(LinkExtractor(allow=r"/Localites\.aspx\?regionId=")),
+        Rule(LinkExtractor(allow=r"/ResultatsRechercheGeographique\.aspx\?inseeCode=")),
+        Rule(LinkExtractor(allow=r"/fr/agence/"), callback="parse"),
     ]
 
     def parse(self, response):


### PR DESCRIPTION
CIC uses the same website platform as Credit Mutuel (same group).
ATM detected via ei_rogi_picto_withdrawal_bills_eur CSS class ("Retrait de billets EUR").

Changes:
- Bank item tagged with atm=yes/no via apply_yes_no
- Separate ATM item (amenity=atm, ref=XXXX-ATM) yielded when ATM present
- Pattern matches credit_mutuel_fr