### PR TITLE
[M&T Bank] Fix spider

### DIFF
--- a/locations/spiders/mt_bank_us.py
+++ b/locations/spiders/mt_bank_us.py
@@ -66,11 +66,11 @@ class MtBankUSSpider(SitemapSpider, StructuredDataSpider):
             apply_category(Categories.BANK, item)
             apply_yes_no(Extras.ATM, item, cat == "Branch & ATM")
 
-            if not item.get("name") or not item["name"].startswith("M&T Bank in "):
+            if not item.get("name") or not item["name"].startswith("M&T Bank Branch & ATM: "):
                 # Duplicates, eg:
                 # https://locations.mtb.com/ma/agawam/bank-branches-and-atms-agawam-ma-8422.html
                 # https://locations.mtb.com/ma/agawam/bank-branches-and-atms-agawam-ma-sa7000.html
                 return
-            item["branch"] = item.pop("name").removeprefix("M&T Bank in ")
+            item["branch"] = item.pop("name").removeprefix("M&T Bank Branch & ATM: ")
 
         yield item


### PR DESCRIPTION
ld+json removed, replaced by HTML microdata; canonical name pattern changed from `"M&T Bank in <city>"` to `"M&T Bank Branch & ATM: <city>"` so the dedup-against-ATM-only-duplicate-pages filter no longer fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)