### PR TITLE
[Scotiabank] Fix spider

### DIFF
--- a/locations/spiders/scotiabank.py
+++ b/locations/spiders/scotiabank.py
@@ -1,113 +1,64 @@
-import csv
-import math
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
+from uuid import uuid4
 
 from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.items import Feature
-from locations.searchable_points import open_searchable_points
-
-
-def calculate_offset_point(x, y, d, b):
-    """Calculate an offset point for a given lat, lon, distance and bearing.
-    formula source: https://www.movable-type.co.uk/scripts/latlong.html
-
-    :param x: longitude in decimal degrees
-    :param y: latitude in decimal degrees
-    :param d: distance in km
-    :param b: bearing in degrees
-    :return: new x, y in decimal degrees
-    """
-    R = 6378.137  # km # noqa: N806
-    x, y, b = math.radians(x), math.radians(y), math.radians(b)
-    new_y = math.asin((math.sin(y) * math.cos(d / R)) + (math.cos(y) * math.sin(d / R) * math.cos(b)))
-    new_x = x + math.atan2(
-        math.sin(b) * math.sin(d / R) * math.cos(y),
-        math.cos(d / R) - math.sin(y) * math.sin(new_y),
-    )
-
-    return math.degrees(new_x), math.degrees(new_y)
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class ScotiabankSpider(Spider):
     name = "scotiabank"
-    allowed_domains = ["scotiabank.com"]
     item_attributes = {"brand": "Scotiabank", "brand_wikidata": "Q451476"}
-    base_url = "https://mapsms.scotiabank.com/branches?1=1&latitude={lat}&longitude={lon}&recordlimit=20&locationtypes=1&options=&languagespoken=any&language=en&address=&province=&city="
-    refs = set()
+    allowed_domains = ["api.scotiabank.com"]
+    base_url = "https://api.scotiabank.com/assets-locator/v1/search/asset/near?asset_types=branch&lat=56.13&lon=-106.34&radius=8000&page={page}&count=50&country=CA&locale=en-CA&rolling_days=true&show_holidays=true&include_abm_info=true"
 
-    custom_settings = {"DEFAULT_REQUEST_HEADERS": {"Accept": "application/json"}}
+    def request_page(self, page: int) -> JsonRequest:
+        return JsonRequest(
+            url=self.base_url.format(page=page),
+            headers={
+                "x-b3-traceid": str(uuid4()),
+                "x-b3-spanid": str(uuid4()),
+                "x-channel-id": "Online",
+                "x-originating-appl-code": "BGMN",
+                "x-country-code": "CA",
+            },
+            meta={"page": page},
+        )
 
-    async def start(self) -> AsyncIterator[Request]:
-        with open_searchable_points("ca_centroids_100mile_radius.csv") as points:
-            reader = csv.DictReader(points)
-            for row in reader:
-                lat, lon = row["latitude"], row["longitude"]
-                yield Request(
-                    self.base_url.format(lat=lat, lon=lon),
-                    meta={"request_x": lon, "request_y": lat},
-                )
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield self.request_page(1)
 
-    def parse_hours(self, hours):
-        opening_hours = OpeningHours()
-        for day, times in hours.items():
-            if times["open"] and times["close"]:
-                opening_hours.add_range(
-                    day=day[:2],
-                    open_time=times["open"],
-                    close_time=times["close"],
-                    time_format="%I:%M %p",
-                )
-        return opening_hours.as_opening_hours()
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        branches = response.json()["data"] or []
+        for branch in branches:
+            if branch["status"]["code"] != "OPE":
+                continue
+            branch.update((branch.pop("addresses", None) or [{}])[0])
+            item = DictParser.parse(branch)
+            item["branch"] = item.pop("name").strip()
+            item["street_address"] = merge_address_lines([branch.get("line_1_addr"), branch.get("line_2_addr")])
+            item["state"] = branch.get("state")
+            item["postcode"] = branch.get("postal_cd")
 
-    def parse(self, response):
-        data = response.json()
-        branches = (data["branchInfo"] or {}).get("marker", [])
+            for contact in branch.get("contact_numbers") or []:
+                if contact["contact_type_cd"]["code"] == "P":
+                    item["phone"] = "+{} {} {}".format(
+                        contact["phone_country_cd"], contact["phone_area_cd"], contact["phone_no"]
+                    )
+
+            item["opening_hours"] = OpeningHours()
+            for rule in branch.get("open_hours") or []:
+                if rule["open_time"] and rule["close_time"]:
+                    item["opening_hours"].add_range(rule["day_of_week"], rule["open_time"], rule["close_time"])
+                else:
+                    item["opening_hours"].set_closed(rule["day_of_week"])
+
+            apply_category(Categories.BANK, item)
+            yield item
+
         if branches:
-            if data["branchCount"] == 20:
-                refs = {x["@attributes"]["id"] for x in branches}
-                if refs.issubset(self.refs):
-                    return
-                max_distance = branches[-1]["@attributes"]["distance"]
-                # Make more requests around this location. These are angles:
-                for b in [45.0, 135.0, 225.0, 315.0]:
-                    new_x, new_y = calculate_offset_point(
-                        x=float(response.meta["request_x"]),
-                        y=float(response.meta["request_y"]),
-                        d=float(max_distance),
-                        b=b,
-                    )
-                    yield Request(
-                        self.base_url.format(lat=new_y, lon=new_x),
-                        meta={"request_x": new_x, "request_y": new_y},
-                    )
-
-            for branch in branches:
-                address = branch["address"]
-                address1, city, state_postal, country = address.rsplit(", ", 3)
-                state, postal = state_postal.rsplit(" ", 1)
-                ref = branch["@attributes"]["id"]
-                self.refs.add(ref)
-
-                properties = {
-                    "name": branch["name"],
-                    "ref": ref,
-                    "addr_full": address1.strip(", "),
-                    "city": city.strip(),
-                    "state": state,
-                    "postcode": postal,
-                    "country": country,
-                    "phone": branch["phoneNo"],
-                    "lat": float(branch["@attributes"]["lat"]),
-                    "lon": float(branch["@attributes"]["lng"]),
-                }
-
-                hours = self.parse_hours(branch["hours"])
-                if hours:
-                    properties["opening_hours"] = hours
-
-                apply_category(Categories.BANK, properties)
-                yield Feature(**properties)
+            yield self.request_page(response.meta["page"] + 1)


### PR DESCRIPTION
The mapsms.scotiabank.com branch host was decommissioned and 404s on every request. Repoint to the api.scotiabank.com/assets-locator/v1 branch API, paginating until the result set is exhausted, and read the branch name, address, phone and opening hours from the new response shape. Branches flagged closed or temporarily closed are skipped.