### PR TITLE
[Fjällräven] Fix spider

### DIFF
--- a/locations/spiders/fjallraven.py
+++ b/locations/spiders/fjallraven.py
@@ -1,18 +1,22 @@
-from locations.categories import Categories
-from locations.storefinders.where2getit import Where2GetItSpider
+import re
+from typing import Iterable
+
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.locally import LocallySpider
 
 
-class FjallravenSpider(Where2GetItSpider):
+class FjallravenSpider(LocallySpider):
     name = "fjallraven"
-    item_attributes = {
-        "brand": "Fjällräven",
-        "brand_wikidata": "Q1422481",
-        "extras": Categories.SHOP_OUTDOOR.value,
-    }
-    api_brand_name = "fjallraven"
-    api_key = "FE424754-8D89-11E7-A07A-F839407E493E"
-    api_filter = {
-        "brand_store": {"eq": "1"},
-    }
-    # Website seems to be generic
-    drop_attributes = {"website"}
+    item_attributes = {"brand": "Fjällräven", "brand_wikidata": "Q1422481"}
+    company_id = 1392
+    categories = ["brandstore", "Outlet"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
+        if store_name := item.pop("name", None):
+            item["branch"] = re.sub(r"^Fj[äa]llr[äa]ven\s*-?\s*", "", store_name)
+        item["street_address"] = item.pop("addr_full")
+        apply_category(Categories.SHOP_OUTDOOR, item)
+        yield item


### PR DESCRIPTION
The Where2GetIt appkey is no longer valid (`code 1004 "not a valid appkey"`); the brand moved its store locator to Locally.

Rebase the spider onto `LocallySpider` (`company_id` 1392, `brandstore` + `Outlet` categories), stripping the brand prefix into `branch` and applying the outdoor-shop category. Address, geo, phone and opening hours all come from the Locally API.