### PR TITLE
[Greene King Pubs GB] Fix Spider

### DIFF
--- a/locations/spiders/greene_king_pubs_gb.py
+++ b/locations/spiders/greene_king_pubs_gb.py
@@ -17,7 +17,7 @@ class GreeneKingPubsGBSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://www.greeneking.co.uk/sitemap.xml"]
     sitemap_rules = [(r"\/pubs\/([-\w]+)\/([-\w]+)\/?$", "parse_sd")]
-    custom_settings = {"REDIRECT_ENABLED": False, "USER_AGENT": BROWSER_DEFAULT,"DOWNLOAD_TIMEOUT":60}
+    custom_settings = {"REDIRECT_ENABLED": False, "USER_AGENT": BROWSER_DEFAULT, "DOWNLOAD_TIMEOUT": 60}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         apply_category(Categories.PUB, item)

--- a/locations/spiders/greene_king_pubs_gb.py
+++ b/locations/spiders/greene_king_pubs_gb.py
@@ -1,7 +1,12 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class GreeneKingPubsGBSpider(SitemapSpider, StructuredDataSpider):
@@ -9,8 +14,11 @@ class GreeneKingPubsGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Greene King",
         "brand_wikidata": "Q5564162",
-        "extras": Categories.PUB.value,
     }
     sitemap_urls = ["https://www.greeneking.co.uk/sitemap.xml"]
     sitemap_rules = [(r"\/pubs\/([-\w]+)\/([-\w]+)\/?$", "parse_sd")]
-    custom_settings = {"REDIRECT_ENABLED": False}
+    custom_settings = {"REDIRECT_ENABLED": False, "USER_AGENT": BROWSER_DEFAULT}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.PUB, item)
+        yield item

--- a/locations/spiders/greene_king_pubs_gb.py
+++ b/locations/spiders/greene_king_pubs_gb.py
@@ -17,7 +17,7 @@ class GreeneKingPubsGBSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://www.greeneking.co.uk/sitemap.xml"]
     sitemap_rules = [(r"\/pubs\/([-\w]+)\/([-\w]+)\/?$", "parse_sd")]
-    custom_settings = {"REDIRECT_ENABLED": False, "USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = {"REDIRECT_ENABLED": False, "USER_AGENT": BROWSER_DEFAULT,"DOWNLOAD_TIMEOUT":60}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         apply_category(Categories.PUB, item)


### PR DESCRIPTION
```python
{'atp/brand/Greene King': 946,
 'atp/brand_wikidata/Q5564162': 946,
 'atp/category/amenity/pub': 946,
 'atp/country/GB': 946,
 'atp/duplicate_count': 830,
 'atp/field/branch/missing': 946,
 'atp/field/city/missing': 887,
 'atp/field/country/from_spider_name': 887,
 'atp/field/email/missing': 60,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 946,
 'atp/field/operator_wikidata/missing': 946,
 'atp/field/state/missing': 887,
 'atp/field/street_address/missing': 887,
 'atp/field/twitter/missing': 940,
 'atp/item_scraped_host_count/www.greeneking.co.uk': 1776,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 946,
 'downloader/request_bytes': 495192,
 'downloader/request_count': 892,
 'downloader/request_method_count/GET': 892,
 'downloader/response_bytes': 79870751,
 'downloader/response_count': 892,
 'downloader/response_status_count/200': 892,
 'dupefilter/filtered': 19,
 'elapsed_time_seconds': 1109.367907,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 13, 11, 20, 33, 856186, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 293192040,
 'httpcompression/response_count': 892,
 'item_dropped_count': 830,
 'item_dropped_reasons_count/DropItem': 830,
 'item_scraped_count': 946,
 'items_per_minute': 51.181244364292155,
 'log_count/DEBUG': 2669,
 'log_count/INFO': 261,
 'request_depth_max': 2,
 'response_received_count': 892,
 'responses_per_minute': 48.25969341749323,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 891,
 'scheduler/dequeued/memory': 891,
 'scheduler/enqueued': 891,
 'scheduler/enqueued/memory': 891,
 'start_time': datetime.datetime(2026, 5, 13, 11, 2, 4, 488279, tzinfo=datetime.timezone.utc)}
```