### PR TITLE
[Flo, Connected Kerb] Use Categories enum

### DIFF
--- a/locations/spiders/connected_kerb_gb.py
+++ b/locations/spiders/connected_kerb_gb.py
@@ -48,5 +48,5 @@ class ConnectedKerbGBSpider(JSONBlobSpider):
             apply_yes_no(f"socket:{socket_type}", point_item, True)
             point_item["extras"][f"socket:{socket_type}:output"] = point_location["maxPower"]
 
-            apply_category({"man_made": "charge_point"}, point_item)
+            apply_category(Categories.CHARGE_POINT, point_item)
             yield point_item

--- a/locations/spiders/flo_ca_us.py
+++ b/locations/spiders/flo_ca_us.py
@@ -90,5 +90,5 @@ class FloCAUSSpider(Spider):
             apply_yes_no(f"socket:{socket_type}", item, True)
             item["extras"][f"socket:{socket_type}:output"] = f"{location['chargingSpeed']} kW"
 
-        apply_category({"man_made": "charge_point"}, item)
+        apply_category(Categories.CHARGE_POINT, item)
         return item


### PR DESCRIPTION
`Categories.CHARGE_POINT` was added in #15705 but these two spiders were written before that was merged.