### PR TITLE
[Hammer DE] Fix spider

### DIFF
--- a/locations/spiders/hammer_de.py
+++ b/locations/spiders/hammer_de.py
@@ -7,6 +7,7 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_DE, OpeningHours, sanitise_day
 from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class HammerDESpider(SitemapSpider):
@@ -18,11 +19,11 @@ class HammerDESpider(SitemapSpider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
         item["branch"] = (
-            response.xpath('//h2[starts-with(normalize-space(text()),"Hammer Fachmarkt")]/text()')
+            response.xpath('//h2[starts-with(normalize-space(text()), "Hammer Fachmarkt")]/text()')
             .get()
             .removeprefix("Hammer Fachmarkt ")
         )
-        item["addr_full"] = response.xpath('//*[@id="brxe-vqslzw"]//li//span').xpath("normalize-space()").get()
+        item["addr_full"] = merge_address_lines(response.xpath('//*[@id="brxe-vqslzw"]//li[1]//span/text()').getall())
         item["phone"] = response.xpath('//*[contains(@href,"tel:")]//span//text()').get()
         item["email"] = response.xpath('//*[contains(@href,"mailto")]//span//text()').get()
         item["ref"] = item["website"] = response.url

--- a/locations/spiders/hammer_de.py
+++ b/locations/spiders/hammer_de.py
@@ -4,6 +4,7 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_DE, OpeningHours, sanitise_day
 from locations.items import Feature
 
@@ -16,7 +17,11 @@ class HammerDESpider(SitemapSpider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
-        item["branch"] = response.xpath("//h1/text()").get().removeprefix("Hammer ")
+        item["branch"] = (
+            response.xpath('//h2[starts-with(normalize-space(text()),"Hammer Fachmarkt")]/text()')
+            .get()
+            .removeprefix("Hammer Fachmarkt ")
+        )
         item["addr_full"] = response.xpath('//*[@id="brxe-vqslzw"]//li//span').xpath("normalize-space()").get()
         item["phone"] = response.xpath('//*[contains(@href,"tel:")]//span//text()').get()
         item["email"] = response.xpath('//*[contains(@href,"mailto")]//span//text()').get()
@@ -36,4 +41,5 @@ class HammerDESpider(SitemapSpider):
                 open_time, close_time = time.split(" - ")
                 oh.add_range(day=day, open_time=open_time.strip(), close_time=close_time.strip())
         item["opening_hours"] = oh
+        apply_category(Categories.SHOP_DOITYOURSELF, item)
         yield item


### PR DESCRIPTION
The site dropped the per-store `<h1>` element; the spider's
`response.xpath("//h1/text()").get()` returned `None`, raising
`AttributeError` on the subsequent `.removeprefix("Hammer ")` and
dropping 21 of 22 stores.

Switch the branch XPath to the per-store `<h2>` that starts with
"Hammer Fachmarkt" (present on both old and new templates) and
preserve the original "Hammer Fachmarkt " stripping intent so
branches are e.g. "Gießen" rather than "Fachmarkt Gießen".

Also add an explicit `apply_category(Categories.SHOP_DOITYOURSELF, item)`.

```python
{'atp/brand/Hammer': 22,
 'atp/brand_wikidata/Q52159668': 22,
 'atp/category/shop/doityourself': 22,
 'atp/country/DE': 22,
 'atp/nsi/perfect_match': 22,
 'item_scraped_count': 22}
```