### PR TITLE
[Tuev Nord DE] Fix Spider

### DIFF
--- a/locations/spiders/tuev_nord_de.py
+++ b/locations/spiders/tuev_nord_de.py
@@ -1,24 +1,20 @@
 import json
+from typing import Any
 
 import scrapy
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 
 
 class TuevNordDESpider(scrapy.Spider):
-
     name = "tuev_nord_de"
     item_attributes = {"brand": "TÜV Nord", "brand_wikidata": "Q2463547"}
-    baseurl = ""
     start_urls = ["https://www.tuev-nord.de/de/privatkunden/tuev-stationen/"]
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data_locations = json.loads(response.xpath("//div/@data-locations").get())
         for location in data_locations:
-            location["street_address"] = location.pop("address")
-            location["zipcode"] = location.pop("plz")
-            location["name"] = location.pop("station")
-            location["ref"] = location["name"]
-            location["website"] = response.urljoin(location.pop("link"))
             item = DictParser.parse(location)
+            item["website"] = response.urljoin(location.pop("link"))
             yield item

--- a/locations/spiders/tuev_nord_de.py
+++ b/locations/spiders/tuev_nord_de.py
@@ -16,5 +16,6 @@ class TuevNordDESpider(scrapy.Spider):
         data_locations = json.loads(response.xpath("//div/@data-locations").get())
         for location in data_locations:
             item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
             item["website"] = response.urljoin(location.pop("link"))
             yield item


### PR DESCRIPTION
```python
{'atp/brand/TÜV Nord': 579,
 'atp/brand_wikidata/Q2463547': 579,
 'atp/category/amenity/vehicle_inspection': 579,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/postcode': 12,
 'atp/clean_strings/street': 2,
 'atp/country/DE': 579,
 'atp/field/branch/missing': 579,
 'atp/field/country/from_spider_name': 579,
 'atp/field/email/missing': 579,
 'atp/field/housenumber/missing': 579,
 'atp/field/opening_hours/missing': 579,
 'atp/field/operator/missing': 579,
 'atp/field/operator_wikidata/missing': 579,
 'atp/field/phone/missing': 579,
 'atp/field/state/missing': 579,
 'atp/field/street/missing': 9,
 'atp/field/street_address/missing': 579,
 'atp/field/twitter/missing': 579,
 'atp/field/unit/missing': 579,
 'atp/item_scraped_host_count/www.tuev-nord.de': 579,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 579,
 'downloader/request_bytes': 1273,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 199753,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 5.468000000008033,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 11, 0, 2, 133036, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3465856,
 'httpcompression/response_count': 2,
 'item_scraped_count': 579,
 'items_per_minute': 6948.0,
 'log_count/DEBUG': 582,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 5, 26, 10, 59, 56, 661610, tzinfo=datetime.timezone.utc)}
```