### PR TITLE
[Rei US] Fix spider

### DIFF
--- a/locations/spiders/rei_us.py
+++ b/locations/spiders/rei_us.py
@@ -1,27 +1,56 @@
-from scrapy.spiders import SitemapSpider
+import json
+from typing import Iterable
 
-from locations.hours import OpeningHours, day_range
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response, TextResponse
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class ReiUSSpider(SitemapSpider, StructuredDataSpider):
+class ReiUSSpider(JSONBlobSpider, PlaywrightSpider):
     name = "rei_us"
-    item_attributes = {"brand": "REI", "brand_wikidata": "Q3414933", "country": "US"}
-    sitemap_urls = ["https://www.rei.com/sitemap-stores.xml"]
-    sitemap_rules = [(r"^https://www.rei.com/stores/([^/]+)$", "parse_sd")]
-    wanted_types = ["Store"]
+    item_attributes = {
+        "brand": "REI",
+        "brand_wikidata": "Q3414933",
+        "country": "US",
+    }
+
+    start_urls = ["https://www.rei.com/stores/map"]
     requires_proxy = True
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = response.url
-        item["branch"] = item.pop("name")
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "USER_AGENT": BROWSER_DEFAULT,
+    }
 
-        item["opening_hours"] = OpeningHours()
-        for rule in ld_data.get("openingHours", []):
-            days, times = rule.rsplit(" ", 1)
-            if "-" in days:
-                start_day, end_day = days.split(" - ")
-            else:
-                start_day = end_day = days
-            item["opening_hours"].add_days_range(day_range(start_day, end_day), *times.split("-"))
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        raw_data = response.xpath('//script[@id="modelData"]/text()').get()
+        if not raw_data:
+            return []
+        data = json.loads(raw_data)
+        raw_stores = data.get("pageData", {}).get("allStores", {}).get("storeLocatorDataQueryModelList", [])
+        return [s.get("storeDataModel") for s in raw_stores if s.get("storeDataModel")]
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = str(feature.get("storeNumber"))
+
+        if url_path := feature.get("storePageUrl"):
+            item["website"] = f"https://www.rei.com/{url_path.lstrip('/')}"
+
+        if hours_list := feature.get("storeHours"):
+            item["opening_hours"] = self.parse_opening_hours(hours_list)
+
         yield item
+
+    def parse_opening_hours(self, hours_list: list) -> str:
+        oh = OpeningHours()
+        for h in hours_list:
+            day_part = h.get("days")
+            open_t = h.get("openAt")
+            close_t = h.get("closeAt")
+            if day_part and open_t and close_t:
+                oh.add_ranges_from_string(f"{day_part} {open_t} - {close_t}")
+        return oh

--- a/locations/spiders/rei_us.py
+++ b/locations/spiders/rei_us.py
@@ -3,7 +3,7 @@ from typing import Iterable
 
 from scrapy.http import Response, TextResponse
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider

--- a/locations/spiders/rei_us.py
+++ b/locations/spiders/rei_us.py
@@ -3,6 +3,7 @@ from typing import Iterable
 
 from scrapy.http import Response, TextResponse
 
+from locations.categories import apply_category, Categories
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -13,18 +14,12 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class ReiUSSpider(JSONBlobSpider, PlaywrightSpider):
     name = "rei_us"
-    item_attributes = {
-        "brand": "REI",
-        "brand_wikidata": "Q3414933",
-        "country": "US",
-    }
+    item_attributes = {"brand": "REI", "brand_wikidata": "Q3414933"}
 
     start_urls = ["https://www.rei.com/stores/map"]
     requires_proxy = True
 
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "USER_AGENT": BROWSER_DEFAULT,
-    }
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def extract_json(self, response: TextResponse) -> list[dict]:
         raw_data = response.xpath('//script[@id="modelData"]/text()').get()
@@ -36,6 +31,7 @@ class ReiUSSpider(JSONBlobSpider, PlaywrightSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(feature.get("storeNumber"))
+        item["branch"] = item.pop("name")
 
         if url_path := feature.get("storePageUrl"):
             item["website"] = f"https://www.rei.com/{url_path.lstrip('/')}"
@@ -43,14 +39,12 @@ class ReiUSSpider(JSONBlobSpider, PlaywrightSpider):
         if hours_list := feature.get("storeHours"):
             item["opening_hours"] = self.parse_opening_hours(hours_list)
 
+        apply_category(Categories.SHOP_OUTDOOR, item)
+
         yield item
 
-    def parse_opening_hours(self, hours_list: list) -> str:
+    def parse_opening_hours(self, hours_list: list) -> OpeningHours:
         oh = OpeningHours()
         for h in hours_list:
-            day_part = h.get("days")
-            open_t = h.get("openAt")
-            close_t = h.get("closeAt")
-            if day_part and open_t and close_t:
-                oh.add_ranges_from_string(f"{day_part} {open_t} - {close_t}")
+            oh.add_ranges_from_string("{} {} - {}".format(h.get("days"), h.get("openAt"), h.get("closeAt")))
         return oh


### PR DESCRIPTION
``` python
{'atp/brand/REI': 195,
 'atp/brand_wikidata/Q3414933': 195,
 'atp/category/shop/outdoor': 195,
 'atp/country/US': 195,
 'atp/field/branch/missing': 195,
 'atp/field/email/missing': 195,
 'atp/field/image/missing': 195,
 'atp/field/operator/missing': 195,
 'atp/field/operator_wikidata/missing': 195,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 195,
 'atp/item_scraped_host_count/www.rei.com': 195,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 195,
 'downloader/request_bytes': 522,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1374457,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.315834,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 17, 5, 52, 52, 340098, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 195,
 'items_per_minute': 1462.5,
 'log_count/DEBUG': 267,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 33,
 'playwright/request_count/aborted': 31,
 'playwright/request_count/method/GET': 33,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/image': 1,
 'playwright/request_count/resource_type/script': 16,
 'playwright/request_count/resource_type/stylesheet': 14,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 17, 5, 52, 44, 24264, tzinfo=datetime.timezone.utc)}
```