### PR TITLE
[Dick Blick] Fix spider

### DIFF
--- a/locations/spiders/dick_blick.py
+++ b/locations/spiders/dick_blick.py
@@ -1,7 +1,10 @@
+from typing import Any
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -12,22 +15,18 @@ class DickBlickSpider(SitemapSpider, StructuredDataSpider):
     allowed_domains = ["www.dickblick.com"]
     sitemap_urls = ["https://www.dickblick.com/robots.txt"]
     sitemap_rules = [(r"/stores/[-\w]+/[-\w]+/$", "parse_sd")]
-    wanted_types = ["HobbyShop"]
+    time_format = "%I:%M%p"
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        oh = OpeningHours()
-        for day in response.xpath('//li[contains(@data-testid,"hours")]'):
-            if day.xpath("./text()").get().strip() == "Closed":
-                continue
-            oh.add_range(
-                day=day.xpath("normalize-space(./span/text())").get().strip(":")[:3],
-                open_time=day.xpath("./text()").get().split(" - ")[0],
-                close_time=day.xpath("./text()").get().split(" - ")[1],
-                time_format="%I:%M%p",
-            )
-        item["opening_hours"] = oh
+    def _get_sitemap_body(self, response: Response) -> bytes:
+        if "/v2/sitemap/" in response.url:
+            return response.body
+        return super()._get_sitemap_body(response)
 
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        if (item.get("name") or "").upper().startswith("CLOSED"):
+            return
+        item["twitter"] = None
+        item["facebook"] = None
         apply_category(Categories.SHOP_CRAFT, item)
-
         yield item

--- a/locations/spiders/dick_blick_us.py
+++ b/locations/spiders/dick_blick_us.py
@@ -17,6 +17,8 @@ class DickBlickSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/stores/[-\w]+/[-\w]+/$", "parse_sd")]
     time_format = "%I:%M%p"
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    search_for_twitter = False
+    search_for_facebook = False
 
     def _get_sitemap_body(self, response: Response) -> bytes:
         if "/v2/sitemap/" in response.url:
@@ -26,7 +28,5 @@ class DickBlickSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         if (item.get("name") or "").upper().startswith("CLOSED"):
             return
-        item["twitter"] = None
-        item["facebook"] = None
         apply_category(Categories.SHOP_CRAFT, item)
         yield item

--- a/locations/spiders/dick_blick_us.py
+++ b/locations/spiders/dick_blick_us.py
@@ -26,7 +26,8 @@ class DickBlickSpider(SitemapSpider, StructuredDataSpider):
         return super()._get_sitemap_body(response)
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
-        if (item.get("name") or "").upper().startswith("CLOSED"):
-            return
+        if "CLOSED" in item["name"]:
+            set_closed(item)
+        item["branch"] = item.pop("name")
         apply_category(Categories.SHOP_CRAFT, item)
         yield item

--- a/locations/spiders/dick_blick_us.py
+++ b/locations/spiders/dick_blick_us.py
@@ -4,13 +4,13 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.items import Feature, set_closed
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class DickBlickSpider(SitemapSpider, StructuredDataSpider):
-    name = "dick_blick"
+class DickBlickUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "dick_blick_us"
     item_attributes = {"brand": "Dick Blick", "brand_wikidata": "Q5272692"}
     allowed_domains = ["www.dickblick.com"]
     sitemap_urls = ["https://www.dickblick.com/robots.txt"]


### PR DESCRIPTION
The store sitemap moved to `/v2/sitemap/` URLs without a `.xml`
extension. `SitemapSpider` drops those under the Zyte fetch path
(they come back as a non-`XmlResponse`), so no store pages were
crawled and the spider produced zero features.

Changes:
- Override `_get_sitemap_body` to keep the body for `/v2/sitemap/`
  URLs (same pattern as `schuh_gb`/`kroger_us`).
- Parse opening hours from the page ld+json instead of the removed
  HTML hours block.
- Drop permanently-closed (`CLOSED - …`) stores.

Recovers from 0 to 73 stores.