### PR TITLE
Improve dead-spider-killer failure categorization

### DIFF
--- a/ci/dead_spider_killer.py
+++ b/ci/dead_spider_killer.py
@@ -10,6 +10,7 @@ See: https://github.com/alltheplaces/alltheplaces/issues/9885
 """
 
 import argparse
+import difflib
 import json
 import logging
 import re
@@ -34,6 +35,14 @@ class FailureType(Enum):
     TIMEOUT = "timeout"
     ZYTE_PROXY = "zyte_proxy"
     NEEDS_PROXY = "needs_proxy"
+    BOT_PROTECTION_CLOUDFLARE = "bot_protection_cloudflare"
+    BOT_PROTECTION_AKAMAI = "bot_protection_akamai"
+    BOT_PROTECTION_SPUR = "bot_protection_spur"
+    BOT_PROTECTION_YANDEX = "bot_protection_yandex"
+    BOT_PROTECTION_SERVICEPIPE = "bot_protection_servicepipe"
+    API_AUTH_FAILURE = "api_auth_failure"
+    API_DECOMMISSIONED = "api_decommissioned"
+    POSSIBLE_RENAME = "possible_rename"
     DNS_FAILURE = "dns_failure"
     SITE_GONE_404 = "site_gone_404"
     PARSE_ERROR = "parse_error"
@@ -51,6 +60,7 @@ PR_FAILURES = {
     FailureType.DNS_FAILURE,
     FailureType.CONNECTION_REFUSED,
     FailureType.NO_RESPONSE,
+    FailureType.API_DECOMMISSIONED,
 }
 # Which failure types should result in an investigation issue (potentially fixable)
 ISSUE_FAILURES = {
@@ -61,10 +71,16 @@ ISSUE_FAILURES = {
     FailureType.HTTP_ERROR,
     FailureType.SITE_CHANGED,
     FailureType.NEEDS_PROXY,
+    FailureType.BOT_PROTECTION_CLOUDFLARE,
+    FailureType.BOT_PROTECTION_AKAMAI,
+    FailureType.BOT_PROTECTION_SPUR,
+    FailureType.BOT_PROTECTION_YANDEX,
+    FailureType.BOT_PROTECTION_SERVICEPIPE,
+    FailureType.API_AUTH_FAILURE,
     FailureType.UNKNOWN,
 }
 # Which failure types are skipped entirely
-SKIP_FAILURES = {FailureType.TIMEOUT, FailureType.ZYTE_PROXY}
+SKIP_FAILURES = {FailureType.TIMEOUT, FailureType.ZYTE_PROXY, FailureType.POSSIBLE_RENAME}
 
 
 def fetch_recent_runs(n):
@@ -158,6 +174,86 @@ def fetch_spider_stats(run_id, spider_name):
     return resp.json()
 
 
+def fetch_spider_log(run_id, spider_name):
+    """Best-effort fetch of the spider's log file. Returns the text or empty string."""
+    url = f"{DATA_BASE_URL}/runs/{run_id}/logs/{spider_name}.txt"
+    try:
+        resp = session.get(url, timeout=30)
+        if resp.status_code != 200:
+            return ""
+        return resp.text or ""
+    except requests.RequestException:
+        return ""
+
+
+# Substring signatures for detecting bot-protection vendors and API failures in
+# spider log text. Each entry: (failure_type, signatures, case_sensitive).
+# The log rarely contains full response bodies, but tracebacked URLs, redirect
+# chains, and error-type headers often leak these markers.
+_LOG_SIGNATURES = [
+    (
+        FailureType.BOT_PROTECTION_SPUR,
+        ["mcl.spur.us", "validate_spur_captcha", "spur.us/d/mcl.js"],
+        False,
+    ),
+    (
+        FailureType.BOT_PROTECTION_YANDEX,
+        ["/tmgrdfrend/showcaptcha", "SmartCaptcha"],
+        False,
+    ),
+    (
+        FailureType.BOT_PROTECTION_SERVICEPIPE,
+        ["X-SP-CRID", "servicepipe.ru"],
+        False,
+    ),
+    (
+        FailureType.API_DECOMMISSIONED,
+        [
+            "MissingAuthenticationTokenException",
+            "InvalidSignatureException",
+            "x-amzn-errortype",
+        ],
+        False,
+    ),
+    (
+        FailureType.API_AUTH_FAILURE,
+        [
+            '"status":"Forbidden"',
+            "permission to use this route",
+            "InvalidApiKey",
+            "WWW-Authenticate",
+        ],
+        False,
+    ),
+    (
+        FailureType.BOT_PROTECTION_CLOUDFLARE,
+        ["Just a moment...", "cf-mitigated", "_cf_chl_opt"],
+        False,
+    ),
+]
+
+# Buckets that are worth a second look via log scanning for a more precise label.
+_LOG_REFINEABLE_BUCKETS = {
+    FailureType.NEEDS_PROXY,
+    FailureType.BOT_PROTECTION_CLOUDFLARE,
+    FailureType.BOT_PROTECTION_AKAMAI,
+    FailureType.HTTP_ERROR,
+    FailureType.UNKNOWN,
+}
+
+
+def _classify_from_log(log_text):
+    """Scan log text for known failure signatures. Returns a FailureType or None."""
+    if not log_text:
+        return None
+    for failure_type, signatures, case_sensitive in _LOG_SIGNATURES:
+        haystack = log_text if case_sensitive else log_text.lower()
+        needles = signatures if case_sensitive else [s.lower() for s in signatures]
+        if any(needle in haystack for needle in needles):
+            return failure_type
+    return None
+
+
 def _extract_evidence(stats):
     """Extract status codes, exceptions, and other evidence from Scrapy stats."""
     evidence = {}
