### PR TITLE
Reduce log noise from xargs command execution

### DIFF
--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -74,7 +74,7 @@ else
 fi
 
 (>&2 echo "Running ${SPIDER_COUNT} spiders ${PARALLELISM} at a time")
-xargs -t -L 1 -P "${PARALLELISM}" -a "${SPIDER_RUN_DIR}/commands.txt" -i sh -c "{} || true"
+xargs -P "${PARALLELISM}" -a "${SPIDER_RUN_DIR}/commands.txt" -I CMD sh -c "CMD || true"
 
 retval=$?
 if [ ! $retval -eq 0 ]; then


### PR DESCRIPTION
## Problem
The weekly ECS runs produce massive amounts of log noise that makes troubleshooting difficult:
- **~4,674 lines** of command echoes (one per spider) cluttering CloudWatch logs
- xargs warning: `options --max-lines and --replace/-I/-i are mutually exclusive`

Example of noise (repeated 4,674 times):
```
sh -c 'timeout -k 15m 495m uv run scrapy crawl --output /tmp/output/output/walmart.geojson:geojson ...
```

This makes it hard to find actual issues in the logs (like the parquet generation failure we're investigating).

## Changes
1. **Remove `-t` flag**: Stop echoing every command to stderr
2. **Fix xargs warning**: Replace `-i` with `-I CMD` and remove `-L 1` (they're mutually exclusive)
3. **Maintain functionality**: Commands still run in parallel with error tolerance (`|| true`)

## Impact
- **Before**: ~4,674 lines of command echoes + warnings
- **After**: Clean logs with only essential script output
- Easier to spot real issues in CloudWatch logs
- Reduces CloudWatch storage costs

## Testing
Local testing shows the same behavior (parallel execution, error handling) without the noise.