### PR TITLE
[Scooter Hut AU] Fix spider

### DIFF
--- a/locations/spiders/scooter_hut_au.py
+++ b/locations/spiders/scooter_hut_au.py
@@ -1,10 +1,30 @@
-from locations.storefinders.stockinstore import StockInStoreSpider
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.items import Feature
 
 
-class ScooterHutAUSpider(StockInStoreSpider):
+class ScooterHutAUSpider(Spider):
     name = "scooter_hut_au"
     item_attributes = {"brand": "Scooter Hut", "brand_wikidata": "Q117747623", "extras": {"shop": "scooter"}}
-    api_site_id = "10112"
-    api_widget_id = "119"
-    api_widget_type = "product"
-    api_origin = "https://scooterhut.com.au"
+    start_urls = ["https://scooterhut.com.au/pages/store-locator"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.xpath('//div[@class="store-details"]'):
+            item = Feature()
+            item["branch"] = store.xpath("./h3/text()").get("").replace("Scooter Hut", "").strip()
+            item["ref"] = item["branch"]
+            item["addr_full"] = (
+                store.xpath('.//p[contains(text(), "Address")]/text()').get("").replace("Address:", "").strip()
+            )
+            item["email"] = store.xpath('.//a[starts-with(@href, "mailto:")]/@href').get("").replace("mailto:", "")
+            item["phone"] = store.xpath('.//p[contains(text(), "Phone")]//a/text()').get()
+
+            if destination := store.xpath('.//a[contains(@href, "destination=")]/@href').re_first(
+                r"destination=([\d.-]+,[\d.-]+)"
+            ):
+                item["lat"], item["lon"] = destination.split(",")
+
+            yield item


### PR DESCRIPTION
The StockInStore widget API is gone. Repoint to the scooterhut.com.au store-locator page and parse the store blocks for branch, address, email, phone and coordinates.

Scooter Hut went into receivership and closed all stores, then reopened; the locator now lists 2 stores (Balcatta and Fairfield), down from the ~13 it had previously.