### PR TITLE
[Cvs US] Fix spider

### DIFF
--- a/locations/spiders/cvs_us.py
+++ b/locations/spiders/cvs_us.py
@@ -23,9 +23,14 @@ PHARMACY_BRANDS = {
 class CvsUSSpider(SitemapSpider, StructuredDataSpider):
     name = "cvs_us"
     allowed_domains = ["www.cvs.com"]
-    sitemap_urls = ["https://www.cvs.com/sitemap/store-details.xml"]
+    sitemap_urls = ["https://www.cvs.com/sitemap/store_locations_cities.xml"]
+    sitemap_rules = [("/store-locator/cvs-pharmacy-locations/", "parse")]
 
     def parse(self, response):
+        for link in response.xpath('//a[contains(@href, "storeid=")]/@href').getall():
+            yield response.follow(link, callback=self.parse_store)
+
+    def parse_store(self, response):
         if response.css("link[rel~=canonical]").attrib["href"] == "https://www.cvs.comundefined":
             # Weird garbage, seemingly for closed locations
             return


### PR DESCRIPTION
Switched to city based sitemap(https://www.cvs.com/sitemap/store_locations_cities.xml) and added link-extraction logic to resolve empty crawl results from the broken store-details sitemap(https://www.cvs.com/sitemap/store-details.xml).

Stats generated for few stores:
```python
{'atp/brand/CVS Pharmacy': 511,
 'atp/brand_wikidata/Q2078880': 511,
 'atp/category/amenity/pharmacy': 511,
 'atp/category/multiple': 511,
 'atp/country/US': 511,
 'atp/cvs_us/hours/failed': 1,
 'atp/cvs_us/unmapped_store_type/CVS': 4,
 'atp/cvs_us/unmapped_store_type/MinuteClinic': 42,
 'atp/cvs_us/unmapped_store_type/Oak St. Health now part of CVS Health': 1,
 'atp/field/branch/missing': 511,
 'atp/field/email/missing': 511,
 'atp/field/image/missing': 511,
 'atp/field/operator/missing': 511,
 'atp/field/operator_wikidata/missing': 511,
 'atp/field/postcode/missing': 28,
 'atp/field/twitter/missing': 511,
 'atp/item_scraped_host_count/www.cvs.com': 511,
 'atp/lineage': 'S_?',
 'atp/located_in/Target': 74,
 'atp/located_in_wikidata/Q1046951': 74,
 'atp/nsi/match_failed': 511,
 'downloader/exception_count': 33,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 33,
 'downloader/request_bytes': 3363735,
 'downloader/request_count': 876,
 'downloader/request_method_count/GET': 876,
 'downloader/response_bytes': 376070644,
 'downloader/response_count': 843,
 'downloader/response_status_count/200': 840,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 1,
 'dupefilter/filtered': 4,
 'elapsed_time_seconds': 1085.87296,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2026, 4, 29, 14, 6, 15, 304385, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4988318385,
 'httpcompression/response_count': 840,
 'item_scraped_count': 511,
 'items_per_minute': 28.258064516129036,
 'log_count/DEBUG': 1388,
 'log_count/INFO': 80,
 'log_count/WARNING': 510,
 'request_depth_max': 2,
 'response_received_count': 840,
 'responses_per_minute': 46.45161290322581,
 'retry/count': 33,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 33,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 875,
 'scheduler/dequeued/memory': 875,
 'scheduler/enqueued': 4876,
 'scheduler/enqueued/memory': 4876,
 'start_time': datetime.datetime(2026, 4, 29, 13, 48, 9, 431425, tzinfo=datetime.timezone.utc)}
```