### PR TITLE
[DaGrasso PL] Fix spider

### DIFF
--- a/locations/spiders/da_grasso_pl.py
+++ b/locations/spiders/da_grasso_pl.py
@@ -1,31 +1,24 @@
-from scrapy import Spider
-
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, day_range
+from locations.hours import DAYS, OpeningHours
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class DaGrassoPLSpider(Spider):
+class DaGrassoPLSpider(JSONBlobSpider):
     name = "da_grasso_pl"
     item_attributes = {"brand": "Da Grasso", "brand_wikidata": "Q11692586"}
-    start_urls = ["https://www.dagrasso.pl/api/v1/restaurant_list"]
+    start_urls = ["https://api.dagrasso.pl/localization-api/api/v2/stores/pickup"]
 
-    def parse(self, response, **kwargs):
-        for feature in response.json():
-            if feature["isMenu"]:
-                continue
-            feature["street_address"] = feature["street"]
-            del feature["street"]
-            item = DictParser.parse(feature)
-            item["phone"] = ";".join(
-                [feature[key] for key in ["phone", "phone2", "phone3", "mobilePhone"] if feature[key]]
-            )
-            opening_hours = OpeningHours()
-            for hours in feature["workingHours"]:
-                opening_hours.add_days_range(
-                    days=day_range(hours["from"], hours["to"] or hours["from"]),
-                    open_time=hours["open"],
-                    close_time=hours["close"],
-                )
-            item["opening_hours"] = opening_hours
-            item.pop("name", None)
-            yield item
+    def post_process_item(self, item, response, feature):
+        if raw_name := item.pop("name", ""):
+            item["branch"] = raw_name.replace("aaa.", "").strip()
+
+        self.parse_opening_hours(item, feature)
+        yield item
+
+    def parse_opening_hours(self, item, feature):
+        opening_times = feature.get("openingTimes", [])
+        closing_times = feature.get("closingTimes", [])
+
+        if opening_times and closing_times:
+            oh = OpeningHours()
+            oh.add_days_range(DAYS, opening_times[0].split("T")[1][:5], closing_times[0].split("T")[1][:5])
+            item["opening_hours"] = oh


### PR DESCRIPTION
``` python
{'atp/brand/Da Grasso': 198,
 'atp/brand_wikidata/Q11692586': 198,
 'atp/category/amenity/restaurant': 198,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/city': 1,
 'atp/country/PL': 198,
 'atp/field/country/from_spider_name': 198,
 'atp/field/email/missing': 198,
 'atp/field/image/missing': 198,
 'atp/field/operator/missing': 198,
 'atp/field/operator_wikidata/missing': 198,
 'atp/field/phone/missing': 198,
 'atp/field/state/missing': 198,
 'atp/field/street_address/missing': 198,
 'atp/field/twitter/missing': 198,
 'atp/field/website/missing': 198,
 'atp/item_scraped_host_count/api.dagrasso.pl': 198,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 198,
 'downloader/request_bytes': 693,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 15132,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.915681,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 7, 15, 31, 31, 863040, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 125419,
 'httpcompression/response_count': 2,
 'item_scraped_count': 198,
 'items_per_minute': 3960.0,
 'log_count/DEBUG': 201,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 7, 15, 31, 27, 947359, tzinfo=datetime.timezone.utc)}
```