### PR TITLE
[Express] Fix spider

### DIFF
--- a/locations/spiders/express.py
+++ b/locations/spiders/express.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any
+from typing import Any, Iterable
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
@@ -19,23 +18,16 @@ class ExpressSpider(SitemapSpider, StructuredDataSpider):
     ]
     sitemap_rules = [(r"/[a-z]{2}/[^/]+/[^/]+/[^/]+$", "parse_sd")]
 
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        for ld_obj in LinkedDataParser.iter_linked_data(response):
+            if ld_obj.get("credentialSubject"):
+                yield ld_obj["credentialSubject"]
+
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         item["image"] = item["name"] = None
 
         if branch := response.xpath("//title/text()").re_first(r" at (.+?) \|"):
             item["branch"] = branch
-
-        for blob in response.xpath('//script[@type="application/ld+json"]/text()').getall():
-            try:
-                data = json.loads(blob)
-            except json.JSONDecodeError:
-                continue
-            if subject := data.get("credentialSubject"):
-                if geo := subject.get("geo"):
-                    item["lat"] = geo.get("latitude")
-                    item["lon"] = geo.get("longitude")
-                item["opening_hours"] = LinkedDataParser.parse_opening_hours(subject)
-                break
 
         apply_category(Categories.SHOP_CLOTHES, item)
         yield item

--- a/locations/spiders/express.py
+++ b/locations/spiders/express.py
@@ -4,7 +4,7 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.items import Feature, set_closed
 from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -24,7 +24,9 @@ class ExpressSpider(SitemapSpider, StructuredDataSpider):
                 yield ld_obj["credentialSubject"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
-        item["image"] = item["name"] = None
+        item["image"] = None
+        if "Closed" in item["name"]:
+            set_closed(item)
 
         if branch := response.xpath("//title/text()").re_first(r" at (.+?) \|"):
             item["branch"] = branch

--- a/locations/spiders/express.py
+++ b/locations/spiders/express.py
@@ -1,83 +1,41 @@
-import re
+import json
+from typing import Any
 
-import scrapy
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ExpressSpider(scrapy.Spider):
+class ExpressSpider(SitemapSpider, StructuredDataSpider):
     name = "express"
     item_attributes = {"brand": "Express", "brand_wikidata": "Q1384784"}
-    allowed_domains = ["stores.express.com", "stores.expressfactoryoutlet.com"]
-    start_urls = (
-        "https://stores.express.com/us",
-        "https://stores.express.com/cr",
-        "https://stores.express.com/gt",
-        "https://stores.express.com/pa",
-        "https://stores.express.com/sv",
-        "https://stores.express.com/mx",
-        "https://stores.express.com/pr",
-        "https://stores.expressfactoryoutlet.com/us",
-        "https://stores.expressfactoryoutlet.com/pr",
-    )
+    sitemap_urls = [
+        "https://stores.express.com/sitemap.xml",
+        "https://stores.expressfactoryoutlet.com/sitemap.xml",
+    ]
+    sitemap_rules = [(r"/[a-z]{2}/[^/]+/[^/]+/[^/]+$", "parse_sd")]
 
-    def parse_hours(self, hours):
-        o = OpeningHours()
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["image"] = item["name"] = None
 
-        for h in hours:
+        if branch := response.xpath("//title/text()").re_first(r" at (.+?) \|"):
+            item["branch"] = branch
+
+        for blob in response.xpath('//script[@type="application/ld+json"]/text()').getall():
             try:
-                day, open, close = re.search(r"(.{2})\s([\d:]+)-([\d:]+)", h).groups()
-                o.add_range(day, open_time=open, close_time=close, time_format="%H:%M")
-            except AttributeError:
+                data = json.loads(blob)
+            except json.JSONDecodeError:
                 continue
+            if subject := data.get("credentialSubject"):
+                if geo := subject.get("geo"):
+                    item["lat"] = geo.get("latitude")
+                    item["lon"] = geo.get("longitude")
+                item["opening_hours"] = LinkedDataParser.parse_opening_hours(subject)
+                break
 
-        return o.as_opening_hours()
-
-    def parse_stores(self, response):
-        ref = re.findall(r"[^(\/)]+$", response.url)
-        if len(ref) > 0:
-            ref = ref[0].split(".")[0]
-        properties = {
-            "name": response.xpath('//h1[contains(@class, "Hero-subTitle")]/text()').extract_first(),
-            "street_address": response.xpath('//meta[@itemprop="streetAddress"]/@content').extract_first(),
-            "phone": response.xpath('normalize-space(//div[@itemprop="telephone"]/text())').extract_first(),
-            "city": response.xpath('//meta[@itemprop="addressLocality"]/@content').extract_first(),
-            "state": response.xpath('//abbr[@itemprop="addressRegion"]/text()').extract_first(),
-            "postcode": response.xpath('//span[@itemprop="postalCode"]/text()').extract_first(),
-            "country": response.xpath('//abbr[@itemprop="addressCountry"]/text()').extract_first(),
-            "ref": ref,
-            "website": response.url,
-            "lat": float(response.xpath('normalize-space(//meta[@itemprop="latitude"]/@content)').extract_first()),
-            "lon": float(response.xpath('normalize-space(//meta[@itemprop="longitude"]/@content)').extract_first()),
-            "brand": response.xpath('//h1[@itemprop="name"]/text()')
-            .extract_first()
-            .replace(" - Temporarily Closed", ""),
-        }
-
-        hours = response.xpath('//tr[@itemprop="openingHours"]/@content').extract()
-        if hours:
-            opening_hours = self.parse_hours(hours)
-            if opening_hours:
-                properties["opening_hours"] = opening_hours
-
-        apply_category(Categories.SHOP_CLOTHES, properties)
-        yield Feature(**properties)
-
-    def parse_city_stores(self, response):
-        stores = response.xpath('//li[@class="Directory-listTeaser"]/a/@href').extract()
-        for store in stores:
-            yield scrapy.Request(response.urljoin(store), callback=self.parse_stores)
-
-    def parse(self, response):
-        urls = response.xpath('//li[@class="Directory-listItem"]/a/@href').extract()
-        for path in urls:
-            pattern = re.compile(r"^[a-z]{2}\/[^()\/]+$")
-            pattern1 = re.compile(r"^[a-z]{2}\/[^()]+\/[^()]+\/[^()]+$")
-            if pattern.match(path.strip("./")):
-                yield scrapy.Request(response.urljoin(path))
-            elif pattern1.match(path.strip("./")):
-                yield scrapy.Request(response.urljoin(path), callback=self.parse_stores)
-            else:
-                yield scrapy.Request(response.urljoin(path), callback=self.parse_city_stores)
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
The store directory markup changed (the `Directory-listItem` /
`itemprop` selectors are gone), so the spider crawled no store pages
and produced zero features.

Rewrite as a `SitemapSpider` + `StructuredDataSpider` over both store
domains' sitemaps (`stores.express.com`, `stores.expressfactoryoutlet.com`):
- Address, phone and name come from the `ClothingStore` ld+json.
- Geo and opening hours come from the Yext `credentialSubject` ld+json
  (the main block's `openingHours` is a `00:00-00:00` sentinel).
- Branch from the page title.

Recovers from 0 to 405 stores (US plus the international PR/PA/CR/SV/MX/GT
locations).