### PR TITLE
[Auntie Anne's GB] Fix spider

### DIFF
--- a/locations/spiders/auntie_annes_gb.py
+++ b/locations/spiders/auntie_annes_gb.py
@@ -4,6 +4,7 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response, TextResponse
 
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -24,16 +25,20 @@ class AuntieAnnesGBSpider(JSONBlobSpider):
         )
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
-        item["addr_full"] = feature["location"]["address"]["formatted"]
-        if feature["location"]["address"].get("postal_town"):
-            item["city"] = feature["location"]["address"]["postal_town"]
-        else:
-            item["city"] = feature["location"]["address"]["locality"]
+        if not isinstance(feature.get("location"), dict):
+            return
+        address = feature["location"]["address"]
+        item["addr_full"] = address["formatted"]
+        item["city"] = address.get("postal_town") or address.get("locality")
         item["lat"], item["lon"] = feature["location"]["geoPoint"]["lat"], feature["location"]["geoPoint"]["lng"]
         item["branch"] = item.pop("name")
-        item["country"] = feature["location"]["address"]["country"]
+        item["country"] = address["country"]
         item["opening_hours"] = OpeningHours()
-        time = str(feature["opening_hours"])
-        time = re.sub("<[^<]+?>", "", time)
+        time = re.sub("<[^<]+?>", "", str(feature.get("opening_hours") or ""))
         item["opening_hours"].add_ranges_from_string(time)
+        if store_image := feature.get("store_image"):
+            item["image"] = response.urljoin(store_image[0]["full"])
+        apply_yes_no(Extras.DELIVERY, item, feature.get("delivery_available"))
+        apply_yes_no(Extras.INDOOR_SEATING, item, feature.get("dinein_available"))
+        apply_category(Categories.FAST_FOOD, item)
         yield item


### PR DESCRIPTION
One store has malformed `"location": ""` (empty string instead of the usual nested dict). The unguarded loop crashed on that record and dropped the remaining 36 stores.

Added an `isinstance` check at the top of `post_process_item` and tolerated empty opening_hours. Also picked up `image`, `delivery`, `indoor_seating` (44 / 20 / 14 of 45 stores), and added `apply_category(Categories.FAST_FOOD, item)`.

Local crawl: 45 items.