### PR TITLE
[Burger King IL] Fix spider using alternative API

### DIFF
--- a/locations/spiders/burger_king_il.py
+++ b/locations/spiders/burger_king_il.py
@@ -1,47 +1,26 @@
-from typing import AsyncIterator
+from typing import Iterable
 
-from chompjs import parse_js_object
-from scrapy.http import Request
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class BurgerKingILSpider(JSONBlobSpider):
     name = "burger_king_il"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    start_urls = ["https://www.burgerking.co.il/branch/"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
-    requires_proxy = True
+    # API found on order's page: https://order.burgerking.co.il/branchespage/burgerking#!/branchesPage/burgerking
+    start_urls = ["https://webapi.mishloha.co.il/api/Rests/GetRestaurantsInfoByChainName/burgerking"]
+    locations_key = ["data", "allBranches"]
 
-    async def start(self) -> AsyncIterator[Request]:
-        headers = {
-            "Sec-Ch-Ua-Platform": "Linux",
-            "Sec-Fetch-Mode": "navigate",
-            "Sec-Fetch-Site": "none",
-            "Sec-Fetch-User": "?1",
-        }
-        for url in self.start_urls:
-            yield Request(url=url, headers=headers)
-
-    def extract_json(self, response):
-        return parse_js_object(
-            response.xpath("//script[contains(text(), '\"branches\":')]/text()").get().split('"branches":')[1]
-        )
-
-    def post_process_item(self, item, response, location):
-        item["branch"] = item.pop("name").replace(" (כשר)", "").strip()
-
-        # This does not work for all items, some have an extra word in the slug
-        # slug = item["branch"].replace(" – ", " ").replace(" ", "-")
-        # item["website"] = "https://www.burgerking.co.il/branch/" + slug
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["housenumber"] = feature.get("streetNum")
+        item["branch"] = feature.get("restName").removeprefix("ברגר קינג ")
 
         apply_category(Categories.FAST_FOOD, item)
-        apply_yes_no(Extras.KOSHER, item, location["icons_tags"]["is_kosher"] == 1)
-        apply_yes_no(Extras.WIFI, item, location["icons_tags"]["is_wifi"] == 1)
-        apply_yes_no(Extras.WHEELCHAIR, item, location["icons_tags"]["is_acc"] == 1)
-        apply_yes_no(Extras.DELIVERY, item, location["icons_tags"]["can_ship"] == 1)
+        apply_yes_no(Extras.INDOOR_SEATING, item, feature.get("isEnableSitting") is True)
+        apply_yes_no(Extras.TAKEAWAY, item, feature.get("enableTakeaway") is True)
+        apply_yes_no(Extras.DELIVERY, item, feature.get("enableDelivery") is True)
         yield item
-        # TODO could parse hours from individual store pages, but they are in Hebrew


### PR DESCRIPTION
The earlier version of the spider required token-based cookies to be added to fetch data, which didn’t seem feasible. As a result, an alternative `API` is used to get the spider working.

```python
{'atp/brand/Burger King': 33,
 'atp/brand_wikidata/Q177054': 33,
 'atp/category/amenity/fast_food': 33,
 'atp/cdn/cloudfront/response_count': 2,
 'atp/cdn/cloudfront/response_status_count/200': 1,
 'atp/cdn/cloudfront/response_status_count/403': 1,
 'atp/clean_strings/street': 2,
 'atp/country/IL': 33,
 'atp/field/country/from_spider_name': 33,
 'atp/field/email/missing': 33,
 'atp/field/geometry/missing': 33,
 'atp/field/image/missing': 33,
 'atp/field/opening_hours/missing': 33,
 'atp/field/operator/missing': 33,
 'atp/field/operator_wikidata/missing': 33,
 'atp/field/phone/missing': 33,
 'atp/field/postcode/missing': 33,
 'atp/field/state/missing': 33,
 'atp/field/street_address/missing': 33,
 'atp/field/twitter/missing': 33,
 'atp/field/website/missing': 33,
 'atp/item_scraped_host_count/webapi.mishloha.co.il': 33,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 33,
 'downloader/request_bytes': 718,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 4904,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 2.570273,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 27, 15, 7, 29, 240449, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24327,
 'httpcompression/response_count': 1,
 'item_scraped_count': 33,
 'items_per_minute': 990.0,
 'log_count/DEBUG': 38,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 27, 15, 7, 26, 670176, tzinfo=datetime.timezone.utc)}
```