### PR TITLE
[Five Guys CN] Fix spider

### DIFF
--- a/locations/spiders/five_guys_cn.py
+++ b/locations/spiders/five_guys_cn.py
@@ -1,18 +1,6 @@
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
-
-from locations.items import Feature
-from locations.spiders.five_guys_us import FIVE_GUYS_SHARED_ATTRIBUTES
-from locations.structured_data_spider import StructuredDataSpider
+from locations.spiders.five_guys_au import FiveGuysAUSpider
 
 
-class FiveGuysCNSpider(SitemapSpider, StructuredDataSpider):
+class FiveGuysCNSpider(FiveGuysAUSpider):
     name = "five_guys_cn"
-    item_attributes = FIVE_GUYS_SHARED_ATTRIBUTES
-    sitemap_urls = ["https://restaurants.fiveguys.cn/sitemap.xml"]
-    sitemap_rules = [(r"restaurants\.fiveguys\.cn/en/(?!search$)[^/]+$", "parse_sd")]
-    wanted_types = ["FastFoodRestaurant"]  # Explicitly mention the type to ignore duplicate linked data
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["website"] = response.url
-        yield item
+    experience_key = "search-backend-cn"


### PR DESCRIPTION
Site dropped the `/en/` path segment from store URLs, so the existing sitemap regex matches zero URLs.

Switched to the Yext Answers backend (`experience_key="search-backend-cn"`) by subclassing `FiveGuysAUSpider`, matching the rest of the Five Guys family.

Local crawl: 5 items, all NSI perfect_match.