### PR TITLE
[Eatn Park US] Fix Spider

### DIFF
--- a/locations/spiders/eatn_park_us.py
+++ b/locations/spiders/eatn_park_us.py
@@ -1,16 +1,34 @@
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+import json
+from urllib.parse import urljoin
 
+from scrapy.http import Response, TextResponse
+
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class EatnParkUSSpider(SitemapSpider, StructuredDataSpider):
+class EatnParkUSSpider(JSONBlobSpider):
     name = "eatn_park_us"
     item_attributes = {"brand": "Eat'n Park", "brand_wikidata": "Q5331211"}
-    sitemap_urls = ["https://locations.eatnpark.com/robots.txt"]
-    sitemap_rules = [(r"/restaurants-(\d+)\.html", "parse_sd")]
+    start_urls = ["https://locations.eatnpark.com/"]
+
+    def extract_json(self, response: TextResponse) -> dict | list[dict]:
+        json_data = json.loads(response.xpath('//*[@type="application/json"]/text()').get())["props"]["pageProps"][
+            "locations"
+        ]
+        return json_data
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("Eat'n Park Restaurant").strip(" -")
+        item["street_address"] = merge_address_lines(ld_data["addressLines"])
+        item["phone"] = ld_data["phoneNumbers"][0]
+        item["website"] = urljoin("https://locations.eatnpark.com/", ld_data["localPageUrl"])
+        try:
+            oh = OpeningHours()
+            for day_time in ld_data["formattedBusinessHours"]:
+                oh.add_ranges_from_string(day_time)
+            item["opening_hours"] = oh
+        except:
+            pass
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Eat'n Park": 55,
 'atp/brand_wikidata/Q5331211': 55,
 'atp/category/amenity/restaurant': 55,
 'atp/country/US': 55,
 'atp/field/branch/missing': 55,
 'atp/field/email/missing': 55,
 'atp/field/image/missing': 55,
 'atp/field/operator/missing': 55,
 'atp/field/operator_wikidata/missing': 55,
 'atp/field/twitter/missing': 55,
 'atp/item_scraped_host_count/locations.eatnpark.com': 55,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 55,
 'downloader/request_bytes': 670,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 22336,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.286245,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 8, 11, 14, 29, 488123, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 265812,
 'httpcompression/response_count': 1,
 'item_scraped_count': 55,
 'items_per_minute': 1650.0,
 'log_count/DEBUG': 57,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 8, 11, 14, 27, 201878, tzinfo=datetime.timezone.utc)}
```