### PR TITLE
[HowardHanna] Fix spider

### DIFF
--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -16,6 +16,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class HowardHannaSpider(PlaywrightSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
+    requires_proxy = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "DOWNLOAD_DELAY": 5,
         "CONCURRENT_REQUESTS": 1,

--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -17,6 +17,8 @@ class HowardHannaSpider(PlaywrightSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "DOWNLOAD_DELAY": 5,
+        "CONCURRENT_REQUESTS": 1,
         "DEFAULT_REQUEST_HEADERS": {
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
@@ -24,7 +26,7 @@ class HowardHannaSpider(PlaywrightSpider):
             "Origin": "https://www.howardhanna.com",
             "Referer": "https://www.howardhanna.com/Office/Map",
             "User-Agent": BROWSER_DEFAULT,
-        }
+        },
     }
 
     async def start(self) -> AsyncIterator[Request]:

--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -16,10 +16,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class HowardHannaSpider(PlaywrightSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
-    requires_proxy = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "DOWNLOAD_DELAY": 5,
-        "CONCURRENT_REQUESTS": 1,
         "DEFAULT_REQUEST_HEADERS": {
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",

--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -1,43 +1,65 @@
+import json
 import re
+from typing import Any, AsyncIterator
 
-from scrapy.spiders import SitemapSpider
+import scrapy
+from scrapy import Request
+from scrapy.http import Response
 
-from locations.items import Feature
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class HowardHannaSpider(SitemapSpider):
+class HowardHannaSpider(PlaywrightSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
-    allowed_domains = ["howardhanna.com"]
-    sitemap_urls = ["https://www.howardhanna.com/Seo/OfficeSitemap"]
-    sitemap_rules = [(r"/Office/Detail/", "parse")]
-
-    def parse(self, response):
-        info = response.css(".prop-main .row .row")[0]
-        addr_full = info.css("div.font-13.font-sm-16").xpath("normalize-space()").get()
-        properties = {
-            "ref": response.url.split("/")[-1],
-            "name": response.css("h1::text").get().strip(),
-            "website": response.url,
-            "phone": info.xpath('.//*[@title="Phone"]/../..//a/text()').get(),
-            "extras": {
-                "fax": info.xpath('.//*[@title="Fax"]/../..//a/text()').get(),
-            },
-            "addr_full": addr_full,
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "DEFAULT_REQUEST_HEADERS": {
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+            "Origin": "https://www.howardhanna.com",
+            "Referer": "https://www.howardhanna.com/Office/Map",
+            "User-Agent": BROWSER_DEFAULT,
         }
-        yield response.follow(
-            response.css("a[href*=ViewOnStreet]")[0],
-            meta={"properties": properties},
-            callback=self.parse2,
-        )
+    }
 
-    def parse2(self, response):
-        properties = response.meta["properties"]
-        lat, lon = re.search(r"LatLng\('(.*)', '(.*)'\)", response.text).groups()
-        properties.update(
-            {
-                "lat": lat,
-                "lon": lon,
-            }
-        )
-        yield Feature(**properties)
+    async def start(self) -> AsyncIterator[Request]:
+        url = "https://www.howardhanna.com/Office/MapOffices"
+        formdata = {
+            "SouthLat": "10.236576558188718",
+            "WestLng": "-115.57812500000001",
+            "NorthLat": "59.53851123957454",
+            "EastLng": "-80.42187500000001",
+            "RadiusCenterPointLatitude": "NaN",
+            "RadiusCenterPointLongitude": "NaN",
+            "Location": "My Current Location",
+            "Radius": "10",
+            "OrderBy": "Closest",
+            "Polygon": "",
+        }
+
+        yield scrapy.FormRequest(url=url, method="POST", formdata=formdata, callback=self.parse)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # This fixes the JSONDecodeError by stripping the <pre> tag
+        for office in json.loads(response.xpath("//pre/text()").get()).get("Properties", []):
+            branch = office.get("OfficeName")
+            mls_number = office.get("MlsNumber")
+
+            item = DictParser.parse(office)
+            item["ref"] = mls_number
+            item["branch"] = branch
+            item["street_address"] = item.pop("addr_full")
+            item["website"] = f"https://www.howardhanna.com/Office/Detail/{self.slugify(branch)}/{mls_number}"
+
+            apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+
+            yield item
+
+    def slugify(self, text: str) -> str:
+        slug = re.sub(r"[^a-z0-9\s-]", "", re.split(r"\s-\s|/|\\|\s&\s", text)[0].lower())
+        return re.sub(r"\s+", "-", slug.strip())


### PR DESCRIPTION
Fixed the spider and it is working fine on US network.

```
{'atp/brand/Howard Hanna': 463,
 'atp/brand_wikidata/Q119573413': 463,
 'atp/category/office/estate_agent': 463,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/street_address': 6,
 'atp/country/US': 463,
 'atp/field/country/from_reverse_geocoding': 463,
 'atp/field/email/missing': 463,
 'atp/field/housenumber/missing': 463,
 'atp/field/opening_hours/missing': 463,
 'atp/field/operator/missing': 463,
 'atp/field/operator_wikidata/missing': 463,
 'atp/field/phone/missing': 463,
 'atp/field/street/missing': 463,
 'atp/field/twitter/missing': 463,
 'atp/field/unit/missing': 463,
 'atp/item_scraped_host_count/www.howardhanna.com': 463,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 463,
 'downloader/request_bytes': 1274,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 110518,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 9.108999999999469,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 1, 11, 57, 42, 177330, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 463,
 'items_per_minute': 3086.666666666667,
 'log_count/DEBUG': 474,
 'log_count/INFO': 7,
 'log_count/WARNING': 1,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/method/POST': 1,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 1, 11, 57, 33, 63946, tzinfo=datetime.timezone.utc)}
```