### PR TITLE
Fix: Add error logging to parquet generation script

### DIFF
--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import sys
+import traceback
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
@@ -9,7 +11,15 @@ import duckdb
 import pyarrow.parquet as pq
 
 logger = getLogger(__name__)
-logging.basicConfig(level=logging.INFO, filename="ndgeojson_to_parquet.log", filemode="a", encoding="utf-8")
+# Log to both file and stderr so errors appear in ECS logs
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler("ndgeojson_to_parquet.log", mode="a", encoding="utf-8"),
+        logging.StreamHandler(sys.stderr)
+    ]
+)
 
 
 def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
@@ -18,18 +28,25 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
         output_file_path.unlink()
 
     input_files_pattern = str(input_dir_path / "*.ndgeojson")
+    logger.info(f"Processing ndgeojson files matching: {input_files_pattern}")
 
     with TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "temp.db"
+        logger.info(f"Using DuckDB version: {duckdb.__version__}")
+        logger.info(f"Creating temporary database at: {db_path}")
         with duckdb.connect(db_path.as_posix()) as con:
+            logger.info("Installing spatial extension...")
             con.install_extension("spatial")
             con.load_extension("spatial")
+            logger.info("Spatial extension loaded successfully")
 
+            logger.info("Configuring DuckDB settings...")
             con.execute(f"SET temp_directory='{temp_dir}'")
             con.execute("SET memory_limit='8GB'")
             con.execute("SET threads=2")
             con.execute("SET preserve_insertion_order=false")
 
+            logger.info("Creating geojson_data table from ndgeojson files...")
             con.execute(f"""
             CREATE TABLE geojson_data AS
                 SELECT
@@ -49,18 +66,24 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
                         }}
                     );
             """)
+            logger.info("Table created successfully")
 
             # compute overall bbox and geometry types from the created table
+            logger.info("Computing bounding box...")
             bbox_res = con.execute(
                 "SELECT min(ST_XMin(geom)), min(ST_YMin(geom)), max(ST_XMax(geom)), max(ST_YMax(geom)) FROM geojson_data"
             ).fetchone()
+            logger.info(f"Bounding box: {bbox_res}")
 
+            logger.info("Computing geometry types...")
             geom_types_raw = con.execute("SELECT DISTINCT ST_GeometryType(geom) FROM geojson_data").fetchall()
             geom_types = [t[0] for t in geom_types_raw if t and t[0] is not None]
+            logger.info(f"Found geometry types: {geom_types}")
 
             # write parquet with a larger row group size (target 64-256 MB). 128MB chosen here.
             row_group_size = 134217728
 
+            logger.info(f"Writing parquet file with row group size {row_group_size}...")
             con.execute(f"""
             COPY (
                 SELECT
@@ -80,8 +103,9 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             ) TO '{str(output_file_path)}'
             (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE {row_group_size});
             """)
+            logger.info("Parquet file written successfully")
 
-            # Write GeoParquet metadata using pyarrow (pyarrow must be installed)
+            logger.info("Adding GeoParquet metadata...")
             table = pq.read_table(str(output_file_path))
 
             xmin, ymin, xmax, ymax = bbox_res
@@ -100,9 +124,11 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
 
             table = table.replace_schema_metadata(new_md)
 
+            logger.info("Writing final parquet file with metadata...")
             pq.write_table(table, str(output_file_path), compression="ZSTD")
 
-    logger.info(f"✓ Created {output_file_path}")
+    file_size = output_file_path.stat().st_size
+    logger.info(f"✓ Created {output_file_path} ({file_size:,} bytes)")
 
 
 def main() -> None:
@@ -116,11 +142,17 @@ def main() -> None:
     input_directory = Path(args.directory)
     output_file_path = Path(args.output)
 
-    ndgeojson_file_paths = list(input_directory.glob("*.ndgeojson"))
-    if not ndgeojson_file_paths:
-        raise FileNotFoundError(f"No NdGeoJSON files found in directory: {input_directory}")
+    try:
+        ndgeojson_file_paths = list(input_directory.glob("*.ndgeojson"))
+        if not ndgeojson_file_paths:
+            raise FileNotFoundError(f"No NdGeoJSON files found in directory: {input_directory}")
 
-    to_parquet(input_directory, output_file_path)
+        logger.info(f"Found {len(ndgeojson_file_paths)} ndgeojson files to process")
+        to_parquet(input_directory, output_file_path)
+    except Exception as e:
+        logger.error(f"Failed to create parquet file: {e}")
+        logger.error(traceback.format_exc())
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -14,11 +14,11 @@ logger = getLogger(__name__)
 # Log to both file and stderr so errors appear in ECS logs
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
         logging.FileHandler("ndgeojson_to_parquet.log", mode="a", encoding="utf-8"),
-        logging.StreamHandler(sys.stderr)
-    ]
+        logging.StreamHandler(sys.stderr),
+    ],
 )
 
 


### PR DESCRIPTION
## Problem
The weekly runs have been producing empty (0 byte) parquet files since April 4, 2026, coinciding with the DuckDB 1.5.0 → 1.5.1 upgrade (commit 9175efd67). 

All runs since April 4 show:
- ✅ PMTiles generation: Working (4+ GB files)
- ✅ Output zip: Working (2+ GB files)
- ❌ Parquet files: 0 bytes

The script was failing with a non-zero exit code, triggering the error message "Couldn't create parquet file from ndgeojsons, won't include in output" but the actual error details were only logged to a file (`ndgeojson_to_parquet.log`) that wasn't being uploaded to S3 or shown in the ECS logs.

## Changes
- **Log to stderr**: Errors now appear in ECS CloudWatch logs instead of only going to a file
- **Detailed diagnostics**: Added logging at each processing step to identify where failures occur
- **Version logging**: Log DuckDB version to confirm which version is actually running  
- **Better error handling**: Properly catch and report exceptions with full tracebacks
- **File size reporting**: Show output file size in success message

## Testing
This change improves observability without changing functionality. The next weekly run (or manual test) will now show detailed error messages in the ECS logs at `/ecs/atp-runallspiders` around the parquet generation step.

Once we see the actual error, we can determine if:
1. There's a bug in DuckDB 1.5.1+ spatial extension
2. We need to downgrade to DuckDB 1.5.0
3. A newer DuckDB version fixes the issue
4. The issue is something else entirely

## Related
- Last successful parquet: 2026-03-28 (2.5 GB)
- First failure: 2026-04-04 (0 bytes)
- DuckDB upgrade: March 30, 2026 (1.5.0 → 1.5.1)