### PR TITLE
[WrenKitchens GB] Fix spider

### DIFF
--- a/locations/spiders/wren_kitchens_gb.py
+++ b/locations/spiders/wren_kitchens_gb.py
@@ -1,20 +1,25 @@
+from typing import Iterable
+
 from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class WrenKitchensGBSpider(CrawlSpider, StructuredDataSpider):
+class WrenKitchensGBSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "wren_kitchens_gb"
     item_attributes = {"brand": "Wren Kitchens", "brand_wikidata": "Q8037744"}
     allowed_domains = ["wrenkitchens.com"]
     start_urls = ["https://www.wrenkitchens.com/showrooms/"]
     rules = [Rule(LinkExtractor(allow=r"https:\/\/www\.wrenkitchens\.com\/showrooms\/([-\w]+)$"), callback="parse_sd")]
     wanted_types = ["HomeAndConstructionBusiness"]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
         item["website"] = response.url  # Some URLs redirect
         yield item


### PR DESCRIPTION
```
{'atp/brand/Wren Kitchens': 124,
 'atp/brand_wikidata/Q8037744': 124,
 'atp/category/shop/kitchen': 124,
 'atp/country/GB': 124,
 'atp/field/country/from_spider_name': 124,
 'atp/field/email/missing': 124,
 'atp/field/geometry/missing': 124,
 'atp/field/housenumber/missing': 124,
 'atp/field/image/dropped': 1,
 'atp/field/operator/missing': 124,
 'atp/field/operator_wikidata/missing': 124,
 'atp/field/street/missing': 124,
 'atp/field/unit/missing': 124,
 'atp/item_scraped_host_count/www.wrenkitchens.com': 124,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 124,
 'downloader/request_bytes': 60049,
 'downloader/request_count': 137,
 'downloader/request_method_count/GET': 137,
 'downloader/response_bytes': 70314347,
 'downloader/response_count': 137,
 'downloader/response_status_count/200': 137,
 'elapsed_time_seconds': 179.15700000000015,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 27, 5, 2, 25, 310384, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 124,
 'items_per_minute': 41.564245810055866,
 'log_count/DEBUG': 34302,
 'log_count/INFO': 9,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 137,
 'playwright/page_count/closed': 137,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 16951,
 'playwright/request_count/aborted': 16813,
 'playwright/request_count/method/GET': 16951,
 'playwright/request_count/navigation': 138,
 'playwright/request_count/resource_type/document': 138,
 'playwright/request_count/resource_type/image': 8981,
 'playwright/request_count/resource_type/media': 124,
 'playwright/request_count/resource_type/script': 6010,
 'playwright/request_count/resource_type/stylesheet': 1698,
 'playwright/response_count': 138,
 'playwright/response_count/method/GET': 138,
 'playwright/response_count/resource_type/document': 138,
 'request_depth_max': 1,
 'response_received_count': 137,
 'responses_per_minute': 45.9217877094972,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 136,
 'scheduler/dequeued/memory': 136,
 'scheduler/enqueued': 136,
 'scheduler/enqueued/memory': 136,
 'start_time': datetime.datetime(2026, 5, 27, 4, 59, 26, 160376, tzinfo=datetime.timezone.utc)}
```