### PR TITLE
[AdriaticFurniture AU] Fix spider

### DIFF
--- a/locations/spiders/adriatic_furniture_au.py
+++ b/locations/spiders/adriatic_furniture_au.py
@@ -17,33 +17,50 @@ class AdriaticFurnitureAUSpider(CrawlSpider):
     item_attributes = {"brand": "Adriatic Furniture", "brand_wikidata": "Q117856796"}
     allowed_domains = ["www.adriatic.com.au"]
     start_urls = ["https://www.adriatic.com.au/pages/store-locator"]
-    rules = [
-        Rule(
-            LinkExtractor(
-                restrict_text="VIEW TRADING HOURS",
-                process_value=lambda x: x.replace("adriaticfurniture-au.myshopify.com", "www.adriatic.com.au"),
-            ),
-            follow=False,
-            callback="parse",
-        )
-    ]
 
-    def parse(self, response: Response) -> Iterable[Feature]:
-        store_details = response.xpath('(//div[@class="hdt-ourstore_inner"]/div[@class="hdt-rte"])[1]')
+    rules = [Rule(LinkExtractor(allow=r"/pages/[a-z0-9\-]+$"), follow=False, callback="parse_store")]
+
+    def parse_store(self, response: Response) -> Iterable[Feature]:
+        store_details = response.xpath(
+            '(//div[contains(@class, "hdt-ourstore_inner")]/div[contains(@class, "hdt-rte")])[1]'
+        )
+        if not store_details:
+            return
+
+        if phone_match_link := store_details.xpath('.//a[contains(@href, "tel:")]/@href').get():
+            phone = phone_match_link.replace("tel:", "").strip()
+        else:
+            contact_text = " ".join(store_details.xpath(".//text()").getall())
+            phone = re.search(r"\(?03\)?[\s\-]*\d{4}[\s\-]*\d{4}", contact_text).group(0).strip()
+
         properties = {
             "ref": response.url,
-            "addr_full": merge_address_lines(store_details.xpath("./p[1]//text()").getall()),
-            "phone": re.sub(r"Phone\s*:\s*", "", " ".join(store_details.xpath("./p[2]//text()").getall())).strip(),
-            "email": re.sub(r"Email\s*:\s*", "", " ".join(store_details.xpath("./p[3]//text()").getall())).strip(),
+            "branch": response.xpath("normalize-space(//title/text())")
+            .get("")
+            .split("|")[0]
+            .replace("Furniture Store", "")
+            .strip(),
+            "phone": phone,
+            "email": store_details.xpath('.//a[contains(@href, "mailto:")]/@href').get().replace("mailto:", "").strip(),
             "website": response.url,
-            "opening_hours": OpeningHours(),
+            "addr_full": merge_address_lines(store_details.xpath("./p[1]//text()").getall()),
         }
-        if ("VIC" in properties["addr_full"] or "Victoria" in properties["addr_full"]) and not properties[
-            "phone"
-        ].startswith("0"):
+
+        if not properties["phone"].startswith(("0", "(")):
             properties["phone"] = "03 {}".format(properties["phone"])
-        hours_text = " ".join(store_details.xpath('//div[@class="timing"]//span/text()').getall())
-        properties["opening_hours"].add_ranges_from_string(hours_text)
-        extract_google_position(properties, response)
+
+        if map_wrapper := response.xpath('//div[contains(@class, "hdt-map-inner")]'):
+            extract_google_position(properties, map_wrapper[0])
+
+            oh = OpeningHours()
+            if timing_block := response.xpath('//div[contains(@class, "timing")]'):
+                for row in timing_block.xpath(".//li"):
+                    day = row.xpath("./span[1]/text()").get()
+                    hours = row.xpath("./span[2]/text()").get()
+                    if day and hours:
+                        oh.add_ranges_from_string(f"{day}: {hours}")
+
+                properties["opening_hours"] = oh
+
         apply_category(Categories.SHOP_FURNITURE, properties)
         yield Feature(**properties)


### PR DESCRIPTION
Used XPath based parsing as the site's JSON-LD implementation contains stale, duplicated data that causes store collisions. This approach reliably extracts all 8 unique store locations.

```
{'atp/brand/Adriatic Furniture': 8,
 'atp/brand_wikidata/Q117856796': 8,
 'atp/category/shop/furniture': 8,
 'atp/cdn/cloudflare/response_count': 23,
 'atp/cdn/cloudflare/response_status_count/200': 23,
 'atp/country/AU': 8,
 'atp/field/city/missing': 8,
 'atp/field/country/from_spider_name': 8,
 'atp/field/name/missing': 8,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 8,
 'atp/field/operator_wikidata/missing': 8,
 'atp/field/postcode/missing': 8,
 'atp/field/state/missing': 8,
 'atp/field/street_address/missing': 8,
 'atp/field/twitter/missing': 8,
 'atp/item_scraped_host_count/www.adriatic.com.au': 8,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 8,
 'downloader/request_bytes': 27919,
 'downloader/request_count': 23,
 'downloader/request_method_count/GET': 23,
 'downloader/response_bytes': 1215091,
 'downloader/response_count': 23,
 'downloader/response_status_count/200': 23,
 'elapsed_time_seconds': 27.38836,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 21, 9, 34, 50, 496259, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5840845,
 'httpcompression/response_count': 23,
 'item_scraped_count': 8,
 'items_per_minute': 17.77777777777778,
 'log_count/DEBUG': 31,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 23,
 'responses_per_minute': 51.11111111111111,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 22,
 'scheduler/dequeued/memory': 22,
 'scheduler/enqueued': 22,
 'scheduler/enqueued/memory': 22,
 'start_time': datetime.datetime(2026, 5, 21, 9, 34, 23, 107899, tzinfo=datetime.timezone.utc)}
```