### PR TITLE
[Victra US] Fix spider

### DIFF
--- a/locations/spiders/victra_us.py
+++ b/locations/spiders/victra_us.py
@@ -1,14 +1,15 @@
-from typing import Iterable
+from typing import Any, AsyncIterator, Iterable
 
+from scrapy import Request, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_EN
+from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
 from locations.items import Feature
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class VictraUSSpider(WPStoreLocatorSpider):
+class VictraUSSpider(Spider):
     name = "victra_us"
     item_attributes = {
         "brand": "Verizon",
@@ -17,14 +18,22 @@ class VictraUSSpider(WPStoreLocatorSpider):
         "operator_wikidata": "Q118402656",
     }
     allowed_domains = ["victra.com"]
-    iseadgg_countries_list = ["US"]
-    search_radius = 24
-    max_results = 50
-    days = DAYS_EN
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if branch_name := item.pop("name", None):
-            item["branch"] = branch_name.removeprefix(item.get("state", "") + "-")
+    async def start(self) -> AsyncIterator[Request]:
+        for lat, lon in country_iseadgg_centroids(["US"], 158):
+            yield Request(
+                url=f"https://victra.com/wp-json/vcsl/v1/stores?lat={lat}&lng={lon}&radius=100&max=500",
+                callback=self.parse,
+            )
 
-        apply_category(Categories.SHOP_MOBILE_PHONE, item)
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for store in response.json().get("stores"):
+            item = DictParser.parse(store)
+
+            item["branch"] = (
+                item.pop("name", None).replace(item.get("state", ""), "").replace("Verizon Store in ", "").strip(" -,")
+            )
+            item["addr_full"] = None
+
+            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+            yield item


### PR DESCRIPTION
SitemapSpider is also possible, but store detail pages and ld+json data on the site do not contain geometry. This API-based grid search ensures we obtain precise lat/lon coordinates for 100% of the crawled stores.

```
{'atp/brand/Verizon': 1483,
 'atp/brand_wikidata/Q919641': 1483,
 'atp/category/shop/mobile_phone': 1483,
 'atp/clean_strings/branch': 9,
 'atp/country/US': 1483,
 'atp/duplicate_count': 5517,
 'atp/field/country/from_spider_name': 1,
 'atp/field/email/missing': 1483,
 'atp/field/housenumber/missing': 1483,
 'atp/field/opening_hours/missing': 1483,
 'atp/field/phone/missing': 2,
 'atp/field/street/missing': 1483,
 'atp/field/twitter/missing': 1483,
 'atp/field/unit/missing': 1483,
 'atp/item_scraped_host_count/victra.com': 7000,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 1483,
 'atp/operator/Victra': 1483,
 'atp/operator_wikidata/Q118402656': 1483,
 'downloader/request_bytes': 133576,
 'downloader/request_count': 226,
 'downloader/request_method_count/GET': 226,
 'downloader/response_bytes': 1302728,
 'downloader/response_count': 226,
 'downloader/response_status_count/200': 226,
 'elapsed_time_seconds': 281.46900000000096,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 5, 29, 13, 33, 43, 541687, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6599773,
 'httpcompression/response_count': 226,
 'item_dropped_count': 5517,
 'item_dropped_reasons_count/DropItem': 5517,
 'item_scraped_count': 1483,
 'items_per_minute': 316.6548042704626,
 'log_count/DEBUG': 7226,
 'log_count/INFO': 7,
 'response_received_count': 226,
 'responses_per_minute': 48.256227758007114,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 225,
 'scheduler/dequeued/memory': 225,
 'scheduler/enqueued': 225,
 'scheduler/enqueued/memory': 225,
 'start_time': datetime.datetime(2026, 5, 29, 13, 29, 2, 76195, tzinfo=datetime.timezone.utc)}
```