### PR TITLE
[Howard Hanna] Fix spider

### DIFF
--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -11,10 +11,11 @@ class HowardHannaSpider(SitemapSpider):
     allowed_domains = ["howardhanna.com"]
     sitemap_urls = ["https://www.howardhanna.com/Seo/OfficeSitemap"]
     sitemap_rules = [(r"/Office/Detail/", "parse")]
+    requires_proxy = "US"  # Cloudflare bot protection
 
     def parse(self, response):
         info = response.css(".prop-main .row .row")[0]
-        addr_full = info.css("div.font-13.font-sm-16").xpath("normalize-space()").get()
+        addr_full = info.css("div.fs-13px.fs-md-16px").xpath("normalize-space()").get()
         properties = {
             "ref": response.url.split("/")[-1],
             "name": response.css("h1::text").get().strip(),


### PR DESCRIPTION
Site is now behind Cloudflare bot protection — every endpoint on
howardhanna.com returns HTTP 403 with `cf-mitigated: challenge` to
non-browser clients. Item count fell from 366 (BR 2026-05-07) to 0
(BR 2026-05-14).

Add `requires_proxy = "US"` so production routes via Zyte, and update
the `addr_full` CSS selector from `div.font-13.font-sm-16` (the old
Bootstrap utility classes) to `div.fs-13px.fs-md-16px` (the new ones)
to match the current page markup.