### PR TITLE
[Proper Job GB] Fix spider

### DIFF
--- a/locations/spiders/proper_job_gb.py
+++ b/locations/spiders/proper_job_gb.py
@@ -1,12 +1,48 @@
-from locations.categories import Categories
-from locations.hours import DAYS_EN
-from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+import html
+from typing import Any
+
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.structured_data_spider import extract_phone
 
 
-class ProperJobGBSpider(WPStoreLocatorSpider):
+class ProperJobGBSpider(SitemapSpider):
     name = "proper_job_gb"
-    item_attributes = {"brand_wikidata": "Q83741810", "brand": "Proper Job", "extras": Categories.SHOP_HARDWARE.value}
-    allowed_domains = [
-        "www.properjob.biz",
-    ]
-    days = DAYS_EN
+    item_attributes = {"brand": "Proper Job", "brand_wikidata": "Q83741810"}
+    sitemap_urls = ["https://www.properjob.biz/wpsl_stores-sitemap.xml"]
+    sitemap_rules = [(r"/stores/[^/]+/$", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        location = chompjs.parse_js_object(response.text[response.text.index("wpslMap_0") :])["locations"][0]
+        brand, _, branch = html.unescape(location["store"]).partition("–")
+        if brand.strip() != "Proper Job":
+            return
+
+        item = DictParser.parse(location)
+        item["addr_full"] = None
+        item["street_address"] = merge_address_lines([location["address"], location["address2"]])
+        item["website"] = response.url
+        item["branch"] = branch.strip()
+
+        extract_phone(item, response)
+        if item.get("phone") == "N/A":
+            item["phone"] = None
+
+        item["opening_hours"] = OpeningHours()
+        for rule in response.xpath('//table[@class="wpsl-opening-hours"]//tr'):
+            day = rule.xpath("./td[1]/text()").get()
+            if rule.xpath("./td[2]/text()").get() == "Closed":
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_range(
+                    day, *rule.xpath("./td/time/text()").get().split(" - "), time_format="%I:%M %p"
+                )
+
+        apply_category(Categories.SHOP_HARDWARE, item)
+        yield item


### PR DESCRIPTION
The WP Store Locator admin-ajax store_search endpoint now returns 403,
so the spider yielded 0 items.

Rewritten as a SitemapSpider over the WP stores sitemap, parsing each
store page's embedded wpslMap_0 JSON (address, coordinates) plus the
opening-hours table and phone. Excludes the one co-located "Proper
Foods" food unit, which is a different brand.