### PR TITLE
[FortyWinks AU] Fix spider

### DIFF
--- a/locations/spiders/forty_winks_au.py
+++ b/locations/spiders/forty_winks_au.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category, Categories
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider
@@ -15,32 +16,31 @@ class FortyWinksAUSpider(SitemapSpider, PlaywrightSpider, StructuredDataSpider):
     item_attributes = {"brand": "Forty Winks", "brand_wikidata": "Q106283438"}
     allowed_domains = ["www.fortywinks.com.au"]
     sitemap_urls = ["https://www.fortywinks.com.au/sitemap.xml"]
-    sitemap_rules = [(r"/store-finder/", "parse_sd")]
+    sitemap_rules = [(r"/store-finder/[^/]+/[^/]+/$", "parse_sd")]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    search_for_facebook = False
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["ref"] = response.url.strip("/").split("/")[-1]
         item["branch"] = item.pop("name").removeprefix("Forty Winks ")
+        item["image"] = None
 
         # Opening hours in JSON-LD is not the actual values
-        item["opening_hours"] = None
-
         # Extract real opening hours directly from the HTML list elements
+        oh = OpeningHours()
         if hours_elements := response.xpath("//ul[contains(@class, 'mb-6')]/li"):
-            oh = OpeningHours()
             for li in hours_elements:
                 day_text = "".join(li.xpath("./div[1]/text()").getall()).strip()
                 time_text = "".join(li.xpath("./div[2]/text()").getall()).strip()
 
-                if not day_text or not time_text or "closed" in time_text.lower():
+                if not day_text or not time_text:
                     continue
 
-                open_t, close_t = time_text.split("-")
-                oh.add_range(day=day_text, open_time=open_t.strip(), close_time=close_t.strip(), time_format="%I:%M%p")
+                open_t, close_t = time_text.split(" - ")
+                oh.add_range(day_text, open_t, close_t, "%I:%M%p")
 
-            if oh:
-                item["opening_hours"] = oh
+        item["opening_hours"] = oh
 
-        item["image"] = item["facebook"] = None
+        apply_category(Categories.SHOP_BED, item)
 
         yield item

--- a/locations/spiders/forty_winks_au.py
+++ b/locations/spiders/forty_winks_au.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider

--- a/locations/spiders/forty_winks_au.py
+++ b/locations/spiders/forty_winks_au.py
@@ -1,64 +1,46 @@
-import json
-from datetime import datetime
-from typing import AsyncIterator
-from zoneinfo import ZoneInfo
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_FULL, OpeningHours
-
-STATE_TIMEZONES = {
-    "Australian Capital Territory": "Australia/Sydney",
-    "New South Wales": "Australia/Sydney",
-    "Northern Territory": "Australia/Darwin",
-    "Queensland": "Australia/Brisbane",
-    "South Australia": "Australia/Adelaide",
-    "Tasmania": "Australia/Hobart",
-    "Victoria": "Australia/Melbourne",
-    "Western Australia": "Australia/Perth",
-}
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FortyWinksAUSpider(Spider):
+class FortyWinksAUSpider(SitemapSpider, PlaywrightSpider, StructuredDataSpider):
     name = "forty_winks_au"
     item_attributes = {"brand": "Forty Winks", "brand_wikidata": "Q106283438"}
-    allowed_domains = ["fortywinks-prod.azure-api.net"]
-    start_urls = ["https://fortywinks-prod.azure-api.net/store-app/stores?storeUrl=undefined"]
+    allowed_domains = ["www.fortywinks.com.au"]
+    sitemap_urls = ["https://www.fortywinks.com.au/sitemap.xml"]
+    sitemap_rules = [(r"/store-finder/", "parse_sd")]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["ref"] = response.url.strip("/").split("/")[-1]
+        item["branch"] = item.pop("name").removeprefix("Forty Winks ")
 
