### PR TITLE
[Macys Backstage] Fix spider and try without proxy to save cost

### DIFF
--- a/locations/spiders/macys_backstage.py
+++ b/locations/spiders/macys_backstage.py
@@ -1,11 +1,13 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class MacysBackstageSpider(CrawlSpider, StructuredDataSpider):
+class MacysBackstageSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "macys_backstage"
     item_attributes = {"brand": "Macy's Backstage", "brand_wikidata": "Q122914589"}
     start_urls = ["https://www.macys.com/stores/backstage/browse/"]
@@ -15,8 +17,8 @@ class MacysBackstageSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(r"/stores/backstage/\w\w/[^/]+/[^/]+\_(\d+b).html$"), "parse"),
     ]
     wanted_types = ["store"]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
-    requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    drop_attributes = {"facebook", "twitter"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None


### PR DESCRIPTION
```python
{"atp/brand/Macy's Backstage": 294,
 'atp/brand_wikidata/Q122914589': 294,
 'atp/category/shop/department_store': 294,
 'atp/country/PR': 1,
 'atp/country/US': 293,
 'atp/field/branch/missing': 294,
 'atp/field/country/from_reverse_geocoding': 294,
 'atp/field/email/missing': 294,
 'atp/field/image/dropped': 294,
 'atp/field/image/missing': 294,
 'atp/field/operator/missing': 294,
 'atp/field/operator_wikidata/missing': 294,
 'atp/field/twitter/missing': 294,
 'atp/item_scraped_host_count/www.macys.com': 294,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 294,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/playwright._impl._errors.TimeoutError': 2,
 'downloader/request_bytes': 1249586,
 'downloader/request_count': 622,
 'downloader/request_method_count/GET': 622,
 'downloader/response_bytes': 122277621,
 'downloader/response_count': 620,
 'downloader/response_status_count/200': 620,
 'dupefilter/filtered': 283,
 'elapsed_time_seconds': 854.916963,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 30, 5, 35, 4, 723704, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 294,
 'items_per_minute': 20.655737704918035,
 'log_count/DEBUG': 34998,
 'log_count/INFO': 21,
 'log_count/WARNING': 2,
 'memusage/max': 645062656,
 'memusage/startup': 288923648,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 622,
 'playwright/page_count/closed': 622,
 'playwright/page_count/max_concurrent': 6,
 'playwright/request_count': 16730,
 'playwright/request_count/aborted': 16108,
 'playwright/request_count/method/GET': 16730,
 'playwright/request_count/navigation': 622,
 'playwright/request_count/resource_type/document': 622,
 'playwright/request_count/resource_type/image': 2128,
 'playwright/request_count/resource_type/script': 12662,
 'playwright/request_count/resource_type/stylesheet': 1318,
 'playwright/response_count': 622,
 'playwright/response_count/method/GET': 622,
 'playwright/response_count/resource_type/document': 622,
 'request_depth_max': 3,
 'response_received_count': 620,
 'responses_per_minute': 43.559718969555036,
 'scheduler/dequeued': 622,
 'scheduler/dequeued/memory': 622,
 'scheduler/enqueued': 622,
 'scheduler/enqueued/memory': 622,
 'start_time': datetime.datetime(2026, 4, 30, 5, 20, 49, 806741, tzinfo=datetime.timezone.utc)}
```