### PR TITLE
[Mitsubishi UY] Fix spider

### DIFF
--- a/locations/spiders/mitsubishi_uy.py
+++ b/locations/spiders/mitsubishi_uy.py
@@ -1,29 +1,33 @@
-import json
-import re
-from typing import Any
-
-import scrapy
-from scrapy.http import Response
+from scrapy import Spider
+from scrapy.selector import Selector
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
+from locations.google_url import extract_google_position
+from locations.items import Feature
 
 
-class MitsubishiUYSpider(scrapy.Spider):
+class MitsubishiUYSpider(Spider):
     name = "mitsubishi_uy"
     item_attributes = {
         "brand": "Mitsubishi",
         "brand_wikidata": "Q36033",
     }
-    start_urls = ["https://www.mitsubishi-motors.com.uy/Ventas/Concesionarios"]
+    start_urls = ["https://www.mitsubishi-motors.com.uy/concesionarios"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(
-            re.search(
-                r"\((\[.*\])\);", response.xpath('//*[@id="form1"]//*[contains(text(),"InitMap")]/text()').get()
-            ).group(1)
-        ):
-            item = DictParser.parse(location)
-            item["branch"] = item.pop("name")
+    def parse(self, response):
+        for shop_node in response.css("a.link-ubicacion"):
+            item = Feature()
+            name = shop_node.xpath('.//*[@fs-list-field="nombre"]/text()').get("").strip()
+            item["street_address"] = shop_node.xpath('.//*[@fs-list-field="direccion"]/text()').get()
+            item["phone"] = shop_node.xpath('.//*[@fs-list-field="telefono"]/text()').get()
+            item["email"] = shop_node.xpath('.//*[@fs-list-field="mail"]/text()').get()
+
+            dept = shop_node.xpath('.//*[@fs-list-field="departamento"]/text()').get(default="").strip()
+            # Combine name and department for a unique ref and descriptive branch
+            item["ref"] = item["branch"] = f"{name} - {dept}" if dept else name
+
+            if map_url := shop_node.xpath("./@data-map").get():
+                extract_google_position(item, Selector(text=f'<a href="{map_url}"></a>'))
+
             apply_category(Categories.SHOP_CAR, item)
             yield item

--- a/locations/spiders/mitsubishi_uy.py
+++ b/locations/spiders/mitsubishi_uy.py
@@ -1,20 +1,19 @@
+from typing import Any
+
 from scrapy import Spider
-from scrapy.selector import Selector
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.google_url import extract_google_position
+from locations.google_url import url_to_coords
 from locations.items import Feature
 
 
 class MitsubishiUYSpider(Spider):
     name = "mitsubishi_uy"
-    item_attributes = {
-        "brand": "Mitsubishi",
-        "brand_wikidata": "Q36033",
-    }
+    item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
     start_urls = ["https://www.mitsubishi-motors.com.uy/concesionarios"]
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for shop_node in response.css("a.link-ubicacion"):
             item = Feature()
             name = shop_node.xpath('.//*[@fs-list-field="nombre"]/text()').get("").strip()
@@ -27,7 +26,7 @@ class MitsubishiUYSpider(Spider):
             item["ref"] = item["branch"] = f"{name} - {dept}" if dept else name
 
             if map_url := shop_node.xpath("./@data-map").get():
-                extract_google_position(item, Selector(text=f'<a href="{map_url}"></a>'))
+                item["lat"], item["lon"] = url_to_coords(map_url)
 
             apply_category(Categories.SHOP_CAR, item)
             yield item

--- a/locations/spiders/mitsubishi_uy.py
+++ b/locations/spiders/mitsubishi_uy.py
@@ -16,14 +16,10 @@ class MitsubishiUYSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for shop_node in response.css("a.link-ubicacion"):
             item = Feature()
-            name = shop_node.xpath('.//*[@fs-list-field="nombre"]/text()').get("").strip()
+            item["ref"] = item["name"] = shop_node.xpath('.//*[@fs-list-field="nombre"]/text()').get("").strip()
             item["street_address"] = shop_node.xpath('.//*[@fs-list-field="direccion"]/text()').get()
             item["phone"] = shop_node.xpath('.//*[@fs-list-field="telefono"]/text()').get()
             item["email"] = shop_node.xpath('.//*[@fs-list-field="mail"]/text()').get()
-
-            dept = shop_node.xpath('.//*[@fs-list-field="departamento"]/text()').get(default="").strip()
-            # Combine name and department for a unique ref and descriptive branch
-            item["ref"] = item["branch"] = f"{name} - {dept}" if dept else name
 
             if map_url := shop_node.xpath("./@data-map").get():
                 item["lat"], item["lon"] = url_to_coords(map_url)


### PR DESCRIPTION
JSON-LD is available but using XPath extraction to bypass missing coordinate data in the structured payload, successfully recovering geometry for 5 locations.

``` python
{'atp/brand/Mitsubishi': 20,
 'atp/brand_wikidata/Q36033': 20,
 'atp/category/shop/car': 20,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/phone': 1,
 'atp/country/UY': 20,
 'atp/field/city/missing': 20,
 'atp/field/country/from_spider_name': 20,
 'atp/field/email/missing': 5,
 'atp/field/geometry/missing': 15,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 20,
 'atp/field/operator_wikidata/missing': 20,
 'atp/field/postcode/missing': 20,
 'atp/field/state/missing': 20,
 'atp/field/twitter/missing': 20,
 'atp/item_scraped_host_count/www.mitsubishi-motors.com.uy': 20,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 20,
 'downloader/request_bytes': 828,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 24502,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.289997,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 12, 8, 15, 50, 423656, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 78029,
 'httpcompression/response_count': 2,
 'item_scraped_count': 20,
 'items_per_minute': 600.0,
 'log_count/DEBUG': 22,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 12, 8, 15, 48, 133659, tzinfo=datetime.timezone.utc)}
```