### PR TITLE
[Green Motion] Fix spider

### DIFF
--- a/locations/spiders/green_motion.py
+++ b/locations/spiders/green_motion.py
@@ -14,6 +14,7 @@ class GreenMotionSpider(JSONBlobSpider):
     start_urls = ["https://api.greenmotion.com/api/locations/?include=opening_days,country"]
     custom_settings = {"DOWNLOAD_TIMEOUT": 60}
     locations_key = "data"
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name")


### PR DESCRIPTION
Cloudflare on `api.greenmotion.com` blocks production egress IPs; the API itself is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)