### PR TITLE
[Gucci ] Fix Spider

### DIFF
--- a/locations/spiders/gucci.py
+++ b/locations/spiders/gucci.py
@@ -1,34 +1,25 @@
-import json
-from typing import Any, AsyncIterator
+from typing import Iterable
 
-from scrapy.http import Request, Response
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.playwright_spider import PlaywrightSpider
+from locations.google_url import extract_google_position
+from locations.items import Feature
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import FIREFOX_LATEST
+from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class GucciSpider(PlaywrightSpider):
+class GucciSpider(SitemapSpider, StructuredDataSpider):
     name = "gucci"
     item_attributes = {"brand": "Gucci", "brand_wikidata": "Q178516"}
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": FIREFOX_LATEST} | DEFAULT_PLAYWRIGHT_SETTINGS
+    sitemap_urls = ["https://www.gucci.com/robots.txt"]
+    sitemap_follow = ["sitemap/STORE"]
+    sitemap_rules = [(r"https://www.gucci.com/\w+/en_\w+|\w+/store/[a-z-0-9]+", "parse_sd")]
+    is_playwright_spider = True
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield Request(
-            url="https://www.gucci.com/int/en/store/all?south=-90&west=-180&north=90&east=180&latitude=0&longitude=0",
-            headers={"Referer": "https://www.gucci.com/int/en/store?store-search=&search-cat=store-locator"},
-        )
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get())["features"]:
-            if location["properties"]["active"] is not True:
-                continue
-            item = DictParser.parse(location["properties"])
-            item["website"] = "https://www.gucci.com/int/en{}".format(item["website"])
-            item["ref"] = location["properties"]["storeCode"]
-            item["street_address"] = location["properties"]["address"]["location"]
-            item["phone"] = location["properties"]["address"]["phone"]
-            self.crawler.stats.inc_value("z/type/{}".format(location["properties"]["type"]))
-
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        extract_google_position(item, response)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Gucci': 549,
'atp/brand_wikidata/Q178516': 549,
'atp/category/shop/clothes': 549,
'atp/clean_strings/phone': 3,
'atp/country/AE': 24,
'atp/country/AT': 2,
'atp/country/AU': 20,
'atp/country/BE': 3,
'atp/country/CA': 24,
'atp/country/CH': 12,
'atp/country/CZ': 1,
'atp/country/DE': 22,
'atp/country/DK': 2,
'atp/country/ES': 7,
'atp/country/FR': 50,
'atp/country/GB': 38,
'atp/country/GR': 4,
'atp/country/HU': 1,
'atp/country/IE': 1,
'atp/country/IT': 31,
'atp/country/JP': 75,
'atp/country/KR': 54,
'atp/country/KW': 8,
'atp/country/LU': 2,
'atp/country/MX': 26,
'atp/country/NL': 6,
'atp/country/NO': 1,
'atp/country/NZ': 2,
'atp/country/PT': 1,
'atp/country/QA': 10,
'atp/country/SA': 7,
'atp/country/SE': 1,
'atp/country/SG': 7,
'atp/country/TR': 7,
'atp/country/US': 97,
'atp/country/ZA': 3,
'atp/field/city/missing': 9,
'atp/field/email/missing': 316,
'atp/field/opening_hours/missing': 341,
'atp/field/operator/missing': 549,
'atp/field/operator_wikidata/missing': 549,
'atp/field/phone/invalid': 29,
'atp/field/postcode/missing': 17,
'atp/field/state/from_reverse_geocoding': 7,
'atp/field/state/missing': 284,
'atp/field/street_address/missing': 1,
'atp/geometry/null_island': 2,
'atp/item_scraped_host_count/www.gucci.com': 549,
'atp/lineage': 'S_?',
'atp/nsi/perfect_match': 549,
'downloader/request_bytes': 1372197,
'downloader/request_count': 688,
'downloader/request_method_count/GET': 688,
'downloader/response_bytes': 504472027,
'downloader/response_count': 688,
'downloader/response_status_count/200': 686,
'downloader/response_status_count/404': 2,
'elapsed_time_seconds': 874.892684,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2026, 4, 14, 6, 28, 8, 895026, tzinfo=datetime.timezone.utc),
'httperror/response_ignored_count': 2,
'httperror/response_ignored_status_count/404': 2,
'item_scraped_count': 549,
'items_per_minute': 37.68878718535469,
'log_count/DEBUG': 70980,
'log_count/INFO': 29,
'log_count/WARNING': 329,
'playwright/browser_count': 1,
'playwright/context_count': 1,
'playwright/context_count/max_concurrent': 1,
'playwright/context_count/persistent/False': 1,
'playwright/context_count/remote/False': 1,
'playwright/page_count': 687,
'playwright/page_count/closed': 687,
'playwright/page_count/max_concurrent': 8,
'playwright/request_count': 34524,
'playwright/request_count/aborted': 33833,
'playwright/request_count/method/GET': 34524,
'playwright/request_count/navigation': 689,
'playwright/request_count/resource_type/document': 689,
'playwright/request_count/resource_type/image': 2612,
'playwright/request_count/resource_type/script': 17922,
'playwright/request_count/resource_type/stylesheet': 12724,
'playwright/request_count/resource_type/xhr': 577,
'playwright/response_count': 689,
'playwright/response_count/method/GET': 689,
'playwright/response_count/resource_type/document': 689,
'request_depth_max': 3,
'response_received_count': 688,
'responses_per_minute': 47.23112128146453,
'robotstxt/request_count': 1,
'robotstxt/response_count': 1,
'robotstxt/response_status_count/200': 1,
'scheduler/dequeued': 687,
'scheduler/dequeued/memory': 687,
'scheduler/enqueued': 687,
'scheduler/enqueued/memory': 687,
'start_time': datetime.datetime(2026, 4, 14, 6, 13, 34, 2342, tzinfo=datetime.timezone.utc)}
```