### PR TITLE
[Circle K ] Fix Spider

### DIFF
--- a/locations/spiders/circle_k.py
+++ b/locations/spiders/circle_k.py
@@ -20,9 +20,21 @@ class CircleKSpider(Spider):
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for country in ["US", "CA"]:
-            yield JsonRequest(
-                url=f"https://api.circlek.com/us/ngrp-store-locator/v1/stations?bottomRightLongitude=180.0&bottomRightLatitude=-90.0&topLeftLongitude=-180.0&topLeftLatitude=90.0&maxResults=10000&country={country}&brand=CIRCLEK,COUCHE_TARD,HOLIDAY",
-            )
+            for lat_lon in [
+                (-125.0, 49.0, -115.0, 42.0),
+                (-115.0, 49.0, -105.0, 42.0),
+                (-105.0, 49.0, -95.0, 42.0),
+                (-95.0, 49.0, -85.0, 42.0),
+                (-85.0, 49.0, -75.0, 42.0),
+                (-125.0, 42.0, -115.0, 35.0),
+                (-115.0, 42.0, -105.0, 35.0),
+                (-105.0, 42.0, -95.0, 35.0),
+                (-95.0, 42.0, -85.0, 35.0),
+                (-180.0, 90.0, 180.0, -90.0),
+            ]:
+                yield JsonRequest(
+                    url=f"https://api.circlek.com/us/ngrp-store-locator/v1/stations?bottomRightLongitude={lat_lon[2]}&bottomRightLatitude={lat_lon[3]}&topLeftLongitude={lat_lon[0]}&topLeftLatitude={lat_lon[1]}&maxResults=2000&country={country}&brand=CIRCLEK,COUCHE_TARD,HOLIDAY",
+                )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():


### PR DESCRIPTION
```python
{'atp/brand/Circle K': 5084,
 'atp/brand/Couche-Tard': 617,
 'atp/brand/Holiday': 340,
 'atp/brand_wikidata/Q2836957': 617,
 'atp/brand_wikidata/Q3268010': 5084,
 'atp/brand_wikidata/Q5880490': 340,
 'atp/category/shop/convenience': 6041,
 'atp/clean_strings/phone': 5914,
 'atp/country/CA': 1460,
 'atp/country/US': 4581,
 'atp/duplicate_count': 1977,
 'atp/field/email/missing': 6041,
 'atp/field/housenumber/missing': 6041,
 'atp/field/opening_hours/missing': 6041,
 'atp/field/operator/missing': 6041,
 'atp/field/operator_wikidata/missing': 6041,
 'atp/field/phone/invalid': 5,
 'atp/field/phone/missing': 127,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/street/missing': 6041,
 'atp/field/twitter/missing': 6041,
 'atp/field/unit/missing': 6041,
 'atp/item_scraped_host_count/api.circlek.com': 8018,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 6041,
 'downloader/request_bytes': 10917,
 'downloader/request_count': 21,
 'downloader/request_method_count/GET': 21,
 'downloader/response_bytes': 871223,
 'downloader/response_count': 21,
 'downloader/response_status_count/200': 20,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 28.07799999997951,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 28, 8, 58, 43, 775888, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10363474,
 'httpcompression/response_count': 20,
 'item_dropped_count': 1977,
 'item_dropped_reasons_count/DropItem': 1977,
 'item_scraped_count': 6041,
 'items_per_minute': 12945.0,
 'log_count/DEBUG': 8167,
 'log_count/INFO': 3,
 'response_received_count': 21,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 20,
 'scheduler/dequeued/memory': 20,
 'scheduler/enqueued': 20,
 'scheduler/enqueued/memory': 20,
 'start_time': datetime.datetime(2026, 5, 28, 8, 58, 15, 704645, tzinfo=datetime.timezone.utc)}

```