### PR TITLE
Fixed dennys_us spider

### DIFF
--- a/locations/spiders/dennys_us.py
+++ b/locations/spiders/dennys_us.py
@@ -10,18 +10,13 @@ class DennysUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Denny's", "brand_wikidata": "Q1189695"}
     sitemap_urls = ["https://locations.dennys.com/robots.txt"]
     sitemap_rules = [(r"https://locations.dennys.com/[^/]+/[^/]+/(\d+)$", "parse_sd")]
-    time_format = "%I:%M %p"
-
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        for rule in ld_data["openingHoursSpecification"]:
-            if rule["opens"] == "Closed":
-                continue
-            if rule["opens"] == "Open 24 Hours":
-                rule["opens"] = "12:00 AM  to  11:59 PM"
-            rule["opens"], rule["closes"] = rule["opens"].split("  to  ", 1)
+    search_for_twitter = False 
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["name"] = None
+
+        if any("Coming Soon!" in t for t in response.css(".location-info ::text").getall()):
+            return
 
         item["extras"]["website:menu"] = response.xpath('//a[@data-event-name="loc_view_menu"]/@href').get()
         item["extras"]["website:orders"] = response.xpath('//a[@data-event-name="loc_order_online"]/@href').get()

--- a/locations/spiders/dennys_us.py
+++ b/locations/spiders/dennys_us.py
@@ -10,7 +10,7 @@ class DennysUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Denny's", "brand_wikidata": "Q1189695"}
     sitemap_urls = ["https://locations.dennys.com/robots.txt"]
     sitemap_rules = [(r"https://locations.dennys.com/[^/]+/[^/]+/(\d+)$", "parse_sd")]
-    search_for_twitter = False 
+    search_for_twitter = False
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["name"] = None


### PR DESCRIPTION
The opening hours data changed, causing the old opening hours parser to break, leading the spider to only return coming soon stores. This PR removes the opening hours parser and prevents coming soon stores from being returned. Opening hours are still collected automatically by parse_sd.