### PR TITLE
[JD Sports ES] Fix Spider

### DIFF
--- a/locations/spiders/jd_sports_es.py
+++ b/locations/spiders/jd_sports_es.py
@@ -1,6 +1,7 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,4 +10,6 @@ class JdSportsESSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.es/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
     requires_proxy = True

--- a/locations/spiders/jd_sports_fr.py
+++ b/locations/spiders/jd_sports_fr.py
@@ -1,6 +1,7 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,4 +10,6 @@ class JdSportsFRSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.fr/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
     requires_proxy = True


### PR DESCRIPTION
```python
{'atp/brand/JD Sports': 129,
 'atp/brand_wikidata/Q6108019': 129,
 'atp/category/shop/clothes': 129,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 4,
 'atp/clean_strings/street_address': 4,
 'atp/country/ES': 129,
 'atp/duplicate_count': 2,
 'atp/field/branch/missing': 129,
 'atp/field/email/missing': 129,
 'atp/field/image/dropped': 129,
 'atp/field/image/missing': 129,
 'atp/field/operator/missing': 129,
 'atp/field/operator_wikidata/missing': 129,
 'atp/field/phone/missing': 5,
 'atp/field/state/missing': 93,
 'atp/item_scraped_host_count/www.jdsports.es': 131,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 129,
 'downloader/exception_count': 3,
 'downloader/exception_type_count/playwright._impl._errors.TimeoutError': 3,
 'downloader/request_bytes': 61527,
 'downloader/request_count': 138,
 'downloader/request_method_count/GET': 138,
 'downloader/response_bytes': 36278879,
 'downloader/response_count': 135,
 'downloader/response_status_count/200': 135,
 'dupefilter/filtered': 26,
 'elapsed_time_seconds': 253.934501,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 29, 12, 10, 26, 917571, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 129,
 'items_per_minute': 30.59288537549407,
 'log_count/DEBUG': 19589,
 'log_count/INFO': 11,
 'log_count/WARNING': 3,
 'memusage/max': 473194496,
 'memusage/startup': 297857024,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 138,
 'playwright/page_count/closed': 138,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 9606,
 'playwright/request_count/aborted': 9437,
 'playwright/request_count/method/GET': 9606,
 'playwright/request_count/navigation': 139,
 'playwright/request_count/resource_type/document': 139,
 'playwright/request_count/resource_type/font': 548,
 'playwright/request_count/resource_type/image': 6549,
 'playwright/request_count/resource_type/script': 1844,
 'playwright/request_count/resource_type/stylesheet': 526,
 'playwright/response_count': 139,
 'playwright/response_count/method/GET': 139,
 'playwright/response_count/resource_type/document': 139,
 'request_depth_max': 1,
 'response_received_count': 135,
 'responses_per_minute': 32.015810276679844,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 137,
 'scheduler/dequeued/memory': 137,
 'scheduler/enqueued': 137,
 'scheduler/enqueued/memory': 137,
 'start_time': datetime.datetime(2026, 4, 29, 12, 6, 12, 983070, tzinfo=datetime.timezone.utc)}
```