### PR TITLE
[Togo's US] Fix spider

### DIFF
--- a/locations/spiders/togos_us.py
+++ b/locations/spiders/togos_us.py
@@ -1,43 +1,46 @@
-from scrapy import Spider
+from typing import Any
 
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS, OpeningHours
-from locations.items import SocialMedia, set_social_media
+from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class TogosUSSpider(Spider):
+class TogosUSSpider(SitemapSpider):
     name = "togos_us"
     item_attributes = {"brand": "Togo's", "brand_wikidata": "Q3530375"}
-    start_urls = [
-        "https://www.togos.com/locations/getLocationJson?"
-        "northEastLat=90&"
-        "northEastLng=180&"
-        "northWestLat=90&"
-        "northWestLng=-180&"
-        "southEastLat=-90&"
-        "southEastLng=180&"
-        "southWestLat=-90&"
-        "southWestLng=-180"
-    ]
+    sitemap_urls = ["https://locations.togos.com/sitemap.xml"]
+    sitemap_rules = [(r"https://locations\.togos\.com/[a-z]{2}/[a-z0-9-]+/[a-z0-9-]+$", "parse")]
 
-    def parse(self, response):
-        for location in response.json()["markers"]:
-            if location.get("opening") == "Closed":
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        poi_js = response.xpath('//script[contains(., "W2GI.collection.poi")]/text()').get()
+        if not poi_js:
+            return
+        poi = chompjs.parse_js_object(poi_js[poi_js.index("W2GI.collection.poi") :].split("=", 1)[1])[0]
+
+        if poi.get("opening_status") != "open":
+            return
+
+        branch = poi.pop("name", None)
+        item = DictParser.parse(poi)
+        item["ref"] = item["website"] = response.url
+        item["branch"] = branch or None
+        item["street_address"] = merge_address_lines([poi.get("address1"), poi.get("address2")])
+        item["phone"] = poi.get("phone")
+
+        oh = OpeningHours()
+        for index, day_hours in enumerate(chompjs.parse_js_object(poi["bho"])):
+            if len(day_hours) != 2:
                 continue
+            open_time, close_time = day_hours
+            if not open_time or not close_time or open_time == "9999" or close_time == "9999":
+                continue
+            oh.add_range(DAYS_FROM_SUNDAY[index], open_time, close_time, time_format="%H%M")
+        item["opening_hours"] = oh
 
-            item = DictParser.parse(location)
-            item["street_address"] = item.pop("addr_full")
-            item["website"] = location["fields"].get("website")
-            item["extras"]["website:menu"] = location["fields"].get("menu_url")
-            set_social_media(item, SocialMedia.FACEBOOK, location["facebook_url"])
-            set_social_media(item, SocialMedia.YELP, location["yelp_url"])
-
-            oh = OpeningHours()
-            for day_hours in location["hours"].split(";"):
-                if day_hours.count(",") != 2:
-                    continue
-                day, open_time, close_time = day_hours.split(",")
-                oh.add_range(DAYS[int(day) - 1], open_time, close_time, time_format="%H%M")
-            item["opening_hours"] = oh
-
-            yield item
+        apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
Site replatformed to SOCi-hosted store locator at `locations.togos.com`. Old endpoint `www.togos.com/locations/getLocationJson` now 404s (CloudFront 301→404).

Rewrote as `SitemapSpider` over `locations.togos.com/sitemap.xml`, parsing inline `W2GI.collection.poi` JS var via `chompjs`. Picked up per-store `branch` from the poi `name` field (e.g. "Fullerton - N State College Blvd" disambiguates same-city stores) and merged `address2` (suite info, populated for ~57 of 139 stores) into `street_address`. Opening hours come from the JSON-encoded `bho` field (Sun-Sat indexed, `"9999"` treated as no-data). Skips entries with `opening_status != "open"` (2 not-yet-activated CA stores). Dropped the old per-store `website`/`facebook`/`yelp`/`menu_url` fields (new source does not expose them) and added `apply_category(Categories.FAST_FOOD, item)`.

Local crawl: 139 items.