### PR TITLE
[Disc Replay US ] Fix Spider

### DIFF
--- a/locations/spiders/disc_replay_us.py
+++ b/locations/spiders/disc_replay_us.py
@@ -12,6 +12,7 @@ class DiscReplayUSSpider(CrawlSpider):
     allowed_domains = ["www.discreplay.com"]
     start_urls = ["https://www.discreplay.com/locations-list/"]
     rules = [Rule(LinkExtractor(allow=r"/locations/.+"), callback="parse")]
+    requires_proxy = True
 
     def parse(self, response):
         item = Feature()


### PR DESCRIPTION
```python
{'atp/brand/Disc Replay': 38,
 'atp/brand_wikidata/Q108202431': 38,
 'atp/category/shop/video_games': 38,
 'atp/cdn/cloudflare/response_count': 40,
 'atp/cdn/cloudflare/response_status_count/200': 40,
 'atp/country/US': 38,
 'atp/field/branch/missing': 38,
 'atp/field/city/missing': 38,
 'atp/field/country/from_spider_name': 38,
 'atp/field/email/missing': 38,
 'atp/field/image/missing': 38,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/postcode/missing': 38,
 'atp/field/state/from_reverse_geocoding': 38,
 'atp/field/street_address/missing': 38,
 'atp/field/twitter/missing': 38,
 'atp/item_scraped_host_count/www.discreplay.com': 38,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 38,
 'downloader/request_bytes': 24741,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 864170,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 40,
 'elapsed_time_seconds': 47.320117,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 7, 10, 17, 46, 1592, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3777987,
 'httpcompression/response_count': 40,
 'item_scraped_count': 38,
 'items_per_minute': 48.51063829787234,
 'log_count/DEBUG': 78,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 40,
 'responses_per_minute': 51.06382978723404,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2026, 5, 7, 10, 16, 58, 681475, tzinfo=datetime.timezone.utc)}

```