### PR TITLE
[AllstateInsuranceAgents] Fix spider

### DIFF
--- a/locations/spiders/allstate_insurance_agents.py
+++ b/locations/spiders/allstate_insurance_agents.py
@@ -4,18 +4,20 @@ from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AllstateInsuranceAgentsSpider(SitemapSpider, StructuredDataSpider):
+class AllstateInsuranceAgentsSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "allstate_insurance_agents"
     item_attributes = {"brand": "Allstate", "brand_wikidata": "Q2645636"}
     allowed_domains = ["agents.allstate.com"]
     sitemap_urls = ["https://agents.allstate.com/sitemap.xml"]
+    sitemap_rules = [(r"https://agents\.allstate\.com/[^/]+\.html$", "parse_sd")]
+
     wanted_types = ["InsuranceAgency"]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:


### PR DESCRIPTION
Fixed spider by adding regex rules to target only agent profile pages significantly reducing extraneous requests and improving overall performance.

Stats generated for few item.
```
{'atp/brand/Allstate': 516,
 'atp/brand_wikidata/Q2645636': 516,
 'atp/category/office/insurance': 516,
 'atp/country/US': 488,
 'atp/field/city/missing': 28,
 'atp/field/country/missing': 28,
 'atp/field/email/missing': 516,
 'atp/field/geometry/missing': 28,
 'atp/field/operator/missing': 516,
 'atp/field/operator_wikidata/missing': 516,
 'atp/field/postcode/missing': 28,
 'atp/field/state/missing': 28,
 'atp/field/street_address/missing': 28,
 'atp/item_scraped_host_count/agents.allstate.com': 516,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 516,
 'downloader/request_bytes': 288373,
 'downloader/request_count': 517,
 'downloader/request_method_count/GET': 517,
 'downloader/response_bytes': 188571691,
 'downloader/response_count': 517,
 'downloader/response_status_count/200': 517,
 'elapsed_time_seconds': 637.417671,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2026, 5, 19, 11, 20, 27, 388406, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 516,
 'items_per_minute': 48.602825745682885,
 'log_count/DEBUG': 35009,
 'log_count/INFO': 19,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 517,
 'playwright/page_count/closed': 517,
 'playwright/page_count/max_concurrent': 7,
 'playwright/request_count': 16729,
 'playwright/request_count/aborted': 16210,
 'playwright/request_count/method/GET': 16729,
 'playwright/request_count/navigation': 519,
 'playwright/request_count/resource_type/document': 519,
 'playwright/request_count/resource_type/font': 3090,
 'playwright/request_count/resource_type/image': 11568,
 'playwright/request_count/resource_type/script': 1552,
 'playwright/response_count': 519,
 'playwright/response_count/method/GET': 519,
 'playwright/response_count/resource_type/document': 519,
 'request_depth_max': 1,
 'response_received_count': 517,
 'responses_per_minute': 48.69701726844584,
 'scheduler/dequeued': 517,
 'scheduler/dequeued/memory': 517,
 'scheduler/enqueued': 7054,
 'scheduler/enqueued/memory': 7054,
 'start_time': datetime.datetime(2026, 5, 19, 11, 9, 49, 970735, tzinfo=datetime.timezone.utc)}
```