### PR TITLE
[Mitre 10 AU] Fix spider

### DIFF
--- a/locations/spiders/mitre_10_au.py
+++ b/locations/spiders/mitre_10_au.py
@@ -1,32 +1,26 @@
-import json
-
-import scrapy
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class Mitre10AUSpider(StructuredDataSpider):
+class Mitre10AUSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "mitre_10_au"
     item_attributes = {"brand": "Mitre 10", "brand_wikidata": "Q6882393"}
     allowed_domains = ["mitre10.com.au"]
-    start_urls = ["https://www.mitre10.com.au/stores"]
-    requires_proxy = True
-
-    def parse(self, response):
-        data_raw = response.xpath(
-            '//div[contains(@class, "store-search")]/following::script[@type="text/x-magento-init"]/text()'
-        ).extract_first()
-        data_clean = " ".join(data_raw.splitlines()).replace("\\/", "/")
-        data_json = json.loads(data_clean)
-        stores = data_json["*"]["Magento_Ui/js/core/app"]["components"]["store-locator-search"]["markers"]
-        for store in stores:
-            yield scrapy.Request(response.urljoin(store["url"]), self.parse_sd)
+    sitemap_urls = ["https://www.mitre10.com.au/media/sitemap_retailer_mitre10.xml"]
+    sitemap_rules = [
+        (r"/stores/.+?-(\d+)$", "parse_sd"),
+    ]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item.pop("facebook")
         item.pop("image")
         item["branch"] = item.pop("name").removesuffix("Mitre 10")
         item["addr_full"] = response.xpath('//*[@class="address"]').xpath("normalize-space()").get()
+        item["website"] = response.url
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Mitre 10': 429,
 'atp/brand_wikidata/Q6882393': 429,
 'atp/category/shop/doityourself': 429,
 'atp/clean_strings/branch': 321,
 'atp/country/AU': 429,
 'atp/field/country/from_spider_name': 429,
 'atp/field/email/missing': 429,
 'atp/field/housenumber/missing': 429,
 'atp/field/operator/missing': 429,
 'atp/field/operator_wikidata/missing': 429,
 'atp/field/postcode/missing': 429,
 'atp/field/street/missing': 429,
 'atp/field/twitter/missing': 429,
 'atp/field/unit/missing': 429,
 'atp/item_scraped_host_count/www.mitre10.com.au': 429,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 429,
 'downloader/request_bytes': 191702,
 'downloader/request_count': 431,
 'downloader/request_method_count/GET': 431,
 'downloader/response_bytes': 484480915,
 'downloader/response_count': 431,
 'downloader/response_status_count/200': 431,
 'elapsed_time_seconds': 525.9219999999987,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 1, 9, 36, 14, 140705, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 429,
 'items_per_minute': 49.02857142857143,
 'log_count/DEBUG': 55493,
 'log_count/INFO': 15,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 431,
 'playwright/page_count/closed': 431,
 'playwright/page_count/max_concurrent': 3,
 'playwright/request_count': 27103,
 'playwright/request_count/aborted': 26661,
 'playwright/request_count/method/GET': 27098,
 'playwright/request_count/method/POST': 5,
 'playwright/request_count/navigation': 431,
 'playwright/request_count/resource_type/document': 431,
 'playwright/request_count/resource_type/font': 429,
 'playwright/request_count/resource_type/image': 6618,
 'playwright/request_count/resource_type/other': 5,
 'playwright/request_count/resource_type/script': 7986,
 'playwright/request_count/resource_type/stylesheet': 11634,
 'playwright/response_count': 436,
 'playwright/response_count/method/GET': 431,
 'playwright/response_count/method/POST': 5,
 'playwright/response_count/resource_type/document': 431,
 'playwright/response_count/resource_type/other': 5,
 'request_depth_max': 1,
 'response_received_count': 431,
 'responses_per_minute': 49.25714285714286,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 430,
 'scheduler/dequeued/memory': 430,
 'scheduler/enqueued': 430,
 'scheduler/enqueued/memory': 430,
 'start_time': datetime.datetime(2026, 6, 1, 9, 27, 28, 214253, tzinfo=datetime.timezone.utc)}

```