### PR TITLE
[Citroen] Add protection against http 403 error

### DIFF
--- a/locations/spiders/citroen.py
+++ b/locations/spiders/citroen.py
@@ -16,7 +16,7 @@ class CitroenSpider(scrapy.Spider):
         "https://www.citroen.nl/apps/atomic/DealersServlet?distance=300&latitude=52.36993&longitude=4.90787&maxResults=40&orderResults=false&path=L2NvbnRlbnQvY2l0cm9lbi93b3JsZHdpZGUvbmV0aGVybGFuZHMvbmw=&searchType=latlong",
         "https://www.citroen.se/apps/atomic/DealersServlet?distance=300&latitude=59.33257&longitude=18.06682&maxResults=40&orderResults=false&path=L2NvbnRlbnQvY2l0cm9lbi93b3JsZHdpZGUvc3dlZGVuL3Nl&searchType=latlong",
     ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "CONCURRENT_REQUESTS": 1}
 
     def parse(self, response, **kwargs):
         for store in response.json().get("payload").get("dealers"):


### PR DESCRIPTION
Some URLs are returning 403 errors when accessed from regions outside the United States. Updating the custom_settings configuration resolved the issue and ensured successful access from outside the US as well. This change will also help prevent similar issues for US-based access in the future

``` python
{'atp/brand/Citroën': 515,
 'atp/brand_wikidata/Q6746': 515,
 'atp/category/shop/car': 378,
 'atp/category/shop/car_repair': 137,
 'atp/country/BE': 139,
 'atp/country/GB': 194,
 'atp/country/NL': 112,
 'atp/country/SE': 70,
 'atp/duplicate_count': 26,
 'atp/field/branch/missing': 515,
 'atp/field/email/missing': 136,
 'atp/field/image/missing': 515,
 'atp/field/opening_hours/missing': 190,
 'atp/field/operator/missing': 515,
 'atp/field/operator_wikidata/missing': 515,
 'atp/field/state/missing': 515,
 'atp/field/twitter/missing': 515,
 'atp/field/website/missing': 124,
 'atp/item_scraped_host_count/www.citroen.be': 164,
 'atp/item_scraped_host_count/www.citroen.co.uk': 195,
 'atp/item_scraped_host_count/www.citroen.nl': 112,
 'atp/item_scraped_host_count/www.citroen.se': 70,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 515,
 'downloader/request_bytes': 1956,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 73376,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 5.733881,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 22, 7, 1, 21, 235080, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 893680,
 'httpcompression/response_count': 4,
 'item_dropped_count': 26,
 'item_dropped_reasons_count/DropItem': 26,
 'item_scraped_count': 515,
 'items_per_minute': 6180.0,
 'log_count/DEBUG': 545,
 'log_count/INFO': 3,
 'response_received_count': 4,
 'responses_per_minute': 48.0,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2026, 4, 22, 7, 1, 15, 501199, tzinfo=datetime.timezone.utc)}
```