### PR TITLE
[Jigsaw GB] Fix spider

### DIFF
--- a/locations/spiders/jigsaw_gb.py
+++ b/locations/spiders/jigsaw_gb.py
@@ -3,6 +3,7 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -10,14 +11,14 @@ from locations.hours import OpeningHours
 class JigsawGBSpider(Spider):
     name = "jigsaw_gb"
     item_attributes = {"brand": "Jigsaw", "brand_wikidata": "Q6192383"}
-    start_urls = ["https://jigsawimagestorage.blob.core.windows.net/jigsaw/google-map-data.json"]
+    start_urls = ["https://www.jigsaw-online.com/cdn/shop/t/619/assets/jigsaw-stores.json"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["features"]:
             newlocation = {key.replace("branch_", ""): value for key, value in location["properties"].items()}
             item = DictParser.parse(newlocation)
             item["branch"] = newlocation["name"]
-            item["name"] = "Jigsaw"
+            item["name"] = None
             item["street_address"] = newlocation["address_2"]
             item["lon"], item["lat"] = location["geometry"]["coordinates"]
 
@@ -26,12 +27,13 @@ class JigsawGBSpider(Spider):
             oh = oh.replace("</li><li>", ", ")
             oh = oh.replace("<li>", "")
             oh = oh.replace("</li>", "")
-            days = oh.split(", ")
-            for range in days:
+            for range in oh.split(", "):
                 day, time_range = range.split(": ")
                 time_range = time_range.replace(" ", "")
                 if "closed" not in time_range.lower():
                     open_time, close_time = time_range.split("-")
                     opening_hours.add_range(day, open_time, close_time)
-                    item["opening_hours"] = opening_hours
+            item["opening_hours"] = opening_hours
+
+            apply_category(Categories.SHOP_CLOTHES, item)
             yield item


### PR DESCRIPTION
The old Azure blob storage host
`jigsawimagestorage.blob.core.windows.net` is DNS-dead (NXDOMAIN);
Jigsaw moved their storefinder data to a Shopify-hosted asset.

Point `start_urls` at the new Shopify-hosted JSON
(`https://www.jigsaw-online.com/cdn/shop/t/619/assets/jigsaw-stores.json`,
identical `branch_*`-prefixed GeoJSON schema as the dead endpoint),
let NSI fill `name` (instead of hardcoding `"Jigsaw"`), apply
`Categories.SHOP_CLOTHES`, and assign `OpeningHours` once after the
day loop rather than on every iteration.

```python
{'atp/brand/Jigsaw': 43,
 'atp/brand_wikidata/Q6192383': 43,
 'atp/category/shop/clothes': 43,
 'atp/country/GB': 42,
 'atp/country/IE': 1,
 'atp/field/email/missing': 43,
 'atp/field/twitter/missing': 43,
 'atp/nsi/perfect_match': 43,
 'item_scraped_count': 43}
```