### PR TITLE
[Burgermeister DE] Fix spider

### DIFF
--- a/locations/spiders/burgermeister_de.py
+++ b/locations/spiders/burgermeister_de.py
@@ -1,7 +1,9 @@
 from locations.storefinders.wp_go_maps import WpGoMapsSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BurgermeisterDESpider(WpGoMapsSpider):
     name = "burgermeister_de"
     item_attributes = {"brand": "Burgermeister", "brand_wikidata": "Q116382535"}
     allowed_domains = ["burgermeister.com"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
Fixed 404 error by setting USER_AGENT to BROWSER_DEFAULT.

``` python
{'atp/brand/Burgermeister': 108,
 'atp/brand_wikidata/Q116382535': 108,
 'atp/category/amenity/fast_food': 108,
 'atp/clean_strings/name': 6,
 'atp/closed_check': 1,
 'atp/country/DE': 108,
 'atp/field/branch/missing': 108,
 'atp/field/city/missing': 108,
 'atp/field/country/from_spider_name': 108,
 'atp/field/email/missing': 108,
 'atp/field/image/missing': 108,
 'atp/field/opening_hours/missing': 108,
 'atp/field/operator/missing': 108,
 'atp/field/operator_wikidata/missing': 108,
 'atp/field/phone/missing': 108,
 'atp/field/postcode/missing': 108,
 'atp/field/state/missing': 108,
 'atp/field/street_address/missing': 108,
 'atp/field/twitter/missing': 108,
 'atp/field/website/missing': 108,
 'atp/item_scraped_host_count/burgermeister.com': 108,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 108,
 'downloader/request_bytes': 551,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 25906,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.719629,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 29, 5, 48, 15, 428146, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 555049,
 'httpcompression/response_count': 2,
 'item_scraped_count': 108,
 'items_per_minute': 1296.0,
 'log_count/DEBUG': 110,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 29, 5, 48, 9, 708517, tzinfo=datetime.timezone.utc)}
```