### PR TITLE
[Migros CH] Fix spider

### DIFF
--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -115,16 +115,10 @@ class MigrosCHSpider(Spider):
             if not block.get("active"):
                 continue
             for hours in block.get("opening_hours") or []:
-                day = DAYS[hours["day_of_week"] - 1]
-                ranges = [
-                    (hours.get("time_open1"), hours.get("time_close1")),
-                    (hours.get("time_open2"), hours.get("time_close2")),
-                ]
-                opened = False
-                for open_time, close_time in ranges:
-                    if open_time and close_time:
-                        oh.add_range(day, open_time, close_time)
-                        opened = True
-                if not opened and not hours.get("on_request1") and not hours.get("on_request2"):
-                    oh.set_closed(day)
+                for period in ["1", "2"]:
+                    oh.add_range(
+                        DAYS[hours["day_of_week"] - 1],
+                        hours["time_open{}".format(period)],
+                        hours["time_close{}".format(period)],
+                    )
         return oh

--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -56,7 +56,7 @@ class MigrosCHSpider(Spider):
         "out": ("Outlet Migros", "Q115659564", Categories.SHOP_SUPERMARKET),
         "pickmup": ("PickMup Box", "Q115679275", Categories.PRODUCT_PICKUP),
         "res": ("Migros Restaurant", "Q111803848", Categories.RESTAURANT),
-        "super": ("Migros", "Q115661152", Categories.SHOP_SUPERMARKET),
+        "super": ("Migros", "Q680727", Categories.SHOP_SUPERMARKET),
         "voi": ("VOI", "Q110277616", Categories.SHOP_SUPERMARKET),
     }
     api_url = "https://api.migros.ch/migros/sales/branches/v1/graphql"
@@ -71,14 +71,12 @@ class MigrosCHSpider(Spider):
             url=self.api_url,
             data={"query": QUERY, "variables": {"limit": self.page_size, "offset": offset}},
             headers={"x-api-key": self.api_key, "Accept-Language": "de"},
-            meta={"offset": offset},
+            cb_kwargs={"offset": offset},
         )
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        offset = response.meta["offset"]
+    def parse(self, response: Response, offset: int, **kwargs: Any) -> Any:
         facilities = response.json()["data"]["facilities"]
-        results = facilities["results"]
-        for facility in results:
+        for facility in facilities["results"]:
             yield from self.parse_facility(facility)
         if offset + self.page_size < facilities["total"]:
             yield self.api_request(offset + self.page_size)

--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -1,78 +1,104 @@
-import json
-import re
 from datetime import datetime
 from typing import Any
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
-from locations.items import Feature, set_closed
+from locations.items import set_closed
+
+QUERY = """
+query($limit: Int!, $offset: Int!) {
+  facilities(first: $limit, skip: $offset) {
+    total
+    results {
+      id
+      slug
+      location { address zip city country geo { lat lon } }
+      markets {
+        id
+        type
+        name
+        phone
+        email
+        opening_date
+        closing_date
+        opening_hours {
+          active
+          opening_hours {
+            day_of_week
+            time_open1
+            time_close1
+            time_open2
+            time_close2
+            on_request1
+            on_request2
+          }
+        }
+      }
+    }
+  }
+}
+"""
 
 
-class MigrosCHSpider(SitemapSpider):
+class MigrosCHSpider(Spider):
     name = "migros_ch"
     brands = {
-        "alna": ("Alnatura", "Q876811", Categories.SHOP_SUPERMARKET),
         "chng": ("Migros Change", "Q115659823", Categories.BUREAU_DE_CHANGE),
         "cof": ("Migros Café", "Q115661379", Categories.COFFEE_SHOP),
-        "doi": ("Do It + Garden", "Q108866119", Categories.SHOP_DOITYOURSELF),
         "flori": ("Florissimo", "Q115659418", Categories.SHOP_FLORIST),
         "gour": ("Migros Take Away", "Q111826610", Categories.FAST_FOOD),
-        "mec": ("melectronics", "Q110276002", Categories.SHOP_ELECTRONICS),
-        "mica": ("Micasa", "Q1926676", Categories.SHOP_FURNITURE),
         "mno": ("Migrolino", "Q56745088", Categories.SHOP_CONVENIENCE),
         "mp": ("Migros Partner", "Q115661515", Categories.SHOP_SUPERMARKET),
-        "obi": ("OBI", "Q300518", Categories.SHOP_DOITYOURSELF),
         "out": ("Outlet Migros", "Q115659564", Categories.SHOP_SUPERMARKET),
         "pickmup": ("PickMup Box", "Q115679275", Categories.PRODUCT_PICKUP),
         "res": ("Migros Restaurant", "Q111803848", Categories.RESTAURANT),
         "super": ("Migros", "Q115661152", Categories.SHOP_SUPERMARKET),
-        "spx": ("SportXX", "Q19309319", Categories.SHOP_SPORTS),
         "voi": ("VOI", "Q110277616", Categories.SHOP_SUPERMARKET),
     }