@@ -168,6 +264,17 @@ def _extract_evidence(stats):
         if m:
             status_codes[int(m.group(1))] = value
     evidence["status_codes"] = status_codes
+
+    # Per-CDN status codes from locations/middlewares/cdnstats.py:
+    # atp/cdn/<vendor>/response_status_count/<code>
+    cdn_status_codes = {}
+    for key, value in stats.items():
+        m = re.match(r"atp/cdn/([^/]+)/response_status_count/(\d+)", key)
+        if m:
+            vendor = m.group(1)
+            code = int(m.group(2))
+            cdn_status_codes.setdefault(vendor, {})[code] = value
+    evidence["cdn_status_codes"] = cdn_status_codes
 
     exceptions = {}
     for key, value in stats.items():
@@ -193,6 +300,7 @@ def _classify_from_evidence(evidence, filename):  # noqa: C901
     status_codes = evidence["status_codes"]
     exceptions = evidence["exceptions"]
     stats = evidence["full_stats"]
+    cdn_status_codes = evidence.get("cdn_status_codes", {})
 
     total_requests = sum(status_codes.values()) + sum(exceptions.values())
     count_404 = status_codes.get(404, 0)
@@ -235,8 +343,14 @@ def _classify_from_evidence(evidence, filename):  # noqa: C901
     if _sum_matching(exceptions, "KeyError", "TypeError", "AttributeError", "IndexError", "UnboundLocalError") > 0:
         return FailureType.SPIDER_EXCEPTION
 
-    # 8. Needs proxy
+    # 8. Needs proxy — split by CDN vendor when known, otherwise generic.
     if status_codes.get(403, 0) + status_codes.get(429, 0) > 0 and not has_requires_proxy(filename):
+        cloudflare_blocks = sum(c for code, c in cdn_status_codes.get("cloudflare", {}).items() if code in (403, 429))
+        akamai_blocks = sum(c for code, c in cdn_status_codes.get("akamai", {}).items() if code in (403, 429))
+        if cloudflare_blocks > 0:
+            return FailureType.BOT_PROTECTION_CLOUDFLARE
+        if akamai_blocks > 0:
+            return FailureType.BOT_PROTECTION_AKAMAI
         return FailureType.NEEDS_PROXY
 
     # 9. Redirect-only
