### PR TITLE
[Great Wolf Resorts US] Fix spider

### DIFF
--- a/locations/spiders/great_wolf_resorts_us.py
+++ b/locations/spiders/great_wolf_resorts_us.py
@@ -1,6 +1,6 @@
-from re import search
-from urllib.parse import unquote
+from typing import Any
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
@@ -16,12 +16,10 @@ class GreatWolfResortsUSSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["www.greatwolf.com"]
     sitemap_urls = ["https://www.greatwolf.com/php-root.sitemap.xml"]
     sitemap_rules = [(r"/customer-service$", "parse_sd")]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Any, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         item.pop("facebook")
-        item.pop("image")
         item.pop("twitter")
-        has_map = unquote(ld_data["hasMap"])
-        item["lat"], item["lon"] = search(r"[@=](-?\d+\.\d+),(-?\d+\.\d+)", has_map).groups()
-
+        item["branch"] = item.pop("name").removeprefix("Great Wolf Lodge ")
         yield item

--- a/locations/spiders/great_wolf_resorts_us.py
+++ b/locations/spiders/great_wolf_resorts_us.py
@@ -3,16 +3,13 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class GreatWolfResortsUSSpider(SitemapSpider, StructuredDataSpider):
     name = "great_wolf_resorts_us"
-    item_attributes = {
-        "brand": "Great Wolf Resorts",
-        "brand_wikidata": "Q5600260",
-        "extras": {"leisure": "water_park"},
-    }
+    item_attributes = {"name": "Great Wolf Lodge", "brand": "Great Wolf Lodge", "brand_wikidata": "Q5600260"}
     allowed_domains = ["www.greatwolf.com"]
     sitemap_urls = ["https://www.greatwolf.com/php-root.sitemap.xml"]
     sitemap_rules = [(r"/customer-service$", "parse_sd")]
@@ -22,4 +19,6 @@ class GreatWolfResortsUSSpider(SitemapSpider, StructuredDataSpider):
         item.pop("facebook")
         item.pop("twitter")
         item["branch"] = item.pop("name").removeprefix("Great Wolf Lodge ")
+
+        apply_category({"leisure": "water_park"}, item)
         yield item


### PR DESCRIPTION
The sitemap (php-root.sitemap.xml) matches the robots.txt rule
`Disallow: /*-root`, so recent runs fetched nothing and produced 0
items. The same robots.txt also declares this sitemap via
`Sitemap: https://www.greatwolf.com/php-root.sitemap.xml`, so the
Disallow match is an incidental wildcard, not an intent to block it.

Set ROBOTSTXT_OBEY = False so the declared sitemap is fetched.
Coordinates now come from the ld+json geo block (the old hasMap regex
was dropped), and branch is taken from the per-store name.

The spider now also collects one image per store (the location-specific
hero image), which was previously being dropped.