### PR TITLE
[Urbn] Fix Spider

### DIFF
--- a/locations/spiders/urbn.py
+++ b/locations/spiders/urbn.py
@@ -1,19 +1,20 @@
 from typing import AsyncIterator
 
-from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class UrbnSpider(Spider):
+class UrbnSpider(PlaywrightSpider):
     name = "urbn"
     allowed_domains = ["www.anthropologie.com"]
     start_urls = ["https://www.anthropologie.com/api/misl/v1/stores/search"]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     brands = {
         "ANTHROPOLOGIE": {

--- a/locations/spiders/urbn.py
+++ b/locations/spiders/urbn.py
@@ -6,13 +6,14 @@ from scrapy.http import JsonRequest
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class UrbnSpider(Spider):
     name = "urbn"
     allowed_domains = ["www.anthropologie.com"]
     start_urls = ["https://www.anthropologie.com/api/misl/v1/stores/search"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     brands = {
         "ANTHROPOLOGIE": {


### PR DESCRIPTION
```python
{'atp/brand/Anthropologie': 261,
 'atp/brand/Free People': 279,
 'atp/brand/Urban Outfitters': 255,
 'atp/brand_wikidata/Q3552193': 255,
 'atp/brand_wikidata/Q4773903': 261,
 'atp/brand_wikidata/Q5499945': 279,
 'atp/category/shop/clothes': 795,
 'atp/clean_strings/name': 38,
 'atp/clean_strings/street_address': 7,
 'atp/country/AT': 1,
 'atp/country/BE': 3,
 'atp/country/CA': 19,
 'atp/country/DE': 17,
 'atp/country/DK': 2,
 'atp/country/ES': 4,
 'atp/country/FR': 6,
 'atp/country/GB': 67,
 'atp/country/IE': 2,
 'atp/country/IT': 1,
 'atp/country/NL': 7,
 'atp/country/PL': 1,
 'atp/country/SE': 2,
 'atp/country/US': 663,
 'atp/field/branch/missing': 795,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/housenumber/missing': 795,
 'atp/field/operator/missing': 795,
 'atp/field/operator_wikidata/missing': 795,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 795,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 13,
 'atp/field/street/missing': 795,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 795,
 'atp/field/unit/missing': 795,
 'atp/item_scraped_host_count/www.anthropologie.com': 795,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 795,
 'downloader/request_bytes': 301,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 357439,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 12.547000000020489,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 29, 9, 4, 5, 866642, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2927831,
 'httpcompression/response_count': 1,
 'item_scraped_count': 795,
 'items_per_minute': 3975.0,
 'log_count/DEBUG': 796,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 5.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 5, 29, 9, 3, 53, 308838, tzinfo=datetime.timezone.utc)}
```