### PR TITLE
[NicholsonsPubs GB] Use playwright to fix spider

### DIFF
--- a/locations/spiders/nicholsons_pubs_gb.py
+++ b/locations/spiders/nicholsons_pubs_gb.py
@@ -1,11 +1,14 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class NicholsonsPubsGBSpider(CrawlSpider, StructuredDataSpider):
+class NicholsonsPubsGBSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "nicholsons_pubs_gb"
     item_attributes = {"brand": "Nicholson's", "brand_wikidata": "Q113130666"}
     start_urls = ["https://www.nicholsonspubs.co.uk/ourvenues"]
     rules = [Rule(LinkExtractor("/restaurants/"), "parse_sd")]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS


### PR DESCRIPTION
```
{"atp/brand/Nicholson's": 79,
 'atp/brand_wikidata/Q113130666': 79,
 'atp/category/amenity/pub': 79,
 'atp/country/GB': 79,
 'atp/field/branch/missing': 79,
 'atp/field/email/missing': 79,
 'atp/field/operator/missing': 79,
 'atp/field/operator_wikidata/missing': 79,
 'atp/field/state/missing': 11,
 'atp/item_scraped_host_count/www.nicholsonspubs.co.uk': 79,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 79,
 'downloader/request_bytes': 52615,
 'downloader/request_count': 81,
 'downloader/request_method_count/GET': 81,
 'downloader/response_bytes': 7217036,
 'downloader/response_count': 81,
 'downloader/response_status_count/200': 81,
 'elapsed_time_seconds': 101.844462,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 25, 11, 29, 59, 884359, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 79,
 'items_per_minute': 46.93069306930693,
 'log_count/DEBUG': 5066,
 'log_count/INFO': 8,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 81,
 'playwright/page_count/closed': 81,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2406,
 'playwright/request_count/aborted': 2184,
 'playwright/request_count/method/GET': 2267,
 'playwright/request_count/method/POST': 139,
 'playwright/request_count/navigation': 83,
 'playwright/request_count/resource_type/document': 83,
 'playwright/request_count/resource_type/image': 466,
 'playwright/request_count/resource_type/other': 139,
 'playwright/request_count/resource_type/script': 1158,
 'playwright/request_count/resource_type/stylesheet': 560,
 'playwright/response_count': 222,
 'playwright/response_count/method/GET': 83,
 'playwright/response_count/method/POST': 139,
 'playwright/response_count/resource_type/document': 83,
 'playwright/response_count/resource_type/other': 139,
 'request_depth_max': 1,
 'response_received_count': 81,
 'responses_per_minute': 48.118811881188115,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 80,
 'scheduler/dequeued/memory': 80,
 'scheduler/enqueued': 80,
 'scheduler/enqueued/memory': 80,
 'start_time': datetime.datetime(2026, 5, 25, 11, 28, 18, 39897, tzinfo=datetime.timezone.utc)}
```