### PR TITLE
(Paris Miki JP) add spider

### DIFF
--- a/locations/spiders/parismiki_jp.py
+++ b/locations/spiders/parismiki_jp.py
@@ -12,7 +12,9 @@ class ParismikiJPSpider(CanlySpider):
     brand_key = "27"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["branch"] = feature.get("nameKanji").removeprefix("パリミキ ").removeprefix("OPTIQUE PARIS MIKI ").removesuffix("店")
+        item["branch"] = (
+            feature.get("nameKanji").removeprefix("パリミキ ").removeprefix("OPTIQUE PARIS MIKI ").removesuffix("店")
+        )
         item["website"] = f"https://shop.paris-miki.co.jp/detail/{feature.get('storeCode')}/"
 
         yield item

--- a/locations/spiders/parismiki_jp.py
+++ b/locations/spiders/parismiki_jp.py
@@ -1,0 +1,18 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class ParismikiJPSpider(CanlySpider):
+    name = "parismiki_jp"
+    item_attributes = {"brand_wikidata": "Q11354808"}
+    brand_key = "27"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = feature.get("nameKanji").removeprefix("パリミキ ").removeprefix("OPTIQUE PARIS MIKI ").removesuffix("店")
+        item["website"] = f"https://shop.paris-miki.co.jp/detail/{feature.get('storeCode')}/"
+
+        yield item


### PR DESCRIPTION
{'atp/brand/メガネの三城': 600,
 'atp/brand_wikidata/Q11354808': 600,
 'atp/category/shop/optician': 600,
 'atp/country/JP': 600,
 'atp/field/city/missing': 600,
 'atp/field/country/from_spider_name': 600,
 'atp/field/email/missing': 600,
 'atp/field/image/missing': 600,
 'atp/field/opening_hours/missing': 600,
 'atp/field/operator/missing': 600,
 'atp/field/operator_wikidata/missing': 600,
 'atp/field/state/missing': 600,
 'atp/field/street_address/missing': 600,
 'atp/field/twitter/missing': 600,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 600,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 600,
 'downloader/request_bytes': 723,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 149273,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.860469,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 11, 23, 48, 25, 816180, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3532188,
 'httpcompression/response_count': 1,
 'item_scraped_count': 600,
 'items_per_minute': 12000.0,
 'log_count/DEBUG': 603,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 11, 23, 48, 21, 955711, tzinfo=datetime.timezone.utc)}