### PR TITLE
[Pho GB] Fix spider

### DIFF
--- a/locations/spiders/pho_gb.py
+++ b/locations/spiders/pho_gb.py
@@ -1,48 +1,58 @@
-from scrapy.spiders import SitemapSpider
+import json
+from typing import Iterable
+
+from scrapy.http import TextResponse
 
 from locations.categories import Extras, apply_yes_no
 from locations.hours import OpeningHours
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class PhoGBSpider(SitemapSpider, StructuredDataSpider):
+class PhoGBSpider(JSONBlobSpider):
     name = "pho_gb"
     item_attributes = {
         "brand": "Pho",
         "brand_wikidata": "Q108443630",
     }
-    sitemap_urls = ["https://www.phocafe.co.uk/locations-sitemap.xml"]
-    wanted_types = ["Restaurant"]
+    start_urls = ["https://www.phocafe.co.uk/all-locations/"]
 
-    def extract_amenities(self, item, response):
-        wheelchair = response.xpath("//i[@class='fa fa-wheelchair']").get()
-        wifi = response.xpath("//i[@class='fa fa-wifi']").get()
-        # kid_friendly = response.xpath("//i[@class='fa fa-child']").get()
+    def extract_json(self, response: TextResponse) -> dict | list[dict]:
+        return json.loads(
+            response.xpath('//script[contains(text(), "locationsData")]/text()').re_first(
+                r"locationsData[=\s]+(\[.+\])\s*;"
+            )
+        )
 
-        if wheelchair:
-            apply_yes_no(Extras.WHEELCHAIR, item, True)
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("acf"))
+        feature.update(feature.pop("map_location"))
 
-        if wifi:
-            apply_yes_no(Extras.WIFI, item, True)
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item.pop("name")
+        item["branch"] = feature["title"]["rendered"]
+        if item.get("housenumber"):
+            item["housenumber"] = str(item["housenumber"])
+        item["addr_full"] = feature["nice_address"]
+        item["website"] = feature["location_hp"]["url"].replace(
+            "https://content.phocafe.co.uk/", "https://www.phocafe.co.uk/"
+        )
 
-    def extract_opening_hours(self, item, response):
-        hours = response.xpath(
-            "//section[@class='location-contact']/div/div/div/div[@class='col-7']/div[@class='contact-details']/p/text()"
-        ).get()
+        facilities_info = ""
+        opening_times = feature["opening_times"]
+        if "Please note" in opening_times:  # Split opening times from additional facility notes
+            opening_times, facilities_info = feature["opening_times"].split("Please note", 1)
 
-        oh = OpeningHours()
-        oh.add_ranges_from_string(hours)
+        facilities_info = facilities_info.replace("wheel chair", "wheelchair")
+        apply_yes_no(
+            Extras.WHEELCHAIR, item, "wheelchair access" in facilities_info or "step free access" in facilities_info
+        )
+        apply_yes_no(Extras.TOILETS_WHEELCHAIR, item, "disabled toilet" in facilities_info)
 
-        item["opening_hours"] = oh
-
-    def extract_coords(self, item, response):
-        url = response.xpath("//a[contains(@href, 'https://citymapper.com/directions?startcoord=')]/@href").get()
-
-        item["lat"], item["lon"] = url.split("https://citymapper.com/directions?startcoord=")[1].split(",")
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        self.extract_opening_hours(item, response)
-        self.extract_coords(item, response)
-        self.extract_amenities(item, response)
-
+        item["opening_hours"] = self.parse_opening_hours(opening_times)
         yield item
+
+    def parse_opening_hours(self, hours: str) -> OpeningHours:
+        opening_hours = OpeningHours()
+        opening_hours.add_ranges_from_string(hours)
+        return opening_hours


### PR DESCRIPTION
`Structured Data` doesn't have `coordinates`, that's why fixing involved more simpler approach where it's easy to get location wise `coordinates`.

```python
{'atp/brand/Pho': 53,
 'atp/brand_wikidata/Q108443630': 53,
 'atp/category/amenity/restaurant': 53,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/addr_full': 5,
 'atp/clean_strings/phone': 5,
 'atp/country/GB': 53,
 'atp/field/city/missing': 29,
 'atp/field/country/from_spider_name': 24,
 'atp/field/housenumber/missing': 33,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 53,
 'atp/field/operator_wikidata/missing': 53,
 'atp/field/state/missing': 24,
 'atp/field/street/missing': 28,
 'atp/field/street_address/missing': 53,
 'atp/field/twitter/missing': 53,
 'atp/field/unit/missing': 53,
 'atp/item_scraped_host_count/www.phocafe.co.uk': 53,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 53,
 'downloader/request_bytes': 674,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 46110,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.26500000001397,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 4, 10, 53, 0, 489643, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 393418,
 'httpcompression/response_count': 2,
 'item_scraped_count': 53,
 'items_per_minute': 1590.0,
 'log_count/DEBUG': 55,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 4, 10, 52, 58, 218060, tzinfo=datetime.timezone.utc)}
```