### PR TITLE
[Deka Lash] Fix spider

### DIFF
--- a/locations/spiders/deka_lash.py
+++ b/locations/spiders/deka_lash.py
@@ -1,11 +1,17 @@
-from scrapy.spiders import SitemapSpider
+from locations.categories import Categories, apply_category
+from locations.storefinders.storepoint import StorepointSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 
-
-class DekaLashSpider(SitemapSpider, StructuredDataSpider):
+class DekaLashSpider(StorepointSpider):
     name = "deka_lash"
     item_attributes = {"brand": "Deka Lash", "brand_wikidata": "Q120505973"}
-    sitemap_urls = ["https://dekalash.com/page-sitemap.xml"]
-    sitemap_rules = [(r"/find-a-studio/.+/.+/$", "parse")]
-    wanted_types = ["BeautySalon"]
+    key = "15e2b4dd23ff14"
+
+    def parse_item(self, item, location):
+        if branch := item.pop("name", "").removeprefix("Deka Lash ").strip():
+            item["branch"] = branch
+        if website := item.get("website"):
+            if not website.startswith("http"):
+                item["website"] = "https://" + website
+        apply_category(Categories.SHOP_BEAUTY, item)
+        yield item


### PR DESCRIPTION
The `page-sitemap.xml` the spider relied on has gone stale — most of its
`/find-a-studio/{state}/{city}/` URLs now 301 to the landing page, and
the spider yields 0 items.

Switch to `StorepointSpider` (the widget the site embeds, key
`15e2b4dd23ff14`), strip the "Deka Lash " prefix from `branch`, and
apply `Categories.SHOP_BEAUTY`. The Storepoint API is the site's own
canonical store source and yields 89 stores — 21 more than the live
sitemap holds, with consistent per-store `addr_full` and coordinates.

```python
{'atp/brand/Deka Lash': 89,
 'atp/brand_wikidata/Q120505973': 89,
 'atp/category/shop/beauty': 89,
 'atp/country/US': 89,
 'atp/field/city/missing': 89,
 'atp/field/email/missing': 89,
 'atp/field/opening_hours/missing': 89,
 'atp/field/postcode/missing': 89,
 'atp/field/street_address/missing': 89,
 'atp/nsi/perfect_match': 89,
 'item_scraped_count': 89}
```