### PR TITLE
[The Food Warehouse GB] Fix spider

### DIFF
--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -14,6 +14,7 @@ class IcelandFoodsSpider(Spider):
     name = "iceland_foods"
     item_attributes = {"brand": "Iceland", "brand_wikidata": "Q721810"}
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    drop_attributes = {"email"}
     access_token = ""
 
     async def start(self) -> AsyncIterator[JsonRequest]:

--- a/locations/spiders/iceland_foods.py
+++ b/locations/spiders/iceland_foods.py
@@ -1,10 +1,11 @@
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Iterable
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -34,13 +35,7 @@ class IcelandFoodsSpider(Spider):
             item = DictParser.parse(store)
 
             item["branch"] = item.pop("name")
-            if (
-                "FWH" in item["branch"].upper()
-                or "FOOD WAR" in item["branch"].upper()
-                or "TEST2" in item["branch"].upper()
-            ):
-                # The Food Warehouse, obtained via its own spider
-                # The name usually ends with FWH or has Food Warehouse, sometime truncated.
+            if not self.wanted(item["branch"]):
                 continue
 
             item["street_address"] = merge_address_lines([store.get("address1"), store.get("address2")])
@@ -62,9 +57,20 @@ class IcelandFoodsSpider(Spider):
                 f'https://www.iceland.co.uk/store-finder/store?StoreID={item["ref"]}&StoreName={item["branch"].replace(" ", "-")}'
             )
 
-            yield item
+            yield from self.post_process_item(item)
 
         if next_page := response.json().get("next"):
             yield JsonRequest(
                 url=next_page, headers={"authorization": f"Bearer {self.access_token}"}, callback=self.parse_stores
             )
+
+    def wanted(self, branch: str) -> bool:
+        # Food Warehouse stores are scraped by the_food_warehouse_gb; test stores are dropped.
+        return not (self.is_food_warehouse(branch) or "TEST2" in branch.upper())
+
+    @staticmethod
+    def is_food_warehouse(branch: str) -> bool:
+        return "FWH" in branch.upper() or "FOOD WAR" in branch.upper()
+
+    def post_process_item(self, item: Feature) -> Iterable[Feature]:
+        yield item

--- a/locations/spiders/the_food_warehouse_gb.py
+++ b/locations/spiders/the_food_warehouse_gb.py
@@ -1,32 +1,21 @@
-from scrapy import Selector, Spider
+import re
+from typing import Iterable
 
-from locations.categories import Categories
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
-from locations.pipelines.address_clean_up import merge_address_lines
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.iceland_foods import IcelandFoodsSpider
 
 
-class TheFoodWarehouseGBSpider(Spider):
+class TheFoodWarehouseGBSpider(IcelandFoodsSpider):
     name = "the_food_warehouse_gb"
-    item_attributes = {
-        "brand": "The Food Warehouse",
-        "brand_wikidata": "Q87263899",
-        "extras": Categories.SHOP_SUPERMARKET.value,
-    }
-    allowed_domains = ["www.thefoodwarehouse.com"]
-    start_urls = ["https://www.thefoodwarehouse.com/assets/foodwarehouse/ajax/"]
-    no_refs = True  # https://github.com/alltheplaces/alltheplaces/issues/8237
+    item_attributes = {"brand": "The Food Warehouse", "brand_wikidata": "Q87263899"}
 
-    def parse(self, response):
-        for store in response.json():
-            item = DictParser.parse(store)
-            if "CLOSED" in item["name"].upper() or "COMING SOON" in item["name"].upper():
-                continue
-            if store["url"] != "/store-locator/default-store":
-                item["website"] = "https://www.thefoodwarehouse.com" + store["url"]
-            item["branch"] = item.pop("name").removesuffix(" - Now Open")
-            item["phone"] = store.get("store-number")
-            item["addr_full"] = merge_address_lines(Selector(text=item["addr_full"]).xpath("//text()").getall())
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(store.get("opening-times", ""))
-            yield item
+    def wanted(self, branch: str) -> bool:
+        return self.is_food_warehouse(branch)
+
+    def post_process_item(self, item: Feature) -> Iterable[Feature]:
+        item["branch"] = re.sub(r"\s*(FWH|FOOD WAR\w*|E?HOUSE?)\b.*$", "", item["branch"], flags=re.IGNORECASE).strip(
+            " -("
+        )
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item


### PR DESCRIPTION
The standalone thefoodwarehouse.com store-locator endpoint now
301-redirects (The Food Warehouse was folded into Iceland's site), so
the spider produced 0 items.

The Food Warehouse and Iceland are the same parent (Iceland Foods) and
share one store API. Moved the shared auth/stores/parse logic into the
iceland_foods spider as a base class with wanted()/post_process_item()
hooks and a shared is_food_warehouse() test, and rewrote
the_food_warehouse_gb as a thin subclass that keeps only the Food
Warehouse stores. iceland_foods output is unchanged.