### PR TITLE
[StadtZuerich CH] Fix spider

### DIFF
--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -12,7 +12,7 @@ from locations.materials import MATERIALS_DE
 class StadtZuerichCHSpider(scrapy.Spider):
     name = "stadt_zuerich_ch"
     allowed_domains = ["ogd.stadt-zuerich.ch"]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 20}
+    custom_settings = {"DOWNLOAD_TIMEOUT": 120}
 
     dataset_attributes = Licenses.CC0.value | {
         "attribution:name:de": "Stadt Zürich",

--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -204,21 +204,25 @@ class StadtZuerichCHSpider(scrapy.Spider):
     def parse_bicycle_parking(self, p):
         # For bicycle and motorcycle parkings, the data feed puts the
         # feature type into the name; the parkings have no real names.
+        default_tags = {"amenity": "bicycle_parking"}  # Fallback so category is never missing
         tags = {
             "Motorrad": {"amenity": "motorcycle_parking", "bicycle": "no"},
             "Velo": {"amenity": "bicycle_parking", "motorcycle": "no"},
             "Beide": {"amenity": "bicycle_parking", "motorcycle": "yes"},
-        }.get(p.get("name"))
+        }.get(p.get("name"), default_tags)
         operator, operator_wikidata = self.operators["Tiefbauamt"]
-        if tags is not None:
-            tags.update(
-                {
-                    "capacity": str(int(p.get("anzahl_pp", 0))) or None,
-                    "name": None,
-                    "operator": operator,
-                    "operator:wikidata": operator_wikidata,
-                }
-            )
+
+        raw_cap = str(p.get("anzahl_pp", "")).strip()
+        capacity = raw_cap if raw_cap.isdigit() else None
+
+        tags.update(
+            {
+                "capacity": capacity,
+                "name": None,
+                "operator": operator,
+                "operator:wikidata": operator_wikidata,
+            }
+        )
         return tags
 
     def parse_fountain(self, p):

--- a/locations/spiders/stadt_zuerich_ch.py
+++ b/locations/spiders/stadt_zuerich_ch.py
@@ -208,7 +208,7 @@ class StadtZuerichCHSpider(scrapy.Spider):
             "Motorrad": {"amenity": "motorcycle_parking", "bicycle": "no"},
             "Velo": {"amenity": "bicycle_parking", "motorcycle": "no"},
             "Beide": {"amenity": "bicycle_parking", "motorcycle": "yes"},
-        }.get(p["name"])
+        }.get(p.get("name"))
         operator, operator_wikidata = self.operators["Tiefbauamt"]
         if tags is not None:
             tags.update(


### PR DESCRIPTION
``` python
{'atp/category/amenity/bench': 7267,
 'atp/category/amenity/bicycle_parking': 2846,
 'atp/category/amenity/fountain': 1287,
 'atp/category/amenity/kindergarten': 374,
 'atp/category/amenity/police': 88,
 'atp/category/amenity/recycling': 180,
 'atp/category/amenity/school': 660,
 'atp/category/amenity/toilets': 91,
 'atp/category/highway/street_lamp': 42365,
 'atp/category/leisure/park': 126,
 'atp/category/multiple': 1,
 'atp/clean_strings/email': 3,
 'atp/clean_strings/street': 3,
 'atp/country/CH': 55284,
 'atp/field/branch/missing': 55284,
 'atp/field/brand/missing': 55284,
 'atp/field/brand_wikidata/missing': 55284,
 'atp/field/email/missing': 55040,
 'atp/field/name/missing': 53945,
 'atp/field/opening_hours/missing': 54719,
 'atp/field/operator/missing': 1287,
 'atp/field/operator_wikidata/missing': 1287,
 'atp/field/phone/invalid': 16,
 'atp/field/phone/missing': 53921,
 'atp/field/postcode/missing': 53893,
 'atp/field/state/missing': 55284,
 'atp/field/street_address/missing': 55284,
 'atp/field/twitter/missing': 55284,
 'atp/item_scraped_host_count/www.ogd.stadt-zuerich.ch': 55284,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 126,
 'atp/nsi/match_failed': 49632,
 'atp/nsi/operator_missing': 3971,
 'atp/nsi/perfect_match': 268,
 'atp/operator/Elektrizitätswerk der Stadt Zürich': 42365,
 'atp/operator/Entsorgung + Recycling Zürich': 180,
 'atp/operator/Grün Stadt Zürich': 7393,
 'atp/operator/Schul- und Sportdepartement': 1,
 'atp/operator/Schulamt der Stadt Zürich': 1033,
 'atp/operator/Stadtpolizei Zürich': 88,
 'atp/operator/Tiefbauamt der Stadt Zürich': 2846,
 'atp/operator/Umwelt- und Gesundheitsschutz Zürich': 91,
 'atp/operator_wikidata/Q115267460': 2846,
 'atp/operator_wikidata/Q115271935': 91,
 'atp/operator_wikidata/Q115322776': 1033,
 'atp/operator_wikidata/Q1326645': 42365,
 'atp/operator_wikidata/Q1345452': 180,
 'atp/operator_wikidata/Q1551785': 7393,
 'atp/operator_wikidata/Q2327949': 88,
 'atp/operator_wikidata/Q33121519': 1,
 'downloader/request_bytes': 5799,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 17546489,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 12,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 122.585074,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 20, 6, 56, 25, 729223, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 55284,
 'items_per_minute': 27188.852459016394,
 'log_count/DEBUG': 55312,
 'log_count/INFO': 5,
 'response_received_count': 13,
 'responses_per_minute': 6.39344262295082,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2026, 5, 20, 6, 54, 23, 144149, tzinfo=datetime.timezone.utc)}
```