### PR TITLE
[Harbor Freight Tools] Fix spider

### DIFF
--- a/locations/spiders/harbor_freight_tools_us.py
+++ b/locations/spiders/harbor_freight_tools_us.py
@@ -14,13 +14,15 @@ class HarborFreightToolsUSSpider(JSONBlobSpider):
     name = "harbor_freight_tools_us"
     item_attributes = {"brand": "Harbor Freight Tools", "brand_wikidata": "Q5654601"}
     allowed_domains = ["api.harborfreight.com"]
+    requires_proxy = True
     start_urls = [
         'https://api.harborfreight.com/graphql?operationName=FindStoresNearCoordinates&variables={"filter":{"status":"OPEN"},"latitude":0,"longitude":0,"withDistance":true}&extensions={"persistedQuery":{"version":1,"sha256Hash":"3af6e542b419920c44979e2521ef6b73cd998b9089694f1c12f8f3c29edb7eb1"}}'
     ]
     locations_key = ["data", "findStoresNearCoordinates", "stores"]
     custom_settings = {
-        "DOWNLOAD_DELAY": 10
-    }  # Aggressive HTTP 403 rate limiting is used, robots.txt wants a delay of 10s
+        "DOWNLOAD_DELAY": 10,  # Aggressive HTTP 403 rate limiting is used, robots.txt wants a delay of 10s
+        "ZYTE_API_AUTOMAP_PARAMS": {"customHttpRequestHeaders": []},
+    }
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         # GraphQL query returns results in a 60mi radius.


### PR DESCRIPTION
PerimeterX on `api.harborfreight.com` newly returns the challenge body as HTTP 200, breaking the JSON parser at burst scale. Route via Zyte and suppress forwarded headers so PX accepts the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)