### PR TITLE
[Coinflip] Fix Spider

### DIFF
--- a/locations/spiders/coinflip.py
+++ b/locations/spiders/coinflip.py
@@ -1,41 +1,13 @@
-import re
+from scrapy.spiders import SitemapSpider
 
-from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-
-from locations.hours import DAYS_FULL, OpeningHours
-from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class CoinflipSpider(CrawlSpider, StructuredDataSpider):
+class CoinflipSpider(SitemapSpider, StructuredDataSpider):
     name = "coinflip"
     item_attributes = {"brand": "CoinFlip", "brand_wikidata": "Q109850256"}
-    start_urls = ["https://locations.coinflip.tech/"]
-
-    rules = [
-        Rule(LinkExtractor(allow=r"/\w+$", restrict_xpaths="//main//ul")),
-        Rule(LinkExtractor(allow=r"/\w+/[a-z-]+$", restrict_xpaths="//main//ul")),
-        Rule(LinkExtractor(allow=r"/\w+/[a-z-]+/[a-z-]+$", restrict_xpaths="//main//ul")),
-        Rule(
-            LinkExtractor(
-                allow=r"/\w+/[a-z-]+/[a-z-]+/[a-z-0-9]+$",
-            ),
-            callback="parse_sd",
-        ),
-    ]
+    sitemap_urls = ["https://coinflip.tech/locations-sitemap.xml"]
+    sitemap_rules = [(r"https://locations.coinflip.tech/[^/]+/[^/]+/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["AutomatedTeller"]
     custom_settings = {"ROBOTSTXT_OBEY": False, "CONCURRENT_REQUESTS": 1, "USER_AGENT": BROWSER_DEFAULT}
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["lat"], item["lon"] = re.search(r"q=(-?\d+\.\d+),(-?\d+\.\d+)", ld_data["hasMap"]).groups()
-        oh = OpeningHours()
-        for day_time in ld_data["openingHoursSpecification"]:
-            day = DAYS_FULL[int(day_time["dayOfWeek"][0])]
-            open_time = day_time["opens"]
-            close_time = day_time["closes"]
-            oh.add_range(day=day, open_time=open_time.strip(), close_time=close_time.strip(), time_format="%I:%M %p")
-        item["opening_hours"] = oh
-        yield item


### PR DESCRIPTION
```python
{'atp/brand/CoinFlip': 500,
 'atp/brand_wikidata/Q109850256': 500,
 'atp/category/amenity/atm': 500,
 'atp/cdn/cloudflare/response_count': 501,
 'atp/cdn/cloudflare/response_status_count/200': 501,
 'atp/country/AU': 216,
 'atp/country/CA': 13,
 'atp/country/IT': 26,
 'atp/country/NZ': 21,
 'atp/country/PR': 5,
 'atp/country/US': 212,
 'atp/country/ZA': 7,
 'atp/field/branch/missing': 500,
 'atp/field/housenumber/missing': 500,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 500,
 'atp/field/operator_wikidata/missing': 500,
 'atp/field/street/missing': 500,
 'atp/field/unit/missing': 500,
 'atp/item_scraped_host_count/locations.coinflip.tech': 500,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 500,
 'downloader/request_bytes': 284592,
 'downloader/request_count': 501,
 'downloader/request_method_count/GET': 501,
 'downloader/response_bytes': 20250653,
 'downloader/response_count': 501,
 'downloader/response_status_count/200': 501,
 'elapsed_time_seconds': 613.2029999999795,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 8, 6, 44, 36, 925832, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 127706855,
 'httpcompression/response_count': 501,
 'item_scraped_count': 500,
 'items_per_minute': 48.939641109298535,
 'log_count/DEBUG': 1001,
 'log_count/INFO': 13,
 'request_depth_max': 1,
 'response_received_count': 501,
 'responses_per_minute': 49.03752039151713,
 'scheduler/dequeued': 501,
 'scheduler/dequeued/memory': 501,
 'scheduler/enqueued': 501,
 'scheduler/enqueued/memory': 501,
 'start_time': datetime.datetime(2026, 6, 8, 6, 34, 23, 716349, tzinfo=datetime.timezone.utc)}
```