### PR TITLE
[posta_si]: update API URL path, remove ROBOTSTXT_OBEY override

### DIFF
--- a/locations/spiders/posta_si.py
+++ b/locations/spiders/posta_si.py
@@ -10,11 +10,9 @@ class PostaSISpider(scrapy.Spider):
     item_attributes = {"operator": "Pošta Slovenije", "operator_wikidata": "Q6522631"}
     allowed_domains = ["www.posta.si"]
 
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-
     # There is no "show all" option, but we can search for every letter to get all of them
     start_urls = [
-        "https://www.posta.si/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/PostalOffice/" + c
+        "https://www.posta.si/zasebno-site/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/PostalOffice/" + c
         for c in "abcčdefghijklmnoprsštuvzž"
     ]
 


### PR DESCRIPTION
 ## Summary
   - Updated the API endpoint from `/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/PostalOffice/` to `/zasebno-site/_vti_bin/PostaSI/PostOffices/PostOfficesService.svc/PostalOffice/` to match the current site API path.
   - Removed the `ROBOTSTXT_OBEY: False` override since the new path is not blocked by `robots.txt` (`Disallow: /_vti_bin/`), making the spider compliant without needing an override.

   ## Context
   The spider was returning 0 results because Scrapy's protego robots.txt parser correctly blocks `/_vti_bin/` paths per the site's `robots.txt`. The site has moved the API to a new path under `/zasebno-site/`. The response JSON format is unchanged — all existing
   parsing logic still works.

