### PR TITLE
Dead spider killer: skip intermittent failures using lookback window

### DIFF
--- a/ci/dead_spider_killer.py
+++ b/ci/dead_spider_killer.py
@@ -94,6 +94,27 @@ def fetch_recent_runs(n):
     return runs
 
 
+def fetch_lookback_runs(n, lookback):
+    """Fetch the last n+lookback runs, returning (recent_runs, lookback_runs).
+
+    recent_runs: the last n runs used for dead-spider detection.
+    lookback_runs: the lookback older runs used to check for recent successes.
+    """
+    logger.info("Fetching run history from %s", HISTORY_URL)
+    resp = session.get(HISTORY_URL, timeout=30)
+    resp.raise_for_status()
+    history = resp.json()
+    total = n + lookback
+    window = history[-total:]
+    lookback_runs = window[:lookback]  # older runs
+    recent_runs = window[lookback:]   # the last n runs
+    logger.info(
+        "Found %d total runs, using last %d for detection + %d for lookback",
+        len(history), len(recent_runs), len(lookback_runs),
+    )
+    return recent_runs, lookback_runs
+
+
 def fetch_run_results(stats_url):
     """Fetch a run's _results.json and return the results list."""
     logger.info("Fetching results from %s", stats_url)
@@ -103,13 +124,16 @@ def fetch_run_results(stats_url):
     return data.get("results", [])
 
 
-def find_dead_spiders(runs):
+def find_dead_spiders(runs, lookback_runs=None):
     """Find spiders that produced 0 features in ALL of the given runs.
 
     Returns a dict of {spider_name: {"filename": str, "run_history": [{run_id, features, errors}]}}
     Only includes spiders that were present in every run and had 0 features each time.
+
+    If lookback_runs is provided, any spider that produced non-zero features in ANY
+    of those older runs is excluded — it's intermittently failing, not truly dead.
     """
-    # Build per-spider history across all runs
+    # Build per-spider history across detection runs
     spider_data = {}
     run_ids = []
 
@@ -128,6 +152,15 @@ def find_dead_spiders(runs):
                 "elapsed_time": entry.get("elapsed_time", 0),
             }
 
+    # Build per-spider feature counts from lookback runs
+    lookback_successes = set()
+    if lookback_runs:
+        for run in lookback_runs:
+            results = fetch_run_results(run["stats_url"])
+            for entry in results:
+                if entry.get("features", 0) > 0:
+                    lookback_successes.add(entry["spider"])
+
     # Filter to spiders present in ALL runs with 0 features each time
     dead_spiders = {}
     for name, data in spider_data.items():
@@ -135,11 +168,17 @@ def find_dead_spiders(runs):
         if len(data["runs"]) != len(run_ids):
             continue
         # Must have 0 features in every run
-        if all(r["features"] == 0 for r in data["runs"].values()):
-            dead_spiders[name] = {
-                "filename": data["filename"],
-                "run_history": [{"run_id": rid, **data["runs"][rid]} for rid in run_ids],
-            }
+        if not all(r["features"] == 0 for r in data["runs"].values()):
+            continue
+        # Skip spiders that produced results in the lookback window — they're
+        # intermittently failing, not consistently dead.
+        if name in lookback_successes:
+            logger.info("Skipping %s — had successful runs in the lookback window", name)
+            continue
+        dead_spiders[name] = {
+            "filename": data["filename"],
+            "run_history": [{"run_id": rid, **data["runs"][rid]} for rid in run_ids],
+        }
 
     logger.info("Found %d spiders with 0 features across all %d runs", len(dead_spiders), len(run_ids))
     return dead_spiders
@@ -834,6 +873,10 @@ def main():  # noqa: C901
     parser.add_argument(
         "--weeks", type=int, default=5, help="Number of consecutive zero-result runs required (default: 5)"
     )
