### PR TITLE
(Tsuruha Drug) create spider

### DIFF
--- a/locations/spiders/tsuruhadrug.py
+++ b/locations/spiders/tsuruhadrug.py
@@ -1,0 +1,39 @@
+from locations.categories import Categories, apply_category
+from locations.storefinders.yext_answers import YextAnswersSpider
+
+brands = {
+    "ツルハ": {"brand": "ツルハドラッグ", "brand_wikidata": "Q11318826"},
+    "福太郎": {"brand": "くすりの福太郎", "brand_wikidata": "Q17214460"},
+    "杏林堂": {"brand": "杏林堂", "brand_wikidata": "Q11522605"},
+    "イレブン": {"brand": "ドラッグイレブン", "brand_wikidata": "Q11323075"},
+    "ウォンツ": {"brand": "ウォンツ"}, #no wikidata for below
+    "ウェルネス": {"brand": "ウェルネス"},
+    "レデイ": {"brand": "くすりのレデイ"},
+    "B＆D": {"brand": "B＆D調剤薬局"},
+}
+
+class TsuruhadrugSpider(YextAnswersSpider):
+    name = "tsuruhadrug"
+    # item_attributes = {"brand": "ツルハドラッグ", "brand_wikidata": "Q11318826"}
+
+    endpoint = "https://prod-cdn.us.yextapis.com/v2/accounts/me/search/vertical/query"
+    api_key = "6f3d5119d849cfdb44094409f825f542"
+    experience_key = "shop-search"
+    locale = "ja"
+
+    def parse_item(self, location, item):
+        if "c" in item["ref"]:
+            item = None #skip pharmacy ids
+            return
+
+        for brand_key in brands.keys():
+            if brand_key in item["name"]:
+                item.update(brands[brand_key])
+
+        item["branch"] = item.get("name").removeprefix("ツルハドラッグ").removeprefix("くすりの福太郎").removeprefix("杏林堂").removeprefix("ドラッグイレブン").removeprefix("ウォンツ").removeprefix("くすりのレデイ").removeprefix("B＆D調剤薬局")
+
+        item["name"] = None
+
+        apply_category(Categories.SHOP_CHEMIST, item)
+
+        yield item

--- a/locations/spiders/tsuruhadrug.py
+++ b/locations/spiders/tsuruhadrug.py
@@ -6,11 +6,12 @@ brands = {
     "福太郎": {"brand": "くすりの福太郎", "brand_wikidata": "Q17214460"},
     "杏林堂": {"brand": "杏林堂", "brand_wikidata": "Q11522605"},
     "イレブン": {"brand": "ドラッグイレブン", "brand_wikidata": "Q11323075"},
-    "ウォンツ": {"brand": "ウォンツ"}, #no wikidata for below
+    "ウォンツ": {"brand": "ウォンツ"},  # no wikidata for below
     "ウェルネス": {"brand": "ウェルネス"},
     "レデイ": {"brand": "くすりのレデイ"},
     "B＆D": {"brand": "B＆D調剤薬局"},
 }
+
 
 class TsuruhadrugSpider(YextAnswersSpider):
     name = "tsuruhadrug"
@@ -23,14 +24,23 @@ class TsuruhadrugSpider(YextAnswersSpider):
 
     def parse_item(self, location, item):
         if "c" in item["ref"]:
-            item = None #skip pharmacy ids
+            item = None  # skip pharmacy ids
             return
 
         for brand_key in brands.keys():
             if brand_key in item["name"]:
                 item.update(brands[brand_key])
 
-        item["branch"] = item.get("name").removeprefix("ツルハドラッグ").removeprefix("くすりの福太郎").removeprefix("杏林堂").removeprefix("ドラッグイレブン").removeprefix("ウォンツ").removeprefix("くすりのレデイ").removeprefix("B＆D調剤薬局")
+        item["branch"] = (
+            item.get("name")
+            .removeprefix("ツルハドラッグ")
+            .removeprefix("くすりの福太郎")
+            .removeprefix("杏林堂")
+            .removeprefix("ドラッグイレブン")
+            .removeprefix("ウォンツ")
+            .removeprefix("くすりのレデイ")
+            .removeprefix("B＆D調剤薬局")
+        )
 
         item["name"] = None
 


### PR DESCRIPTION
{'atp/brand/B＆D調剤薬局': 6,
 'atp/brand/くすりのレデイ': 250,
 'atp/brand/くすりの福太郎': 317,
 'atp/brand/ウェルネス': 142,
 'atp/brand/ウォンツ': 315,
 'atp/brand/ツルハドラッグ': 1570,
 'atp/brand/ドラッグイレブン': 205,
 'atp/brand/杏林堂': 103,
 'atp/brand_wikidata/Q11318826': 1570,
 'atp/brand_wikidata/Q11323075': 205,
 'atp/brand_wikidata/Q11522605': 103,
 'atp/brand_wikidata/Q17214460': 317,
 'atp/category/shop/chemist': 2922,
 'atp/cdn/cloudflare/response_count': 72,
 'atp/cdn/cloudflare/response_status_count/200': 71,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/branch': 2149,
 'atp/country/JP': 2897,
 'atp/country/TH': 24,
 'atp/country/VN': 1,
 'atp/field/brand/missing': 14,
 'atp/field/brand_wikidata/missing': 727,
 'atp/field/email/missing': 2922,
 'atp/field/image/missing': 2922,
 'atp/field/name/missing': 727,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 2922,
 'atp/field/operator_wikidata/missing': 2922,
 'atp/field/state/missing': 19,
 'atp/field/twitter/missing': 2922,
 'atp/field/website/missing': 2,
 'atp/item_scraped_host_count/prod-cdn.us.yextapis.com': 2922,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2195,
 'downloader/request_bytes': 66726,
 'downloader/request_count': 72,
 'downloader/request_method_count/GET': 72,
 'downloader/response_bytes': 1541560,
 'downloader/response_count': 72,
 'downloader/response_status_count/200': 71,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 89.366289,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 12, 11, 14, 19, 112552, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 18670992,
 'httpcompression/response_count': 71,
 'item_scraped_count': 2922,
 'items_per_minute': 1969.887640449438,
 'log_count/DEBUG': 2994,
 'log_count/INFO': 4,
 'request_depth_max': 70,
 'response_received_count': 72,
 'responses_per_minute': 48.53932584269663,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 71,
 'scheduler/dequeued/memory': 71,
 'scheduler/enqueued': 71,
 'scheduler/enqueued/memory': 71,
 'start_time': datetime.datetime(2026, 4, 12, 11, 12, 49, 746263, tzinfo=datetime.timezone.utc)}