### PR TITLE
feat: add KjellAndCompanySpider [148]

### DIFF
--- a/locations/spiders/kjell_and_company.py
+++ b/locations/spiders/kjell_and_company.py
@@ -32,6 +32,7 @@ class KjellAndCompanySpider(Spider):
                 item = DictParser.parse(location)
                 item["country"] = country
                 item["opening_hours"] = self.parse_hours(location)
+                item["branch"] = item.pop("name")
                 apply_yes_no(PaymentMethods.CASH, item, not location.get("noCash", False))
                 apply_category(Categories.SHOP_ELECTRONICS, item)
                 yield item

--- a/locations/spiders/kjell_and_company.py
+++ b/locations/spiders/kjell_and_company.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from scrapy import Spider
+from scrapy.http import JsonRequest
+
+from locations.categories import Categories, PaymentMethods, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+COUNTRIES = {"NOR": "NO", "SWE": "SE"}
+REQUEST_BODY = '[{t:"Avensia.Common.Store.ChooseStoreListViewModel,Avensia.Common"}]'
+
+
+class KjellAndCompanySpider(Spider):
+    name = "kjell_and_company"
+    item_attributes = {"brand": "Kjell & Company", "brand_wikidata": "Q6419332"}
+    allowed_domains = ["kjell.com"]
+
+    def start_requests(self):
+        for country_code, country in COUNTRIES.items():
+            yield JsonRequest(
+                url="https://www.kjell.com/resolvedynamicdata",
+                data=REQUEST_BODY,
+                cookies={"CountryCode": country_code},
+                cb_kwargs={"country": country},
+                dont_filter=True,
+            )
+
+    def parse(self, response, country):
+        for component in response.json():
+            for location in component.get("stores", []):
+                item = DictParser.parse(location)
+                item["country"] = country
+                item["opening_hours"] = self.parse_hours(location)
+                apply_yes_no(PaymentMethods.CASH, item, not location.get("noCash", False))
+                apply_category(Categories.SHOP_ELECTRONICS, item)
+                yield item
+
+    @staticmethod
+    def parse_hours(location: dict) -> OpeningHours | None:
+        if not (hours_data := location.get("openHours")):
+            return None
+        oh = OpeningHours()
+        for entry in hours_data:
+            day = DAYS[datetime.strptime(f'{entry["date"]}/{entry["year"]}', "%d/%m/%Y").weekday()]
+            if entry.get("isClosed"):
+                oh.set_closed(day)
+            else:
+                oh.add_range(day, entry.get("open"), entry.get("close"))
+        return oh


### PR DESCRIPTION
2026-04-13 18:59:07 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Kjell & Company': 148,
 'atp/brand_wikidata/Q6419332': 148,
 'atp/category/shop/electronics': 148,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/clean_strings/name': 1,
 'atp/country/NO': 31,
 'atp/country/SE': 117,
 'atp/field/branch/missing': 148,
 'atp/field/image/missing': 148,
 'atp/field/operator/missing': 148,
 'atp/field/operator_wikidata/missing': 148,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 148,
 'atp/field/street_address/missing': 148,
 'atp/field/twitter/missing': 148,
 'atp/field/website/missing': 148,
 'atp/item_scraped_host_count/www.kjell.com': 148,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 148,
 'downloader/request_bytes': 1235,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 27888,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 2.697187,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 13, 16, 59, 7, 84814, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 262443,
 'httpcompression/response_count': 3,
 'item_scraped_count': 148,
 'items_per_minute': 4440.0,
 'log_count/DEBUG': 151,
 'log_count/INFO': 3,
 'memusage/max': 268337152,
 'memusage/startup': 268337152,
 'response_received_count': 3,
 'responses_per_minute': 90.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 4, 13, 16, 59, 4, 387627, tzinfo=datetime.timezone.utc)}
2026-04-13 18:59:07 [scrapy.core.engine] INFO: Spider closed (finished)
uv run scrapy crawl kjell_and_company  2.18s user 0.61s system 48% cpu 5.796 total
