### PR TITLE
[Woops US] Fix spider

### DIFF
--- a/locations/spiders/woops_us.py
+++ b/locations/spiders/woops_us.py
@@ -1,7 +1,7 @@
-from typing import Any
+from scrapy.http import Response
 
-import chompjs
-
+from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
@@ -11,14 +11,49 @@ class WoopsUSSpider(JSONBlobSpider):
         "brand_wikidata": "Q110474786",
         "brand": "Woops!",
     }
-    allowed_domains = [
-        "bywoops.com",
+    allowed_domains = ["mobi2go.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    start_urls = [
+        "https://www.mobi2go.com/api/1/headoffice/9492/locations?fields=address,opening_hours,status&include_hidden=true"
     ]
-    start_urls = ["https://bywoops.com/locations-list/"]
 
-    def extract_json(self, response):
-        return chompjs.parse_js_object(response.xpath("//div/@data-positions").get())
+    def pre_process_data(self, feature: dict):
+        feature.update(feature.pop("address", {}))
 
-    def pre_process_data(self, location) -> Any:
-        location["id"] = location["postName"]
-        location["website"] = "https://bywoops.com/locations/" + location["postName"] + "/"
+    def post_process_item(self, item: Feature, response: Response, feature: dict):
+        if feature.get("status") == "hidden":
+            return None
+
+        item["ref"] = feature["id"]
+        item["branch"] = feature.get("name", "").replace("Woops!", "").strip()
+        street_address = f"{feature.get('street_number', '')} {feature.get('street_name', '')}".strip()
+
+        # Handle Minnesota's "Mobile" and Jenna's "PLACEHOLDER" addresses
+        if "Mobile" in street_address or "PLACEHOLDER" in street_address:
+            item["street_address"] = None
+            item["city"] = feature.get("suburb")
+        else:
+            item["street_address"] = street_address
+
+        item.pop("street", None)
+        item.pop("housenumber", None)
+
+        item["opening_hours"] = self.parse_hours(feature.get("opening_hours", {}))
+
+        yield item
+
+    def parse_hours(self, oh_dict: dict) -> OpeningHours:
+        oh = OpeningHours()
+        rules = oh_dict.get("pickup", {})
+
+        if not any(isinstance(v, list) and v for v in rules.values()):
+            rules = oh_dict.get("delivery", {})
+
+        rules.pop("is_experimental_format", None)
+        for day, times in rules.items():
+            if isinstance(times, list):
+                for time_range in times:
+                    open_time, close_time = time_range.split("-")
+                    oh.add_range(day, open_time.strip(), close_time.strip())
+        return oh


### PR DESCRIPTION
Fixed the spider to use the backend Mobi2Go JSON API after upstream site structure changes.

``` python
{'atp/brand/Woops!': 22,
 'atp/brand_wikidata/Q110474786': 22,
 'atp/category/shop/bakery': 22,
 'atp/country/US': 22,
 'atp/field/image/missing': 22,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 22,
 'atp/field/operator_wikidata/missing': 22,
 'atp/field/phone/invalid': 1,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 22,
 'atp/field/website/missing': 22,
 'atp/item_scraped_host_count/www.mobi2go.com': 22,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 22,
 'downloader/request_bytes': 410,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 5746,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.816929,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 4, 30, 12, 53, 59, 931109, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39232,
 'httpcompression/response_count': 1,
 'item_scraped_count': 22,
 'items_per_minute': 660.0,
 'log_count/DEBUG': 23,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 4, 30, 12, 53, 57, 114180, tzinfo=datetime.timezone.utc)}
```