### PR TITLE
[Race Trac US] Fix Spider

### DIFF
--- a/locations/spiders/race_trac_us.py
+++ b/locations/spiders/race_trac_us.py
@@ -1,6 +1,7 @@
+import json
+import re
 from typing import Any
 
-import chompjs
 from scrapy.http import Response
 from scrapy.spiders import Spider
 
@@ -41,22 +42,23 @@ class RaceTracUSSpider(Spider):
     item_attributes = {"brand": "RaceTrac", "brand_wikidata": "Q735942"}
     allowed_domains = ["www.racetrac.com"]
     start_urls = ["https://www.racetrac.com/locations/"]
-    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        raw_data = chompjs.parse_js_object(response.xpath('//*[contains(text(),"storedata")]/text()').get())
-        for location in raw_data:
-            item = DictParser.parse(location)
-            item["street_address"] = location.get("StoreAddress1")
-            if item.get("website"):
-                item["website"] = response.urljoin(item["website"])
-            apply_category(Categories.FUEL_STATION, item)
-            if amenities := location.get("Amenities"):
-                for amenity in amenities:
-                    if attribute := ATTRIBUTES_MAP.get(amenity["DisplayName"]):
-                        apply_yes_no(attribute, item, True)
-                    else:
-                        self.crawler.stats.inc_value(
-                            "atp/racetrac_us/unmapped_attribute/{}".format(amenity["DisplayName"])
-                        )
-            yield item
+        if raw_data := re.search(
+            r"storedata\s*=\s*(\[.*\]);\s*var", response.xpath('//*[contains(text(),"storedata")]/text()').get()
+        ):
+            for location in json.loads(raw_data.group(1)):
+                item = DictParser.parse(location)
+                item["street_address"] = location.get("StoreAddress1")
+                if item.get("website"):
+                    item["website"] = response.urljoin(item["website"])
+                apply_category(Categories.FUEL_STATION, item)
+                if amenities := location.get("Amenities"):
+                    for amenity in amenities:
+                        if attribute := ATTRIBUTES_MAP.get(amenity["DisplayName"]):
+                            apply_yes_no(attribute, item, True)
+                        else:
+                            self.crawler.stats.inc_value(
+                                "atp/racetrac_us/unmapped_attribute/{}".format(amenity["DisplayName"])
+                            )
+                yield item

--- a/locations/spiders/race_trac_us.py
+++ b/locations/spiders/race_trac_us.py
@@ -41,6 +41,7 @@ class RaceTracUSSpider(Spider):
     item_attributes = {"brand": "RaceTrac", "brand_wikidata": "Q735942"}
     allowed_domains = ["www.racetrac.com"]
     start_urls = ["https://www.racetrac.com/locations/"]
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         raw_data = chompjs.parse_js_object(response.xpath('//*[contains(text(),"storedata")]/text()').get())

--- a/locations/spiders/race_trac_us.py
+++ b/locations/spiders/race_trac_us.py
@@ -1,9 +1,11 @@
-from urllib.parse import urljoin
+from typing import Any
 
-from scrapy.spiders import SitemapSpider
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import Spider
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
 
 ATTRIBUTES_MAP = {
     "Bulk DEF": None,
@@ -34,28 +36,26 @@ ATTRIBUTES_MAP = {
 }
 
 
-class RaceTracUSSpider(SitemapSpider, StructuredDataSpider):
+class RaceTracUSSpider(Spider):
     name = "race_trac_us"
     item_attributes = {"brand": "RaceTrac", "brand_wikidata": "Q735942"}
     allowed_domains = ["www.racetrac.com"]
-    sitemap_urls = ["https://www.racetrac.com/robots.txt"]
-    sitemap_rules = [(r"/locations/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    start_urls = ["https://www.racetrac.com/locations/"]
 
-    def sitemap_filter(self, entries):
-        for entry in entries:
-            if entry["loc"].startswith("/"):
-                entry["loc"] = urljoin("https://www.racetrac.com/", entry["loc"])
-            yield entry
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["name"] = None
-        item["website"] = response.url
-        apply_category(Categories.FUEL_STATION, item)
-
-        for amenity in response.xpath('//li[@class="amCol"]/span[@class="displayName"]/text()').getall():
-            if attribute := ATTRIBUTES_MAP.get(amenity):
-                apply_yes_no(attribute, item, True)
-            else:
-                self.crawler.stats.inc_value("atp/racetrac_us/unmapped_attribute/{}".format(amenity))
-
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = chompjs.parse_js_object(response.xpath('//*[contains(text(),"storedata")]/text()').get())
+        for location in raw_data:
+            item = DictParser.parse(location)
+            item["street_address"] = location.get("StoreAddress1")
+            if item.get("website"):
+                item["website"] = response.urljoin(item["website"])
+            apply_category(Categories.FUEL_STATION, item)
+            if amenities := location.get("Amenities"):
+                for amenity in amenities:
+                    if attribute := ATTRIBUTES_MAP.get(amenity["DisplayName"]):
+                        apply_yes_no(attribute, item, True)
+                    else:
+                        self.crawler.stats.inc_value(
+                            "atp/racetrac_us/unmapped_attribute/{}".format(amenity["DisplayName"])
+                        )
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/RaceTrac': 853,
 'atp/brand_wikidata/Q735942': 853,
 'atp/category/amenity/fuel': 853,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/street_address': 13,
 'atp/country/US': 853,
 'atp/field/branch/missing': 853,
 'atp/field/country/from_spider_name': 853,
 'atp/field/email/missing': 853,
 'atp/field/image/missing': 853,
 'atp/field/opening_hours/missing': 853,
 'atp/field/operator/missing': 853,
 'atp/field/operator_wikidata/missing': 853,
 'atp/field/phone/invalid': 7,
 'atp/field/twitter/missing': 853,
 'atp/item_scraped_host_count/www.racetrac.com': 853,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 853,
 'atp/racetrac_us/unmapped_attribute/Check Cashing': 87,
 'atp/racetrac_us/unmapped_attribute/EV Fast Charging': 10,
 'atp/racetrac_us/unmapped_attribute/Gaming Machines': 7,
 'atp/racetrac_us/unmapped_attribute/Online Ordering': 554,
 'atp/racetrac_us/unmapped_attribute/Reserve Truck Parking': 9,
 'atp/racetrac_us/unmapped_attribute/Seating Area': 488,
 'atp/racetrac_us/unmapped_attribute/Swirl World': 500,
 'atp/racetrac_us/unmapped_attribute/Travel Center': 32,
 'atp/racetrac_us/unmapped_attribute/Truck Merchandise': 2,
 'atp/racetrac_us/unmapped_attribute/Truck Parking': 11,
 'atp/racetrac_us/unmapped_attribute/Truck Scale CAT': 41,
 'downloader/request_bytes': 1009,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 124985,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.660142,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 14, 10, 45, 21, 693487, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1983180,
 'httpcompression/response_count': 2,
 'item_scraped_count': 853,
 'items_per_minute': 8530.0,
 'log_count/DEBUG': 855,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 14, 10, 45, 15, 33345, tzinfo=datetime.timezone.utc)}
```