### PR TITLE
Fix wsp spider: update to parse server-rendered HTML from en-gl URL

### DIFF
--- a/locations/spiders/wsp.py
+++ b/locations/spiders/wsp.py
@@ -1,47 +1,58 @@
-import json
-
 import scrapy
+from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 
-class WspSpider(scrapy.Spider):
+COUNTRY_MAP = {
+    "Greater China": "CN",
+    "Viet Nam": "VN",
+}
+
+
+class WspSpider(CamoufoxSpider):
     name = "wsp"
     item_attributes = {"brand": "WSP", "brand_wikidata": "Q1333162"}
-    allowed_domains = ["www.wsp.com"]
-    start_urls = ("https://www.wsp.com/",)
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    handle_httpstatus_list = [403]
+    captcha_type = "cloudflare_turnstile"
+    captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
+
+    async def start(self):
+        yield scrapy.Request("https://www.wsp.com/en-gl/contact-us/offices")
 
     def parse(self, response):
-        url = "https://www.wsp.com/api/sitecore/Maps/GetMapPoints"
+        current_country = ""
+        for office in response.css("div.offices-address"):
+            country_heading = office.css("h2.title-h2::text").get("").strip()
+            if country_heading:
+                current_country = country_heading
 
-        formdata = {
-            "itemId": "{2F436202-D2B9-4F3D-8ECC-5E0BCA533888}",
-        }
+            name = office.css("h4.title-h4 a.news-title::attr(title)").get("").strip()
+            href = office.css("h4.title-h4 a.news-title::attr(href)").get("")
+            ref = href.rstrip("/").split("/")[-1]
+            website = response.urljoin(href)
 
-        yield scrapy.http.FormRequest(
-            url,
-            self.parse_store,
-            method="POST",
-            formdata=formdata,
-        )
-
-    def parse_store(self, response):
-        office_data = json.loads(response.text)
-
-        for office in office_data:
-            try:
-                properties = {
-                    "ref": office["ID"]["Guid"],
-                    "addr_full": office["Address"],
-                    "lat": office["Location"].split(",")[0],
-                    "lon": office["Location"].split(",")[1],
-                    "name": office["Name"],
-                    "website": response.urljoin(office["MapPointURL"]),
-                }
-            except IndexError:
+            if not ref:
                 continue
 
-            apply_category(Categories.OFFICE_ENGINEER, properties)
+            texts = [
+                t.strip()
+                for t in office.css("div.office-address div.text::text").getall()
+                if t.strip()
+            ]
+            addr_full = ", ".join(texts) if texts else None
 
+            properties = {
+                "ref": ref,
+                "name": name,
+                "addr_full": addr_full,
+                "country": COUNTRY_MAP.get(current_country, current_country),
+                "website": website,
+            }
+
+            apply_category(Categories.OFFICE_ENGINEER, properties)
             yield Feature(**properties)

--- a/locations/spiders/wsp.py
+++ b/locations/spiders/wsp.py
@@ -1,11 +1,9 @@
 import scrapy
-from scrapy.http import Response
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
-
 
 COUNTRY_MAP = {
     "Greater China": "CN",
@@ -39,11 +37,7 @@ class WspSpider(CamoufoxSpider):
             if not ref:
                 continue
 
-            texts = [
-                t.strip()
-                for t in office.css("div.office-address div.text::text").getall()
-                if t.strip()
-            ]
+            texts = [t.strip() for t in office.css("div.office-address div.text::text").getall() if t.strip()]
             addr_full = ", ".join(texts) if texts else None
 
             properties = {


### PR DESCRIPTION
The previous Sitecore API endpoint no longer works. The office list is now server-rendered at https://www.wsp.com/en-gl/contact-us/offices which returns all 555 offices globally. Updated spider to parse HTML directly using CamoufoxSpider to handle Cloudflare protection.