### PR TITLE
[EstheticCenter FR] Fix spider

### DIFF
--- a/locations/spiders/esthetic_center_fr.py
+++ b/locations/spiders/esthetic_center_fr.py
@@ -1,14 +1,45 @@
-from locations.categories import Categories
-from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+import re
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import CLOSED_FR, DAYS_FR, DELIMITERS_FR, OpeningHours
+from locations.items import Feature
 
 
-class EstheticCenterFRSpider(AgileStoreLocatorSpider):
+class EstheticCenterFRSpider(SitemapSpider):
     name = "esthetic_center_fr"
-    item_attributes = {
-        "brand_wikidata": "Q123321775",
-        "brand": "Esthetic Center",
-        "extras": Categories.SHOP_BEAUTY.value,
-    }
-    allowed_domains = [
-        "www.esthetic-center.com",
-    ]
+    item_attributes = {"brand": "Esthetic Center", "brand_wikidata": "Q123321775"}
+    sitemap_urls = ["https://www.esthetic-center.com/institut-sitemap.xml"]
+    sitemap_rules = [("/trouver-institut/", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["ref"] = response.url.strip("/").split("/")[-1]
+        item["website"] = response.url
+        item["branch"] = response.xpath("//h1/span/text()").get("").removeprefix("Esthetic Center ")
+        item["addr_full"] = response.xpath("//div[contains(@id, 'text_block-238')]/span/text()").get()
+        item["phone"] = (
+            response.xpath("//a[contains(@href, 'tel:')]/@href").get("").replace("tel:", "").replace(" ", "")
+        )
+
+        script_content = response.text
+        item["lat"] = re.search(r'var latitude = "(.*?)";', script_content).group(1)
+        item["lon"] = re.search(r'var longitude = "(.*?)";', script_content).group(1)
+
+        oh = OpeningHours()
+        for row in response.xpath("//div[contains(@class, 'horaire-row')]"):
+            day = row.xpath(".//span[contains(@class, 'horaire-jour')]/text()").get()
+            time_str = row.xpath(".//span[contains(@class, 'horaire-heures')]/text()").get()
+
+            if day and time_str:
+                oh.add_ranges_from_string(
+                    f"{day} {time_str.replace('h', ':')}", days=DAYS_FR, closed=CLOSED_FR, delimiters=DELIMITERS_FR
+                )
+
+        item["opening_hours"] = oh
+        apply_category(Categories.SHOP_BEAUTY, item)
+
+        yield item


### PR DESCRIPTION
Refactored esthetic_center_fr using SitemapSpider to replace the broken Agile Store Locator setup. While an alternative WordPress REST API endpoint was discovered, load testing with higher per_page limits triggers upstream 500 Internal Server Error responses and maxes out retry limits, whereas the XML sitemap yields 112 stable 200 OK requests. 

```
{'atp/brand/Esthetic Center': 110,
 'atp/brand_wikidata/Q123321775': 110,
 'atp/category/shop/beauty': 110,
 'atp/cdn/cloudflare/response_count': 112,
 'atp/cdn/cloudflare/response_status_count/200': 112,
 'atp/country/FR': 110,
 'atp/field/city/missing': 110,
 'atp/field/country/from_spider_name': 110,
 'atp/field/email/missing': 110,
 'atp/field/housenumber/missing': 110,
 'atp/field/operator/missing': 110,
 'atp/field/operator_wikidata/missing': 110,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 110,
 'atp/field/state/missing': 110,
 'atp/field/street/missing': 110,
 'atp/field/street_address/missing': 110,
 'atp/field/twitter/missing': 110,
 'atp/field/unit/missing': 110,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/www.esthetic-center.com': 110,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 110,
 'downloader/request_bytes': 70011,
 'downloader/request_count': 112,
 'downloader/request_method_count/GET': 112,
 'downloader/response_bytes': 7309362,
 'downloader/response_count': 112,
 'downloader/response_status_count/200': 112,
 'elapsed_time_seconds': 139.78099999999904,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 3, 13, 41, 46, 272333, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 31051703,
 'httpcompression/response_count': 112,
 'item_scraped_count': 110,
 'items_per_minute': 47.482014388489205,
 'log_count/DEBUG': 222,
 'log_count/INFO': 5,
 'request_depth_max': 1,
 'response_received_count': 112,
 'responses_per_minute': 48.34532374100719,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 111,
 'scheduler/dequeued/memory': 111,
 'scheduler/enqueued': 111,
 'scheduler/enqueued/memory': 111,
 'start_time': datetime.datetime(2026, 6, 3, 13, 39, 26, 477906, tzinfo=datetime.timezone.utc)}
```