### PR TITLE
[Kruidvat BE] Fix Spider

### DIFF
--- a/locations/spiders/kruidvat.py
+++ b/locations/spiders/kruidvat.py
@@ -1,11 +1,12 @@
+import json
 from typing import Any
+from urllib.parse import urljoin
 
 import scrapy
 from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.items import Feature
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -13,10 +14,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class KruidvatSpider(scrapy.Spider):
     name = "kruidvat"
     item_attributes = {"brand": "Kruidvat", "brand_wikidata": "Q2226366"}
-    start_urls = [
-        "https://www.kruidvat.be/api/v2/kvb/stores?lang=nl_BE&radius=100&pageSize=3000&fields=FULL",
-        "https://www.kruidvat.nl/api/v2/kvn/stores?lang=nl&radius=500&pageSize=3000&fields=FULL",
-    ]
+    start_urls = ["https://www.kruidvat.be/nl/winkelzoeker"]
     is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "ROBOTSTXT_OBEY": False,
@@ -25,33 +23,23 @@ class KruidvatSpider(scrapy.Spider):
         "CONCURRENT_REQUESTS": 1,
     }
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.xpath("//stores"):
-            item = Feature()
-            item["ref"] = store.xpath("code/text()").get()
-
-            if item["ref"] == "8000":
-                continue
-
-            item["state"] = store.xpath(".//province/text()").get()
-            item["postcode"] = store.xpath(".//postalCode/text()").get()
-            item["street_address"] = store.xpath(".//line1/text()").get()
-            item["lat"] = store.xpath(".//latitude/text()").get()
-            item["lon"] = store.xpath(".//longitude/text()").get()
-            item["addr_full"] = store.xpath(".//formattedAddress/text()").get()
-
-            item["opening_hours"] = OpeningHours()
-            for rule in store.xpath(".//weekDayOpeningList"):
-                if rule.xpath("./closed/text()").get() == "true":
-                    continue
-                item["opening_hours"].add_range(
-                    rule.xpath("shortenedWeekDay/text()").get(),
-                    rule.xpath("openingTime/formattedHour/text()").get(),
-                    rule.xpath("closingTime/formattedHour/text()").get(),
-                )
-
-            item["website"] = response.urljoin(store.xpath("url/text()").get())
-
-            apply_category(Categories.SHOP_CHEMIST, item)
-
+    def parse(self, response: Response, **kwargs) -> Any:
+        location_data = json.loads(response.xpath('//*[@type="application/json"]/text()').get())["all-stores-query"][
+            "stores"
+        ]
+        for location in location_data:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name").replace("DROGISTERIJ KRUIDVAT", "")
+            item["state"] = location["address"].get("province", "")
+            item["ref"] = item["website"] = urljoin("https://www.kruidvat.be", item["website"])
+            oh = OpeningHours()
+            for day_time in location["openingHours"]["weekDayOpeningList"]:
+                day = day_time.get("shortenedWeekDay")
+                if day_time["closed"]:
+                    oh.set_closed(day)
+                else:
+                    open_time = day_time.get("openingTime").get("formattedHour")
+                    close_time = day_time.get("closingTime").get("formattedHour")
+                    oh.add_range(day, open_time, close_time)
+            item["opening_hours"] = oh
             yield item

--- a/locations/spiders/kruidvat_be.py
+++ b/locations/spiders/kruidvat_be.py
@@ -25,15 +25,16 @@ class KruidvatBESpider(PlaywrightSpider):
             item = DictParser.parse(location)
             item["name"] = None
             item["state"] = location["address"].get("province", "")
-            item["ref"] = item["website"] = urljoin("https://www.kruidvat.be", item["website"])
+            item["ref"] = item["website"] = response.urljoin(item["website"])
             oh = OpeningHours()
-            for day_time in location["openingHours"]["weekDayOpeningList"]:
-                day = day_time.get("shortenedWeekDay")
-                if day_time["closed"]:
-                    oh.set_closed(day)
+            for rule in location["openingHours"]["weekDayOpeningList"]:
+                if rule["closed"]:
+                    oh.set_closed(rule["shortenedWeekDay"])
                 else:
