### PR TITLE
fix(statens_vegvesen_nvdb_no): increase download timeout

### DIFF
--- a/locations/spiders/infrastructure/statens_vegvesen_nvdb_no.py
+++ b/locations/spiders/infrastructure/statens_vegvesen_nvdb_no.py
@@ -169,7 +169,10 @@ class StatensVegvesenNvdbNOSpider(scrapy.Spider):
 
     name = "statens_vegvesen_nvdb_no"
     allowed_domains = ["nvdb-eksport.atlas.vegvesen.no"]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 600}
+    custom_settings = {
+        "CONCURRENT_REQUESTS": 1,
+        "DOWNLOAD_TIMEOUT": 1800,
+    }
     dataset_attributes = Licenses.NO_NLODv2.value | {
         "attribution:name": "Contains data under the Norwegian licence for Open Government data (NLOD) distributed by Statens vegvesen"
     }


### PR DESCRIPTION
This aims to increase success by allowing more time to download the massive JSON files, and reduce strain on server by only sending one request at a time
