### PR TITLE
[A1 AT] Fix spider

### DIFF
--- a/locations/spiders/a1_at.py
+++ b/locations/spiders/a1_at.py
@@ -1,15 +1,17 @@
-from typing import AsyncIterator
+from typing import AsyncIterator, Iterable
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_AT, OpeningHours
+from locations.items import Feature
 
 
 class A1ATSpider(Spider):
     name = "a1_at"
     item_attributes = {"brand": "A1", "brand_wikidata": "Q688755"}
+    requires_proxy = True
     allowed_domains = ["www.a1.net"]
     start_urls = ["https://www.a1.net/o/gucci/widgets/apis/shopfinder/bff/microservice-shopfinder/shop/basicData"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
@@ -18,7 +20,7 @@ class A1ATSpider(Spider):
         for url in self.start_urls:
             yield JsonRequest(url=url, callback=self.parse_store_list)
 
-    def parse_store_list(self, response):
+    def parse_store_list(self, response: Response) -> Iterable[JsonRequest]:
         for location in response.json():
             if location["type"] != "SHOP":
                 # Only SHOP is an A1 corporate store. Other types
@@ -27,13 +29,14 @@ class A1ATSpider(Spider):
                 continue
             item = DictParser.parse(location)
             item["street_address"] = item.pop("addr_full", None)
+            item["branch"] = item.pop("name").replace("A1 Shop ", "").strip()
             yield JsonRequest(
                 url=f'https://www.a1.net/o/gucci/widgets/apis/shopfinder/bff/microservice-shopfinder/shop/detail/id/{item["ref"]}',
                 meta={"item": item},
                 callback=self.parse_store,
             )
 
-    def parse_store(self, response):
+    def parse_store(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
         item["opening_hours"] = OpeningHours()
         for day_hours in response.json().get("hoursShops", []):


### PR DESCRIPTION
The spider works fine on my local setup but returns a 403 error on the US network. Therefore, set requires_proxy to true

```
{'atp/brand/A1': 76,
 'atp/brand_wikidata/Q688755': 76,
 'atp/category/shop/telecommunication': 76,
 'atp/country/AT': 76,
 'atp/field/city/missing': 76,
 'atp/field/country/from_spider_name': 76,
 'atp/field/email/missing': 76,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 76,
 'atp/field/operator_wikidata/missing': 76,
 'atp/field/phone/missing': 76,
 'atp/field/state/missing': 76,
 'atp/field/twitter/missing': 76,
 'atp/item_scraped_host_count/www.a1.net': 76,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 76,
 'downloader/request_bytes': 84087,
 'downloader/request_count': 77,
 'downloader/request_method_count/GET': 77,
 'downloader/response_bytes': 112166,
 'downloader/response_count': 77,
 'downloader/response_status_count/200': 77,
 'elapsed_time_seconds': 93.068375,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 21, 3, 14, 35, 675124, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 211764,
 'httpcompression/response_count': 77,
 'item_scraped_count': 76,
 'items_per_minute': 49.03225806451613,
 'log_count/DEBUG': 153,
 'log_count/INFO': 4,
 'request_depth_max': 1,
 'response_received_count': 77,
 'responses_per_minute': 49.67741935483871,
 'scheduler/dequeued': 77,
 'scheduler/dequeued/memory': 77,
 'scheduler/enqueued': 77,
 'scheduler/enqueued/memory': 77,
 'start_time': datetime.datetime(2026, 5, 21, 3, 13, 2, 606749, tzinfo=datetime.timezone.utc)}
```