### PR TITLE
[Radisson Hotels] Protect spider against timeout error properly

### DIFF
--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -1,16 +1,16 @@
 import json
 from typing import Any, AsyncIterator
 
-from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class RadissonHotelsSpider(Spider):
+class RadissonHotelsSpider(PlaywrightSpider):
     name = "radisson_hotels"
     allowed_domains = ["www.radissonhotels.com"]
     brand_mapping = {
@@ -27,11 +27,10 @@ class RadissonHotelsSpider(Spider):
         "ri": ["Radisson Individuals", None],
         "pis": ["Park Inn & Suites by Radisson", None],
     }
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "USER_AGENT": BROWSER_DEFAULT,
         "ROBOTSTXT_OBEY": False,
-        "DOWNLOAD_TIMEOUT": 300,
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 300 * 1000,
     }
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
```python
{'atp/brand/Art’otel': 7,
 'atp/brand/Country Inn & Suites by Radisson': 10,
 'atp/brand/Park Inn': 93,
 'atp/brand/Park Inn & Suites by Radisson': 3,
 'atp/brand/Park Plaza': 38,
 'atp/brand/Prizeotel': 20,
 'atp/brand/Radisson': 144,
 'atp/brand/Radisson Blu': 334,
 'atp/brand/Radisson Collection': 45,
 'atp/brand/Radisson Individuals': 102,
 'atp/brand/Radisson RED': 31,
 'atp/brand_wikidata/Q14516231': 7,
 'atp/brand_wikidata/Q1751979': 144,
 'atp/brand_wikidata/Q2052550': 38,
 'atp/brand_wikidata/Q28233721': 31,
 'atp/brand_wikidata/Q5177332': 10,
 'atp/brand_wikidata/Q60711675': 93,
 'atp/brand_wikidata/Q60716706': 45,
 'atp/brand_wikidata/Q7281341': 334,
 'atp/category/tourism/hotel': 848,
 'atp/clean_strings/email': 25,
 'atp/clean_strings/phone': 28,
 'atp/clean_strings/postcode': 29,
 'atp/clean_strings/street_address': 25,
 'atp/country/AE': 15,
 'atp/country/AL': 1,
 'atp/country/AM': 2,
 'atp/country/AT': 10,
 'atp/country/AU': 2,
 'atp/country/AZ': 1,
 'atp/country/BD': 2,
 'atp/country/BE': 16,
 'atp/country/BG': 2,
 'atp/country/BH': 2,
 'atp/country/BN': 1,
 'atp/country/CG': 1,
 'atp/country/CH': 9,
 'atp/country/CI': 1,
 'atp/country/CN': 56,
 'atp/country/CY': 2,
 'atp/country/CZ': 1,
 'atp/country/DE': 58,
 'atp/country/DK': 6,
 'atp/country/EE': 5,
 'atp/country/EG': 4,
 'atp/country/ES': 12,
 'atp/country/ET': 1,
 'atp/country/FI': 9,
 'atp/country/FJ': 1,
 'atp/country/FR': 26,
 'atp/country/GA': 2,
 'atp/country/GB': 65,
 'atp/country/GE': 6,
 'atp/country/GN': 1,
 'atp/country/GR': 8,
 'atp/country/HR': 7,
 'atp/country/HU': 7,
 'atp/country/ID': 3,
 'atp/country/IE': 8,
 'atp/country/IN': 143,
 'atp/country/IQ': 2,
 'atp/country/IS': 3,
 'atp/country/IT': 17,
 'atp/country/JO': 1,
 'atp/country/KE': 3,
 'atp/country/KW': 2,
 'atp/country/KZ': 4,
 'atp/country/LB': 2,
 'atp/country/LK': 5,
 'atp/country/LT': 4,
 'atp/country/LU': 1,
 'atp/country/LV': 7,
 'atp/country/LY': 1,
 'atp/country/MA': 10,
 'atp/country/MD': 1,
 'atp/country/ME': 1,
 'atp/country/MG': 3,
 'atp/country/ML': 2,
 'atp/country/MT': 3,
 'atp/country/MU': 3,
 'atp/country/MV': 1,
 'atp/country/MY': 1,
 'atp/country/MZ': 1,
 'atp/country/NE': 1,
 'atp/country/NG': 4,
 'atp/country/NL': 11,
 'atp/country/NO': 25,
 'atp/country/NP': 1,
 'atp/country/NZ': 1,
 'atp/country/OM': 7,
 'atp/country/PH': 8,
 'atp/country/PK': 2,
 'atp/country/PL': 20,
 'atp/country/PT': 2,
 'atp/country/QA': 1,
 'atp/country/RE': 1,
 'atp/country/RO': 7,
 'atp/country/RS': 4,
 'atp/country/RU': 39,
 'atp/country/RW': 2,
 'atp/country/SA': 33,
 'atp/country/SE': 10,
 'atp/country/SI': 1,
 'atp/country/SK': 2,
 'atp/country/SL': 1,
 'atp/country/SN': 2,
 'atp/country/SS': 1,
 'atp/country/TD': 1,
 'atp/country/TH': 11,
 'atp/country/TN': 4,
 'atp/country/TR': 41,
 'atp/country/UA': 5,
 'atp/country/UZ': 2,
 'atp/country/VN': 8,
 'atp/country/ZA': 14,
 'atp/country/ZM': 2,
 'atp/field/branch/missing': 848,
 'atp/field/brand/missing': 21,
 'atp/field/brand_wikidata/missing': 146,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 5,
 'atp/field/housenumber/missing': 848,
 'atp/field/opening_hours/missing': 848,
 'atp/field/operator/missing': 848,
 'atp/field/operator_wikidata/missing': 848,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 48,
 'atp/field/state/missing': 848,
 'atp/field/street/missing': 848,
 'atp/field/twitter/missing': 848,
 'atp/field/unit/missing': 848,
 'atp/item_scraped_host_count/www.radissonhotels.com': 848,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 702,
 'atp/radisson_hotels/unknown_brand/Golden Tulip': 2,
 'atp/radisson_hotels/unknown_brand/J.': 1,
 'atp/radisson_hotels/unknown_brand/Jin Jiang': 15,
 'atp/radisson_hotels/unknown_brand/Kunlun': 3,
 'downloader/request_bytes': 307,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 3051510,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 7.530999999999949,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 8, 8, 53, 56, 895947, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 848,
 'items_per_minute': 7268.571428571428,
 'log_count/DEBUG': 853,
 'log_count/INFO': 7,
 'log_count/WARNING': 1,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 8.571428571428571,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 8, 8, 53, 49, 365127, tzinfo=datetime.timezone.utc)}
```