### PR TITLE
[Inditex] Fix Spider

### DIFF
--- a/locations/spiders/inditex.py
+++ b/locations/spiders/inditex.py
@@ -7,12 +7,10 @@ from scrapy.http import Response
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class InditexSpider(PlaywrightSpider):
+class InditexSpider(scrapy.Spider):
     name = "inditex"
     my_brands = {
         "bershka": {"brand": "Bershka", "brand_wikidata": "Q827258"},
@@ -25,37 +23,30 @@ class InditexSpider(PlaywrightSpider):
     }
     # Each site has the same multi-brand catalogue JSON, could have picked any site!
     start_urls = ["https://www.massimodutti.com/itxrest/2/web/seo/config?appId=1"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+    custom_settings = {
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
-        "CONCURRENT_REQUESTS": 1,
-        "DOWNLOAD_DELAY": 5,
-        "DEFAULT_REQUEST_HEADERS": {
-            "Host": "www.massimodutti.com",
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Connection": "keep-alive",
-        },
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        config = json.loads(response.xpath("//pre/text()").get())["seoParamMap"]
+        config = json.loads(response.text)["seoParamMap"]
         for store_id, country in config["storeId"].items():
-            # First character of the store_id is the index into the brand table.
-            brand = config["brandId"][store_id[0]]
-            if brand == "dutti":
-                brand = "massimodutti"
-            if brand == "uterque":
-                # Discontinued brand, still in their config as time of writing.
-                continue
-            url = "https://www.{}.com/itxrest/2/bam/store/{}/physical-stores-by-country?countryCode={}".format(
-                brand,
-                store_id,
-                country.upper(),
-            )
-            yield scrapy.http.JsonRequest(url, callback=self.parse_stores, cb_kwargs=dict(brand=brand))
+            for brand in config["brandId"].values():
+                if brand == "dutti":
+                    brand = "massimodutti"
+                if brand == "uterque":
+                    # Discontinued brand, still in their config as time of writing.
+                    continue
+                url = "https://www.{}.com/itxrest/2/bam/store/{}/physical-stores-by-country?countryCode={}".format(
+                    brand,
+                    store_id,
+                    country.upper(),
+                )
+                yield scrapy.http.JsonRequest(url, callback=self.parse_stores, cb_kwargs=dict(brand=brand))
 
+    #
     def parse_stores(self, response: Response, brand: str) -> Iterable[Feature]:
-        for store in json.loads(response.xpath("//pre/text()").get())["stores"]:
+        for store in json.loads(response.text)["stores"]:
             item = DictParser.parse(store)
             item["website"] = "https://www.{}.com/".format(brand) + item["country"].lower()
             item.update(self.my_brands.get(brand))

--- a/locations/spiders/inditex.py
+++ b/locations/spiders/inditex.py
@@ -7,11 +7,12 @@ from scrapy.http import Response
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class InditexSpider(scrapy.Spider):
+class InditexSpider(PlaywrightSpider):
     name = "inditex"
     my_brands = {
         "bershka": {"brand": "Bershka", "brand_wikidata": "Q827258"},
@@ -24,10 +25,11 @@ class InditexSpider(scrapy.Spider):
     }
     # Each site has the same multi-brand catalogue JSON, could have picked any site!
     start_urls = ["https://www.massimodutti.com/itxrest/2/web/seo/config?appId=1"]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
+        "CONCURRENT_REQUESTS": 1,
+        "DOWNLOAD_DELAY": 5,
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
@@ -46,7 +48,6 @@ class InditexSpider(scrapy.Spider):
                 )
                 yield scrapy.http.JsonRequest(url, callback=self.parse_stores, cb_kwargs=dict(brand=brand))
 
-    #
     def parse_stores(self, response: Response, brand: str) -> Iterable[Feature]:
         for store in json.loads(response.xpath("//pre/text()").get())["stores"]:
             item = DictParser.parse(store)

--- a/locations/spiders/inditex.py
+++ b/locations/spiders/inditex.py
@@ -7,6 +7,7 @@ from scrapy.http import Response
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
@@ -23,13 +24,14 @@ class InditexSpider(scrapy.Spider):
     }
     # Each site has the same multi-brand catalogue JSON, could have picked any site!
     start_urls = ["https://www.massimodutti.com/itxrest/2/web/seo/config?appId=1"]
