### PR TITLE
[Playa Bowls US] Fix Spider

### DIFF
--- a/locations/spiders/playa_bowls_us.py
+++ b/locations/spiders/playa_bowls_us.py
@@ -5,8 +5,9 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_FULL, OpeningHours
+from locations.linked_data_parser import LinkedDataParser
 
 
 class PlayaBowlsUSSpider(SitemapSpider):
@@ -23,8 +24,8 @@ class PlayaBowlsUSSpider(SitemapSpider):
                 (response.xpath('//*[@type="application/ld+json"]//text()').get().strip()),
             )
         )
-        item = DictParser.parse((ld_data))
-        item["ref"] = response.url
+        item = LinkedDataParser.parse_ld(ld_data)
+        item["ref"] = response.url.split("/")[-1]
         item["branch"] = item.pop("name").replace("Playa Bowls - ", "")
         oh = OpeningHours()
         try:
@@ -39,4 +40,6 @@ class PlayaBowlsUSSpider(SitemapSpider):
         except:
             pass
         item["opening_hours"] = oh
+        apply_category(Categories.FAST_FOOD, item)
+
         yield item

--- a/locations/spiders/playa_bowls_us.py
+++ b/locations/spiders/playa_bowls_us.py
@@ -1,37 +1,42 @@
+import json
+import re
 from typing import Any
 
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
-from locations.google_url import extract_google_position
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_FULL, OpeningHours
 
 
-class PlayaBowlsUSSpider(CrawlSpider):
+class PlayaBowlsUSSpider(SitemapSpider):
     name = "playa_bowls_us"
     item_attributes = {"brand": "Playa Bowls", "brand_wikidata": "Q114618507"}
-    start_urls = ["https://playabowls.com/locations"]
-    rules = [Rule(LinkExtractor("/location/"), callback="parse_store")]
+    sitemap_urls = ["https://playabowls.com/sitemap.xml"]
+    sitemap_rules = [("/location/", "parse")]
 
-    def parse_store(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
-        item["ref"] = response.url.split("/")[-1]
-        item["website"] = response.url
-
-        address_text_list = response.css("div.elementor-widget-heading .elementor-heading-title::text").getall()
-        address_text_list = [t.replace("\xa0", "").strip(", ") for t in address_text_list]
-        item["branch"] = address_text_list[0]
-        item["street_address"] = address_text_list[1]
-        item["city"] = address_text_list[2]
-        item["state"] = address_text_list[3]
-        item["postcode"] = address_text_list[4]
-
-        phone_link = response.css('a[href^="tel:"]::attr(href)').get()
-        item["phone"] = phone_link.split(":")[1].replace("%20", " ")
-
-        extract_google_position(item, response)
-        apply_category(Categories.FAST_FOOD, item)
-
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        ld_data = json.loads(
+            re.sub(
+                r'([}\]"])\s*(?=")',  # end of value followed by next key
+                r"\1,",
+                (response.xpath('//*[@type="application/ld+json"]//text()').get().strip()),
+            )
+        )
+        item = DictParser.parse((ld_data))
+        item["ref"] = response.url
+        item["branch"] = item.pop("name").replace("Playa Bowls - ", "")
+        oh = OpeningHours()
+        try:
+            if "Open Everyday " in ld_data.get("openingHours"):
+                for day in DAYS_FULL:
+                    open_time, close_time = ld_data.get("openingHours").replace("Open Everyday ", "").split("-")
+                    oh.add_range(
+                        day=day, open_time=open_time.strip(), close_time=close_time.strip(), time_format="%I%p"
+                    )
+            else:
+                oh.add_ranges_from_string(ld_data["openingHours"])
+        except:
+            pass
+        item["opening_hours"] = oh
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Playa Bowls': 410,
 'atp/brand_wikidata/Q114618507': 410,
 'atp/category/amenity/fast_food': 410,
 'atp/cdn/cloudflare/response_count': 413,
 'atp/cdn/cloudflare/response_status_count/200': 412,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/street_address': 2,
 'atp/country/US': 410,
 'atp/field/geometry/invalid': 5,
 'atp/field/image/missing': 410,
 'atp/field/opening_hours/missing': 52,
 'atp/field/operator/missing': 410,
 'atp/field/operator_wikidata/missing': 410,
 'atp/field/phone/missing': 32,
 'atp/field/postcode/missing': 2,
 'atp/field/twitter/missing': 410,
 'atp/item_scraped_host_count/playabowls.com': 410,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 410,
 'downloader/request_bytes': 214243,
 'downloader/request_count': 413,
 'downloader/request_method_count/GET': 413,
 'downloader/response_bytes': 10688037,
 'downloader/response_count': 413,
 'downloader/response_status_count/200': 412,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 495.559534,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 30, 6, 24, 20, 217143, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 33817045,
 'httpcompression/response_count': 413,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 410,
 'items_per_minute': 49.696969696969695,
 'log_count/DEBUG': 823,
 'log_count/INFO': 100,
 'request_depth_max': 1,
 'response_received_count': 413,
 'responses_per_minute': 50.06060606060606,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 412,
 'scheduler/dequeued/memory': 412,
 'scheduler/enqueued': 412,
 'scheduler/enqueued/memory': 412,
 'start_time': datetime.datetime(2026, 4, 30, 6, 16, 4, 657609, tzinfo=datetime.timezone.utc)}
```