### PR TITLE
[Kate Spade CA US] Fix spider

### DIFF
--- a/locations/spiders/kate_spade_ca_us.py
+++ b/locations/spiders/kate_spade_ca_us.py
@@ -17,5 +17,5 @@ class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider)
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("Kate Spade ")
+        item["branch"] = item.pop("name").removeprefix("About ")
         yield item

--- a/locations/spiders/kate_spade_ca_us.py
+++ b/locations/spiders/kate_spade_ca_us.py
@@ -2,15 +2,19 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.spiders.kate_spade import KateSpadeSpider
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider):
+class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "kate_spade_ca_us"
     item_attributes = KateSpadeSpider.item_attributes
-    sitemap_urls = ["https://www.katespade.com/robots.txt"]
-    sitemap_rules = [(r"/stores/\w\w/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
+    sitemap_urls = ["https://www.katespade.com/stores/sitemap.xml"]
+    sitemap_rules = [(r"/stores/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Kate Spade ")

--- a/locations/spiders/kate_spade_ca_us.py
+++ b/locations/spiders/kate_spade_ca_us.py
@@ -15,6 +15,7 @@ class KateSpadeCAUSSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider)
     sitemap_urls = ["https://www.katespade.com/stores/sitemap.xml"]
     sitemap_rules = [(r"/stores/\w\w/[-\w]+/[-\w]+$", "parse_sd")]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    drop_attributes = {"facebook"}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["branch"] = item.pop("name").removeprefix("About ")


### PR DESCRIPTION
```python
{'atp/brand/Kate Spade New York': 169,
 'atp/brand_wikidata/Q6375797': 169,
 'atp/category/shop/clothes': 169,
 'atp/country/CA': 16,
 'atp/country/MX': 1,
 'atp/country/PR': 1,
 'atp/country/US': 151,
 'atp/field/country/from_reverse_geocoding': 169,
 'atp/field/image/dropped': 169,
 'atp/field/image/missing': 169,
 'atp/field/operator/missing': 169,
 'atp/field/operator_wikidata/missing': 169,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/twitter/missing': 169,
 'atp/item_scraped_host_count/www.katespade.com': 169,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 169,
 'downloader/request_bytes': 76608,
 'downloader/request_count': 171,
 'downloader/request_method_count/GET': 171,
 'downloader/response_bytes': 123857472,
 'downloader/response_count': 171,
 'downloader/response_status_count/200': 171,
 'elapsed_time_seconds': 8.139577,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 24, 10, 57, 9, 504351, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 171,
 'item_scraped_count': 169,
 'items_per_minute': 1267.5,
 'log_count/DEBUG': 363,
 'log_count/INFO': 5,
 'request_depth_max': 1,
 'response_received_count': 171,
 'responses_per_minute': 1282.5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 170,
 'scheduler/dequeued/memory': 170,
 'scheduler/enqueued': 170,
 'scheduler/enqueued/memory': 170,
 'start_time': datetime.datetime(2026, 4, 24, 10, 57, 1, 364774, tzinfo=datetime.timezone.utc)}
```