### PR TITLE
[EgOnTheMove GB] Add custom setting to fix spider

### DIFF
--- a/locations/spiders/eg_on_the_move_gb.py
+++ b/locations/spiders/eg_on_the_move_gb.py
@@ -12,6 +12,7 @@ class EgOnTheMoveGBSpider(Spider):
     name = "eg_on_the_move_gb"
     item_attributes = {"brand": "EG On the Move", "brand_wikidata": "Q130223576"}
     start_urls = ["https://eg-otm.com/api/sites"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():


### PR DESCRIPTION
``` python
{'atp/brand/EG On the Move': 49,
 'atp/brand_wikidata/Q130223576': 49,
 'atp/category/amenity/fuel': 49,
 'atp/country/GB': 49,
 'atp/field/email/missing': 49,
 'atp/field/opening_hours/missing': 49,
 'atp/field/operator/missing': 49,
 'atp/field/operator_wikidata/missing': 49,
 'atp/field/phone/missing': 49,
 'atp/field/street_address/missing': 49,
 'atp/field/twitter/missing': 49,
 'atp/item_scraped_host_count/eg-otm.com': 49,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 49,
 'downloader/request_bytes': 327,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 60656,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.145173,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 15, 4, 38, 7, 137765, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 49,
 'items_per_minute': 980.0,
 'log_count/DEBUG': 50,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 20.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 15, 4, 38, 3, 992592, tzinfo=datetime.timezone.utc)}
```