@@ -282,7 +396,72 @@ def classify_failure(spider_name, filename, run_id):
 
     evidence = _extract_evidence(stats)
     classification = _classify_from_evidence(evidence, filename)
+
+    # For ambiguous buckets, scan the log for vendor signatures that
+    # aren't visible in the stats counters alone (Spur, Yandex, ServicePipe,
+    # revoked API keys, decommissioned AWS endpoints, Cloudflare challenge).
+    if classification in _LOG_REFINEABLE_BUCKETS:
+        log_text = fetch_spider_log(run_id, spider_name)
+        refined = _classify_from_log(log_text)
+        if refined is not None:
+            classification = refined
+
     return classification, evidence
+
+
+def _recently_added_spiders(since="4 weeks ago"):
+    """Return spider file stems added to locations/spiders/ since the given date."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "--diff-filter=A",
+                f"--since={since}",
+                "--name-only",
+                "--format=",
+                "--",
+                "locations/spiders/",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    stems = set()
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.endswith(".py"):
+            continue
+        stems.add(Path(line).stem)
+    return stems
+
+
+def _is_similar_name(old_name, new_name):
+    """Return True if new_name looks like a rename of old_name.
+
+    Matches token-subset (e.g. cue -> cue_au) or difflib ratio >= 0.75.
+    """
+    if old_name == new_name:
+        return False
+    old_tokens = set(old_name.split("_"))
+    new_tokens = set(new_name.split("_"))
+    if old_tokens and old_tokens.issubset(new_tokens):
+        return True
+    if new_tokens and new_tokens.issubset(old_tokens):
+        return True
+    return difflib.SequenceMatcher(None, old_name, new_name).ratio() >= 0.75
+
+
+def _find_recent_similarly_named_spider(spider_name, recent_additions):
+    """Return the best similarly-named recent addition, or None."""
+    for candidate in recent_additions:
+        if _is_similar_name(spider_name, candidate):
+            return candidate
+    return None
 
 
 def _is_only_robots(stats):
@@ -400,9 +579,49 @@ FAILURE_EXPLANATIONS = {
         "suggestion": "Visit the site and compare its current structure to what the spider expects. The CSS selectors, XPath expressions, or JSON paths in the spider probably need updating.",
     },
     FailureType.NEEDS_PROXY: {
-        "title": "Blocked by bot protection",
-        "explanation": "The spider is getting 403 Forbidden or 429 Too Many Requests responses, suggesting the site is blocking automated access.",
-        "suggestion": "Try adding `requires_proxy = True` to the spider class to route requests through the Zyte proxy.",
+        "title": "Blocked (unidentified vendor)",
+        "explanation": "The spider is getting 403 Forbidden or 429 Too Many Requests responses but no CDN signature was detected in the stats. Could be a real WAF block, a user-agent blacklist, or an API-level auth failure — the labeler can't tell from counters alone.",
+        "suggestion": "Inspect the response body or headers directly. If it's a real WAF, try `requires_proxy = True`. If it's a UA blacklist, a plain Chrome UA may be enough. If it's a revoked API key or decommissioned endpoint, the spider needs a rewrite.",
+    },
+    FailureType.BOT_PROTECTION_CLOUDFLARE: {
+        "title": "Blocked by Cloudflare",
+        "explanation": "The spider is getting 403/429 responses from Cloudflare (detected via `Server: cloudflare` header). Could be a standard challenge, managed challenge (Turnstile), or a UA-substring blacklist.",
+        "suggestion": "For managed challenges, pair `requires_proxy = True` with Camoufox. For simple WAF rules, plain proxy may suffice. For UA-only blacklists, a real browser UA via `custom_settings` may be enough.",
+    },
+    FailureType.BOT_PROTECTION_AKAMAI: {
+        "title": "Blocked by Akamai",
+        "explanation": "The spider is getting 403/429 responses from Akamai (detected via `Server: AkamaiGHost`). Akamai Bot Manager fingerprints TLS, HTTP/2 frame order, and header ordering, so UA rotation alone rarely helps.",
+        "suggestion": "Add `requires_proxy = True` with appropriate geolocation. If a single-shot JSON API exists, target that directly to minimize proxy cost.",
+    },
+    FailureType.BOT_PROTECTION_SPUR: {
+        "title": "Blocked by Spur Monocle",
+        "explanation": "The spider is hitting a Spur Monocle JS challenge (detected via `mcl.spur.us` / `validate_spur_captcha` in the log). Spur requires solving a captcha bundle before any content is served.",
+        "suggestion": "Pair `requires_proxy = True` with browser rendering. Expect higher proxy cost than plain Cloudflare.",
+    },
+    FailureType.BOT_PROTECTION_YANDEX: {
+        "title": "Blocked by Yandex SmartCaptcha",
+        "explanation": "The spider is being redirected to Yandex SmartCaptcha (detected via `/tmgrdfrend/showcaptcha` redirect). Yandex gates non-RU ASNs more aggressively.",
+        "suggestion": 'Set `requires_proxy = "RU"` so requests originate from a Russian IP where SmartCaptcha is less aggressive.',
+    },
+    FailureType.BOT_PROTECTION_SERVICEPIPE: {
+        "title": "Blocked by ServicePipe",
+        "explanation": "The spider is hitting the ServicePipe anti-bot CDN (detected via `X-SP-CRID` header or `servicepipe.ru` references). ServicePipe rotates its JS challenge variants frequently — keeping up imposes recurring maintenance cost.",
+        "suggestion": 'Set `requires_proxy = "RU"` and reproduce the latest challenge (`spid`/`spsn` cookies, JS decrypt). Consider removing the spider if the maintenance burden outweighs the data value.',
+    },
+    FailureType.API_AUTH_FAILURE: {
+        "title": "API authentication failure",
+        "explanation": 'The spider received a 403/401 with an auth-related body or header (detected via `"status":"Forbidden"`, `WWW-Authenticate`, `permission to use this route`, etc.). The API key or route permissions have been revoked.',
+        "suggestion": "The backend no longer accepts the hardcoded credentials. Inspect the site's current requests for a new auth scheme, or rewrite against a different data source.",
+    },
+    FailureType.API_DECOMMISSIONED: {
+        "title": "API endpoint decommissioned",
+        "explanation": "The spider is hitting an AWS/GCP API Gateway route that no longer exists (detected via `MissingAuthenticationTokenException` / `x-amzn-errortype`). The backend has been removed, not just rate-limited.",
+        "suggestion": None,
+    },
+    FailureType.POSSIBLE_RENAME: {
+        "title": "Possible spider rename",
+        "explanation": "The spider file is missing from `locations/spiders/` but a similarly-named spider was added recently. This is likely a rename, not a dead spider.",
+        "suggestion": None,
     },
     FailureType.UNKNOWN: {
         "title": "Unknown failure",
@@ -420,6 +639,14 @@ def _format_evidence_summary(evidence):
     if status_codes:
         codes_str = ", ".join(f"{code}: {count}" for code, count in sorted(status_codes.items()))
         lines.append(f"**Response status codes**: {codes_str}")
+
+    cdn_status_codes = evidence.get("cdn_status_codes", {})
+    if cdn_status_codes:
+        cdn_lines = []
+        for vendor, codes in sorted(cdn_status_codes.items()):
+            codes_str = ", ".join(f"{code}: {count}" for code, count in sorted(codes.items()))
+            cdn_lines.append(f"{vendor} ({codes_str})")
+        lines.append(f"**CDN responses**: {', '.join(cdn_lines)}")
 
     exceptions = evidence.get("exceptions", {})
     if exceptions:
@@ -602,7 +829,7 @@ Spider `{spider_name}` (`{filename}`) has produced **0 results for {len(run_hist
     return True
 
 
-def main():
+def main():  # noqa: C901
     parser = argparse.ArgumentParser(description="Dead Spider Killer - find and remove broken spiders")
     parser.add_argument(
         "--weeks", type=int, default=5, help="Number of consecutive zero-result runs required (default: 5)"
@@ -634,11 +861,23 @@ def main():
     # Step 3: Filter out protected spiders and classify failures
     latest_run_id = runs[-1]["run_id"]
     classified = []
+    recent_additions = _recently_added_spiders()
 
     for spider_name, data in sorted(dead_spiders.items()):
         if has_skip_flag(data["filename"]):
             logger.info("Skipping %s (has skip_auto_delete flag)", spider_name)
             continue
+
+        # If the spider file is gone but a similar name appeared recently, it's
+        # likely a rename — skip rather than file a bogus dead-spider issue.
+        repo_root = Path(__file__).parent.parent
+        spider_path = repo_root / data["filename"]
+        if not spider_path.exists():
+            similar = _find_recent_similarly_named_spider(spider_name, recent_additions)
+            if similar:
+                logger.info("Skipping %s — likely renamed to %s", spider_name, similar)
+                classified.append((spider_name, data, FailureType.POSSIBLE_RENAME, {"renamed_to": similar}))
+                continue
 
         classification, evidence = classify_failure(spider_name, data["filename"], latest_run_id)
         classified.append((spider_name, data, classification, evidence))


### PR DESCRIPTION
The weekly dead-spider triage was bucketing every 403/429 under "Blocked by bot protection" regardless of vendor. Recent manual triage surfaced systematic mis-categorizations — for example, #15951 (burger_king_uy) was actually a revoked API key returning JSON, #15947 (bottlemart_au) was a decommissioned AWS API Gateway route, #16020 (chargepoint) was just a UA substring blacklist, and #16028 (cue) was a rename to `cue_au` (#15983) rather than a dead spider.

### What changed

- **Per-vendor bot protection**: uses the `atp/cdn/{cloudflare,akamai,cloudfront}/response_status_count/*` stats already emitted by `locations/middlewares/cdnstats.py` to split generic 403s into `BOT_PROTECTION_CLOUDFLARE` / `BOT_PROTECTION_AKAMAI`. Generic `NEEDS_PROXY` remains the fallback with its explanation text updated to note that stats alone can't distinguish UA blacklists from real WAF challenges.
- **API-level failures**: new `API_AUTH_FAILURE` (revoked key / forbidden route) and `API_DECOMMISSIONED` (AWS `MissingAuthenticationTokenException` etc.). Decommissioned results in a removal PR since the backend is unambiguously gone.
- **Log signature scanning**: for ambiguous buckets the script now fetches the spider's log file and scans for vendor markers (`mcl.spur.us`, `/tmgrdfrend/showcaptcha`, `X-SP-CRID`, `Just a moment...`, `x-amzn-errortype`) to refine the classification to Spur Monocle / Yandex SmartCaptcha / ServicePipe / Cloudflare-challenge when the signature leaks into a logged URL or traceback.
- **Rename detection**: before classifying, if the spider file is missing and a similarly-named spider was added in the last 4 weeks (`git log --diff-filter=A --since="4 weeks ago"`), mark as `POSSIBLE_RENAME` and skip — suppresses false positives like cue → cue_au.
- **Issue bodies surface CDN counters** (`cloudflare (403: 5)` / `akamai (403: 3)`) so triagers see the vendor split at a glance.

### Follow-up scope

Scrapy stats don't currently capture response headers or bodies, so body-level signatures (JSON "Forbidden" bodies, full challenge HTML) are only seen opportunistically. A cleaner long-term path is to extend `locations/middlewares/cdnstats.py` to emit dedicated counters like `atp/bot/spur`, `atp/bot/yandex`, `atp/bot/servicepipe`, `atp/bot/cloudflare_challenge`, `atp/api/auth_failure`, and `atp/api/aws_missing_token` — once those exist, the log-scanning shortcut here can be removed and detection becomes deterministic.