### PR TITLE
[MaidenheadAquatics GB] Remove DOWNLOAD_HANDLERS to fix spider

### DIFF
--- a/locations/spiders/maidenhead_aquatics_gb.py
+++ b/locations/spiders/maidenhead_aquatics_gb.py
@@ -11,7 +11,6 @@ class MaidenheadAquaticsGBSpider(Spider):
     name = "maidenhead_aquatics_gb"
     item_attributes = {"brand": "Maidenhead Aquatics", "brand_wikidata": "Q120800751"}
     start_urls = ["https://www.fishkeeper.co.uk/storefinder"]
-    custom_settings = {"DOWNLOAD_HANDLERS": {"https": "scrapy.core.downloader.handlers.http2.H2DownloadHandler"}}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in json.loads(response.xpath("//@data-custommage-init").get())["locator"]["stores"]:


### PR DESCRIPTION
```
{'atp/brand/Maidenhead Aquatics': 139,
 'atp/brand_wikidata/Q120800751': 139,
 'atp/category/shop/pet': 139,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/addr_full': 127,
 'atp/clean_strings/branch': 10,
 'atp/clean_strings/lon': 1,
 'atp/country/GB': 139,
 'atp/field/city/missing': 139,
 'atp/field/country/from_spider_name': 139,
 'atp/field/email/missing': 139,
 'atp/field/opening_hours/missing': 139,
 'atp/field/operator/missing': 139,
 'atp/field/operator_wikidata/missing': 139,
 'atp/field/postcode/missing': 1,
 'atp/field/street_address/missing': 139,
 'atp/field/twitter/missing': 139,
 'atp/item_scraped_host_count/www.fishkeeper.co.uk': 139,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 139,
 'downloader/request_bytes': 677,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 210861,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.544761,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 25, 10, 47, 21, 583335, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 823082,
 'httpcompression/response_count': 2,
 'item_scraped_count': 139,
 'items_per_minute': 1042.5,
 'log_count/DEBUG': 141,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 25, 10, 47, 13, 38574, tzinfo=datetime.timezone.utc)}
```