### PR TITLE
[Cashbuild] Re-enable ZA proxy

### DIFF
--- a/locations/spiders/cashbuild.py
+++ b/locations/spiders/cashbuild.py
@@ -15,6 +15,7 @@ class CashbuildSpider(JSONBlobSpider):
     allowed_domains = ["www.cashbuild.co.za"]
     start_urls = ["https://www.cashbuild.co.za/module/radiusdelivery/StoreSelectorAjax"]
     locations_key = "stores"
+    requires_proxy = "ZA"
 
     async def start(self) -> AsyncIterator[FormRequest]:
         for country_code in ["BW", "LS", "MW", "NA", "SZ", "ZA"]:


### PR DESCRIPTION
- Re-add `requires_proxy = "ZA"` — the site returns empty `stores[]` to Zyte datacenter IPs since it was removed in #15876
- No other code change needed; storefinder JSON schema is unchanged

seen in #15955