### PR TITLE
[HSBC TW] Fix Spider

### DIFF
--- a/locations/spiders/hsbc_tw.py
+++ b/locations/spiders/hsbc_tw.py
@@ -14,9 +14,11 @@ class HsbcTWSpider(StructuredDataSpider):
         for location in response.xpath('//*[@class="desktop"]//tbody//tr'):
             item = Feature()
             item["city"] = location.xpath("./td[1]//text()").get()
-            item["branch"] = location.xpath("./td[2]//text()").get()
+            item["branch"] = location.xpath("./td[2]//text()").get().removesuffix(" Branch")
             item["addr_full"] = location.xpath("./td[3]//text()").get()
             item["phone"] = location.xpath("./td[4]//text()").get()
             item["ref"] = location.xpath("./td[5]//text()").get()
+
             apply_category(Categories.BANK, item)
+
             yield item

--- a/locations/spiders/hsbc_tw.py
+++ b/locations/spiders/hsbc_tw.py
@@ -1,10 +1,7 @@
-from typing import Iterable
-
-import scrapy
 from requests_cache import Response
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.linked_data_parser import LinkedDataParser
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,28 +10,13 @@ class HsbcTWSpider(StructuredDataSpider):
     item_attributes = {"brand": "HSBC", "brand_wikidata": "Q5635861"}
     start_urls = ["https://www.hsbc.com.tw/en-tw/ways-to-bank/branch/"]
 
-    def iter_linked_data(self, response: Response) -> Iterable[dict]:
-        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
-            if ld_obj.get("address"):  # @type key is not present for the desired ld_data
-                yield ld_obj
-
-    def parse(self, response: Response, **kwargs):
-        for branch in response.xpath(r'//*[@class="desktop"]//td[2]').xpath("normalize-space()").getall():
-            url = (
-                "https://www.hsbc.com.tw/en-tw/branch-list/"
-                + branch.lower()
-                .replace("taoyuan branch", "tahsin branch")
-                .replace(" (bilingual branch)", "")
-                .replace(" ", "-")
-                + "/"
-            )
-            yield scrapy.Request(url=url, callback=self.parse_sd)
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("HSBC - ").removesuffix(" Branch")
-        for service in ld_data["hasOfferCatalog"]["itemListElement"]:
-            apply_yes_no(Extras.ATM, item, "atm" in service["itemOffered"]["name"].lower())
-
-        apply_category(Categories.BANK, item)
-
-        yield item
+    def parse(self, response: Response):
+        for location in response.xpath('//*[@class="desktop"]//tbody//tr'):
+            item = Feature()
+            item["city"] = location.xpath("./td[1]//text()").get()
+            item["branch"] = location.xpath("./td[2]//text()").get()
+            item["addr_full"] = location.xpath("./td[3]//text()").get()
+            item["phone"] = location.xpath("./td[4]//text()").get()
+            item["ref"] = location.xpath("./td[5]//text()").get()
+            apply_category(Categories.BANK, item)
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/HSBC': 26,
 'atp/brand_wikidata/Q5635861': 26,
 'atp/category/amenity/bank': 26,
 'atp/country/TW': 26,
 'atp/field/country/from_spider_name': 26,
 'atp/field/email/missing': 26,
 'atp/field/geometry/missing': 26,
 'atp/field/housenumber/missing': 26,
 'atp/field/opening_hours/missing': 26,
 'atp/field/operator/missing': 26,
 'atp/field/operator_wikidata/missing': 26,
 'atp/field/postcode/missing': 26,
 'atp/field/state/missing': 26,
 'atp/field/street/missing': 26,
 'atp/field/street_address/missing': 26,
 'atp/field/twitter/missing': 26,
 'atp/field/unit/missing': 26,
 'atp/item_scraped_host_count/www.hsbc.com.tw': 26,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 26,
 'downloader/request_bytes': 910,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23529,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.3280000000377186,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 28, 10, 29, 57, 123784, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 182656,
 'httpcompression/response_count': 2,
 'item_scraped_count': 26,
 'items_per_minute': 520.0,
 'log_count/DEBUG': 28,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 28, 10, 29, 53, 805344, tzinfo=datetime.timezone.utc)}
```