### PR TITLE
Correct website URLs returned by cex.py

### DIFF
--- a/locations/spiders/cex.py
+++ b/locations/spiders/cex.py
@@ -33,7 +33,7 @@ class CexSpider(scrapy.Spider):
         item["city"] = store["city"]
         item["state"] = store["county"]
         item["postcode"] = store["postcode"]
-        item["website"] = "https://uk.webuy.com/site/storeDetail?branchId=" + ref
+        item["website"] = "https://uk.webuy.com/site/storeDetail/?branchId=" + ref
         item["ref"] = ref
         item["image"] = ";".join(store["storeImageUrls"])
 


### PR DESCRIPTION
The CeX store website URLs currently returned by the spider now redirect to URLs of the form https://uk.webuy.com/site/storeDetail/?branchId=340 with an additional forward slash before the question mark.