### PR TITLE
[YX] Fix Spider

### DIFF
--- a/locations/spiders/yx.py
+++ b/locations/spiders/yx.py
@@ -1,7 +1,7 @@
-from typing import Any, AsyncIterator
+from typing import Any
 
 from scrapy import Spider
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -14,44 +14,36 @@ YX = {"brand": "YX", "brand_wikidata": "Q4580519"}
 
 class YxSpider(Spider):
     name = "yx"
-
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield JsonRequest(
-            url="https://www.preem.no/api/Stations/AllStations?$select=Id,Name,Address,PostalCode,City,PhoneNumber,StationType,StationSort,StationCardImage,OpeningHourWeekdayTime,ClosingHourWeekdayTime,OpeningHourSaturdayTime,ClosingHourSaturdayTime,OpeningHourSundayTime,ClosingHourSundayTime,CoordinateLatitude,CoordinateLongitude,Services/Name,Services/LinkedPage,Services/IconCssClass,FuelTypes/Name,FuelTypes/LinkedPage,FuelTypes/IconCssClass,FuelTypes/TextColor,FuelTypes/BackgroundColor,FuelTypes/BorderColor,FuelTypes/Type,FriendlyUrl,CampaignImage,CampaignUrl,TrailerRentalUrl,IsTrb,IsSaifa,IsSaifaStation,IsUnoX,IsUnoXTruck,TillhorInternationellaAllianser&$expand=FuelTypes,Services&currentLanguage=no",
-        )
+    start_urls = ["https://www.preem.no/stations-store.json"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json():
+        for location in response.json().get("data"):
             item = DictParser.parse(location)
-            item["ref"] = location["FriendlyUrl"]
-            item["lat"] = location["CoordinateLatitude"]
-            item["lon"] = location["CoordinateLongitude"]
-            item["street_address"] = item.pop("addr_full")
-            if "https:" not in location["FriendlyUrl"]:
-                item["website"] = "https://www.preem.no" + location["FriendlyUrl"]
-            else:
-                item["website"] = item["ref"]
-            if "Yx" in item["name"] and "7-eleven" not in item["name"]:
+            item["name"] = location["stationName"]
+            item["ref"] = location["stationCode"]
+
+            if "YX" in item["name"] and "7-Eleven" not in item["name"]:
                 item.update(YX)
-                item["branch"] = item.pop("name").removeprefix("Yx ")
+                item["branch"] = item.pop("name").removeprefix("YX ")
                 apply_category(Categories.FUEL_STATION, item)
-            elif "Uno-x" in item["name"] and "7-eleven" not in item["name"]:
+            elif "Uno-X" in item["name"] and "7-Eleven" not in item["name"]:
                 item.update(UNOX)
                 item["branch"] = item.pop("name").removeprefix("Uno-x ")
                 apply_category(Categories.FUEL_STATION, item)
-            elif "7-eleven" in item["name"]:
+            elif "7-Eleven" in item["name"]:
                 item.update(SEVEN_ELEVEN_SHARED_ATTRIBUTES)
-                item["branch"] = item.pop("name").removeprefix("Yx ").removeprefix("7-eleven ")
+                item["branch"] = item.pop("name").removeprefix("Yx ").removeprefix("7-eleven ").removeprefix("Uno-X ")
                 apply_category(Categories.SHOP_CONVENIENCE, item)
             else:
                 item.update(PREEM)
                 item["name"] = None
                 apply_category(Categories.FUEL_STATION, item)
 
-            for fuel_type in location["FuelTypes"]:
-                apply_yes_no(Fuel.ADBLUE, item, "adblue" in fuel_type["Name"].lower())
-                apply_yes_no(Fuel.DIESEL, item, "diesel" in fuel_type["Name"].lower())
-                apply_yes_no(Fuel.OCTANE_95, item, "bensin 95" in fuel_type["Name"].lower())
-                apply_yes_no(Fuel.OCTANE_98, item, "bensin 98" in fuel_type["Name"].lower())
-                apply_yes_no(Fuel.BIODIESEL, item, "hvo100" in fuel_type["Name"].lower())
+            for fuel_type in location.get("fuelTypes") or []:
+                apply_yes_no(Fuel.ADBLUE, item, "adblue" in fuel_type["name"].lower())
+                apply_yes_no(Fuel.DIESEL, item, "diesel" in fuel_type["name"].lower())
+                apply_yes_no(Fuel.OCTANE_95, item, "bensin95" in fuel_type["name"].lower())
+                apply_yes_no(Fuel.OCTANE_98, item, "bensin98" in fuel_type["name"].lower())
+                apply_yes_no(Fuel.BIODIESEL, item, "hvo100" in fuel_type["name"].lower())
             yield item


### PR DESCRIPTION
```python
{'atp/brand/7-Eleven': 20,
 'atp/brand/Preem': 591,
 'atp/brand/Uno-X': 313,
 'atp/brand/YX': 204,
 'atp/brand_wikidata/Q259340': 20,
 'atp/brand_wikidata/Q3362746': 313,
 'atp/brand_wikidata/Q4580519': 204,
 'atp/brand_wikidata/Q598835': 591,
 'atp/category/amenity/fuel': 1108,
 'atp/category/shop/convenience': 20,
 'atp/clean_strings/street_address': 1,
 'atp/country/NO': 638,
 'atp/country/SE': 490,
 'atp/field/branch/missing': 591,
 'atp/field/city/missing': 3,
 'atp/field/country/from_reverse_geocoding': 1128,
 'atp/field/email/missing': 1128,
 'atp/field/image/missing': 1128,
 'atp/field/opening_hours/missing': 1128,
 'atp/field/operator/missing': 1128,
 'atp/field/operator_wikidata/missing': 1128,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 641,
 'atp/field/twitter/missing': 1128,
 'atp/field/website/missing': 1128,
 'atp/item_scraped_host_count/www.preem.no': 1128,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1128,
 'downloader/request_bytes': 339,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 73973,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 6.375194,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 21, 12, 26, 28, 706939, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 941625,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1128,
 'items_per_minute': 11280.0,
 'log_count/DEBUG': 1129,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 10.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 21, 12, 26, 22, 331745, tzinfo=datetime.timezone.utc)}
```