### PR TITLE
[Dats 24 BE] Fix Spider

### DIFF
--- a/locations/spiders/dats_24_be.py
+++ b/locations/spiders/dats_24_be.py
@@ -30,6 +30,7 @@ class Dats24BESpider(Spider):
     def parse_locations_list(self, response):
         for location in response.json():
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
             item["street_address"] = merge_address_lines([location["addressNumber"], item["street_address"]])
             yield scrapy.Request(
                 url=f"https://dats24.be/nl/particulier/sdp/tankstation-{item.get('name').replace(' (','-').replace(')','_')}_{location['id']}",

--- a/locations/spiders/dats_24_be.py
+++ b/locations/spiders/dats_24_be.py
@@ -2,7 +2,6 @@ import json
 import re
 from typing import AsyncIterator
 
-import scrapy
 from scrapy import Spider
 from scrapy.http import Request
 
@@ -32,8 +31,8 @@ class Dats24BESpider(Spider):
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
             item["street_address"] = merge_address_lines([location["addressNumber"], item["street_address"]])
-            yield scrapy.Request(
-                url=f"https://dats24.be/nl/particulier/sdp/tankstation-{item.get('name').replace(' (','-').replace(')','_')}_{location['id']}",
+            yield Request(
+                url=f"https://dats24.be/nl/particulier/sdp/tankstation-{item.get('branch').replace(' (','-').replace(')','_')}_{location['id']}",
                 meta={"item": item},
                 callback=self.parse_fuel_details,
             )

--- a/locations/spiders/dats_24_be.py
+++ b/locations/spiders/dats_24_be.py
@@ -1,11 +1,14 @@
+import json
+import re
 from typing import AsyncIterator
 
+import scrapy
 from scrapy import Spider
 from scrapy.http import Request
 
 from locations.categories import Categories, Extras, Fuel, apply_yes_no
 from locations.dict_parser import DictParser
-from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class Dats24BESpider(Spider):
@@ -15,7 +18,7 @@ class Dats24BESpider(Spider):
     allowed_domains = ["dats24.be"]
 
     async def start(self) -> AsyncIterator[Request]:
-        query = '{"latitude":0,"longitude":0,"searchRadius":1000000000,"filterCriteria":{"serviceDeliveryPointType":["FUEL"],"serviceDeliveryPointAvailability":[],"chargingConnectorType":[],"chargingConnectorPowerType":[],"chargingLocationOperatorName":["ALL"],"fuelProductType":[]}}'
+        query = '{"latitude":50.7360328,"longitude":2.4155658,"searchRadius":230447,"serviceDeliveryPointType":["FUEL"],"fuelProductType":[]}'
         yield Request(
             url=self.start_urls[0],
             method="POST",
@@ -25,37 +28,24 @@ class Dats24BESpider(Spider):
         )
 
     def parse_locations_list(self, response):
-        for location in response.json()["serviceDeliveryPoints"]:
-            item = Feature()
-            item["ref"] = location["fuelStation"]["id"]
-            item["name"] = location["fuelStation"]["name"]
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-            query = '{"deliveryPointId":' + str(location["fuelStation"]["id"]) + ',"deliveryPointType":"FUEL"}'
-            yield Request(
-                url="https://dats24.be/api/service_point_details",
-                method="POST",
-                body=query,
-                headers={"Content-Type": "text/plain;charset=UTF-8"},
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["street_address"] = merge_address_lines([location["addressNumber"], item["street_address"]])
+            yield scrapy.Request(
+                url=f"https://dats24.be/nl/particulier/sdp/tankstation-{item.get('name').replace(' (','-').replace(')','_')}_{location['id']}",
                 meta={"item": item},
-                callback=self.parse_location_details,
+                callback=self.parse_fuel_details,
             )
 
-    def parse_location_details(self, response):
+    def parse_fuel_details(self, response):
         item = response.meta["item"]
-        location_details = response.json()["serviceDeliveryPoint"]
-        location_details["street_address"] = location_details.pop("street", None)
-        item2 = DictParser.parse(location_details)
-        item2["ref"] = item["ref"]
-        item2["name"] = item["name"]
-        item2["lat"] = item["lat"]
-        item2["lon"] = item["lon"]
-        item2["addr_full"] = location_details.pop("address", None)
-        product_codes = [product["code"] for product in location_details["fuelStation"]["products"]]
-        apply_yes_no(Fuel.E10, item2, "U" in product_codes, False)
-        apply_yes_no(Fuel.OCTANE_98, item2, "P" in product_codes, False)
-        apply_yes_no(Fuel.DIESEL, item2, "D" in product_codes, False)
-        apply_yes_no(Fuel.CNG, item2, "C" in product_codes, False)
-        apply_yes_no(Fuel.ADBLUE, item2, "A" in product_codes, False)
-        apply_yes_no(Extras.COMPRESSED_AIR, item2, "B" in product_codes, False)
-        yield item2
+        item["website"] = response.url
+        fuel_details = json.loads(re.search(r"FuelProduct\"\s*:\s*(\[.+\]),\"FuelPump", response.text).group(1))
+        product_codes = [product["code"] for product in fuel_details]
+        apply_yes_no(Fuel.E10, item, "U" in product_codes, False)
+        apply_yes_no(Fuel.OCTANE_98, item, "P" in product_codes, False)
+        apply_yes_no(Fuel.DIESEL, item, "D" in product_codes, False)
+        apply_yes_no(Fuel.CNG, item, "C" in product_codes, False)
+        apply_yes_no(Fuel.ADBLUE, item, "A" in product_codes, False)
+        apply_yes_no(Extras.COMPRESSED_AIR, item, "B" in product_codes, False)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/DATS 24': 142,
 'atp/brand_wikidata/Q15725576': 142,
 'atp/category/amenity/fuel': 142,
 'atp/clean_strings/city': 1,
 'atp/country/BE': 142,
 'atp/field/branch/missing': 142,
 'atp/field/country/from_spider_name': 142,
 'atp/field/email/missing': 142,
 'atp/field/image/missing': 142,
 'atp/field/opening_hours/missing': 142,
 'atp/field/operator/missing': 142,
 'atp/field/operator_wikidata/missing': 142,
 'atp/field/phone/missing': 142,
 'atp/field/state/missing': 142,
 'atp/field/twitter/missing': 142,
 'atp/item_scraped_host_count/dats24.be': 142,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 142,
 'downloader/request_bytes': 138129,
 'downloader/request_count': 288,
 'downloader/request_method_count/GET': 287,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 33216863,
 'downloader/response_count': 288,
 'downloader/response_status_count/200': 144,
 'downloader/response_status_count/301': 144,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 357.139062,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 13, 6, 17, 15, 433447, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 170451920,
 'httpcompression/response_count': 143,
 'item_scraped_count': 142,
 'items_per_minute': 23.865546218487395,
 'log_count/DEBUG': 432,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 144,
 'responses_per_minute': 24.201680672268907,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 287,
 'scheduler/dequeued/memory': 287,
 'scheduler/enqueued': 287,
 'scheduler/enqueued/memory': 287,
 'start_time': datetime.datetime(2026, 4, 13, 6, 11, 18, 294385, tzinfo=datetime.timezone.utc)}
```