### PR TITLE
[CarMax US] Re-enable US proxy

### DIFF
--- a/locations/spiders/car_max_us.py
+++ b/locations/spiders/car_max_us.py
@@ -14,6 +14,7 @@ class CarMaxUSSpider(Spider):
     item_attributes = {"brand": "CarMax", "brand_wikidata": "Q5037190"}
     start_urls = ["https://www.carmax.com/stores/api/all"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    requires_proxy = "US"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():


### PR DESCRIPTION
- `carmax.com` is behind Akamai Bot Manager (`akBMG` cookie, 388-byte 403 to plain curl). The `/stores/api/all` JSON endpoint still exists and works via proxy.
- Single-request spider, so proxy cost is trivial. No rewrite needed.

seen in #15952