### PR TITLE
[Hans im Glück DE] Add spider (58 locations)

### DIFF
--- a/locations/spiders/hans_im_glueck.py
+++ b/locations/spiders/hans_im_glueck.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response
 
-from locations.hours import OpeningHours, DAYS_FULL
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 

--- a/locations/spiders/hans_im_glueck.py
+++ b/locations/spiders/hans_im_glueck.py
@@ -1,0 +1,42 @@
+from typing import Iterable
+
+import chompjs
+from scrapy.http import Response
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class HansImGlueckSpider(JSONBlobSpider):
+    name = "hans_im_glueck"
+    start_urls = ["https://hansimglueck-burgergrill.de/typo3conf/ext/hig_site/Yext/locations.js"]
+    item_attributes = {"brand": "Hans im Glück", "brand_wikidata": "Q22569868"}
+
+    def extract_json(self, response: Response) -> list[dict]:
+        return chompjs.parse_js_object(response.text)
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if item.get("name"):
+            if item["name"].startswith("HANS IM GLÜCK - "):
+                item["branch"] = item["name"].removeprefix("HANS IM GLÜCK - ").title()
+        else:
+            item["branch"] = feature["c_website_hig_name"]
+        item["name"] = "Hans im Glück"
+        item["ref"] = feature["meta"]["id"]
+        if "googlePlaceId" in feature:
+            item["extras"]["ref:google"] = feature["googlePlaceId"]
+        item["website"] = feature["c_baseURL"]
+        if "emails" in feature:
+            item["email"] = feature["emails"][0]
+        if "c_website_standortfotos" in feature:
+            item["image"] = response.urljoin(feature["c_website_standortfotos"][0]["url"])
+
+        if "c_websiteÖffnungszeiten" in feature:
+            oh = OpeningHours()
+            for day, intervals in feature["c_websiteÖffnungszeiten"].items():
+                for interval in intervals.get("openIntervals", []):
+                    oh.add_range(day, interval["start"], interval["end"])
+            item["opening_hours"] = oh
+
+        yield item

--- a/locations/spiders/hans_im_glueck.py
+++ b/locations/spiders/hans_im_glueck.py
@@ -3,15 +3,15 @@ from typing import Iterable
 import chompjs
 from scrapy.http import Response
 
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, DAYS_FULL
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
 class HansImGlueckSpider(JSONBlobSpider):
     name = "hans_im_glueck"
-    start_urls = ["https://hansimglueck-burgergrill.de/typo3conf/ext/hig_site/Yext/locations.js"]
     item_attributes = {"brand": "Hans im Glück", "brand_wikidata": "Q22569868"}
+    start_urls = ["https://hansimglueck-burgergrill.de/typo3conf/ext/hig_site/Yext/locations.js"]
 
     def extract_json(self, response: Response) -> list[dict]:
         return chompjs.parse_js_object(response.text)
@@ -24,8 +24,7 @@ class HansImGlueckSpider(JSONBlobSpider):
             item["branch"] = feature["c_website_hig_name"]
         item["name"] = "Hans im Glück"
         item["ref"] = feature["meta"]["id"]
-        if "googlePlaceId" in feature:
-            item["extras"]["ref:google"] = feature["googlePlaceId"]
+        item["extras"]["ref:google"] = feature.get("googlePlaceId")
         item["website"] = feature["c_baseURL"]
         if "emails" in feature:
             item["email"] = feature["emails"][0]
@@ -34,8 +33,12 @@ class HansImGlueckSpider(JSONBlobSpider):
 
         if "c_websiteÖffnungszeiten" in feature:
             oh = OpeningHours()
-            for day, intervals in feature["c_websiteÖffnungszeiten"].items():
-                for interval in intervals.get("openIntervals", []):
+            for day in map(str.lower, DAYS_FULL):
+                rule = feature["c_websiteÖffnungszeiten"]
+                if rule.get("isClosed") is True:
+                    oh.set_closed(day)
+                    continue
+                for interval in rule.get("openIntervals", []):
                     oh.add_range(day, interval["start"], interval["end"])
             item["opening_hours"] = oh
 


### PR DESCRIPTION
[Hans im Glück](https://hansimglueck-burgergrill.de/) is a burger chain mostly in DE, and with a few stores in AT and CH.

```
2026-06-03 11:51:11 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'atp/brand/Hans im Glück': 58,
 'atp/brand_wikidata/Q22569868': 58,
 'atp/category/amenity/restaurant': 58,
 'atp/country/AT': 1,
 'atp/country/CH': 3,
 'atp/country/DE': 54,
 'atp/field/image/missing': 1,
 'atp/field/opening_hours/missing': 4,
 'atp/field/operator/missing': 58,
 'atp/field/operator_wikidata/missing': 58,
 'atp/field/state/missing': 55,
 'atp/field/twitter/missing': 58,
 'atp/item_scraped_host_count/hansimglueck-burgergrill.de': 58,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/perfect_match': 58,
```