### PR TITLE
[Claudia Sträter NL] Enable proxy to bypass Cloudflare

### DIFF
--- a/locations/spiders/claudia_strater_nl.py
+++ b/locations/spiders/claudia_strater_nl.py
@@ -11,6 +11,7 @@ class ClaudiaStraterNLSpider(JSONBlobSpider):
     }
     start_urls = ["https://www.claudiastrater.com/over-ons/winkels/"]
     no_refs = True
+    requires_proxy = True
 
     def extract_json(self, response):
         return chompjs.parse_js_object(


### PR DESCRIPTION
- Site is behind Cloudflare Managed Challenge (`cf-mitigated: challenge` on all paths); plain HTTP requests return 403.
- Adds `requires_proxy = True` to route the single storefinder request through Zyte; brand is active (~30 NL/BE stores) and crawl is one request per run, so proxy cost is negligible.

seen in #16022