### PR TITLE
[Aquila AU] Fix spider

### DIFF
--- a/locations/spiders/aquila_au.py
+++ b/locations/spiders/aquila_au.py
@@ -1,47 +1,35 @@
-import re
+import json
 from typing import Iterable
 
-from chompjs import parse_js_object
-from scrapy import Spider
 from scrapy.http import Request, Response
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
+from locations.storefinders.stockinstore import StockInStoreSpider
 
 
-class AquilaAUSpider(Spider):
+class AquilaAUSpider(StockInStoreSpider):
     name = "aquila_au"
     item_attributes = {"brand": "Aquila", "brand_wikidata": "Q17985574"}
-    allowed_domains = ["www.aquila.com.au"]
-    start_urls = ["https://www.aquila.com.au/store-locator"]
+    api_site_id = "10379"
+    api_widget_id = "383"
+    api_widget_type = "storelocator"
+    api_origin = "https://aquila.com.au"
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        js_blob = response.xpath('//script[contains(text(), "storesInfo_scriptManager = ")]/text()').get()
-        js_blob = re.sub(r"\s+", " ", js_blob.split("storesInfo_scriptManager = ", 1)[1].split("];", 1)[0] + "]")
-        features = parse_js_object(js_blob)
-        for feature in features:
-            item = DictParser.parse(feature)
-            if feature["name"].startswith("Aquila Myer"):
-                item["located_in"] = "Myer"
-                item["located_in_wikidata"] = "Q1110323"
-                item["branch"] = item.pop("name", None).removeprefix("Aquila Myer ").removesuffix(" Store")
-            else:
-                item["branch"] = item.pop("name", None).removeprefix("Aquila ").removesuffix(" Store")
-            item["addr_full"] = re.sub(
-                r"\s+", " ", item["addr_full"].replace("<br>", " ").replace("<b>", "").replace("</b>", "")
-            ).strip()
-            item["website"] = "https://www.aquila.com.au/store-locator/" + feature["id"]
-            item["ref"] = item["website"]
-            apply_category(Categories.SHOP_SHOES, item)
-            yield Request(url=item["ref"], meta={"item": item}, callback=self.parse_opening_hours)
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Request]:
+        item["branch"] = item.pop("name")
+        if item["branch"].startswith("Myer "):
+            item["located_in"] = "Myer"
+            item["located_in_wikidata"] = "Q1110323"
+            item["branch"] = item["branch"].removeprefix("Myer ")
+        if page_url := location.get("store_locator_page_url"):
+            item["website"] = "https://aquila.com.au" + page_url
+        apply_category(Categories.SHOP_SHOES, item)
+        yield Request(url=item["website"], meta={"item": item}, callback=self.parse_hours)
 
-    def parse_opening_hours(self, response: Response) -> Iterable[Feature]:
+    def parse_hours(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
-        hours_text = re.sub(
-            r"\s+", " ", " ".join(response.xpath('//div[@class="js-store-description"]//td/text()').getall())
-        )
-        item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_ranges_from_string(hours_text)
+        if schema := response.xpath('//script[@id="stockinstore-schema"]/text()').get():
+            item["opening_hours"] = LinkedDataParser.parse_opening_hours(json.loads(schema))
         yield item


### PR DESCRIPTION
Rewrote the spider to use the project's existing `StockInStoreSpider` storefinder helper (site 10379 / widget 383 / origin `https://aquila.com.au`) and added a follow-up fetch of each standard store's detail page to parse opening hours from its `stockinstore-schema` LocalBusiness ld+json via `LinkedDataParser.parse_opening_hours`. The previous spider scraped a `storesInfo_scriptManager` JS blob that no longer exists since the brand migrated to Shopify.

Yields 31 POIs (was 0 in BR134; historical norm ~38). The 7-store gap is explained by store closures during the Shopify migration — only active stores are in the new API. 12/31 carry `opening_hours`; the remaining 19 (11 Myer concessions + 8 DFO/outlet stores) have no `stockinstore-schema` block on their detail pages and no `OpeningHoursSpecification` anywhere on the site, so there's no upstream source for those hours.

## Alternative considered

We also considered using `SitemapSpider` + `StructuredDataSpider` against `aquila.com.au/sitemap.xml`, but only the 12 standard branded stores embed a `stockinstore-schema` LocalBusiness ld+json block on their detail page — the 11 Myer concessions and 8 DFO/outlet pages have no usable structured data, so that route would yield 12 POIs vs 31 from the storefinder. Per-item coverage is otherwise equivalent for the 12 in common.