-                    open_time = day_time.get("openingTime").get("formattedHour")
-                    close_time = day_time.get("closingTime").get("formattedHour")
-                    oh.add_range(day, open_time, close_time)
+                    oh.add_range(
+                        rule["shortenedWeekDay"],
+                        rule["openingTime"]["formattedHour"],
+                        rule["closingTime"]["formattedHour"],
+                    )
             item["opening_hours"] = oh
             yield item

--- a/locations/spiders/kruidvat_be.py
+++ b/locations/spiders/kruidvat_be.py
@@ -23,7 +23,7 @@ class KruidvatBESpider(PlaywrightSpider):
         ]
         for location in location_data:
             item = DictParser.parse(location)
-            item["branch"] = item.pop("name").replace("DROGISTERIJ KRUIDVAT", "")
+            item["name"] = None
             item["state"] = location["address"].get("province", "")
             item["ref"] = item["website"] = urljoin("https://www.kruidvat.be", item["website"])
             oh = OpeningHours()

--- a/locations/spiders/kruidvat_be.py
+++ b/locations/spiders/kruidvat_be.py
@@ -1,6 +1,5 @@
 import json
 from typing import Any
-from urllib.parse import urljoin
 
 from scrapy.http import Response
 

--- a/locations/spiders/kruidvat_be.py
+++ b/locations/spiders/kruidvat_be.py
@@ -2,26 +2,20 @@ import json
 from typing import Any
 from urllib.parse import urljoin
 
-import scrapy
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class KruidvatBESpider(scrapy.Spider):
+class KruidvatBESpider(PlaywrightSpider):
     name = "kruidvat_be"
     item_attributes = {"brand": "Kruidvat", "brand_wikidata": "Q2226366"}
     start_urls = ["https://www.kruidvat.be/nl/winkelzoeker"]
-    is_playwright_spider = True
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "ROBOTSTXT_OBEY": False,
-        "USER_AGENT": BROWSER_DEFAULT,
-        "DOWNLOAD_TIMEOUT": 120,
-        "CONCURRENT_REQUESTS": 1,
-    }
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs) -> Any:
         location_data = json.loads(response.xpath('//*[@type="application/json"]/text()').get())["all-stores-query"][

--- a/locations/spiders/kruidvat_be.py
+++ b/locations/spiders/kruidvat_be.py
@@ -11,8 +11,8 @@ from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class KruidvatSpider(scrapy.Spider):
-    name = "kruidvat"
+class KruidvatBESpider(scrapy.Spider):
+    name = "kruidvat_be"
     item_attributes = {"brand": "Kruidvat", "brand_wikidata": "Q2226366"}
     start_urls = ["https://www.kruidvat.be/nl/winkelzoeker"]
     is_playwright_spider = True


### PR DESCRIPTION
```python
{'atp/brand/Kruidvat': 320,
 'atp/brand_wikidata/Q2226366': 320,
 'atp/category/shop/chemist': 320,
 'atp/clean_strings/branch': 315,
 'atp/country/BE': 320,
 'atp/field/email/missing': 320,
 'atp/field/operator/missing': 320,
 'atp/field/operator_wikidata/missing': 320,
 'atp/field/phone/missing': 320,
 'atp/field/state/missing': 1,
 'atp/field/twitter/missing': 320,
 'atp/item_scraped_host_count/www.kruidvat.be': 320,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 320,
 'downloader/request_bytes': 270,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1826960,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.7292,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 20, 10, 17, 49, 472287, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 320,
 'items_per_minute': 3840.0,
 'log_count/DEBUG': 387,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 32,
 'playwright/request_count/aborted': 31,
 'playwright/request_count/method/GET': 32,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/request_count/resource_type/font': 5,
 'playwright/request_count/resource_type/image': 5,
 'playwright/request_count/resource_type/script': 20,
 'playwright/request_count/resource_type/stylesheet': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 12.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 20, 10, 17, 43, 743087, tzinfo=datetime.timezone.utc)}
```