### PR TITLE
[Banco Del Bienestar MX] Fix spider

### DIFF
--- a/locations/spiders/banco_del_bienestar_mx.py
+++ b/locations/spiders/banco_del_bienestar_mx.py
@@ -1,16 +1,17 @@
+import json
 from typing import Any
 
 import scrapy
-from scrapy import FormRequest
+from scrapy import FormRequest, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address
+from locations.pipelines.address_clean_up import clean_address, merge_address_lines
 
 
-class BancoDelBienestarMXSpider(scrapy.Spider):
+class BancoDelBienestarMXSpider(Spider):
     name = "banco_del_bienestar_mx"
     item_attributes = {
         "brand": "Banco del Bienestar",
@@ -18,24 +19,37 @@ class BancoDelBienestarMXSpider(scrapy.Spider):
     }
     start_urls = ["https://directoriodesucursales.bancodelbienestar.gob.mx"]
     no_refs = True
+    token = ""
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for state_info in response.xpath('//select[@id="bandas"]/option'):
-            if state_id := state_info.xpath("./@value").get(""):
-                yield FormRequest(
-                    url="https://directoriodesucursales.bancodelbienestar.gob.mx/home.php",
-                    formdata={"entidadtxt": state_id},
-                    callback=self.parse_locations,
-                    cb_kwargs={"state": state_info.xpath("./text()").get("")},
-                )
+        self.token = response.xpath('//input[@name="__RequestVerificationToken"]/@value').get()
+        for state in json.loads(response.xpath('//input[@id="datosEntidad"]/@value').get()):
+            yield FormRequest(
+                url="https://directoriodesucursales.bancodelbienestar.gob.mx/Home/ListarMunalc",
+                formdata={"idEnt": str(state["id_entidad"])},
+                callback=self.parse_state,
+                cb_kwargs={"state":  state["descripcion"]},
+            )
+
+    def parse_state(self, response: Response, state: str) -> Any:
+        for area in response.json()["response"]:
+            yield FormRequest(
+                url="https://directoriodesucursales.bancodelbienestar.gob.mx/Busqueda",
+                formdata={"entidad": str(area["idEnt"]), "munalc": area["munalc"], "__RequestVerificationToken": self.token},
+                callback=self.parse_locations,
+                cb_kwargs={"state": state},
+            )
 
     def parse_locations(self, response: Response, state: str) -> Any:
-        for location in response.xpath('//*[@class="card hsucursal"]'):
-            item = Feature()
-            item["state"] = state
-            item["ref"] = item["branch"] = location.xpath('.//*[@class="card-title"]/text()').get("").strip()
-            item["addr_full"] = clean_address(location.xpath('.//p[@class="card-text"]/text()').getall())
-            if map_url := location.xpath('.//a[contains(@href, "maps")]/@href').get():
-                item["lat"], item["lon"] = url_to_coords(map_url)
-            apply_category(Categories.BANK, item)
-            yield item
+        if locations_data:= response.xpath('//@data-sucursales').get():
+            for location in json.loads(locations_data).get("response", []):
+                item = Feature()
+                item["state"] = state
+                item["city"] = location["munalc"]
+                item["ref"] = location["id"]
+                item["branch"] = location["nomSuc"]
+                item["addr_full"] = location["domicilio"]
+                if map_url := location.get("liga"):
+                    item["lat"], item["lon"] = url_to_coords(map_url)
+                apply_category(Categories.BANK, item)
+                yield item

--- a/locations/spiders/banco_del_bienestar_mx.py
+++ b/locations/spiders/banco_del_bienestar_mx.py
@@ -1,14 +1,12 @@
 import json
 from typing import Any
 
-import scrapy
 from scrapy import FormRequest, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.items import Feature
-from locations.pipelines.address_clean_up import clean_address, merge_address_lines
 
 
 class BancoDelBienestarMXSpider(Spider):
@@ -28,20 +26,24 @@ class BancoDelBienestarMXSpider(Spider):
                 url="https://directoriodesucursales.bancodelbienestar.gob.mx/Home/ListarMunalc",
                 formdata={"idEnt": str(state["id_entidad"])},
                 callback=self.parse_state,
-                cb_kwargs={"state":  state["descripcion"]},
+                cb_kwargs={"state": state["descripcion"]},
             )
 
     def parse_state(self, response: Response, state: str) -> Any:
         for area in response.json()["response"]:
             yield FormRequest(
                 url="https://directoriodesucursales.bancodelbienestar.gob.mx/Busqueda",
-                formdata={"entidad": str(area["idEnt"]), "munalc": area["munalc"], "__RequestVerificationToken": self.token},
+                formdata={
+                    "entidad": str(area["idEnt"]),
+                    "munalc": area["munalc"],
+                    "__RequestVerificationToken": self.token,
+                },
                 callback=self.parse_locations,
                 cb_kwargs={"state": state},
             )
 
     def parse_locations(self, response: Response, state: str) -> Any:
-        if locations_data:= response.xpath('//@data-sucursales').get():
+        if locations_data := response.xpath("//@data-sucursales").get():
             for location in json.loads(locations_data).get("response", []):
                 item = Feature()
                 item["state"] = state

--- a/locations/spiders/banco_del_bienestar_mx.py
+++ b/locations/spiders/banco_del_bienestar_mx.py
@@ -16,7 +16,6 @@ class BancoDelBienestarMXSpider(Spider):
         "brand_wikidata": "Q5719137",
     }
     start_urls = ["https://directoriodesucursales.bancodelbienestar.gob.mx"]
-    no_refs = True
     token = ""
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
```python
{'atp/brand/Banco del Bienestar': 3150,
 'atp/brand_wikidata/Q5719137': 3150,
 'atp/category/amenity/bank': 3150,
 'atp/clean_strings/branch': 2,
 'atp/country/MX': 3150,
 'atp/field/country/from_spider_name': 3150,
 'atp/field/email/missing': 3150,
 'atp/field/image/missing': 3150,
 'atp/field/opening_hours/missing': 3150,
 'atp/field/operator/missing': 3150,
 'atp/field/operator_wikidata/missing': 3150,
 'atp/field/phone/missing': 3150,
 'atp/field/postcode/missing': 3150,
 'atp/field/street_address/missing': 3150,
 'atp/field/twitter/missing': 3150,
 'atp/field/website/missing': 3150,
 'atp/item_scraped_host_count/directoriodesucursales.bancodelbienestar.gob.mx': 3150,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 3150,
 'downloader/request_bytes': 1819643,
 'downloader/request_count': 2005,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 2003,
 'downloader/response_bytes': 7854449,
 'downloader/response_count': 2005,
 'downloader/response_status_count/200': 2004,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2450.699725,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 6, 11, 54, 14, 368651, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 3150,
 'items_per_minute': 77.14285714285714,
 'log_count/DEBUG': 5155,
 'log_count/INFO': 230,
 'request_depth_max': 2,
 'response_received_count': 2005,
 'responses_per_minute': 49.10204081632653,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2004,
 'scheduler/dequeued/memory': 2004,
 'scheduler/enqueued': 2004,
 'scheduler/enqueued/memory': 2004,
 'start_time': datetime.datetime(2026, 5, 6, 11, 13, 23, 668926, tzinfo=datetime.timezone.utc)}
```