### PR TITLE
[Fosters Freeze] Fix spider

### DIFF
--- a/locations/spiders/fosters_freeze_us.py
+++ b/locations/spiders/fosters_freeze_us.py
@@ -1,20 +1,30 @@
-from scrapy import Spider
+from typing import Iterable
 
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class FostersFreezeUSSpider(Spider):
+class FostersFreezeUSSpider(JSONBlobSpider):
     name = "fosters_freeze_us"
     item_attributes = {"brand": "Fosters Freeze", "brand_wikidata": "Q5473851"}
-    start_urls = ["https://www.fostersfreeze.com/locations/"]
-    no_refs = True
+    start_urls = [
+        "https://www.fostersfreeze.com/api/trpc/locations.list?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D%7D"
+    ]
+    locations_key = [0, "result", "data", "json"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response):
-        for location in response.xpath("//mappress-map/poi"):
-            lat, lon = location.xpath("@point").get().split(",")
-            yield Feature(
-                addr_full=location.xpath("@address").get(),
-                lat=lat,
-                lon=lon,
-                branch=location.xpath("@title").get().removeprefix("Fosters Freeze, "),
-            )
+    def pre_process_data(self, location: dict) -> None:
+        location["street_address"] = location.pop("address", None)
+        location.pop("name", None)
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["branch"] = location.get("label")
+        if hours := location.get("hours"):
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours)
+        apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
The site was rebuilt as an SPA; the old `<mappress-map/poi>` markup
is gone, and locations are now served from a tRPC API endpoint under
`/api/` (blocked by robots.txt).

Switch to `JSONBlobSpider` hitting the tRPC `locations.list` batch
endpoint, set `ROBOTSTXT_OBEY: False`, rename the API's `address`
field to `street_address`, drop the per-store `name` (so NSI fills
the brand-level "Fosters Freeze"), set `branch` from the API's
`label` field, parse the inline `hours` string via
`add_ranges_from_string`, and apply `Categories.FAST_FOOD`.

```python
{'atp/brand/Fosters Freeze': 58,
 'atp/brand_wikidata/Q5473851': 58,
 'atp/category/amenity/fast_food': 58,
 'atp/country/US': 58,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/state/from_reverse_geocoding': 56,
 'atp/field/state/missing': 2,
 'atp/nsi/perfect_match': 58,
 'item_scraped_count': 58}
```