-    obsolete_brands = {"mod"}
-    allowed_domains = ["filialen.migros.ch"]
-    sitemap_urls = ["https://filialen.migros.ch/robots.txt"]
-    sitemap_follow = ["/de/"]
-    sitemap_rules = [(r"https://filialen\.migros\.ch/de/[-\w]+$", "parse")]
+    api_url = "https://api.migros.ch/migros/sales/branches/v1/graphql"
+    api_key = "c3C2RemDDaYV8b2NPDev1MEDn12KsonY"
+    page_size = 200
+
+    async def start(self):
+        yield self.api_request(0)
+
+    def api_request(self, offset: int) -> JsonRequest:
+        return JsonRequest(
+            url=self.api_url,
+            data={"query": QUERY, "variables": {"limit": self.page_size, "offset": offset}},
+            headers={"x-api-key": self.api_key, "Accept-Language": "de"},
+            meta={"offset": offset},
+        )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
+        offset = response.meta["offset"]
+        facilities = response.json()["data"]["facilities"]
+        results = facilities["results"]
+        for facility in results:
+            yield from self.parse_facility(facility)
+        if offset + self.page_size < facilities["total"]:
+            yield self.api_request(offset + self.page_size)
 
-        data = json.loads(
-            re.search(
-                r"({.*})\]n",
-                response.xpath('//*[contains(text(),"initialActiveStore")]/text()').get().replace("\\", ""),
-            ).group(1)
-        )
-        store = data["initialActiveStore"]
-        loc = store["location"]
-        for market in store["markets"]:
-            if market["slug"] != data["initialSlug"]:
-                continue
+    def parse_facility(self, facility: dict) -> Any:
+        for market in facility["markets"]:
             brand_key = market["type"].split("_")[0]
             if brand_key not in self.brands:
-                if brand_key not in self.obsolete_brands:
-                    self.logger.error('unknown brand: "%s"' % brand_key)
                 continue
             brand, brand_wikidata, category = self.brands[brand_key]
-            item = Feature(
-                brand=brand,
-                brand_wikidata=brand_wikidata,
-                city=loc["city"],
-                country=loc["country"],
-                email=market["email"],
-                lat=loc["geo"]["lat"],
-                lon=loc["geo"]["lon"],
-                name=brand,
-                opening_hours=self.parse_opening_hours(market),
-                phone=market.get("phone"),
-                postcode=loc.get("zip"),
-                ref=market["id"],
-                street_address=loc.get("address"),
-                website=response.url,
-            )
+            market.update(facility["location"])
+            if geo := market.pop("geo", None):
+                market.update(geo)
+
+            item = DictParser.parse(market)
+            item["brand"] = brand
+            item["brand_wikidata"] = brand_wikidata
+            item["name"] = brand
+            item["street_address"] = item.pop("addr_full", None)
+            item["opening_hours"] = self.parse_opening_hours(market)
 
             if start_date := market.get("opening_date"):
                 item["extras"]["start_date"] = datetime.fromisoformat(start_date).strftime("%Y-%m-%d")
@@ -83,17 +109,24 @@ class MigrosCHSpider(SitemapSpider):
             yield item
 
     @staticmethod
-    def parse_opening_hours(market):
+    def parse_opening_hours(market: dict) -> Any:
         if market["type"] == "pickmup_247pmubox":
             return "24/7"
         oh = OpeningHours()
