### PR TITLE
[Purebaby AU] Fix spider

### DIFF
--- a/locations/spiders/purebaby_au.py
+++ b/locations/spiders/purebaby_au.py
@@ -1,7 +1,8 @@
-from typing import AsyncIterator
+import json
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import Request, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -12,24 +13,28 @@ class PurebabyAUSpider(Spider):
     name = "purebaby_au"
     item_attributes = {"brand": "Purebaby", "brand_wikidata": "Q122431533"}
     allowed_domains = ["purebaby.com.au"]
-    start_urls = ["https://purebaby.com.au/page-data/pages/stores/page-data.json"]
+    start_urls = ["https://purebaby.com.au/pages/stores"]
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
+    async def start(self) -> AsyncIterator[Request]:
         for url in self.start_urls:
-            yield JsonRequest(url=url)
+            yield Request(url=url)
 
-    def parse(self, response):
-        for location in response.json()["result"]["data"]["stores"]["edges"]:
-            if "purebaby-" not in location["node"]["handle"]["current"]:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        config = json.loads(response.xpath("//script[@data-stores-page-config]/text()").get())
+
+        if response.url == self.start_urls[0]:
+            param = config["paginationPageParam"]
+            for page in range(2, config["paginationPages"] + 1):
+                yield Request(url=f"{self.start_urls[0]}?{param}={page}")
+
+        for location in config["stores"]:
+            if location["type"] != "Store":
                 continue
-            item = DictParser.parse(location["node"])
-            item["website"] = "https://purebaby.com.au/pages/stores/" + location["node"]["url"]
+            item = DictParser.parse(location)
+            item["branch"] = location["title"].removeprefix("Purebaby ")
+            item["name"] = None
+            item["image"] = location["image"]
             item["opening_hours"] = OpeningHours()
-            hours_string = ""
-            for day_hours in location["node"]["openhours"]:
-                day_name = day_hours["day"]
-                hours_range = day_hours["hours"]
-                hours_string = f"{hours_string} {day_name}: {hours_range}"
-            item["opening_hours"].add_ranges_from_string(hours_string)
+            item["opening_hours"].add_ranges_from_string(location["openHours"])
             apply_category(Categories.SHOP_CLOTHES, item)
             yield item

--- a/locations/spiders/purebaby_au.py
+++ b/locations/spiders/purebaby_au.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, AsyncIterator
+from typing import Any
 
 from scrapy import Spider
 from scrapy.http import Request, Response
@@ -11,23 +11,18 @@ from locations.hours import OpeningHours
 
 class PurebabyAUSpider(Spider):
     name = "purebaby_au"
-    item_attributes = {"brand": "Purebaby", "brand_wikidata": "Q122431533"}
+    item_attributes = {"name": "Purebaby", "brand": "Purebaby", "brand_wikidata": "Q122431533"}
     allowed_domains = ["purebaby.com.au"]
     start_urls = ["https://purebaby.com.au/pages/stores"]
 
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url)
-
     def parse(self, response: Response, **kwargs: Any) -> Any:
         config = json.loads(response.xpath("//script[@data-stores-page-config]/text()").get())
+        param = config["paginationPageParam"]
+        for page in range(2, config["paginationPages"] + 1):
+            yield Request(url=f"https://purebaby.com.au/pages/stores?{param}={page}", callback=self.parse_stores)
 
-        if response.url == self.start_urls[0]:
-            param = config["paginationPageParam"]
-            for page in range(2, config["paginationPages"] + 1):
-                yield Request(url=f"{self.start_urls[0]}?{param}={page}")
-
-        for location in config["stores"]:
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
+        for location in json.loads(response.xpath("//script[@data-stores-page-config]/text()").get())["stores"]:
             if location["type"] != "Store":
                 continue
             item = DictParser.parse(location)

--- a/locations/spiders/purebaby_au.py
+++ b/locations/spiders/purebaby_au.py
@@ -28,6 +28,7 @@ class PurebabyAUSpider(Spider):
             item = DictParser.parse(location)
             item["branch"] = location["title"].removeprefix("Purebaby ")
             item["name"] = None
+            item["website"] = response.urljoin(location["id"])
             item["image"] = location["image"]
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(location["openHours"])


### PR DESCRIPTION
The site moved off Gatsby, so the page-data.json store-locator endpoint
now 404s and the spider yielded 0 items.

Rewritten to read the data-stores-page-config JSON embedded in the
/pages/stores page, following its pagination and keeping only
type=="Store" entries (the 16 Purebaby-owned shops, excluding ~250
third-party stockists and the online entry). branch comes from the
per-store title; opening hours and per-store image are also collected.