### PR TITLE
[Kfc PH] fix spider

### DIFF
--- a/locations/spiders/kfc_ph.py
+++ b/locations/spiders/kfc_ph.py
@@ -1,49 +1,66 @@
-from typing import Iterable
+import json
 
-from scrapy import Request
-from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
-from scrapy.spiders.sitemap import iterloc, logger
-from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.spiders.kfc_us import KFC_SHARED_ATTRIBUTES
-from locations.structured_data_spider import StructuredDataSpider
 
 
-class KfcPHSpider(SitemapSpider, StructuredDataSpider):
+class KfcPHSpider(SitemapSpider):
     name = "kfc_ph"
     item_attributes = KFC_SHARED_ATTRIBUTES
-    allowed_domains = ["stores.kfc.com.ph"]
-    sitemap_urls = ["https://stores.kfc.com.ph/robots.txt"]
-    sitemap_rules = [(r"-fast-food-restaurant-.+-\d+\/Map$", "parse_sd")]
-    wanted_types = ["Restaurant"]
-    time_format = "%I:%M %p"
+    allowed_domains = ["www.kfc.com.ph"]
+    sitemap_urls = ["https://www.kfc.com.ph/sitemap.xml"]
+    sitemap_rules = [(r"/en/store-locator/.+", "parse")]
 
-    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
-        if response.url.endswith("/robots.txt"):
-            for url in sitemap_urls_from_robots(response.text, base_url=response.url):
-                if url.endswith("locations.xml"):
-                    yield Request(url, callback=self._parse_sitemap)
-        else:
-            body = self._get_sitemap_body(response)
-            if body is None:
-                logger.warning(
-                    "Ignoring invalid sitemap: %(response)s",
-                    {"response": response},
-                    extra={"spider": self},
-                )
-                return
+    def parse(self, response):
+        data = json.loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
+        store = data.get("props", {}).get("pageProps", {}).get("selectedStore", {})
+        item = DictParser.parse(store)
 
-            s = Sitemap(body)
-            it = self.sitemap_filter(s)
+        # one non PH location is present at https://www.kfc.com.ph/en/store-locator/kfc_cogeo_antipolo
+        # it incorrectly points to Santa Monica, CA, USA
+        if item.get("country") == "US":
+            return
 
-            if s.type == "sitemapindex":
-                for loc in iterloc(it, self.sitemap_alternate_links):
-                    if any(x.search(loc) for x in self._follow):
-                        yield Request(loc, callback=self._parse_sitemap)
-            elif s.type == "urlset":
-                for loc in iterloc(it, self.sitemap_alternate_links):
-                    for r, c in self._cbs:
-                        if r.search(loc):
-                            yield Request(loc, callback=c)
-                            break
+        address = store.get("address", {})
+        item["addr_full"] = address.get("formatted")
+
+        # Santa Monica, CA, USA is present as city in all urls
+        item["city"] = None
+
+        if latlng := address.get("latLng"):
+            item["lat"], item["lon"] = latlng.get("lat"), latlng.get("lng")
+
+        name_data = item.get("name").get("en_US", "")
+        item["name"] = name_data
+        item["branch"] = name_data.replace("KFC", "").strip()
+        item["website"] = response.url
+
+        raw_hours = store.get("openingHours", [{}])[0].get("en", [])
+        all_intervals = [i.lower() for day in raw_hours for i in day]
+
+        if all_intervals and all(i == "open all day" for i in all_intervals):
+            item["opening_hours"] = "24/7"
+
+        elif raw_hours:
+            oh = OpeningHours()
+            for idx, intervals in enumerate(raw_hours):
+
+                # doing this because first OH in the data belongs to Sun whereas first element in DAYS_FULL is Mon
+                day_name = DAYS_FULL[(idx - 1) % 7]
+
+                for interval in intervals:
+                    low_interval = interval.lower()
+
+                    if "closed" in low_interval:
+                        continue
+                    elif "open all day" in low_interval:
+                        oh.add_range(day_name, "00:00", "23:59")
+                    else:
+                        oh.add_ranges_from_string(f"{day_name} {interval}")
+
+            item["opening_hours"] = oh
+
+        yield item


### PR DESCRIPTION
``` python
{'atp/brand/KFC': 359,
 'atp/brand_wikidata/Q524757': 359,
 'atp/category/amenity/fast_food': 359,
 'atp/clean_strings/name': 3,
 'atp/clean_strings/phone': 1,
 'atp/country/PH': 359,
 'atp/field/city/missing': 359,
 'atp/field/image/missing': 359,
 'atp/field/operator/missing': 359,
 'atp/field/operator_wikidata/missing': 359,
 'atp/field/postcode/missing': 359,
 'atp/field/state/missing': 359,
 'atp/field/street_address/missing': 359,
 'atp/field/twitter/missing': 359,
 'atp/item_scraped_host_count/www.kfc.com.ph': 359,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 359,
 'downloader/request_bytes': 144892,
 'downloader/request_count': 362,
 'downloader/request_method_count/GET': 362,
 'downloader/response_bytes': 21577902,
 'downloader/response_count': 362,
 'downloader/response_status_count/200': 362,
 'elapsed_time_seconds': 441.344296,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 21, 17, 59, 3, 960882, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 93591964,
 'httpcompression/response_count': 362,
 'item_scraped_count': 359,
 'items_per_minute': 48.843537414965986,
 'log_count/DEBUG': 721,
 'log_count/INFO': 16,
 'request_depth_max': 1,
 'response_received_count': 362,
 'responses_per_minute': 49.25170068027211,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 361,
 'scheduler/dequeued/memory': 361,
 'scheduler/enqueued': 361,
 'scheduler/enqueued/memory': 361,
 'start_time': datetime.datetime(2026, 4, 21, 17, 51, 42, 616586, tzinfo=datetime.timezone.utc)}
```