### PR TITLE
[NZ_Post]: add NZ Post (3421 locations)

### DIFF
--- a/locations/spiders/nz_post.py
+++ b/locations/spiders/nz_post.py
@@ -1,0 +1,67 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+# The NZ Post API truncates responses at 500 records, so the country
+# extent is searched recursively: any bbox that hits the cap is split
+# into four quadrants until each cell returns under it.
+CATEGORY_MAP = {
+    "PostShop": Categories.POST_OFFICE,
+    "Third Party Partner": Categories.POST_OFFICE,  # Co-branded post office in third-party retailers
+    "Postbox Lobby": Categories.POST_OFFICE,  # Private (PO) box lobby inside a partner store
+    "Postbox": Categories.POST_BOX,
+    "Depot": Categories.POST_DEPOT,
+}
+
+
+class NzPostSpider(Spider):
+    name = "nz_post"
+    item_attributes = {"operator": "New Zealand Post", "operator_wikidata": "Q1144511"}
+    allowed_domains = ["api.nzpost.co.nz"]
+    max_results = 500
+
+    def bbox_request(self, lat1: float, lat2: float, lon1: float, lon2: float) -> Request:
+        return Request(
+            url=(
+                "https://api.nzpost.co.nz/digital/postshop-locations/v2/locations"
+                f'?type=MAP_EXTENT&value={{"latitude1":{lat1},"latitude2":{lat2},"longitude1":{lon1},"longitude2":{lon2}}}'
+                f"&max={self.max_results}"
+            ),
+            cb_kwargs={"bbox": (lat1, lat2, lon1, lon2)},
+        )
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield self.bbox_request(-34, -48, 165, 179)
+
+    def parse(self, response: Response, bbox: tuple[float, float, float, float], **kwargs: Any) -> Any:
+        locations = response.json().get("locations", [])
+
+        if len(locations) >= self.max_results:
+            lat1, lat2, lon1, lon2 = bbox
+            lat_mid = (lat1 + lat2) / 2
+            lon_mid = (lon1 + lon2) / 2
+            yield self.bbox_request(lat1, lat_mid, lon1, lon_mid)
+            yield self.bbox_request(lat1, lat_mid, lon_mid, lon2)
+            yield self.bbox_request(lat_mid, lat2, lon1, lon_mid)
+            yield self.bbox_request(lat_mid, lat2, lon_mid, lon2)
+            return
+
+        for location in locations:
+            item = DictParser.parse(location)
+
+            address_details = location.get("address_details") or {}
+            item["street_address"] = address_details.get("address_line_1")
+            item["city"] = address_details.get("city") or address_details.get("suburb")
+            item["postcode"] = address_details.get("post_code")
+
+            if category := CATEGORY_MAP.get(location.get("type")):
+                apply_category(category, item)
+            else:
+                self.logger.error("Unexpected category: {}".format(location.get("type")))
+                continue
+
+            yield item


### PR DESCRIPTION
New spider scraping NZ Post locations in New Zealand.
Operator: New Zealand Post (Q1144511)

## Data source
GET API: api.nzpost.co.nz/digital/postshop-locations/v2/locations
Uses recursive bounding box splitting when results hit 500 cap.

## Category mapping
- PostShop → POST_OFFICE
- Third Party Partner → POST_OFFICE (co-branded post offices in third-party retailers)
- Postbox Lobby → POST_OFFICE (private box lobby inside partner stores)
- Postbox → POST_BOX
- Depot → POST_DEPOT

## Stats
- Total: 3,421 locations
- post_office: 1,462
- post_box: 1,947
- post_depot: 12
- 0 errors, 37 API requests
- nsi/cc_match: 3,421 (100%)

{
 "atp/category/amenity/post_box": 1947,
 "atp/category/amenity/post_depot": 12,
 "atp/category/amenity/post_office": 1462,
 "atp/clean_strings/addr_full": 2,
 "atp/clean_strings/name": 3,
 "atp/clean_strings/phone": 5,
 "atp/clean_strings/street_address": 1,
 "atp/country/NZ": 3421,
 "atp/field/branch/missing": 3421,
 "atp/field/brand/missing": 3421,
 "atp/field/brand_wikidata/missing": 3421,
 "atp/field/city/missing": 41,
 "atp/field/country/from_reverse_geocoding": 3421,
 "atp/field/email/missing": 3421,
 "atp/field/image/missing": 3421,
 "atp/field/opening_hours/missing": 3421,
 "atp/field/postcode/missing": 1922,
 "atp/field/street_address/missing": 1928,
 "atp/field/twitter/missing": 3421,
 "atp/field/website/missing": 3421,
 "atp/item_scraped_host_count/api.nzpost.co.nz": 3421,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 3421,
 "atp/operator/New Zealand Post": 3421,
 "atp/operator_wikidata/Q1144511": 3421,
 "downloader/request_bytes": 25611,
 "downloader/request_count": 38,
 "downloader/request_method_count/GET": 38,
 "downloader/response_bytes": 5320274,
 "downloader/response_count": 38,
 "downloader/response_status_count/200": 37,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 49.717336,
 "finish_reason": "finished",
 "finish_time": "2026-04-27T15:21:09.556544+00:00",
 "item_scraped_count": 3421,
 "items_per_minute": 4188.9795918367345,
 "request_depth_max": 5,
 "response_received_count": 38,
 "responses_per_minute": 46.53061224489796,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/404": 1,
 "scheduler/dequeued": 37,
 "scheduler/dequeued/memory": 37,
 "scheduler/enqueued": 37,
 "scheduler/enqueued/memory": 37,
 "start_time": "2026-04-27T15:20:19.839208+00:00"

Note: 1,922 items missing postcode and 1,928 missing street_address — nearly all are post boxes (1,947 total). This is expected: post boxes are standalone street furniture (like red mailboxes) that typically only have a general location description (e.g. "Corner of Main St and Park Ave") rather than a formal street address with postcode. The coordinates are present for all items.