### PR TITLE
[Joe & The Juice] Fix spider

### DIFF
--- a/locations/spiders/joe_and_the_juice.py
+++ b/locations/spiders/joe_and_the_juice.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -10,20 +10,21 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class JoeAndTheJuiceSpider(JSONBlobSpider):
     name = "joe_and_the_juice"
-    item_attributes = {"brand": "Joe & The Juice", "brand_wikidata": "Q26221514", "extras": Categories.CAFE.value}
+    item_attributes = {"brand": "Joe & The Juice", "brand_wikidata": "Q26221514"}
     allowed_domains = ["joepay-api.joejuice.com"]
-    start_urls = ["https://joepay-api.joejuice.com/me/stores"]
+    start_urls = ["https://joepay-api.joejuice.com/stores"]
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if not feature.get("isOpen"):
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        if not location.get("isVisible"):
             return
         item["branch"] = item.pop("name", None)
         item["opening_hours"] = OpeningHours()
-        for day_hours in feature.get("storeBusinessHours"):
+        for day_hours in location.get("storeBusinessHours", []):
             if day_hours["closed"]:
                 item["opening_hours"].set_closed(DAYS[day_hours["day"]])
             else:
                 item["opening_hours"].add_range(
                     DAYS[day_hours["day"]], day_hours["openTime"], day_hours["closeTime"], "%H%M"
                 )
+        apply_category(Categories.CAFE, item)
         yield item


### PR DESCRIPTION
The `/me/stores` endpoint returns an IP-geolocated subset — production
crawls saw the count swing 89/283/84/409/144 across recent runs as
the production egress IP varied between runs.

Switch `start_urls` to the canonical `/stores` (global list), replace
the `isOpen` quality filter with the structural `isVisible` filter,
add a defensive `[]` default on `storeBusinessHours`, apply
`Categories.CAFE` explicitly (and drop the equivalent
`item_attributes["extras"]`), and rename the post-process parameter
from `feature` to `location` per ATP naming convention.

```python
{'atp/brand/Joe & The Juice': 508,
 'atp/brand_wikidata/Q26221514': 508,
 'atp/category/amenity/cafe': 508,
 'atp/country/GB': 91,
 'atp/country/US': 86,
 'atp/country/DK': 81,
 'atp/country/SE': 43,
 'atp/country/NO': 35,
 'atp/country/AE': 33,
 'atp/country/SA': 25,
 'atp/country/FR': 21,
 'atp/country/NL': 19,
 'atp/country/KW': 18,
 'atp/country/CH': 12,
 'atp/country/QA': 10,
 'atp/country/FI': 7,
 'atp/country/IS': 7,
 'atp/country/BE': 5,
 'atp/country/LB': 4,
 'atp/country/GR': 2,
 'atp/country/DE': 2,
 'atp/country/EG': 1,
 'atp/country/IE': 1,
 'atp/country/MA': 1,
 'atp/country/MC': 1,
 'atp/country/MX': 1,
 'atp/country/OM': 1,
 'atp/nsi/perfect_match': 508,
 'item_scraped_count': 508}
```