### PR TITLE
[Game ZA] convert to JSONBlobSpider

### DIFF
--- a/locations/spiders/game_za.py
+++ b/locations/spiders/game_za.py
@@ -1,43 +1,49 @@
-from typing import Any
+from typing import AsyncIterator, Iterable
 
-from scrapy import Selector, Spider
-from scrapy.http import Response
+from scrapy.http import JsonRequest, TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class GameZASpider(Spider):
+class GameZASpider(JSONBlobSpider):
     name = "game_za"
     item_attributes = {"brand": "Game", "brand_wikidata": "Q126811048"}
-    start_urls = ["https://www.game.co.za/occ/v2/game/stores?fields=FULL"]
+    locations_key = "stores"
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        sel = Selector(text=response.text, type="xml")
-        for location in sel.xpath("//stores"):
-            item = Feature()
-            item["ref"] = location.xpath("./name/text()").get()
-            item["branch"] = location.xpath("./displayName/text()").get().removeprefix("Game ")
-            item["addr_full"] = location.xpath(".//address/formattedAddress/text()").get()
-            item["state"] = location.xpath(".//address/region/name/text()").get()
-            item["phone"] = location.xpath(".//address/phone/text()").get()
-            item["email"] = location.xpath(".//address/email/text()").get()
-            item["lat"] = location.xpath(".//geoPoint/latitude/text()").get()
-            item["lon"] = location.xpath(".//geoPoint/longitude/text()").get()
-            item["website"] = "https://www.game.co.za/"
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-            item["opening_hours"] = self.parse_opening_hours(location)
-            yield item
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest("https://www.game.co.za/occ/v2/game/stores?fields=FULL")
 
-    def parse_opening_hours(self, location: Selector) -> OpeningHours:
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("address"))
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = feature["displayName"].removeprefix("Game ")
+        item["name"] = None
+        item["state"] = feature["region"]["isocodeShort"]
+        item["website"] = None
+        item["addr_full"] = item.pop("street_address")
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        if oh_data := feature.get("openingHours"):
+            item["opening_hours"] = self.parse_opening_hours(oh_data)
+
+        yield item
+
+    def parse_opening_hours(self, opening_hours: dict) -> OpeningHours:
         oh = OpeningHours()
-        try:
-            for day_time in location.xpath(".//openingHours//weekDayOpeningList"):
-                day = day_time.xpath("./weekDay/text()").get()
-                open_time = day_time.xpath("./openingTime/formattedHour/text()").get()
-                close_time = day_time.xpath("./closingTime/formattedHour/text()").get()
-                oh.add_range(day, open_time, close_time, "%I:%M %p")
-        except Exception:
-            pass
+        for rule in opening_hours.get("weekDayOpeningList", []):
+            day = rule.get("weekDay")
+            if rule.get("closed"):
+                oh.set_closed(day)
+            elif rule.get("openingTime") and rule.get("closingTime"):
+                oh.add_range(
+                    day,
+                    rule["openingTime"]["formattedHour"],
+                    rule["closingTime"]["formattedHour"],
+                    "%I:%M %p",
+                )
         return oh


### PR DESCRIPTION
``` python
{'atp/brand/Game': 98,
 'atp/brand_wikidata/Q126811048': 98,
 'atp/category/shop/supermarket': 98,
 'atp/clean_strings/addr_full': 98,
 'atp/clean_strings/branch': 1,
 'atp/country/ZA': 98,
 'atp/field/city/missing': 88,
 'atp/field/email/missing': 1,
 'atp/field/image/missing': 98,
 'atp/field/operator/missing': 98,
 'atp/field/operator_wikidata/missing': 98,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 90,
 'atp/field/street_address/missing': 98,
 'atp/field/twitter/missing': 98,
 'atp/field/website/missing': 98,
 'atp/item_scraped_host_count/www.game.co.za': 98,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 98,
 'downloader/request_bytes': 1008,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 21371,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.020175,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 9, 12, 14, 21, 777927, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 225230,
 'httpcompression/response_count': 2,
 'item_scraped_count': 98,
 'items_per_minute': 1176.0,
 'log_count/DEBUG': 100,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 9, 12, 14, 16, 757752, tzinfo=datetime.timezone.utc)}
```