### PR TITLE
[Ag Warehouse AU] Fix errors (drop website attribute)

### DIFF
--- a/locations/spiders/ag_warehouse_au.py
+++ b/locations/spiders/ag_warehouse_au.py
@@ -5,3 +5,4 @@ class AgWarehouseAUSpider(AgileStoreLocatorSpider):
     name = "ag_warehouse_au"
     item_attributes = {"brand": "AG Warehouse", "brand_wikidata": "Q119261591"}
     allowed_domains = ["www.agwarehouse.com.au"]
+    drop_attributes = {"website"}


### PR DESCRIPTION
Website attribute was producing errors due to invalid values. There are no websites for individual pages being returned by this spider so the attribute should be dropped.