### PR TITLE
[JdSports DE] Fix spider

### DIFF
--- a/locations/spiders/jd_sports_de.py
+++ b/locations/spiders/jd_sports_de.py
@@ -1,12 +1,15 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class JdSportsDESpider(CrawlSpider, StructuredDataSpider):
+class JdSportsDESpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "jd_sports_de"
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.de/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
     requires_proxy = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS


### PR DESCRIPTION
``` python
{'atp/brand/JD Sports': 86,
 'atp/brand_wikidata/Q6108019': 86,
 'atp/category/shop/clothes': 86,
 'atp/clean_strings/street_address': 1,
 'atp/country/DE': 86,
 'atp/duplicate_count': 2,
 'atp/field/branch/missing': 86,
 'atp/field/email/missing': 86,
 'atp/field/image/dropped': 86,
 'atp/field/image/missing': 86,
 'atp/field/operator/missing': 86,
 'atp/field/operator_wikidata/missing': 86,
 'atp/field/phone/missing': 51,
 'atp/field/state/missing': 86,
 'atp/item_scraped_host_count/www.jdsports.de': 88,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 86,
 'downloader/request_bytes': 40331,
 'downloader/request_count': 92,
 'downloader/request_method_count/GET': 92,
 'downloader/response_bytes': 25308934,
 'downloader/response_count': 92,
 'downloader/response_status_count/200': 92,
 'dupefilter/filtered': 26,
 'elapsed_time_seconds': 116.481725,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 24, 6, 21, 8, 284737, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 86,
 'items_per_minute': 44.48275862068966,
 'log_count/DEBUG': 12455,
 'log_count/INFO': 8,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 92,
 'playwright/page_count/closed': 92,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 6093,
 'playwright/request_count/aborted': 5994,
 'playwright/request_count/method/GET': 6093,
 'playwright/request_count/navigation': 93,
 'playwright/request_count/resource_type/document': 93,
 'playwright/request_count/resource_type/font': 364,
 'playwright/request_count/resource_type/image': 4361,
 'playwright/request_count/resource_type/script': 992,
 'playwright/request_count/resource_type/stylesheet': 283,
 'playwright/response_count': 93,
 'playwright/response_count/method/GET': 93,
 'playwright/response_count/resource_type/document': 93,
 'request_depth_max': 1,
 'response_received_count': 92,
 'responses_per_minute': 47.58620689655172,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 91,
 'scheduler/dequeued/memory': 91,
 'scheduler/enqueued': 91,
 'scheduler/enqueued/memory': 91,
 'start_time': datetime.datetime(2026, 4, 24, 6, 19, 11, 803012, tzinfo=datetime.timezone.utc)}
```