### PR TITLE
[First Hotels] Fix spider

### DIFF
--- a/locations/spiders/first_hotels.py
+++ b/locations/spiders/first_hotels.py
@@ -1,29 +1,50 @@
 import json
+import re
+from typing import Any, Iterable
 
-import scrapy
+import chompjs
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature, SocialMedia, set_social_media
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class FirstHotelsSpider(StructuredDataSpider):
+class FirstHotelsSpider(JSONBlobSpider):
     name = "first_hotels"
     item_attributes = {"brand": "First Hotels", "brand_wikidata": "Q11969007"}
     start_urls = ["https://www.firsthotels.com/general-info/about-first-hotels/map-of-hotels/"]
 
-    def parse(self, response):
-        hotels = json.loads(response.xpath('//*[@class="allhotels"]/div/@data-pois').get())
-        for hotel in hotels:
-            yield scrapy.Request(url="https://www.firsthotels.com" + hotel["url"], callback=self.parse_sd)
+    def extract_json(self, response: Response) -> list[dict]:
+        stream = "".join(
+            json.loads(chunk) for chunk in re.findall(r'self\.__next_f\.push\(\[1,(".*?")\]\)', response.text, re.S)
+        )
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        coords = ld_data["hasMap"].split("@")[1]
-        item["name"] = item["name"].strip()
-        item["lat"] = coords.split(",")[0]
-        item["lon"] = coords.split(",")[1]
+        countries = {}
+        for match in re.finditer(r'\{"id":\d+,"_order":', stream):
+            city = chompjs.parse_js_object(stream[match.start() :])
+            if city.get("countrySlug"):
+                countries[city["id"]] = city["countrySlug"]
 
-        for alt in response.xpath('//link[@rel="alternate"][@hreflang]'):
-            item["extras"]["website:{}".format(alt.xpath("@hreflang").get())] = alt.xpath("@href").get()
+        locations = {}
+        for match in re.finditer(r'"synxis_id":', stream):
+            location = chompjs.parse_js_object(stream[stream.rfind("{", 0, match.start()) :])
+            if "lat" not in location or location.get("hotelType") == "partner":
+                continue
+            location["country_slug"] = countries.get(location["city"])
+            locations[location["id"]] = location
+        return list(locations.values())
+
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full", None)
+        item["city"] = location.get("postalAddress")
+        item["email"] = location.get("mail")
+        if instagram := location.get("instagramUrl"):
+            set_social_media(item, SocialMedia.INSTAGRAM, instagram)
+        if location.get("country_slug"):
+            item["website"] = "https://www.firsthotels.com/{}/{}".format(location["country_slug"], location["slug"])
+        if images := location.get("images"):
+            item["image"] = images[0].get("image", {}).get("external")
 
         apply_category(Categories.HOTEL, item)
         yield item


### PR DESCRIPTION
The site was rebuilt on Next.js, dropping the `data-pois` attribute and ld+json the spider relied on, so it produced zero features.

Reconstruct the Next.js RSC (`__next_f`) stream and parse the hotel records with `chompjs` + `DictParser`. Exclude `partner` (non-First-branded) hotels via `hotelType`; add per-hotel `image` and Instagram.

Recovers from 0 to 28 hotels.