### PR TITLE
[Q8] Fix spider

### DIFF
--- a/locations/spiders/q8.py
+++ b/locations/spiders/q8.py
@@ -12,8 +12,6 @@ from locations.spiders.q8_italia import Q8ItaliaSpider
 # AKA Q8 NWE https://www.q8.be/nl/stations
 class Q8Spider(JSONBlobSpider):
     name = "q8"
-    start_urls = ["https://www.q8.be/fr/get/stations.json"]
-
     BRANDS = {
         "Q8Easy": {"brand": "Q8 Easy", "brand_wikidata": "Q1806948"},
         "Q8": Q8ItaliaSpider.item_attributes,
@@ -28,7 +26,7 @@ class Q8Spider(JSONBlobSpider):
                     "latitude": 50.46192477912935,
                     "longitude": 4.469899999999987,
                     "radius": 600000,
-                    "take": 2000,
+                    "take": 1500,
                     "hasFueling": True,
                     "locationTypes": ["Q8", "Q8Easy"],
                     "serviceCodes": [],


### PR DESCRIPTION
```python
{'atp/brand/Q8': 294,
 'atp/brand/Q8 Easy': 217,
 'atp/brand_wikidata/Q1806948': 217,
 'atp/brand_wikidata/Q4119207': 294,
 'atp/category/amenity/fuel': 511,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/BE': 463,
 'atp/country/LU': 48,
 'atp/field/city/missing': 2,
 'atp/field/email/missing': 511,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 511,
 'atp/field/operator_wikidata/missing': 511,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 11,
 'atp/field/state/missing': 511,
 'atp/field/twitter/missing': 511,
 'atp/item_scraped_host_count/www.q8.be': 511,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 511,
 'downloader/request_bytes': 858,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 94755,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.629789,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 20, 13, 25, 1, 811628, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2234070,
 'httpcompression/response_count': 2,
 'item_scraped_count': 511,
 'items_per_minute': 3832.5,
 'log_count/DEBUG': 513,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 20, 13, 24, 53, 181839, tzinfo=datetime.timezone.utc)}
```