### PR TITLE
[Five Guys CN] Fix spider

### DIFF
--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -1,7 +1,3 @@
-import re
-from urllib import parse
-
-import chompjs
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
@@ -14,13 +10,9 @@ class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
     name = "five_guys_cn"
     item_attributes = FIVE_GUYS_SHARED_ATTRIBUTES
     sitemap_urls = ["https://restaurants.fiveguys.cn/sitemap.xml"]
-    sitemap_rules = [(r"restaurants.fiveguys.cn/zh_hans_cn/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    sitemap_rules = [(r"restaurants\.fiveguys\.cn/en/(?!search$)[^/]+$", "parse_sd")]
     wanted_types = ["FastFoodRestaurant"]  # Explicitly mention the type to ignore duplicate linked data
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        if match := re.search(r"yextDisplay.+?,", response.text):
-            coordinates = chompjs.parse_js_object(parse.unquote(match.group(0)))
-            item["lat"] = coordinates["latitude"]
-            item["lon"] = coordinates["longitude"]
         item["website"] = response.url
         yield item


### PR DESCRIPTION
- Update sitemap_rules regex to match new /en/<slug> store URL format (excluding /en/search)
- Rely on microdata for coordinates; drop yextDisplayCoordinate JS scraping which no longer parses

seen in #16039