### PR TITLE
[Mendocino Farms US] Fix spider

### DIFF
--- a/locations/spiders/mendocino_farms_us.py
+++ b/locations/spiders/mendocino_farms_us.py
@@ -1,38 +1,56 @@
-from typing import Iterable
+from typing import Any, Iterable
 
-from scrapy.http import TextResponse
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+import chompjs
+from scrapy import Spider
+from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, sanitise_day
 from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.react_server_components import parse_rsc
 
 
-class MendocinoFarmsUSSpider(CrawlSpider, StructuredDataSpider):
+class MendocinoFarmsUSSpider(Spider):
     name = "mendocino_farms_us"
     item_attributes = {"brand": "Mendocino Farms", "brand_wikidata": "Q110671982"}
-    start_urls = ["https://www.mendocinofarms.com/locations"]
-    rules = [Rule(LinkExtractor(restrict_xpaths='//li[@class="location-item"]/a'), "parse")]
-    search_for_amenity_features = False
-    search_for_twitter = False
-    search_for_facebook = False
-    json_parser = "chompjs"  # Some pages include broken json eg https://www.mendocinofarms.com/locations/609-main
-    time_format = "%I:%M%p"
-    # The site lists both LocalBusiness and Restaurant. Both of these are accepded by StructuredDataSpider by default, so only allowing one removes duplicates.
-    wanted_types = ["LocalBusiness"]
+    start_urls = ["https://www.mendocinofarms.com/location-directory/"]
 
-    def pre_process_data(self, ld_data: dict, **kwargs) -> None:
-        for rule in ld_data["openingHoursSpecification"]:
-            if rule.get("opens") and "am" not in rule["opens"]:
-                rule["opens"] += "am"
-            if rule.get("closes") and "pm" not in rule["closes"]:
-                rule["closes"] += "pm"
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        data = dict(parse_rsc(rsc))
 
-    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["branch"] = item.pop("name")
-        item["website"] = response.url
+        for sublist in DictParser.iter_matching_keys(data, "items"):
+            for store in sublist:
+                if not store.get("status", {}).get("available"):
+                    continue
+                if "coming_soon" in (store.get("data") or {}).get("attributes", []):
+                    continue
 
-        apply_category(Categories.RESTAURANT, item)
+                item = DictParser.parse(store)
+                item["ref"] = str(store["id"])
+                item["branch"] = item.pop("name", None)
+                item["street_address"] = item.pop("street", None)
+                item["lat"] = store["address"].get("latitude")
+                item["lon"] = store["address"].get("longitude")
+                if slug := store.get("slug"):
+                    item["website"] = f"https://www.mendocinofarms.com/location-directory/{slug}/"
 
-        yield item
+                item["opening_hours"] = OpeningHours()
+                for day, slot in (store.get("hours") or {}).get("business", {}).items():
+                    if (day_code := sanitise_day(day)) and slot.get("start") and slot.get("end"):
+                        item["opening_hours"].add_range(
+                            day_code, slot["start"].split(" ", 1)[1][:5], slot["end"].split(" ", 1)[1][:5]
+                        )
+
+                additionals = store.get("additionals") or []
+                apply_yes_no(Extras.WIFI, item, "wi_fi" in additionals)
+                apply_yes_no(Extras.WHEELCHAIR, item, "has_wheelchair_accessible_entrance" in additionals)
+                apply_yes_no(Extras.TOILETS, item, "has_restroom" in additionals)
+                apply_yes_no(Extras.INDOOR_SEATING, item, "has_seating" in additionals)
+                apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, "has_wheelchair_accessible_restroom" in additionals)
+
+                apply_category(Categories.RESTAURANT, item)
+                yield item


### PR DESCRIPTION
Site replatformed to Next.js / React Server Components. The old `/locations` index no longer has `<li class="location-item">` links and per-store pages no longer ship ld+json — the data is now in `__next_f.push()` chunks on `/location-directory/`.

Rewrote as a plain `Spider` using `parse_rsc + DictParser.iter_matching_keys`, filtered out `coming_soon` / unavailable stores, parsed `hours.business` timestamps, and added `apply_category(Categories.RESTAURANT)`. Picked up the per-store `additionals` amenity flags (wifi, wheelchair, toilets, indoor_seating, toilets:wheelchair).

Local crawl: 95 items.