### PR TITLE
[Mcdonalds LU] Fix Spider

### DIFF
--- a/locations/spiders/mcdonalds_lu.py
+++ b/locations/spiders/mcdonalds_lu.py
@@ -1,7 +1,9 @@
 import re
 
-from scrapy import Request
+import scrapy
+from scrapy.http import TextResponse
 
+from locations.items import Feature
 from locations.spiders.mcdonalds import McdonaldsSpider
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -9,27 +11,20 @@ from locations.structured_data_spider import StructuredDataSpider
 class McdonaldsLUSpider(StructuredDataSpider):
     name = "mcdonalds_lu"
     item_attributes = McdonaldsSpider.item_attributes
-    allowed_domains = ["mcd.lu"]
-    start_urls = ["https://mcd.lu/"]
+    allowed_domains = ["mcdonalds.lu"]
+    start_urls = ["https://mcdonalds.lu/fr/restaurants/"]
 
-    def parse_latlon(self, data):
-        match = re.search(r"sll=(.*),(.*)&amp;ss", data)
-        if match:
-            return match.groups()[0].strip(), match.groups()[1].strip()
-        else:
-            return None, None
+    def parse(self, response: TextResponse, **kwargs):
+        for url in response.xpath(
+            '//*[@class="restaurantlist-card"]//*[@class="restaurantlist-infos"]/a/@href'
+        ).getall():
+            yield scrapy.Request(url=url, callback=self.parse_details)
 
-    def parse(self, response, **kwargs):
-        for ref in response.xpath('//a[starts-with(@id, "snav_1_")]/@id').getall():
-            yield Request(
-                "https://mcd.lu/content.php?r={}&lang=de".format(ref.replace("snav_", "")), callback=self.parse_sd
-            )
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = None
-        item["addr_full"] = " ".join(
-            filter(None, map(str.strip, response.xpath('//div[@class="txt"]/h2/following::text()').getall()))
-        ).split(" Tel ", 1)[0]
-        item["lat"], item["lon"] = self.parse_latlon(response.text)
-
+    def parse_details(self, response):
+        item = Feature()
+        item["branch"] = (
+            response.xpath("//h2//text()").get().replace("McDonald’s ", "").replace("» ", "").replace(" «", "")
+        )
+        item["lat"], item["lon"] = re.search(r"setView\(\[(\d+\.\d+),\s*(\d+\.\d+)\],", response.text).groups()
+        item["ref"] = item["website"] = response.url
         yield item


### PR DESCRIPTION
```python
{"atp/brand/McDonald's": 11,
 'atp/brand_wikidata/Q38076': 11,
 'atp/category/amenity/fast_food': 11,
 'atp/clean_strings/branch': 1,
 'atp/country/LU': 11,
 'atp/field/city/missing': 11,
 'atp/field/country/from_spider_name': 11,
 'atp/field/email/missing': 11,
 'atp/field/image/missing': 11,
 'atp/field/opening_hours/missing': 11,
 'atp/field/operator/missing': 11,
 'atp/field/operator_wikidata/missing': 11,
 'atp/field/phone/missing': 11,
 'atp/field/postcode/missing': 11,
 'atp/field/state/missing': 11,
 'atp/field/street_address/missing': 11,
 'atp/field/twitter/missing': 11,
 'atp/item_scraped_host_count/mcdonalds.lu': 11,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 11,
 'downloader/request_bytes': 5377,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 169666,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 13,
 'elapsed_time_seconds': 16.156301,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 21, 8, 56, 30, 647355, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 868594,
 'httpcompression/response_count': 13,
 'item_scraped_count': 11,
 'items_per_minute': 41.25,
 'log_count/DEBUG': 24,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 13,
 'responses_per_minute': 48.75,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2026, 4, 21, 8, 56, 14, 491054, tzinfo=datetime.timezone.utc)}
```