-    def parse(self, response):
-        for location in response.json():
-            item = DictParser.parse(location)
-            item["ref"] = location["key"]
-            item["street_address"] = location["address"]["address"].replace(" , ", ", ")
-            if item["website"]:
-                item["website"] = "https://www.fortywinks.com.au/store-finder" + item["website"]
-            time_zone = ZoneInfo(STATE_TIMEZONES[item["state"]])
-            item["opening_hours"] = OpeningHours()
-            hours_dict = {}
-            for hours_raw in location["openingHours"]:
-                hours_json = json.loads(hours_raw)
-                hours_dict.update(hours_json)
-            for day_name, hours_ranges in hours_dict.items():
-                if not day_name:
-                    specified_day_names = list(filter(None, hours_dict.keys()))
-                    missing_day_names = list(set(DAYS_FULL) - set(specified_day_names))
-                    if len(missing_day_names) == 1:
-                        day_name = missing_day_names[0]
-                    else:
-                        self.logger.error(
-                            "Multiple missing day names in provided opening hours. Extracted opening hours data will be partially incomplete."
-                        )
-                        continue
-                for hours_range in hours_ranges:
-                    if not hours_range["Start"] or not hours_range["Finish"]:
-                        continue
-                    open_time = datetime.fromisoformat(hours_range["Start"]).astimezone(time_zone).strftime("%H:%M")
-                    close_time = datetime.fromisoformat(hours_range["Finish"]).astimezone(time_zone).strftime("%H:%M")
-                    item["opening_hours"].add_range(day_name, open_time, close_time)
-            yield item
+        # Opening hours in JSON-LD is not the actual values
+        item["opening_hours"] = None
+
+        # Extract real opening hours directly from the HTML list elements
+        if hours_elements := response.xpath("//ul[contains(@class, 'mb-6')]/li"):
+            oh = OpeningHours()
+            for li in hours_elements:
+                day_text = "".join(li.xpath("./div[1]/text()").getall()).strip()
+                time_text = "".join(li.xpath("./div[2]/text()").getall()).strip()
+
+                if not day_text or not time_text or "closed" in time_text.lower():
+                    continue
+
+                open_t, close_t = time_text.split("-")
+                oh.add_range(day=day_text, open_time=open_t.strip(), close_time=close_t.strip(), time_format="%I:%M%p")
+
+            if oh:
+                item["opening_hours"] = oh
+
+        item["image"] = item["facebook"] = None
+
+        yield item


### PR DESCRIPTION
```
{'atp/brand/Forty Winks': 115,
 'atp/brand_wikidata/Q106283438': 115,
 'atp/category/shop/bed': 115,
 'atp/country/AU': 115,
 'atp/field/operator/missing': 115,
 'atp/field/operator_wikidata/missing': 115,
 'atp/field/twitter/missing': 115,
 'atp/item_scraped_host_count/www.fortywinks.com.au': 115,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 115,
 'downloader/request_bytes': 48333,
 'downloader/request_count': 118,
 'downloader/request_method_count/GET': 118,
 'downloader/response_bytes': 10066448,
 'downloader/response_count': 118,
 'downloader/response_status_count/200': 118,
 'elapsed_time_seconds': 145.666448,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 22, 10, 29, 52, 486111, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 115,
 'items_per_minute': 47.58620689655173,
 'log_count/DEBUG': 7572,
 'log_count/INFO': 9,
 'log_count/WARNING': 6,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 118,
 'playwright/page_count/closed': 118,
 'playwright/page_count/max_concurrent': 6,
 'playwright/request_count': 3607,
 'playwright/request_count/aborted': 3489,
 'playwright/request_count/method/GET': 3607,
 'playwright/request_count/navigation': 118,
 'playwright/request_count/resource_type/document': 118,
 'playwright/request_count/resource_type/font': 116,
 'playwright/request_count/resource_type/image': 464,
 'playwright/request_count/resource_type/script': 2561,
 'playwright/request_count/resource_type/stylesheet': 348,
 'playwright/response_count': 118,
 'playwright/response_count/method/GET': 118,
 'playwright/response_count/resource_type/document': 118,
 'request_depth_max': 1,
 'response_received_count': 118,
 'responses_per_minute': 48.827586206896555,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 117,
 'scheduler/dequeued/memory': 117,
 'scheduler/enqueued': 117,
 'scheduler/enqueued/memory': 117,
 'start_time': datetime.datetime(2026, 5, 22, 10, 27, 26, 819663, tzinfo=datetime.timezone.utc)}
```