### PR TITLE
[Motrio] Fix spider

### DIFF
--- a/locations/spiders/motrio.py
+++ b/locations/spiders/motrio.py
@@ -28,7 +28,6 @@ class MotrioSpider(Spider):
         for store in data.get("content"):
             store.update(store.pop("billingAddress"))
             item = DictParser.parse(store)
-            item["branch"] = item.pop("name")
             item["street_address"] = item.pop("street")
             if website := item.get("website"):
                 item["website"] = self.repair_website(website)

--- a/locations/spiders/motrio.py
+++ b/locations/spiders/motrio.py
@@ -1,7 +1,7 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -15,13 +15,15 @@ class MotrioSpider(Spider):
 
     def make_request(self, page: int, page_size: int = 100) -> JsonRequest:
         return JsonRequest(
-            "https://www.motrio.fr/api/establishments?domain=motrio&size={}&page={}".format(page_size, page)
+            "https://www.motrio.fr/web2c/establishments/by-location?domain=motrio&longitude=2.3513765&latitude=48.8575475&unit=KM&limitDistance=6000&size={}&page={}".format(
+                page_size, page
+            )
         )
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield self.make_request(0)
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         data = response.json()
         for store in data.get("content"):
             store.update(store.pop("billingAddress"))
@@ -49,7 +51,7 @@ class MotrioSpider(Spider):
         if not data["last"]:
             yield self.make_request(data["number"] + 1, data["size"])
 
-    def repair_website(self, website):
+    def repair_website(self, website: str) -> str | None:
         if any(keyword in website for keyword in ["maps.", "bing.com", "google", "|", "@"]):
             return None
 

--- a/locations/spiders/motrio.py
+++ b/locations/spiders/motrio.py
@@ -58,7 +58,5 @@ class MotrioSpider(Spider):
             if time in [" ", None, []]:
                 continue
             for open_close_time in time:
-                open_time = open_close_time.get("startAt")
-                close_time = open_close_time.get("endAt")
-                opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M:%S")
+                opening_hours.add_range(day, open_close_time.get("startAt"), open_close_time.get("endAt"), "%H:%M:%S")
         return opening_hours

--- a/locations/spiders/motrio.py
+++ b/locations/spiders/motrio.py
@@ -37,16 +37,7 @@ class MotrioSpider(Spider):
             if lat_lon := store.get("location"):
                 item["lon"], item["lat"] = lat_lon["coordinates"]
             apply_category(Categories.SHOP_CAR_REPAIR, item)
-            item["opening_hours"] = OpeningHours()
-            for day, time in store.get("timeTable").items():
-                if time in [" ", None, []]:
-                    continue
-                for open_close_time in time:
-                    open_time = open_close_time.get("startAt")
-                    close_time = open_close_time.get("endAt")
-                    item["opening_hours"].add_range(
-                        day=day, open_time=open_time, close_time=close_time, time_format="%H:%M:%S"
-                    )
+            item["opening_hours"] = self.parse_opening_hours(store.get("timeTable"))
             yield item
         if not data["last"]:
             yield self.make_request(data["number"] + 1, data["size"])
@@ -60,3 +51,14 @@ class MotrioSpider(Spider):
         elif "https://" not in website:
             website = "https://" + website
         return website
+
+    def parse_opening_hours(self, rules: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day, time in rules.items():
+            if time in [" ", None, []]:
+                continue
+            for open_close_time in time:
+                open_time = open_close_time.get("startAt")
+                close_time = open_close_time.get("endAt")
+                opening_hours.add_range(day=day, open_time=open_time, close_time=close_time, time_format="%H:%M:%S")
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/Motrio': 2553,
 'atp/brand_wikidata/Q6918585': 2553,
 'atp/category/shop/car_repair': 2553,
 'atp/clean_strings/branch': 98,
 'atp/clean_strings/city': 55,
 'atp/clean_strings/email': 2,
 'atp/clean_strings/phone': 27,
 'atp/clean_strings/postcode': 36,
 'atp/clean_strings/street_address': 135,
 'atp/clean_strings/website': 2,
 'atp/country/BE': 19,
 'atp/country/CZ': 33,
 'atp/country/DZ': 94,
 'atp/country/ES': 364,
 'atp/country/FR': 1360,
 'atp/country/GB': 39,
 'atp/country/HR': 21,
 'atp/country/HU': 4,
 'atp/country/IT': 278,
 'atp/country/MA': 15,
 'atp/country/PL': 95,
 'atp/country/PT': 49,
 'atp/country/RO': 40,
 'atp/country/RS': 15,
 'atp/country/SI': 11,
 'atp/country/SK': 9,
 'atp/country/TR': 107,
 'atp/duplicate_count': 2,
 'atp/field/city/missing': 1,
 'atp/field/housenumber/missing': 2553,
 'atp/field/opening_hours/missing': 61,
 'atp/field/operator/missing': 2553,
 'atp/field/operator_wikidata/missing': 2553,
 'atp/field/phone/invalid': 8,
 'atp/field/phone/missing': 10,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 1887,
 'atp/field/street/missing': 2553,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2553,
 'atp/field/unit/missing': 2553,
 'atp/item_scraped_host_count/www.motrio.fr': 2555,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2553,
 'downloader/request_bytes': 16171,
 'downloader/request_count': 26,
 'downloader/request_method_count/GET': 26,
 'downloader/response_bytes': 741397,
 'downloader/response_count': 26,
 'downloader/response_status_count/200': 26,
 'elapsed_time_seconds': 35.75,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 2, 7, 21, 43, 837748, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5101241,
 'httpcompression/response_count': 26,
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 2553,
 'items_per_minute': 4376.571428571428,
 'log_count/DEBUG': 2581,
 'log_count/INFO': 3,
 'request_depth_max': 25,
 'response_received_count': 26,
 'responses_per_minute': 44.57142857142857,
 'scheduler/dequeued': 26,
 'scheduler/dequeued/memory': 26,
 'scheduler/enqueued': 26,
 'scheduler/enqueued/memory': 26,
 'start_time': datetime.datetime(2026, 6, 2, 7, 21, 8, 90665, tzinfo=datetime.timezone.utc)}
```