### PR TITLE
[Total Tools AU] Fix spider

### DIFF
--- a/locations/spiders/total_tools_au.py
+++ b/locations/spiders/total_tools_au.py
@@ -1,27 +1,35 @@
+import json
+from typing import Any, Iterable
+
 import scrapy
+from scrapy.http import Response
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.spiders.outdoor_supply_hardware_us import decode_email
 
 
-class TotalToolsAUSpider(scrapy.Spider):
+class TotalToolsAUSpider(PlaywrightSpider):
     name = "total_tools_au"
     item_attributes = {"brand": "Total Tools", "brand_wikidata": "Q116779059"}
     allowed_domains = ["www.totaltools.com.au"]
     start_urls = ["https://www.totaltools.com.au/totaltools_storelocator/index/loadStoreRewrite"]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
-    def parse(self, response):
-        for store in response.json()["storesjson"]:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in json.loads(response.xpath("//pre/text()").get())["storesjson"]:
             item = DictParser.parse(store)
             item["ref"] = store["storelocator_id"]
             item["street_address"] = item.pop("addr_full")
             item["website"] = "https://www.totaltools.com.au/" + store["rewrite_request_path"]
             yield scrapy.Request(url=item["website"], callback=self.parse_store_page, meta={"item": item})
 
-    def parse_store_page(self, response):
+    def parse_store_page(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
-        email_raw = response.xpath('//a[contains(@class, "group-info") and contains(@href, "mailto:")]/@href').get()
-        item["email"] = email_raw.split(":", 1)[1]
+        item["email"] = decode_email(response.xpath("//@data-cfemail").get(""))
         hours_raw = (
             " ".join(response.xpath('//div[@id="open_hour"]/div/table/tbody/tr/td/text()').getall())
             .replace("-", " ")

--- a/locations/spiders/total_tools_au.py
+++ b/locations/spiders/total_tools_au.py
@@ -22,6 +22,7 @@ class TotalToolsAUSpider(PlaywrightSpider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in json.loads(response.xpath("//pre/text()").get())["storesjson"]:
             item = DictParser.parse(store)
+            item["branch"] = item.pop("name").removeprefix("Total Tools ")
             item["ref"] = store["storelocator_id"]
             item["street_address"] = item.pop("addr_full")
             item["website"] = "https://www.totaltools.com.au/" + store["rewrite_request_path"]

--- a/locations/spiders/total_tools_au.py
+++ b/locations/spiders/total_tools_au.py
@@ -30,6 +30,10 @@ class TotalToolsAUSpider(PlaywrightSpider):
     def parse_store_page(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
         item["email"] = decode_email(response.xpath("//@data-cfemail").get(""))
+        item["opening_hours"] = self.parse_opening_hours(response)
+        yield item
+
+    def parse_opening_hours(self, response: Response) -> OpeningHours:
         hours_raw = (
             " ".join(response.xpath('//div[@id="open_hour"]/div/table/tbody/tr/td/text()').getall())
             .replace("-", " ")
@@ -42,5 +46,4 @@ class TotalToolsAUSpider(PlaywrightSpider):
             if day[0] not in DAYS_EN:
                 continue
             oh.add_range(DAYS_EN[day[0]], day[1], day[2], "%H:%M")
-        item["opening_hours"] = oh.as_opening_hours()
-        yield item
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Total Tools': 130,
 'atp/brand_wikidata/Q116779059': 130,
 'atp/category/shop/hardware': 130,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/phone': 2,
 'atp/clean_strings/street_address': 5,
 'atp/country/AU': 130,
 'atp/field/country/from_spider_name': 130,
 'atp/field/housenumber/missing': 130,
 'atp/field/operator/missing': 130,
 'atp/field/operator_wikidata/missing': 130,
 'atp/field/street/missing': 130,
 'atp/field/twitter/missing': 130,
 'atp/field/unit/missing': 130,
 'atp/item_scraped_host_count/www.totaltools.com.au': 130,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 130,
 'downloader/request_bytes': 86097,
 'downloader/request_count': 132,
 'downloader/request_method_count/GET': 132,
 'downloader/response_bytes': 26331695,
 'downloader/response_count': 132,
 'downloader/response_status_count/200': 132,
 'elapsed_time_seconds': 162.59400000000096,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 11, 27, 43, 862890, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 130,
 'items_per_minute': 48.148148148148145,
 'log_count/DEBUG': 9952,
 'log_count/INFO': 9,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 132,
 'playwright/page_count/closed': 132,
 'playwright/page_count/max_concurrent': 5,
 'playwright/request_count': 4772,
 'playwright/request_count/aborted': 4608,
 'playwright/request_count/method/GET': 4772,
 'playwright/request_count/navigation': 132,
 'playwright/request_count/resource_type/document': 132,
 'playwright/request_count/resource_type/image': 262,
 'playwright/request_count/resource_type/script': 3208,
 'playwright/request_count/resource_type/stylesheet': 1170,
 'playwright/response_count': 132,
 'playwright/response_count/method/GET': 132,
 'playwright/response_count/resource_type/document': 132,
 'request_depth_max': 1,
 'response_received_count': 132,
 'responses_per_minute': 48.888888888888886,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 131,
 'scheduler/dequeued/memory': 131,
 'scheduler/enqueued': 131,
 'scheduler/enqueued/memory': 131,
 'start_time': datetime.datetime(2026, 5, 26, 11, 25, 1, 284100, tzinfo=datetime.timezone.utc)}
```