-    custom_settings = {
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        config = json.loads(response.text)["seoParamMap"]
+        config = json.loads(response.xpath("//pre/text()").get())["seoParamMap"]
         for store_id, country in config["storeId"].items():
             for brand in config["brandId"].values():
                 if brand == "dutti":
@@ -46,7 +48,7 @@ class InditexSpider(scrapy.Spider):
 
     #
     def parse_stores(self, response: Response, brand: str) -> Iterable[Feature]:
-        for store in json.loads(response.text)["stores"]:
+        for store in json.loads(response.xpath("//pre/text()").get())["stores"]:
             item = DictParser.parse(store)
             item["website"] = "https://www.{}.com/".format(brand) + item["country"].lower()
             item.update(self.my_brands.get(brand))


### PR DESCRIPTION
```python
{'atp/brand/Bershka': 821,
 'atp/brand/Lefties': 211,
 'atp/brand/Massimo Dutti': 466,
 'atp/brand/Oysho': 375,
 'atp/brand/Pull & Bear': 783,
 'atp/brand/Stradivarius': 814,
 'atp/brand/Zara Home': 334,
 'atp/brand_wikidata/Q12391713': 211,
 'atp/brand_wikidata/Q3114054': 334,
 'atp/brand_wikidata/Q3322945': 814,
 'atp/brand_wikidata/Q3327046': 375,
 'atp/brand_wikidata/Q691029': 783,
 'atp/brand_wikidata/Q788231': 466,
 'atp/brand_wikidata/Q827258': 821,
 'atp/category/shop/clothes': 3470,
 'atp/category/shop/interior_decoration': 334,
 'atp/cdn/akamai/response_count': 9,
 'atp/cdn/akamai/response_status_count/403': 9,
 'atp/clean_strings/branch': 3,
 'atp/country/AD': 7,
 'atp/country/AE': 64,
 'atp/country/AL': 7,
 'atp/country/AM': 12,
 'atp/country/AT': 18,
 'atp/country/AZ': 17,
 'atp/country/BA': 11,
 'atp/country/BE': 43,
 'atp/country/BG': 28,
 'atp/country/BH': 14,
 'atp/country/BY': 11,
 'atp/country/CA': 3,
 'atp/country/CH': 21,
 'atp/country/CO': 49,
 'atp/country/CR': 9,
 'atp/country/CY': 33,
 'atp/country/CZ': 16,
 'atp/country/DE': 69,
 'atp/country/DK': 2,
 'atp/country/DO': 14,
 'atp/country/DZ': 9,
 'atp/country/EC': 11,
 'atp/country/EE': 6,
 'atp/country/EG': 39,
 'atp/country/ES': 846,
 'atp/country/FI': 1,
 'atp/country/FR': 164,
 'atp/country/GB': 60,
 'atp/country/GE': 18,
 'atp/country/GR': 100,
 'atp/country/GT': 12,
 'atp/country/HK': 2,
 'atp/country/HN': 9,
 'atp/country/HR': 30,
 'atp/country/HU': 33,
 'atp/country/ID': 37,
 'atp/country/IE': 12,
 'atp/country/IL': 70,
 'atp/country/IN': 7,
 'atp/country/IQ': 1,
 'atp/country/IT': 230,
 'atp/country/JO': 15,
 'atp/country/KR': 15,
 'atp/country/KW': 26,
 'atp/country/KZ': 34,
 'atp/country/LB': 27,
 'atp/country/LT': 22,
 'atp/country/LU': 7,
 'atp/country/LV': 13,
 'atp/country/MA': 30,
 'atp/country/MK': 10,
 'atp/country/MT': 14,
 'atp/country/MX': 339,
 'atp/country/MY': 8,
 'atp/country/NL': 45,
 'atp/country/PA': 9,
 'atp/country/PE': 2,
 'atp/country/PH': 24,
 'atp/country/PL': 169,
 'atp/country/PT': 220,
 'atp/country/QA': 30,
 'atp/country/RO': 118,
 'atp/country/RS': 31,
 'atp/country/SA': 131,
 'atp/country/SE': 7,
 'atp/country/SG': 5,
 'atp/country/SI': 10,
 'atp/country/SK': 18,
 'atp/country/TH': 14,
 'atp/country/TN': 27,
 'atp/country/TR': 161,
 'atp/country/TW': 10,
 'atp/country/UA': 44,
 'atp/country/US': 1,
 'atp/country/UZ': 6,
 'atp/country/VN': 6,
 'atp/country/XK': 11,
 'atp/field/country/from_reverse_geocoding': 88,
 'atp/field/email/missing': 3804,
 'atp/field/image/missing': 3804,
 'atp/field/opening_hours/missing': 3804,
 'atp/field/operator/missing': 3804,
 'atp/field/operator_wikidata/missing': 3804,
 'atp/field/phone/invalid': 70,
 'atp/field/phone/missing': 209,
 'atp/field/postcode/missing': 44,
 'atp/field/state/from_reverse_geocoding': 4,
 'atp/field/twitter/missing': 3804,
 'atp/item_scraped_host_count/www.bershka.com': 821,
 'atp/item_scraped_host_count/www.lefties.com': 211,
 'atp/item_scraped_host_count/www.massimodutti.com': 466,
 'atp/item_scraped_host_count/www.oysho.com': 375,
 'atp/item_scraped_host_count/www.pullandbear.com': 783,
 'atp/item_scraped_host_count/www.stradivarius.com': 814,
 'atp/item_scraped_host_count/www.zarahome.com': 334,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3804,
 'downloader/request_bytes': 1712983,
 'downloader/request_count': 1081,
 'downloader/request_method_count/GET': 1081,
 'downloader/response_bytes': 2064243,
 'downloader/response_count': 1081,
 'downloader/response_status_count/200': 639,
 'downloader/response_status_count/403': 9,
 'downloader/response_status_count/404': 290,
 'downloader/response_status_count/500': 143,
 'elapsed_time_seconds': 177.692296,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 27, 11, 24, 50, 649217, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7976408,
 'httpcompression/response_count': 426,
 'httperror/response_ignored_count': 346,
 'httperror/response_ignored_status_count/403': 9,
 'httperror/response_ignored_status_count/404': 290,
 'httperror/response_ignored_status_count/500': 47,
 'item_scraped_count': 3804,
 'items_per_minute': 1289.4915254237287,
 'log_count/DEBUG': 4885,
 'log_count/ERROR': 47,
 'log_count/INFO': 352,
 'log_count/WARNING': 5,
 'request_depth_max': 1,
 'response_received_count': 985,
 'responses_per_minute': 333.89830508474574,
 'retry/count': 96,
 'retry/max_reached': 47,
 'retry/reason_count/500 Internal Server Error': 96,
 'scheduler/dequeued': 1081,
 'scheduler/dequeued/memory': 1081,
 'scheduler/enqueued': 1081,
 'scheduler/enqueued/memory': 1081,
 'start_time': datetime.datetime(2026, 4, 27, 11, 21, 52, 956921, tzinfo=datetime.timezone.utc)}
```