### PR TITLE
[Tempur-Pedic US] Add spider

### DIFF
--- a/locations/spiders/tempur_pedic_us.py
+++ b/locations/spiders/tempur_pedic_us.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import apply_category, Categories
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TempurPedicUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "tempur_pedic_us"
+    item_attributes = {"brand":"Tempur-Pedic", "brand_wikidata":"Q1756920"}
+    sitemap_urls = ["https://www.tempurpedic.com/robots.txt"]
+    sitemap_rules = [("/tempur-pedic-stores/tempur-pedic-", "parse")]
+    wanted_types = ["Store"]
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Tempur-Pedic ")
+        apply_category(Categories.SHOP_BED, item)
+        yield item

--- a/locations/spiders/tempur_pedic_us.py
+++ b/locations/spiders/tempur_pedic_us.py
@@ -3,14 +3,14 @@ from typing import Iterable
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class TempurPedicUSSpider(SitemapSpider, StructuredDataSpider):
     name = "tempur_pedic_us"
-    item_attributes = {"brand":"Tempur-Pedic", "brand_wikidata":"Q1756920"}
+    item_attributes = {"brand": "Tempur-Pedic", "brand_wikidata": "Q1756920"}
     sitemap_urls = ["https://www.tempurpedic.com/robots.txt"]
     sitemap_rules = [("/tempur-pedic-stores/tempur-pedic-", "parse")]
     wanted_types = ["Store"]


### PR DESCRIPTION
```python
{'atp/brand/Tempur-Pedic': 113,
 'atp/brand_wikidata/Q1756920': 113,
 'atp/category/shop/bed': 113,
 'atp/cdn/cloudfront/response_count': 116,
 'atp/cdn/cloudfront/response_status_count/200': 116,
 'atp/country/US': 113,
 'atp/field/email/missing': 113,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 113,
 'atp/field/operator_wikidata/missing': 113,
 'atp/field/twitter/missing': 113,
 'atp/item_scraped_host_count/www.tempurpedic.com': 113,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 113,
 'downloader/request_bytes': 48586,
 'downloader/request_count': 116,
 'downloader/request_method_count/GET': 116,
 'downloader/response_bytes': 5088369,
 'downloader/response_count': 116,
 'downloader/response_status_count/200': 116,
 'elapsed_time_seconds': 1.721688,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 18, 15, 33, 54, 361931, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 116,
 'httpcompression/response_bytes': 29454304,
 'httpcompression/response_count': 114,
 'item_scraped_count': 113,
 'items_per_minute': 6780.0,
 'log_count/DEBUG': 230,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 299675648,
 'memusage/startup': 299675648,
 'request_depth_max': 2,
 'response_received_count': 116,
 'responses_per_minute': 6960.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 115,
 'scheduler/dequeued/memory': 115,
 'scheduler/enqueued': 115,
 'scheduler/enqueued/memory': 115,
 'start_time': datetime.datetime(2026, 5, 18, 15, 33, 52, 640243, tzinfo=datetime.timezone.utc)}
```