### PR TITLE
[BpPulse GB] Fix spider

### DIFF
--- a/locations/spiders/bp_pulse_gb.py
+++ b/locations/spiders/bp_pulse_gb.py
@@ -8,5 +8,6 @@ class BpPulseGBSpider(UberallSpider):
     key = "Ngy4Zpj26HVGztRS6HikqkGY8AEUZ2"
 
     def post_process_item(self, item, response, location):
+        item["name"] = item["phone"] = None
         apply_category(Categories.CHARGING_STATION, item)
         yield item

--- a/locations/spiders/bp_pulse_gb.py
+++ b/locations/spiders/bp_pulse_gb.py
@@ -1,36 +1,12 @@
-from typing import AsyncIterator
-
-from scrapy import Spider
-from scrapy.http import JsonRequest
-
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
 
 
-class BpPulseGBSpider(Spider):
+class BpPulseGBSpider(UberallSpider):
     name = "bp_pulse_gb"
     item_attributes = {"brand_wikidata": "Q39057719"}
+    key = "Ngy4Zpj26HVGztRS6HikqkGY8AEUZ2"
 
-    @staticmethod
-    def make_request(page: int) -> JsonRequest:
-        return JsonRequest(
-            url=f"https://chargevision4.com/api/polar-plus/posts?page={page}",
-            headers={"API_KEY": "6147-f93fad682f5a-2a927fe95546-2d31"},
-            meta={"page": page},
-        )
-
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield self.make_request(1)
-
-    def parse(self, response, **kwargs):
-        for ref, location in response.json()["data"].items():
-            item = Feature()
-
-            item["lat"] = location[0]
-            item["lon"] = location[1]
-            item["ref"] = ref
-            apply_category(Categories.CHARGING_STATION, item)
-            yield item
-
-        if response.json()["per_page"] * response.meta["page"] < response.json()["total"]:
-            yield self.make_request(response.meta["page"] + 1)
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.CHARGING_STATION, item)
+        yield item


### PR DESCRIPTION
The old Chargevision API endpoint returned HTTP 410. BP Pulse has migrated their locator to Uberall. So, refactored the spider to inherit from UberallSpider.

``` python
{'atp/brand/bp pulse': 1583,
 'atp/brand_wikidata/Q39057719': 1583,
 'atp/category/amenity/charging_station': 1583,
 'atp/country/GB': 1583,
 'atp/field/branch/missing': 1583,
 'atp/field/email/missing': 1583,
 'atp/field/image/missing': 332,
 'atp/field/opening_hours/missing': 1,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 2,
 'atp/field/twitter/missing': 1583,
 'atp/field/website/missing': 1583,
 'atp/item_scraped_host_count/uberall.com': 1583,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1583,
 'atp/operator/bp pulse': 1583,
 'atp/operator_wikidata/Q39057719': 1583,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 149837,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 10.535001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 5, 7, 23, 38, 474, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1703597,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1583,
 'items_per_minute': 9498.0,
 'log_count/DEBUG': 1585,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 12.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 5, 7, 23, 27, 465473, tzinfo=datetime.timezone.utc)}

```