### PR TITLE
(Pronto JP) create spider

### DIFF
--- a/locations/spiders/pronto_jp.py
+++ b/locations/spiders/pronto_jp.py
@@ -1,0 +1,20 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class ProntoJPSpider(CanlySpider):
+    name = "pronto_jp"
+    item_attributes = {"brand": "プロント", "brand_wikidata": "Q11336224"}
+    brand_key = "122"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+
+        item["branch"] = feature.get("nameKanji").removeprefix("PRONTO　")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana").removeprefix("プロント ")
+        item["website"] = f"https://shop.pronto.co.jp/detail/{feature.get('storeCode')}/"
+
+        yield item


### PR DESCRIPTION
{'atp/brand/プロント': 282,
 'atp/brand_wikidata/Q11336224': 282,
 'atp/category/amenity/cafe': 282,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 1,
 'atp/country/JP': 282,
 'atp/field/city/missing': 282,
 'atp/field/country/from_spider_name': 282,
 'atp/field/email/missing': 282,
 'atp/field/image/missing': 282,
 'atp/field/opening_hours/missing': 282,
 'atp/field/operator/missing': 282,
 'atp/field/operator_wikidata/missing': 282,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 282,
 'atp/field/street_address/missing': 282,
 'atp/field/twitter/missing': 282,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 282,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 282,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 140531,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.594787,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 10, 12, 11, 35, 484588, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2532009,
 'httpcompression/response_count': 1,
 'item_scraped_count': 282,
 'items_per_minute': 8460.0,
 'log_count/DEBUG': 285,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 10, 12, 11, 32, 889801, tzinfo=datetime.timezone.utc)}