### PR TITLE
Add grouped spider runs infrastructure

### DIFF
--- a/ci/assemble_latest.sh
+++ b/ci/assemble_latest.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${S3_BUCKET:-}" ]; then
+    (>&2 echo "Please set S3_BUCKET environment variable")
+    exit 1
+fi
+
+if [ -z "${R2_BUCKET:-}" ]; then
+    (>&2 echo "Please set R2_BUCKET environment variable")
+    exit 1
+fi
+
+if [ -z "${R2_ENDPOINT_URL:-}" ]; then
+    (>&2 echo "Please set R2_ENDPOINT_URL environment variable")
+    exit 1
+fi
+
+if [ -z "${R2_ACCESS_KEY_ID:-}" ]; then
+    (>&2 echo "Please set R2_ACCESS_KEY_ID environment variable")
+    exit 1
+fi
+
+if [ -z "${R2_SECRET_ACCESS_KEY:-}" ]; then
+    (>&2 echo "Please set R2_SECRET_ACCESS_KEY environment variable")
+    exit 1
+fi
+
+if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+    (>&2 echo "Please set GITHUB_WORKSPACE environment variable")
+    exit 1
+fi
+
+URL_PREFIX="https://alltheplaces-data.openaddresses.io"
+WORK_DIR="${GITHUB_WORKSPACE}/assemble"
+MANIFESTS_DIR="${WORK_DIR}/manifests"
+STATS_DIR="${WORK_DIR}/stats"
+OUTPUT_DIR="${WORK_DIR}/output"
+DOWNLOAD_PARALLELISM=${DOWNLOAD_PARALLELISM:-12}
+
+mkdir -p "${MANIFESTS_DIR}" "${STATS_DIR}" "${OUTPUT_DIR}"
+
+# ──────────────────────────────────────────────
+# Step 1: Download all group manifest files
+# ──────────────────────────────────────────────
+(>&2 echo "Downloading manifest files from S3")
+uv run aws s3 sync \
+    --only-show-errors \
+    --exclude "*" \
+    --include "*.manifest.json" \
+    "s3://${S3_BUCKET}/runs/latest/" \
+    "${MANIFESTS_DIR}/"
+
+MANIFEST_COUNT=$(ls "${MANIFESTS_DIR}"/*.manifest.json 2>/dev/null | wc -l | tr -d ' ')
+if [ "${MANIFEST_COUNT}" -eq 0 ]; then
+    (>&2 echo "No manifest files found, nothing to assemble")
+    exit 1
+fi
+(>&2 echo "Downloaded ${MANIFEST_COUNT} manifest files")
+
+# ──────────────────────────────────────────────
+# Step 2: Merge manifests into latest.json
+# ──────────────────────────────────────────────
+(>&2 echo "Building latest.json from manifests")
+uv run python ci/build_latest_json.py \
+    --manifests-dir "${MANIFESTS_DIR}" \
+    --url-prefix "${URL_PREFIX}" \
+    --output "${WORK_DIR}/latest.json"
+
+(>&2 echo "Built latest.json")
+
+# ──────────────────────────────────────────────
+# Step 3: Build global stats/_results.json
+# ──────────────────────────────────────────────
+(>&2 echo "Building _results.json from manifests")
+
+NOW_EPOCH=$(date +%s)
+
+# Start with an empty results array
+echo '{"count": 0, "results": []}' > "${STATS_DIR}/_results.json"
+
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    group_name=$(jq -r '.group // empty' "${manifest_file}")
+    run_id=$(jq -r '.run_id // empty' "${manifest_file}")
+    updated_at=$(jq -r '.updated_at // empty' "${manifest_file}")
+
+    # Iterate each spider in this manifest
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        spider_entry=$(jq -c --arg s "${spider_name}" '.spiders[$s]' "${manifest_file}")
+
+        feature_count=$(echo "${spider_entry}" | jq -r '.feature_count // 0')
+        error_count=$(echo "${spider_entry}" | jq -r '.error_count // 0')
+        elapsed_time=$(echo "${spider_entry}" | jq -r '.elapsed_time // 0')
+        ran_at=$(echo "${spider_entry}" | jq -r '.ran_at // empty')
+
+        # Compute data_age_days
+        data_age_days=0
+        if [ -n "${ran_at}" ]; then
+            ran_at_epoch=$(date -d "${ran_at}" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "${ran_at}" +%s 2>/dev/null || echo "0")
+            if [ "${ran_at_epoch}" -gt 0 ]; then
+                data_age_days=$(( (NOW_EPOCH - ran_at_epoch) / 86400 ))
+            fi
+        fi
+
+        jq --compact-output \
+            --arg spider_name "${spider_name}" \
+            --arg spider_feature_count "${feature_count}" \
+            --arg spider_error_count "${error_count}" \
+            --arg spider_elapsed_time "${elapsed_time}" \
+            --arg run_group "${group_name}" \
+            --arg last_run_time "${ran_at}" \
+            --arg last_run_id "${run_id}" \
+            --arg data_age_days "${data_age_days}" \
+            '.count += 1 | .results += [{"spider": $spider_name, "features": ($spider_feature_count | tonumber), "errors": ($spider_error_count | tonumber), "elapsed_time": ($spider_elapsed_time | tonumber), "run_group": $run_group, "last_run_time": $last_run_time, "last_run_id": $last_run_id, "data_age_days": ($data_age_days | tonumber)}]' \
+            "${STATS_DIR}/_results.json" > "${STATS_DIR}/_results.json.tmp"
+        mv "${STATS_DIR}/_results.json.tmp" "${STATS_DIR}/_results.json"
+    done
+done
+
+SPIDER_COUNT=$(jq '.count' "${STATS_DIR}/_results.json")
+(>&2 echo "Built _results.json with ${SPIDER_COUNT} spiders")
+
+# ──────────────────────────────────────────────
+# Step 4: Download per-spider geojsons for insights
+# ──────────────────────────────────────────────
+(>&2 echo "Downloading geojson files for insights")
+
+> "${WORK_DIR}/download_commands.txt"
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        geojson_url=$(jq -r --arg s "${spider_name}" '.spiders[$s].geojson_url // empty' "${manifest_file}")
+        if [ -n "${geojson_url}" ]; then
+            # Convert URL to S3 key: strip the URL prefix to get the path
+            s3_key="${geojson_url#${URL_PREFIX}/}"
+            echo "uv run aws s3 cp --only-show-errors s3://${S3_BUCKET}/${s3_key} ${OUTPUT_DIR}/${spider_name}.geojson" >> "${WORK_DIR}/download_commands.txt"
+        fi
+    done
+done
+
+DOWNLOAD_COUNT=$(wc -l < "${WORK_DIR}/download_commands.txt" | tr -d ' ')
+if [ "${DOWNLOAD_COUNT}" -gt 0 ]; then
+    (>&2 echo "Downloading ${DOWNLOAD_COUNT} geojson files ${DOWNLOAD_PARALLELISM} at a time")
+    xargs -L 1 -P "${DOWNLOAD_PARALLELISM}" -a "${WORK_DIR}/download_commands.txt" -I{} sh -c "{} || true"
+    (>&2 echo "Done downloading geojson files")
+else
+    (>&2 echo "No geojson files to download")
+fi
+
+# ──────────────────────────────────────────────
+# Step 5: Run insights
+# ──────────────────────────────────────────────
+(>&2 echo "Running insights")
+uv run scrapy insights --atp-nsi-osm "${OUTPUT_DIR}" --outfile "${STATS_DIR}/_insights.json"
+(>&2 echo "Done comparing against Name Suggestion Index and OpenStreetMap")
+
+# ──────────────────────────────────────────────
+# Step 6: Upload stats to S3 and R2
+# ──────────────────────────────────────────────
+(>&2 echo "Uploading stats to S3")
+uv run aws s3 sync \
+    --only-show-errors \
+    "${STATS_DIR}/" \
+    "s3://${S3_BUCKET}/runs/latest/stats/"
+
+(>&2 echo "Uploading stats to R2")
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 sync \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    --only-show-errors \
+    "${STATS_DIR}/" \
+    "s3://${R2_BUCKET}/runs/latest/stats/"
+
+(>&2 echo "Done uploading stats")
+
+# ──────────────────────────────────────────────
+# Step 7: Upload latest.json to S3 and R2
+# ──────────────────────────────────────────────
+(>&2 echo "Uploading latest.json to S3")
+uv run aws s3 cp \
+    --only-show-errors \
+    "${WORK_DIR}/latest.json" \
+    "s3://${S3_BUCKET}/runs/latest.json"
+
+(>&2 echo "Uploading latest.json to R2")
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    cp \
+    --only-show-errors \
+    "${WORK_DIR}/latest.json" \
+    "s3://${R2_BUCKET}/runs/latest.json"
+
+(>&2 echo "Saved latest.json")
+
+# ──────────────────────────────────────────────
+# Step 8: Append to global history.json
+# ──────────────────────────────────────────────
+(>&2 echo "Updating history.json")
+
+uv run aws s3 cp \
+    --only-show-errors \
+    "s3://${S3_BUCKET}/runs/history.json" \
+    "${WORK_DIR}/history.json" || true
+
+if [ ! -s "${WORK_DIR}/history.json" ]; then
+    echo '[]' > "${WORK_DIR}/history.json"
+fi
+
+jq --compact-output \
+    --argjson latest_run_info "$(<"${WORK_DIR}/latest.json")" \
+    '. += [$latest_run_info]' "${WORK_DIR}/history.json" > "${WORK_DIR}/history.json.tmp"
+mv "${WORK_DIR}/history.json.tmp" "${WORK_DIR}/history.json"
+
+uv run aws s3 cp \
+    --only-show-errors \
+    "${WORK_DIR}/history.json" \
+    "s3://${S3_BUCKET}/runs/history.json"
+
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    cp \
+    --only-show-errors \
+    "${WORK_DIR}/history.json" \
+    "s3://${R2_BUCKET}/runs/history.json"
+
+(>&2 echo "Saved history.json")
+
+# ──────────────────────────────────────────────
+# Step 9: Update per-group artifact redirects
+# ──────────────────────────────────────────────
+(>&2 echo "Updating per-group artifact redirects")
+
+touch "${WORK_DIR}/latest_placeholder.txt"
+
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    group_name=$(jq -r '.group // empty' "${manifest_file}")
+    run_id=$(jq -r '.run_id // empty' "${manifest_file}")
+
+    if [ -z "${group_name}" ] || [ -z "${run_id}" ]; then
+        continue
+    fi
+
+    group_run_url="${URL_PREFIX}/runs/${group_name}/${run_id}"
+
+    for ext in zip parquet pmtiles; do
+        uv run aws s3 cp \
+            --only-show-errors \
+            --website-redirect="${group_run_url}/${group_name}.${ext}" \
+            "${WORK_DIR}/latest_placeholder.txt" \
+            "s3://${S3_BUCKET}/runs/latest/${group_name}.${ext}" || \
+            (>&2 echo "Couldn't update latest/${group_name}.${ext} redirect")
+    done
+done
+
+(>&2 echo "Done updating per-group artifact redirects")
+
+# ──────────────────────────────────────────────
+# Step 10: Update per-spider geojson redirects
+# ──────────────────────────────────────────────
+(>&2 echo "Updating per-spider geojson redirects")
+
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        geojson_url=$(jq -r --arg s "${spider_name}" '.spiders[$s].geojson_url // empty' "${manifest_file}")
+        if [ -z "${geojson_url}" ]; then
+            continue
+        fi
+
+        uv run aws s3 cp \
+            --only-show-errors \
+            --website-redirect="${geojson_url}" \
+            "${WORK_DIR}/latest_placeholder.txt" \
+            "s3://${S3_BUCKET}/runs/latest/output/${spider_name}.geojson" || \
+            (>&2 echo "Couldn't update latest/output/${spider_name}.geojson redirect in S3")
+
+        AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+        AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+        uv run aws s3 \
+            --endpoint-url="${R2_ENDPOINT_URL}" \
+            cp \
+            --only-show-errors \
+            --website-redirect="${geojson_url}" \
+            "${WORK_DIR}/latest_placeholder.txt" \
+            "s3://${R2_BUCKET}/runs/latest/output/${spider_name}.geojson" || \
+            (>&2 echo "Couldn't update latest/output/${spider_name}.geojson redirect in R2")
+    done
+done
+
+(>&2 echo "Done updating per-spider geojson redirects")
+
+# ──────────────────────────────────────────────
+# Step 11: Write info_embed.html
+# ──────────────────────────────────────────────
+(>&2 echo "Writing info_embed.html")
+
+{
+    echo '<html><body>'
+    echo '<table>'
+    echo '<tr><th>Group</th><th>Spiders</th><th>Features</th><th>Download</th></tr>'
+
+    for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+        group_name=$(jq -r '.group // empty' "${manifest_file}")
+        spider_count=$(jq -r '.spiders | length' "${manifest_file}")
+        feature_count=$(jq -r '[.spiders[].feature_count // 0] | add // 0' "${manifest_file}")
+
+        echo "<tr><td>${group_name}</td><td>${spider_count}</td><td>${feature_count}</td><td><a href=\"${URL_PREFIX}/runs/latest/${group_name}.zip\">zip</a></td></tr>"
+    done
+
+    echo '</table>'
+    echo "<small>Updated $(date)</small>"
+    echo '</body></html>'
+} > "${WORK_DIR}/info_embed.html"
+
+uv run aws s3 cp \
+    --only-show-errors \
+    --content-type "text/html; charset=utf-8" \
+    "${WORK_DIR}/info_embed.html" \
+    "s3://${S3_BUCKET}/runs/latest/info_embed.html"
+
+(>&2 echo "Saved info_embed.html")
+
+# ──────────────────────────────────────────────
+# Step 12: Purge CDN
+# ──────────────────────────────────────────────
+if [ -z "${BUNNY_API_KEY:-}" ]; then
+    (>&2 echo "Skipping CDN cache purge because BUNNY_API_KEY environment variable not set")
+else
+    curl --request GET \
+         --silent \
+         --url 'https://api.bunny.net/purge?url=https%3A%2F%2Falltheplaces.b-cdn.net%2Fruns%2Flatest.json&async=false' \
+         --header "AccessKey: ${BUNNY_API_KEY}" \
+         --header 'accept: application/json'
+    (>&2 echo "Purged latest.json from CDN")
+
+    curl --request GET \
+         --silent \
+         --url 'https://api.bunny.net/purge?url=https%3A%2F%2Falltheplaces.b-cdn.net%2Fruns%2Fhistory.json&async=false' \
+         --header "AccessKey: ${BUNNY_API_KEY}" \
+         --header 'accept: application/json'
+    (>&2 echo "Purged history.json from CDN")
+
+    curl --request GET \
+         --silent \
+         --url 'https://api.bunny.net/purge?url=https%3A%2F%2Falltheplaces.b-cdn.net%2Fruns%2Flatest%2Foutput%2F%2A&async=false' \
+         --header "AccessKey: ${BUNNY_API_KEY}" \
+         --header 'accept: application/json'
+    (>&2 echo "Purged latest/output/* from CDN")
+fi
+
+(>&2 echo "Assembly complete")

--- a/ci/build_group_manifest.py
+++ b/ci/build_group_manifest.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -58,7 +59,6 @@ def build_manifest(
 
 
 def main():
-    import argparse
 
     parser = argparse.ArgumentParser(description="Build or update a group manifest")
     parser.add_argument("--group", required=True, help="Group name")
@@ -71,7 +71,7 @@ def main():
 
     args = parser.parse_args()
 
-    spider_names = Path(args.spider_list).read_text().strip().splitlines()
+    spider_names = [s for s in Path(args.spider_list).read_text().strip().splitlines() if s]
     stats_dir = Path(args.stats_dir)
 
     previous_manifest = None

--- a/ci/build_group_manifest.py
+++ b/ci/build_group_manifest.py
@@ -1,0 +1,94 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build_manifest(
+    group: str,
+    run_id: str,
+    run_url_prefix: str,
+    spider_names: list[str],
+    stats_dir: Path,
+    previous_manifest: dict | None,
+) -> dict:
+    """Build a group manifest by merging current run results with previous manifest.
+
+    Spiders that succeeded (non-zero item_scraped_count) get fresh entries.
+    Spiders that failed or produced zero items keep their previous entry.
+    Spiders no longer in the group are dropped.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    previous_spiders = (previous_manifest or {}).get("spiders", {})
+    spiders = {}
+
+    for spider_name in spider_names:
+        stats_file = stats_dir / f"{spider_name}.json"
+
+        if stats_file.exists():
+            try:
+                stats = json.loads(stats_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                stats = {}
+
+            feature_count = stats.get("item_scraped_count", 0) or 0
+            error_count = stats.get("log_count/ERROR", 0) or 0
+            elapsed_time = stats.get("elapsed_time_seconds", 0) or 0
+
+            if feature_count > 0:
+                spiders[spider_name] = {
+                    "run_id": run_id,
+                    "ran_at": now,
+                    "geojson_url": f"{run_url_prefix}/output/{spider_name}.geojson",
+                    "stats_url": f"{run_url_prefix}/stats/{spider_name}.json",
+                    "feature_count": feature_count,
+                    "error_count": error_count,
+                    "elapsed_time": elapsed_time,
+                }
+                continue
+
+        if spider_name in previous_spiders:
+            spiders[spider_name] = previous_spiders[spider_name]
+
+    return {
+        "group": group,
+        "updated_at": now,
+        "run_id": run_id,
+        "spiders": spiders,
+    }
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build or update a group manifest")
+    parser.add_argument("--group", required=True, help="Group name")
+    parser.add_argument("--run-id", required=True, help="Run timestamp ID")
+    parser.add_argument("--run-url-prefix", required=True, help="URL prefix for this run")
+    parser.add_argument("--spider-list", required=True, help="File with spider names, one per line")
+    parser.add_argument("--stats-dir", required=True, help="Directory containing per-spider stats JSON files")
+    parser.add_argument("--previous-manifest", help="Path to previous manifest JSON file (optional)")
+    parser.add_argument("--output", required=True, help="Output manifest file path")
+
+    args = parser.parse_args()
+
+    spider_names = Path(args.spider_list).read_text().strip().splitlines()
+    stats_dir = Path(args.stats_dir)
+
+    previous_manifest = None
+    if args.previous_manifest and Path(args.previous_manifest).exists():
+        previous_manifest = json.loads(Path(args.previous_manifest).read_text())
+
+    manifest = build_manifest(
+        group=args.group,
+        run_id=args.run_id,
+        run_url_prefix=args.run_url_prefix,
+        spider_names=spider_names,
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    Path(args.output).write_text(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build_latest_json.py
+++ b/ci/build_latest_json.py
@@ -1,0 +1,96 @@
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def build_latest_json(manifests_dir: Path, url_prefix: str) -> dict:
+    """Merge all group manifests into a single latest.json.
+
+    Args:
+        manifests_dir: Directory containing *.manifest.json files.
+        url_prefix: Base URL for constructing per-group artifact URLs.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    manifest_files = sorted(manifests_dir.glob("*.manifest.json"))
+
+    all_spiders: dict[str, tuple[str, dict]] = {}
+    group_data: dict[str, dict] = {}
+
+    for mf in manifest_files:
+        try:
+            manifest = json.loads(mf.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Skipping %s: %s", mf, e)
+            continue
+
+        group_name = manifest.get("group", mf.stem.replace(".manifest", ""))
+        group_data[group_name] = manifest
+
+        for spider_name, entry in manifest.get("spiders", {}).items():
+            if spider_name in all_spiders:
+                existing_group, existing_entry = all_spiders[spider_name]
+                if entry.get("ran_at", "") > existing_entry.get("ran_at", ""):
+                    logger.warning(
+                        "Spider %s found in both %s and %s, keeping %s (more recent)",
+                        spider_name, existing_group, group_name, group_name,
+                    )
+                    all_spiders[spider_name] = (group_name, entry)
+                else:
+                    logger.warning(
+                        "Spider %s found in both %s and %s, keeping %s (more recent)",
+                        spider_name, existing_group, group_name, existing_group,
+                    )
+            else:
+                all_spiders[spider_name] = (group_name, entry)
+
+    groups = []
+    for group_name, manifest in sorted(group_data.items()):
+        spiders_in_group = {
+            name: entry for name, (g, entry) in all_spiders.items() if g == group_name
+        }
+        spider_count = len(spiders_in_group)
+        feature_count = sum(e.get("feature_count", 0) for e in spiders_in_group.values())
+        run_id = manifest.get("run_id", "")
+
+        groups.append({
+            "name": group_name,
+            "spider_count": spider_count,
+            "feature_count": feature_count,
+            "last_run_time": manifest.get("updated_at", ""),
+            "last_run_id": run_id,
+            "zip_url": f"{url_prefix}/runs/latest/{group_name}.zip",
+            "parquet_url": f"{url_prefix}/runs/latest/{group_name}.parquet",
+            "pmtiles_url": f"{url_prefix}/runs/latest/{group_name}.pmtiles",
+        })
+
+    total_spiders = len(all_spiders)
+    total_lines = sum(entry.get("feature_count", 0) for _, entry in all_spiders.values())
+
+    return {
+        "updated_at": now,
+        "stats_url": f"{url_prefix}/runs/latest/stats/_results.json",
+        "insights_url": f"{url_prefix}/runs/latest/stats/_insights.json",
+        "spiders": total_spiders,
+        "total_lines": total_lines,
+        "groups": groups,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build latest.json from group manifests")
+    parser.add_argument("--manifests-dir", required=True, help="Directory containing *.manifest.json files")
+    parser.add_argument("--url-prefix", required=True, help="Base URL prefix")
+    parser.add_argument("--output", required=True, help="Output latest.json path")
+
+    args = parser.parse_args()
+
+    latest = build_latest_json(Path(args.manifests_dir), args.url_prefix)
+    Path(args.output).write_text(json.dumps(latest))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build_latest_json.py
+++ b/ci/build_latest_json.py
@@ -36,36 +36,42 @@ def build_latest_json(manifests_dir: Path, url_prefix: str) -> dict:
                 if entry.get("ran_at", "") > existing_entry.get("ran_at", ""):
                     logger.warning(
                         "Spider %s found in both %s and %s, keeping %s (more recent)",
-                        spider_name, existing_group, group_name, group_name,
+                        spider_name,
+                        existing_group,
+                        group_name,
+                        group_name,
                     )
                     all_spiders[spider_name] = (group_name, entry)
                 else:
                     logger.warning(
                         "Spider %s found in both %s and %s, keeping %s (more recent)",
-                        spider_name, existing_group, group_name, existing_group,
+                        spider_name,
+                        existing_group,
+                        group_name,
+                        existing_group,
                     )
             else:
                 all_spiders[spider_name] = (group_name, entry)
 
     groups = []
     for group_name, manifest in sorted(group_data.items()):
-        spiders_in_group = {
-            name: entry for name, (g, entry) in all_spiders.items() if g == group_name
-        }
+        spiders_in_group = {name: entry for name, (g, entry) in all_spiders.items() if g == group_name}
         spider_count = len(spiders_in_group)
         feature_count = sum(e.get("feature_count", 0) for e in spiders_in_group.values())
         run_id = manifest.get("run_id", "")
 
-        groups.append({
-            "name": group_name,
-            "spider_count": spider_count,
-            "feature_count": feature_count,
-            "last_run_time": manifest.get("updated_at", ""),
-            "last_run_id": run_id,
-            "zip_url": f"{url_prefix}/runs/latest/{group_name}.zip",
-            "parquet_url": f"{url_prefix}/runs/latest/{group_name}.parquet",
-            "pmtiles_url": f"{url_prefix}/runs/latest/{group_name}.pmtiles",
-        })
+        groups.append(
+            {
+                "name": group_name,
+                "spider_count": spider_count,
+                "feature_count": feature_count,
+                "last_run_time": manifest.get("updated_at", ""),
+                "last_run_id": run_id,
+                "zip_url": f"{url_prefix}/runs/latest/{group_name}.zip",
+                "parquet_url": f"{url_prefix}/runs/latest/{group_name}.parquet",
+                "pmtiles_url": f"{url_prefix}/runs/latest/{group_name}.pmtiles",
+            }
+        )
 
     total_spiders = len(all_spiders)
     total_lines = sum(entry.get("feature_count", 0) for _, entry in all_spiders.values())

--- a/ci/run_group_spiders.sh
+++ b/ci/run_group_spiders.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_GROUP="${1:-}"
+if [ -z "${RUN_GROUP}" ]; then
+    (>&2 echo "Usage: $0 <group-name>")
+    exit 1
+fi
+
+echo "git revision: ${GIT_COMMIT:-unknown}"
+echo "Running group: ${RUN_GROUP}"
+
+if [ -z "${S3_BUCKET}" ]; then
+    (>&2 echo "Please set S3_BUCKET environment variable")
+    exit 1
+fi
+
+if [ -z "${GITHUB_WORKSPACE}" ]; then
+    (>&2 echo "Please set GITHUB_WORKSPACE environment variable")
+    exit 1
+fi
+
+RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+RUN_TIMESTAMP=$(date -u +%F-%H-%M-%S)
+RUN_KEY_PREFIX="runs/${RUN_GROUP}/${RUN_TIMESTAMP}"
+RUN_S3_PREFIX="s3://${S3_BUCKET}/${RUN_KEY_PREFIX}"
+RUN_R2_PREFIX="s3://${R2_BUCKET}/${RUN_KEY_PREFIX}"
+RUN_URL_PREFIX="https://alltheplaces-data.openaddresses.io/${RUN_KEY_PREFIX}"
+SPIDER_RUN_DIR="${GITHUB_WORKSPACE}/output"
+PARALLELISM=${PARALLELISM:-12}
+SPIDER_TIMEOUT=${SPIDER_TIMEOUT:-28800} # default to 8 hours
+
+mkdir -p "${SPIDER_RUN_DIR}"
+mkdir -p "${SPIDER_RUN_DIR}/logs"
+mkdir -p "${SPIDER_RUN_DIR}/stats"
+mkdir -p "${SPIDER_RUN_DIR}/output"
+
+# Save the spider list for the manifest builder
+(>&2 echo "Listing spiders in group ${RUN_GROUP}")
+uv run scrapy list_group "${RUN_GROUP}" -s REQUESTS_CACHE_ENABLED=False > "${SPIDER_RUN_DIR}/spider_list.txt"
+
+SPIDER_COUNT=$(wc -l < "${SPIDER_RUN_DIR}/spider_list.txt" | tr -d ' ')
+if [ "${SPIDER_COUNT}" -eq 0 ]; then
+    (>&2 echo "No spiders found in group ${RUN_GROUP}")
+    exit 1
+fi
+
+(>&2 echo "Writing to ${SPIDER_RUN_DIR}")
+while IFS= read -r spider; do
+    echo "timeout -k 15m 495m uv run scrapy crawl --output ${SPIDER_RUN_DIR}/output/${spider}.geojson:geojson --output ${SPIDER_RUN_DIR}/output/${spider}.ndgeojson:ndgeojson --logfile ${SPIDER_RUN_DIR}/logs/${spider}.txt --loglevel ERROR --set TELNETCONSOLE_ENABLED=0 --set CLOSESPIDER_TIMEOUT=${SPIDER_TIMEOUT} --set LOGSTATS_FILE=${SPIDER_RUN_DIR}/stats/${spider}.json ${spider}" >> "${SPIDER_RUN_DIR}/commands.txt"
+done < "${SPIDER_RUN_DIR}/spider_list.txt"
+
+# Send a message to Slack that we're starting
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+    (>&2 echo "Skipping Slack notification because SLACK_WEBHOOK_URL environment variable not set")
+else
+    curl -X POST \
+         --silent \
+         -H 'Content-type: application/json' \
+         --data "{\"text\": \"Starting group '${RUN_GROUP}' run ${RUN_TIMESTAMP} with ${SPIDER_COUNT} spiders\"}" \
+         "${SLACK_WEBHOOK_URL}"
+
+    # Set a hook to send a message to Slack when the job completes, including the exit code
+    trap '{
+        retval=$?
+        if [ $retval -eq 0 ]; then
+            curl -X POST \
+                 --silent \
+                 -H "Content-type: application/json" \
+                 --data "{\"text\": \"Group '"'"'${RUN_GROUP}'"'"' run ${RUN_TIMESTAMP} completed successfully with ${SPIDER_COUNT} spiders\"}" \
+                 "${SLACK_WEBHOOK_URL}"
+        else
+            curl -X POST \
+                 --silent \
+                 -H "Content-type: application/json" \
+                 --data "{\"text\": \"Group '"'"'${RUN_GROUP}'"'"' run ${RUN_TIMESTAMP} failed with exit code ${retval} with ${SPIDER_COUNT} spiders\"}" \
+                 "${SLACK_WEBHOOK_URL}"
+        fi
+    }' EXIT
+fi
+
+(>&2 echo "Running ${SPIDER_COUNT} spiders ${PARALLELISM} at a time")
+xargs -t -L 1 -P "${PARALLELISM}" -a "${SPIDER_RUN_DIR}/commands.txt" -i sh -c "{} || true"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "xargs failed with exit code ${retval}")
+    exit 1
+fi
+(>&2 echo "Done running spiders")
+
+OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson | wc -l | tr -d ' ')
+(>&2 echo "Generated ${OUTPUT_LINECOUNT} lines")
+
+# Generate pmtiles
+tippecanoe --cluster-distance=25 \
+           --drop-rate=1 \
+           --maximum-zoom=15 \
+           --cluster-maxzoom=g \
+           --maximum-tile-bytes=10000000 \
+           --layer="alltheplaces" \
+           --read-parallel \
+           --attribution="<a href=\"https://www.alltheplaces.xyz/\">All the Places</a> ${RUN_GROUP} ${RUN_TIMESTAMP}" \
+           -o "${SPIDER_RUN_DIR}/${RUN_GROUP}.pmtiles" \
+           "${SPIDER_RUN_DIR}"/output/*.geojson \
+           2>&1 | grep -v -E '^\s*[0-9]+\.[0-9]+%\s|^Reordering geometry:\s*[0-9]|^Read [0-9]+\.[0-9]+ million features|^Sorting\.\.\.' >&2
+retval=${PIPESTATUS[0]}
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't generate pmtiles, won't include in output")
+    include_pmtiles=false
+else
+    (>&2 echo "Done generating pmtiles")
+    include_pmtiles=true
+fi
+
+# Generate parquet
+uv run python ci/ndgeojsons_to_parquet.py \
+    --directory "${SPIDER_RUN_DIR}/output" \
+    --output "${SPIDER_RUN_DIR}/${RUN_GROUP}.parquet"
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't create parquet file from ndgeojsons, won't include in output")
+    include_parquet=false
+else
+    include_parquet=true
+fi
+
+# Clean up ndgeojson files as they are packed into parquet and no longer needed
+rm "${SPIDER_RUN_DIR}"/output/*.ndgeojson
+
+(>&2 echo "Done creating parquet file")
+
+# Summarize stats from spider_list.txt instead of calling scrapy list again
+(>&2 echo "Writing out summary JSON")
+echo "{\"count\": ${SPIDER_COUNT}, \"results\": []}" >> "${SPIDER_RUN_DIR}/stats/_results.json"
+while IFS= read -r spider; do
+    statistics_json="${SPIDER_RUN_DIR}/stats/${spider}.json"
+
+    if [ ! -f "${statistics_json}" ]; then
+        (>&2 echo "Couldn't find ${statistics_json}")
+        continue
+    fi
+
+    feature_count=$(jq --raw-output '.item_scraped_count' "${statistics_json}")
+    retval=$?
+    if [ ! $retval -eq 0 ] || [ "${feature_count}" == "null" ]; then
+        feature_count="0"
+    fi
+
+    error_count=$(jq --raw-output '."log_count/ERROR"' "${statistics_json}")
+    retval=$?
+    if [ ! $retval -eq 0 ] || [ "${error_count}" == "null" ]; then
+        error_count="0"
+    fi
+
+    elapsed_time=$(jq --raw-output '.elapsed_time_seconds' "${statistics_json}")
+    retval=$?
+    if [ ! $retval -eq 0 ] || [ "${elapsed_time}" == "null" ]; then
+        elapsed_time="0"
+    fi
+
+    spider_filename=$(uv run scrapy spider_filename "${spider}")
+
+    jq --compact-output \
+        --arg spider_name "${spider}" \
+        --arg spider_feature_count ${feature_count} \
+        --arg spider_error_count ${error_count} \
+        --arg spider_elapsed_time ${elapsed_time} \
+        --arg spider_filename ${spider_filename} \
+        '.results += [{"spider": $spider_name, "filename": $spider_filename, "errors": $spider_error_count | tonumber, "features": $spider_feature_count | tonumber, "elapsed_time": $spider_elapsed_time | tonumber}]' \
+        "${SPIDER_RUN_DIR}/stats/_results.json" > "${SPIDER_RUN_DIR}/stats/_results.json.tmp"
+    mv "${SPIDER_RUN_DIR}/stats/_results.json.tmp" "${SPIDER_RUN_DIR}/stats/_results.json"
+done < "${SPIDER_RUN_DIR}/spider_list.txt"
+(>&2 echo "Wrote out summary JSON")
+
+# Create per-group zip
+(>&2 echo "Compressing output files")
+(cd "${SPIDER_RUN_DIR}" && zip -qr "${RUN_GROUP}.zip" output)
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't zip output dir")
+    exit 1
+fi
+
+# Sync to S3
+(>&2 echo "Saving output files to ${RUN_S3_PREFIX}")
+uv run aws s3 sync \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/" \
+    "${RUN_S3_PREFIX}/"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't sync to s3")
+    exit 1
+fi
+
+# Sync to R2
+(>&2 echo "Saving output files to ${RUN_R2_PREFIX}")
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 sync \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/" \
+    "${RUN_R2_PREFIX}/"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't sync to r2")
+    exit 1
+fi
+
+RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+OUTPUT_FILESIZE=$(du -b "${SPIDER_RUN_DIR}/${RUN_GROUP}.zip" | awk '{ print $1 }')
+
+# Create per-group latest.json
+(>&2 echo "Creating per-group latest.json")
+
+jq -n --compact-output \
+    --arg run_id "${RUN_TIMESTAMP}" \
+    --arg run_group "${RUN_GROUP}" \
+    --arg run_output_url "${RUN_URL_PREFIX}/${RUN_GROUP}.zip" \
+    --arg run_pmtiles_url "${RUN_URL_PREFIX}/${RUN_GROUP}.pmtiles" \
+    --arg run_parquet_url "${RUN_URL_PREFIX}/${RUN_GROUP}.parquet" \
+    --arg run_stats_url "${RUN_URL_PREFIX}/stats/_results.json" \
+    --arg run_start_time "${RUN_START}" \
+    --arg run_end_time "${RUN_END}" \
+    --arg run_output_size "${OUTPUT_FILESIZE}" \
+    --arg run_spider_count "${SPIDER_COUNT}" \
+    --arg run_line_count "${OUTPUT_LINECOUNT}" \
+    '{"run_id": $run_id, "group": $run_group, "output_url": $run_output_url, "pmtiles_url": $run_pmtiles_url, "parquet_url": $run_parquet_url, "stats_url": $run_stats_url, "start_time": $run_start_time, "end_time": $run_end_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber }' \
+    > latest.json
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't create latest.json")
+    exit 1
+fi
+
+# Upload per-group latest.json to S3 and R2
+uv run aws s3 cp \
+    --only-show-errors \
+    latest.json \
+    "s3://${S3_BUCKET}/runs/${RUN_GROUP}/latest.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't copy latest.json to S3")
+    exit 1
+fi
+
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    cp \
+    --only-show-errors \
+    latest.json \
+    "s3://${R2_BUCKET}/runs/${RUN_GROUP}/latest.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't copy latest.json to R2")
+    exit 1
+fi
+
+(>&2 echo "Saved per-group latest.json")
+
+# Create per-group history.json
+(>&2 echo "Creating per-group history.json")
+
+uv run aws s3 cp \
+    --only-show-errors \
+    "s3://${S3_BUCKET}/runs/${RUN_GROUP}/history.json" \
+    history.json || true
+
+if [ ! -s history.json ]; then
+    echo '[]' > history.json
+fi
+
+jq --compact-output \
+    --argjson latest_run_info "$(<latest.json)" \
+    '. += [$latest_run_info]' history.json > history.json.tmp
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't append latest.json to history.json")
+    exit 1
+fi
+
+mv history.json.tmp history.json
+
+uv run aws s3 cp \
+    --only-show-errors \
+    history.json \
+    "s3://${S3_BUCKET}/runs/${RUN_GROUP}/history.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't copy history.json to S3")
+    exit 1
+fi
+
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    cp \
+    --only-show-errors \
+    history.json \
+    "s3://${R2_BUCKET}/runs/${RUN_GROUP}/history.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't copy history.json to R2")
+    exit 1
+fi
+
+(>&2 echo "Saved per-group history.json")
+
+# Build group manifest
+(>&2 echo "Building group manifest for ${RUN_GROUP}")
+
+# Download previous manifest (if it exists)
+uv run aws s3 cp \
+    --only-show-errors \
+    "s3://${S3_BUCKET}/runs/latest/${RUN_GROUP}.manifest.json" \
+    "${SPIDER_RUN_DIR}/previous_manifest.json" || true
+
+MANIFEST_ARGS=(
+    --group "${RUN_GROUP}"
+    --run-id "${RUN_TIMESTAMP}"
+    --run-url-prefix "${RUN_URL_PREFIX}"
+    --spider-list "${SPIDER_RUN_DIR}/spider_list.txt"
+    --stats-dir "${SPIDER_RUN_DIR}/stats"
+    --output "${SPIDER_RUN_DIR}/${RUN_GROUP}.manifest.json"
+)
+
+if [ -s "${SPIDER_RUN_DIR}/previous_manifest.json" ]; then
+    MANIFEST_ARGS+=(--previous-manifest "${SPIDER_RUN_DIR}/previous_manifest.json")
+fi
+
+uv run python ci/build_group_manifest.py "${MANIFEST_ARGS[@]}"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't build group manifest")
+    exit 1
+fi
+
+# Upload manifest to S3 and R2
+uv run aws s3 cp \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/${RUN_GROUP}.manifest.json" \
+    "s3://${S3_BUCKET}/runs/latest/${RUN_GROUP}.manifest.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't upload manifest to S3")
+    exit 1
+fi
+
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    cp \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/${RUN_GROUP}.manifest.json" \
+    "s3://${R2_BUCKET}/runs/latest/${RUN_GROUP}.manifest.json"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't upload manifest to R2")
+    exit 1
+fi
+
+(>&2 echo "Uploaded group manifest")
+
+# Invoke the assembler to combine all group manifests into the global latest
+(>&2 echo "Invoking assembler")
+ci/assemble_latest.sh
+
+(>&2 echo "Group ${RUN_GROUP} run ${RUN_TIMESTAMP} complete")

--- a/docs/superpowers/plans/2026-04-16-grouped-spider-runs.md
+++ b/docs/superpowers/plans/2026-04-16-grouped-spider-runs.md
@@ -1,0 +1,1406 @@
+# Grouped Spider Runs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run spider groups at independent cadences with per-group download artifacts, replacing the monolithic weekly `run_all_spiders.sh`.
+
+**Architecture:** Reuse the existing `Lineage` enum (`locations/extensions/add_lineage.py`) to classify spiders into five groups (brands, addresses, aggregators, government, infrastructure). A new scrapy command lists spiders by group. A new `ci/run_group_spiders.sh` runs one group at a time, producing per-group zip/parquet/pmtiles. A lightweight `ci/assemble_latest.sh` merges all group manifests into the global `latest.json` and updates S3 redirects.
+
+**Tech Stack:** Python 3.11, Scrapy, bash, jq, tippecanoe, duckdb (via existing `ndgeojsons_to_parquet.py`), AWS CLI (S3 + R2)
+
+**Spec:** `docs/superpowers/specs/2026-04-11-grouped-spider-runs-design.md`
+
+**Key discovery:** The codebase already has `Lineage` enum + `spider_class_to_lineage()` that resolves group from filesystem path with a `lineage` class-attribute override. The spec's `run_group` attribute IS the existing `lineage` attribute. No new spider attribute needed.
+
+---
+
+### Task 1: Add group name mapping to Lineage enum
+
+**Files:**
+- Modify: `locations/extensions/add_lineage.py`
+- Modify: `tests/test_lineage.py`
+
+- [ ] **Step 1: Write failing tests for group property**
+
+Add to `tests/test_lineage.py`:
+
+```python
+from locations.extensions.add_lineage import Lineage, spider_class_to_lineage, VALID_GROUPS, lineage_for_group
+
+
+def test_lineage_group_names():
+    assert Lineage.Brands.group == "brands"
+    assert Lineage.Addresses.group == "addresses"
+    assert Lineage.Aggregators.group == "aggregators"
+    assert Lineage.Governments.group == "government"
+    assert Lineage.Infrastructure.group == "infrastructure"
+    assert Lineage.Unknown.group == "brands"
+
+
+def test_valid_groups():
+    assert VALID_GROUPS == {"brands", "addresses", "aggregators", "government", "infrastructure"}
+
+
+def test_lineage_for_group():
+    assert lineage_for_group("brands") == Lineage.Brands
+    assert lineage_for_group("addresses") == Lineage.Addresses
+    assert lineage_for_group("aggregators") == Lineage.Aggregators
+    assert lineage_for_group("government") == Lineage.Governments
+    assert lineage_for_group("infrastructure") == Lineage.Infrastructure
+
+
+def test_lineage_for_group_invalid():
+    import pytest
+    with pytest.raises(ValueError, match="Unknown group"):
+        lineage_for_group("invalid_group")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_lineage.py -v`
+Expected: FAIL — `VALID_GROUPS` and `lineage_for_group` not defined, `Lineage.Brands.group` doesn't exist
+
+- [ ] **Step 3: Implement group property on Lineage**
+
+In `locations/extensions/add_lineage.py`, add a `group` property to `Lineage` and the helper constants/functions:
+
+```python
+class Lineage(Enum):
+    Addresses = "S_ATP_ADDRESSES"
+    Aggregators = "S_ATP_AGGREGATORS"
+    Brands = "S_ATP_BRANDS"
+    Governments = "S_ATP_GOVERNMENTS"
+    Infrastructure = "S_ATP_INFRASTRUCTURE"
+    Unknown = "S_?"
+
+    @property
+    def group(self) -> str:
+        return _LINEAGE_TO_GROUP.get(self, "brands")
+
+
+_LINEAGE_TO_GROUP = {
+    Lineage.Addresses: "addresses",
+    Lineage.Aggregators: "aggregators",
+    Lineage.Brands: "brands",
+    Lineage.Governments: "government",
+    Lineage.Infrastructure: "infrastructure",
+    Lineage.Unknown: "brands",
+}
+
+_GROUP_TO_LINEAGE = {v: k for k, v in _LINEAGE_TO_GROUP.items() if k != Lineage.Unknown}
+
+VALID_GROUPS = set(_GROUP_TO_LINEAGE.keys())
+
+
+def lineage_for_group(group: str) -> Lineage:
+    if group not in _GROUP_TO_LINEAGE:
+        raise ValueError(f"Unknown group: {group!r}. Valid groups: {sorted(VALID_GROUPS)}")
+    return _GROUP_TO_LINEAGE[group]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_lineage.py -v`
+Expected: All tests PASS (both new and existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add locations/extensions/add_lineage.py tests/test_lineage.py
+git commit -m "Add group name mapping to Lineage enum"
+```
+
+---
+
+### Task 2: Add `scrapy list_group` command
+
+**Files:**
+- Create: `locations/commands/list_group.py`
+- Create: `tests/test_list_group_command.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_list_group_command.py`:
+
+```python
+import sys
+
+from locations.extensions.add_lineage import Lineage, spider_class_to_lineage, VALID_GROUPS
+
+
+def test_spider_group_resolution_from_path():
+    """Verify that spiders in subdirectories resolve to the correct group."""
+    from locations.spiders.infrastructure.aurora_city_council_traffic_signals_us import (
+        AuroraCityCouncilTrafficSignalsUSSpider,
+    )
+
+    assert spider_class_to_lineage(AuroraCityCouncilTrafficSignalsUSSpider).group == "infrastructure"
+
+
+def test_spider_group_resolution_brands_default():
+    """Verify that top-level spiders default to brands."""
+    from locations.spiders.greggs_gb import GreggsGBSpider
+
+    assert spider_class_to_lineage(GreggsGBSpider).group == "brands"
+
+
+def test_spider_group_override_via_lineage():
+    """Verify that the lineage class attribute overrides path-based resolution."""
+    from locations.spiders.greggs_gb import GreggsGBSpider
+
+    original = getattr(GreggsGBSpider, "lineage", None)
+    try:
+        GreggsGBSpider.lineage = Lineage.Infrastructure
+        assert spider_class_to_lineage(GreggsGBSpider).group == "infrastructure"
+    finally:
+        if original is None:
+            del GreggsGBSpider.lineage
+        else:
+            GreggsGBSpider.lineage = original
+
+
+def test_all_groups_have_at_least_one_spider():
+    """Verify every defined group has at least one spider in the codebase."""
+    from locations.exporters.geojson import iter_spider_classes_in_modules
+
+    groups_seen = set()
+    for spider_class in iter_spider_classes_in_modules():
+        lineage = spider_class_to_lineage(spider_class)
+        groups_seen.add(lineage.group)
+
+    for group in VALID_GROUPS:
+        assert group in groups_seen, f"No spiders found for group {group!r}"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_list_group_command.py -v`
+Expected: All PASS (these test existing infrastructure, not the command itself yet)
+
+- [ ] **Step 3: Write the `list_group` command**
+
+Create `locations/commands/list_group.py`:
+
+```python
+import argparse
+import sys
+
+from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
+
+from locations.extensions.add_lineage import VALID_GROUPS, lineage_for_group, spider_class_to_lineage
+
+
+class ListGroupCommand(ScrapyCommand):
+    requires_project = True
+    default_settings = {"LOG_ENABLED": False}
+
+    def syntax(self) -> str:
+        return "<group>"
+
+    def short_desc(self) -> str:
+        return "List spiders belonging to a run group"
+
+    def long_desc(self) -> str:
+        groups = ", ".join(sorted(VALID_GROUPS))
+        return f"List spider names belonging to the given run group. Valid groups: {groups}"
+
+    def run(self, args: list[str], opts: argparse.Namespace) -> None:
+        if len(args) != 1:
+            raise UsageError()
+
+        group = args[0]
+        try:
+            lineage_for_group(group)
+        except ValueError as e:
+            sys.stderr.write(str(e) + "\n")
+            self.exitcode = 1
+            return
+
+        if not self.crawler_process:
+            raise RuntimeError("Crawler process not defined")
+
+        for spider_name in sorted(self.crawler_process.spider_loader.list()):
+            spidercls = self.crawler_process.spider_loader.load(spider_name)
+            spider_lineage = spider_class_to_lineage(spidercls)
+            if spider_lineage.group == group:
+                sys.stdout.write(f"{spider_name}\n")
+```
+
+- [ ] **Step 4: Test the command manually**
+
+Run: `uv run scrapy list_group brands 2>/dev/null | head -5`
+Expected: First 5 brand spider names, one per line
+
+Run: `uv run scrapy list_group infrastructure 2>/dev/null | wc -l`
+Expected: A number around 358
+
+Run: `uv run scrapy list_group invalid_group 2>/dev/null`
+Expected: Error message on stderr, exit code 1
+
+- [ ] **Step 5: Verify all groups sum to total spider count**
+
+Run: `uv run scrapy list -s LOG_ENABLED=False | wc -l` and compare with:
+```bash
+total=0; for g in brands addresses aggregators government infrastructure; do count=$(uv run scrapy list_group $g 2>/dev/null | wc -l); echo "$g: $count"; total=$((total + count)); done; echo "total: $total"
+```
+Expected: Totals match
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add locations/commands/list_group.py tests/test_list_group_command.py
+git commit -m "Add scrapy list_group command for filtering spiders by run group"
+```
+
+---
+
+### Task 3: Create `ci/build_group_manifest.py`
+
+**Files:**
+- Create: `ci/build_group_manifest.py`
+- Create: `tests/test_build_group_manifest.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_build_group_manifest.py`:
+
+```python
+import json
+from pathlib import Path
+
+from ci.build_group_manifest import build_manifest
+
+
+def test_fresh_manifest_from_successful_spiders(tmp_path):
+    """First run: no previous manifest, all spiders succeed."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "log_count/ERROR": 0, "elapsed_time_seconds": 42.5}))
+    (stats_dir / "burger_king.json").write_text(json.dumps({"item_scraped_count": 50, "log_count/ERROR": 1, "elapsed_time_seconds": 30.0}))
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds", "burger_king"],
+        stats_dir=stats_dir,
+        previous_manifest=None,
+    )
+
+    assert manifest["group"] == "brands"
+    assert manifest["run_id"] == "2026-04-16-14-00-00"
+    assert "mcdonalds" in manifest["spiders"]
+    assert manifest["spiders"]["mcdonalds"]["feature_count"] == 100
+    assert manifest["spiders"]["mcdonalds"]["geojson_url"] == "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson"
+    assert "burger_king" in manifest["spiders"]
+
+
+def test_failed_spider_keeps_previous_entry(tmp_path):
+    """Spider fails: previous entry preserved."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    # mcdonalds succeeds
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "elapsed_time_seconds": 42.5}))
+    # burger_king has no stats file (crashed before writing stats)
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "burger_king": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/runs/brands/2026-04-09-14-00-00/output/burger_king.geojson",
+                "stats_url": "https://example.com/runs/brands/2026-04-09-14-00-00/stats/burger_king.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 30.0,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds", "burger_king"],
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    # burger_king keeps the old entry
+    assert manifest["spiders"]["burger_king"]["run_id"] == "2026-04-09-14-00-00"
+    assert manifest["spiders"]["burger_king"]["feature_count"] == 50
+    # mcdonalds gets the new entry
+    assert manifest["spiders"]["mcdonalds"]["run_id"] == "2026-04-16-14-00-00"
+
+
+def test_zero_items_keeps_previous_entry(tmp_path):
+    """Spider produces zero items: previous entry preserved."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 0, "elapsed_time_seconds": 5.0}))
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/mcdonalds.geojson",
+                "stats_url": "https://example.com/old/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds"],
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    assert manifest["spiders"]["mcdonalds"]["run_id"] == "2026-04-09-14-00-00"
+
+
+def test_deleted_spider_dropped_from_manifest(tmp_path):
+    """Spider removed from group: entry dropped."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "elapsed_time_seconds": 42.5}))
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/mcdonalds.geojson",
+                "stats_url": "https://example.com/old/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+            "old_deleted_spider": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/old_deleted_spider.geojson",
+                "stats_url": "https://example.com/old/old_deleted_spider.json",
+                "feature_count": 10,
+                "error_count": 0,
+                "elapsed_time": 5.0,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds"],  # old_deleted_spider not in list
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    assert "old_deleted_spider" not in manifest["spiders"]
+    assert "mcdonalds" in manifest["spiders"]
+
+
+def test_never_run_spider_absent(tmp_path):
+    """Spider has never succeeded: not in manifest."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    # new_spider has no stats file
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["new_spider"],
+        stats_dir=stats_dir,
+        previous_manifest=None,
+    )
+
+    assert "new_spider" not in manifest["spiders"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_build_group_manifest.py -v`
+Expected: FAIL — `ci.build_group_manifest` module not found
+
+- [ ] **Step 3: Implement `build_group_manifest.py`**
+
+Create `ci/build_group_manifest.py`:
+
+```python
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build_manifest(
+    group: str,
+    run_id: str,
+    run_url_prefix: str,
+    spider_names: list[str],
+    stats_dir: Path,
+    previous_manifest: dict | None,
+) -> dict:
+    """Build a group manifest by merging current run results with previous manifest.
+
+    Spiders that succeeded (non-zero item_scraped_count) get fresh entries.
+    Spiders that failed or produced zero items keep their previous entry.
+    Spiders no longer in the group are dropped.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    previous_spiders = (previous_manifest or {}).get("spiders", {})
+    spider_names_set = set(spider_names)
+    spiders = {}
+
+    for spider_name in spider_names:
+        stats_file = stats_dir / f"{spider_name}.json"
+
+        if stats_file.exists():
+            try:
+                stats = json.loads(stats_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                stats = {}
+
+            feature_count = stats.get("item_scraped_count", 0) or 0
+            error_count = stats.get("log_count/ERROR", 0) or 0
+            elapsed_time = stats.get("elapsed_time_seconds", 0) or 0
+
+            if feature_count > 0:
+                spiders[spider_name] = {
+                    "run_id": run_id,
+                    "ran_at": now,
+                    "geojson_url": f"{run_url_prefix}/output/{spider_name}.geojson",
+                    "stats_url": f"{run_url_prefix}/stats/{spider_name}.json",
+                    "feature_count": feature_count,
+                    "error_count": error_count,
+                    "elapsed_time": elapsed_time,
+                }
+                continue
+
+        # Spider failed or produced zero items: keep previous entry if it exists
+        if spider_name in previous_spiders:
+            spiders[spider_name] = previous_spiders[spider_name]
+
+    return {
+        "group": group,
+        "updated_at": now,
+        "run_id": run_id,
+        "spiders": spiders,
+    }
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build or update a group manifest")
+    parser.add_argument("--group", required=True, help="Group name")
+    parser.add_argument("--run-id", required=True, help="Run timestamp ID")
+    parser.add_argument("--run-url-prefix", required=True, help="URL prefix for this run")
+    parser.add_argument("--spider-list", required=True, help="File with spider names, one per line")
+    parser.add_argument("--stats-dir", required=True, help="Directory containing per-spider stats JSON files")
+    parser.add_argument("--previous-manifest", help="Path to previous manifest JSON file (optional)")
+    parser.add_argument("--output", required=True, help="Output manifest file path")
+
+    args = parser.parse_args()
+
+    spider_names = Path(args.spider_list).read_text().strip().splitlines()
+    stats_dir = Path(args.stats_dir)
+
+    previous_manifest = None
+    if args.previous_manifest and Path(args.previous_manifest).exists():
+        previous_manifest = json.loads(Path(args.previous_manifest).read_text())
+
+    manifest = build_manifest(
+        group=args.group,
+        run_id=args.run_id,
+        run_url_prefix=args.run_url_prefix,
+        spider_names=spider_names,
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    Path(args.output).write_text(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_build_group_manifest.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/build_group_manifest.py tests/test_build_group_manifest.py
+git commit -m "Add build_group_manifest.py for manifest merge logic"
+```
+
+---
+
+### Task 4: Create `ci/build_latest_json.py`
+
+**Files:**
+- Create: `ci/build_latest_json.py`
+- Create: `tests/test_build_latest_json.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_build_latest_json.py`:
+
+```python
+import json
+from pathlib import Path
+
+from ci.build_latest_json import build_latest_json
+
+
+def test_basic_latest_json(tmp_path):
+    """Build latest.json from two group manifests."""
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    brands_manifest = {
+        "group": "brands",
+        "updated_at": "2026-04-16T14:00:00Z",
+        "run_id": "2026-04-16-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-16-14-00-00",
+                "ran_at": "2026-04-16T14:31:12Z",
+                "geojson_url": "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson",
+                "stats_url": "https://example.com/runs/brands/2026-04-16-14-00-00/stats/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    infra_manifest = {
+        "group": "infrastructure",
+        "updated_at": "2026-03-01T10:00:00Z",
+        "run_id": "2026-03-01-10-00-00",
+        "spiders": {
+            "511_nl_ca": {
+                "run_id": "2026-03-01-10-00-00",
+                "ran_at": "2026-03-01T10:15:00Z",
+                "geojson_url": "https://example.com/runs/infrastructure/2026-03-01-10-00-00/output/511_nl_ca.geojson",
+                "stats_url": "https://example.com/runs/infrastructure/2026-03-01-10-00-00/stats/511_nl_ca.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 10.0,
+            },
+        },
+    }
+
+    (manifests_dir / "brands.manifest.json").write_text(json.dumps(brands_manifest))
+    (manifests_dir / "infrastructure.manifest.json").write_text(json.dumps(infra_manifest))
+
+    url_prefix = "https://example.com"
+
+    latest = build_latest_json(manifests_dir, url_prefix)
+
+    assert latest["spiders"] == 2
+    assert latest["total_lines"] == 150
+    assert len(latest["groups"]) == 2
+
+    brands_group = next(g for g in latest["groups"] if g["name"] == "brands")
+    assert brands_group["spider_count"] == 1
+    assert brands_group["feature_count"] == 100
+    assert "zip_url" in brands_group
+    assert "parquet_url" in brands_group
+    assert "pmtiles_url" in brands_group
+
+    infra_group = next(g for g in latest["groups"] if g["name"] == "infrastructure")
+    assert infra_group["spider_count"] == 1
+
+
+def test_duplicate_spider_in_two_manifests(tmp_path):
+    """If a spider appears in two manifests, the more recent ran_at wins."""
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    manifest_a = {
+        "group": "brands",
+        "updated_at": "2026-04-16T14:00:00Z",
+        "run_id": "2026-04-16-14-00-00",
+        "spiders": {
+            "dupe_spider": {
+                "run_id": "2026-04-16-14-00-00",
+                "ran_at": "2026-04-16T14:31:12Z",
+                "geojson_url": "https://example.com/brands/dupe_spider.geojson",
+                "stats_url": "https://example.com/brands/dupe_spider.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    manifest_b = {
+        "group": "infrastructure",
+        "updated_at": "2026-03-01T10:00:00Z",
+        "run_id": "2026-03-01-10-00-00",
+        "spiders": {
+            "dupe_spider": {
+                "run_id": "2026-03-01-10-00-00",
+                "ran_at": "2026-03-01T10:15:00Z",
+                "geojson_url": "https://example.com/infra/dupe_spider.geojson",
+                "stats_url": "https://example.com/infra/dupe_spider.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 10.0,
+            },
+        },
+    }
+
+    (manifests_dir / "brands.manifest.json").write_text(json.dumps(manifest_a))
+    (manifests_dir / "infrastructure.manifest.json").write_text(json.dumps(manifest_b))
+
+    latest = build_latest_json(manifests_dir, "https://example.com")
+
+    # Only counted once, from the more recent manifest (brands)
+    assert latest["spiders"] == 1
+    assert latest["total_lines"] == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_build_latest_json.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `build_latest_json.py`**
+
+Create `ci/build_latest_json.py`:
+
+```python
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def build_latest_json(manifests_dir: Path, url_prefix: str) -> dict:
+    """Merge all group manifests into a single latest.json.
+
+    Args:
+        manifests_dir: Directory containing *.manifest.json files.
+        url_prefix: Base URL for constructing per-group artifact URLs (e.g. https://alltheplaces-data.openaddresses.io).
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    manifest_files = sorted(manifests_dir.glob("*.manifest.json"))
+
+    # Merge all spider entries, resolving duplicates by most recent ran_at
+    all_spiders: dict[str, tuple[str, dict]] = {}  # spider_name -> (group, entry)
+    group_data: dict[str, dict] = {}  # group_name -> manifest
+
+    for mf in manifest_files:
+        try:
+            manifest = json.loads(mf.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Skipping %s: %s", mf, e)
+            continue
+
+        group_name = manifest.get("group", mf.stem.replace(".manifest", ""))
+        group_data[group_name] = manifest
+
+        for spider_name, entry in manifest.get("spiders", {}).items():
+            if spider_name in all_spiders:
+                existing_group, existing_entry = all_spiders[spider_name]
+                if entry.get("ran_at", "") > existing_entry.get("ran_at", ""):
+                    logger.warning(
+                        "Spider %s found in both %s and %s, keeping %s (more recent)",
+                        spider_name, existing_group, group_name, group_name,
+                    )
+                    all_spiders[spider_name] = (group_name, entry)
+                else:
+                    logger.warning(
+                        "Spider %s found in both %s and %s, keeping %s (more recent)",
+                        spider_name, existing_group, group_name, existing_group,
+                    )
+            else:
+                all_spiders[spider_name] = (group_name, entry)
+
+    # Build per-group summaries
+    groups = []
+    for group_name, manifest in sorted(group_data.items()):
+        spiders_in_group = {
+            name: entry for name, (g, entry) in all_spiders.items() if g == group_name
+        }
+        spider_count = len(spiders_in_group)
+        feature_count = sum(e.get("feature_count", 0) for e in spiders_in_group.values())
+        run_id = manifest.get("run_id", "")
+
+        groups.append({
+            "name": group_name,
+            "spider_count": spider_count,
+            "feature_count": feature_count,
+            "last_run_time": manifest.get("updated_at", ""),
+            "last_run_id": run_id,
+            "zip_url": f"{url_prefix}/runs/latest/{group_name}.zip",
+            "parquet_url": f"{url_prefix}/runs/latest/{group_name}.parquet",
+            "pmtiles_url": f"{url_prefix}/runs/latest/{group_name}.pmtiles",
+        })
+
+    total_spiders = len(all_spiders)
+    total_lines = sum(entry.get("feature_count", 0) for _, entry in all_spiders.values())
+
+    return {
+        "updated_at": now,
+        "stats_url": f"{url_prefix}/runs/latest/stats/_results.json",
+        "insights_url": f"{url_prefix}/runs/latest/stats/_insights.json",
+        "spiders": total_spiders,
+        "total_lines": total_lines,
+        "groups": groups,
+    }
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build latest.json from group manifests")
+    parser.add_argument("--manifests-dir", required=True, help="Directory containing *.manifest.json files")
+    parser.add_argument("--url-prefix", required=True, help="Base URL prefix")
+    parser.add_argument("--output", required=True, help="Output latest.json path")
+
+    args = parser.parse_args()
+
+    latest = build_latest_json(Path(args.manifests_dir), args.url_prefix)
+    Path(args.output).write_text(json.dumps(latest))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_build_latest_json.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci/build_latest_json.py tests/test_build_latest_json.py
+git commit -m "Add build_latest_json.py to merge group manifests into latest.json"
+```
+
+---
+
+### Task 5: Create `ci/run_group_spiders.sh`
+
+**Files:**
+- Create: `ci/run_group_spiders.sh`
+
+This is adapted from `ci/run_all_spiders.sh`. The differences are: (1) takes a group argument, (2) uses group-scoped S3 paths, (3) uses `scrapy list_group` instead of `scrapy list`, (4) generates per-group zip/parquet/pmtiles, (5) builds the group manifest, (6) invokes the assembler.
+
+- [ ] **Step 1: Create the script**
+
+Create `ci/run_group_spiders.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Validate arguments ---
+RUN_GROUP="${1:-}"
+if [ -z "${RUN_GROUP}" ]; then
+    (>&2 echo "Usage: run_group_spiders.sh <group>")
+    (>&2 echo "Valid groups: addresses, aggregators, brands, government, infrastructure")
+    exit 1
+fi
+
+echo "git revision: ${GIT_COMMIT:-unknown}"
+echo "run group: ${RUN_GROUP}"
+
+if [ -z "${S3_BUCKET}" ]; then
+    (>&2 echo "Please set S3_BUCKET environment variable")
+    exit 1
+fi
+
+if [ -z "${GITHUB_WORKSPACE}" ]; then
+    (>&2 echo "Please set GITHUB_WORKSPACE environment variable")
+    exit 1
+fi
+
+# --- Timestamps and paths (group-scoped) ---
+RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+RUN_TIMESTAMP=$(date -u +%F-%H-%M-%S)
+RUN_KEY_PREFIX="runs/${RUN_GROUP}/${RUN_TIMESTAMP}"
+RUN_S3_PREFIX="s3://${S3_BUCKET}/${RUN_KEY_PREFIX}"
+RUN_R2_PREFIX="s3://${R2_BUCKET}/${RUN_KEY_PREFIX}"
+RUN_URL_PREFIX="https://alltheplaces-data.openaddresses.io/${RUN_KEY_PREFIX}"
+SPIDER_RUN_DIR="${GITHUB_WORKSPACE}/output"
+PARALLELISM=${PARALLELISM:-12}
+SPIDER_TIMEOUT=${SPIDER_TIMEOUT:-28800}
+
+mkdir -p "${SPIDER_RUN_DIR}"
+
+# --- List spiders in this group ---
+(>&2 echo "Listing spiders in group ${RUN_GROUP}")
+uv run scrapy list_group "${RUN_GROUP}" -s REQUESTS_CACHE_ENABLED=False > "${SPIDER_RUN_DIR}/spider_list.txt"
+
+while IFS= read -r spider; do
+    echo "timeout -k 15m 495m uv run scrapy crawl --output ${SPIDER_RUN_DIR}/output/${spider}.geojson:geojson --output ${SPIDER_RUN_DIR}/output/${spider}.ndgeojson:ndgeojson --logfile ${SPIDER_RUN_DIR}/logs/${spider}.txt --loglevel ERROR --set TELNETCONSOLE_ENABLED=0 --set CLOSESPIDER_TIMEOUT=${SPIDER_TIMEOUT} --set LOGSTATS_FILE=${SPIDER_RUN_DIR}/stats/${spider}.json ${spider}" >> "${SPIDER_RUN_DIR}/commands.txt"
+done < "${SPIDER_RUN_DIR}/spider_list.txt"
+
+mkdir -p "${SPIDER_RUN_DIR}/logs"
+mkdir -p "${SPIDER_RUN_DIR}/stats"
+mkdir -p "${SPIDER_RUN_DIR}/output"
+SPIDER_COUNT=$(wc -l < "${SPIDER_RUN_DIR}/commands.txt" | tr -d ' ')
+
+# --- Slack notification ---
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+    (>&2 echo "Skipping Slack notification because SLACK_WEBHOOK_URL not set")
+else
+    curl -X POST \
+         --silent \
+         -H 'Content-type: application/json' \
+         --data "{\"text\": \"Starting ${RUN_GROUP} run ${RUN_TIMESTAMP} with ${SPIDER_COUNT} spiders\"}" \
+         "${SLACK_WEBHOOK_URL}"
+
+    trap '{
+        retval=$?
+        if [ $retval -eq 0 ]; then
+            curl -X POST \
+                 --silent \
+                 -H "Content-type: application/json" \
+                 --data "{\"text\": \"${RUN_GROUP} run ${RUN_TIMESTAMP} completed successfully with ${SPIDER_COUNT} spiders\"}" \
+                 "${SLACK_WEBHOOK_URL}"
+        else
+            curl -X POST \
+                 --silent \
+                 -H "Content-type: application/json" \
+                 --data "{\"text\": \"${RUN_GROUP} run ${RUN_TIMESTAMP} failed with exit code ${retval} with ${SPIDER_COUNT} spiders\"}" \
+                 "${SLACK_WEBHOOK_URL}"
+        fi
+    }' EXIT
+fi
+
+# --- Run spiders in parallel ---
+(>&2 echo "Running ${SPIDER_COUNT} ${RUN_GROUP} spiders ${PARALLELISM} at a time")
+xargs -t -L 1 -P "${PARALLELISM}" -a "${SPIDER_RUN_DIR}/commands.txt" -i sh -c "{} || true"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "xargs failed with exit code ${retval}")
+    exit 1
+fi
+(>&2 echo "Done running ${RUN_GROUP} spiders")
+
+OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson 2>/dev/null | wc -l | tr -d ' ')
+(>&2 echo "Generated ${OUTPUT_LINECOUNT} lines")
+
+# --- Generate per-group pmtiles ---
+tippecanoe --cluster-distance=25 \
+           --drop-rate=1 \
+           --maximum-zoom=15 \
+           --cluster-maxzoom=g \
+           --maximum-tile-bytes=10000000 \
+           --layer="alltheplaces" \
+           --read-parallel \
+           --attribution="<a href=\"https://www.alltheplaces.xyz/\">All the Places</a> ${RUN_GROUP} ${RUN_TIMESTAMP}" \
+           -o "${SPIDER_RUN_DIR}/${RUN_GROUP}.pmtiles" \
+           "${SPIDER_RUN_DIR}"/output/*.geojson \
+           2>&1 | grep -v -E '^\s*[0-9]+\.[0-9]+%\s|^Reordering geometry:\s*[0-9]|^Read [0-9]+\.[0-9]+ million features|^Sorting\.\.\.' >&2
+retval=${PIPESTATUS[0]}
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't generate pmtiles for ${RUN_GROUP}")
+    include_pmtiles=false
+else
+    (>&2 echo "Done generating ${RUN_GROUP} pmtiles")
+    include_pmtiles=true
+fi
+
+# --- Generate per-group parquet ---
+uv run python ci/ndgeojsons_to_parquet.py \
+    --directory "${SPIDER_RUN_DIR}/output" \
+    --output "${SPIDER_RUN_DIR}/${RUN_GROUP}.parquet"
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't create parquet for ${RUN_GROUP}")
+    include_parquet=false
+else
+    include_parquet=true
+fi
+
+# Clean up ndgeojson files
+rm -f "${SPIDER_RUN_DIR}"/output/*.ndgeojson
+(>&2 echo "Done creating ${RUN_GROUP} parquet")
+
+# --- Generate per-group zip ---
+(>&2 echo "Compressing ${RUN_GROUP} output files")
+(cd "${SPIDER_RUN_DIR}" && zip -qr "${RUN_GROUP}.zip" output)
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't zip ${RUN_GROUP} output")
+    exit 1
+fi
+
+# --- Write per-spider stats summary ---
+(>&2 echo "Writing ${RUN_GROUP} summary JSON")
+echo "{\"count\": ${SPIDER_COUNT}, \"results\": []}" > "${SPIDER_RUN_DIR}/stats/_results.json"
+while IFS= read -r spider; do
+    statistics_json="${SPIDER_RUN_DIR}/stats/${spider}.json"
+
+    if [ ! -f "${statistics_json}" ]; then
+        (>&2 echo "Couldn't find ${statistics_json}")
+        continue
+    fi
+
+    feature_count=$(jq --raw-output '.item_scraped_count' "${statistics_json}")
+    if [ "$?" -ne 0 ] || [ "${feature_count}" == "null" ]; then
+        feature_count="0"
+    fi
+
+    error_count=$(jq --raw-output '."log_count/ERROR"' "${statistics_json}")
+    if [ "$?" -ne 0 ] || [ "${error_count}" == "null" ]; then
+        error_count="0"
+    fi
+
+    elapsed_time=$(jq --raw-output '.elapsed_time_seconds' "${statistics_json}")
+    if [ "$?" -ne 0 ] || [ "${elapsed_time}" == "null" ]; then
+        elapsed_time="0"
+    fi
+
+    spider_filename=$(uv run scrapy spider_filename "${spider}")
+
+    jq --compact-output \
+        --arg spider_name "${spider}" \
+        --arg spider_feature_count ${feature_count} \
+        --arg spider_error_count ${error_count} \
+        --arg spider_elapsed_time ${elapsed_time} \
+        --arg spider_filename ${spider_filename} \
+        '.results += [{"spider": $spider_name, "filename": $spider_filename, "errors": $spider_error_count | tonumber, "features": $spider_feature_count | tonumber, "elapsed_time": $spider_elapsed_time | tonumber}]' \
+        "${SPIDER_RUN_DIR}/stats/_results.json" > "${SPIDER_RUN_DIR}/stats/_results.json.tmp"
+    mv "${SPIDER_RUN_DIR}/stats/_results.json.tmp" "${SPIDER_RUN_DIR}/stats/_results.json"
+done < "${SPIDER_RUN_DIR}/spider_list.txt"
+(>&2 echo "Wrote ${RUN_GROUP} summary JSON")
+
+# --- Sync to S3 ---
+(>&2 echo "Saving ${RUN_GROUP} files to ${RUN_S3_PREFIX}")
+uv run aws s3 sync \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/" \
+    "${RUN_S3_PREFIX}/"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't sync ${RUN_GROUP} to S3")
+    exit 1
+fi
+
+# --- Sync to R2 ---
+(>&2 echo "Saving ${RUN_GROUP} files to ${RUN_R2_PREFIX}")
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+uv run aws s3 sync \
+    --endpoint-url="${R2_ENDPOINT_URL}" \
+    --only-show-errors \
+    "${SPIDER_RUN_DIR}/" \
+    "${RUN_R2_PREFIX}/"
+
+retval=$?
+if [ ! $retval -eq 0 ]; then
+    (>&2 echo "Couldn't sync ${RUN_GROUP} to R2")
+    exit 1
+fi
+
+# --- Write per-group latest.json ---
+RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+OUTPUT_FILESIZE=$(du -b "${SPIDER_RUN_DIR}/${RUN_GROUP}.zip" | awk '{ print $1 }')
+
+jq -n --compact-output \
+    --arg run_id "${RUN_TIMESTAMP}" \
+    --arg run_group "${RUN_GROUP}" \
+    --arg run_zip_url "${RUN_URL_PREFIX}/${RUN_GROUP}.zip" \
+    --arg run_pmtiles_url "${RUN_URL_PREFIX}/${RUN_GROUP}.pmtiles" \
+    --arg run_parquet_url "${RUN_URL_PREFIX}/${RUN_GROUP}.parquet" \
+    --arg run_stats_url "${RUN_URL_PREFIX}/stats/_results.json" \
+    --arg run_start_time "${RUN_START}" \
+    --arg run_end_time "${RUN_END}" \
+    --arg run_output_size "${OUTPUT_FILESIZE}" \
+    --arg run_spider_count "${SPIDER_COUNT}" \
+    --arg run_line_count "${OUTPUT_LINECOUNT}" \
+    '{"run_id": $run_id, "group": $run_group, "zip_url": $run_zip_url, "pmtiles_url": $run_pmtiles_url, "parquet_url": $run_parquet_url, "stats_url": $run_stats_url, "start_time": $run_start_time, "end_time": $run_end_time, "size_bytes": $run_output_size | tonumber, "spiders": $run_spider_count | tonumber, "total_lines": $run_line_count | tonumber}' \
+    > "${SPIDER_RUN_DIR}/group_latest.json"
+
+GROUP_S3_PREFIX="s3://${S3_BUCKET}/runs/${RUN_GROUP}"
+GROUP_R2_PREFIX="s3://${R2_BUCKET}/runs/${RUN_GROUP}"
+
+uv run aws s3 cp --only-show-errors "${SPIDER_RUN_DIR}/group_latest.json" "${GROUP_S3_PREFIX}/latest.json"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" cp --only-show-errors "${SPIDER_RUN_DIR}/group_latest.json" "${GROUP_R2_PREFIX}/latest.json"
+
+# --- Append to per-group history.json ---
+uv run aws s3 cp --only-show-errors "${GROUP_S3_PREFIX}/history.json" "${SPIDER_RUN_DIR}/group_history.json" 2>/dev/null || echo '[]' > "${SPIDER_RUN_DIR}/group_history.json"
+if [ ! -s "${SPIDER_RUN_DIR}/group_history.json" ]; then
+    echo '[]' > "${SPIDER_RUN_DIR}/group_history.json"
+fi
+
+jq --compact-output \
+    --argjson latest "$(<"${SPIDER_RUN_DIR}/group_latest.json")" \
+    '. += [$latest]' "${SPIDER_RUN_DIR}/group_history.json" > "${SPIDER_RUN_DIR}/group_history.json.tmp"
+mv "${SPIDER_RUN_DIR}/group_history.json.tmp" "${SPIDER_RUN_DIR}/group_history.json"
+
+uv run aws s3 cp --only-show-errors "${SPIDER_RUN_DIR}/group_history.json" "${GROUP_S3_PREFIX}/history.json"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" cp --only-show-errors "${SPIDER_RUN_DIR}/group_history.json" "${GROUP_R2_PREFIX}/history.json"
+
+# --- Build group manifest ---
+(>&2 echo "Building ${RUN_GROUP} manifest")
+MANIFEST_S3_PATH="s3://${S3_BUCKET}/runs/latest/${RUN_GROUP}.manifest.json"
+uv run aws s3 cp --only-show-errors "${MANIFEST_S3_PATH}" "${SPIDER_RUN_DIR}/previous_manifest.json" 2>/dev/null || true
+
+uv run python ci/build_group_manifest.py \
+    --group "${RUN_GROUP}" \
+    --run-id "${RUN_TIMESTAMP}" \
+    --run-url-prefix "${RUN_URL_PREFIX}" \
+    --spider-list "${SPIDER_RUN_DIR}/spider_list.txt" \
+    --stats-dir "${SPIDER_RUN_DIR}/stats" \
+    --previous-manifest "${SPIDER_RUN_DIR}/previous_manifest.json" \
+    --output "${SPIDER_RUN_DIR}/manifest.json"
+
+uv run aws s3 cp --only-show-errors "${SPIDER_RUN_DIR}/manifest.json" "${MANIFEST_S3_PATH}"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" cp --only-show-errors "${SPIDER_RUN_DIR}/manifest.json" "s3://${R2_BUCKET}/runs/latest/${RUN_GROUP}.manifest.json"
+(>&2 echo "Saved ${RUN_GROUP} manifest")
+
+# --- Invoke assembler ---
+(>&2 echo "Invoking assembler")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/assemble_latest.sh"
+```
+
+- [ ] **Step 2: Make executable**
+
+Run: `chmod +x ci/run_group_spiders.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ci/run_group_spiders.sh
+git commit -m "Add run_group_spiders.sh for running spider groups independently"
+```
+
+---
+
+### Task 6: Create `ci/assemble_latest.sh`
+
+**Files:**
+- Create: `ci/assemble_latest.sh`
+
+The assembler is lightweight: it merges manifests into `latest.json`, downloads per-spider geojsons for insights, builds global `_results.json`, updates S3 redirects, and purges CDN.
+
+- [ ] **Step 1: Create the script**
+
+Create `ci/assemble_latest.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${S3_BUCKET}" ]; then
+    (>&2 echo "Please set S3_BUCKET environment variable")
+    exit 1
+fi
+
+ASSEMBLY_DIR="${GITHUB_WORKSPACE}/assembly"
+MANIFESTS_DIR="${ASSEMBLY_DIR}/manifests"
+STATS_DIR="${ASSEMBLY_DIR}/stats"
+OUTPUT_DIR="${ASSEMBLY_DIR}/output"
+URL_PREFIX="https://alltheplaces-data.openaddresses.io"
+PARALLELISM=${PARALLELISM:-12}
+
+mkdir -p "${MANIFESTS_DIR}" "${STATS_DIR}" "${OUTPUT_DIR}"
+
+# --- Download all group manifests ---
+(>&2 echo "Downloading group manifests")
+uv run aws s3 sync \
+    --only-show-errors \
+    --exclude "*" \
+    --include "*.manifest.json" \
+    "s3://${S3_BUCKET}/runs/latest/" \
+    "${MANIFESTS_DIR}/"
+
+MANIFEST_COUNT=$(ls "${MANIFESTS_DIR}"/*.manifest.json 2>/dev/null | wc -l | tr -d ' ')
+if [ "${MANIFEST_COUNT}" -eq 0 ]; then
+    (>&2 echo "No group manifests found. Nothing to assemble.")
+    exit 1
+fi
+(>&2 echo "Found ${MANIFEST_COUNT} group manifests")
+
+# --- Build global latest.json ---
+(>&2 echo "Building latest.json")
+uv run python ci/build_latest_json.py \
+    --manifests-dir "${MANIFESTS_DIR}" \
+    --url-prefix "${URL_PREFIX}" \
+    --output "${ASSEMBLY_DIR}/latest.json"
+
+# --- Build global _results.json from all manifests ---
+(>&2 echo "Building global _results.json")
+
+# Collect all spider entries from all manifests into a single results file
+TOTAL_SPIDERS=0
+echo '{"count": 0, "results": []}' > "${STATS_DIR}/_results.json"
+
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    group_name=$(jq -r '.group' "${manifest_file}")
+
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        stats_url=$(jq -r --arg s "${spider_name}" '.spiders[$s].stats_url' "${manifest_file}")
+        ran_at=$(jq -r --arg s "${spider_name}" '.spiders[$s].ran_at' "${manifest_file}")
+        run_id=$(jq -r --arg s "${spider_name}" '.spiders[$s].run_id' "${manifest_file}")
+        feature_count=$(jq -r --arg s "${spider_name}" '.spiders[$s].feature_count' "${manifest_file}")
+        error_count=$(jq -r --arg s "${spider_name}" '.spiders[$s].error_count' "${manifest_file}")
+        elapsed_time=$(jq -r --arg s "${spider_name}" '.spiders[$s].elapsed_time' "${manifest_file}")
+
+        # Compute data age in days
+        ran_at_epoch=$(date -d "${ran_at}" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "${ran_at}" +%s 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        data_age_days=$(( (now_epoch - ran_at_epoch) / 86400 ))
+
+        jq --compact-output \
+            --arg spider "${spider_name}" \
+            --arg group "${group_name}" \
+            --arg last_run_time "${ran_at}" \
+            --arg last_run_id "${run_id}" \
+            --argjson features "${feature_count}" \
+            --argjson errors "${error_count}" \
+            --argjson elapsed "${elapsed_time}" \
+            --argjson age "${data_age_days}" \
+            '.results += [{"spider": $spider, "run_group": $group, "features": $features, "errors": $errors, "elapsed_time": $elapsed, "last_run_time": $last_run_time, "last_run_id": $last_run_id, "data_age_days": $age}]' \
+            "${STATS_DIR}/_results.json" > "${STATS_DIR}/_results.json.tmp"
+        mv "${STATS_DIR}/_results.json.tmp" "${STATS_DIR}/_results.json"
+
+        TOTAL_SPIDERS=$((TOTAL_SPIDERS + 1))
+    done
+done
+
+# Update the count
+jq --compact-output --argjson count "${TOTAL_SPIDERS}" '.count = $count' \
+    "${STATS_DIR}/_results.json" > "${STATS_DIR}/_results.json.tmp"
+mv "${STATS_DIR}/_results.json.tmp" "${STATS_DIR}/_results.json"
+(>&2 echo "Built _results.json with ${TOTAL_SPIDERS} spiders")
+
+# --- Download per-spider geojsons for insights ---
+(>&2 echo "Downloading per-spider geojsons for insights")
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        geojson_url=$(jq -r --arg s "${spider_name}" '.spiders[$s].geojson_url' "${manifest_file}")
+        # Convert URL to S3 path
+        s3_key=$(echo "${geojson_url}" | sed "s|${URL_PREFIX}/||")
+        echo "uv run aws s3 cp --only-show-errors s3://${S3_BUCKET}/${s3_key} ${OUTPUT_DIR}/${spider_name}.geojson"
+    done
+done > "${ASSEMBLY_DIR}/download_commands.txt"
+
+xargs -L 1 -P "${PARALLELISM}" -a "${ASSEMBLY_DIR}/download_commands.txt" -i sh -c "{} || true"
+(>&2 echo "Downloaded geojsons")
+
+# --- Run insights ---
+uv run scrapy insights --atp-nsi-osm "${OUTPUT_DIR}" --outfile "${STATS_DIR}/_insights.json"
+(>&2 echo "Done comparing against Name Suggestion Index and OpenStreetMap")
+
+# --- Upload stats ---
+uv run aws s3 sync --only-show-errors "${STATS_DIR}/" "s3://${S3_BUCKET}/runs/latest/stats/"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" sync --only-show-errors "${STATS_DIR}/" "s3://${R2_BUCKET}/runs/latest/stats/"
+(>&2 echo "Uploaded stats")
+
+# --- Upload latest.json ---
+uv run aws s3 cp --only-show-errors "${ASSEMBLY_DIR}/latest.json" "s3://${S3_BUCKET}/runs/latest.json"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" cp --only-show-errors "${ASSEMBLY_DIR}/latest.json" "s3://${R2_BUCKET}/runs/latest.json"
+(>&2 echo "Saved latest.json")
+
+# --- Append to global history.json ---
+uv run aws s3 cp --only-show-errors "s3://${S3_BUCKET}/runs/history.json" "${ASSEMBLY_DIR}/history.json" 2>/dev/null || echo '[]' > "${ASSEMBLY_DIR}/history.json"
+if [ ! -s "${ASSEMBLY_DIR}/history.json" ]; then
+    echo '[]' > "${ASSEMBLY_DIR}/history.json"
+fi
+
+jq --compact-output \
+    --argjson latest "$(<"${ASSEMBLY_DIR}/latest.json")" \
+    '. += [$latest]' "${ASSEMBLY_DIR}/history.json" > "${ASSEMBLY_DIR}/history.json.tmp"
+mv "${ASSEMBLY_DIR}/history.json.tmp" "${ASSEMBLY_DIR}/history.json"
+
+uv run aws s3 cp --only-show-errors "${ASSEMBLY_DIR}/history.json" "s3://${S3_BUCKET}/runs/history.json"
+AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+    uv run aws s3 --endpoint-url="${R2_ENDPOINT_URL}" cp --only-show-errors "${ASSEMBLY_DIR}/history.json" "s3://${R2_BUCKET}/runs/history.json"
+(>&2 echo "Saved history.json")
+
+# --- Update per-group artifact redirects ---
+touch "${ASSEMBLY_DIR}/placeholder.txt"
+
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    group_name=$(jq -r '.group' "${manifest_file}")
+    group_run_id=$(jq -r '.run_id' "${manifest_file}")
+    group_run_prefix="${URL_PREFIX}/runs/${group_name}/${group_run_id}"
+
+    for ext in zip parquet pmtiles; do
+        uv run aws s3 cp --only-show-errors \
+            --website-redirect="${group_run_prefix}/${group_name}.${ext}" \
+            "${ASSEMBLY_DIR}/placeholder.txt" \
+            "s3://${S3_BUCKET}/runs/latest/${group_name}.${ext}"
+    done
+done
+(>&2 echo "Updated per-group artifact redirects")
+
+# --- Update per-spider geojson redirects ---
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    for spider_name in $(jq -r '.spiders | keys[]' "${manifest_file}"); do
+        geojson_url=$(jq -r --arg s "${spider_name}" '.spiders[$s].geojson_url' "${manifest_file}")
+
+        uv run aws s3 cp --only-show-errors \
+            --website-redirect="${geojson_url}" \
+            "${ASSEMBLY_DIR}/placeholder.txt" \
+            "s3://${S3_BUCKET}/runs/latest/output/${spider_name}.geojson"
+
+        AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+        AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+        uv run aws s3 \
+            --endpoint-url="${R2_ENDPOINT_URL}" \
+            cp --only-show-errors \
+            --website-redirect="${geojson_url}" \
+            "${ASSEMBLY_DIR}/placeholder.txt" \
+            "s3://${R2_BUCKET}/runs/latest/output/${spider_name}.geojson"
+    done
+done
+(>&2 echo "Updated per-spider geojson redirects")
+
+# --- Write info_embed.html (static fallback) ---
+(>&2 echo "Writing info_embed.html")
+EMBED_ROWS=""
+for manifest_file in "${MANIFESTS_DIR}"/*.manifest.json; do
+    group_name=$(jq -r '.group' "${manifest_file}")
+    spider_count=$(jq '.spiders | length' "${manifest_file}")
+    feature_count=$(jq '[.spiders[].feature_count] | add // 0' "${manifest_file}")
+    EMBED_ROWS="${EMBED_ROWS}<tr><td>${group_name}</td><td>${spider_count} spiders, $(printf "%'d" "${feature_count}") rows</td><td><a href=\"${URL_PREFIX}/runs/latest/${group_name}.zip\">zip</a></td></tr>"
+done
+
+cat > "${ASSEMBLY_DIR}/info_embed.html" << EOF
+<html><body>
+<table>
+<tr><th>Group</th><th>Data</th><th>Download</th></tr>
+${EMBED_ROWS}
+</table>
+<small>Updated $(date)</small>
+</body></html>
+EOF
+
+uv run aws s3 cp --only-show-errors \
+    --content-type "text/html; charset=utf-8" \
+    "${ASSEMBLY_DIR}/info_embed.html" \
+    "s3://${S3_BUCKET}/runs/latest/info_embed.html"
+(>&2 echo "Saved info_embed.html")
+
+# --- Purge CDN ---
+if [ -z "${BUNNY_API_KEY:-}" ]; then
+    (>&2 echo "Skipping CDN purge because BUNNY_API_KEY not set")
+else
+    for path in "runs%2Flatest.json" "runs%2Fhistory.json" "runs%2Flatest%2Foutput%2F%2A"; do
+        curl --request GET \
+             --silent \
+             --url "https://api.bunny.net/purge?url=https%3A%2F%2Falltheplaces.b-cdn.net%2F${path}&async=false" \
+             --header "AccessKey: ${BUNNY_API_KEY}" \
+             --header 'accept: application/json'
+    done
+    (>&2 echo "Purged CDN cache")
+fi
+
+(>&2 echo "Assembly complete")
+```
+
+- [ ] **Step 2: Make executable**
+
+Run: `chmod +x ci/assemble_latest.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ci/assemble_latest.sh
+git commit -m "Add assemble_latest.sh for merging group manifests into global latest.json"
+```
+
+---
+
+### Task 7: Verify and clean up
+
+**Files:**
+- Modify: `ci/run_all_spiders.sh` (no changes yet — kept for rollback)
+- Run all tests
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All tests pass including the new ones
+
+- [ ] **Step 2: Lint check**
+
+Run: `uv run pre-commit run --all-files`
+Expected: All checks pass
+
+- [ ] **Step 3: Verify list_group command covers all spiders**
+
+Run:
+```bash
+total=0
+for g in brands addresses aggregators government infrastructure; do
+    count=$(uv run scrapy list_group $g 2>/dev/null | wc -l | tr -d ' ')
+    echo "$g: $count"
+    total=$((total + count))
+done
+echo "total: $total"
+all=$(uv run scrapy list -s LOG_ENABLED=False | wc -l | tr -d ' ')
+echo "scrapy list: $all"
+```
+Expected: `total` equals `scrapy list` count
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add -u
+git commit -m "Fix lint issues"
+```
+
+---
+
+### Notes for operational phases (not code tasks)
+
+**Phase 2 (bootstrap):** Run each group manually:
+```bash
+ci/run_group_spiders.sh brands
+ci/run_group_spiders.sh addresses
+ci/run_group_spiders.sh aggregators
+ci/run_group_spiders.sh government
+ci/run_group_spiders.sh infrastructure
+```
+
+**Phase 3 (update consumers):** Update the Cloudflare Worker and alltheplaces.xyz map viewer to read the new `latest.json` schema (these are separate repos).
+
+**Phase 4 (cutover):** Change ECS scheduled task from `run_all_spiders.sh` to `run_group_spiders.sh brands`.
+
+**Phase 5 (add schedules):** Add ECS scheduled tasks for the other four groups.
+
+**Phase 6 (cleanup):** Delete `ci/run_all_spiders.sh`.

--- a/docs/superpowers/specs/2026-04-11-grouped-spider-runs-design.md
+++ b/docs/superpowers/specs/2026-04-11-grouped-spider-runs-design.md
@@ -1,0 +1,263 @@
+# Grouped Spider Runs
+
+Run different categories of spiders at different cadences, producing per-group download artifacts.
+
+## Problem
+
+All ~4,200 spiders run together once a week. Address and infrastructure spiders produce stable data that doesn't need weekly refreshes, while brand/POI spiders benefit from frequent updates. Running everything together wastes compute and proxy budget on data that rarely changes.
+
+## Groups
+
+Five named groups: `brands`, `addresses`, `aggregators`, `government`, `infrastructure`.
+
+### Membership resolution
+
+1. If a spider class defines `run_group = "<name>"`, that value is used.
+2. Otherwise, group is inferred from the spider's filesystem path:
+   - `locations/spiders/addresses/...` -> `addresses`
+   - `locations/spiders/aggregators/...` -> `aggregators`
+   - `locations/spiders/government/...` -> `government`
+   - `locations/spiders/infrastructure/...` -> `infrastructure`
+   - Everything else -> `brands`
+
+The `run_group` attribute is the exception mechanism. Most spiders rely on the path default.
+
+### Scrapy command
+
+A new command, `scrapy list_group <group>`, prints spider names belonging to a group. It errors if any spider has `run_group` set to an unknown group name (typo protection). Lives at `locations/commands/list_group.py`.
+
+## Per-group run script
+
+`ci/run_group_spiders.sh <group>` is the generalized successor to `run_all_spiders.sh`. It takes one positional argument: the group name.
+
+### What it does
+
+1. **Sets up group-scoped paths.** Output lands at `runs/<group>/<timestamp>/...` in S3/R2 (e.g. `runs/brands/2026-04-11-14-00-00/output/mcdonalds.geojson`).
+
+2. **Lists spiders** via `uv run scrapy list_group <group>` and builds `commands.txt` with one `scrapy crawl` per spider, run in parallel via xargs (same parallelism model as today).
+
+3. **Slack notifications** include the group name for attribution.
+
+4. **Per-spider stats summarization** produces `runs/<group>/<timestamp>/stats/_results.json`. The NSI/OSM insights step is NOT run here (only at assembly time).
+
+5. **Generates per-group bundled artifacts** from the local spider output:
+   - `<group>.zip` — all geojsons for this group
+   - `<group>.parquet` — parquet for this group (via on-the-fly geojson-to-ndgeojson conversion, then `ndgeojsons_to_parquet.py`)
+   - `<group>.pmtiles` — tippecanoe over this group's geojsons (same flags as today's combined pmtiles)
+
+6. **Syncs to S3 and R2** under the group-scoped prefix.
+
+7. **Writes `runs/<group>/latest.json`** describing this group's run. Appends to `runs/<group>/history.json`.
+
+8. **Builds the group manifest** at `runs/latest/<group>.manifest.json` (see next section).
+
+9. **Invokes the assembler** as the final step: `ci/assemble_latest.sh`.
+
+### What it does NOT do
+
+- Does not write to the global `runs/latest.json` or `runs/latest/output/<spider>.geojson` redirects. Those are exclusively the assembler's responsibility.
+- Does not produce per-group `logs.zip`. Per-spider logs remain at `runs/<group>/<timestamp>/logs/<spider>.txt` and are accessible directly from S3.
+
+### Scheduling
+
+Each group is an ECS scheduled task in the AWS console, configured with whatever cadence is appropriate. The code does not enforce cadence. Recommended starting cadences (documentation only):
+
+- `brands`: weekly
+- `government`: monthly
+- `aggregators`: monthly
+- `addresses`: quarterly
+- `infrastructure`: quarterly
+
+## Group manifest
+
+Each group maintains a manifest at `runs/latest/<group>.manifest.json`. This is the cross-run state that lets the assembler know what to bundle.
+
+### Schema
+
+```json
+{
+  "group": "brands",
+  "updated_at": "2026-04-11T14:23:00Z",
+  "run_id": "2026-04-11-14-00-00",
+  "spiders": {
+    "mcdonalds": {
+      "run_id": "2026-04-11-14-00-00",
+      "ran_at": "2026-04-11T14:31:12Z",
+      "geojson_url": "https://alltheplaces-data.openaddresses.io/runs/brands/2026-04-11-14-00-00/output/mcdonalds.geojson",
+      "stats_url": "https://alltheplaces-data.openaddresses.io/runs/brands/2026-04-11-14-00-00/stats/mcdonalds.json",
+      "feature_count": 38291,
+      "error_count": 0,
+      "elapsed_time": 412.7
+    }
+  }
+}
+```
+
+### Manifest merge logic
+
+At the end of each group run:
+
+1. Download the existing manifest from S3 (treat 404 as `{"spiders": {}}`).
+2. For each spider the run was supposed to execute:
+   - If the spider produced a geojson AND its stats show non-zero `item_scraped_count`: write a fresh entry pointing at this run's URLs.
+   - Otherwise: leave the previous entry untouched (keep last known good data).
+3. Drop entries for spiders that no longer belong to this group (deleted, or moved to another group via `run_group` override).
+4. Update `group`, `updated_at`, `run_id` at the top level.
+5. Upload the new manifest to S3 + R2.
+
+A spider that has never successfully run simply doesn't appear in any manifest. It enters on its first successful run.
+
+### Concurrency
+
+Each group writes only its own manifest file. Two concurrent group runs cannot race on the same object.
+
+## Assembler
+
+`ci/assemble_latest.sh` is invoked at the end of every group run. It is a lightweight script — all heavy artifact generation (zip, parquet, pmtiles) is done by the group runner. The assembler's job is to merge state across groups and update global pointers.
+
+### Steps
+
+1. **Download all group manifests** from `runs/latest/*.manifest.json`. Merge into a flat dict of `{spider_name -> entry}`. If a spider appears in two manifests (shouldn't happen normally), the more recent `ran_at` wins and a warning is logged.
+
+2. **Download per-spider stats** from S3 using the S3 key derived from each manifest entry's `stats_url` (same AWS account, so uses `aws s3 cp` for speed and zero egress cost). Use `xargs -P` for parallelism.
+
+3. **Build global `stats/_results.json`** from all manifests, with existing fields plus:
+   - `last_run_time` (from manifest `ran_at`)
+   - `last_run_id` (from manifest `run_id`)
+   - `run_group` (which group produced this spider)
+   - `data_age_days` (computed: `now - ran_at`)
+
+4. **Run insights** across all groups: download per-spider geojsons from S3 (using manifest URLs), then `scrapy insights --atp-nsi-osm` to produce `stats/_insights.json`.
+
+5. **Upload stats** to `runs/latest/stats/` in S3 + R2.
+
+6. **Write global `runs/latest.json`** (schema below).
+
+7. **Append to `runs/history.json`**.
+
+8. **Update `runs/latest/` redirects:**
+   - Per-group: `<group>.zip`, `<group>.parquet`, `<group>.pmtiles` for each group, pointing at that group's latest run dir
+   - Per-spider: `output/<spider>.geojson` for every spider across all manifests, pointing at the spider's source group run dir
+
+9. **Write `runs/latest/info_embed.html`** as a static fallback (per-group download links).
+
+10. **Purge Bunny CDN** for `latest.json`, `history.json`, and `latest/output/*`.
+
+### Concurrency
+
+Two groups finishing near-simultaneously could both invoke the assembler. The failure mode is benign: one assembler overwrites the other's near-identical output. Both read the same manifests (one group's manifest was just written; the other's is still the previous version). The result is correct either way; the "losing" assembler's output is simply superseded.
+
+## `runs/latest.json` schema
+
+This is a breaking change from the current schema. The combined `output_url`, `pmtiles_url`, and `parquet_url` fields are removed. The `groups` array is now the primary way to access data. Top-level aggregate fields (`spiders`, `total_lines`) remain as sums for convenience.
+
+```json
+{
+  "updated_at": "2026-04-11T15:00:00Z",
+  "stats_url": "https://.../.../stats/_results.json",
+  "insights_url": "https://.../.../stats/_insights.json",
+  "spiders": 4206,
+  "total_lines": 12345678,
+
+  "groups": [
+    {
+      "name": "brands",
+      "spider_count": 3791,
+      "feature_count": 9876543,
+      "last_run_time": "2026-04-11T14:00:00Z",
+      "last_run_id": "2026-04-11-14-00-00",
+      "zip_url": "https://.../.../brands.zip",
+      "parquet_url": "https://.../.../brands.parquet",
+      "pmtiles_url": "https://.../.../brands.pmtiles"
+    },
+    {
+      "name": "addresses",
+      "spider_count": 31,
+      "feature_count": 2345678,
+      "last_run_time": "2026-03-15T10:00:00Z",
+      "last_run_id": "2026-03-15-10-00-00",
+      "zip_url": "https://.../.../addresses.zip",
+      "parquet_url": "https://.../.../addresses.parquet",
+      "pmtiles_url": "https://.../.../addresses.pmtiles"
+    }
+  ]
+}
+```
+
+`spiders` and `total_lines` at the top level are sums across all groups. Per-group `last_run_time` exposes data freshness. Per-spider freshness is in `_results.json` entries.
+
+Consumers that previously read `output_url` or `pmtiles_url` from `latest.json` will need to be updated to iterate over `groups` instead. Known consumers: the Cloudflare Worker (info embed), the alltheplaces.xyz map viewer, and any third-party scripts using the API.
+
+## Migration plan
+
+### Phase 1 — Code lands, nothing runs in production
+
+- Add `run_group` class attribute support (no spiders use it yet).
+- Add the `scrapy list_group` command + tests.
+- Create `ci/run_group_spiders.sh` and `ci/assemble_combined_output.sh`.
+- The existing `ci/run_all_spiders.sh` and weekly ECS task are untouched.
+
+Safe to merge; nothing changes in production.
+
+### Phase 2 — Manual bootstrap of group manifests
+
+- Run each group manually (one-shot ECS task or local) to populate `runs/latest/<group>.manifest.json`. Brands first (hours), then the others (fast).
+- Invoke `ci/assemble_combined_output.sh` writing to a staging prefix (`runs-staging/...`) to verify output sanity against the most recent production run.
+- Production `runs/latest.json` is untouched.
+
+### Phase 3 — Update consumers
+
+- Update the Cloudflare Worker to read `groups` from `latest.json` and render per-group download links.
+- Update the alltheplaces.xyz map viewer to read per-group `pmtiles_url` entries and add the group selector UI.
+- Deploy both before cutover so they're ready when the new `latest.json` schema goes live.
+
+### Phase 4 — Cutover
+
+- Flip the assembler to write to the real `runs/` prefix.
+- Change the weekly ECS scheduled task from `run_all_spiders.sh` to `run_group_spiders.sh brands`.
+- The next weekly run produces a brands run + assembly. The new `latest.json` schema goes live; the updated Cloudflare Worker and map viewer consume it.
+
+### Phase 5 — Add slower schedules
+
+- Add new ECS scheduled tasks for `addresses`, `aggregators`, `government`, `infrastructure` at their respective cadences.
+
+### Phase 6 — Cleanup
+
+- Delete `ci/run_all_spiders.sh`.
+- Update contributor documentation.
+
+### Failure modes
+
+- **Group run fails partway (Phase 2+).** Re-run it; the manifest merge preserves whatever succeeded previously.
+- **Assembler fails (Phase 3+).** Production `runs/latest.json` is not updated (assembler hadn't reached that step). Previous `latest.json` stays. Slack notification fires.
+- **Group runner fails (Phase 3+).** That group's manifest isn't updated. The assembler runs against previous manifests, producing output identical to the last successful assembly. Stable, no downtime.
+
+## Info embed and Cloudflare Worker
+
+The alltheplaces.xyz website loads an iframe from `https://data.alltheplaces.xyz/runs/latest/info_embed.html`. This HTML is currently generated by `run_all_spiders.sh` as a simple static file, but a Cloudflare Worker reads `latest.json` to serve it.
+
+With groups, the embed shows per-group download options. The Cloudflare Worker reads `latest.json`, iterates over the `groups` array, and renders a download link for each group's zip. Each group row shows:
+
+- Group name
+- Spider count and feature count
+- Data age (derived from `last_run_time`)
+- Download link (zip)
+
+There is no combined "Download All" link. Users download the groups they need.
+
+The assembler also writes a static `info_embed.html` as a fallback with per-group download links. The Cloudflare Worker's dynamic rendering from `latest.json` is the primary path; the static file is the fallback if the Worker is down.
+
+## Map viewer
+
+The map at alltheplaces.xyz currently loads a single `output.pmtiles` layer. With per-group pmtiles, the viewer gains a layer selector that lets users switch between groups.
+
+The viewer reads `latest.json`, discovers the per-group `pmtiles_url` entries, and renders a control (e.g. a dropdown or checkbox group) with one entry per group. `brands` is selected by default (it's the largest and most commonly viewed group).
+
+Switching layers swaps the pmtiles source. Only one pmtiles source is loaded at a time (not overlaid) to keep memory usage reasonable.
+
+The per-group pmtiles URLs come from `latest.json`, so the viewer doesn't need to know the group names at build time. A new group added later automatically appears in the selector.
+
+## Out of scope / follow-up work
+
+- **`ci/dead_spider_killer.py`**: May need adjustment. Its time-based logic ("hasn't been touched in N days") needs to account for non-weekly cadences. The spider-output-based logic ("0 features") still works unchanged.
+- **Third-party consumers of `latest.json`**: The schema is breaking (combined artifact URLs removed). Any external scripts reading `output_url` or `pmtiles_url` from the top level will need updating. Consider announcing the change in advance.

--- a/locations/commands/list_group.py
+++ b/locations/commands/list_group.py
@@ -1,0 +1,47 @@
+import argparse
+import sys
+
+from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
+
+from locations.extensions.add_lineage import (
+    VALID_GROUPS,
+    lineage_for_group,
+    spider_class_to_lineage,
+)
+
+
+class ListGroupCommand(ScrapyCommand):
+    requires_project = True
+    default_settings = {"LOG_ENABLED": False}
+
+    def syntax(self) -> str:
+        return "<group>"
+
+    def short_desc(self) -> str:
+        return "List spiders belonging to a run group"
+
+    def long_desc(self) -> str:
+        groups = ", ".join(sorted(VALID_GROUPS))
+        return f"List spider names belonging to the given run group. Valid groups: {groups}"
+
+    def run(self, args: list[str], opts: argparse.Namespace) -> None:
+        if len(args) != 1:
+            raise UsageError()
+
+        group = args[0]
+        try:
+            lineage_for_group(group)
+        except ValueError as e:
+            sys.stderr.write(str(e) + "\n")
+            self.exitcode = 1
+            return
+
+        if not self.crawler_process:
+            raise RuntimeError("Crawler process not defined")
+
+        for spider_name in sorted(self.crawler_process.spider_loader.list()):
+            spidercls = self.crawler_process.spider_loader.load(spider_name)
+            spider_lineage = spider_class_to_lineage(spidercls)
+            if spider_lineage.group == group:
+                sys.stdout.write(f"{spider_name}\n")

--- a/locations/commands/list_group.py
+++ b/locations/commands/list_group.py
@@ -4,11 +4,7 @@ import sys
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 
-from locations.extensions.add_lineage import (
-    VALID_GROUPS,
-    lineage_for_group,
-    spider_class_to_lineage,
-)
+from locations.extensions.add_lineage import VALID_GROUPS, lineage_for_group, spider_class_to_lineage
 
 
 class ListGroupCommand(ScrapyCommand):

--- a/locations/extensions/add_lineage.py
+++ b/locations/extensions/add_lineage.py
@@ -40,7 +40,7 @@ def lineage_for_group(group: str) -> "Lineage":
     return _GROUP_TO_LINEAGE[group]
 
 
-def spider_class_to_lineage(spider: Spider) -> Lineage:
+def spider_class_to_lineage(spider: type[Spider]) -> Lineage:
     """
     Provide an indication of the origin of the spider.
     :param spider: the spider

--- a/locations/extensions/add_lineage.py
+++ b/locations/extensions/add_lineage.py
@@ -15,6 +15,30 @@ class Lineage(Enum):
     Infrastructure = "S_ATP_INFRASTRUCTURE"
     Unknown = "S_?"
 
+    @property
+    def group(self) -> str:
+        return _LINEAGE_TO_GROUP.get(self, "brands")
+
+
+_LINEAGE_TO_GROUP = {
+    Lineage.Addresses: "addresses",
+    Lineage.Aggregators: "aggregators",
+    Lineage.Brands: "brands",
+    Lineage.Governments: "government",
+    Lineage.Infrastructure: "infrastructure",
+    Lineage.Unknown: "brands",
+}
+
+_GROUP_TO_LINEAGE = {v: k for k, v in _LINEAGE_TO_GROUP.items() if k != Lineage.Unknown}
+
+VALID_GROUPS = set(_GROUP_TO_LINEAGE.keys())
+
+
+def lineage_for_group(group: str) -> "Lineage":
+    if group not in _GROUP_TO_LINEAGE:
+        raise ValueError(f"Unknown group: {group!r}. Valid groups: {sorted(VALID_GROUPS)}")
+    return _GROUP_TO_LINEAGE[group]
+
 
 def spider_class_to_lineage(spider: Spider) -> Lineage:
     """

--- a/locations/extensions/add_lineage.py
+++ b/locations/extensions/add_lineage.py
@@ -40,7 +40,7 @@ def lineage_for_group(group: str) -> "Lineage":
     return _GROUP_TO_LINEAGE[group]
 
 
-def spider_class_to_lineage(spider: type[Spider]) -> Lineage:
+def spider_class_to_lineage(spider: Spider | type[Spider]) -> Lineage:
     """
     Provide an indication of the origin of the spider.
     :param spider: the spider

--- a/tests/test_build_group_manifest.py
+++ b/tests/test_build_group_manifest.py
@@ -1,0 +1,159 @@
+import json
+from pathlib import Path
+
+from ci.build_group_manifest import build_manifest
+
+
+def test_fresh_manifest_from_successful_spiders(tmp_path):
+    """First run: no previous manifest, all spiders succeed."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "log_count/ERROR": 0, "elapsed_time_seconds": 42.5}))
+    (stats_dir / "burger_king.json").write_text(json.dumps({"item_scraped_count": 50, "log_count/ERROR": 1, "elapsed_time_seconds": 30.0}))
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds", "burger_king"],
+        stats_dir=stats_dir,
+        previous_manifest=None,
+    )
+
+    assert manifest["group"] == "brands"
+    assert manifest["run_id"] == "2026-04-16-14-00-00"
+    assert "mcdonalds" in manifest["spiders"]
+    assert manifest["spiders"]["mcdonalds"]["feature_count"] == 100
+    assert manifest["spiders"]["mcdonalds"]["geojson_url"] == "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson"
+    assert "burger_king" in manifest["spiders"]
+
+
+def test_failed_spider_keeps_previous_entry(tmp_path):
+    """Spider fails: previous entry preserved."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "elapsed_time_seconds": 42.5}))
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "burger_king": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/runs/brands/2026-04-09-14-00-00/output/burger_king.geojson",
+                "stats_url": "https://example.com/runs/brands/2026-04-09-14-00-00/stats/burger_king.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 30.0,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds", "burger_king"],
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    assert manifest["spiders"]["burger_king"]["run_id"] == "2026-04-09-14-00-00"
+    assert manifest["spiders"]["burger_king"]["feature_count"] == 50
+    assert manifest["spiders"]["mcdonalds"]["run_id"] == "2026-04-16-14-00-00"
+
+
+def test_zero_items_keeps_previous_entry(tmp_path):
+    """Spider produces zero items: previous entry preserved."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 0, "elapsed_time_seconds": 5.0}))
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/mcdonalds.geojson",
+                "stats_url": "https://example.com/old/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds"],
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    assert manifest["spiders"]["mcdonalds"]["run_id"] == "2026-04-09-14-00-00"
+
+
+def test_deleted_spider_dropped_from_manifest(tmp_path):
+    """Spider removed from group: entry dropped."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "elapsed_time_seconds": 42.5}))
+
+    previous_manifest = {
+        "group": "brands",
+        "run_id": "2026-04-09-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/mcdonalds.geojson",
+                "stats_url": "https://example.com/old/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+            "old_deleted_spider": {
+                "run_id": "2026-04-09-14-00-00",
+                "ran_at": "2026-04-09T14:10:00Z",
+                "geojson_url": "https://example.com/old/old_deleted_spider.geojson",
+                "stats_url": "https://example.com/old/old_deleted_spider.json",
+                "feature_count": 10,
+                "error_count": 0,
+                "elapsed_time": 5.0,
+            },
+        },
+    }
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["mcdonalds"],
+        stats_dir=stats_dir,
+        previous_manifest=previous_manifest,
+    )
+
+    assert "old_deleted_spider" not in manifest["spiders"]
+    assert "mcdonalds" in manifest["spiders"]
+
+
+def test_never_run_spider_absent(tmp_path):
+    """Spider has never succeeded: not in manifest."""
+    stats_dir = tmp_path / "stats"
+    stats_dir.mkdir()
+
+    manifest = build_manifest(
+        group="brands",
+        run_id="2026-04-16-14-00-00",
+        run_url_prefix="https://example.com/runs/brands/2026-04-16-14-00-00",
+        spider_names=["new_spider"],
+        stats_dir=stats_dir,
+        previous_manifest=None,
+    )
+
+    assert "new_spider" not in manifest["spiders"]

--- a/tests/test_build_group_manifest.py
+++ b/tests/test_build_group_manifest.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from ci.build_group_manifest import build_manifest
 
@@ -8,8 +7,12 @@ def test_fresh_manifest_from_successful_spiders(tmp_path):
     """First run: no previous manifest, all spiders succeed."""
     stats_dir = tmp_path / "stats"
     stats_dir.mkdir()
-    (stats_dir / "mcdonalds.json").write_text(json.dumps({"item_scraped_count": 100, "log_count/ERROR": 0, "elapsed_time_seconds": 42.5}))
-    (stats_dir / "burger_king.json").write_text(json.dumps({"item_scraped_count": 50, "log_count/ERROR": 1, "elapsed_time_seconds": 30.0}))
+    (stats_dir / "mcdonalds.json").write_text(
+        json.dumps({"item_scraped_count": 100, "log_count/ERROR": 0, "elapsed_time_seconds": 42.5})
+    )
+    (stats_dir / "burger_king.json").write_text(
+        json.dumps({"item_scraped_count": 50, "log_count/ERROR": 1, "elapsed_time_seconds": 30.0})
+    )
 
     manifest = build_manifest(
         group="brands",
@@ -24,7 +27,10 @@ def test_fresh_manifest_from_successful_spiders(tmp_path):
     assert manifest["run_id"] == "2026-04-16-14-00-00"
     assert "mcdonalds" in manifest["spiders"]
     assert manifest["spiders"]["mcdonalds"]["feature_count"] == 100
-    assert manifest["spiders"]["mcdonalds"]["geojson_url"] == "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson"
+    assert (
+        manifest["spiders"]["mcdonalds"]["geojson_url"]
+        == "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson"
+    )
     assert "burger_king" in manifest["spiders"]
 
 

--- a/tests/test_build_latest_json.py
+++ b/tests/test_build_latest_json.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from ci.build_latest_json import build_latest_json
 

--- a/tests/test_build_latest_json.py
+++ b/tests/test_build_latest_json.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+from ci.build_latest_json import build_latest_json
+
+
+def test_basic_latest_json(tmp_path):
+    """Build latest.json from two group manifests."""
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    brands_manifest = {
+        "group": "brands",
+        "updated_at": "2026-04-16T14:00:00Z",
+        "run_id": "2026-04-16-14-00-00",
+        "spiders": {
+            "mcdonalds": {
+                "run_id": "2026-04-16-14-00-00",
+                "ran_at": "2026-04-16T14:31:12Z",
+                "geojson_url": "https://example.com/runs/brands/2026-04-16-14-00-00/output/mcdonalds.geojson",
+                "stats_url": "https://example.com/runs/brands/2026-04-16-14-00-00/stats/mcdonalds.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    infra_manifest = {
+        "group": "infrastructure",
+        "updated_at": "2026-03-01T10:00:00Z",
+        "run_id": "2026-03-01-10-00-00",
+        "spiders": {
+            "511_nl_ca": {
+                "run_id": "2026-03-01-10-00-00",
+                "ran_at": "2026-03-01T10:15:00Z",
+                "geojson_url": "https://example.com/runs/infrastructure/2026-03-01-10-00-00/output/511_nl_ca.geojson",
+                "stats_url": "https://example.com/runs/infrastructure/2026-03-01-10-00-00/stats/511_nl_ca.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 10.0,
+            },
+        },
+    }
+
+    (manifests_dir / "brands.manifest.json").write_text(json.dumps(brands_manifest))
+    (manifests_dir / "infrastructure.manifest.json").write_text(json.dumps(infra_manifest))
+
+    url_prefix = "https://example.com"
+
+    latest = build_latest_json(manifests_dir, url_prefix)
+
+    assert latest["spiders"] == 2
+    assert latest["total_lines"] == 150
+    assert len(latest["groups"]) == 2
+
+    brands_group = next(g for g in latest["groups"] if g["name"] == "brands")
+    assert brands_group["spider_count"] == 1
+    assert brands_group["feature_count"] == 100
+    assert "zip_url" in brands_group
+    assert "parquet_url" in brands_group
+    assert "pmtiles_url" in brands_group
+
+    infra_group = next(g for g in latest["groups"] if g["name"] == "infrastructure")
+    assert infra_group["spider_count"] == 1
+
+
+def test_duplicate_spider_in_two_manifests(tmp_path):
+    """If a spider appears in two manifests, the more recent ran_at wins."""
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+
+    manifest_a = {
+        "group": "brands",
+        "updated_at": "2026-04-16T14:00:00Z",
+        "run_id": "2026-04-16-14-00-00",
+        "spiders": {
+            "dupe_spider": {
+                "run_id": "2026-04-16-14-00-00",
+                "ran_at": "2026-04-16T14:31:12Z",
+                "geojson_url": "https://example.com/brands/dupe_spider.geojson",
+                "stats_url": "https://example.com/brands/dupe_spider.json",
+                "feature_count": 100,
+                "error_count": 0,
+                "elapsed_time": 42.5,
+            },
+        },
+    }
+
+    manifest_b = {
+        "group": "infrastructure",
+        "updated_at": "2026-03-01T10:00:00Z",
+        "run_id": "2026-03-01-10-00-00",
+        "spiders": {
+            "dupe_spider": {
+                "run_id": "2026-03-01-10-00-00",
+                "ran_at": "2026-03-01T10:15:00Z",
+                "geojson_url": "https://example.com/infra/dupe_spider.geojson",
+                "stats_url": "https://example.com/infra/dupe_spider.json",
+                "feature_count": 50,
+                "error_count": 0,
+                "elapsed_time": 10.0,
+            },
+        },
+    }
+
+    (manifests_dir / "brands.manifest.json").write_text(json.dumps(manifest_a))
+    (manifests_dir / "infrastructure.manifest.json").write_text(json.dumps(manifest_b))
+
+    latest = build_latest_json(manifests_dir, "https://example.com")
+
+    # Only counted once, from the more recent manifest (brands)
+    assert latest["spiders"] == 1
+    assert latest["total_lines"] == 100

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,4 +1,6 @@
-from locations.extensions.add_lineage import Lineage, spider_class_to_lineage
+import pytest
+
+from locations.extensions.add_lineage import VALID_GROUPS, Lineage, lineage_for_group, spider_class_to_lineage
 from locations.spiders.asda_gb import AsdaGBSpider
 from locations.spiders.greggs_gb import GreggsGBSpider
 
@@ -13,3 +15,29 @@ def test_class_override():
 
 def test_expected():
     assert spider_class_to_lineage(GreggsGBSpider) == Lineage.Brands
+
+
+def test_lineage_group_names():
+    assert Lineage.Brands.group == "brands"
+    assert Lineage.Addresses.group == "addresses"
+    assert Lineage.Aggregators.group == "aggregators"
+    assert Lineage.Governments.group == "government"
+    assert Lineage.Infrastructure.group == "infrastructure"
+    assert Lineage.Unknown.group == "brands"
+
+
+def test_valid_groups():
+    assert VALID_GROUPS == {"brands", "addresses", "aggregators", "government", "infrastructure"}
+
+
+def test_lineage_for_group():
+    assert lineage_for_group("brands") == Lineage.Brands
+    assert lineage_for_group("addresses") == Lineage.Addresses
+    assert lineage_for_group("aggregators") == Lineage.Aggregators
+    assert lineage_for_group("government") == Lineage.Governments
+    assert lineage_for_group("infrastructure") == Lineage.Infrastructure
+
+
+def test_lineage_for_group_invalid():
+    with pytest.raises(ValueError, match="Unknown group"):
+        lineage_for_group("invalid_group")

--- a/tests/test_list_group_command.py
+++ b/tests/test_list_group_command.py
@@ -1,8 +1,4 @@
-from locations.extensions.add_lineage import (
-    Lineage,
-    spider_class_to_lineage,
-    VALID_GROUPS,
-)
+from locations.extensions.add_lineage import VALID_GROUPS, Lineage, spider_class_to_lineage
 
 
 def test_spider_group_resolution_from_path():
@@ -11,10 +7,7 @@ def test_spider_group_resolution_from_path():
         AuroraCityCouncilTrafficSignalsUSSpider,
     )
 
-    assert (
-        spider_class_to_lineage(AuroraCityCouncilTrafficSignalsUSSpider).group
-        == "infrastructure"
-    )
+    assert spider_class_to_lineage(AuroraCityCouncilTrafficSignalsUSSpider).group == "infrastructure"
 
 
 def test_spider_group_resolution_brands_default():

--- a/tests/test_list_group_command.py
+++ b/tests/test_list_group_command.py
@@ -1,0 +1,52 @@
+from locations.extensions.add_lineage import (
+    Lineage,
+    spider_class_to_lineage,
+    VALID_GROUPS,
+)
+
+
+def test_spider_group_resolution_from_path():
+    """Verify that spiders in subdirectories resolve to the correct group."""
+    from locations.spiders.infrastructure.aurora_city_council_traffic_signals_us import (
+        AuroraCityCouncilTrafficSignalsUSSpider,
+    )
+
+    assert (
+        spider_class_to_lineage(AuroraCityCouncilTrafficSignalsUSSpider).group
+        == "infrastructure"
+    )
+
+
+def test_spider_group_resolution_brands_default():
+    """Verify that top-level spiders default to brands."""
+    from locations.spiders.greggs_gb import GreggsGBSpider
+
+    assert spider_class_to_lineage(GreggsGBSpider).group == "brands"
+
+
+def test_spider_group_override_via_lineage():
+    """Verify that the lineage class attribute overrides path-based resolution."""
+    from locations.spiders.greggs_gb import GreggsGBSpider
+
+    original = getattr(GreggsGBSpider, "lineage", None)
+    try:
+        GreggsGBSpider.lineage = Lineage.Infrastructure
+        assert spider_class_to_lineage(GreggsGBSpider).group == "infrastructure"
+    finally:
+        if original is None:
+            del GreggsGBSpider.lineage
+        else:
+            GreggsGBSpider.lineage = original
+
+
+def test_all_groups_have_at_least_one_spider():
+    """Verify every defined group has at least one spider in the codebase."""
+    from locations.exporters.geojson import iter_spider_classes_in_modules
+
+    groups_seen = set()
+    for spider_class in iter_spider_classes_in_modules():
+        lineage = spider_class_to_lineage(spider_class)
+        groups_seen.add(lineage.group)
+
+    for group in VALID_GROUPS:
+        assert group in groups_seen, f"No spiders found for group {group!r}"


### PR DESCRIPTION
## Summary

Run different categories of spiders at independent cadences instead of running all ~4,600 spiders together weekly. This PR adds the code infrastructure (Phase 1) — no production behavior changes until the operational phases are executed.

## Problem

All spiders run together once a week. Address and infrastructure spiders produce stable data that doesn't need weekly refreshes, while brand/POI spiders benefit from frequent updates. Running everything together wastes compute and proxy budget on data that rarely changes.

## Design

Five named groups: **brands** (4,200), **infrastructure** (357), **government** (22), **addresses** (16), **aggregators** (2).

Each group runs independently on its own schedule (weekly for brands, monthly/quarterly for others). Each group run produces its own zip, parquet, and pmtiles artifacts. A lightweight assembler merges state across all groups into a global `latest.json` after every group run.

### Key architectural decisions

- **Group membership** is resolved from the spider's filesystem path (existing `Lineage` infrastructure), with a `lineage` class-attribute override for exceptions. No new spider attribute needed.
- **Per-group artifacts** (zip/parquet/pmtiles) are built by the group runner itself (it has the files locally). No combined "all places" output — consumers download the groups they need.
- **Manifest merge logic** preserves last known good data: if a spider fails, its previous successful output stays in the manifest until it's fixed or removed by the dead-spider-killer.
- **The assembler** (`assemble_latest.sh`) is lightweight — it only merges manifests, builds global stats/insights, updates S3 redirects, and purges CDN. All heavy work (tippecanoe, parquet, zip) happens in the group runner.
- **`latest.json` schema is breaking** — the combined `output_url`/`pmtiles_url`/`parquet_url` top-level fields are removed. The `groups` array becomes the primary interface for consumers.

### New `latest.json` schema

```json
{
  "updated_at": "2026-04-16T15:00:00Z",
  "stats_url": "https://.../.../stats/_results.json",
  "insights_url": "https://.../.../stats/_insights.json",
  "spiders": 4597,
  "total_lines": 12345678,
  "groups": [
    {
      "name": "brands",
      "spider_count": 4200,
      "feature_count": 9876543,
      "last_run_time": "2026-04-16T14:00:00Z",
      "last_run_id": "2026-04-16-14-00-00",
      "zip_url": "https://.../.../brands.zip",
      "parquet_url": "https://.../.../brands.parquet",
      "pmtiles_url": "https://.../.../brands.pmtiles"
    }
  ]
}
```

### S3 layout

```
runs/<group>/<timestamp>/output/<spider>.geojson   # per-spider output
runs/<group>/<timestamp>/<group>.zip               # group bundle
runs/<group>/<timestamp>/<group>.parquet           # group parquet
runs/<group>/<timestamp>/<group>.pmtiles           # group tiles
runs/<group>/latest.json                           # group run metadata
runs/<group>/history.json                          # group run history
runs/latest/<group>.manifest.json                  # cross-run spider state
runs/latest.json                                   # global (written by assembler)
runs/latest/output/<spider>.geojson                # redirect to source group
runs/latest/<group>.zip                            # redirect to latest group run
```

## What's in this PR

| File | Purpose |
|------|---------|
| `locations/extensions/add_lineage.py` | Extended `Lineage` enum with `.group` property, `VALID_GROUPS`, `lineage_for_group()` |
| `locations/commands/list_group.py` | New `scrapy list_group <group>` command |
| `ci/build_group_manifest.py` | Manifest merge logic (keep last known good on failure) |
| `ci/build_latest_json.py` | Merge group manifests into global `latest.json` |
| `ci/run_group_spiders.sh` | Group runner script (replaces `run_all_spiders.sh`) |
| `ci/assemble_latest.sh` | Lightweight assembler (stats, insights, redirects, CDN) |
| `tests/test_lineage.py` | Tests for group property |
| `tests/test_list_group_command.py` | Tests for list_group command |
| `tests/test_build_group_manifest.py` | Tests for manifest merge logic |
| `tests/test_build_latest_json.py` | Tests for latest.json builder |
| `docs/superpowers/specs/...` | Design spec |
| `docs/superpowers/plans/...` | Implementation plan |

## Rollout plan (not in this PR)

1. **Phase 2 — Bootstrap**: Run each group manually to populate manifests in S3
2. **Phase 3 — Update consumers**: Update Cloudflare Worker (info embed) and map viewer to read new `latest.json` schema, add group selector to map
3. **Phase 4 — Cutover**: Switch ECS scheduled task from `run_all_spiders.sh` to `run_group_spiders.sh brands`
4. **Phase 5 — Add schedules**: Add ECS tasks for other groups (monthly/quarterly)
5. **Phase 6 — Cleanup**: Delete `run_all_spiders.sh`

## Failure modes

- **Group run fails**: Manifest isn't updated; assembler uses previous manifests. No downtime.
- **Assembler fails**: `latest.json` isn't updated; previous version stays. Slack notifies.
- **Spider fails within a group**: Previous successful data preserved in manifest until spider is fixed.