### PR TITLE
[ChetyreLapy RU] Fix spider

### DIFF
--- a/locations/spiders/chetyre_lapy_ru.py
+++ b/locations/spiders/chetyre_lapy_ru.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import scrapy
@@ -16,15 +17,13 @@ class ChetyreLapyRUSpider(scrapy.Spider):
     requires_proxy = "RU"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        manifest_src = response.xpath("//script[contains(@src, '_ssgManifest.js')]/@src").get()
-        if not manifest_src:
-            self.logger.error(
-                "Could not find _ssgManifest.js script on %s; site may be serving a captcha or non-Next.js page",
-                response.url,
-            )
+        next_data = json.loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
+        if not next_data:
+            self.logger.error(f"Could not find __NEXT_DATA__ script on {response.url}.")
             return
+
         yield JsonRequest(
-            url="https://4lapy.ru/_next/data/{}/shops.json".format(manifest_src.split("/")[3]),
+            url=f"https://4lapy.ru/_next/data/{next_data['buildId']}/shops.json",
             callback=self.parse_pois,
         )
 
@@ -32,7 +31,7 @@ class ChetyreLapyRUSpider(scrapy.Spider):
         for poi in list(response.json()["pageProps"]["fallback"].values())[0]["items"]:
             item = Feature()
             item["ref"] = poi["id"]
-            item["addr_full"] = poi["address"]
+            item["addr_full"] = poi["address"].strip()
             item["city"] = poi["cityName"]
             item["lat"] = poi["coordinates"]["lat"]
             item["lon"] = poi["coordinates"]["lon"]

--- a/locations/spiders/chetyre_lapy_ru.py
+++ b/locations/spiders/chetyre_lapy_ru.py
@@ -31,7 +31,7 @@ class ChetyreLapyRUSpider(scrapy.Spider):
         for poi in list(response.json()["pageProps"]["fallback"].values())[0]["items"]:
             item = Feature()
             item["ref"] = poi["id"]
-            item["addr_full"] = poi["address"].strip()
+            item["addr_full"] = poi["address"]
             item["city"] = poi["cityName"]
             item["lat"] = poi["coordinates"]["lat"]
             item["lon"] = poi["coordinates"]["lon"]


### PR DESCRIPTION
Locally, the spider runs successfully and scrapes 629 locations.

``` python
{'atp/brand/Четыре лапы': 629,
 'atp/brand_wikidata/Q62390783': 629,
 'atp/category/shop/pet': 629,
 'atp/country/RU': 629,
 'atp/field/branch/missing': 629,
 'atp/field/country/from_spider_name': 629,
 'atp/field/email/missing': 629,
 'atp/field/image/missing': 134,
 'atp/field/operator/missing': 629,
 'atp/field/operator_wikidata/missing': 629,
 'atp/field/phone/missing': 629,
 'atp/field/postcode/missing': 629,
 'atp/field/state/missing': 629,
 'atp/field/street_address/missing': 629,
 'atp/field/twitter/missing': 629,
 'atp/item_scraped_host_count/4lapy.ru': 629,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 629,
 'downloader/request_bytes': 945,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 295408,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.818852,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 6, 7, 45, 20, 247963, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3155436,
 'httpcompression/response_count': 2,
 'item_scraped_count': 629,
 'items_per_minute': 4717.5,
 'log_count/DEBUG': 631,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 6, 7, 45, 11, 429111, tzinfo=datetime.timezone.utc)}
```