### PR TITLE
[Lacoste] Fix Spider

### DIFF
--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -1,32 +1,11 @@
-import html
-from typing import Iterable
-
-from scrapy.http import Response
-
-from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
-from locations.user_agents import FIREFOX_LATEST
+from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class LacosteSpider(JSONBlobSpider):
+class LacosteSpider(YextAnswersSpider):
     name = "lacoste"
     item_attributes = {"brand": "Lacoste", "brand_wikidata": "Q309031"}
-    start_urls = ["https://www.lacoste.com/us/stores?country=&city=&json=true"]
-    custom_settings = {"USER_AGENT": FIREFOX_LATEST}
-    requires_proxy = True
-
-    def extract_json(self, response: Response) -> list:
-        return response.json()["stores"]
-
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["street_address"] = item.pop("addr_full")
-        item["website"] = f'https://www.lacoste.com/us/stores{feature["url"]}'
-        item["name"] = html.unescape(item["name"]).strip()
-        country = feature["url"].split("/")[1]
-        if "taiwan" in country:
-            item["country"] = "TW"
-        elif country.startswith("china"):
-            item["country"] = "CN"
-        else:
-            item["country"] = country.title()
-        yield item
+    api_key = "838385fd3ca042db80e71cce34e3d417"
+    api_version = "20220511"
+    environment = "PRODUCTION"
+    experience_key = "locator-search-eu"
+    locale = "en-US"


### PR DESCRIPTION
```python
{'atp/brand/Lacoste': 1106,
 'atp/brand_wikidata/Q309031': 1106,
 'atp/category/shop/clothes': 1106,
 'atp/cdn/cloudflare/response_count': 24,
 'atp/cdn/cloudflare/response_status_count/200': 23,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/AD': 1,
 'atp/country/AT': 7,
 'atp/country/BE': 9,
 'atp/country/BR': 81,
 'atp/country/CA': 19,
 'atp/country/CH': 22,
 'atp/country/DE': 28,
 'atp/country/DK': 2,
 'atp/country/ES': 43,
 'atp/country/FR': 474,
 'atp/country/GB': 17,
 'atp/country/IE': 1,
 'atp/country/IT': 26,
 'atp/country/KR': 213,
 'atp/country/MC': 1,
 'atp/country/MX': 47,
 'atp/country/NL': 5,
 'atp/country/PR': 2,
 'atp/country/PT': 18,
 'atp/country/SE': 1,
 'atp/country/US': 89,
 'atp/field/branch/missing': 1104,
 'atp/field/email/missing': 346,
 'atp/field/housenumber/missing': 1106,
 'atp/field/opening_hours/missing': 321,
 'atp/field/operator/missing': 1106,
 'atp/field/operator_wikidata/missing': 1106,
 'atp/field/phone/missing': 80,
 'atp/field/state/missing': 817,
 'atp/field/street/missing': 1106,
 'atp/field/twitter/missing': 1106,
 'atp/field/unit/missing': 1106,
 'atp/item_scraped_host_count/liveapi.yext.com': 1106,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1106,
 'downloader/request_bytes': 23009,
 'downloader/request_count': 24,
 'downloader/request_method_count/GET': 24,
 'downloader/response_bytes': 811655,
 'downloader/response_count': 24,
 'downloader/response_status_count/200': 23,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 33.453000000008615,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 5, 8, 36, 37, 695552, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6920049,
 'httpcompression/response_count': 23,
 'item_scraped_count': 1106,
 'items_per_minute': 2010.9090909090908,
 'log_count/DEBUG': 1130,
 'log_count/INFO': 3,
 'request_depth_max': 22,
 'response_received_count': 24,
 'responses_per_minute': 43.63636363636363,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 23,
 'scheduler/dequeued/memory': 23,
 'scheduler/enqueued': 23,
 'scheduler/enqueued/memory': 23,
 'start_time': datetime.datetime(2026, 6, 5, 8, 36, 4, 246561, tzinfo=datetime.timezone.utc)}
```