### PR TITLE
[Nike] Fix spider

### DIFF
--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -1,19 +1,22 @@
 import datetime
 import re
+from typing import Any
 
-import scrapy
+from scrapy import Spider
+from scrapy.http import Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import Feature
 
 
-class NikeSpider(scrapy.Spider):
+class NikeSpider(Spider):
     name = "nike"
-    item_attributes = {"brand": "Nike", "brand_wikidata": "Q483915", "extras": Categories.SHOP_CLOTHES.value}
+    item_attributes = {"brand": "Nike", "brand_wikidata": "Q483915"}
     start_urls = ["https://nslp-directory.nike.com/store-locations-static.json"]
 
-    def extract_image(self, item, store):
+    def extract_image(self, item: Feature, store: dict) -> None:
         placeholders = [
             "2e8d9338-b43d-4ef5-96e1-7fdcfd838f8e",
             "d2f5c06a-629d-4f20-a092-9e56315a80b3",
@@ -32,39 +35,12 @@ class NikeSpider(scrapy.Spider):
 
             item["image"] = store["imageURL"]
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         all_stores = response.json()["stores"]
         for store in all_stores.values():
             item = DictParser.parse(store)
+            item["opening_hours"] = self.parse_opening_hours(DictParser.get_nested_key(store, "regularHours"))
 
-            days = DictParser.get_nested_key(store, "regularHours")
-            opening_hours = OpeningHours()
-            for day in days:
-                if not days.get(day):
-                    continue
-
-                oh = days.get(day)[0]
-                opening = oh.get("startTime")
-                closing = oh.get("duration")
-
-                closing_h = closing.split("H")[0].replace("PT", "") if "H" in closing else "0"
-                closing_m = closing[len(closing) - 3 :].replace("M", "") if "M" in closing else "0"
-                closing_m = closing_m.replace("H", "")  # needed for 1 digit minutes
-
-                start = opening.split(":")
-                closing_time = str(
-                    datetime.timedelta(hours=int(start[0]), minutes=int(start[1]))
-                    + datetime.timedelta(hours=int(closing_h), minutes=int(closing_m))
-                )
-                if "day" in closing_time:
-                    closing_time = "00:00"
-                else:
-                    split_closing_time = closing_time.split(":")
-                    closing_time = "".join(split_closing_time[0] + ":" + split_closing_time[1])
-
-                opening_hours.add_range(day[0:2].title(), opening, closing_time)
-
-            item["opening_hours"] = opening_hours.as_opening_hours()
             if re.match(r"^[A-Za-z0-9_-]+$", store["slug"]):
                 item["website"] = "https://www.nike.com/retail/s/" + store["slug"]
             else:
@@ -79,4 +55,34 @@ class NikeSpider(scrapy.Spider):
                 item["brand"] = "Nike Community Store"
             else:
                 item["extras"]["type"] = store["businessConcept"]
+
+            apply_category(Categories.SHOP_CLOTHES, item)
             yield item
+
+    def parse_opening_hours(self, hours: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day in hours:
+            if not hours.get(day):
+                continue
+
+            oh = hours.get(day)[0]
+            opening = oh.get("startTime")
+            closing = oh.get("duration")
+
+            closing_h = closing.split("H")[0].replace("PT", "") if "H" in closing else "0"
+            closing_m = closing[len(closing) - 3 :].replace("M", "") if "M" in closing else "0"
+            closing_m = closing_m.replace("H", "")  # needed for 1 digit minutes
+
+            start = opening.split(":")
+            closing_time = str(
+                datetime.timedelta(hours=int(start[0]), minutes=int(start[1]))
+                + datetime.timedelta(hours=int(closing_h), minutes=int(closing_m))
+            )
+            if "day" in closing_time:
+                closing_time = "00:00"
+            else:
+                split_closing_time = closing_time.split(":")
+                closing_time = "".join(split_closing_time[0] + ":" + split_closing_time[1])
+
+            opening_hours.add_range(day[0:2].title(), opening, closing_time)
+        return opening_hours

--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -11,7 +11,7 @@ from locations.hours import OpeningHours
 class NikeSpider(scrapy.Spider):
     name = "nike"
     item_attributes = {"brand": "Nike", "brand_wikidata": "Q483915", "extras": Categories.SHOP_CLOTHES.value}
-    start_urls = ["https://storeviews-cdn.risedomain-prod.nikecloud.com/store-locations-static.json"]
+    start_urls = ["https://nslp-directory.nike.com/store-locations-static.json"]
 
     def extract_image(self, item, store):
         placeholders = [

--- a/locations/spiders/nike.py
+++ b/locations/spiders/nike.py
@@ -39,13 +39,16 @@ class NikeSpider(Spider):
         all_stores = response.json()["stores"]
         for store in all_stores.values():
             item = DictParser.parse(store)
+            item["name"] = self.item_attributes["brand"]
             item["opening_hours"] = self.parse_opening_hours(DictParser.get_nested_key(store, "regularHours"))
 
             if re.match(r"^[A-Za-z0-9_-]+$", store["slug"]):
                 item["website"] = "https://www.nike.com/retail/s/" + store["slug"]
             else:
                 item["website"] = None
+
             self.extract_image(item, store)
+
             item["extras"] = {"owner:type": store["facilityType"]}
             if store["businessConcept"] == "FACTORY":
                 item["brand"] = "Nike Factory Store"


### PR DESCRIPTION
```python
{'atp/brand/Nike': 3519,
 'atp/brand/Nike Clearance Store': 49,
 'atp/brand/Nike Community Store': 7,
 'atp/brand/Nike Factory Store': 800,
 'atp/brand_wikidata/Q483915': 4375,
 'atp/category/shop/clothes': 4375,
 'atp/clean_strings/phone': 1,
 'atp/clean_strings/street_address': 14,
 'atp/country/AE': 31,
 'atp/country/AL': 2,
 'atp/country/AM': 2,
 'atp/country/AR': 11,
 'atp/country/AT': 8,
 'atp/country/AU': 45,
 'atp/country/AZ': 1,
 'atp/country/BA': 4,
 'atp/country/BE': 12,
 'atp/country/BG': 6,
 'atp/country/BH': 2,
 'atp/country/BR': 21,
 'atp/country/BY': 2,
 'atp/country/CA': 49,
 'atp/country/CH': 5,
 'atp/country/CL': 24,
 'atp/country/CN': 2663,
 'atp/country/CY': 3,
 'atp/country/CZ': 11,
 'atp/country/DE': 28,
 'atp/country/DK': 5,
 'atp/country/DZ': 3,
 'atp/country/EE': 5,
 'atp/country/EG': 18,
 'atp/country/ES': 37,
 'atp/country/FI': 2,
 'atp/country/FR': 57,
 'atp/country/GB': 50,
 'atp/country/GE': 5,
 'atp/country/GR': 14,
 'atp/country/HK': 6,
 'atp/country/HR': 3,
 'atp/country/HU': 7,
 'atp/country/ID': 19,
 'atp/country/IE': 3,
 'atp/country/IL': 36,
 'atp/country/IN': 94,
 'atp/country/IQ': 2,
 'atp/country/IT': 51,
 'atp/country/JO': 3,
 'atp/country/JP': 47,
 'atp/country/KE': 1,
 'atp/country/KG': 1,
 'atp/country/KR': 271,
 'atp/country/KW': 9,
 'atp/country/KZ': 6,
 'atp/country/LB': 5,
 'atp/country/LT': 6,
 'atp/country/LV': 5,
 'atp/country/MA': 4,
 'atp/country/MD': 1,
 'atp/country/ME': 2,
 'atp/country/MK': 3,
 'atp/country/MO': 2,
 'atp/country/MX': 45,
 'atp/country/MY': 14,
 'atp/country/NG': 1,
 'atp/country/NL': 18,
 'atp/country/NO': 2,
 'atp/country/NZ': 9,
 'atp/country/OM': 3,
 'atp/country/PH': 36,
 'atp/country/PL': 34,
 'atp/country/PT': 7,
 'atp/country/QA': 5,
 'atp/country/RO': 11,
 'atp/country/RS': 11,
 'atp/country/SA': 41,
 'atp/country/SE': 3,
 'atp/country/SG': 9,
 'atp/country/SI': 2,
 'atp/country/SK': 2,
 'atp/country/TH': 17,
 'atp/country/TR': 59,
 'atp/country/TW': 12,
 'atp/country/UA': 15,
 'atp/country/US': 288,
 'atp/country/UY': 2,
 'atp/country/UZ': 2,
 'atp/country/ZA': 14,
 'atp/field/branch/missing': 4375,
 'atp/field/email/missing': 4375,
 'atp/field/opening_hours/missing': 15,
 'atp/field/operator/missing': 4375,
 'atp/field/operator_wikidata/missing': 4375,
 'atp/field/phone/invalid': 106,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 39,
 'atp/field/state/missing': 59,
 'atp/field/street_address/missing': 6,
 'atp/field/twitter/missing': 4375,
 'atp/item_scraped_host_count/nslp-directory.nike.com': 4375,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 288,
 'atp/nsi/match_failed': 4087,
 'downloader/request_bytes': 699,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1379618,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 17.491258,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 11, 7, 25, 5, 595796, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8205412,
 'httpcompression/response_count': 1,
 'item_scraped_count': 4375,
 'items_per_minute': 15441.176470588236,
 'log_count/DEBUG': 4377,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 7.0588235294117645,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 11, 7, 24, 48, 104538, tzinfo=datetime.timezone.utc)}
```