### PR TITLE
[Co-op Food GB] Route through GB proxy to bypass Akamai

### DIFF
--- a/locations/spiders/coop_food_gb.py
+++ b/locations/spiders/coop_food_gb.py
@@ -14,6 +14,7 @@ class CoopFoodGBSpider(scrapy.Spider):
     start_urls = (
         "https://www.coop.co.uk/store-finder/api/locations/food?location=54.9966124%2C-7.308574799999974&distance=30000000000&always_one=true&format=json",
     )
+    requires_proxy = "gb"
 
     def parse_hours(self, hours):
         opening_hours = OpeningHours()


### PR DESCRIPTION
- The `/store-finder/api/locations/food` JSON endpoint is now gated by an Akamai "Pardon Our Interruption" HTML interstitial, causing `JSONDecodeError` on every run. Adding `requires_proxy = "gb"` so the challenge can be solved.
- seen in #16027