### PR TITLE
Add test to catch broken cross-spider imports

### DIFF
--- a/tests/test_spider_imports.py
+++ b/tests/test_spider_imports.py
@@ -1,0 +1,11 @@
+from locations.exporters.geojson import iter_spider_classes_in_modules
+
+
+def test_all_spiders_importable():
+    """Ensure all spider modules can be imported without errors.
+
+    This catches broken cross-spider dependencies, e.g. when a spider
+    is removed but another spider still imports from it.
+    """
+    spiders = list(iter_spider_classes_in_modules())
+    assert len(spiders) > 0


### PR DESCRIPTION
## Summary
- Adds a pytest that imports all spider modules, catching broken cross-spider dependencies early
- Would have caught the `ttbbank_th` → `cp_freshmart_th` import breakage before merge

Seen in #15991