### PR TITLE
[Sephora Asia] Fix spider

### DIFF
--- a/locations/spiders/sephora_asia.py
+++ b/locations/spiders/sephora_asia.py
@@ -1,14 +1,15 @@
 import json
 from typing import Any, AsyncIterator
 
-from scrapy import Request, Spider
+from scrapy import Request
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.user_agents import BROWSER_DEFAULT
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 COUNTRIES = {
     "SG": "www.sephora.sg",
@@ -21,10 +22,10 @@ COUNTRIES = {
 }
 
 
-class SephoraAsiaSpider(Spider):
+class SephoraAsiaSpider(PlaywrightSpider):
     name = "sephora_asia"
     item_attributes = {"brand": "Sephora", "brand_wikidata": "Q2408041"}
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     async def start(self) -> AsyncIterator[Request]:
         for cc, domain in COUNTRIES.items():


### PR DESCRIPTION
```
{'atp/brand/Sephora': 112,
 'atp/brand_wikidata/Q2408041': 112,
 'atp/category/shop/cosmetics': 112,
 'atp/clean_strings/branch': 8,
 'atp/clean_strings/phone': 18,
 'atp/clean_strings/street_address': 12,
 'atp/country/AU': 34,
 'atp/country/HK': 9,
 'atp/country/ID': 25,
 'atp/country/MY': 18,
 'atp/country/NZ': 2,
 'atp/country/SG': 11,
 'atp/country/TH': 13,
 'atp/field/city/missing': 112,
 'atp/field/email/missing': 112,
 'atp/field/housenumber/missing': 112,
 'atp/field/operator/missing': 112,
 'atp/field/operator_wikidata/missing': 112,
 'atp/field/phone/invalid': 6,
 'atp/field/postcode/missing': 112,
 'atp/field/state/missing': 112,
 'atp/field/street/missing': 112,
 'atp/field/twitter/missing': 112,
 'atp/field/unit/missing': 112,
 'atp/item_scraped_host_count/www.sephora.co.id': 25,
 'atp/item_scraped_host_count/www.sephora.co.th': 13,
 'atp/item_scraped_host_count/www.sephora.com.au': 34,
 'atp/item_scraped_host_count/www.sephora.hk': 9,
 'atp/item_scraped_host_count/www.sephora.my': 18,
 'atp/item_scraped_host_count/www.sephora.nz': 2,
 'atp/item_scraped_host_count/www.sephora.sg': 11,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 112,
 'downloader/request_bytes': 4703,
 'downloader/request_count': 14,
 'downloader/request_method_count/GET': 14,
 'downloader/response_bytes': 6901653,
 'downloader/response_count': 14,
 'downloader/response_status_count/200': 14,
 'elapsed_time_seconds': 14.125,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 9, 17, 43, 552462, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 112,
 'items_per_minute': 480.0,
 'log_count/DEBUG': 1691,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 14,
 'playwright/page_count/closed': 14,
 'playwright/page_count/max_concurrent': 7,
 'playwright/request_count': 788,
 'playwright/request_count/aborted': 741,
 'playwright/request_count/method/GET': 788,
 'playwright/request_count/navigation': 14,
 'playwright/request_count/resource_type/document': 14,
 'playwright/request_count/resource_type/fetch': 7,
 'playwright/request_count/resource_type/font': 14,
 'playwright/request_count/resource_type/image': 23,
 'playwright/request_count/resource_type/other': 251,
 'playwright/request_count/resource_type/script': 339,
 'playwright/request_count/resource_type/stylesheet': 140,
 'playwright/response_count': 14,
 'playwright/response_count/method/GET': 14,
 'playwright/response_count/resource_type/document': 14,
 'response_received_count': 14,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 7,
 'robotstxt/response_count': 7,
 'robotstxt/response_status_count/200': 7,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2026, 5, 26, 9, 17, 29, 415594, tzinfo=datetime.timezone.utc)}
```