### PR TITLE
[Vernyi RU] Fix spider

### DIFF
--- a/locations/spiders/vernyi_ru.py
+++ b/locations/spiders/vernyi_ru.py
@@ -7,7 +7,7 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class VernyiRUSpider(JSONBlobSpider):
     name = "vernyi_ru"
-    start_urls = ["https://www.verno-info.ru/shops"]
+    start_urls = ["https://verno-info.ru/shops"]
     item_attributes = {"brand_wikidata": "Q110037370"}
 
     def extract_json(self, response):
@@ -36,6 +36,6 @@ class VernyiRUSpider(JSONBlobSpider):
                         continue
                     open, close = time.replace(" ", "").replace("—", "-").replace(".", ":").split("-")
                     oh.add_days_range(days, open, close)
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
             except Exception as e:
                 self.logger.warning(f"Couldn't parse opening hours: {time_weekdays} {time_weekends}, {e}")


### PR DESCRIPTION
The www.verno-info.ru host is behind a QRATOR WAF that returns 403, so
recent runs produced 0 items.

Switched the start URL to the apex host (verno-info.ru), which serves
the same `var shops` JSON blob without the WAF block. Opening hours are
now assigned as an OpeningHours object rather than a pre-stringified
value.