### PR TITLE
[Macys] Fix Spider

### DIFF
--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -27,6 +27,7 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
         },
     }
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None

--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -1,11 +1,13 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import CHROME_LATEST
 
 
-class MacysSpider(CrawlSpider, StructuredDataSpider):
+class MacysSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "macys"
     item_attributes = {"brand": "Macy's", "brand_wikidata": "Q629269"}
     allowed_domains = ["www.macys.com"]
@@ -16,17 +18,13 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/\w\w/[^/]+/[^/]+\_(\d+).html$"), "parse"),
     ]
     wanted_types = ["Store"]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "ROBOTSTXT_OBEY": False,
         "DEFAULT_REQUEST_HEADERS": {
             "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
             "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
             "referer": "https://www.macys.com/stores/ca/",
-            "sec-ch-ua": '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
-            "sec-ch-ua-mobile": "?0",
-            "sec-ch-ua-platform": '"Windows"',
-            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+            "user-agent": CHROME_LATEST,
         },
     }
 

--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -2,13 +2,12 @@ from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class MacysSpider(CrawlSpider, StructuredDataSpider):
     name = "macys"
     item_attributes = {"brand": "Macy's", "brand_wikidata": "Q629269"}
-    allowed_domains = ["macys.com"]
+    allowed_domains = ["www.macys.com"]
     start_urls = ["https://www.macys.com/stores/browse/"]
     rules = [
         Rule(LinkExtractor(r"/stores/\w\w/$")),
@@ -16,9 +15,33 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/\w\w/[^/]+/[^/]+\_(\d+).html$"), "parse"),
     ]
     wanted_types = ["Store"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
-    requires_proxy = True
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "DEFAULT_REQUEST_HEADERS": {
+            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+            "referer": "https://www.macys.com/stores/ca/",
+            "sec-ch-ua": '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"Windows"',
+            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+        },
+    }
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None
         yield item
+
+    # start_urls = ["https://www.macys.com/stores/browse/"]
+    # rules = [
+    #     Rule(LinkExtractor(r"/stores/\w\w/$")),
+    #     Rule(LinkExtractor(r"/stores/\w\w/[^/]+/$")),
+    #     Rule(LinkExtractor(r"/stores/\w\w/[^/]+/[^/]+\_(\d+).html$"), "parse"),
+    # ]
+    # wanted_types = ["Store"]
+    # custom_settings = {"USER_AGENT": BROWSER_DEFAULT,"ROBOTSTXT_OBEY":False}
+    # # requires_proxy = True
+    #
+    # def post_process_item(self, item, response, ld_data, **kwargs):
+    #     item["name"] = None
+    #     yield item

--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -1,6 +1,7 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -15,7 +16,8 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/\w\w/[^/]+/[^/]+\_(\d+).html$"), "parse"),
     ]
     wanted_types = ["Store"]
-    custom_settings = {
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "ROBOTSTXT_OBEY": False,
         "DEFAULT_REQUEST_HEADERS": {
             "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",

--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -31,17 +31,3 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None
         yield item
-
-    # start_urls = ["https://www.macys.com/stores/browse/"]
-    # rules = [
-    #     Rule(LinkExtractor(r"/stores/\w\w/$")),
-    #     Rule(LinkExtractor(r"/stores/\w\w/[^/]+/$")),
-    #     Rule(LinkExtractor(r"/stores/\w\w/[^/]+/[^/]+\_(\d+).html$"), "parse"),
-    # ]
-    # wanted_types = ["Store"]
-    # custom_settings = {"USER_AGENT": BROWSER_DEFAULT,"ROBOTSTXT_OBEY":False}
-    # # requires_proxy = True
-    #
-    # def post_process_item(self, item, response, ld_data, **kwargs):
-    #     item["name"] = None
-    #     yield item

--- a/locations/spiders/macys.py
+++ b/locations/spiders/macys.py
@@ -29,7 +29,6 @@ class MacysSpider(CrawlSpider, StructuredDataSpider):
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
         },
     }
-    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None


### PR DESCRIPTION
```python
{"atp/brand/Macy's": 435,
 'atp/brand_wikidata/Q629269': 435,
 'atp/category/shop/department_store': 435,
 'atp/country/GU': 1,
 'atp/country/PR': 2,
 'atp/country/US': 432,
 'atp/field/branch/missing': 435,
 'atp/field/country/from_reverse_geocoding': 435,
 'atp/field/email/missing': 434,
 'atp/field/image/dropped': 435,
 'atp/field/image/missing': 435,
 'atp/field/operator/missing': 435,
 'atp/field/operator_wikidata/missing': 435,
 'atp/field/twitter/missing': 435,
 'atp/item_scraped_host_count/www.macys.com': 435,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 435,
 'downloader/request_bytes': 3717407,
 'downloader/request_count': 860,
 'downloader/request_method_count/GET': 860,
 'downloader/response_bytes': 33264590,
 'downloader/response_count': 860,
 'downloader/response_status_count/200': 860,
 'dupefilter/filtered': 378,
 'elapsed_time_seconds': 1057.781385,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 30, 4, 39, 35, 290185, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 129868017,
 'httpcompression/response_count': 860,
 'item_scraped_count': 435,
 'items_per_minute': 24.692526017029326,
 'log_count/DEBUG': 1296,
 'log_count/INFO': 397,
 'request_depth_max': 3,
 'response_received_count': 860,
 'responses_per_minute': 48.81740775780511,
 'scheduler/dequeued': 860,
 'scheduler/dequeued/memory': 860,
 'scheduler/enqueued': 860,
 'scheduler/enqueued/memory': 860,
 'start_time': datetime.datetime(2026, 4, 30, 4, 21, 57, 508800, tzinfo=datetime.timezone.utc)}
```