### PR TITLE
[AldiSud CH] Fix spider

### DIFF
--- a/locations/spiders/aldi_sud_ch.py
+++ b/locations/spiders/aldi_sud_ch.py
@@ -1,33 +1,18 @@
-import scrapy
+from typing import Iterable
+
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_CH, OpeningHours, sanitise_day
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
 
 
-class AldiSudCHSpider(scrapy.Spider):
+class AldiSudCHSpider(UberallSpider):
     name = "aldi_sud_ch"
     item_attributes = {"brand_wikidata": "Q41171672"}
-    start_urls = [
-        "https://www.aldi-suisse.ch/ch/de/.get-stores-in-radius.json?latitude=47.61956488197022&longitude=8.110630887500013&radius=2500000"
-    ]
+    drop_attributes = {"name"}
+    key = "lFDqKBoedhfjMheH3C3e0AcRGDuLG4"
 
-    def parse(self, response):
-        for store in response.json()["stores"]:
-            if store["storeType"] == "N":
-                continue
-            if store["countryCode"] != "CH":
-                continue
-
-            item = DictParser.parse(store)
-            item.pop("name")
-
-            item["opening_hours"] = OpeningHours()
-            for rule in store["openUntilSorted"]["openingHours"]:
-                day = sanitise_day(rule["day"], DAYS_CH)
-                if not rule.get("closed", False):
-                    item["opening_hours"].add_range(day, rule["openFormatted"], rule["closeFormatted"])
-
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-
-            yield item
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item

--- a/locations/spiders/aldi_sud_ch.py
+++ b/locations/spiders/aldi_sud_ch.py
@@ -10,9 +10,9 @@ from locations.storefinders.uberall import UberallSpider
 class AldiSudCHSpider(UberallSpider):
     name = "aldi_sud_ch"
     item_attributes = {"brand_wikidata": "Q41171672"}
-    drop_attributes = {"name"}
     key = "lFDqKBoedhfjMheH3C3e0AcRGDuLG4"
 
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["name"] = item["phone"] = None
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item


### PR DESCRIPTION
``` python
{'atp/brand/Aldi': 243,
 'atp/brand_wikidata/Q41171672': 243,
 'atp/category/shop/supermarket': 243,
 'atp/country/CH': 243,
 'atp/field/branch/missing': 243,
 'atp/field/email/missing': 243,
 'atp/field/operator/missing': 243,
 'atp/field/operator_wikidata/missing': 243,
 'atp/field/twitter/missing': 243,
 'atp/item_scraped_host_count/uberall.com': 243,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 243,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23242,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.278015,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 14, 11, 53, 25, 81840, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 213907,
 'httpcompression/response_count': 2,
 'item_scraped_count': 243,
 'items_per_minute': 4860.0,
 'log_count/DEBUG': 245,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 14, 11, 53, 21, 803825, tzinfo=datetime.timezone.utc)}
```