+    parser.add_argument(
+        "--lookback", type=int, default=3,
+        help="Additional older runs to check for recent successes before flagging (default: 3)"
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print report without creating PRs or issues")
     parser.add_argument("--max-prs", type=int, default=5, help="Max removal PRs to create per run (default: 5)")
     parser.add_argument(
@@ -848,12 +891,12 @@ def main():  # noqa: C901
     )
 
     # Step 1: Fetch recent runs
-    runs = fetch_recent_runs(args.weeks)
+    runs, lookback_runs = fetch_lookback_runs(args.weeks, args.lookback)
     if len(runs) < args.weeks:
         logger.warning("Only %d runs available, need %d. Proceeding with what we have.", len(runs), args.weeks)
 
-    # Step 2: Find consistently dead spiders
-    dead_spiders = find_dead_spiders(runs)
+    # Step 2: Find consistently dead spiders (excluding intermittent failures)
+    dead_spiders = find_dead_spiders(runs, lookback_runs=lookback_runs)
     if not dead_spiders:
         logger.info("No consistently dead spiders found.")
         return 0

--- a/ci/dead_spider_killer.py
+++ b/ci/dead_spider_killer.py
@@ -107,10 +107,12 @@ def fetch_lookback_runs(n, lookback):
     total = n + lookback
     window = history[-total:]
     lookback_runs = window[:lookback]  # older runs
-    recent_runs = window[lookback:]   # the last n runs
+    recent_runs = window[lookback:]  # the last n runs
     logger.info(
         "Found %d total runs, using last %d for detection + %d for lookback",
-        len(history), len(recent_runs), len(lookback_runs),
+        len(history),
+        len(recent_runs),
+        len(lookback_runs),
     )
     return recent_runs, lookback_runs
 
@@ -874,8 +876,10 @@ def main():  # noqa: C901
         "--weeks", type=int, default=5, help="Number of consecutive zero-result runs required (default: 5)"
     )
     parser.add_argument(
-        "--lookback", type=int, default=3,
-        help="Additional older runs to check for recent successes before flagging (default: 3)"
+        "--lookback",
+        type=int,
+        default=3,
+        help="Additional older runs to check for recent successes before flagging (default: 3)",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print report without creating PRs or issues")
     parser.add_argument("--max-prs", type=int, default=5, help="Max removal PRs to create per run (default: 5)")

--- a/locations/spiders/coach.py
+++ b/locations/spiders/coach.py
@@ -1,26 +1,22 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.items import SocialMedia, set_social_media
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CoachSpider(CrawlSpider, StructuredDataSpider):
+class CoachSpider(SitemapSpider, StructuredDataSpider):
     name = "coach"
     item_attributes = {"brand": "Coach", "brand_wikidata": "Q727697"}
-    start_urls = [
-        "https://de.coach.com/stores/index.html",
-        "https://es.coach.com/stores/index.html",
-        "https://fr.coach.com/stores/index.html",
-        "https://it.coach.com/stores/index.html",
-        "https://uk.coach.com/stores/index.html",
+    sitemap_urls = [
+        "https://de.coach.com/stores/sitemap.xml",
+        "https://es.coach.com/stores/sitemap.xml",
+        "https://fr.coach.com/stores/sitemap.xml",
+        "https://it.coach.com/stores/sitemap.xml",
+        "https://uk.coach.com/stores/sitemap.xml",
     ]
-    rules = [
-        Rule(LinkExtractor(allow=r"/stores/[-\w]+\.html$")),
-        Rule(LinkExtractor(allow=r"/stores/[-\w]+/[-\w]+\.html$")),
-        Rule(LinkExtractor(allow=r"/stores/[-\w]+/[-\w]+/[-\w]+\.html$"), callback="parse_sd"),
-    ]
+    sitemap_rules = [(r"/stores/[-\w]+/[-\w]+/[-\w]+\.html$", "parse_sd")]
     wanted_types = ["Organization"]
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if not ld_data.get("address", {}).get("streetAddress"):

--- a/locations/spiders/coach_ca.py
+++ b/locations/spiders/coach_ca.py
@@ -1,22 +1,16 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CoachCASpider(CrawlSpider, StructuredDataSpider):
+class CoachCASpider(SitemapSpider, StructuredDataSpider):
     name = "coach_ca"
     item_attributes = {"brand": "Coach", "brand_wikidata": "Q727697"}
-    start_urls = ["https://ca.coach.com/stores/index.html"]
-    rules = [
-        Rule(LinkExtractor(allow=r"/stores/(outlets/)?\w\w$", deny=r"/fr_ca/")),
-        Rule(LinkExtractor(allow=r"/stores/(outlets/)?\w\w/[-\w]+$", deny=r"/fr_ca/")),
-        Rule(
-            LinkExtractor(allow=r"/stores/(outlets/)?\w\w/[-\w]+/.+$", deny=r"/fr_ca/"),
-            callback="parse_sd",
-        ),
-    ]
+    sitemap_urls = ["https://ca.coach.com/sitemap_index.xml"]
+    sitemap_follow = [r"/en/"]
+    sitemap_rules = [(r"/en/stores/(outlets/)?\w\w/[-\w]+/.+$", "parse_sd")]
     wanted_types = ["Store", "OutletStore"]
+    requires_proxy = True
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["extras"]["website:fr"] = response.urljoin(response.xpath('//a[text()="Français"]/@href').get())


### PR DESCRIPTION
## Problem

The automation flags a spider as dead after N consecutive zero-result runs, but doesn't check whether the spider was working just before that streak. This can produce false positives for spiders that are intermittently failing (e.g. transient network issues, occasional bot-detection events) rather than truly dead.

This was observed with `chargepoint` in #16020 — the spider had been failing for 5 runs and got an investigation issue filed, but the root cause turned out to be a misdiagnosis (the ATP default UA actually returns 200 on that API, per testing in the issue comments).

## Fix

Before flagging a spider, fetch an additional `--lookback` window of older runs (default: 3 extra weeks) and check whether the spider produced any non-zero results in that period. If it did, it's intermittently broken, not consistently dead — skip it.

```
--weeks 5   →  detection window (must all be zero)
--lookback 3 →  older runs to check for recent successes
```

A spider with 5 consecutive zeros that was producing results 6–8 runs ago will be skipped. A spider with 8+ consecutive zeros will still be caught correctly.

Closes #16020