### PR TITLE
[AceHardware] Add requires proxy to fix the spider

### DIFF
--- a/locations/spiders/ace_hardware.py
+++ b/locations/spiders/ace_hardware.py
@@ -6,4 +6,5 @@ class AceHardwareSpider(KiboSpider):
     name = "ace_hardware"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
+    requires_proxy = True
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}


### PR DESCRIPTION
On the US network, the spider returned ~1,000 shops. On my local setup, it returned the full count of 4,876 shops. This discrepancy indicates that the proxy is required to restore the complete scrape count. Enabling the proxy to ensure consistent results.

```
{'atp/brand/Ace Hardware': 4876,
 'atp/brand_wikidata/Q4672981': 4876,
 'atp/category/shop/doityourself': 4876,
 'atp/cdn/cloudflare/response_count': 6,
 'atp/cdn/cloudflare/response_status_count/200': 6,
 'atp/country/US': 4876,
 'atp/field/branch/missing': 4876,
 'atp/field/email/missing': 1239,
 'atp/field/housenumber/missing': 4876,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 4876,
 'atp/field/operator_wikidata/missing': 4876,
 'atp/field/phone/missing': 11,
 'atp/field/street/missing': 4876,
 'atp/field/twitter/missing': 4876,
 'atp/field/unit/missing': 4876,
 'atp/item_scraped_host_count/www.acehardware.com': 4876,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4876,
 'downloader/request_bytes': 12883,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 1169821,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'dupefilter/filtered': 3996,
 'elapsed_time_seconds': 19.311999999999898,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 2, 7, 58, 23, 900264, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 23118358,
 'httpcompression/response_count': 6,
 'item_scraped_count': 4876,
 'items_per_minute': 15397.894736842107,
 'log_count/DEBUG': 4883,
 'log_count/INFO': 3,
 'request_depth_max': 4,
 'response_received_count': 6,
 'responses_per_minute': 18.947368421052634,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2026, 6, 2, 7, 58, 4, 591707, tzinfo=datetime.timezone.utc)}
```