### PR TITLE
[Aesop] Fix Spider

### DIFF
--- a/locations/spiders/aesop.py
+++ b/locations/spiders/aesop.py
@@ -1,23 +1,30 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from typing import Any
 
-from locations.camoufox_spider import CamoufoxSpider
-from locations.categories import Categories, apply_category
-from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 
 
-class AesopSpider(CrawlSpider, StructuredDataSpider, CamoufoxSpider):
+class AesopSpider(Spider):
     name = "aesop"
     item_attributes = {"brand": "Aesop", "brand_wikidata": "Q4688560"}
-    allowed_domains = ["shop.aesop.com"]
-    start_urls = ["https://shop.aesop.com/stores/all"]
-    rules = [Rule(LinkExtractor(allow="/stores/"), callback="parse_sd", follow=True)]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
-    requires_proxy = True
+    start_urls = ["https://www.aesop.com.hk/skin/store-list.json"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name").replace("Aesop ", "")
-        item["website"] = response.url
-        apply_category(Categories.SHOP_COSMETICS, item)
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for key, value in response.json().items():
+            for location in value:
+                if "aesop" in location.get("store_name").lower():
+                    item = DictParser.parse(location)
+                    item["branch"] = item["ref"] = item.pop("name").replace("Aesop ", "")
+                    item["country"] = key
+                    if "http" not in item.get("website"):
+                        item.pop("website")
+                    try:
+                        oh = OpeningHours()
+                        oh.add_ranges_from_string(location.get("store_time"))
+                        item["opening_hours"] = oh
+                    except:
+                        pass
+                    yield item


### PR DESCRIPTION
```python
{'atp/brand/Aesop': 363,
 'atp/brand_wikidata/Q4688560': 363,
 'atp/category/shop/cosmetics': 363,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/addr_full': 12,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/email': 9,
 'atp/clean_strings/phone': 2,
 'atp/country/AT': 2,
 'atp/country/AU': 43,
 'atp/country/BE': 2,
 'atp/country/CA': 16,
 'atp/country/CH': 7,
 'atp/country/CN': 6,
 'atp/country/DE': 16,
 'atp/country/DK': 4,
 'atp/country/ES': 4,
 'atp/country/FR': 17,
 'atp/country/GB': 34,
 'atp/country/HK': 13,
 'atp/country/IT': 9,
 'atp/country/JP': 46,
 'atp/country/KR': 16,
 'atp/country/MO': 4,
 'atp/country/MY': 4,
 'atp/country/NL': 4,
 'atp/country/NO': 2,
 'atp/country/NZ': 4,
 'atp/country/SE': 4,
 'atp/country/SG': 9,
 'atp/country/TW': 23,
 'atp/country/US': 74,
 'atp/field/city/missing': 272,
 'atp/field/email/missing': 216,
 'atp/field/geometry/missing': 363,
 'atp/field/image/missing': 363,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 363,
 'atp/field/operator_wikidata/missing': 363,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 330,
 'atp/field/state/missing': 363,
 'atp/field/street_address/missing': 363,
 'atp/field/twitter/missing': 363,
 'atp/field/website/missing': 74,
 'atp/item_scraped_host_count/www.aesop.com.hk': 363,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 363,
 'downloader/request_bytes': 678,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 38853,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.733181,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 4, 7, 2, 40, 419211, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 286993,
 'httpcompression/response_count': 2,
 'item_scraped_count': 363,
 'items_per_minute': 5445.0,
 'log_count/DEBUG': 365,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 4, 7, 2, 35, 686030, tzinfo=datetime.timezone.utc)}

```