### PR TITLE
[Ford Dealers US] Fix Spider

### DIFF
--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -23,8 +23,9 @@ class FordDealersUSSpider(scrapy.Spider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs):
+
         client_id = re.search(r"clientId\":\"([0-9-a-z-]+)\"", response.text).group(1)
-        js_path = response.xpath('//*[@id="baseBrand-5c0f3b34d2"]/script[10]/@src').get()
+        js_path = response.xpath('//*[contains(@src,"clientlibs/skin/")]/@src').get()
         yield scrapy.Request(
             url="https://www.ford.com" + js_path,
             callback=self.parse_state,


### PR DESCRIPTION
```python
{'atp/brand/Ford': 2819,
'atp/brand_wikidata/Q44294': 2819,
'atp/category/shop/car': 2819,
'atp/country/US': 2819,
'atp/field/branch/missing': 2819,
'atp/field/email/invalid': 1,
'atp/field/email/missing': 1200,
'atp/field/opening_hours/missing': 60,
'atp/field/operator/missing': 2819,
'atp/field/operator_wikidata/missing': 2819,
'atp/field/phone/missing': 18,
'atp/field/twitter/missing': 2819,
'atp/item_scraped_host_count/www.ford.com': 2819,
'atp/lineage': 'S_?',
'atp/nsi/cc_match': 2819,
'downloader/request_bytes': 37945,
'downloader/request_count': 54,
'downloader/request_method_count/GET': 54,
'downloader/response_bytes': 11083881,
'downloader/response_count': 54,
'downloader/response_status_count/200': 54,
'elapsed_time_seconds': 85.996485,
'finish_reason': 'finished',
'finish_time': datetime.datetime(2026, 4, 21, 7, 12, 16, 2285, tzinfo=datetime.timezone.utc),
'item_scraped_count': 2819,
'items_per_minute': 1989.8823529411764,
'log_count/DEBUG': 3159,
'log_count/INFO': 8,
'playwright/browser_count': 1,
'playwright/context_count': 1,
'playwright/context_count/max_concurrent': 1,
'playwright/context_count/persistent/False': 1,
'playwright/context_count/remote/False': 1,
'playwright/page_count': 54,
'playwright/page_count/closed': 54,
'playwright/page_count/max_concurrent': 4,
'playwright/request_count': 113,
'playwright/request_count/aborted': 59,
'playwright/request_count/method/GET': 113,
'playwright/request_count/navigation': 54,
'playwright/request_count/resource_type/document': 54,
'playwright/request_count/resource_type/font': 8,
'playwright/request_count/resource_type/image': 3,
'playwright/request_count/resource_type/script': 41,
'playwright/request_count/resource_type/stylesheet': 7,
'playwright/response_count': 54,
'playwright/response_count/method/GET': 54,
'playwright/response_count/resource_type/document': 54,
'request_depth_max': 2,
'response_received_count': 54,
'responses_per_minute': 38.11764705882353,
'robotstxt/request_count': 1,
'robotstxt/response_count': 1,
'robotstxt/response_status_count/200': 1,
'scheduler/dequeued': 53,
'scheduler/dequeued/memory': 53,
'scheduler/enqueued': 53,
'scheduler/enqueued/memory': 53,
'start_time': datetime.datetime(2026, 4, 21, 7, 10, 50, 5800, tzinfo=datetime.timezone.utc)}
```