### PR TITLE
[A101 TR] Try to fix the low scraped count than the expected one for the spider

### DIFF
--- a/locations/spiders/a101_tr.py
+++ b/locations/spiders/a101_tr.py
@@ -20,7 +20,7 @@ class A101TRSpider(Spider):
     requires_proxy = True
     custom_settings = {
         "CONCURRENT_REQUESTS": 1,
-        "DOWNLOAD_DELAY": 1,
+        "DOWNLOAD_DELAY": 2,
         "ROBOTSTXT_OBEY": False,
     }
 

--- a/locations/spiders/a101_tr.py
+++ b/locations/spiders/a101_tr.py
@@ -8,7 +8,7 @@ from scrapy.http import Request
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.geo import country_iseadgg_centroids
+from locations.geo import point_locations
 
 
 class A101TRSpider(Spider):
@@ -25,7 +25,7 @@ class A101TRSpider(Spider):
     }
 
     async def start(self) -> AsyncIterator[Request]:
-        for lat, lon in country_iseadgg_centroids("TR", 24):
+        for lat, lon in point_locations("eu_centroids_20km_radius_country.csv", "TR"):
             data = {"geoHash": encode(lat, lon, precision=9)}
             data = b64encode(dumps(data).encode("utf-8"))
             data = data.decode("utf-8")  # convert bytes back to string


### PR DESCRIPTION
I'm not able to test it completely, because of unavailability of `TR` proxy at my end, but this might help in improving locations count by reducing the geospatial request radius and increasing the number of location-based requests. Since the `nearestStores` endpoint returns a limited number of results per query, a denser grid helps capture more locations and move closer to the expected total store count. But this approach may approximately double proxy usage cost due to the higher number of requests.