### PR TITLE
[Posten] fix categories for post_i_butikk and pakkeutlevering

### DIFF
--- a/locations/spiders/posten_no.py
+++ b/locations/spiders/posten_no.py
@@ -47,10 +47,10 @@ class PostenNOSpider(Spider):
                 apply_category(Categories.POST_OFFICE, item)
                 item["extras"]["post_office"] = "bureau"
             elif attributes["enhetstype"] == 4:
-                apply_category(Categories.GENERIC_POI, item)
+                apply_category(Categories.POST_OFFICE, item)
                 item["extras"]["post_office"] = "post_partner"
             elif attributes["enhetstype"] == 19:
-                apply_category(Categories.GENERIC_POI, item)
+                apply_category(Categories.POST_OFFICE, item)
                 item["extras"]["post_office"] = "post_partner"
                 apply_yes_no("post_office:parcel_pickup", item, True)
             elif attributes["enhetstype"] == 37:


### PR DESCRIPTION
Changed Categories.GENERIC_POI to Categories.POST_OFFICE for:
- enhetstype 4 (Post i butikk) - these are post partners operating inside shops
- enhetstype 19 (Posten pakkeutlevering) - these are post partners with parcel pickup

Both are post office services per https://www.posten.no/kart and should not be tagged as generic POI.

All other category mappings unchanged.