### PR TITLE
[DirckIii NL] Bypass Cloudflare and migrate to JSONBlobSpider

### DIFF
--- a/locations/spiders/dirck_iii_nl.py
+++ b/locations/spiders/dirck_iii_nl.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from scrapy import Selector
 from scrapy.http import Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_NL, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -13,7 +13,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class DirckIiiNLSpider(JSONBlobSpider):
     name = "dirck_iii_nl"
-    item_attributes = {"brand": "Dirck III", "brand_wikidata": "Q109188079", "extras": Categories.SHOP_ALCOHOL.value}
+    item_attributes = {"brand": "Dirck III", "brand_wikidata": "Q109188079"}
     allowed_domains = ["www.dirckiii.nl"]
     start_urls = ["https://www.dirckiii.nl/storelocator/index/ajax/"]
     locations_key = "data"
@@ -38,5 +38,7 @@ class DirckIiiNLSpider(JSONBlobSpider):
                 if day in DAYS_NL and time_str and " - " in time_str:
                     open_t, close_t = time_str.split(" - ", 1)
                     item["opening_hours"].add_range(DAYS_NL[day], open_t.strip(), close_t.strip())
+
+        apply_category(Categories.SHOP_ALCOHOL, item)
 
         yield item

--- a/locations/spiders/dirck_iii_nl.py
+++ b/locations/spiders/dirck_iii_nl.py
@@ -25,6 +25,7 @@ class DirckIiiNLSpider(JSONBlobSpider):
 
         item["ref"] = location.get("storelocator_id")
         item["name"] = location.get("storename")
+        item["email"] = None
 
         item["street_address"] = clean_address(location.get("address")[1:])
 

--- a/locations/spiders/dirck_iii_nl.py
+++ b/locations/spiders/dirck_iii_nl.py
@@ -24,7 +24,7 @@ class DirckIiiNLSpider(JSONBlobSpider):
             return
 
         item["ref"] = location.get("storelocator_id")
-        item["name"] = location.get("storename")
+        item["branch"] = item.pop("name")
         item["email"] = None
 
         item["street_address"] = clean_address(location.get("address")[1:])

--- a/locations/spiders/dirck_iii_nl.py
+++ b/locations/spiders/dirck_iii_nl.py
@@ -1,41 +1,41 @@
-import json
-from typing import AsyncIterator
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy import Selector
+from scrapy.http import Response
 
 from locations.categories import Categories
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import DAYS_NL, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import clean_address
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class DirckIiiNLSpider(Spider):
+class DirckIiiNLSpider(JSONBlobSpider):
     name = "dirck_iii_nl"
     item_attributes = {"brand": "Dirck III", "brand_wikidata": "Q109188079", "extras": Categories.SHOP_ALCOHOL.value}
     allowed_domains = ["www.dirckiii.nl"]
     start_urls = ["https://www.dirckiii.nl/storelocator/index/ajax/"]
+    locations_key = "data"
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        if not location.get("is_active"):
+            return
 
-    def parse(self, response):
-        for location in response.json()["data"]:
-            if not location["is_active"]:
-                continue
+        item["ref"] = location.get("storelocator_id")
+        item["name"] = location.get("storename")
 
-            item = DictParser.parse(location)
-            item["ref"] = location["storelocator_id"]
-            item["street_address"] = clean_address(location["address"][1:])
+        item["street_address"] = clean_address(location.get("address")[1:])
 
-            item["opening_hours"] = OpeningHours()
-            hours_dict = json.loads(location["storetime"])
-            for record in hours_dict:
-                item["opening_hours"].add_range(
-                    record["days"],
-                    "{}:{}".format(record["open_hour"], record["open_minute"]),
-                    "{}:{}".format(record["close_hour"], record["close_minute"]),
-                )
+        item["opening_hours"] = OpeningHours()
+        if html := location.get("storetime"):
+            for row in Selector(text=html).xpath("//p"):
+                day = row.xpath('.//span[contains(@class, "day")]/text()').get("").strip()
+                time_str = row.xpath('.//span[contains(@class, "open-time")]/text()').get()
 
-            yield item
+                if day in DAYS_NL and time_str and " - " in time_str:
+                    open_t, close_t = time_str.split(" - ", 1)
+                    item["opening_hours"].add_range(DAYS_NL[day], open_t.strip(), close_t.strip())
+
+        yield item


### PR DESCRIPTION
``` python
{'atp/brand/Dirck III': 93,
 'atp/brand_wikidata/Q109188079': 93,
 'atp/category/shop/alcohol': 93,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/lat': 1,
 'atp/clean_strings/lon': 4,
 'atp/clean_strings/name': 4,
 'atp/clean_strings/postcode': 2,
 'atp/country/NL': 93,
 'atp/field/branch/missing': 93,
 'atp/field/country/from_spider_name': 52,
 'atp/field/email/missing': 93,
 'atp/field/operator/missing': 93,
 'atp/field/operator_wikidata/missing': 93,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 93,
 'atp/field/twitter/missing': 93,
 'atp/item_scraped_host_count/www.dirckiii.nl': 93,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 93,
 'downloader/request_bytes': 544,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 74466,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.488937,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 8, 7, 35, 58, 952946, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 869902,
 'httpcompression/response_count': 2,
 'item_scraped_count': 93,
 'items_per_minute': 1395.0,
 'log_count/DEBUG': 95,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 8, 7, 35, 54, 464009, tzinfo=datetime.timezone.utc)}
```