### PR TITLE
[Mondial Tissus FR] Fix spider

### DIFF
--- a/locations/spiders/mondialtissus_fr.py
+++ b/locations/spiders/mondialtissus_fr.py
@@ -1,5 +1,10 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -13,3 +18,10 @@ class MondialtissusFRSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"/tissu-mercerie/[\w-]+/[\w\d]+", "parse"),
     ]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 120}
+    drop_attributes = {"facebook", "phone"}
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["branch"] = item.pop("name", None)
+        apply_category({"shop": "fabric"}, item)
+        yield item


### PR DESCRIPTION
The store-locator pages respond slowly, so on the default 15s download
timeout almost every request timed out (recent runs: ~354 timeouts,
8 items scraped).

Raised DOWNLOAD_TIMEOUT to 120s so the pages load; the existing
microdata extraction then yields the full set (125 stores). Also takes
branch from the per-store name and applies shop=fabric. Drops phone
(85% of stores list only the shared head-office number) and the
brand-level facebook link.

Note: the pages are slow, so a full run takes ~5 minutes and the
2-minute PR fetch check times out mid-run (55 items scraped, no errors,
before the cap). A full local run completes cleanly at 125 items;
production runs are not capped at 2 minutes.