### PR TITLE
[E-Net ATM] fix spider to not grab closed locations

### DIFF
--- a/locations/spiders/enet_jp.py
+++ b/locations/spiders/enet_jp.py
@@ -8,16 +8,15 @@ from locations.storefinders.location_cloud import LocationCloudSpider
 class EnetJPSpider(LocationCloudSpider):
     name = "enet_jp"
     item_attributes = {"brand_wikidata": "Q135317450"}
-    
+
     api_endpoint = "https://pkg.navitime.co.jp/enet/api/proxy2/shop/list"
     website_formatter = "https://pkg.navitime.co.jp/enet/spot/detail?code={}"
     additional_args = "&c_d1=1"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
-        
+
         item["branch"] = source_feature.get("name").removesuffix("　共同出張所")
         item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
         apply_category(Categories.ATM, item)
 
         yield item
-

--- a/locations/spiders/enet_jp.py
+++ b/locations/spiders/enet_jp.py
@@ -1,45 +1,23 @@
-from typing import Any, AsyncIterator
-
-from scrapy import Spider
-from scrapy.http import Request, Response
+from typing import Iterable
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
 
 
-class EnetJPSpider(Spider):
+class EnetJPSpider(LocationCloudSpider):
     name = "enet_jp"
-    item_attributes = {"brand": "イーネット", "brand_wikidata": "Q135317450"}
+    item_attributes = {"brand_wikidata": "Q135317450"}
+    
+    api_endpoint = "https://pkg.navitime.co.jp/enet/api/proxy2/shop/list"
+    website_formatter = "https://pkg.navitime.co.jp/enet/spot/detail?code={}"
+    additional_args = "&c_d1=1"
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield self.get_page(0)
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        
+        item["branch"] = source_feature.get("name").removesuffix("　共同出張所")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+        apply_category(Categories.ATM, item)
 
-    def get_page(self, n):
-        return Request(
-            f"https://pkg.navitime.co.jp/enet/api/proxy2/shop/list?datum=wgs84&limit=500&offset={n}",
-            meta={"offset": n},
-        )
+        yield item
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = response.json()
-        stores = data["items"]
-
-        for store in stores:
-            item = DictParser.parse(store)
-            item["name"] = "イーネット"
-            item["extras"]["name:en"] = "E-net"
-            item["branch"] = store["name"].removesuffix("　共同出張所")
-            item["ref"] = store["code"]
-            item["lat"] = store["coord"]["lat"]
-            item["lon"] = store["coord"]["lon"]
-            item["extras"]["branch:ja-Hira"] = store["ruby"]
-            item["addr_full"] = store["address_name"]
-            item["postcode"] = store["postal_code"]
-            item["website"] = f"https://pkg.navitime.co.jp/enet/spot/detail?code={store['code']}"
-
-            apply_category(Categories.ATM, item)
-
-            yield item
-
-        if data["count"]["limit"] == len(data["items"]):
-            yield self.get_page(data["count"]["limit"] + response.meta["offset"])

--- a/locations/storefinders/location_cloud.py
+++ b/locations/storefinders/location_cloud.py
@@ -12,6 +12,7 @@ class LocationCloudSpider(Spider):
     dataset_attributes: dict = {"source": "api"}
 
     api_endpoint: str
+    additional_args: str = ""
     website_formatter: str = ""
 
     async def start(self) -> AsyncIterator[Request]:
@@ -19,7 +20,7 @@ class LocationCloudSpider(Spider):
 
     def _get_page(self, offset: int):
         return Request(
-            "{}?datum=wgs84&limit=500&offset={}".format(self.api_endpoint, offset),
+            "{}?datum=wgs84&limit=500{}&offset={}".format(self.api_endpoint, self.additional_args, offset),
             meta={"offset": offset},
         )
 


### PR DESCRIPTION
fixes #16575
added an additional_args string to the location cloud storefinder so the argument needed can be put in.

{'atp/brand/イーネット': 11671,
 'atp/brand_wikidata/Q135317450': 11671,
 'atp/category/amenity/atm': 11671,
 'atp/country/JP': 11671,
 'atp/field/city/missing': 11671,
 'atp/field/country/from_spider_name': 11671,
 'atp/field/email/missing': 11671,
 'atp/field/housenumber/missing': 11671,
 'atp/field/opening_hours/missing': 11671,
 'atp/field/operator/missing': 11671,
 'atp/field/operator_wikidata/missing': 11671,
 'atp/field/phone/missing': 11671,
 'atp/field/state/missing': 11671,
 'atp/field/street/missing': 11671,
 'atp/field/street_address/missing': 11671,
 'atp/field/twitter/missing': 11671,
 'atp/field/unit/missing': 11671,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 11671,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 11671,
 'downloader/request_bytes': 14021,
 'downloader/request_count': 25,
 'downloader/request_method_count/GET': 25,
 'downloader/response_bytes': 829855,
 'downloader/response_count': 25,
 'downloader/response_status_count/200': 25,
 'elapsed_time_seconds': 60.46900000000005,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 6, 10, 32, 9, 19406, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4513605,
 'httpcompression/response_count': 25,
 'item_scraped_count': 11671,
 'items_per_minute': 11671.0,
 'log_count/DEBUG': 11696,
 'log_count/INFO': 4,
 'request_depth_max': 23,
 'response_received_count': 25,
 'responses_per_minute': 25.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 24,
 'scheduler/dequeued/memory': 24,
 'scheduler/enqueued': 24,
 'scheduler/enqueued/memory': 24,
 'start_time': datetime.datetime(2026, 6, 6, 10, 31, 8, 559089, tzinfo=datetime.timezone.utc)}