### PR TITLE
[Arcelik Global TR] Fix Spider

### DIFF
--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -1,11 +1,9 @@
-from typing import AsyncIterator
-
 from scrapy import Spider
-from scrapy.http import FormRequest, Request
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 BRANDS = {
     "arcelik": {"brand": "Arçelik", "brand_wikidata": "Q640497"},
@@ -15,42 +13,23 @@ BRANDS = {
 
 class ArcelikGlobalTRSpider(Spider):
     name = "arcelik_global_tr"
-    no_refs = True
-    requires_proxy = True
-
-    async def start(self) -> AsyncIterator[Request]:
-        for brand in BRANDS.keys():
-            url = f"https://www.{brand}.com.tr/{brand}-bayileri"
-            yield Request(url, cb_kwargs={"brand": brand})
+    start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
+    is_playwright_spider = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response, **kwargs):
-        brand = kwargs["brand"]
-        city_codes = response.xpath('//select[@id="cityCode"]/option')
-        for city_code in city_codes[1:]:
-            yield FormRequest(
-                url=f"https://www.{brand}.com.tr/getStoreFinderUrl",
-                method="get",
-                formdata={
-                    "postCode": city_code.xpath("./@value").get(),
-                    "isService": "false",
-                },
-                callback=self.parse_city_url,
-                cb_kwargs={"city": city_code.xpath("./text()").get(), "brand": brand},
-            )
-
-    def parse_city_url(self, response, **kwargs):
-        yield response.follow(response.text, callback=self.parse_locations, cb_kwargs=kwargs)
-
-    def parse_locations(self, response, **kwargs):
         for location in response.xpath('//*[@class="srv-item "][@data-order]'):
             item = Feature()
             item["website"] = response.url
             item["lat"], item["lon"] = location.xpath("./@data-coor").get().split("|")
             item["name"] = location.xpath('.//*[@class="srv-name"]/text()').get().replace("\n", " ").strip()
             item["addr_full"] = clean_address(location.xpath('.//*[@class="srv-address"]/text()').get())
-            item["city"] = kwargs["city"]
             item["phone"] = location.xpath('.//*[contains(@data-href, "tel:")]/@data-href').get()
-            item.update(BRANDS[kwargs["brand"]])
+            for key, value in BRANDS.items():
+                if key in response.url:
+                    item.update(BRANDS[key])
+                    item["ref"] = " - ".join([location.xpath("./@data-order").get(), key])
+
             apply_category(Categories.SHOP_APPLIANCE, item)
 
             yield item

--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -16,6 +16,7 @@ class ArcelikGlobalTRSpider(Spider):
     start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    requires_proxy = True
 
     def parse(self, response, **kwargs):
         for location in response.xpath('//*[@class="srv-item "][@data-order]'):


### PR DESCRIPTION
```python
{'atp/brand/Arçelik': 500,
 'atp/brand/Beko': 500,
 'atp/brand_wikidata/Q631792': 500,
 'atp/brand_wikidata/Q640497': 500,
 'atp/category/shop/appliance': 1000,
 'atp/country/TR': 1000,
 'atp/field/branch/missing': 1000,
 'atp/field/city/missing': 1000,
 'atp/field/country/from_spider_name': 1000,
 'atp/field/email/missing': 1000,
 'atp/field/image/missing': 1000,
 'atp/field/opening_hours/missing': 1000,
 'atp/field/operator/missing': 1000,
 'atp/field/operator_wikidata/missing': 1000,
 'atp/field/postcode/missing': 1000,
 'atp/field/state/missing': 1000,
 'atp/field/street_address/missing': 1000,
 'atp/field/twitter/missing': 1000,
 'atp/item_scraped_host_count/www.arcelik.com.tr': 500,
 'atp/item_scraped_host_count/www.beko.com.tr': 500,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 500,
 'atp/nsi/perfect_match': 500,
 'downloader/request_bytes': 1587,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 3483544,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 40.68677,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 4, 8, 54, 50, 70113, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1000,
 'items_per_minute': 1500.0,
 'log_count/DEBUG': 1175,
 'log_count/INFO': 7,
 'memusage/max': 297639936,
 'memusage/startup': 297639936,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 4,
 'playwright/page_count/closed': 4,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 33,
 'playwright/request_count/aborted': 29,
 'playwright/request_count/method/GET': 33,
 'playwright/request_count/navigation': 4,
 'playwright/request_count/resource_type/document': 4,
 'playwright/request_count/resource_type/image': 3,
 'playwright/request_count/resource_type/other': 4,
 'playwright/request_count/resource_type/script': 18,
 'playwright/request_count/resource_type/stylesheet': 4,
 'playwright/response_count': 4,
 'playwright/response_count/method/GET': 4,
 'playwright/response_count/resource_type/document': 4,
 'response_received_count': 4,
 'responses_per_minute': 6.0,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 4, 8, 54, 9, 383343, tzinfo=datetime.timezone.utc)}
```