### PR TITLE
Broaden regex for Costcutter websites

### DIFF
--- a/locations/spiders/costcutter_gb.py
+++ b/locations/spiders/costcutter_gb.py
@@ -14,7 +14,7 @@ class CostcutterGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Costcutter", "brand_wikidata": "Q5175072"}
     allowed_domains = ["costcutter.co.uk"]
     sitemap_urls = ["https://store-locator.costcutter.co.uk/sitemap.xml"]
-    sitemap_rules = [(r"uk/en-gb/[^/]+/[^/]+/(\d+)$", "parse")]
+    sitemap_rules = [(r"uk/en-gb/[-\w]+/[-\w/]+/(\d+)$", "parse")]
     wanted_types = ["FoodEstablishment"]
     drop_attributes = {"image"}
     search_for_facebook = False


### PR DESCRIPTION
Some of the new costcutter store websites have three levels between en-gb and the number (e.g. https://store-locator.costcutter.co.uk/en-gb/west-yorkshire/knottingley/byram-park-road/119644 ) and others have forward slashes in the final level (e.g. https://store-locator.costcutter.co.uk/en-gb/maldon/13/14-dryden-close/57499 ). This PR broadens the regex to allow such URLs.