### PR TITLE
[EKO BG] Fix spider

### DIFF
--- a/locations/spiders/eko_bg.py
+++ b/locations/spiders/eko_bg.py
@@ -1,10 +1,20 @@
-from locations.categories import Categories
+from typing import Iterable
+
+from parsel import Selector
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.storefinders.lighthouse import LighthouseSpider
 
 
 class EkoBGSpider(LighthouseSpider):
     name = "eko_bg"
-    item_attributes = {"brand": "EKO", "brand_wikidata": "Q111603199", "extras": Categories.FUEL_STATION.value}
+    item_attributes = {"brand": "EKO", "brand_wikidata": "Q111603199"}
     allowed_domains = ["www.eko.bg"]
     start_urls = ["https://www.eko.bg/stations/karta-na-obektite/"]
     requires_proxy = True  # Imperva
+
+    def parse_item(self, item: Feature, location: Selector) -> Iterable[Feature]:
+        item["name"] = None
+        apply_category(Categories.FUEL_STATION, item)
+        yield item

--- a/locations/spiders/eko_bg.py
+++ b/locations/spiders/eko_bg.py
@@ -7,3 +7,4 @@ class EkoBGSpider(LighthouseSpider):
     item_attributes = {"brand": "EKO", "brand_wikidata": "Q111603199", "extras": Categories.FUEL_STATION.value}
     allowed_domains = ["www.eko.bg"]
     start_urls = ["https://www.eko.bg/stations/karta-na-obektite/"]
+    requires_proxy = True  # Imperva


### PR DESCRIPTION
The site is now behind Imperva WAF. Unproxied requests return HTTP 403
with `x-cdn: Imperva` and Incapsula session cookies, so the spider
scrapes zero items.

Move to `requires_proxy = True` (canonical ATP pattern for WAF-protected
sites — already used by ~20 spiders).