### PR TITLE
(Hakuyosha JP) create spider

### DIFF
--- a/locations/spiders/hakuyosha_jp.py
+++ b/locations/spiders/hakuyosha_jp.py
@@ -12,13 +12,25 @@ class HakuyoshaJPSpider(CanlySpider):
     brand_key = "380"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        skip = ['株式会社', '営業所']
+        skip = ["株式会社", "営業所"]
         if any(x in feature.get("nameKanji") for x in skip):
             item = None
             return  # skip headquarters, sales locations
 
-        item["branch"] = feature.get("nameKanji").removeprefix("白洋舍スマートプラス").removeprefix("白洋舍 スマートプラス").removeprefix("白洋舍 ").removeprefix("白洋舍").removesuffix("店")
-        item["extras"]["branch:ja-Hira"] = feature.get("nameKana").removeprefix("ハクヨウシャスマートプラス").removeprefix("ハクヨウシャ").removesuffix("テン")
+        item["branch"] = (
+            feature.get("nameKanji")
+            .removeprefix("白洋舍スマートプラス")
+            .removeprefix("白洋舍 スマートプラス")
+            .removeprefix("白洋舍 ")
+            .removeprefix("白洋舍")
+            .removesuffix("店")
+        )
+        item["extras"]["branch:ja-Hira"] = (
+            feature.get("nameKana")
+            .removeprefix("ハクヨウシャスマートプラス")
+            .removeprefix("ハクヨウシャ")
+            .removesuffix("テン")
+        )
         item["website"] = f"https://map.hakuyosha.co.jp/detail/{feature.get('storeCode')}/"
         item["extras"]["start_date"] = feature.get("openingDate")
 

--- a/locations/spiders/hakuyosha_jp.py
+++ b/locations/spiders/hakuyosha_jp.py
@@ -1,0 +1,25 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class HakuyoshaJPSpider(CanlySpider):
+    name = "hakuyosha_jp"
+    item_attributes = {"brand_wikidata": "Q11579995"}
+    brand_key = "380"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        skip = ['株式会社', '営業所']
+        if any(x in feature.get("nameKanji") for x in skip):
+            item = None
+            return  # skip headquarters, sales locations
+
+        item["branch"] = feature.get("nameKanji").removeprefix("白洋舍スマートプラス").removeprefix("白洋舍 スマートプラス").removeprefix("白洋舍 ").removeprefix("白洋舍").removesuffix("店")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana").removeprefix("ハクヨウシャスマートプラス").removeprefix("ハクヨウシャ").removesuffix("テン")
+        item["website"] = f"https://map.hakuyosha.co.jp/detail/{feature.get('storeCode')}/"
+        item["extras"]["start_date"] = feature.get("openingDate")
+
+        yield item


### PR DESCRIPTION
{'atp/brand/白洋舎': 294,
 'atp/brand_wikidata/Q11579995': 294,
 'atp/category/shop/dry_cleaning': 294,
 'atp/clean_strings/branch': 4,
 'atp/country/JP': 294,
 'atp/field/city/missing': 294,
 'atp/field/country/from_spider_name': 294,
 'atp/field/email/missing': 294,
 'atp/field/image/missing': 294,
 'atp/field/opening_hours/missing': 294,
 'atp/field/operator/missing': 294,
 'atp/field/operator_wikidata/missing': 294,
 'atp/field/state/missing': 294,
 'atp/field/street_address/missing': 294,
 'atp/field/twitter/missing': 294,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 294,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 294,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 97297,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.275834,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 12, 5, 26, 38, 761967, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1809186,
 'httpcompression/response_count': 1,
 'item_scraped_count': 294,
 'items_per_minute': 5880.0,
 'log_count/DEBUG': 297,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 12, 5, 26, 35, 486133, tzinfo=datetime.timezone.utc)}