### PR TITLE
[Easy Point TR] Fix Value Error to recover lost POIs

### DIFF
--- a/locations/spiders/easy_point_tr.py
+++ b/locations/spiders/easy_point_tr.py
@@ -36,8 +36,9 @@ class EasyPointTRSpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for item in response.json()["result"]:
             # fix malformed coordinates before giving it to the parser
-            item["latitude"] = parse_float_like_coordinate(item["latitude"])
-            item["longitude"] = parse_float_like_coordinate(item["longitude"])
+            if item["latitude"] not in ["a.", ""]:
+                item["latitude"] = parse_float_like_coordinate(item["latitude"])
+                item["longitude"] = parse_float_like_coordinate(item["longitude"])
 
             d = DictParser.parse(item)
             d["opening_hours"] = parse_opening_hours(item["workingDays"])


### PR DESCRIPTION
```python
{'atp/brand/Easy Point': 51,
 'atp/brand_wikidata/Q131451912': 51,
 'atp/category/amenity/delivery_area': 89,
 'atp/category/amenity/parcel_locker': 51,
 'atp/category/amenity/yes': 9008,
 'atp/clean_strings/addr_full': 73,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/name': 11,
 'atp/clean_strings/postcode': 84,
 'atp/clean_strings/state': 8,
 'atp/clean_strings/street_address': 252,
 'atp/country/TR': 9148,
 'atp/field/branch/missing': 9148,
 'atp/field/brand/missing': 9097,
 'atp/field/brand_wikidata/missing': 9097,
 'atp/field/city/missing': 27,
 'atp/field/country/from_spider_name': 9148,
 'atp/field/email/invalid': 44,
 'atp/field/email/missing': 41,
 'atp/field/geometry/invalid': 2,
 'atp/field/geometry/missing': 74,
 'atp/field/housenumber/missing': 9148,
 'atp/field/opening_hours/missing': 138,
 'atp/field/operator/missing': 9148,
 'atp/field/operator_wikidata/missing': 9148,
 'atp/field/phone/invalid': 19,
 'atp/field/phone/missing': 3040,
 'atp/field/postcode/missing': 28,
 'atp/field/state/missing': 13,
 'atp/field/street/missing': 9148,
 'atp/field/street_address/missing': 4,
 'atp/field/twitter/missing': 9148,
 'atp/field/unit/missing': 9148,
 'atp/item_scraped_host_count/prod.easypointapi.com': 9148,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 51,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 2,
 'downloader/request_bytes': 2943,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 4,
 'downloader/response_bytes': 25272856,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 79.18799999999464,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 1, 8, 41, 40, 781905, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9148,
 'items_per_minute': 6947.848101265823,
 'log_count/DEBUG': 9153,
 'log_count/INFO': 4,
 'log_count/WARNING': 4,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 2.278481012658228,
 'retry/count': 2,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2026, 6, 1, 8, 40, 21, 591635, tzinfo=datetime.timezone.utc)}
```