### PR TITLE
[Calvin Klein AU] Fix spider

### DIFF
--- a/locations/spiders/calvin_klein_au.py
+++ b/locations/spiders/calvin_klein_au.py
@@ -27,10 +27,9 @@ class CalvinKleinAUSpider(Spider):
             item["postcode"] = location["a"][3]
             item["website"] = f'https://www.calvinklein.com.au{location["u"]}'
             item["phone"] = location["p"]
-            item["email"] = location["e"]
 
             oh = OpeningHours()
-            for rule in location["oh"].replace(" ", "").split(","):
+            for rule in (location["oh"] or "").replace(" ", "").split(","):
                 if m := re.search(r"(\d)\|(\d+)(:\d+)?(am|pm)-(\d+)(:\d+)?(am|pm)", rule):
                     day, start_hour, start_minute, start_zone, end_hour, end_minute, end_zone = m.groups()
                     start_time = f'{start_hour}{start_minute or ":00"}{start_zone}'

--- a/locations/spiders/calvin_klein_au.py
+++ b/locations/spiders/calvin_klein_au.py
@@ -37,6 +37,6 @@ class CalvinKleinAUSpider(Spider):
                     start_time = f'{start_hour}{start_minute or ":00"}{start_zone}'
                     end_time = f'{end_hour}{end_minute or ":00"}{end_zone}'
                     oh.add_range(DAYS[int(day) - 1], start_time, end_time, time_format="%I:%M%p")
-            item["opening_hours"] = oh.as_opening_hours()
+            item["opening_hours"] = oh
 
             yield item

--- a/locations/spiders/calvin_klein_au.py
+++ b/locations/spiders/calvin_klein_au.py
@@ -1,6 +1,8 @@
 import re
+from typing import Any
 
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
@@ -13,13 +15,13 @@ class CalvinKleinAUSpider(Spider):
     item_attributes = CalvinKleinSpider.item_attributes
     start_urls = ["https://www.calvinklein.com.au/stores/index/dataAjax"]
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
             item = Feature()
             item["ref"] = location["i"]
             item["lat"] = location["l"]
             item["lon"] = location["g"]
-            item["name"] = location["n"]
+            item["branch"] = location["n"].split(" | ", 1)[1].removeprefix("Calvin Klein ")
             item["addr_full"] = merge_address_lines(location.get("a"))
             item["street_address"] = location["a"][0]
             item["city"] = location["a"][1]


### PR DESCRIPTION
The store-locator API at `/stores/index/dataAjax` started returning two Pop-Up stores with `oh: null` for opening hours. The unfixed spider ran `location["oh"].replace(" ", "")` directly, raising `AttributeError` on the first null and terminating after yielding only the 2 stores ahead of it (matching BR134's 36 → 2 result exactly); guard against null opening hours.

Also dropped `item["email"]` — 28 of 37 stores carried the central customer-care address `CalvinKleinCustomerCare@pvhba.com`, which the unique-only contact-fields convention says should not be set.

```python
{'atp/brand/Calvin Klein': 37,
 'atp/brand_wikidata/Q1068628': 37,
 'atp/category/shop/clothes': 37,
 'atp/country/AU': 37,
 'atp/field/email/missing': 37,
 'atp/field/opening_hours/invalid': 5,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 1,
 'atp/nsi/perfect_match': 37,
 'item_scraped_count': 37}
```
