### PR TITLE
[mitsubishi_by_ru] split pois for sales and repair

### DIFF
--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -21,7 +21,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         extract_phone(item, Selector(text=feature["phone"]))
-        
+
         item["website"] = "https://" + feature["www"] if not feature["www"].startswith("http") else feature["www"]
         if "mitsubishi" not in item["website"]:  # Not a branded location
             return
@@ -39,4 +39,3 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
             repair_item = item.deepcopy()
             apply_category(Categories.SHOP_CAR_REPAIR, repair_item)
             yield repair_item
-

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -21,10 +21,22 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         extract_phone(item, Selector(text=feature["phone"]))
+        
         item["website"] = "https://" + feature["www"] if not feature["www"].startswith("http") else feature["www"]
         if "mitsubishi" not in item["website"]:  # Not a branded location
             return
 
-        apply_category(Categories.SHOP_CAR, item)
-        apply_yes_no(Extras.CAR_REPAIR, item, feature.get("service_partner") == "1")
-        yield item
+        is_shop = not feature.get("no_salon")
+        is_repair = feature.get("service_partner") == "1"
+
+        if is_shop:
+            shop_item = item.deepcopy()
+            apply_category(Categories.SHOP_CAR, shop_item)
+            apply_yes_no(Extras.CAR_REPAIR, shop_item, is_repair)
+            yield shop_item
+
+        if is_repair:
+            repair_item = item.deepcopy()
+            apply_category(Categories.SHOP_CAR_REPAIR, repair_item)
+            yield repair_item
+


### PR DESCRIPTION
```
{'atp/brand/Mitsubishi': 121,
 'atp/brand_wikidata/Q36033': 121,
 'atp/category/shop/car': 82,
 'atp/category/shop/car_repair': 39,
 'atp/clean_strings/addr_full': 1,
 'atp/country/BY': 4,
 'atp/country/RU': 117,
 'atp/field/branch/missing': 121,
 'atp/field/city/missing': 121,
 'atp/field/country/from_website_url': 121,
 'atp/field/email/missing': 121,
 'atp/field/housenumber/missing': 121,
 'atp/field/opening_hours/missing': 121,
 'atp/field/operator/missing': 121,
 'atp/field/operator_wikidata/missing': 121,
 'atp/field/postcode/missing': 121,
 'atp/field/state/missing': 121,
 'atp/field/street/missing': 121,
 'atp/field/street_address/missing': 121,
 'atp/field/twitter/missing': 121,
 'atp/field/unit/missing': 121,
 'atp/item_scraped_host_count/www.mitsubishi-motors.ru': 121,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 121,
 'downloader/request_bytes': 739,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 40591,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.7823290870001074,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 26, 19, 27, 15, 836405, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 685719,
 'httpcompression/response_count': 2,
 'item_scraped_count': 121,
 'items_per_minute': 3630.0,
 'log_count/INFO': 3,
 'memusage/max': 287240192,
 'memusage/startup': 287240192,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 26, 19, 27, 13, 54074, tzinfo=datetime.timezone.utc)}
```