### PR TITLE
[DavidsTea] Fix spider

### DIFF
--- a/locations/spiders/davids_tea.py
+++ b/locations/spiders/davids_tea.py
@@ -1,37 +1,17 @@
-import json
-import re
 from typing import Iterable
 
-from scrapy import Selector
-from scrapy.http import Response
-
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address
+from locations.storefinders.storepoint import StorepointSpider
 
 
-class DavidsTeaSpider(JSONBlobSpider):
+class DavidsTeaSpider(StorepointSpider):
     name = "davids_tea"
     item_attributes = {"brand": "DavidsTea", "brand_wikidata": "Q3019129"}
-    start_urls = ["https://davidstea.com/apps/store-locator/"]
+    key = "169e0f2540d9e8"
 
-    def extract_json(self, response: Response) -> list:
-        return [
-            json.loads(store)
-            for store in re.findall(
-                r"markersCoords.push\(({\".+?)\);",
-                response.xpath('//script[contains(text(),"markersCoords")]/text()').get(""),
-            )
-        ]
-
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        store_info = Selector(text=item.pop("addr_full"))
-        item["branch"] = store_info.xpath('//*[@class="name"]/text()').get("").strip()
-        item["street_address"] = clean_address(store_info.xpath('//*[contains(@class, "address")]/text()').getall())
-        item["city"] = store_info.xpath('//*[@class="city"]/text()').get()
-        item["state"] = store_info.xpath('//*[@class="prov_state"]/text()').get()
-        item["postcode"] = store_info.xpath('//*[@class="postal_zip"]/text()').get()
-        item["country"] = store_info.xpath('//*[@class="country"]/text()').get()
-        if response.url != "https://davidstea.com/apps/store-locator/":
-            item["website"] = response.url
+    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
+        item["ref"] = str(location["id"])
+        item["branch"] = item.pop("name").removeprefix("DAVIDsTEA ")
+        apply_category(Categories.SHOP_TEA, item)
         yield item

--- a/locations/spiders/davids_tea_ca.py
+++ b/locations/spiders/davids_tea_ca.py
@@ -5,8 +5,8 @@ from locations.items import Feature
 from locations.storefinders.storepoint import StorepointSpider
 
 
-class DavidsTeaSpider(StorepointSpider):
-    name = "davids_tea"
+class DavidsTeaCASpider(StorepointSpider):
+    name = "davids_tea_ca"
     item_attributes = {"brand": "DavidsTea", "brand_wikidata": "Q3019129"}
     key = "169e0f2540d9e8"
 


### PR DESCRIPTION
The site migrated to Shopify between BR133 and BR134. The old `/apps/store-locator/` page no longer contains the `markersCoords.push(...)` JS blob the spider's regex parses; the new locator at `/pages/store-locator` embeds a Storepoint widget instead (`StorepointWidget('169e0f2540d9e8', '#storepoint-widget', {})`).

Move to `StorepointSpider`, strip the "DAVIDsTEA " prefix from `branch`, and apply `Categories.SHOP_TEA`.

```python
{'atp/brand/DavidsTea': 21,
 'atp/brand_wikidata/Q3019129': 21,
 'atp/category/shop/tea': 21,
 'atp/country/CA': 21,
 'atp/field/country/from_reverse_geocoding': 21,
 'atp/nsi/perfect_match': 21,
 'item_scraped_count': 21}
```
