### PR TITLE
[rewe_de] Increase timeout

### DIFF
--- a/locations/spiders/rewe_de.py
+++ b/locations/spiders/rewe_de.py
@@ -14,7 +14,7 @@ class ReweDESpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     sitemap_rules = [(r"/marktseite/[^/]+/(\d+)/[^/]+/$", "parse_sd")]
     # Playwright needed to avoid blocking from certain IP address ranges.
     # Probably use of data centre IPs is the main reason.
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60 * 1000}
 
     def post_process_item(self, item, response, ld_data):
         item["name"] = None


### PR DESCRIPTION
Only between 1/3 and 2/3 of all store locations were scraped. The rest failed with a timeout of 30 seconds.

Try to increase the timeout to 60 seconds.

See #14972