### PR TITLE
[GB Addresses] Add Stoke-on-Trent City Council data

### DIFF
--- a/locations/spiders/addresses/gb/gb_stoke_on_trent.py
+++ b/locations/spiders/addresses/gb/gb_stoke_on_trent.py
@@ -12,7 +12,7 @@ from locations.spiders.addresses.gb.owen_base_spider import OwenBaseSpider
 class GBStokeOnTrentSpider(OwenBaseSpider):
     name = "gb_stoke_on_trent"
     dataset_attributes = Licenses.GB_OGLv3.value | {
-        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0."  #  address strings                                                                                # address strings
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0."  # address strings                                                                                # address strings
         + " Contains OS data © Crown copyright and database right 2025."  # OS Open UPRN, coords
         + " Contains Royal Mail data © Royal Mail copyright and Database right."  # Postcodes
         + " Contains GeoPlace data © Local Government Information House Limited copyright and database right."

--- a/locations/spiders/addresses/gb/gb_stoke_on_trent.py
+++ b/locations/spiders/addresses/gb/gb_stoke_on_trent.py
@@ -1,0 +1,110 @@
+import re
+from typing import Any, Self
+
+from scrapy.crawler import Crawler
+
+from locations.items import Feature
+from locations.licenses import Licenses
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.spiders.addresses.gb.owen_base_spider import OwenBaseSpider
+
+
+class GBStokeOnTrentSpider(OwenBaseSpider):
+    name = "gb_stoke_on_trent"
+    dataset_attributes = Licenses.GB_OGLv3.value | {
+        "attribution:name": "Contains public sector information licensed under the Open Government Licence v3.0."  #  address strings                                                                                # address strings
+        + " Contains OS data © Crown copyright and database right 2025."  # OS Open UPRN, coords
+        + " Contains Royal Mail data © Royal Mail copyright and Database right."  # Postcodes
+        + " Contains GeoPlace data © Local Government Information House Limited copyright and database right."
+        + " Office for National Statistics licensed under the Open Government Licence v.3.0."
+    }
+
+    drive_id = "1P9KpC-J3wZGAv48gpDnV3s_5VxllDVDX"
+    csv_filename = "STOKE_CTBANDS_OSOU_202604.csv"
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler, *args: Any, **kwargs: Any) -> Self:
+        spider = super().from_crawler(crawler, *args, **kwargs)
+        spider._re = re.compile(
+            r"^(.+?)(?: ({}))?, (Stoke-on-Trent|Newcastle Under Lyme)$".format(
+                "|".join(
+                    [
+                        # "suburbs"
+                        "Abbey Hulton",
+                        "Adderley Green",
+                        "Baddeley Edge",
+                        "Baddeley Green",
+                        "Ball Green",
+                        "Basford",
+                        "Bentilee",
+                        "Berry Hill",
+                        "Birches Head",
+                        "Blurton",
+                        "Bradeley",
+                        "Bucknall",
+                        "Burslem",
+                        "Chell Heath",
+                        "Chell",
+                        "Cliff Vale",
+                        "Cobridge",
+                        "Dresden",
+                        "Eaton Park",
+                        "Etruria",
+                        "Fegg Hayes",
+                        "Fenton",
+                        "Goldenhill",
+                        "Hanford",
+                        "Hanley",
+                        "Hartshill",
+                        "Heron Cross",
+                        "Lightwood",
+                        "Longport",
+                        "Longton",
+                        "Meir Hay",
+                        "Meir Park",
+                        "Meir",
+                        "Middleport",
+                        "Milton",
+                        "Moss Green Village",
+                        "Newstead",
+                        "Normacot",
+                        "Northwood",
+                        "Norton Chase",
+                        "Norton Green",
+                        "Norton",
+                        "Oakhill",
+                        "Packmoor",
+                        "Penkhull",
+                        "Pittshill",
+                        "Sandford Hill",
+                        "Sandyford",
+                        "Shelton",
+                        "Smallthorne",
+                        "Sneyd Green",
+                        "Stanfield",
+                        "Trent Vale",
+                        "Trentham",
+                        "Tunstall",
+                        "Weston Coyney",
+                    ]
+                )
+            )
+        )
+        return spider
+
+    def parse_row(self, item: Feature, addr: dict):
+        if (
+            addr["ADDR"].endswith(", Burslem")
+            or addr["ADDR"].endswith(", Stockton Brook")
+            or addr["ADDR"].endswith(", Norton")
+        ):
+            addr["ADDR"] += ", Stoke-on-Trent"
+        if m := self._re.match(
+            addr["ADDR"]
+            .replace(", Stoke-on-Trent, Baddeley Green", ", Baddeley Green, Stoke-on-Trent")
+            .replace(", Stoke-on-Trent, Middleport", ", Middleport, Stoke-on-Trent")
+            .replace(", Newcastle, Staffs", ", Newcastle Under Lyme")
+        ):
+            item["street_address"], item["extras"]["addr:suburb"], item["city"] = m.groups()
+        else:
+            item["addr_full"] = merge_address_lines([addr["ADDR"], item.get("postcode")])


### PR DESCRIPTION
```python
{'atp/clean_strings/ref': 2,
 'atp/country/GB': 120616,
 'atp/field/branch/missing': 120616,
 'atp/field/brand/missing': 120616,
 'atp/field/brand_wikidata/missing': 120616,
 'atp/field/email/missing': 120616,
 'atp/field/geometry/invalid': 1842,
 'atp/field/image/missing': 120616,
 'atp/field/name/missing': 120616,
 'atp/field/opening_hours/missing': 120616,
 'atp/field/operator/missing': 120616,
 'atp/field/operator_wikidata/missing': 120616,
 'atp/field/phone/missing': 120616,
 'atp/field/postcode/missing': 2360,
 'atp/field/state/missing': 120616,
 'atp/field/twitter/missing': 120616,
 'atp/field/website/missing': 120616,
 'atp/item_scraped_host_count/drive.usercontent.google.com': 120616,
 'atp/lineage': 'S_ATP_ADDRESSES',
 'downloader/request_bytes': 407,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 11645205,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 33.43566,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 16, 10, 26, 57, 151493, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1,
 'item_scraped_count': 120616,
 'items_per_minute': 219301.81818181818,
 'log_count/INFO': 2,
 'log_count/WARNING': 1,
 'memusage/max': 329396224,
 'memusage/startup': 329396224,
 'response_received_count': 1,
 'responses_per_minute': 1.8181818181818181,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 16, 10, 26, 23, 715833, tzinfo=datetime.timezone.utc)}
```