### PR TITLE
[Itaka PL] Fix spider

### DIFF
--- a/locations/spiders/itaka_pl.py
+++ b/locations/spiders/itaka_pl.py
@@ -1,49 +1,39 @@
-from typing import Any
+from typing import Any, Iterable
 
+import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_PL, OpeningHours
+from locations.hours import OpeningHours, sanitise_day
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
 
 
 class ItakaPLSpider(Spider):
     name = "itaka_pl"
     item_attributes = {"brand": "Itaka", "brand_wikidata": "Q16560452"}
-    start_urls = ["https://www.itaka.pl/biura/ajax/get/all/?q=data"]
+    start_urls = ["https://www.itaka.pl/biura/"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for items in response.json()["data"]:
-            # ignoring "agent-prestizowy" and "agent-zwykly"
-            # which are travel agencies cooperating but not branded by Itaka
-            offices = []
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        data = dict(parse_rsc(rsc))
 
-            if "salon-firmowy" in items:
-                offices.extend(items["salon-firmowy"])
-
-            if "agent-franchising" in items:
-                offices.extend(items["agent-franchising"])
-
-            for office in offices:
-                details = office["showroom"]["library"]
-                item = DictParser.parse(details)
-                item["street_address"] = item.pop("street", None)
-                item["ref"] = office["showroom"]["id"]
-                if "fotos" in details:
-                    item["image"] = ";".join([f"https://www.itaka.pl{url}" for url in details["fotos"]])
-                item["website"] = f"https://www.itaka.pl/{details['www']}"
-
-                if opening_hours_day_array := details.get("opening_hours"):
-                    opening_hours = OpeningHours()
-                    for hours in opening_hours_day_array:
-                        if len(hours) != 2:
-                            continue
-
-                        days, hours_range = hours
-                        hours_range = hours_range.removesuffix("*")
-                        opening_hours.add_ranges_from_string(ranges_string=f"{days} {hours_range}", days=DAYS_PL)
-                    item["opening_hours"] = opening_hours
-
-                item.pop("name", None)
-
-                yield item
+        for office in DictParser.get_nested_key(data, "initialSalesOffices"):
+            item = DictParser.parse(office)
+            item["ref"] = str(office["id"])
+            item["street_address"] = item.pop("addr_full", None)
+            if office_website := office.get("website"):
+                item["website"] = f"https://www.itaka.pl/{office_website}"
+            if (main_image := office.get("mainImage")) and main_image.get("url"):
+                item["image"] = main_image["url"]
+            item["opening_hours"] = OpeningHours()
+            for day, hours in (office.get("openingHours") or {}).items():
+                if (day_code := sanitise_day(day)) and hours.get("from") and hours.get("to"):
+                    item["opening_hours"].add_range(day_code, hours["from"], hours["to"])
+            item.pop("name", None)
+            apply_category(Categories.SHOP_TRAVEL_AGENCY, item)
+            yield item


### PR DESCRIPTION
Site migrated to Next.js / React Server Components. The old `/biura/ajax/get/all/?q=data` AJAX endpoint returns 404. The full 212-office dataset now ships inside `self.__next_f.push()` RSC chunks on `/biura/`, keyed as `initialSalesOffices`.

Replaced the AJAX fetch with `parse_rsc + DictParser.get_nested_key("initialSalesOffices")` (same pattern as `budni_de` and `tortilla_gb`). Mapped the new dict-shape `openingHours` (`{weekday: {from, to}}`) via `sanitise_day` + `OpeningHours.add_range`. Picked up the per-store `mainImage.url`. Added `apply_category(Categories.SHOP_TRAVEL_AGENCY, item)`.

Local crawl: 212 items.