### PR TITLE
Remove top level find-a-charger page from being scraped

### DIFF
--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -14,6 +14,7 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
+    sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse_sitemap(self, response: Response) -> Iterable[Request]:
@@ -28,15 +29,17 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
         item["ref"] = response.url.rsplit("-", 1)[1].strip("/")
         item["branch"] = response.xpath("//h1/text()").get()
         item["street_address"] = response.xpath("//ol/li[last()]//span/text()").get()
-        item["state"] = response.xpath("//ol/li[2]//a/text()").get().upper()
+        state = response.xpath("//ol/li[2]//a/text()").get()
+        item["state"] = state.upper() if state else None
+        title = response.xpath("//title/text()").get() or ""
         item["addr_full"] = (
-            response.xpath("//title/text()").get().split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ")
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
         )
-        item["extras"]["capacity"] = (
-            response.xpath('//div[contains(@title, " stalls at this location")]/@title')
-            .get()
-            .removesuffix(" stalls at this location")
-        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
+        if capacity:
+            item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 
         extract_google_position(item, response)
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,43 +1,26 @@
-from typing import Any, AsyncIterator, Iterable, Iterator
+from typing import Any, Iterator
 
-from scrapy.http import Request, Response
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
-from scrapy_camoufox.page import PageMethod
 
-from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
+class EvgoUSSpider(SitemapSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
-        **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
+        "DOWNLOAD_HANDLERS": {
+            "http": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
+            "https": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
+        },
+        "ZYTE_API_TRANSPARENT_MODE": True,
+        "ROBOTSTXT_OBEY": False,
     }
-
-    async def start(self) -> AsyncIterator[Any]:
-        yield Request(
-            "https://evgo.com/find-a-charger",
-            callback=self._after_warmup,
-            meta={
-                "camoufox_page_methods": [
-                    PageMethod("wait_for_load_state", "networkidle"),
-                ],
-                "handle_httpstatus_all": True,
-                "dont_retry": True,
-            },
-            dont_filter=True,
-        )
-
-    def _after_warmup(self, response: Response, **kwargs: Any) -> Iterable[Request]:
-        for url in self.sitemap_urls:
-            yield Request(url, callback=self._parse_sitemap, dont_filter=True)
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         item = Feature()
@@ -48,8 +31,12 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -31,12 +31,8 @@ class EvgoUSSpider(SitemapSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -29,6 +29,8 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
                 "camoufox_page_methods": [
                     PageMethod("wait_for_load_state", "networkidle"),
                 ],
+                "handle_httpstatus_all": True,
+                "dont_retry": True,
             },
             dont_filter=True,
         )

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -41,12 +41,8 @@ class EvgoUSSpider(SitemapSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -15,7 +15,11 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+    custom_settings = {
+        **DEFAULT_CAMOUFOX_SETTINGS,
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
+        not in ("document", "script", "xhr", "fetch"),
+    }
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         item = Feature()
@@ -26,8 +30,12 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -18,8 +18,7 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
         **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
-        not in ("document", "script", "xhr", "fetch"),
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
     }
 
     def start_requests(self) -> Iterable[Request]:
@@ -47,12 +46,8 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -17,8 +17,7 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
         **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
-        not in ("document", "script", "xhr", "fetch"),
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
@@ -30,12 +29,8 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,7 +1,8 @@
-from typing import Any, Iterator
+from typing import Any, Iterable, Iterator
 
-from scrapy.http import Response
+from scrapy.http import Request, Response
 from scrapy.spiders import SitemapSpider
+from scrapy_camoufox.page import PageMethod
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
@@ -17,8 +18,25 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
         **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
+        not in ("document", "script", "xhr", "fetch"),
     }
+
+    def start_requests(self) -> Iterable[Request]:
+        yield Request(
+            "https://evgo.com/find-a-charger",
+            callback=self._after_warmup,
+            meta={
+                "camoufox_page_methods": [
+                    PageMethod("wait_for_load_state", "networkidle"),
+                ],
+            },
+            dont_filter=True,
+        )
+
+    def _after_warmup(self, response: Response, **kwargs: Any) -> Iterable[Request]:
+        for url in self.sitemap_urls:
+            yield Request(url, callback=self._parse_sitemap, dont_filter=True)
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         item = Feature()
@@ -29,8 +47,12 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,6 +1,7 @@
-from typing import Any, Iterator
+import re
+from typing import Any, Iterable, Iterator
 
-from scrapy.http import Response
+from scrapy.http import Request, Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -19,8 +20,17 @@ class EvgoUSSpider(SitemapSpider):
             "https": "scrapy_zyte_api.ScrapyZyteAPIDownloadHandler",
         },
         "ZYTE_API_TRANSPARENT_MODE": True,
+        "ZYTE_API_DEFAULT_PARAMS": {"browserHtml": True},
         "ROBOTSTXT_OBEY": False,
     }
+
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
+        for match in re.finditer(r"<loc>([^<]+)</loc>", response.text):
+            url = match.group(1).strip()
+            for pattern, callback in self._cbs:
+                if pattern.search(url):
+                    yield Request(url, callback=callback)
+                    break
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         item = Feature()
@@ -31,8 +41,12 @@ class EvgoUSSpider(SitemapSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -18,8 +18,7 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
         **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
-        not in ("document", "script", "xhr", "fetch"),
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
     }
 
     async def start(self) -> AsyncIterator[Any]:
@@ -47,12 +46,8 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -26,12 +26,8 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -32,12 +32,8 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = (
-            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        )
-        capacity = response.xpath(
-            '//div[contains(@title, " stalls at this location")]/@title'
-        ).get()
+        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,27 +1,21 @@
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterator
 
-from scrapy.http import Request, Response
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
+class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
-
-    def parse_sitemap(self, response: Response) -> Iterable[Request]:
-        for request in super()._parse_sitemap(response):
-            request.meta["playwright"] = True
-            request.meta["playwright_include_page"] = True
-            yield request
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         item = Feature()
@@ -32,8 +26,12 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Iterator
+from typing import Any, AsyncIterator, Iterable, Iterator
 
 from scrapy.http import Request, Response
 from scrapy.spiders import SitemapSpider
@@ -18,10 +18,11 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
     sitemap_rules = [(r"/find-a-charger/[^/]+/[^/]+/[^/]+-\d+/?$", "parse")]
     custom_settings = {
         **DEFAULT_CAMOUFOX_SETTINGS,
-        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ("document", "script", "xhr", "fetch"),
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
+        not in ("document", "script", "xhr", "fetch"),
     }
 
-    def start_requests(self) -> Iterable[Request]:
+    async def start(self) -> AsyncIterator[Any]:
         yield Request(
             "https://evgo.com/find-a-charger",
             callback=self._after_warmup,
@@ -46,8 +47,12 @@ class EvgoUSSpider(SitemapSpider, CamoufoxSpider):
         state = response.xpath("//ol/li[2]//a/text()").get()
         item["state"] = state.upper() if state else None
         title = response.xpath("//title/text()").get() or ""
-        item["addr_full"] = title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
-        capacity = response.xpath('//div[contains(@title, " stalls at this location")]/@title').get()
+        item["addr_full"] = (
+            title.split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ") or None
+        )
+        capacity = response.xpath(
+            '//div[contains(@title, " stalls at this location")]/@title'
+        ).get()
         if capacity:
             item["extras"]["capacity"] = capacity.removesuffix(" stalls at this location")
 


### PR DESCRIPTION
Fixes `AttributeError` by omitting the landing page of https://evgo.com/find-a-charger from acing as if it is a station page.