### PR TITLE
[Hornbach] Fix spider

### DIFF
--- a/locations/spiders/hornbach.py
+++ b/locations/spiders/hornbach.py
@@ -1,15 +1,17 @@
-from typing import Any, Iterable
+import json
+from typing import Any
 
 import chompjs
 from scrapy.http import JsonRequest, Response, TextResponse
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, day_range
-from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
-class HornbachSpider(JSONBlobSpider):
+class HornbachSpider(PlaywrightSpider):
     name = "hornbach"
     BRANDS = {
         "bodenhaus": {"name": "Bodenhaus", "brand": "Bodenhaus"},
@@ -27,7 +29,7 @@ class HornbachSpider(JSONBlobSpider):
         "https://www.hornbach.se",
         "https://www.hornbach.sk",
     ]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 180}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         client_config = chompjs.parse_js_object(
@@ -42,18 +44,18 @@ class HornbachSpider(JSONBlobSpider):
             )
 
     def parse_locations(self, response: TextResponse) -> Any:
-        yield from super().parse(response)
+        for store in json.loads(response.xpath("//pre/text()").get()):
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("street")
+            item["branch"] = item.pop("name", "").removeprefix("BODENHAUS ").removeprefix("HORNBACH ").strip()
 
-    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
-        item["street_address"] = item.pop("street")
-        item["branch"] = item.pop("name").removeprefix("BODENHAUS ").removeprefix("HORNBACH ")
-        if brand_info := self.BRANDS.get(feature["client"]):
-            item.update(brand_info)
-        if feature["client"] == "bodenhaus":
-            apply_category(Categories.SHOP_FLOORING, item)
+            if brand_info := self.BRANDS.get(store.get("client")):
+                item.update(brand_info)
+            if store.get("client") == "bodenhaus":
+                apply_category(Categories.SHOP_FLOORING, item)
 
-        item["opening_hours"] = self.parse_opening_hours(feature.get("simplifiedOpeningHours", []))
-        yield item
+            item["opening_hours"] = self.parse_opening_hours(store.get("simplifiedOpeningHours", []))
+            yield item
 
     def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
         oh = OpeningHours()


### PR DESCRIPTION
Verified that the spider scrapes 178 locations, maintaining parity with existing data records.

```
{'atp/brand/Bodenhaus': 3,
 'atp/brand/HORNBACH': 175,
 'atp/brand_wikidata/Q685926': 175,
 'atp/category/shop/doityourself': 175,
 'atp/category/shop/flooring': 3,
 'atp/clean_strings/street_address': 1,
 'atp/country/AT': 15,
 'atp/country/CH': 8,
 'atp/country/CZ': 10,
 'atp/country/DE': 100,
 'atp/country/LU': 1,
 'atp/country/NL': 19,
 'atp/country/RO': 11,
 'atp/country/SE': 8,
 'atp/country/SK': 6,
 'atp/duplicate_count': 178,
 'atp/field/brand_wikidata/missing': 3,
 'atp/field/country/from_website_url': 178,
 'atp/field/email/missing': 178,
 'atp/field/housenumber/missing': 178,
 'atp/field/operator/missing': 178,
 'atp/field/operator_wikidata/missing': 178,
 'atp/field/state/missing': 178,
 'atp/field/street/missing': 178,
 'atp/field/twitter/missing': 178,
 'atp/field/unit/missing': 178,
 'atp/item_scraped_host_count/svc.hornbach.de': 356,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 175,
 'downloader/request_bytes': 11805,
 'downloader/request_count': 31,
 'downloader/request_method_count/GET': 31,
 'downloader/response_bytes': 3323526,
 'downloader/response_count': 31,
 'downloader/response_status_count/200': 30,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 22.875,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 4, 12, 45, 31, 88839, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 178,
 'item_dropped_reasons_count/DropItem': 178,
 'item_scraped_count': 178,
 'items_per_minute': 485.4545454545455,
 'log_count/DEBUG': 1270,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 31,
 'playwright/page_count/closed': 31,
 'playwright/page_count/max_concurrent': 10,
 'playwright/request_count': 354,
 'playwright/request_count/aborted': 323,
 'playwright/request_count/method/GET': 354,
 'playwright/request_count/navigation': 31,
 'playwright/request_count/resource_type/document': 31,
 'playwright/request_count/resource_type/font': 31,
 'playwright/request_count/resource_type/image': 78,
 'playwright/request_count/resource_type/other': 10,
 'playwright/request_count/resource_type/script': 130,
 'playwright/request_count/resource_type/stylesheet': 74,
 'playwright/response_count': 31,
 'playwright/response_count/method/GET': 31,
 'playwright/response_count/resource_type/document': 31,
 'request_depth_max': 1,
 'response_received_count': 31,
 'responses_per_minute': 84.54545454545455,
 'robotstxt/request_count': 11,
 'robotstxt/response_count': 11,
 'robotstxt/response_status_count/200': 10,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 20,
 'scheduler/dequeued/memory': 20,
 'scheduler/enqueued': 20,
 'scheduler/enqueued/memory': 20,
 'start_time': datetime.datetime(2026, 6, 4, 12, 45, 8, 214621, tzinfo=datetime.timezone.utc)}
```