### PR TITLE
[Levis] Fix JsonDecodeError

### DIFF
--- a/locations/spiders/levis.py
+++ b/locations/spiders/levis.py
@@ -1,10 +1,44 @@
+from json import loads
+from typing import Iterable
+
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.items import Feature, set_closed
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.storefinders.rio_seo import RioSeoSpider
 
 
 class LevisSpider(RioSeoSpider):
     name = "levis"
     end_point = "https://maps.levi.com"
+
+    def parse(self, response, **kwargs) -> Iterable[Feature]:
+        # Overriding this method from RioSeoSpider because the source data contains
+        # unescaped control characters that cause a JSONDecodeError in the standard parser.
+        map_list = response.json().get("maplist", "")
+        if not map_list:
+            return
+
+        map_list = map_list.removeprefix('<div class="tlsmap_list">').removesuffix(",</div>").replace("\t", " ")
+
+        # fix for the JSONDecodeError: strict=False ignores literal tabs/newlines
+        for location in loads(f"[{map_list}]", strict=False):
+            item = DictParser.parse(location)
+
+            item["ref"] = location["fid"]
+            item["street_address"] = merge_address_lines([location["address_1"], location["address_2"]])
+            item["phone"] = location["local_phone"]
+            item["image"] = location.get("location_image")
+            item["located_in"] = location.get("shopping_center_name", location.get("location_shopping_center"))
+            item["extras"]["start_date"] = location.get("opening_date", location.get("grand_opening_date"))
+
+            if hours := location.get("hours_sets:primary"):
+                item["opening_hours"] = self.parse_hours(hours)
+
+            if location.get("location_closure_message"):
+                set_closed(item)
+
+            yield from self.post_process_feature(item, location)
 
     def post_process_feature(self, item, location):
         apply_category(Categories.SHOP_CLOTHES, item)


### PR DESCRIPTION
This spider produces JSONDecodeError when ran locally on US network. This fix ensures the spider will not fail during the next weekly run.

``` python
{'atp/brand/Dockers': 1,
 "atp/brand/Levi's": 1022,
 'atp/brand_wikidata/Q127962': 1022,
 'atp/brand_wikidata/Q538792': 1,
 'atp/category/shop/clothes': 1023,
 'atp/clean_strings/branch': 5,
 'atp/country/AD': 2,
 'atp/country/AL': 1,
 'atp/country/AT': 16,
 'atp/country/BE': 22,
 'atp/country/CA': 58,
 'atp/country/CH': 15,
 'atp/country/CY': 1,
 'atp/country/CZ': 7,
 'atp/country/DE': 81,
 'atp/country/DK': 5,
 'atp/country/EE': 1,
 'atp/country/ES': 90,
 'atp/country/FI': 1,
 'atp/country/FR': 126,
 'atp/country/GB': 73,
 'atp/country/GE': 4,
 'atp/country/GR': 6,
 'atp/country/HU': 6,
 'atp/country/IE': 4,
 'atp/country/IS': 2,
 'atp/country/IT': 75,
 'atp/country/LT': 2,
 'atp/country/LU': 2,
 'atp/country/LV': 5,
 'atp/country/MD': 1,
 'atp/country/MT': 2,
 'atp/country/NL': 29,
 'atp/country/NO': 18,
 'atp/country/PL': 35,
 'atp/country/PT': 31,
 'atp/country/RO': 11,
 'atp/country/SE': 2,
 'atp/country/SK': 1,
 'atp/country/SM': 1,
 'atp/country/TR': 32,
 'atp/country/UA': 12,
 'atp/country/US': 243,
 'atp/field/email/missing': 1023,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 1023,
 'atp/field/operator_wikidata/missing': 1023,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 79,
 'atp/field/postcode/missing': 1,
 'atp/field/twitter/missing': 1023,
 'atp/geometry/null_island': 4,
 'atp/item_scraped_host_count/maps.levi.com': 1023,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 1,
 'atp/nsi/perfect_match': 1022,
 'downloader/request_bytes': 1256,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 1069786,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 9.350048,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 11, 18, 31, 44, 739270, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24371076,
 'httpcompression/response_count': 3,
 'item_scraped_count': 1023,
 'items_per_minute': 6820.0,
 'log_count/DEBUG': 1026,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 11, 18, 31, 35, 389222, tzinfo=datetime.timezone.utc)}
```