### PR TITLE
[Taito Station] create spider (248 locations)

### DIFF
--- a/locations/spiders/taito.py
+++ b/locations/spiders/taito.py
@@ -11,7 +11,6 @@ class TaitoSpider(Spider):
     item_attributes = {"brand_wikidata": "Q1054844"}
 
     start_urls = ["https://www.taito.co.jp/api/LanguageStoreSearch/?isGlobalOnly=false&lang=ja"]
-    
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():

--- a/locations/spiders/taito.py
+++ b/locations/spiders/taito.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
+
+
+class TaitoSpider(Spider):
+    name = "taito"
+    item_attributes = {"brand_wikidata": "Q1054844"}
+
+    start_urls = ["https://www.taito.co.jp/api/LanguageStoreSearch/?isGlobalOnly=false&lang=ja"]
+    
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json():
+            store.update(store.pop("StoreData"))
+            item = DictParser.parse(store)
+            item["ref"] = store.get("StoreID")
+            item["website"] = f"https://www.taito.co.jp{store.get('LinkUrl')}"
+            item["image"] = "https://" + store.get("ImagePath") + store.get("MobileImageName01")
+            item["extras"]["branch:ja-Hira"] = store.get("StoreNameCana")
+            item["phone"] = store.get("TelephoneNo")
+            yield item

--- a/locations/spiders/taito.py
+++ b/locations/spiders/taito.py
@@ -17,7 +17,10 @@ class TaitoSpider(Spider):
             store.update(store.pop("StoreData"))
             item = DictParser.parse(store)
             item["ref"] = store.get("StoreID")
-            item["website"] = f"https://www.taito.co.jp{store.get('LinkUrl')}"
+            if "http" in store.get("LinkUrl"):
+                item["website"] = store.get("LinkUrl")
+            else:
+                item["website"] = f"https://www.taito.co.jp{store.get('LinkUrl')}"
             item["image"] = "https://" + store.get("ImagePath") + store.get("MobileImageName01")
             item["extras"]["branch:ja-Hira"] = store.get("StoreNameCana")
             item["phone"] = store.get("TelephoneNo")


### PR DESCRIPTION
{'atp/brand/Taito Station': 8,
 'atp/brand/タイトーステーション': 240,
 'atp/brand_wikidata/Q1054844': 248,
 'atp/category/leisure/amusement_arcade': 248,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 2,
 'atp/clean_strings/street_address': 5,
 'atp/country/HK': 8,
 'atp/country/JP': 240,
 'atp/field/branch/missing': 248,
 'atp/field/email/missing': 248,
 'atp/field/opening_hours/missing': 248,
 'atp/field/operator/missing': 248,
 'atp/field/operator_wikidata/missing': 248,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 8,
 'atp/field/twitter/missing': 248,
 'atp/field/website/invalid': 3,
 'atp/item_scraped_host_count/[www.taito.co.jp](http://www.taito.co.jp/)': 248,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 248,
 'downloader/request_bytes': 707,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1528804,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.552385,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 5, 1, 9, 20, 741078, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 248,
 'items_per_minute': 4960.0,
 'log_count/DEBUG': 250,
 'log_count/INFO': 3,
 'log_count/WARNING': 4,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 5, 1, 9, 17, 188693, tzinfo=datetime.timezone.utc)}