### PR TITLE
Costco spiders: various fixes for opening hours, field extraction

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -773,6 +773,23 @@ DAYS_JP = {
     "日": "Su",
 }
 
+DAYS_IS = {
+    "Mán": "Mo",
+    "Mánudagur": "Mo",
+    "Þri": "Tu",
+    "Þriðjudagur": "Tu",
+    "Mið": "We",
+    "Miðvikudagur": "We",
+    "Fim": "Th",
+    "Fimmtudagur": "Th",
+    "Fös": "Fr",
+    "Föstudagur": "Fr",
+    "Lau": "Sa",
+    "Laugardagur": "Sa",
+    "Sun": "Su",
+    "Sunnudagur": "Su",
+}
+
 # See https://github.com/alltheplaces/alltheplaces/issues/7360
 # A list ordered by languages most frequently used for web content as of January 2024, by share of websites.
 # See WPStoreLocator for example usage.
@@ -799,6 +816,7 @@ DAYS_BY_FREQUENCY = [
     DAYS_HR,
     DAYS_HU,
     DAYS_IL,
+    DAYS_IS,
     DAYS_NL,
     DAYS_NO,
     DAYS_RO,

--- a/locations/spiders/costco_au.py
+++ b/locations/spiders/costco_au.py
@@ -4,7 +4,7 @@ from urllib.parse import quote, urljoin
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, DAYS_EN
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -17,18 +17,29 @@ class CostcoAUSpider(JSONBlobSpider):
     allowed_domains = ["www.costco.com.au"]
     locations_key = "stores"
     stores_url = "https://www.costco.com.au/rest/v2/australia/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
+    days = DAYS_EN
+    time_format = "%I:%M %p"
 
     async def start(self) -> AsyncIterator[Any]:
         yield JsonRequest(url=self.stores_url)
 
     def pre_process_data(self, feature: dict) -> None:
+        if region_dict := feature["address"].pop("region", None):
+            feature["state"] = region_dict["name"]
+        if country_dict := feature["address"].pop("country", None):
+            feature["country"] = country_dict["name"]
         feature.update(feature.pop("address"))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["ref"] = feature["warehouseCode"]
+        if warehouse_code := feature.get("warehouseCode"):
+            item["ref"] = warehouse_code
+        else:
+            # Features without a warehouse code seem to be stubs for announced
+            # but unopened stores.
+            return
         item["branch"] = feature["displayName"]
         item.pop("name", None)
-        item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2")])
+        item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2"), feature.get("line3"), feature.get("line4")])
         item["website"] = urljoin(response.url, f"/store-finder/{quote(item['branch'])}")
 
         warehouse = item.deepcopy()
@@ -95,13 +106,14 @@ class CostcoAUSpider(JSONBlobSpider):
     def parse_opening_hours(self, opening_hours: list) -> OpeningHours:
         oh = OpeningHours()
         for rule in opening_hours:
+            day_name = self.days[rule["weekDay"].removesuffix(".").title()]
             if rule.get("closed"):
-                oh.set_closed(rule["weekDay"])
+                oh.set_closed(day_name)
             else:
                 oh.add_range(
-                    rule["weekDay"],
+                    day_name,
                     rule["openingTime"]["formattedHour"],
                     rule["closingTime"]["formattedHour"],
-                    "%I:%M %p",
+                    self.time_format,
                 )
         return oh

--- a/locations/spiders/costco_au.py
+++ b/locations/spiders/costco_au.py
@@ -4,7 +4,7 @@ from urllib.parse import quote, urljoin
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
-from locations.hours import OpeningHours, DAYS_EN
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -39,7 +39,9 @@ class CostcoAUSpider(JSONBlobSpider):
             return
         item["branch"] = feature["displayName"]
         item.pop("name", None)
-        item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2"), feature.get("line3"), feature.get("line4")])
+        item["street_address"] = merge_address_lines(
+            [feature.get("line1"), feature.get("line2"), feature.get("line3"), feature.get("line4")]
+        )
         item["website"] = urljoin(response.url, f"/store-finder/{quote(item['branch'])}")
 
         warehouse = item.deepcopy()

--- a/locations/spiders/costco_es.py
+++ b/locations/spiders/costco_es.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_ES
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,5 @@ class CostcoESSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.es/rest/v2/spain/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_ES
+    time_format = "%H:%M"

--- a/locations/spiders/costco_fr.py
+++ b/locations/spiders/costco_fr.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_FR
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,5 @@ class CostcoFRSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.fr/rest/v2/france/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_FR
+    time_format = "%H:%M"

--- a/locations/spiders/costco_is.py
+++ b/locations/spiders/costco_is.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_IS
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,5 @@ class CostcoISSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.is/rest/v2/iceland/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_IS
+    time_format = "%H:%M"

--- a/locations/spiders/costco_jp.py
+++ b/locations/spiders/costco_jp.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_JP
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,5 @@ class CostcoJPSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.co.jp/rest/v2/japan/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_JP
+    time_format = "%H:%M"

--- a/locations/spiders/costco_kr.py
+++ b/locations/spiders/costco_kr.py
@@ -1,4 +1,4 @@
-from locations.hours import OpeningHours, DAYS_KR
+from locations.hours import DAYS_KR, OpeningHours
 from locations.spiders.costco_au import CostcoAUSpider
 
 

--- a/locations/spiders/costco_kr.py
+++ b/locations/spiders/costco_kr.py
@@ -1,3 +1,4 @@
+from locations.hours import OpeningHours, DAYS_KR
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,22 @@ class CostcoKRSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.co.kr/rest/v2/korea/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_KR
+
+    def parse_opening_hours(self, opening_hours: list) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours:
+            day_name = self.days[rule["weekDay"].removesuffix(".").title()]
+            if rule.get("closed"):
+                oh.set_closed(day_name)
+            else:
+                # Note: raw data contains errors where, for example, opening
+                # times have the "PM" prefix ("오후"). It's necessary to
+                # ignore all "AM" and "PM" prefixes from the raw data.
+                oh.add_range(
+                    day_name,
+                    rule["openingTime"]["formattedHour"].removeprefix("오전 ").removeprefix("오후 ") + " AM",
+                    rule["closingTime"]["formattedHour"].removeprefix("오후 ").removeprefix("오전 ") + " PM",
+                    self.time_format,
+                )
+        return oh

--- a/locations/spiders/costco_mx.py
+++ b/locations/spiders/costco_mx.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_ES
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,4 @@ class CostcoMXSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.com.mx/rest/v2/mexico/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_ES

--- a/locations/spiders/costco_se.py
+++ b/locations/spiders/costco_se.py
@@ -1,3 +1,4 @@
+from locations.hours import DAYS_SE
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,5 @@ class CostcoSESpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.se/rest/v2/sweden/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_SE
+    time_format = "%H:%M"

--- a/locations/spiders/costco_tw.py
+++ b/locations/spiders/costco_tw.py
@@ -1,4 +1,4 @@
-from locations.hours import OpeningHours, DAYS_CN
+from locations.hours import DAYS_CN, OpeningHours
 from locations.spiders.costco_au import CostcoAUSpider
 
 

--- a/locations/spiders/costco_tw.py
+++ b/locations/spiders/costco_tw.py
@@ -1,3 +1,4 @@
+from locations.hours import OpeningHours, DAYS_CN
 from locations.spiders.costco_au import CostcoAUSpider
 
 
@@ -7,3 +8,22 @@ class CostcoTWSpider(CostcoAUSpider):
     stores_url = (
         "https://www.costco.com.tw/rest/v2/taiwan/stores?fields=FULL&radius=3000000&returnAllStores=true&pageSize=999"
     )
+    days = DAYS_CN
+
+    def parse_opening_hours(self, opening_hours: list) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours:
+            day_name = self.days[rule["weekDay"].removesuffix(".").title()]
+            if rule.get("closed"):
+                oh.set_closed(day_name)
+            else:
+                # Note: raw data contains errors where, for example, opening
+                # times have the "PM" prefix ("下午"). It's necessary to
+                # ignore all "AM" and "PM" prefixes from the raw data.
+                oh.add_range(
+                    day_name,
+                    rule["openingTime"]["formattedHour"].removeprefix("上午 ").removeprefix("下午 ") + " AM",
+                    rule["closingTime"]["formattedHour"].removeprefix("下午 ").removeprefix("上午 ") + " PM",
+                    self.time_format,
+                )
+        return oh


### PR DESCRIPTION
* Opening hours extraction is now localised according to the language of the Costco country website.
* Additional address fields are extracted where the raw data populates the fields.
* Minor bug fixes to avoid errors in some spiders resulting for data format differences/changes. Each country website has some quirks about how they have implemented what otherwise looks like a common data model.