### PR TITLE
[Manchu Wok] Fix spider

### DIFF
--- a/locations/spiders/manchu_wok_ca_us.py
+++ b/locations/spiders/manchu_wok_ca_us.py
@@ -1,3 +1,9 @@
+from typing import Iterable
+
+from parsel import Selector
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.storefinders.super_store_finder import SuperStoreFinderSpider
 
 
@@ -8,5 +14,10 @@ class ManchuWokCAUSSpider(SuperStoreFinderSpider):
         "brand": "Manchu Wok",
     }
     allowed_domains = [
-        "manchuwok.com",
+        "locations.manchuwok.com",
     ]
+
+    def parse_item(self, item: Feature, location: Selector) -> Iterable[Feature]:
+        item["branch"] = item.pop("name", None)
+        apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
The SuperStoreFinder XML feed moved from `manchuwok.com` to a
dedicated `locations.manchuwok.com` subdomain — the old URL returns
404.

Point `allowed_domains` at `locations.manchuwok.com`, override
`parse_item` to pop the per-store XML name into `branch` (so NSI
fills `name` with the brand canonical) and apply
`Categories.FAST_FOOD` explicitly.

```python
{'atp/brand/Manchu Wok': 88,
 'atp/brand_wikidata/Q6747622': 88,
 'atp/category/amenity/fast_food': 88,
 'atp/country/CA': 69,
 'atp/country/KR': 1,
 'atp/country/US': 18,
 'atp/field/phone/missing': 6,
 'atp/nsi/perfect_match': 88,
 'item_scraped_count': 88}
```