### PR TITLE
[Verizon US] Fix Spider

### DIFF
--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -1,81 +1,47 @@
-import re
-from typing import Any, Iterable
+import json
 
-import chompjs
-from scrapy.http import Response, TextResponse
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_3_LETTERS, OpeningHours
+from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class VerizonUSSpider(CrawlSpider, StructuredDataSpider):
+class VerizonUSSpider(SitemapSpider, StructuredDataSpider):
     name = "verizon_us"
     item_attributes = {"brand": "Verizon", "brand_wikidata": "Q919641"}
-    start_urls = ["https://www.verizon.com/nextgendigital/nos/storelocator"]
-    rules = [
-        Rule(
-            LinkExtractor(allow=r"/storelocator/[-\w]+$"),
-        ),
-        Rule(LinkExtractor(allow=r"/storelocator/[-\w]+/[-\w]+$"), callback="parse"),
-    ]
+    sitemap_urls = ["https://www.verizon.com/business/locations/sitemap.xml"]
+    sitemap_rules = [(r"https://www.verizon.com/business/locations/[^/]+/[^/]+/[^/]+/$", "parse")]
 
-    OPERATORS = {
-        "Asurion FSL": {"operator": "Asurion FSL"},
-        "BeMobile": {"operator": "BeMobile"},
-        "Best Buy": {"operator": "Best Buy", "operator_wikidata": "Q533415"},
-        "Best Wireless": {"operator": "Best Wireless"},
-        "Cellular Plus": {"operator": "Cellular Plus"},
-        "Cellular Sales": {"operator": "Cellular Sales", "operator_wikidata": "Q5058345"},
-        "Mobile Generation": {"operator": "Mobile Generation"},
-        "R Wireless": {"operator": "R Wireless"},
-        "Russell Cellular": {"operator": "Russell Cellular", "operator_wikidata": "Q125523800"},
-        "TCC": {"operator": "The Cellular Connection", "operator_wikidata": "Q121336519"},
-        "Team Wireless": {"operator": "Team Wireless"},
-        "Victra": {"operator": "Victra", "operator_wikidata": "Q118402656"},
-        "Wireless Plus": {"operator": "Wireless Plus"},
-        "Wireless World": {"operator": "Wireless World"},
-        "Wireless Zone": {"operator": "Wireless Zone", "operator_wikidata": "Q122517436"},
-        "Your Wireless": {"operator": "Your Wireless"},
-    }
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store_url in re.findall(r'\\"storeUrl\\":\\"(.+?)\\"', response.text):
-            if "/details/" not in store_url:
-                store_url = store_url.replace("/stores/", "/stores/details/")
-            yield response.follow(url=store_url, callback=self.parse_sd)
-
-    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["website"] = response.url
-        store_data = chompjs.parse_js_object(response.xpath('//script[contains(text(), "storeJSON")]/text()').get())
-        item["ref"] = store_data["storeNumber"]
-        item["name"] = store_data["storeName"]
-
-        if "Authorized Retailer" in store_data["typeOfStore"]:
-            for operator, tags in self.OPERATORS.items():
-                if item["name"].startswith(operator):
-                    item["branch"] = item.pop("name").removeprefix(operator).strip(" -")
-                    item.update(tags)
-                    break
-        else:
-            item["branch"] = item.pop("name")
-            item["operator"] = self.item_attributes["brand"]
-            item["operator_wikidata"] = self.item_attributes["brand_wikidata"]
-
-        if item.get("branch") and "#" in item["branch"]:
-            item["branch"] = item["branch"].split("#")[1].split(" ", 1)[-1]
-
-        #  ld_data hours don't match with Google Maps data, hence skipped.
-        item["opening_hours"] = self.parse_hours(store_data.get("StoreHours"))
-
-        apply_category(Categories.SHOP_MOBILE_PHONE, item)
-        yield item
-
-    def parse_hours(self, store_hours: dict) -> OpeningHours:
-        opening_hours = OpeningHours()
-        for day in DAYS_3_LETTERS:
-            opening_hours.add_range(day, store_hours.get(f"{day}Open"), store_hours.get(f"{day}Close"), "%I:%M %p")
-        return opening_hours
+    def parse(self, response: TextResponse, **kwargs):
+        if street_address := response.xpath('//*[@class="vbg-address-text"]/strong/text()').get():
+            item = Feature()
+            item["branch"] = (
+                response.xpath("//title//text()")
+                .get()
+                .removeprefix("Verizon Business Services - ")
+                .removesuffix("| Verizon")
+            )
+            item["street_address"] = street_address
+            item["addr_full"] = merge_address_lines(
+                response.xpath('//*[@class="vbg-address-text"]//text()').getall()
+            ).replace("Address, ", "")
+            item["lat"] = response.xpath("//@data-lat").get()
+            item["lon"] = response.xpath("//@data-lng").get()
+            item["ref"] = item["website"] = response.url
+            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+            day_time_data = response.xpath("//@data-hours-json").get()
+            oh = OpeningHours()
+            if data := json.loads(day_time_data):
+                for day, time in data.items():
+                    day = day
+                    if time in ["Closed", "Closed Closed"]:
+                        oh.set_closed(day)
+                    else:
+                        open_time, close_time = time.split("-")
+                        oh.add_range(day, open_time.strip(), close_time.strip(), "%I:%M %p")
+            item["opening_hours"] = oh
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Verizon': 1443,
 'atp/brand_wikidata/Q919641': 1443,
 'atp/category/shop/mobile_phone': 1443,
 'atp/clean_strings/branch': 1443,
 'atp/country/US': 1443,
 'atp/field/city/missing': 1443,
 'atp/field/country/from_spider_name': 1443,
 'atp/field/email/missing': 1443,
 'atp/field/image/missing': 1443,
 'atp/field/operator/missing': 1443,
 'atp/field/operator_wikidata/missing': 1443,
 'atp/field/phone/missing': 1443,
 'atp/field/postcode/missing': 1443,
 'atp/field/state/from_reverse_geocoding': 1443,
 'atp/field/twitter/missing': 1443,
 'atp/item_scraped_host_count/www.verizon.com': 1443,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1443,
 'downloader/request_bytes': 2750161,
 'downloader/request_count': 1455,
 'downloader/request_method_count/GET': 1455,
 'downloader/response_bytes': 66599079,
 'downloader/response_count': 1455,
 'downloader/response_status_count/200': 1446,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/404': 8,
 'elapsed_time_seconds': 36.486491,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 12, 12, 48, 58, 422920, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1455,
 'httpcompression/response_bytes': 359098579,
 'httpcompression/response_count': 1454,
 'httperror/response_ignored_count': 8,
 'httperror/response_ignored_status_count/404': 8,
 'item_scraped_count': 1443,
 'items_per_minute': 2405.0,
 'log_count/DEBUG': 2899,
 'log_count/INFO': 11,
 'request_depth_max': 1,
 'response_received_count': 1454,
 'responses_per_minute': 2423.3333333333335,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1454,
 'scheduler/dequeued/memory': 1454,
 'scheduler/enqueued': 1454,
 'scheduler/enqueued/memory': 1454,
 'start_time': datetime.datetime(2026, 5, 12, 12, 48, 21, 936429, tzinfo=datetime.timezone.utc)}
```