### PR TITLE
fix(europris_no): re-add removed fields

### DIFF
--- a/locations/spiders/europris_no.py
+++ b/locations/spiders/europris_no.py
@@ -1,10 +1,15 @@
+import re
 from typing import Iterable
 
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.hours import CLOSED_NO, DAYS_WEEKDAY, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.structured_data_spider import clean_facebook
+
+HOURS_RANGE_RE = re.compile(r"^(\d{1,2})-(\d{1,2})$")
 
 
 class EuroprisNOSpider(JSONBlobSpider):
@@ -17,5 +22,25 @@ class EuroprisNOSpider(JSONBlobSpider):
         item["ref"] = store.get("source_code")
         item["branch"] = item.pop("name").removeprefix("Europris").strip()
         item["street_address"] = item.pop("street", None)
+
+        extension_attributes = store.get("extension_attributes", {})
+        item["state"] = extension_attributes.get("district")
+        if facebook := clean_facebook(extension_attributes.get("facebook_url")):
+            item["facebook"] = facebook
+
+        oh = OpeningHours()
+        for days, key in (
+            (DAYS_WEEKDAY, "open_hours_workdays"),
+            (["Sa"], "open_hours_saturday"),
+            (["Su"], "open_hours_sunday"),
+        ):
+            value = (extension_attributes.get(key) or "").replace(" ", "")
+            if value.lower() in CLOSED_NO:
+                oh.set_closed(days)
+            elif m := HOURS_RANGE_RE.match(value):
+                oh.add_days_range(days, m[1], m[2], time_format="%H")
+
+        item["opening_hours"] = oh
+
         apply_category(Categories.SHOP_GENERAL, item)
         yield item


### PR DESCRIPTION
Seems like some AI slop from claud in https://github.com/alltheplaces/alltheplaces/pull/16476 removed fields like `facebook_url`, `open_hours_workdays`, `open_hours_saturday` and `open_hours_sunday` that was actually still being returned from the API

The AI also broke the region by returning this as the region: `Region 2 (Nord)`
This is due to the AI removing the `store.pop("region")`. I added code back to use a correct region from extension_attributes called `district`