### PR TITLE
Remove generic email from ackermans

### DIFF
--- a/locations/spiders/ackermans.py
+++ b/locations/spiders/ackermans.py
@@ -28,6 +28,7 @@ class AckermansSpider(scrapy.Spider):
     def parse_details(self, response):
         for store in response.json():
             item = DictParser.parse(store)
+            item.pop("email")
             item["website"] = "https://www.ackermans.co.za/pages/store-details?storeId=" + str(item["ref"])
             item["opening_hours"] = OpeningHours()
             for key, value in json.loads(store.get("openingHours")).items():


### PR DESCRIPTION
All of the emails were "customercare@ackermans.co.za"