### PR TITLE
[Apache Pizza IE] Fix spider

### DIFF
--- a/locations/spiders/apache_pizza_ie.py
+++ b/locations/spiders/apache_pizza_ie.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from scrapy import FormRequest, Spider
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -13,9 +13,9 @@ class ApachePizzaIESpider(Spider):
     start_urls = ["https://apache.ie/stores"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        yield FormRequest(
+        yield JsonRequest(
             url="https://apache.ie/General/GetFilteredStores/",
-            formdata={"includeSliceStores": "true"},
+            data={"includeSliceStores": "true"},
             headers={
                 "RequestVerificationToken": response.xpath('//input[@id="completeAntiForgeryToken"]/@value').get()
             },


### PR DESCRIPTION
```python
{'atp/brand/Apache Pizza': 166,
 'atp/brand_wikidata/Q22031794': 166,
 'atp/category/amenity/fast_food': 166,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/clean_strings/phone': 1,
 'atp/country/IE': 166,
 'atp/field/city/missing': 166,
 'atp/field/country/from_spider_name': 166,
 'atp/field/email/missing': 166,
 'atp/field/image/missing': 166,
 'atp/field/opening_hours/missing': 166,
 'atp/field/operator/missing': 166,
 'atp/field/operator_wikidata/missing': 166,
 'atp/field/phone/invalid': 2,
 'atp/field/postcode/missing': 4,
 'atp/field/state/missing': 166,
 'atp/field/street_address/missing': 166,
 'atp/field/twitter/missing': 166,
 'atp/item_scraped_host_count/apache.ie': 166,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 166,
 'downloader/request_bytes': 1743,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 48258,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.802733,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 7, 10, 37, 18, 120851, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 313117,
 'httpcompression/response_count': 3,
 'item_scraped_count': 166,
 'items_per_minute': 2490.0,
 'log_count/DEBUG': 169,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 4, 7, 10, 37, 13, 318118, tzinfo=datetime.timezone.utc)}
```