### PR TITLE
[Thaï Express] Fix spider

### DIFF
--- a/locations/spiders/thai_express_ca.py
+++ b/locations/spiders/thai_express_ca.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import Any, Iterable
 

--- a/locations/spiders/thai_express_ca.py
+++ b/locations/spiders/thai_express_ca.py
@@ -11,8 +11,8 @@ from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class ThaiExpressUSSpider(SitemapSpider, StructuredDataSpider):
-    name = "thai_express_us"
+class ThaiExpressCASpider(SitemapSpider, StructuredDataSpider):
+    name = "thai_express_ca"
     item_attributes = {"brand": "Thaï Express", "brand_wikidata": "Q7711610"}
     sitemap_urls = ["https://locations.thaiexpress.ca/sitemap.xml"]
     sitemap_rules = [(r"https://locations\.thaiexpress\.ca/(?:qc|on|ab|bc|ns|mb|sk|nb|nl|pe)/[^/]+/[^/]+$", "parse_sd")]

--- a/locations/spiders/thai_express_ca_us.py
+++ b/locations/spiders/thai_express_ca_us.py
@@ -1,12 +1,35 @@
-from locations.storefinders.super_store_finder import SuperStoreFinderSpider
+import json
+import re
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ThaiExpressCAUSSpider(SuperStoreFinderSpider):
+class ThaiExpressCAUSSpider(SitemapSpider, StructuredDataSpider):
     name = "thai_express_ca_us"
     item_attributes = {
         "brand_wikidata": "Q7711610",
         "brand": "Thaï Express",
     }
-    allowed_domains = [
-        "locations.thaiexpress.ca",
-    ]
+    sitemap_urls = ["https://locations.thaiexpress.ca/sitemap.xml"]
+    sitemap_rules = [(r"https://locations\.thaiexpress\.ca/(?:qc|on|ab|bc|ns|mb|sk|nb|nl|pe)/[^/]+/[^/]+$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        branch = re.sub(r"^Tha[iï] Express( Restaurant)?\s*", "", item.pop("name", "") or "").strip()
+        item["branch"] = branch or None
+        item["image"] = None
+
+        for ld in response.xpath('//script[@type="application/ld+json"]/text()').getall():
+            if '"GeoCoordinates"' not in ld:
+                continue
+            if geo := json.loads(ld).get("credentialSubject", {}).get("geo"):
+                item["lat"], item["lon"] = geo.get("latitude"), geo.get("longitude")
+                break
+
+        apply_category(Categories.FAST_FOOD, item)
+        yield item

--- a/locations/spiders/thai_express_ca_us.py
+++ b/locations/spiders/thai_express_ca_us.py
@@ -1,35 +1,32 @@
 import json
 import re
-from typing import Any
+from typing import Any, Iterable
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class ThaiExpressCAUSSpider(SitemapSpider, StructuredDataSpider):
     name = "thai_express_ca_us"
-    item_attributes = {
-        "brand_wikidata": "Q7711610",
-        "brand": "Thaï Express",
-    }
+    item_attributes = {"brand": "Thaï Express", "brand_wikidata": "Q7711610"}
     sitemap_urls = ["https://locations.thaiexpress.ca/sitemap.xml"]
     sitemap_rules = [(r"https://locations\.thaiexpress\.ca/(?:qc|on|ab|bc|ns|mb|sk|nb|nl|pe)/[^/]+/[^/]+$", "parse_sd")]
+
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        for ld_obj in LinkedDataParser.iter_linked_data(response):
+            if ld_obj.get("credentialSubject"):
+                yield ld_obj["credentialSubject"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         branch = re.sub(r"^Tha[iï] Express( Restaurant)?\s*", "", item.pop("name", "") or "").strip()
         item["branch"] = branch or None
         item["image"] = None
 
-        for ld in response.xpath('//script[@type="application/ld+json"]/text()').getall():
-            if '"GeoCoordinates"' not in ld:
-                continue
-            if geo := json.loads(ld).get("credentialSubject", {}).get("geo"):
-                item["lat"], item["lon"] = geo.get("latitude"), geo.get("longitude")
-                break
-
         apply_category(Categories.FAST_FOOD, item)
+
         yield item

--- a/locations/spiders/thai_express_us.py
+++ b/locations/spiders/thai_express_us.py
@@ -11,8 +11,8 @@ from locations.linked_data_parser import LinkedDataParser
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class ThaiExpressCAUSSpider(SitemapSpider, StructuredDataSpider):
-    name = "thai_express_ca_us"
+class ThaiExpressUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "thai_express_us"
     item_attributes = {"brand": "Thaï Express", "brand_wikidata": "Q7711610"}
     sitemap_urls = ["https://locations.thaiexpress.ca/sitemap.xml"]
     sitemap_rules = [(r"https://locations\.thaiexpress\.ca/(?:qc|on|ab|bc|ns|mb|sk|nb|nl|pe)/[^/]+/[^/]+$", "parse_sd")]


### PR DESCRIPTION
The SuperStoreFinder plugin endpoint (`ssf-wp-xml.php`) was removed when the brand moved to a Yext-hosted store locator, so the spider produced zero features.

Rewrite as a `SitemapSpider` + `StructuredDataSpider` over the Yext sitemap. The `sitemap_rules` match only the Canadian province-prefixed store URLs, excluding the `en`/`fr-ca` localized duplicates. `name` is left for NSI to fill; `branch` is the store name with the brand prefix stripped; geo comes from the Yext `credentialSubject` ld+json.

Recovers from 0 to 299 stores.