### PR TITLE
[Pepe Jeans IN] Add Spider (190 locations)

### DIFF
--- a/locations/spiders/pepe_jeans_in.py
+++ b/locations/spiders/pepe_jeans_in.py
@@ -3,6 +3,7 @@ from typing import Any, AsyncIterator
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -25,4 +26,7 @@ class PepeJeansINSpider(Spider):
                 item = DictParser.parse(location)
                 item["branch"] = item.pop("name").replace("Pepe Jeans - ", "")
                 item["addr_full"] = merge_address_lines([item.pop("street_address"), location["address2"]])
+
+                apply_category(Categories.SHOP_CLOTHES, item)
+
                 yield item

--- a/locations/spiders/pepe_jeans_in.py
+++ b/locations/spiders/pepe_jeans_in.py
@@ -1,0 +1,28 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.dict_parser import DictParser
+from locations.geo import city_locations
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class PepeJeansINSpider(Spider):
+    name = "pepe_jeans_in"
+    item_attributes = {"brand": "Pepe Jeans", "brand_wikidata": "Q426992"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for city in city_locations("IN", 100000):
+            yield JsonRequest(
+                url=f"https://www.pepejeans.in/on/demandware.store/Sites-MIRAI-Site/default/Stores-FindStores?radius=4000.0&postalCode={city['name']}"
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if data := response.json().get("stores"):
+            for location in data:
+                item = DictParser.parse(location)
+                item["branch"] = item.pop("name").replace("Pepe Jeans - ", "")
+                item["addr_full"] = merge_address_lines([item.pop("street_address"), location["address2"]])
+                yield item


### PR DESCRIPTION
```python
{'atp/brand/Pepe Jeans': 190,
 'atp/brand_wikidata/Q426992': 190,
 'atp/category/shop/clothes': 190,
 'atp/cdn/cloudflare/response_count': 531,
 'atp/cdn/cloudflare/response_status_count/200': 531,
 'atp/country/IN': 190,
 'atp/duplicate_count': 240,
 'atp/field/country/from_reverse_geocoding': 71,
 'atp/field/email/missing': 190,
 'atp/field/opening_hours/missing': 190,
 'atp/field/operator/missing': 190,
 'atp/field/operator_wikidata/missing': 190,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/street_address/missing': 190,
 'atp/field/twitter/missing': 190,
 'atp/item_scraped_host_count/www.pepejeans.in': 430,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 190,
 'downloader/request_bytes': 1219095,
 'downloader/request_count': 531,
 'downloader/request_method_count/GET': 531,
 'downloader/response_bytes': 1801462,
 'downloader/response_count': 531,
 'downloader/response_status_count/200': 531,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 48.46022,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 5, 37, 56, 763450, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 531,
 'httpcompression/response_bytes': 1776696,
 'httpcompression/response_count': 531,
 'item_dropped_count': 240,
 'item_dropped_reasons_count/DropItem': 240,
 'item_scraped_count': 190,
 'items_per_minute': 237.5,
 'log_count/DEBUG': 971,
 'log_count/INFO': 3,
 'response_received_count': 531,
 'responses_per_minute': 663.75,
 'scheduler/dequeued': 531,
 'scheduler/dequeued/memory': 531,
 'scheduler/enqueued': 531,
 'scheduler/enqueued/memory': 531,
 'start_time': datetime.datetime(2026, 5, 26, 5, 37, 8, 303230, tzinfo=datetime.timezone.utc)}
 
```