### PR TITLE
[ChefAndBrewer GB] Fix spider

### DIFF
--- a/locations/spiders/chef_and_brewer_gb.py
+++ b/locations/spiders/chef_and_brewer_gb.py
@@ -1,14 +1,13 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class ChefAndBrewerGBSpider(SitemapSpider, StructuredDataSpider):
     name = "chef_and_brewer_gb"
-    item_attributes = {
-        "brand": "Chef & Brewer",
-        "brand_wikidata": "Q5089491",
-    }
+    item_attributes = {"brand": "Chef & Brewer", "brand_wikidata": "Q5089491"}
     sitemap_urls = ["https://www.chefandbrewer.com/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.chefandbrewer\.com\/pubs\/([-\w]+)\/([-\w]+)$", "parse_sd")]
     wanted_types = ["BarOrPub"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
``` python
{'atp/brand/Chef & Brewer': 141,
 'atp/brand_wikidata/Q5089491': 141,
 'atp/category/amenity/pub': 141,
 'atp/country/GB': 141,
 'atp/field/branch/missing': 141,
 'atp/field/city/missing': 141,
 'atp/field/country/from_spider_name': 141,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 141,
 'atp/field/operator_wikidata/missing': 141,
 'atp/field/state/missing': 141,
 'atp/field/street_address/missing': 141,
 'atp/field/twitter/missing': 141,
 'atp/item_scraped_host_count/www.chefandbrewer.com': 141,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 141,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 1,
 'downloader/request_bytes': 75050,
 'downloader/request_count': 144,
 'downloader/request_method_count/GET': 144,
 'downloader/response_bytes': 10352254,
 'downloader/response_count': 143,
 'downloader/response_status_count/200': 143,
 'elapsed_time_seconds': 1813.136439,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 14, 13, 48, 18, 749709, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 36980626,
 'httpcompression/response_count': 143,
 'item_scraped_count': 141,
 'items_per_minute': 4.666298952013238,
 'log_count/DEBUG': 285,
 'log_count/INFO': 23,
 'request_depth_max': 1,
 'response_received_count': 143,
 'responses_per_minute': 4.7324875896304475,
 'retry/count': 1,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 143,
 'scheduler/dequeued/memory': 143,
 'scheduler/enqueued': 143,
 'scheduler/enqueued/memory': 143,
 'start_time': datetime.datetime(2026, 5, 14, 13, 18, 5, 613270, tzinfo=datetime.timezone.utc)}
```