### PR TITLE
(Yoshinoya JP) create spider (1285 stores)

### DIFF
--- a/locations/spiders/yoshinoya_jp.py
+++ b/locations/spiders/yoshinoya_jp.py
@@ -1,0 +1,24 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class YoshinoyaJPSpider(LocationCloudSpider):
+    name = "yoshinoya_jp"
+    item_attributes = {"brand": "吉野家", "brand_wikidata": "Q776272"}
+    api_endpoint = "https://stores.yoshinoya.com/yoshinoya/api/proxy2/shop/list"
+    website_formatter = "https://stores.yoshinoya.com/yoshinoya/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if source_feature["categories"][0]["code"] == "02":
+            return  # skip offices
+
+        item["branch"] = source_feature.get("name").removeprefix("吉野家 ")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby").removeprefix("ヨシノヤ ")
+        item["phone"] = f"+81 {source_feature.get('phone')}"
+
+        apply_category(Categories.FAST_FOOD, item)
+
+        yield item


### PR DESCRIPTION
{'atp/brand/吉野家': 1285,
 'atp/brand_wikidata/Q776272': 1285,
 'atp/category/amenity/fast_food': 1285,
 'atp/country/JP': 1285,
 'atp/field/city/missing': 1285,
 'atp/field/country/from_spider_name': 1285,
 'atp/field/email/missing': 1285,
 'atp/field/image/missing': 1285,
 'atp/field/opening_hours/missing': 1285,
 'atp/field/operator/missing': 1285,
 'atp/field/operator_wikidata/missing': 1285,
 'atp/field/state/missing': 1285,
 'atp/field/street_address/missing': 1285,
 'atp/field/twitter/missing': 1285,
 'atp/item_scraped_host_count/stores.yoshinoya.com': 1285,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1285,
 'downloader/request_bytes': 1886,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 112226,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 6.700909,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 5, 7, 37, 41, 352491, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1047091,
 'httpcompression/response_count': 4,
 'item_scraped_count': 1285,
 'items_per_minute': 12850.0,
 'log_count/DEBUG': 1289,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'request_depth_max': 2,
 'response_received_count': 4,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 5, 5, 7, 37, 34, 651582, tzinfo=datetime.timezone.utc)}