### PR TITLE
[Dfs GB] Fix spider

### DIFF
--- a/locations/spiders/dfs_gb.py
+++ b/locations/spiders/dfs_gb.py
@@ -1,22 +1,25 @@
+import json
 from typing import Any
 
 from scrapy.http import Response
-from scrapy.spiders import Spider
 
 from locations.categories import Extras, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
-class DfsGBSpider(Spider):
+class DfsGBSpider(PlaywrightSpider):
     name = "dfs_gb"
     item_attributes = {"brand": "DFS", "brand_wikidata": "Q5204927"}
     start_urls = ["https://www.dfs.co.uk/wcs/resources/store/10202/stores?langId=-1"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["stores"]:
+        data = json.loads(response.xpath("//pre/text()").get())
+        for location in data["stores"]:
             item = DictParser.parse(location)
             item["phone"] = None
             item["branch"] = item.pop("name").removeprefix("DFS ")


### PR DESCRIPTION
``` python
{'atp/brand/DFS': 117,
 'atp/brand_wikidata/Q5204927': 117,
 'atp/category/shop/furniture': 117,
 'atp/country/GB': 112,
 'atp/country/IE': 5,
 'atp/field/email/missing': 117,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/phone/missing': 117,
 'atp/field/state/missing': 66,
 'atp/field/twitter/missing': 117,
 'atp/item_scraped_host_count/www.dfs.co.uk': 117,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 117,
 'downloader/request_bytes': 911,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 224589,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.445816,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 23, 13, 2, 2, 766674, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 117,
 'items_per_minute': 1755.0,
 'log_count/DEBUG': 150,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 23, 13, 1, 58, 320858, tzinfo=datetime.timezone.utc)}
```