### PR TITLE
[Orange FR] Fix Spider

### DIFF
--- a/locations/spiders/orange_fr.py
+++ b/locations/spiders/orange_fr.py
@@ -17,7 +17,7 @@ class OrangeFRSpider(Spider):
 
     def make_request(self, page: int, page_size: int = 100) -> JsonRequest:
         return JsonRequest(
-            url="https://7jl9sk5vbq-dsn.algolia.net/1/indexes/stores_locator_ofr/query?x-algolia-application-id=7JL9SK5VBQ&x-algolia-api-key=409fd5e4ef65efe7dacf57d93698910c",
+            url="https://7jl9sk5vbq-dsn.algolia.net/1/indexes/stores_locator_ofr/query?x-algolia-application-id=7JL9SK5VBQ&x-algolia-api-key=b2b7037d97e57d65b53dc5daab37b989",
             data={"params": "hitsPerPage={}&page={}".format(page_size, page)},
         )
 

--- a/locations/spiders/orange_fr.py
+++ b/locations/spiders/orange_fr.py
@@ -11,7 +11,7 @@ from locations.items import Feature
 
 class OrangeFRSpider(Spider):
     name = "orange_fr"
-    item_attributes = {"brand": "Orange", "brand_wikidata": "Q1431486", "nsi_id": "N/A"}
+    item_attributes = {"brand": "Orange", "brand_wikidata": "Q1431486"}
     skip_auto_cc_domain = True
     skip_auto_cc_spider_name = True
 
@@ -45,7 +45,7 @@ class OrangeFRSpider(Spider):
                 for time in times:
                     item["opening_hours"].add_range(day, time[0], time[1])
 
-            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+            apply_category(Categories.SHOP_TELECOMMUNICATION, item)
 
             yield item
 

--- a/locations/spiders/orange_fr.py
+++ b/locations/spiders/orange_fr.py
@@ -31,7 +31,7 @@ class OrangeFRSpider(Spider):
                 continue
             item = Feature()
             item["ref"] = location["objectID"]
-            item["name"] = location["Location name"]
+            item["branch"] = location["Location name"].removeprefix("Orange").strip(" -")
             item["lat"] = location["_geoloc"]["lat"]
             item["lon"] = location["_geoloc"]["lng"]
             item["website"] = urljoin("https://agence.orange.fr/", location["URL"])


### PR DESCRIPTION
```python
{'atp/brand/Orange': 579,
 'atp/brand_wikidata/Q1431486': 579,
 'atp/category/shop/mobile_phone': 579,
 'atp/country/BL': 1,
 'atp/country/ES': 1,
 'atp/country/FR': 547,
 'atp/country/GF': 5,
 'atp/country/GP': 6,
 'atp/country/MC': 1,
 'atp/country/MF': 1,
 'atp/country/MQ': 5,
 'atp/country/RE': 10,
 'atp/country/YT': 2,
 'atp/field/branch/missing': 579,
 'atp/field/country/from_reverse_geocoding': 579,
 'atp/field/email/missing': 579,
 'atp/field/image/missing': 579,
 'atp/field/operator/missing': 579,
 'atp/field/operator_wikidata/missing': 579,
 'atp/field/state/missing': 3,
 'atp/field/twitter/missing': 579,
 'atp/item_scraped_host_count/7jl9sk5vbq-dsn.algolia.net': 579,
 'atp/lineage': 'S_?',
 'downloader/request_bytes': 5275,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 7,
 'downloader/response_bytes': 101503,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 7,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 8.545594,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 16, 11, 10, 1, 469614, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 7,
 'httpcache/hit': 2,
 'httpcache/miss': 7,
 'httpcache/store': 7,
 'httpcompression/response_bytes': 1242877,
 'httpcompression/response_count': 6,
 'item_scraped_count': 579,
 'items_per_minute': 4342.5,
 'log_count/DEBUG': 590,
 'log_count/INFO': 3,
 'request_depth_max': 6,
 'response_received_count': 8,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2026, 4, 16, 11, 9, 52, 924020, tzinfo=datetime.timezone.utc)}
```