### PR TITLE
[Kia US] Update request payload schema to fix 500 error

### DIFF
--- a/locations/spiders/kia_us.py
+++ b/locations/spiders/kia_us.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, apply_category
@@ -8,7 +8,7 @@ from locations.dict_parser import DictParser
 from locations.geo import postal_regions
 
 
-class KiaUSSpider(scrapy.Spider):
+class KiaUSSpider(Spider):
     name = "kia_us"
     item_attributes = {"brand": "Kia", "brand_wikidata": "Q35349"}
 
@@ -20,7 +20,12 @@ class KiaUSSpider(scrapy.Spider):
             if index % 140 == 0:
                 yield JsonRequest(
                     url="https://www.kia.com/us/services/en/dealers/search",
-                    data={"type": "zip", "zipCode": record["postal_region"]},
+                    data={
+                        "type": "zip",
+                        "zipCode": record["postal_region"],
+                        "dealerCertifications": [],
+                        "dealerServices": [],
+                    },
                     headers={"Referer": "https://www.kia.com/us/en/find-a-dealer/"},
                 )
 


### PR DESCRIPTION
The backend now requires 'dealerCertifications' and 'dealerServices' keys in the JSON payload. Missing keys currently trigger a 500 internal server Error on US-based networks when checked locally. This fix ensures the spider will not fail during the next weekly run.

``` python
{'atp/brand/Kia': 1582,
 'atp/brand_wikidata/Q35349': 1582,
 'atp/category/shop/car': 800,
 'atp/category/shop/car_repair': 782,
 'atp/cdn/cloudflare/response_count': 243,
 'atp/cdn/cloudflare/response_status_count/200': 243,
 'atp/clean_strings/street_address': 1581,
 'atp/country/US': 1582,
 'atp/duplicate_count': 8041,
 'atp/field/branch/missing': 1582,
 'atp/field/country/from_spider_name': 1582,
 'atp/field/email/missing': 1582,
 'atp/field/image/missing': 1582,
 'atp/field/opening_hours/missing': 1582,
 'atp/field/operator/missing': 1582,
 'atp/field/operator_wikidata/missing': 1582,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 4,
 'atp/field/twitter/missing': 1582,
 'atp/field/website/invalid': 2,
 'atp/item_scraped_host_count/www.kia.com': 9623,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1582,
 'downloader/request_bytes': 253988,
 'downloader/request_count': 243,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 242,
 'downloader/response_bytes': 704919,
 'downloader/response_count': 243,
 'downloader/response_status_count/200': 243,
 'elapsed_time_seconds': 299.469591,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 11, 9, 42, 32, 592078, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2199573,
 'httpcompression/response_count': 243,
 'item_dropped_count': 8041,
 'item_dropped_reasons_count/DropItem': 8041,
 'item_scraped_count': 1582,
 'items_per_minute': 317.4581939799331,
 'log_count/DEBUG': 9866,
 'log_count/INFO': 8,
 'log_count/WARNING': 2,
 'response_received_count': 243,
 'responses_per_minute': 48.76254180602007,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 242,
 'scheduler/dequeued/memory': 242,
 'scheduler/enqueued': 242,
 'scheduler/enqueued/memory': 242,
 'start_time': datetime.datetime(2026, 5, 11, 9, 37, 33, 122487, tzinfo=datetime.timezone.utc)}
```