### PR TITLE
[McDonald's NZ/US] Consolidate NZ into main spider, ISEADGG coverage improves count

### DIFF
--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -5,7 +5,7 @@ from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
-from locations.geo import city_locations
+from locations.geo import city_locations, country_iseadgg_centroids
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
@@ -20,12 +20,15 @@ class McdonaldsSpider(Spider):
     }
     allowed_domains = ["www.mcdonalds.com"]
 
+    ISEADGG_COUNTRIES = {"NZ"}
+
     async def start(self) -> AsyncIterator[Request]:
         template = "https://www.mcdonalds.com/googleappsv2/geolocation?latitude={}&longitude={}&radius=50&maxResults=250&country={}&language={}&showClosed="
         for locale in [
             "en-au",
             "en-ca",
             "en-gb",
+            "en-nz",
             "fi-fi",
             "en-ie",
             "en-us",
@@ -47,16 +50,25 @@ class McdonaldsSpider(Spider):
             "hr-hr",
         ]:
             country = locale.split("-")[1]
-            for city in city_locations(country.upper(), 20000):
-                if country == "sa":
-                    url = template.format(city["latitude"], city["longitude"], "sar", "en")
-                else:
-                    url = template.format(city["latitude"], city["longitude"], country, locale)
-                yield Request(
-                    url,
-                    self.parse_major_api,
-                    cb_kwargs=dict(country=country, locale=locale),
-                )
+            if country.upper() in self.ISEADGG_COUNTRIES:
+                for lat, lon in country_iseadgg_centroids(country.upper(), 48):
+                    url = template.format(lat, lon, country, locale)
+                    yield Request(
+                        url,
+                        self.parse_major_api,
+                        cb_kwargs=dict(country=country, locale=locale),
+                    )
+            else:
+                for city in city_locations(country.upper(), 20000):
+                    if country == "sa":
+                        url = template.format(city["latitude"], city["longitude"], "sar", "en")
+                    else:
+                        url = template.format(city["latitude"], city["longitude"], country, locale)
+                    yield Request(
+                        url,
+                        self.parse_major_api,
+                        cb_kwargs=dict(country=country, locale=locale),
+                    )
 
     def parse_major_api(self, response: Response, country: str, locale: str) -> Iterable[Feature]:
         if len(response.body) == 0:
@@ -66,7 +78,19 @@ class McdonaldsSpider(Spider):
             properties = store["properties"]
             store_identifier = properties["identifierValue"]
             store_url = None
-            if locale in ["en-ca", "en-gb", "en-ie", "en-us", "fi-fi", "fr-ch", "hu-hu", "sv-se", "zh-tw", "hr-hr"]:
+            if locale in [
+                "en-ca",
+                "en-gb",
+                "en-ie",
+                "en-nz",
+                "en-us",
+                "fi-fi",
+                "fr-ch",
+                "hu-hu",
+                "sv-se",
+                "zh-tw",
+                "hr-hr",
+            ]:
                 # Individual store site pages in these locale's have a common pattern.
                 store_url = "https://www.mcdonalds.com/{}/{}/location/{}.html".format(country, locale, store_identifier)
             elif locale in ["de-de"]:

--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -20,7 +20,7 @@ class McdonaldsSpider(Spider):
     }
     allowed_domains = ["www.mcdonalds.com"]
 
-    ISEADGG_COUNTRIES = {"NZ"}
+    ISEADGG_COUNTRIES = {"NZ", "US"}
 
     async def start(self) -> AsyncIterator[Request]:
         template = "https://www.mcdonalds.com/googleappsv2/geolocation?latitude={}&longitude={}&radius=50&maxResults=250&country={}&language={}&showClosed="

--- a/locations/spiders/mcdonalds_nz.py
+++ b/locations/spiders/mcdonalds_nz.py
@@ -1,7 +1,0 @@
-from locations.spiders.mcdonalds_eg import McdonaldsEGSpider
-
-
-class McdonaldsNZSpider(McdonaldsEGSpider):
-    name = "mcdonalds_nz"
-    allowed_domains = ["mcdonalds.co.nz"]
-    start_urls = ["https://mcdonalds.co.nz/data/store"]


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                    
  - Consolidate `mcdonalds_nz` spider into the main `mcdonalds` spider by adding the `en-nz` locale to the centralized geolocation  API                                                                                                                               
  - Use ISEADGG evenly-spaced search points (radius 48km) for NZ and US instead of `city_locations()`, which missed smaller towns   
  - Delete the now-redundant `mcdonalds_nz.py` (which inherited from the Egypt spider)                                              
  - Extend approach to US
                                                                                                                                    
  ## Testing                                                                                                                        
                                                                                                                                    
  ### New Zealand                                                                                                                   
                                                                                                                                    
  The main API was confirmed to return NZ data. Three search strategies were compared:                                              
                                                                                                                                    
  | Approach | McDonald's locations | McCafé | Total | Requests |                                                                   
  |----------|---------------------|--------|-------|----------|                                                                    
  | `mcdonalds_nz` (old dedicated spider) | 173 | 0 | 173 | 1 |                                                                     
  | Main spider + `city_locations` | 161 | 2 | 163 | 42 |                                                                           
  | Main spider + ISEADGG(48) | 176 | 2 | 178 | 100 |                                                                               
                                                                                                                                    
  The old `mcdonalds.co.nz/data/store` endpoint has no date metadata and returns fewer locations (173) than the main API (176), suggesting it may not be kept fully up to date.           
                                                                                                                                    
  ### United States                                                                                                                 
   
  | Approach | McDonald's locations | Requests |                                                                                    
  |----------|---------------------|----------|             
  | `city_locations('US', 20000)` (current) | 12,540 | 2,592 |
  | ISEADGG(48) | 13,728 | 1,927 |                                                                                                  
   
  +1,188 locations (~9.5% more) with 665 fewer requests. The additional locations are primarily rural/small-town McDonald's that fell outside the city-based search radius.  New count aligns well with known Yext and Tripadvisor numbers.       
                                                                                                                                    
  ## Follow-up                                              

  The ISEADGG approach will be attempted for other locales in the main spider that are a few burgers short of a Big Mac (AU, CA)  where `city_locations()` likely leaves rural coverage gaps.
                                                                                                                                    
  🤖 Generated with [Claude Code](https://claude.com/claude-code)