### PR TITLE
[Greater Bendigo City Council AU] Improve spider for trees

### DIFF
--- a/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
+++ b/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
@@ -13,10 +13,10 @@ class GreaterBendigoCityCouncilTreesAUSpider(VectorFileSpider):
     item_attributes = {"operator": "Greater Bendigo City Council", "operator_wikidata": "Q134285890", "state": "VIC"}
     allowed_domains = ["connect.pozi.com"]
     start_urls = [
-        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2026.fgb", # 2026
-        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2025.fgb", # 2025
-        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2024.fgb", # 2024
-        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Trees.fgb", # Pre 2024
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2026.fgb",  # 2026
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2025.fgb",  # 2025
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2024.fgb",  # 2024
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Trees.fgb",  # Pre 2024
     ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:

--- a/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
+++ b/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
@@ -1,3 +1,4 @@
+import re
 from typing import Iterable
 
 from scrapy.http import Response
@@ -11,28 +12,50 @@ class GreaterBendigoCityCouncilTreesAUSpider(VectorFileSpider):
     name = "greater_bendigo_city_council_trees_au"
     item_attributes = {"operator": "Greater Bendigo City Council", "operator_wikidata": "Q134285890", "state": "VIC"}
     allowed_domains = ["connect.pozi.com"]
-    start_urls = ["https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Trees.fgb"]
+    start_urls = [
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2026.fgb", # 2026
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2025.fgb", # 2025
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Tree_Planting_2024.fgb", # 2024
+        "https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Trees.fgb", # Pre 2024
+    ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(feature["AssetID"])
-        item["housenumber"] = feature["House"]
-        item["street"] = feature["St_Name"]
-        item["city"] = feature["Suburb"]
         apply_category(Categories.NATURAL_TREE, item)
-        if feature["Species"] and feature["Species"] != "Not Specified":
-            species = feature["Species"]
-            if " - " in species:
-                item["extras"]["species"] = species.split(" - ", 1)[0]
-                item["extras"]["taxon:en"] = species.split(" - ", 1)[1]
-            elif " (" in species and species.endswith(")"):
-                item["extras"]["species"] = species.split(" (", 1)[0]
-                item["extras"]["taxon:en"] = species.split(" (", 1)[1].removesuffix(")")
+        if house_number := feature.get("House_Number"):
+            item["housenumber"] = house_number
+        if street_name := feature.get("Street_Name"):
+            item["street"] = street_name
+        if suburb := feature.get("Suburb"):
+            item["city"] = suburb
+        if planting_year := feature.get("Planting_Year"):
+            item["extras"]["start_date"] = str(planting_year)
+
+        if asset_type := feature.get("Asset Type"):
+            # Pre 2024 dataset format
+            taxon_cn = asset_type
+            cultivar = None
+        elif species_raw := feature.get("Species"):
+            # 2024-2026 dataset format
+            taxon_cn = species_raw
+            if cultivar_raw := feature.get("Cultivar"):
+                cultivar = cultivar_raw
+        else:
+            return
+
+        if m := re.match(r"^([\w ]+) - ([\w ]+)", taxon_cn):
+            if cultivar and cultivar != "Not Specified":
+                item["extras"]["species"] = re.sub(r"\s+", " ", m.group(1) + f" '{cultivar}'").strip()
+                item["extras"]["taxon:en"] = re.sub(r"\s+", " ", m.group(2) + f" '{cultivar}'").strip()
             else:
-                item["extras"]["species"] = species
-        if feature["Cultivar"] and feature["Cultivar"] != "Not Specified":
-            if "taxon:en" in item["extras"].keys():
-                item["extras"]["taxon:en"] = '{} "{}"'.format(item["extras"]["taxon:en"], feature["Cultivar"])
-        # Ignore feature["Genus"] because it includes values such as
-        # "Eucalyptus M to Z". feature["Species"] is used instead and is much
-        # more useful and accurate.
+                item["extras"]["species"] = re.sub(r"\s+", " ", m.group(1)).strip()
+                item["extras"]["taxon:en"] = re.sub(r"\s+", " ", m.group(2)).strip()
+        elif taxon_cn == "Not Specified":
+            pass
+        else:
+            if cultivar and cultivar != "Not Specified":
+                item["extras"]["species"] = re.sub(r"\s+", " ", taxon_cn + f" '{cultivar}'").strip()
+            else:
+                item["extras"]["species"] = re.sub(r"\s+", " ", taxon_cn).strip()
+
         yield item

--- a/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
+++ b/locations/spiders/infrastructure/greater_bendigo_city_council_trees_au.py
@@ -10,11 +10,8 @@ from locations.vector_file_spider import VectorFileSpider
 class GreaterBendigoCityCouncilTreesAUSpider(VectorFileSpider):
     name = "greater_bendigo_city_council_trees_au"
     item_attributes = {"operator": "Greater Bendigo City Council", "operator_wikidata": "Q134285890", "state": "VIC"}
-    allowed_domains = ["data.gov.au"]
-    start_urls = [
-        "https://data.gov.au/data/dataset/d17c9e50-fab1-40e6-b91d-6e665faf2656/resource/b3f01081-924c-41b7-989a-cf521ca136ea/download/cogb-environment-trees.shz"
-    ]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    allowed_domains = ["connect.pozi.com"]
+    start_urls = ["https://connect.pozi.com/userdata/bendigo-publisher/Pozi_Public_City_of_Greater_Bendigo/Trees.fgb"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(feature["AssetID"])


### PR DESCRIPTION
Use Pozi (official council map) data rather than outdated dataset on
data.gov.au (126k trees extracted instead of 121k).

Due to the data being split by year, there are some instances where old
trees which have been replaced will now show as two nearby POIs--a POI
for a now-removed tree, and a POI for the replacement tree.
Deduplication is arguably better performed by consumers of this dataset
from ATP, rather than performed within this spider. The reason is
suspected performance impacts of loading all trees into memory and then
using Python code to try and find nearby matches between 126k trees and
deduplicating any nearby matches.