### PR TITLE
[Deloitte] Fix Spider

### DIFF
--- a/locations/spiders/deloitte.py
+++ b/locations/spiders/deloitte.py
@@ -1,154 +1,52 @@
-import json
-import re
-from typing import AsyncIterator
+from typing import Any, Iterable
 
-from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
+from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class DeloitteSpider(Spider):
+class DeloitteSpider(SitemapSpider, StructuredDataSpider):
     name = "deloitte"
     item_attributes = {"brand": "Deloitte", "brand_wikidata": "Q491748"}
     allowed_domains = ["deloitte.com"]
+    sitemap_urls = [
+        "https://www.deloitte.com/sitemap_index.xml",
+    ]
+    sitemap_rules = [(r"/offices/[^/]+/[^/]+\.html$", "parse_sd")]
 
-    async def start(self) -> AsyncIterator[Request]:
-        start_urls = (
-            (
-                "https://www2.deloitte.com/us/en/footerlinks/office-locator.html",
-                self.parse,
-            ),
-            (
-                "https://www2.deloitte.com/us/en/footerlinks/global-office-directory.html",
-                self.parse_global,
-            ),
-        )
+    def sitemap_filter(self, entries: Iterable[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+        for entry in entries:
+            for sitemap_url in [
+                "tr_tr",
+                "global_en",
+                "nl_nl",
+                "ch_de",
+                "ch_fr",
+                "ro_ro",
+                "hu_hu",
+                "cz-sk_sk",
+                "cz-sk_cs",
+                "az_az",
+                "ca_fr",
+                "kz_ru",
+                "il_he",
+                "cn_zh",
+                "tw_tc",
+            ]:
+                if sitemap_url in entry:
+                    continue
+                else:
+                    yield entry
 
-        for url, callback in start_urls:
-            yield Request(url, callback=callback)
-
-    def parse(self, response):
-        """First scrape the data from the location list page.  If there is a link to the details page, then
-        scrape from that page and replace the existing data.
-
-        Some of the locations do not have details page, so we will get what data we can for those locations.
-
-        :param response:
-        :return:
-        """
-        offices = response.xpath('//div[contains(@class, "offices-container")]//div[@class="offices"]')
-
-        for office in offices:
-            address_parts = office.xpath('.//div[@class="address"]//p//text()').extract()
-            address_parts = [a.strip().replace("\u200b", "").replace("\n", "").replace("\t", "") for a in address_parts]
-            country = address_parts.pop(-1)
-            if country == "United States":
-                postcode = address_parts.pop(-1)
-                try:
-                    city, state = address_parts.pop(-1).split(",")
-                    city, state = city.strip().replace("\u200b", ""), state.strip().replace("\u200b", "")
-                except:
-                    city, state = None, None
-            else:
-                # too much variation to figure out address parsing
-                city, state, postcode = None, None, None
-                address_parts.append(country)
-            address = clean_address(address_parts)
-
-            name = office.xpath(".//h3/a/text()").extract_first() or ""
-            if not name:
-                name = office.xpath(".//h3/text()").extract_first() or ""
-
-            properties = {
-                "ref": name.strip().replace(" ", "-"),
-                "name": name.strip(),
-                "phone": (office.xpath('.//div[@class="contact"]//a/text()').extract_first() or "").replace(
-                    "\u200b", ""
-                ),
-                "street_address": address,
-                "city": city,
-                "state": state,
-                "postcode": postcode,
-                "country": country,
-                "website": response.url,
-                "lat": None,
-                "lon": None,
-            }
-
-            details_url = office.xpath(".//h3/a/@href").extract_first()
-            if details_url:
-                yield Request(
-                    response.urljoin(details_url),
-                    callback=self.parse_location,
-                    meta={"properties": properties},
-                )
-            else:
-                yield Feature(**properties)
-
-    def parse_global(self, response):
-        countries = response.xpath('////div[contains(@class, "country-details")]')
-        for country in countries:
-            links = country.xpath(".//a/@href").extract()
-            en_links = [link for link in links if "/en/" in link]
-            if en_links:
-                url = en_links[0]
-            else:
-                url = links[0]
-            yield Request(response.urljoin(url), callback=self.parse)
-
-    def parse_location(self, response):
-        properties = response.meta["properties"]
-
-        try:
-            store_data = json.loads(response.xpath('//script[@type="application/ld+json"]/text()').extract_first())
-
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if ld_data.get("address").get("streetAddress"):
+            item["website"] = response.url
             try:
-                lat = float(store_data["geo"]["latitude"])
-                lon = float(store_data["geo"]["longitude"])
-            except KeyError:
-                map_url = store_data.get("hasMap", "").replace("\u003d", "=")
-                try:
-                    lat, lon = re.search(r"ll=([\d\.-]+),([\d\.\-]+)", map_url).groups()
-                    lat, lon = float(lat), float(lon)
-                except AttributeError:
-                    lat, lon = (
-                        None,
-                        None,
-                    )  # gmap url is a /place/<address> type url (no lat/lon available)
-
-            phone = store_data.get("telephone") or None
-            if phone:
-                phone = phone[0].replace("\u200b", "")
-
-            addresses = store_data["address"].get("streetAddress") or []
-            address = " ".join([a.strip().replace("\u200b", "") for a in addresses]) or None
-
-            properties.update(
-                {
-                    "ref": "-".join(re.search(r".*/(.*)/(.*).html", response.url).groups()),
-                    "name": store_data["name"],
-                    "lat": lat,
-                    "lon": lon,
-                    "phone": phone,
-                    "street_address": address,
-                    "city": store_data["address"].get("addressLocality", "").strip().replace("\u200b", "") or None,
-                    "state": store_data["address"].get("addressRegion", "").strip().replace("\u200b", "") or None,
-                    "postcode": store_data["address"].get("postalCode", "").strip().replace("\u200b", "") or None,
-                    "country": (store_data["address"]["addressCountry"] or {}).get("name"),
-                    "website": response.url,
-                }
-            )
-
-        except TypeError:
-            # a few of the office pages don't have the store data json object, so just go with the original
-            # properties from the overview page
-            properties.update(
-                {
-                    "ref": "-".join(re.search(r".*/(.*)/(.*).html", response.url).groups()),
-                    "website": response.url,
-                }
-            )
-
-        yield Feature(**properties)
+                if not ld_data.get("geo"):
+                    extract_google_position(item, response)
+            except:
+                pass
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Deloitte': 591,
 'atp/brand_wikidata/Q491748': 591,
 'atp/category/office/consulting': 591,
 'atp/clean_strings/name': 5,
 'atp/clean_strings/phone': 27,
 'atp/clean_strings/postcode': 3,
 'atp/clean_strings/street_address': 1,
 'atp/country/AE': 9,
 'atp/country/AN': 2,
 'atp/country/AR': 4,
 'atp/country/AU': 10,
 'atp/country/AZ': 1,
 'atp/country/BB': 1,
 'atp/country/BD': 3,
 'atp/country/BE': 11,
 'atp/country/BH': 1,
 'atp/country/BM': 1,
 'atp/country/BN': 1,
 'atp/country/BO': 1,
 'atp/country/BR': 18,
 'atp/country/BS': 2,
 'atp/country/BW': 1,
 'atp/country/CE': 1,
 'atp/country/CH': 21,
 'atp/country/CL': 5,
 'atp/country/CO': 5,
 'atp/country/CR': 1,
 'atp/country/CY': 4,
 'atp/country/CZ': 6,
 'atp/country/DE': 4,
 'atp/country/DK': 6,
 'atp/country/DO': 1,
 'atp/country/EC': 2,
 'atp/country/EG': 1,
 'atp/country/ES': 22,
 'atp/country/ET': 1,
 'atp/country/FI': 3,
 'atp/country/GB': 1,
 'atp/country/GE': 1,
 'atp/country/GH': 1,
 'atp/country/GR': 4,
 'atp/country/GT': 1,
 'atp/country/GZ': 1,
 'atp/country/HN': 2,
 'atp/country/HU': 4,
 'atp/country/ID': 7,
 'atp/country/IE': 2,
 'atp/country/IL': 16,
 'atp/country/IQ': 1,
 'atp/country/IS': 6,
 'atp/country/IT': 82,
 'atp/country/JO': 2,
 'atp/country/JP': 59,
 'atp/country/KE': 1,
 'atp/country/KH': 1,
 'atp/country/KR': 2,
 'atp/country/KW': 1,
 'atp/country/KY': 1,
 'atp/country/KZ': 10,
 'atp/country/LA': 1,
 'atp/country/LB': 2,
 'atp/country/LK': 1,
 'atp/country/LT': 1,
 'atp/country/LU': 2,
 'atp/country/LV': 1,
 'atp/country/LY': 1,
 'atp/country/MM': 1,
 'atp/country/MT': 3,
 'atp/country/MX': 18,
 'atp/country/MY': 4,
 'atp/country/NA': 1,
 'atp/country/NI': 1,
 'atp/country/NL': 26,
 'atp/country/NO': 3,
 'atp/country/NZ': 8,
 'atp/country/OM': 1,
 'atp/country/PA': 1,
 'atp/country/PE': 1,
 'atp/country/PG': 1,
 'atp/country/PH': 2,
 'atp/country/PL': 9,
 'atp/country/PT': 11,
 'atp/country/PY': 1,
 'atp/country/QA': 1,
 'atp/country/RO': 8,
 'atp/country/SA': 4,
 'atp/country/SE': 7,
 'atp/country/SG': 1,
 'atp/country/SK': 3,
 'atp/country/SV': 1,
 'atp/country/TH': 2,
 'atp/country/TR': 5,
 'atp/country/TT': 1,
 'atp/country/TW': 5,
 'atp/country/UG': 1,
 'atp/country/US': 82,
 'atp/country/UY': 3,
 'atp/country/VE': 2,
 'atp/country/VG': 1,
 'atp/country/VN': 2,
 'atp/country/YE': 1,
 'atp/country/ZA': 4,
 'atp/duplicate_count': 5,
 'atp/field/branch/missing': 591,
 'atp/field/city/missing': 12,
 'atp/field/country/from_reverse_geocoding': 2,
 'atp/field/country/invalid': 2,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 430,
 'atp/field/geometry/missing': 333,
 'atp/field/image/invalid': 17,
 'atp/field/opening_hours/missing': 591,
 'atp/field/operator/missing': 591,
 'atp/field/operator_wikidata/missing': 591,
 'atp/field/phone/invalid': 35,
 'atp/field/phone/missing': 87,
 'atp/field/postcode/missing': 125,
 'atp/field/state/missing': 278,
 'atp/item_scraped_host_count/www.deloitte.com': 596,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 591,
 'downloader/request_bytes': 353248,
 'downloader/request_count': 744,
 'downloader/request_method_count/GET': 744,
 'downloader/response_bytes': 19507247,
 'downloader/response_count': 744,
 'downloader/response_status_count/200': 741,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 2,
 'dupefilter/filtered': 10944,
 'elapsed_time_seconds': 58.577639,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 21, 5, 20, 19, 392920, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 744,
 'httpcompression/response_bytes': 187945409,
 'httpcompression/response_count': 743,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/404': 2,
 'item_dropped_count': 5,
 'item_dropped_reasons_count/DropItem': 5,
 'item_scraped_count': 591,
 'items_per_minute': 611.3793103448276,
 'log_count/DEBUG': 1342,
 'log_count/ERROR': 3,
 'log_count/INFO': 5,
 'log_count/WARNING': 17,
 'request_depth_max': 2,
 'response_received_count': 743,
 'responses_per_minute': 768.6206896551724,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 743,
 'scheduler/dequeued/memory': 743,
 'scheduler/enqueued': 743,
 'scheduler/enqueued/memory': 743,
 'spider_exceptions/XMLSyntaxError': 1,
 'spider_exceptions/count': 1,
 'start_time': datetime.datetime(2026, 4, 21, 5, 19, 20, 815281, tzinfo=datetime.timezone.utc)}
```