### PR TITLE
mitsubishi_vn: split POIs into sales and service, add opening hours

### DIFF
--- a/locations/spiders/mitsubishi_vn.py
+++ b/locations/spiders/mitsubishi_vn.py
@@ -1,5 +1,19 @@
+from copy import deepcopy
+from datetime import datetime
+
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
+
+DAYS_VN = {
+    "Thứ 2": "Mo",
+    "Thứ 3": "Tu",
+    "Thứ 4": "We",
+    "Thứ 5": "Th",
+    "Thứ 6": "Fr",
+    "Thứ 7": "Sa",
+    "Chủ nhật": "Su",
+}
 
 
 class MitsubishiVNSpider(JSONBlobSpider):
@@ -15,6 +29,26 @@ class MitsubishiVNSpider(JSONBlobSpider):
         feature.update(feature.pop("acf"))
         feature.update(feature.pop("dealer_location"))
 
+    def parse_hours(self, working_items):
+        oh = OpeningHours()
+        for entry in working_items:
+            day = DAYS_VN.get(entry.get("working_date", ""))
+            if not day:
+                continue
+            try:
+                open_str, close_str = entry["working_hour"].split(" - ")
+                for fmt in ["%I:%M:%S %p", "%I:%M %p"]:
+                    try:
+                        open_t = datetime.strptime(open_str.strip(), fmt).strftime("%H:%M")
+                        close_t = datetime.strptime(close_str.strip(), fmt).strftime("%H:%M")
+                        oh.add_range(day, open_t, close_t)
+                        break
+                    except ValueError:
+                        continue
+            except Exception:
+                continue
+        return oh
+
     def post_process_item(self, item, response, location):
         phone = location.get("phone", "")
 
@@ -26,23 +60,33 @@ class MitsubishiVNSpider(JSONBlobSpider):
         if isinstance(location.get("phone_services", []), list):
             phone_services = [p["phone_service"] for p in location["phone_services"]]
 
-        item["phone"] = "; ".join(filter(None, [phone] + phone_sales + phone_services))
-
         services = [s["id"] for s in location.get("dealer_service", [])]
+
+        service_hours = {}
+        for si in location.get("service_items", []):
+            name = si.get("\x1dservice_name", "").strip()
+            service_hours[name] = si.get("working_items", [])
 
         SALES = 219
         SERVICE_AND_PARTS = 220
         USED_CAR_SALES = 364
 
-        if SALES or USED_CAR_SALES in services:
-            apply_category(Categories.SHOP_CAR, item)
-            apply_yes_no(Extras.CAR_REPAIR, item, SERVICE_AND_PARTS in services)
-            apply_yes_no(Extras.CAR_PARTS, item, SERVICE_AND_PARTS in services)
-        elif SERVICE_AND_PARTS in services:
-            apply_category(Categories.SHOP_CAR_REPAIR, item)
-            apply_yes_no(Extras.CAR_PARTS, item, SERVICE_AND_PARTS in services)
+        if SALES in services or USED_CAR_SALES in services:
+            sales_item = deepcopy(item)
+            sales_item["ref"] = f"{item['ref']}-sales"
+            sales_item["phone"] = "; ".join(filter(None, phone_sales)) or phone
+            sales_item["opening_hours"] = self.parse_hours(service_hours.get("Bán hàng", []))
+            apply_category(Categories.SHOP_CAR, sales_item)
+            apply_yes_no(Extras.CAR_REPAIR, sales_item, SERVICE_AND_PARTS in services)
+            apply_yes_no(Extras.CAR_PARTS, sales_item, SERVICE_AND_PARTS in services)
+            apply_yes_no(Extras.USED_CAR_SALES, sales_item, USED_CAR_SALES in services)
+            yield sales_item
 
-        apply_yes_no(Extras.USED_CAR_SALES, item, USED_CAR_SALES in services)
-
-        # TODO: hours
-        yield item
+        if SERVICE_AND_PARTS in services:
+            service_item = deepcopy(item)
+            service_item["ref"] = f"{item['ref']}-service"
+            service_item["phone"] = "; ".join(filter(None, phone_services)) or phone
+            service_item["opening_hours"] = self.parse_hours(service_hours.get("Dịch vụ", []))
+            apply_category(Categories.SHOP_CAR_REPAIR, service_item)
+            apply_yes_no(Extras.CAR_PARTS, service_item, True)
+            yield service_item


### PR DESCRIPTION
## Changes

- Split each location into separate `shop=car` (sales) and `shop=car_repair` (service) items
- Sales item gets `CAR_REPAIR`, `CAR_PARTS` and `USED_CAR_SALES` extras where applicable
- Service item gets `CAR_PARTS` extra
- Phone assigned per department: `phone_sales` → sales, `phone_services` → service, with general `phone` as fallback
- Add opening hours from `service_items` using Vietnamese day mapping (`Thứ 2`–`Thứ 7`, `Chủ nhật`)
- Fix bug: `if SALES or USED_CAR_SALES in services` was always `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)