-        for o in market.get("opening_hours", []):
-            if o.get("active"):
-                for hours in o.get("opening_hours", []):
-                    day = DAYS[hours["day_of_week"] - 1]
-                    for i in range(5):
-                        open_time = hours.get("time_open%d" % i)
-                        close_time = hours.get("time_close%d" % i)
-                        if open_time and close_time:
-                            oh.add_range(day, open_time, close_time)
+        for block in market.get("opening_hours") or []:
+            if not block.get("active"):
+                continue
+            for hours in block.get("opening_hours") or []:
+                day = DAYS[hours["day_of_week"] - 1]
+                ranges = [
+                    (hours.get("time_open1"), hours.get("time_close1")),
+                    (hours.get("time_open2"), hours.get("time_close2")),
+                ]
+                opened = False
+                for open_time, close_time in ranges:
+                    if open_time and close_time:
+                        oh.add_range(day, open_time, close_time)
+                        opened = True
+                if not opened and not hours.get("on_request1") and not hours.get("on_request2"):
+                    oh.set_closed(day)
         return oh

--- a/locations/spiders/migros_ch.py
+++ b/locations/spiders/migros_ch.py
@@ -59,8 +59,8 @@ class MigrosCHSpider(Spider):
         "super": ("Migros", "Q680727", Categories.SHOP_SUPERMARKET),
         "voi": ("VOI", "Q110277616", Categories.SHOP_SUPERMARKET),
     }
-    api_url = "https://api.migros.ch/migros/sales/branches/v1/graphql"
-    api_key = "c3C2RemDDaYV8b2NPDev1MEDn12KsonY"
+    obsolete_brands = {"mod"}
+
     page_size = 200
 
     async def start(self):
@@ -68,9 +68,9 @@ class MigrosCHSpider(Spider):
 
     def api_request(self, offset: int) -> JsonRequest:
         return JsonRequest(
-            url=self.api_url,
+            url="https://api.migros.ch/migros/sales/branches/v1/graphql",
             data={"query": QUERY, "variables": {"limit": self.page_size, "offset": offset}},
-            headers={"x-api-key": self.api_key, "Accept-Language": "de"},
+            headers={"x-api-key": "c3C2RemDDaYV8b2NPDev1MEDn12KsonY", "Accept-Language": "de"},
             cb_kwargs={"offset": offset},
         )
 
@@ -85,6 +85,9 @@ class MigrosCHSpider(Spider):
         for market in facility["markets"]:
             brand_key = market["type"].split("_")[0]
             if brand_key not in self.brands:
+                if brand_key not in self.obsolete_brands:
+                    self.logger.warning('unknown brand: "%s"' % brand_key)
+
                 continue
             brand, brand_wikidata, category = self.brands[brand_key]
             market.update(facility["location"])
@@ -107,18 +110,17 @@ class MigrosCHSpider(Spider):
             yield item
 
     @staticmethod
-    def parse_opening_hours(market: dict) -> Any:
+    def parse_opening_hours(market: dict) -> OpeningHours | str:
         if market["type"] == "pickmup_247pmubox":
             return "24/7"
         oh = OpeningHours()
-        for block in market.get("opening_hours") or []:
-            if not block.get("active"):
-                continue
-            for hours in block.get("opening_hours") or []:
-                for period in ["1", "2"]:
-                    oh.add_range(
-                        DAYS[hours["day_of_week"] - 1],
-                        hours["time_open{}".format(period)],
-                        hours["time_close{}".format(period)],
-                    )
+        for o in market.get("opening_hours") or []:
+            if o.get("active"):
+                for hours in o.get("opening_hours") or []:
+                    day = DAYS[hours["day_of_week"] - 1]
+                    for i in range(5):
+                        open_time = hours.get("time_open%d" % i)
+                        close_time = hours.get("time_close%d" % i)
+                        if open_time and close_time:
+                            oh.add_range(day, open_time, close_time)
         return oh


### PR DESCRIPTION
The store-locator sitemap (`filialen.migros.ch`) was emptied of store URLs — the data moved to a GraphQL backend — so the `SitemapSpider` produced zero features.

Rewrite as a paginated GraphQL spider over the `facilities`/`markets` endpoint. Each market maps to one POI via the curated Migros retail-brand → wikidata/category table, with `DictParser` handling address/geo/phone/email and per-day opening hours (incl. closed-day capture). Divested formats (SportXX, melectronics, Micasa, OBI, Do It + Garden, Alnatura) are gone from the API and dropped from the brand map.

Recovers from 0 to 1901 POIs across 11 Migros retail formats.