### PR TITLE
[Postbank BG] Fix broken async start function

### DIFF
--- a/locations/spiders/postbank_bg.py
+++ b/locations/spiders/postbank_bg.py
@@ -18,13 +18,11 @@ class PostbankBGSpider(Spider):
     requires_proxy = True
 
     async def start(self) -> AsyncIterator[FormRequest]:
-        return [
-            FormRequest(
-                "https://www.postbank.bg/bg-BG/api/locations/locations",
-                formdata={"contextItemPath": "/sitecore/content/postbank/home"},
-                callback=self.parse,
-            )
-        ]
+        yield FormRequest(
+            "https://www.postbank.bg/bg-BG/api/locations/locations",
+            formdata={"contextItemPath": "/sitecore/content/postbank/home"},
+            callback=self.parse,
+        )
 
     def parse(self, response):
         for city in response.json():


### PR DESCRIPTION
Incorrect return type for async start function fixed.

HTTP 403 experienced outside of country so the spider still may fail. Proxy was previously flagged as being required.