### PR TITLE
[PGA TOUR Superstore US] Fix spider

### DIFF
--- a/locations/spiders/pga_tour_superstore_us.py
+++ b/locations/spiders/pga_tour_superstore_us.py
@@ -10,6 +10,7 @@ class PgaTourSuperstoreUSSpider(CrawlSpider, StructuredDataSpider):
     start_urls = ["https://www.pgatoursuperstore.com/stores"]
     rules = [Rule(LinkExtractor(r"stores/detail\?StoreID=(\d+)$"), "parse")]
     drop_attributes = {"image"}
+    requires_proxy = "US"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if "Club Fittings" in item["name"]:


### PR DESCRIPTION
Cloudflare now serves a managed challenge (HTTP 403,
`cf-mitigated: challenge`) to non-US-IP requests on
pgatoursuperstore.com; the spider had been returning zero items.

Sets `requires_proxy = "US"` to route requests through Zyte's
US residential proxy.