### PR TITLE
[Spar IE] Increase download timeout to fix spider

### DIFF
--- a/locations/spiders/spar_ie.py
+++ b/locations/spiders/spar_ie.py
@@ -16,6 +16,7 @@ class SparIESpider(Spider):
     name = "spar_ie"
     item_attributes = SPAR_SHARED_ATTRIBUTES
     start_urls = ["https://www.spar.ie/store-locator/"]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 90}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         match = re.search(


### PR DESCRIPTION
When tested on the US network, the spider was hitting timeouts with the default download timeout setting. Increased DOWNLOAD_TIMEOUT to 90 to resolve the issue.
```
{'atp/brand/Spar': 412,
 'atp/brand_wikidata/Q610492': 412,
 'atp/category/shop/convenience': 412,
 'atp/country/IE': 412,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 412,
 'atp/field/email/missing': 412,
 'atp/field/housenumber/missing': 412,
 'atp/field/opening_hours/missing': 272,
 'atp/field/operator/missing': 412,
 'atp/field/operator_wikidata/missing': 412,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 24,
 'atp/field/postcode/missing': 22,
 'atp/field/state/missing': 412,
 'atp/field/street/missing': 412,
 'atp/field/street_address/missing': 412,
 'atp/field/twitter/missing': 412,
 'atp/field/unit/missing': 412,
 'atp/item_scraped_host_count/www.spar.ie': 412,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 412,
 'downloader/request_bytes': 978,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 734594,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.531000000000006,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 5, 6, 57, 54, 334572, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 412,
 'items_per_minute': 3090.0,
 'log_count/DEBUG': 414,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 5, 6, 57, 45, 799966, tzinfo=datetime.timezone.utc)}
```