### PR TITLE
[Fleet Feet US] Fix spider

### DIFF
--- a/locations/spiders/fleet_feet_us.py
+++ b/locations/spiders/fleet_feet_us.py
@@ -2,6 +2,7 @@ import re
 
 from scrapy import Spider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -10,22 +11,27 @@ class FleetFeetUSSpider(Spider):
     name = "fleet_feet_us"
     item_attributes = {"brand": "Fleet Feet", "brand_wikidata": "Q117062761"}
     start_urls = ["https://www.fleetfeet.com/locations"]
+    no_refs = True
 
     def parse(self, response, **kwargs):
         for location in response.xpath('//div[@class="location"]'):
             item = Feature()
             item["lat"] = location.xpath("./@data-lat").get()
             item["lon"] = location.xpath("./@data-lng").get()
-            item["branch"] = location.xpath("./h3/text()").get()
-            item["ref"] = item["website"] = response.urljoin(location.xpath(".//*[@href][last()]/@href").get())
+            item["branch"] = location.xpath("./h3//text()").get("").strip() or None
 
-            if addr := location.xpath('./p[@class="address"]/text()').getall():
-                if m := re.search(r"([. \w]+), (\w\w) (\d+)", addr[1].strip()):
-                    item["street_address"] = addr[0]
-                    item["city"] = m.group(1)
+            addr_lines = [s.strip() for s in location.xpath('./p[@class="address"]/text()').getall() if s.strip()]
+            city_idx = None
+            for i, line in enumerate(addr_lines):
+                if m := re.match(r"^(.+),\s*([A-Z]{2})\s+(\d{5})$", line):
+                    item["city"] = m.group(1).strip()
                     item["state"] = m.group(2)
                     item["postcode"] = m.group(3)
-                else:
-                    item["street_address"] = merge_address_lines([addr[0], addr[1]])
+                    city_idx = i
+                    break
+            if city_idx is not None and city_idx > 0:
+                item["street_address"] = merge_address_lines(addr_lines[:city_idx])
+
+            apply_category(Categories.SHOP_SHOES, item)
 
             yield item


### PR DESCRIPTION
Two site changes broke the spider together:

1. The store name was moved inside `<h3><button>`, so the original
   `./h3/text()` returned nothing.
2. The site consolidated per-store URLs into city-level slugs (e.g.
   `/s/birmingham`, now shared by every Birmingham store). Since the
   spider used that URL as `ref`, the duplicates pipeline collapsed
   multiple stores per city into one — BR yield fell from ~460 to 174.

Switch branch extraction to `./h3//text()`, set `no_refs = True`,
harden the multi-line address parsing to find the `City, ST ZIP` line
regardless of street formatting, drop the now-non-unique `website`
field, and add an explicit `apply_category(Categories.SHOP_SHOES, item)`.

```python
{'atp/brand/Fleet Feet': 290,
 'atp/brand_wikidata/Q117062761': 290,
 'atp/category/shop/shoes': 290,
 'atp/country/US': 290,
 'atp/field/city/missing': 1,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 1,
 'atp/field/street_address/missing': 1,
 'atp/nsi/perfect_match': 290,
 'item_scraped_count': 290}
```