### PR TITLE
[Denns Biomarkt DE] Fix Spider

### DIFF
--- a/locations/spiders/denns_biomarkt_de.py
+++ b/locations/spiders/denns_biomarkt_de.py
@@ -8,8 +8,8 @@ from locations.structured_data_spider import StructuredDataSpider
 class DennsBiomarktDESpider(SitemapSpider, StructuredDataSpider):
     name = "denns_biomarkt_de"
     DENNS_BIO_MARKT = {"brand": "Denns BioMarkt", "brand_wikidata": "Q48883773"}
-    sitemap_urls = ["https://www.biomarkt.de/robots.txt"]
-    sitemap_rules = [(r"de/([^/]+)/marktseite$", "parse_sd")]
+    sitemap_urls = ["https://www.biomarkt.de/sitemap-index.xml"]
+    sitemap_rules = [(r"de/([^/]+)/marktseite/$", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if item["name"].startswith("Denns BioMarkt"):


### PR DESCRIPTION
```python
{'atp/brand/Denns BioMarkt': 387,
 'atp/brand_wikidata/Q48883773': 387,
 'atp/category/shop/supermarket': 516,
 'atp/clean_strings/postcode': 6,
 'atp/country/DE': 516,
 'atp/field/branch/missing': 516,
 'atp/field/brand/missing': 129,
 'atp/field/brand_wikidata/missing': 129,
 'atp/field/email/missing': 516,
 'atp/field/image/missing': 465,
 'atp/field/opening_hours/missing': 8,
 'atp/field/operator/missing': 129,
 'atp/field/operator_wikidata/missing': 129,
 'atp/field/phone/missing': 17,
 'atp/field/state/missing': 516,
 'atp/field/twitter/missing': 516,
 'atp/geometry/null_island': 7,
 'atp/item_scraped_host_count/www.biomarkt.de': 516,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 387,
 'atp/operator/Dennree GmbH': 387,
 'atp/operator_wikidata/Q1189641': 387,
 'downloader/request_bytes': 212376,
 'downloader/request_count': 519,
 'downloader/request_method_count/GET': 519,
 'downloader/response_bytes': 9343276,
 'downloader/response_count': 519,
 'downloader/response_status_count/200': 519,
 'elapsed_time_seconds': 641.290367,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 15, 12, 54, 35, 944143, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 36151142,
 'httpcompression/response_count': 519,
 'item_scraped_count': 516,
 'items_per_minute': 48.29953198127925,
 'log_count/DEBUG': 1035,
 'log_count/INFO': 80,
 'log_count/WARNING': 508,
 'request_depth_max': 2,
 'response_received_count': 519,
 'responses_per_minute': 48.58034321372855,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 518,
 'scheduler/dequeued/memory': 518,
 'scheduler/enqueued': 518,
 'scheduler/enqueued/memory': 518,
 'start_time': datetime.datetime(2026, 4, 15, 12, 43, 54, 653776, tzinfo=datetime.timezone.utc)}
```