### PR TITLE
[Shopko] Fix Spider

### DIFF
--- a/locations/spiders/shopko.py
+++ b/locations/spiders/shopko.py
@@ -1,24 +1,34 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class ShopkoSpider(Spider):
     name = "shopko"
     item_attributes = {"brand": "Shopko Optical", "brand_wikidata": "Q109228833"}
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
+    async def start(self) -> AsyncIterator[Any]:
         yield JsonRequest(
-            url="https://api.scheduler.fielmannusa.com/api/FindNearestRetailStores?bn=shopko",
-            data={"latitude": 41.8780025, "longitude": -93.097702},
+            url="https://api.scheduler.fielmannusa.com/api/auth/login",
+            headers={"user-agent": BROWSER_DEFAULT},
             method="POST",
         )
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        yield JsonRequest(
+            url="https://api.scheduler.fielmannusa.com/api/FindNearestRetailStores?bn=shopko",
+            data={"latitude": 41.8780025, "longitude": -93.097702},
+            headers={"authorization": "Bearer " + response.json()["token"]},
+            method="POST",
+            callback=self.parse_details,
+        )
+
+    def parse_details(self, response: Response) -> Any:
         for store in response.json():
             item = DictParser.parse(store)
             item["branch"] = item.pop("name")


### PR DESCRIPTION
```python
{'atp/brand/Shopko Optical': 156,
 'atp/brand_wikidata/Q109228833': 156,
 'atp/category/shop/optician': 156,
 'atp/country/US': 156,
 'atp/field/city/missing': 156,
 'atp/field/country/from_reverse_geocoding': 156,
 'atp/field/email/missing': 156,
 'atp/field/housenumber/missing': 156,
 'atp/field/operator/missing': 156,
 'atp/field/operator_wikidata/missing': 156,
 'atp/field/postcode/missing': 156,
 'atp/field/street/missing': 156,
 'atp/field/street_address/missing': 156,
 'atp/field/twitter/missing': 156,
 'atp/field/unit/missing': 156,
 'atp/item_scraped_host_count/api.scheduler.fielmannusa.com': 156,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 156,
 'downloader/request_bytes': 1307,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 2,
 'downloader/response_bytes': 75523,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/401': 1,
 'elapsed_time_seconds': 6.187999999994645,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 9, 20, 30, 946459, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 156,
 'items_per_minute': 1560.0,
 'log_count/DEBUG': 159,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/401': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 26, 9, 20, 24, 766246, tzinfo=datetime.timezone.utc)}
```