### PR TITLE
[Hackett London] Fix spider

### DIFF
--- a/locations/spiders/hackett_london.py
+++ b/locations/spiders/hackett_london.py
@@ -1,28 +1,42 @@
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from typing import Any, AsyncIterator
+
+from scrapy.http import FormRequest, JsonRequest, Response
+from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class HackettLondonSpider(SitemapSpider, StructuredDataSpider):
+class HackettLondonSpider(Spider):
     name = "hackett_london"
     item_attributes = {"brand": "Hackett London", "brand_wikidata": "Q1136426"}
-    sitemap_urls = ["https://storelocator.hackett.com/sitemap.xml"]
-    sitemap_rules = [
-        ("https://storelocator.hackett.com/hackett-", "parse"),
-        # ("https://storelocator.hackett.com/hackett-london-regent-street-193-564e196a7412", "parse"),
-    ]
-    wanted_types = ["ClothingStore"]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        if item["name"].startswith("Hackett Outlet "):
-            item["branch"] = item.pop("name").removeprefix("Hackett Outlet ")
-            item["name"] = "Hackett Outlet"
-        else:
-            item["branch"] = item.pop("name").removeprefix("Hackett ").removeprefix("London ")
+    async def start(self) -> AsyncIterator[FormRequest]:
+        yield FormRequest(
+            url="https://www.hackett.com/mobify/slas/private/shopper/auth/v1/organizations/f_ecom_blrq_prd/oauth2/token",
+            formdata={
+                "grant_type": "refresh_token",
+                "refresh_token": "cZ5zAoHyxVCwqOccdo2EPeVG8sP8OWRiiMlx9DqrHhQ",  # refresh token (valid ~30 days), couldn't find a way to generate it dynamically.
+                "channel_id": "HKT-ES",
+                "dnt": "false",
+            },
+        )
 
-        apply_category(Categories.SHOP_CLOTHES, item)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        token = response.json()["access_token"]
+        yield JsonRequest(
+            url="https://www.hackett.com/mobify/proxy/api/store/shopper-stores/v1/organizations/f_ecom_blrq_prd/store-search?distanceUnit=km&latitude=0&longitude=0&maxDistance=20000&siteId=HKT-ES&limit=200",
+            headers={"Authorization": f"Bearer {token}"},
+            callback=self.parse_location,
+        )
 
-        yield item
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            location["address"] = merge_address_lines([location.pop("address1", None), location.pop("address2", None)])
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name").removeprefix("Hackett ").removeprefix("Outlet ")
+            if "Outlet" in location["name"]:
+                item["name"] = "Hackett London Outlet"
+            apply_category(Categories.SHOP_CLOTHES, item)
+            yield item


### PR DESCRIPTION
Last successful run yielded [124](https://alltheplaces-data.openaddresses.io/runs/2026-05-02-13-32-25/stats/hackett_london.json) locations. However, the current count appears to have dropped, as Spain alone previously contributed over 60 locations, but now only 9 are present.

```python
{'atp/brand/Hackett London': 68,
 'atp/brand_wikidata/Q1136426': 68,
 'atp/category/shop/clothes': 68,
 'atp/cdn/cloudflare/response_count': 3,
 'atp/cdn/cloudflare/response_status_count/200': 3,
 'atp/country/BE': 3,
 'atp/country/CH': 3,
 'atp/country/DE': 8,
 'atp/country/ES': 9,
 'atp/country/FR': 6,
 'atp/country/GB': 22,
 'atp/country/IE': 1,
 'atp/country/MX': 11,
 'atp/country/PT': 5,
 'atp/field/email/missing': 2,
 'atp/field/housenumber/missing': 68,
 'atp/field/opening_hours/missing': 68,
 'atp/field/operator/missing': 68,
 'atp/field/operator_wikidata/missing': 68,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 36,
 'atp/field/street/missing': 68,
 'atp/field/street_address/missing': 68,
 'atp/field/twitter/missing': 68,
 'atp/field/unit/missing': 68,
 'atp/item_scraped_host_count/www.hackett.com': 68,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 68,
 'downloader/request_bytes': 4253,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 11442,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.0,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 9, 9, 5, 132036, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 36846,
 'httpcompression/response_count': 3,
 'item_scraped_count': 68,
 'items_per_minute': 1020.0,
 'log_count/DEBUG': 71,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 26, 9, 9, 1, 128362, tzinfo=datetime.timezone.utc)}
```