### PR TITLE
[Ionity] Fix Spider

### DIFF
--- a/locations/spiders/ionity.py
+++ b/locations/spiders/ionity.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncIterator
+import re
+from typing import Any
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
@@ -10,36 +11,15 @@ from locations.dict_parser import DictParser
 class IonitySpider(Spider):
     name = "ionity"
     item_attributes = {"brand": "Ionity", "brand_wikidata": "Q42717773"}
-    SOCKET_MAP = {
-        "CHAdeMO": "chademo",
-        "Type 2": "type2",
-        "CCS": "type2_combo",
-    }
-
-    # Ionity API found from its payment website: https://payment.ionity.eu/dashboard
-
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield JsonRequest(url="https://ionity-api.ionity.cloud/api/v1/user/collective")
+    start_urls = ["https://www.ionity.eu/network"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        yield JsonRequest(
-            url="https://ionity-api.ionity.cloud/api/v2/charging-point",
-            headers={"Authorization": f'Bearer {response.json()["accessToken"]}'},
-            callback=self.parse_locations,
-        )
+        json_url = re.search(r"MAP_DATA\s*:\s*\"(.+)\",\s*", response.text).group(1)
+        yield JsonRequest(url=json_url, callback=self.parse_locations)
 
-    def parse_locations(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["items"]:
-            location.update(location.pop("address"))
-            if "Ionity" not in location["label"].title():
-                continue
+    def parse_locations(self, response):
+        for location in response.json()["LocationDetails"]:
             item = DictParser.parse(location)
-            item["street_address"] = item.pop("street")
-            item["branch"] = location["label"].title().removeprefix("Ionity ")
-            item["website"] = f'https://payment.ionity.eu/charger-detail/{location["id"]}'
+            item["ref"] = item["name"]
             apply_category(Categories.CHARGING_STATION, item)
-
-            for connector in location.get("connectors", []):
-                if match := self.SOCKET_MAP.get(connector["type"]):
-                    item["extras"][f"socket:{match}:output"] = f'{connector["power"]} kW'
             yield item


### PR DESCRIPTION
```python
{'atp/brand/Ionity': 908,
 'atp/brand_wikidata/Q42717773': 908,
 'atp/category/amenity/charging_station': 908,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AT': 30,
 'atp/country/BE': 23,
 'atp/country/CH': 19,
 'atp/country/CZ': 9,
 'atp/country/DE': 200,
 'atp/country/DK': 14,
 'atp/country/EE': 2,
 'atp/country/ES': 51,
 'atp/country/FI': 27,
 'atp/country/FR': 181,
 'atp/country/GB': 89,
 'atp/country/HR': 8,
 'atp/country/HU': 12,
 'atp/country/IE': 7,
 'atp/country/IT': 47,
 'atp/country/LT': 3,
 'atp/country/LV': 2,
 'atp/country/NL': 21,
 'atp/country/NO': 54,
 'atp/country/PL': 17,
 'atp/country/PT': 21,
 'atp/country/SE': 58,
 'atp/country/SI': 8,
 'atp/country/SK': 5,
 'atp/field/branch/missing': 908,
 'atp/field/city/missing': 908,
 'atp/field/country/from_reverse_geocoding': 98,
 'atp/field/email/missing': 908,
 'atp/field/image/missing': 908,
 'atp/field/opening_hours/missing': 908,
 'atp/field/operator/missing': 908,
 'atp/field/operator_wikidata/missing': 908,
 'atp/field/phone/missing': 908,
 'atp/field/postcode/missing': 908,
 'atp/field/street_address/missing': 908,
 'atp/field/twitter/missing': 908,
 'atp/field/website/missing': 908,
 'atp/item_scraped_host_count/wf-assets.com': 908,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 908,
 'downloader/request_bytes': 1517,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 341299,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 8.114702,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 23, 6, 45, 21, 396455, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 440762,
 'httpcompression/response_count': 2,
 'item_scraped_count': 908,
 'items_per_minute': 6810.0,
 'log_count/DEBUG': 913,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 4, 23, 6, 45, 13, 281753, tzinfo=datetime.timezone.utc)}
```