### PR TITLE
[Burlington] Fix spider

### DIFF
--- a/locations/spiders/burlington_us.py
+++ b/locations/spiders/burlington_us.py
@@ -1,14 +1,46 @@
+from typing import Any, Iterable
+
+import chompjs
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
 
 
-class BurlingtonUSSpider(SitemapSpider, StructuredDataSpider):
+class BurlingtonUSSpider(SitemapSpider):
     name = "burlington_us"
-    sitemap_urls = ["https://stores.burlington.com/sitemap.xml"]
-    sitemap_rules = [(r"^https://stores\.burlington\.com/.*/.*/.*/$", "parse")]
     item_attributes = {
         "brand": "Burlington",
         "brand_wikidata": "Q4999220",
     }
-    drop_attributes = {"image"}
+    sitemap_urls = ["https://www.burlington.com/sitemap.xml"]
+    sitemap_rules = [(r"^https://www\.burlington\.com/stores/[a-z]{2}/[^/]+/$", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        rsc = "".join(s for _, s in (chompjs.parse_js_object(s) for s in scripts) if isinstance(s, str)).encode()
+        data = dict(parse_rsc(rsc))
+
+        for store in DictParser.get_nested_key(data, "locations") or []:
+            location = store["storeLocation"]
+            item = DictParser.parse(location)
+            item["ref"] = location["storeNumber"]
+            item["branch"] = location["projectName"].split(" (#")[0]
+            item["website"] = response.urljoin(store["storeDetailsHref"])
+
+            item["opening_hours"] = OpeningHours()
+            for rule in store.get("standardHours", []):
+                if " - " not in rule["hours"]:
+                    continue
+                open_time, close_time = rule["hours"].split(" - ")
+                item["opening_hours"].add_range(DAYS_EN[rule["label"]], open_time, close_time, time_format="%I:%M %p")
+
+            if (start_date := location.get("grandOpeningDate")) and not start_date.startswith("$"):
+                item["extras"]["start_date"] = start_date
+
+            apply_category(Categories.SHOP_DEPARTMENT_STORE, item)
+            yield item


### PR DESCRIPTION
The store locator moved off `stores.burlington.com` (now dead) to `www.burlington.com`, which serves store data as React Server Components instead of ld+json, so the old `StructuredDataSpider` produced zero features.

Rewrite as a `SitemapSpider` over the `www.burlington.com` sitemap, parsing the RSC `locations` array (via the shared `parse_rsc` helper) with `DictParser` for address/geo/phone. Branch from `projectName`, website from `storeDetailsHref`, opening hours from `standardHours`, `start_date` from `grandOpeningDate`, and an explicit `SHOP_DEPARTMENT_STORE` category.

Recovers from 0 to 1267 stores.