### PR TITLE
(Tomod's JP) create spider

### DIFF
--- a/locations/spiders/tomods_jp.py
+++ b/locations/spiders/tomods_jp.py
@@ -18,7 +18,13 @@ class TomodsJPSpider(CanlySpider):
 
         if "トモズ" in feature["nameKanji"]:
             item["brand_wikidata"] = "Q7820097"
-            item["branch"] = feature.get("nameKanji").removeprefix("トモズ ").removeprefix("薬局トモズ ").removeprefix("トモズ").removeprefix("薬局トモズ")
+            item["branch"] = (
+                feature.get("nameKanji")
+                .removeprefix("トモズ ")
+                .removeprefix("薬局トモズ ")
+                .removeprefix("トモズ")
+                .removeprefix("薬局トモズ")
+            )
             item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
         elif "AP" in feature["nameKanji"]:
             item["branch"] = feature.get("nameKanji").removeprefix("AP by AMERICAN PHARMACY ")

--- a/locations/spiders/tomods_jp.py
+++ b/locations/spiders/tomods_jp.py
@@ -1,0 +1,33 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class TomodsJPSpider(CanlySpider):
+    name = "tomods_jp"
+    brand_key = "37"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+
+        if "薬局" in feature["nameKanji"]:
+            apply_category(Categories.PHARMACY, item)
+
+        if "トモズ" in feature["nameKanji"]:
+            item["brand_wikidata"] = "Q7820097"
+            item["branch"] = feature.get("nameKanji").removeprefix("トモズ ").removeprefix("薬局トモズ ").removeprefix("トモズ").removeprefix("薬局トモズ")
+            item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
+        elif "AP" in feature["nameKanji"]:
+            item["branch"] = feature.get("nameKanji").removeprefix("AP by AMERICAN PHARMACY ")
+            item["brand"] = "AP"
+            apply_category(Categories.SHOP_CHEMIST, item)
+        else:
+            item["name"] = feature.get("nameKanji")
+            apply_category(Categories.PHARMACY, item)
+
+        item["website"] = f"https://shop.tomods.jp/detail/{feature.get('storeCode')}/"
+
+        yield item


### PR DESCRIPTION
{'atp/brand/AP': 5,
 'atp/brand/トモズ': 259,
 'atp/brand_wikidata/Q7820097': 259,
 'atp/category/amenity/pharmacy': 88,
 'atp/category/multiple': 88,
 'atp/category/shop/chemist': 196,
 'atp/clean_strings/branch': 2,
 'atp/country/JP': 284,
 'atp/field/branch/missing': 20,
 'atp/field/brand/missing': 20,
 'atp/field/brand_wikidata/missing': 25,
 'atp/field/city/missing': 284,
 'atp/field/country/from_spider_name': 284,
 'atp/field/email/missing': 284,
 'atp/field/image/missing': 284,
 'atp/field/name/missing': 5,
 'atp/field/opening_hours/missing': 284,
 'atp/field/operator/missing': 284,
 'atp/field/operator_wikidata/missing': 284,
 'atp/field/state/missing': 284,
 'atp/field/street_address/missing': 284,
 'atp/field/twitter/missing': 284,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 284,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 259,
 'downloader/request_bytes': 723,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 136395,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.848747,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 11, 12, 54, 44, 679343, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2496948,
 'httpcompression/response_count': 1,
 'item_scraped_count': 284,
 'items_per_minute': 8520.0,
 'log_count/DEBUG': 287,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 11, 12, 54, 41, 830596, tzinfo=datetime.timezone.utc)}