### PR TITLE
[DyDo Drinco JP] create spider (107599 items)

### DIFF
--- a/locations/spiders/dydo_jp.py
+++ b/locations/spiders/dydo_jp.py
@@ -37,21 +37,23 @@ class DydoJPSpider(Spider):
         for lt, ln in country_iseadgg_centroids("JP", 24):
             yield JsonRequest(
                 url="https://vending-api.dydo.cmsod.jp/v1/graphql",
-                data={"query": GRAPHQL_QUERY, "variables": {"lon": ln, "lat": lt, "radius": 24000}, },
+                data={
+                    "query": GRAPHQL_QUERY,
+                    "variables": {"lon": ln, "lat": lt, "radius": 24000},
+                },
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["data"]["search_vending_machines"]:
-           
+
             item = Feature()
-            
+
             item["ref"] = store.get("vending_machine_id")
             item["lon"] = store.get("longitude")
             item["lat"] = store.get("latitude")
             item["extras"]["addr:province"] = store.get("prefecture")
             item["city"] = store.get("city")
             item["street_address"] = store.get("address")
-            
+
             apply_category(Categories.VENDING_MACHINE, item)
             yield item
-

--- a/locations/spiders/dydo_jp.py
+++ b/locations/spiders/dydo_jp.py
@@ -1,0 +1,57 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.geo import country_iseadgg_centroids
+from locations.items import Feature
+
+GRAPHQL_QUERY = """
+query SearchVendingMachines($lon: numeric!, $lat: numeric!, $radius: Int!) {
+	search_vending_machines(args: {
+		p_longitude: $lon
+		p_latitude: $lat
+		p_max: $radius
+	}) {
+		vending_machine_id
+		longitude
+		latitude
+		prefecture
+		city
+		address
+		base
+		inner
+		vending_machine_type1
+		product_name1
+		product_name2
+	}
+}"""
+
+
+class DydoJPSpider(Spider):
+    name = "dydo_jp"
+    item_attributes = {"brand": "ダイドー", "brand_wikidata": "Q11316814"}
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for lt, ln in country_iseadgg_centroids("JP", 24):
+            yield JsonRequest(
+                url="https://vending-api.dydo.cmsod.jp/v1/graphql",
+                data={"query": GRAPHQL_QUERY, "variables": {"lon": ln, "lat": lt, "radius": 24000}, },
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["data"]["search_vending_machines"]:
+           
+            item = Feature()
+            
+            item["ref"] = store.get("vending_machine_id")
+            item["lon"] = store.get("longitude")
+            item["lat"] = store.get("latitude")
+            item["extras"]["addr:province"] = store.get("prefecture")
+            item["city"] = store.get("city")
+            item["street_address"] = store.get("address")
+            
+            apply_category(Categories.VENDING_MACHINE, item)
+            yield item
+

--- a/locations/spiders/dydo_jp.py
+++ b/locations/spiders/dydo_jp.py
@@ -9,23 +9,23 @@ from locations.items import Feature
 
 GRAPHQL_QUERY = """
 query SearchVendingMachines($lon: numeric!, $lat: numeric!, $radius: Int!) {
-	search_vending_machines(args: {
-		p_longitude: $lon
-		p_latitude: $lat
-		p_max: $radius
-	}) {
-		vending_machine_id
-		longitude
-		latitude
-		prefecture
-		city
-		address
-		base
-		inner
-		vending_machine_type1
-		product_name1
-		product_name2
-	}
+    search_vending_machines(args: {
+        p_longitude: $lon
+        p_latitude: $lat
+        p_max: $radius
+    }) {
+        vending_machine_id
+        longitude
+        latitude
+        prefecture
+        city
+        address
+        base
+        inner
+        vending_machine_type1
+        product_name1
+        product_name2
+    }
 }"""
 
 


### PR DESCRIPTION
{'atp/brand/ダイドー': 125017,
 'atp/brand_wikidata/Q11316814': 125017,
 'atp/category/amenity/vending_machine': 125017,
 'atp/clean_strings/ref': 15728,
 'atp/country/JP': 125017,
 'atp/duplicate_count': 27779,
 'atp/field/branch/missing': 125017,
 'atp/field/country/from_spider_name': 125017,
 'atp/field/email/missing': 125017,
 'atp/field/image/missing': 125017,
 'atp/field/opening_hours/missing': 125017,
 'atp/field/operator/missing': 125017,
 'atp/field/operator_wikidata/missing': 125017,
 'atp/field/phone/missing': 125017,
 'atp/field/postcode/missing': 125017,
 'atp/field/state/missing': 125017,
 'atp/field/street_address/missing': 9,
 'atp/field/twitter/missing': 125017,
 'atp/field/website/missing': 125017,
 'atp/item_scraped_host_count/vending-api.dydo.cmsod.jp': 152796,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 125017,
 'downloader/request_bytes': 382464,
 'downloader/request_count': 470,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 469,
 'downloader/response_bytes': 4511776,
 'downloader/response_count': 470,
 'downloader/response_status_count/200': 469,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 606.843728,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 4, 3, 56, 6, 243253, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39010211,
 'httpcompression/response_count': 352,
 'item_dropped_count': 27779,
 'item_dropped_reasons_count/DropItem': 27779,
 'item_scraped_count': 125017,
 'items_per_minute': 12377.920792079209,
 'log_count/DEBUG': 153267,
 'log_count/INFO': 13,
 'log_count/WARNING': 1,
 'response_received_count': 470,
 'responses_per_minute': 46.53465346534654,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 469,
 'scheduler/dequeued/memory': 469,
 'scheduler/enqueued': 469,
 'scheduler/enqueued/memory': 469,
 'start_time': datetime.datetime(2026, 5, 4, 3, 45, 59, 399525, tzinfo=datetime.timezone.utc)}