### PR TITLE
[Mountain Equipment Company CA] Fix Spider

### DIFF
--- a/locations/spiders/mountain_equipment_company_ca.py
+++ b/locations/spiders/mountain_equipment_company_ca.py
@@ -1,11 +1,14 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class MountainEquipmentCompanyCASpider(CrawlSpider, StructuredDataSpider):
+class MountainEquipmentCompanyCASpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "mountain_equipment_company_ca"
     item_attributes = {"brand_wikidata": "Q104867916"}
     start_urls = ["https://www.mec.ca/en/stores"]
     rules = [Rule(LinkExtractor(allow="/en/stores/"), callback="parse_sd")]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS


### PR DESCRIPTION
```python
{'atp/brand/MEC Mountain Equipment Company': 24,
 'atp/brand_wikidata/Q104867916': 24,
 'atp/category/shop/outdoor': 24,
 'atp/clean_strings/street_address': 2,
 'atp/country/CA': 24,
 'atp/field/branch/missing': 24,
 'atp/field/email/missing': 24,
 'atp/field/housenumber/missing': 24,
 'atp/field/opening_hours/missing': 24,
 'atp/field/operator/missing': 24,
 'atp/field/operator_wikidata/missing': 24,
 'atp/field/state/from_reverse_geocoding': 4,
 'atp/field/street/missing': 24,
 'atp/field/unit/missing': 24,
 'atp/item_scraped_host_count/www.mec.ca': 24,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 24,
 'downloader/request_bytes': 15080,
 'downloader/request_count': 26,
 'downloader/request_method_count/GET': 26,
 'downloader/response_bytes': 17492075,
 'downloader/response_count': 26,
 'downloader/response_status_count/200': 26,
 'elapsed_time_seconds': 80.09400000000005,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 1, 12, 4, 35, 661156, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 24,
 'items_per_minute': 18.0,
 'log_count/DEBUG': 1676,
 'log_count/INFO': 8,
 'log_count/WARNING': 24,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 26,
 'playwright/page_count/closed': 26,
 'playwright/page_count/max_concurrent': 7,
 'playwright/request_count': 799,
 'playwright/request_count/aborted': 773,
 'playwright/request_count/method/GET': 799,
 'playwright/request_count/navigation': 26,
 'playwright/request_count/resource_type/document': 26,
 'playwright/request_count/resource_type/font': 75,
 'playwright/request_count/resource_type/image': 100,
 'playwright/request_count/resource_type/script': 523,
 'playwright/request_count/resource_type/stylesheet': 75,
 'playwright/response_count': 26,
 'playwright/response_count/method/GET': 26,
 'playwright/response_count/resource_type/document': 26,
 'request_depth_max': 1,
 'response_received_count': 26,
 'responses_per_minute': 19.5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 25,
 'scheduler/dequeued/memory': 25,
 'scheduler/enqueued': 25,
 'scheduler/enqueued/memory': 25,
 'start_time': datetime.datetime(2026, 6, 1, 12, 3, 15, 552971, tzinfo=datetime.timezone.utc)}
```