### PR TITLE
[VÚB banka SK] Add spider (701 locations)

### DIFF
--- a/locations/spiders/vub_sk.py
+++ b/locations/spiders/vub_sk.py
@@ -1,0 +1,38 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class VubSKSpider(Spider):
+    name = "vub_sk"
+    item_attributes = {"brand": "VÚB banka", "brand_wikidata": "Q12778981"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for location_type in ("BRANCH", "ATM"):
+            yield JsonRequest(
+                url="https://www.vub.sk/digitalServicesServlet/?operation=searchLocations&headers=lbsHeader&endpointName=searchLocations&locale=en&bank=VUB",
+                data={"search": {"locationType": location_type, "size": 1000, "start": 0}},
+                headers={
+                    "Origin": "https://www.vub.sk",
+                    "Referer": "https://www.vub.sk/ludia/pobocky-bankomaty.html",
+                },
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json().get("availableLocations", []):
+            item = DictParser.parse(poi)
+
+            if poi.get("type") == "BRANCH":
+                item["branch"] = item.pop("name", None)
+                apply_category(Categories.BANK, item)
+            elif poi.get("type") == "ATM":
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected VÚB location type: %s", poi.get("type"))
+                continue
+
+            yield item


### PR DESCRIPTION
Single POST per location type to VÚB's locator service; DictParser handles all field mapping. Branches use `branch = item.pop("name", None)` per the chain-bank convention; ATMs keep DictParser's `name` (venue label). NSI matches all 701 items via `Q12778981`.

**Data source**: `POST https://www.vub.sk/digitalServicesServlet/?operation=searchLocations&...` with `{"search": {"locationType": "BRANCH|ATM", "size": 1000, "start": 0}}`. Single POST per type returns up to 1000 locations.

**Category mapping** (via API's `type` field):
- `BRANCH` → `Categories.BANK` (151 items)
- `ATM` → `Categories.ATM` (550 items)

**Stats**:

```json
{
  "atp/brand/VÚB banka": 701,
  "atp/brand_wikidata/Q12778981": 701,
  "atp/category/amenity/bank": 151,
  "atp/category/amenity/atm": 550,
  "atp/country/SK": 701,
  "atp/nsi/cc_match": 701,
  "atp/operator/VÚB banka": 550,
  "atp/operator_wikidata/Q12778981": 550,
  "item_scraped_count": 701,
  "elapsed_time_seconds": 5.1,
  "finish_reason": "finished"
}
```

**Sample POIs**:

Bank in Bratislava:
```json
{
  "ref": "20030",
  "amenity": "bank",
  "name": "VÚB banka",
  "branch": "Bratislava Petržalka City, Magnifica pobočka",
  "addr:street": "Rusovská cesta",
  "addr:housenumber": "50",
  "addr:postcode": "851 01",
  "addr:city": "Bratislava",
  "addr:country": "SK",
  "phone": "+421 850 123 000",
  "email": "ba_petrzalka_city@vub.sk",
  "brand": "VÚB banka",
  "brand:wikidata": "Q12778981"
}
```

ATM at Kaufland Danubia:
```json
{
  "ref": "S6AV112O",
  "amenity": "atm",
  "name": "Kaufland Danubia",
  "addr:street": "Panónska cesta",
  "addr:housenumber": "16",
  "addr:postcode": "85104",
  "addr:city": "Bratislava",
  "addr:country": "SK",
  "brand": "VÚB banka",
  "brand:wikidata": "Q12778981",
  "operator": "VÚB banka",
  "operator:wikidata": "Q12778981"
}
```

**Wikidata**:

```
$ uv run scrapy nsi --code Q12778981
"Všeobecná úverová banka", "Q12778981"
  -> commercial bank located in Slovakia
  -> {amenity:atm,  brand:VÚB banka, ...}   (vubbanka-6843ee)   [sk]
  -> {amenity:bank, brand:VÚB banka, ...}   (vubbanka-6a1dfb)   [sk]
```