### PR TITLE
[Desa TR] Fix Spider

### DIFF
--- a/locations/spiders/desa_tr.py
+++ b/locations/spiders/desa_tr.py
@@ -1,28 +1,28 @@
-from locations.json_blob_spider import JSONBlobSpider
+from typing import Any
+
+import scrapy
+from scrapy.http import Response
+
+from locations.dict_parser import DictParser
 
 
-class DesaTRSpider(JSONBlobSpider):
+class DesaTRSpider(scrapy.Spider):
     name = "desa_tr"
     item_attributes = {
         "brand": "Desa",
         "brand_wikidata": "Q17513880",
     }
-    start_urls = ["https://www.desa.com.tr/stores/?format=json&country=1"]
+    start_urls = ["https://www.desa.com.tr/api/Store/GetStoriesLite"]
 
-    def extract_json(self, response):
-        return response.json()["results"]
-
-    def post_process_item(self, item, response, location):
-        # {"pk": 679,
-        # "name": "DESA / SAMSONITE  Çorlu Orion",
-        # "township": {"pk": 876, "is_active": True, "name": "ÇORLU", "city": {"pk": 73, "is_active": True, "name": "TEKİRDAĞ", "country": {"pk": 1, "is_active": True, "name": "TÜRKİYE", "code": "tr", "translations": None}}},
-        # "district": None, "address": "Omurtak Cad. Muhittin Mah. Mağaza No:9",
-        # "phone_number": "0282 673 53 14",
-        # "fax_phone_number": None, "image": None,
-        # "store_hours": [],
-        # "latitude": "41.15190400", "longitude": "27.83437700",
-        # "is_active": True, "click_and_collect": False, "store_type": None, "kapida_enabled": False, "fast_delivery": False, "config": {"districts": [], "price_list_id": None, "quota": None, "stock_list_id": None}, "group": None, "sort_order": None, "erp_code": "121-1", "translations": None, "related_retail_stores": [], "absolute_url": "/address/retail_store/679/"}}
-        item["ref"] = location["pk"]
-        item["city"] = location["township"]["city"]["name"]  # TODO: What is township name vs this?
-        item["street_address"] = item.pop("addr_full")
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["magazalar"]:
+            if "desa" in location.get("tanim").lower():
+                item = DictParser.parse(location)
+                item["branch"] = (
+                    location["tanim"].replace("Desa ", "").replace("DESA ", "").replace("-", "").replace("/", "")
+                )
+                item["phone"] = location["telefon"]
+                item["state"] = location["il"]
+                item["city"] = location["ilce"]
+                item["street_address"] = location["adres"]
+                yield item


### PR DESCRIPTION
```python
{'atp/brand/Desa': 38,
 'atp/brand_wikidata/Q17513880': 38,
 'atp/category/shop/clothes': 38,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/branch': 32,
 'atp/clean_strings/street_address': 1,
 'atp/country/TR': 38,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 38,
 'atp/field/email/missing': 38,
 'atp/field/geometry/invalid': 5,
 'atp/field/image/missing': 38,
 'atp/field/opening_hours/missing': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/postcode/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/field/website/missing': 38,
 'atp/item_scraped_host_count/www.desa.com.tr': 38,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 38,
 'downloader/request_bytes': 832,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 12861,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.063115,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 6, 5, 45, 3, 785540, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 104330,
 'httpcompression/response_count': 2,
 'item_scraped_count': 38,
 'items_per_minute': 760.0,
 'log_count/DEBUG': 40,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 6, 5, 45, 0, 722425, tzinfo=datetime.timezone.utc)}
```