### PR TITLE
[Bags To Go AU] Fix spider

### DIFF
--- a/locations/spiders/bags_to_go_au.py
+++ b/locations/spiders/bags_to_go_au.py
@@ -12,7 +12,7 @@ from locations.items import Feature
 
 class BagsToGoAUSpider(Spider):
     name = "bags_to_go_au"
-    item_attributes = {"brand": "Bags To Go", "brand_wikidata": "Q117745930"}
+    item_attributes = {"name": "Bags To Go", "brand": "Bags To Go", "brand_wikidata": "Q117745930"}
     start_urls = ["https://bagstogo.com.au/pages/store-locator"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/bags_to_go_au.py
+++ b/locations/spiders/bags_to_go_au.py
@@ -1,16 +1,27 @@
+from typing import Any
+from urllib.parse import urljoin
+
+from scrapy.http import Response
+from scrapy.spiders import Spider
+
 from locations.categories import Categories, apply_category
+from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.storefinders.stockinstore import StockInStoreSpider
 
 
-class BagsToGoAUSpider(StockInStoreSpider):
+class BagsToGoAUSpider(Spider):
     name = "bags_to_go_au"
     item_attributes = {"brand": "Bags To Go", "brand_wikidata": "Q117745930"}
-    api_site_id = "10017"
-    api_widget_id = "25"
-    api_widget_type = "sis"
-    api_origin = "https://bagstogo.com.au"
+    start_urls = ["https://bagstogo.com.au/pages/store-locator"]
 
-    def parse_item(self, item: Feature, location: dict):
-        apply_category(Categories.SHOP_BAG, item)
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.xpath("//details[@id]"):
+            item = Feature()
+            item["city"] = location.xpath("./@id").get("").title()
+            item["ref"] = location.xpath('.//a[contains(text(),"View")]/@href').get()
+            item["branch"] = item["ref"].title().replace("-", " ")
+            item["addr_full"] = response.xpath(f'//*[@data-title="{item["branch"]}"]/@data-address').get()
+            item["website"] = urljoin("https://bagstogo.com.au/pages/", item["ref"])
+            extract_google_position(item, location)
+            apply_category(Categories.SHOP_BAG, item)
+            yield item

--- a/locations/spiders/bags_to_go_au.py
+++ b/locations/spiders/bags_to_go_au.py
@@ -1,11 +1,12 @@
 from typing import Any
 from urllib.parse import urljoin
 
-from scrapy.http import Response
+from scrapy.http import Response, TextResponse
 from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
+from locations.hours import OpeningHours
 from locations.items import Feature
 
 
@@ -22,6 +23,15 @@ class BagsToGoAUSpider(Spider):
             item["branch"] = item["ref"].title().replace("-", " ")
             item["addr_full"] = response.xpath(f'//*[@data-title="{item["branch"]}"]/@data-address').get()
             item["website"] = urljoin("https://bagstogo.com.au/pages/", item["ref"])
+            item["opening_hours"] = self.parse_opening_hours(location)
             extract_google_position(item, location)
             apply_category(Categories.SHOP_BAG, item)
             yield item
+
+    def parse_opening_hours(self, location: TextResponse) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for rule in location.xpath('.//*[contains(text(),"Opening hours")]/following-sibling::table/tr'):
+            opening_hours.add_ranges_from_string(
+                f"{rule.xpath('./td[1]/text()').get()}: {rule.xpath('./td[2]/text()').get()}"
+            )
+        return opening_hours


### PR DESCRIPTION
`Stock In Store API` is no longer working.

```python
{'atp/brand/Bags To Go': 5,
 'atp/brand_wikidata/Q117745930': 5,
 'atp/category/shop/bag': 5,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/AU': 5,
 'atp/field/country/from_spider_name': 5,
 'atp/field/email/missing': 5,
 'atp/field/name/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/field/phone/missing': 5,
 'atp/field/postcode/missing': 5,
 'atp/field/state/missing': 5,
 'atp/field/street_address/missing': 5,
 'atp/field/twitter/missing': 5,
 'atp/item_scraped_host_count/bagstogo.com.au': 5,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 5,
 'downloader/request_bytes': 1433,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 105198,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.146773,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 21, 8, 30, 43, 963729, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 562068,
 'httpcompression/response_count': 2,
 'item_scraped_count': 5,
 'items_per_minute': 150.0,
 'log_count/DEBUG': 7,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 21, 8, 30, 41, 816956, tzinfo=datetime.timezone.utc)}
```