### PR TITLE
[Bubbakoos Burritos US] Rewrite spider for Marqii Next.js

### DIFF
--- a/locations/spiders/bubbakoos_burritos_us.py
+++ b/locations/spiders/bubbakoos_burritos_us.py
@@ -1,11 +1,6 @@
-import json
-import re
-
-from scrapy.http import TextResponse
+import chompjs
 from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,23 +8,14 @@ class BubbakoosBurritosUSSpider(SitemapSpider, StructuredDataSpider):
     name = "bubbakoos_burritos_us"
     item_attributes = {"brand": "Bubbakoo's Burritos", "brand_wikidata": "Q114619751"}
     sitemap_urls = ["https://locations.bubbakoos.com/sitemap.xml"]
-    sitemap_rules = [(r"^https:\/\/locations\.bubbakoos\.com\/locations\/[a-z]{2}\/[\w\-]+$", "parse")]
+    sitemap_rules = [(r"^https://locations\.bubbakoos\.com/locations/[a-z]{2}/[\w-]+$", "parse")]
     wanted_types = ["Restaurant"]
 
-    def parse(self, response: TextResponse, **kwargs):
-        ld_data = json.loads(
-            re.search(
-                r"\"({.*})\"\]", response.xpath('//*[contains(text(),"GeoCoordinates")]/text()').get().replace("\\", "")
-            ).group(1)
-        )
-        item = DictParser.parse(ld_data)
-        item["ref"] = item["website"] = response.url
-        oh = OpeningHours()
-        if ld_data["openingHoursSpecification"]:
-            for day_time in ld_data["openingHoursSpecification"]:
-                day = day_time["dayOfWeek"]
-                open_time = day_time["opens"]
-                close_time = day_time["closes"]
-                oh.add_range(day=day, open_time=open_time, close_time=close_time)
-        item["opening_hours"] = oh
-        yield item
+    def parse(self, response):
+        for nextjs_script in response.xpath(
+            "//script[starts-with(text(), 'self.__next_f.push([1,\"{\\\"@context')]/text()"
+        ).getall():
+            script_el = response.selector.root.makeelement("script", {"type": "application/ld+json"})
+            script_el.text = chompjs.parse_js_object(nextjs_script)[1]
+            response.selector.root.append(script_el)
+        yield from super().parse(response)


### PR DESCRIPTION
- Site migrated to a Marqii Next.js storefinder; JSON-LD now lives inside `self.__next_f.push` RSC flight chunks instead of a plain `<script type="application/ld+json">`
- Use the same pattern as `dog_haus_us`: extract JSON-LD from the Next flight script, inject it into the DOM, and let `StructuredDataSpider` do the rest. 26 items locally.

seen in #15948