### PR TITLE
[Belhaven Pubs GB] Fix Spider

### DIFF
--- a/locations/spiders/belhaven_pubs_gb.py
+++ b/locations/spiders/belhaven_pubs_gb.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BelhavenPubsGBSpider(SitemapSpider, StructuredDataSpider):
@@ -12,6 +13,7 @@ class BelhavenPubsGBSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.belhaven.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.belhaven\.co\.uk\/pubs\/([-\w]+)\/([-\w]+)$", "parse_sd")]
     wanted_types = ["BarOrPub"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["facebook"] = None


### PR DESCRIPTION
```python
{'atp/brand/Belhaven Pubs': 90,
 'atp/brand_wikidata/Q105516156': 90,
 'atp/category/amenity/pub': 90,
 'atp/country/GB': 90,
 'atp/field/branch/missing': 90,
 'atp/field/city/missing': 90,
 'atp/field/country/from_spider_name': 90,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 90,
 'atp/field/operator_wikidata/missing': 90,
 'atp/field/state/missing': 90,
 'atp/field/street_address/missing': 90,
 'atp/field/twitter/missing': 90,
 'atp/item_scraped_host_count/www.belhaven.co.uk': 90,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 90,
 'downloader/request_bytes': 48347,
 'downloader/request_count': 97,
 'downloader/request_method_count/GET': 97,
 'downloader/response_bytes': 7135353,
 'downloader/response_count': 97,
 'downloader/response_status_count/200': 92,
 'downloader/response_status_count/404': 5,
 'elapsed_time_seconds': 121.583517,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 14, 9, 44, 5, 207256, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 25364382,
 'httpcompression/response_count': 92,
 'httperror/response_ignored_count': 5,
 'httperror/response_ignored_status_count/404': 5,
 'item_scraped_count': 90,
 'items_per_minute': 44.62809917355372,
 'log_count/DEBUG': 187,
 'log_count/INFO': 10,
 'request_depth_max': 1,
 'response_received_count': 97,
 'responses_per_minute': 48.09917355371901,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 96,
 'scheduler/dequeued/memory': 96,
 'scheduler/enqueued': 96,
 'scheduler/enqueued/memory': 96,
 'start_time': datetime.datetime(2026, 5, 14, 9, 42, 3, 623739, tzinfo=datetime.timezone.utc)}
```