### PR TITLE
[La Salsa] Fix spider

### DIFF
--- a/locations/spiders/la_salsa_us.py
+++ b/locations/spiders/la_salsa_us.py
@@ -1,22 +1,34 @@
+from typing import Any, Iterable
+
+import chompjs
+from scrapy import Request
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class LaSalsaUSSpider(CrawlSpider, StructuredDataSpider):
+class LaSalsaUSSpider(JSONBlobSpider):
     name = "la_salsa_us"
     item_attributes = {"brand": "La Salsa", "brand_wikidata": "Q48835190"}
-    start_urls = ["https://www.lasalsa.com/locator/index.php?brand=26&pagesize=1000&q=us"]
-    rules = [
-        Rule(LinkExtractor(allow="/stores/"), callback="parse_sd"),
-    ]
+    start_urls = ["https://www.lasalsa.com/locator/index.php?brand=26&mode=desktop&pagesize=7000&q=us"]
 
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        ld_data["openingHours"] = None  # Requires fix, only a few locations, not worth the effort
+    def extract_json(self, response: Response) -> Iterable[dict]:
+        for location_js in response.xpath("//div[starts-with(@id, 'store_')]/script/text()").getall():
+            yield chompjs.parse_js_object(location_js.split(" = ", 1)[1])
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["ref"] = item.pop("name").removeprefix("La Salsa Store ")
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Any:
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = item.pop("name")
+        item["website"] = response.urljoin(f"/stores/{location['SEOPath']}/{location['StoreId']}")
+        apply_category(Categories.FAST_FOOD, item)
+        yield Request(item["website"], callback=self.parse_hours, cb_kwargs={"item": item})
+
+    def parse_hours(self, response: Response, item: Feature, **kwargs: Any) -> Any:
+        oh = OpeningHours()
+        for line in response.xpath('//div[@class="dineInHours"]//li/text()').getall():
+            oh.add_ranges_from_string(line)
+        item["opening_hours"] = oh
         yield item


### PR DESCRIPTION
The store locator re-platformed: the `locator/index.php` endpoint redirects and the store pages dropped their `LocalBusiness` ld+json, so the old `CrawlSpider` + `StructuredDataSpider` produced zero features.

Rewrite as a `JSONBlobSpider` parsing the locator's `Locator.stores` JS blobs (chompjs), following each store page for `dineInHours` opening hours, with an explicit fast-food category.