### PR TITLE
[Coach CA] Fix Spider

### DIFF
--- a/locations/spiders/coach_ca.py
+++ b/locations/spiders/coach_ca.py
@@ -1,32 +1,24 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from typing import Iterable
 
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class CoachCASpider(CrawlSpider, StructuredDataSpider):
+class CoachCASpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "coach_ca"
     item_attributes = {"brand": "Coach", "brand_wikidata": "Q727697"}
-    start_urls = ["https://ca.coach.com/stores/index.html"]
-    rules = [
-        Rule(LinkExtractor(allow=r"/stores/(outlets/)?\w\w$", deny=r"/fr_ca/")),
-        Rule(LinkExtractor(allow=r"/stores/(outlets/)?\w\w/[-\w]+$", deny=r"/fr_ca/")),
-        Rule(
-            LinkExtractor(allow=r"/stores/(outlets/)?\w\w/[-\w]+/.+$", deny=r"/fr_ca/"),
-            callback="parse_sd",
-        ),
-    ]
-    wanted_types = ["Store", "OutletStore"]
+    sitemap_urls = ["https://ca.coach.com/en/stores/sitemap.xml"]
+    sitemap_rules = [("https://ca.coach.com/en/stores/[^/]+/[^/]+/[^/]+", "parse_sd")]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["extras"]["website:fr"] = response.urljoin(response.xpath('//a[text()="Français"]/@href').get())
-        item["extras"]["website:en"] = response.url
-
-        if item["name"].startswith("COACH Outlet"):
-            item["name"] = "COACH Outlet"
-        else:
-            item["name"] = "COACH"
-
-        item["branch"] = ld_data["name"].removeprefix(item["name"]).strip()
-
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = (item.pop("name", "") or "").removeprefix("About ")
+        apply_category(Categories.SHOP_BAG, item)
         yield item

--- a/locations/spiders/coach_ca.py
+++ b/locations/spiders/coach_ca.py
@@ -15,7 +15,7 @@ class CoachCASpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "coach_ca"
     item_attributes = {"brand": "Coach", "brand_wikidata": "Q727697"}
     sitemap_urls = ["https://ca.coach.com/en/stores/sitemap.xml"]
-    sitemap_rules = [("https://ca.coach.com/en/stores/[^/]+/[^/]+/[^/]+", "parse_sd")]
+    sitemap_rules = [(r"https://ca.coach.com/en/stores/[^/]+/[^/]+/[^/]+", "parse_sd")]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:

--- a/locations/spiders/coach_ca.py
+++ b/locations/spiders/coach_ca.py
@@ -20,5 +20,6 @@ class CoachCASpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = (item.pop("name", "") or "").removeprefix("About ")
+        item["name"] = response.xpath('//h4[@class="location-type mt-0 mb-10"]/text()').get()
         apply_category(Categories.SHOP_BAG, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Coach': 29,
 'atp/brand_wikidata/Q727697': 29,
 'atp/category/shop/bag': 29,
 'atp/country/CA': 29,
 'atp/field/country/from_spider_name': 29,
 'atp/field/image/dropped': 29,
 'atp/field/image/missing': 29,
 'atp/field/operator/missing': 29,
 'atp/field/operator_wikidata/missing': 29,
 'atp/field/twitter/missing': 29,
 'atp/item_scraped_host_count/ca.coach.com': 29,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 29,
 'downloader/request_bytes': 14198,
 'downloader/request_count': 31,
 'downloader/request_method_count/GET': 31,
 'downloader/response_bytes': 18640954,
 'downloader/response_count': 31,
 'downloader/response_status_count/200': 31,
 'elapsed_time_seconds': 41.747856,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 6, 10, 17, 51, 276072, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 29,
 'items_per_minute': 42.4390243902439,
 'log_count/DEBUG': 2230,
 'log_count/INFO': 7,
 'memusage/max': 298229760,
 'memusage/startup': 298229760,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 31,
 'playwright/page_count/closed': 31,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 1058,
 'playwright/request_count/aborted': 1027,
 'playwright/request_count/method/GET': 1058,
 'playwright/request_count/navigation': 31,
 'playwright/request_count/resource_type/document': 31,
 'playwright/request_count/resource_type/image': 315,
 'playwright/request_count/resource_type/script': 563,
 'playwright/request_count/resource_type/stylesheet': 149,
 'playwright/response_count': 31,
 'playwright/response_count/method/GET': 31,
 'playwright/response_count/resource_type/document': 31,
 'request_depth_max': 1,
 'response_received_count': 31,
 'responses_per_minute': 45.36585365853659,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 30,
 'scheduler/dequeued/memory': 30,
 'scheduler/enqueued': 30,
 'scheduler/enqueued/memory': 30,
 'start_time': datetime.datetime(2026, 5, 6, 10, 17, 9, 528216, tzinfo=datetime.timezone.utc)}
```