### PR TITLE
[OKQ8] Fix Spider

### DIFF
--- a/locations/spiders/okq8.py
+++ b/locations/spiders/okq8.py
@@ -1,4 +1,9 @@
+import json
+import re
+from typing import Any
+
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -7,48 +12,36 @@ from locations.hours import DAYS, OpeningHours
 
 class Okq8Spider(Spider):
     name = "okq8"
-    start_urls = [
-        "https://www.okq8.se/-/Station/GetGlobalMapStations?appDataSource=9d780912-2801-4457-9376-16c48d02e688"
-    ]
+    start_urls = ["https://www.okq8.se/hitta-station/"]
 
     BRANDS = {
         "OKQ8": {"brand": "OKQ8", "brand_wikidata": "Q2789310"},
-        "Tanka": {"brand": "Tanka", "brand_wikidata": "Q10690640"},
+        "TANKA": {"brand": "Tanka", "brand_wikidata": "Q10690640"},
         "IDS": None,  # {"brand": "Ids"} # Some kind of private? HGV?
         "Eon": None,  # {"brand": "Eon"} # ?
     }
 
-    def parse(self, response, **kwargs):
-        for location in response.json()["stations"]:
-            location["ref"] = str(location["stationNumber"])
-            location["geo"] = location.pop("position")
-            location["street_address"] = location.pop("address")
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = json.loads(
+            re.search(
+                r"stations\":(\[.+\]),\"filters",
+                response.xpath('//*[contains(text(),"__APP_INIT_DATA__")]/text()').get(),
+            ).group(1)
+        )
+        for location in raw_data:
             item = DictParser.parse(location)
-
-            # TODO: parse fuel types using response.json()["filters"]
-
-            item["website"] = f'https://www.okq8.se{location["url"]}'
-
-            if location.get("openingHours"):
-                if location["openingHours"]["AlwaysOpen"]:
-                    item["opening_hours"] = "24/7"
-                else:
-                    item["opening_hours"] = OpeningHours()
-                    for rule in ["WeekDays", "Saturday", "Sunday"]:
-                        self.add_rule(item["opening_hours"], rule, location["openingHours"].get(rule))
-
+            item["website"] = location["stationPageUrl"]
             apply_category(Categories.FUEL_STATION, item)
-
-            if brand := self.BRANDS.get(location["net"]):
+            if brand := self.BRANDS.get(location["network"]):
                 item.update(brand)
-
-                yield item  # Other brands too small to worry about right now
-
-    @staticmethod
-    def add_rule(oh: OpeningHours, day: str, rule: dict):
-        if rule.get("Closed"):
-            return
-        if day == "WeekDays":
-            oh.add_days_range(DAYS[:5], rule["From"], rule["To"])
-        else:
-            oh.add_range(day, rule["From"], rule["To"])
+            oh = OpeningHours()
+            for days in ["Weekday", "Saturday", "Sunday"]:
+                if time := location[f"openHours{days}"]:
+                    open_time = time["open"]
+                    close_time = time["close"]
+                    if days == "Weekday":
+                        oh.add_days_range(DAYS[:5], open_time, close_time)
+                    else:
+                        oh.add_range(days, open_time, close_time)
+            item["opening_hours"] = oh
+            yield item

--- a/locations/spiders/okq8.py
+++ b/locations/spiders/okq8.py
@@ -30,10 +30,13 @@ class Okq8Spider(Spider):
         )
         for location in raw_data:
             item = DictParser.parse(location)
+            item["street_address"] = item.pop("street")
             item["website"] = location["stationPageUrl"]
             apply_category(Categories.FUEL_STATION, item)
+
             if brand := self.BRANDS.get(location["network"]):
                 item.update(brand)
+
             oh = OpeningHours()
             for days in ["Weekday", "Saturday", "Sunday"]:
                 if time := location[f"openHours{days}"]:
@@ -44,4 +47,5 @@ class Okq8Spider(Spider):
                     else:
                         oh.add_range(days, open_time, close_time)
             item["opening_hours"] = oh
+
             yield item

--- a/locations/spiders/okq8.py
+++ b/locations/spiders/okq8.py
@@ -31,11 +31,14 @@ class Okq8Spider(Spider):
         for location in raw_data:
             item = DictParser.parse(location)
             item["street_address"] = item.pop("street")
+            item["branch"] = item.pop("name").removesuffix(" (Tanka)")
             item["website"] = location["stationPageUrl"]
             apply_category(Categories.FUEL_STATION, item)
 
             if brand := self.BRANDS.get(location["network"]):
                 item.update(brand)
+            else:
+                continue
 
             oh = OpeningHours()
             for days in ["Weekday", "Saturday", "Sunday"]:


### PR DESCRIPTION
```python
{'atp/brand/OKQ8': 551,
 'atp/brand/Tanka': 146,
 'atp/brand_wikidata/Q10690640': 146,
 'atp/brand_wikidata/Q2789310': 551,
 'atp/category/amenity/fuel': 734,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/street': 1,
 'atp/country/SE': 734,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 734,
 'atp/field/brand/missing': 37,
 'atp/field/brand_wikidata/missing': 37,
 'atp/field/city/missing': 1,
 'atp/field/country/from_website_url': 734,
 'atp/field/email/missing': 734,
 'atp/field/opening_hours/missing': 466,
 'atp/field/operator/missing': 734,
 'atp/field/operator_wikidata/missing': 734,
 'atp/field/phone/missing': 734,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 24,
 'atp/field/street_address/missing': 734,
 'atp/field/twitter/missing': 734,
 'atp/item_scraped_host_count/www.okq8.se': 735,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 697,
 'downloader/request_bytes': 1042,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 139309,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.756764,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 14, 7, 58, 15, 918174, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2166059,
 'httpcompression/response_count': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 734,
 'items_per_minute': 6291.428571428572,
 'log_count/DEBUG': 737,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 17.142857142857142,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 14, 7, 58, 8, 161410, tzinfo=datetime.timezone.utc)}
```