### PR TITLE
[FarmhouseInns GB] Fix spider

### DIFF
--- a/locations/spiders/farmhouse_inns_gb.py
+++ b/locations/spiders/farmhouse_inns_gb.py
@@ -1,6 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class FarmhouseInnsGBSpider(SitemapSpider, StructuredDataSpider):
@@ -9,3 +10,4 @@ class FarmhouseInnsGBSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.farmhouseinns.co.uk/sitemap.xml"]
     sitemap_rules = [(r"/pubs/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["BarOrPub"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
``` python
{'atp/brand/Farmhouse Inns': 63,
 'atp/brand_wikidata/Q105504972': 63,
 'atp/category/amenity/restaurant': 63,
 'atp/country/GB': 63,
 'atp/field/branch/missing': 63,
 'atp/field/city/missing': 63,
 'atp/field/country/from_spider_name': 63,
 'atp/field/operator/missing': 63,
 'atp/field/operator_wikidata/missing': 63,
 'atp/field/state/missing': 63,
 'atp/field/street_address/missing': 63,
 'atp/field/twitter/missing': 63,
 'atp/item_scraped_host_count/www.farmhouseinns.co.uk': 63,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 63,
 'downloader/request_bytes': 29266,
 'downloader/request_count': 65,
 'downloader/request_method_count/GET': 65,
 'downloader/response_bytes': 4861758,
 'downloader/response_count': 65,
 'downloader/response_status_count/200': 65,
 'elapsed_time_seconds': 83.157412,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 15, 5, 10, 50, 51414, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 16856367,
 'httpcompression/response_count': 65,
 'item_scraped_count': 63,
 'items_per_minute': 45.54216867469879,
 'log_count/DEBUG': 128,
 'log_count/INFO': 21,
 'request_depth_max': 1,
 'response_received_count': 65,
 'responses_per_minute': 46.98795180722892,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 64,
 'scheduler/dequeued/memory': 64,
 'scheduler/enqueued': 64,
 'scheduler/enqueued/memory': 64,
 'start_time': datetime.datetime(2026, 5, 15, 5, 9, 26, 894002, tzinfo=datetime.timezone.utc)}
```