### PR TITLE
[Beaverbrooks GB] Fix Spider

### DIFF
--- a/locations/spiders/beaverbrooks_gb.py
+++ b/locations/spiders/beaverbrooks_gb.py
@@ -1,19 +1,22 @@
 import json
 from typing import Any
 
-import scrapy
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class BeaverbrooksGBSpider(scrapy.Spider):
+class BeaverbrooksGBSpider(PlaywrightSpider):
     name = "beaverbrooks_gb"
     item_attributes = {"brand": "Beaverbrooks", "brand_wikidata": "Q4878226"}
     start_urls = [
         "https://www.beaverbrooks.co.uk/stores",
     ]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for stores in json.loads(response.xpath('//*[@id="__NEXT_DATA__"]/text()').get())["props"]["pageProps"][


### PR DESCRIPTION
```python
{'atp/brand/Beaverbrooks': 79,
 'atp/brand_wikidata/Q4878226': 79,
 'atp/category/shop/jewelry': 79,
 'atp/clean_strings/housenumber': 1,
 'atp/clean_strings/phone': 1,
 'atp/country/GB': 79,
 'atp/field/operator/missing': 79,
 'atp/field/operator_wikidata/missing': 79,
 'atp/field/street_address/missing': 79,
 'atp/field/twitter/missing': 79,
 'atp/item_scraped_host_count/www.beaverbrooks.co.uk': 79,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 79,
 'downloader/request_bytes': 540,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 562403,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 12.336974,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 21, 6, 10, 56, 916968, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 79,
 'items_per_minute': 395.0,
 'log_count/DEBUG': 171,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 43,
 'playwright/request_count/aborted': 41,
 'playwright/request_count/method/GET': 43,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/font': 8,
 'playwright/request_count/resource_type/image': 2,
 'playwright/request_count/resource_type/script': 26,
 'playwright/request_count/resource_type/stylesheet': 5,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 10.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 21, 6, 10, 44, 579994, tzinfo=datetime.timezone.utc)}
```