### PR TITLE
[Invitro RU]  Fix spider

### DIFF
--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -8,11 +12,16 @@ class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
     name = "invitro_ru"
     item_attributes = {"brand": "Инвитро", "brand_wikidata": "Q4200546"}
     sitemap_urls = ["https://www.invitro.ru/sitemap/offices.xml"]
-    sitemap_rules = [(r"/offices/.*/clinic.php\?ID=.*", "parse_sd")]
+    sitemap_rules = [(r"/offices/[-\w]+", "parse")]
+    link_extractor = LinkExtractor(allow=r"/offices/[-\w]+/clinic.php\?ID=\d+$")
     wanted_types = ["MedicalBusiness"]
     json_parser = "chompjs"
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 300, "RETRY_TIMES": 5}
     requires_proxy = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for link in self.link_extractor.extract_links(response):
+            yield response.follow(url=link.url, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None

--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -13,14 +13,13 @@ class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Инвитро", "brand_wikidata": "Q4200546"}
     sitemap_urls = ["https://www.invitro.ru/sitemap/offices.xml"]
     sitemap_rules = [(r"/offices/[-\w]+", "parse")]
-    link_extractor = LinkExtractor(allow=r"/offices/[-\w]+/clinic.php\?ID=\d+$")
     wanted_types = ["MedicalBusiness"]
     json_parser = "chompjs"
     custom_settings = {"ROBOTSTXT_OBEY": False, "DOWNLOAD_TIMEOUT": 300, "RETRY_TIMES": 5}
     requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for link in self.link_extractor.extract_links(response):
+        for link in LinkExtractor(allow=r"/offices/[-\w]+/clinic.php\?ID=\d+$").extract_links(response):
             yield response.follow(url=link.url, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data, **kwargs):

--- a/locations/spiders/invitro_ru.py
+++ b/locations/spiders/invitro_ru.py
@@ -25,6 +25,7 @@ class InvitroRUSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["name"] = None
+        item["ref"] = response.url.split("ID=")[-1]
         coords = response.xpath('//div[@id="mapOfficeDetail"]/@data-coord').get()
         if coords:
             item["lat"], item["lon"] = coords.strip().split(",")


### PR DESCRIPTION
`Sitemap` no longer has ultimate  URLs of `POI`s.

```
{'atp/brand/Инвитро': 1897,
 'atp/brand_wikidata/Q4200546': 1897,
 'atp/category/healthcare/laboratory': 1897,
 'atp/clean_strings/lon': 130,
 'atp/country/RU': 1897,
 'atp/field/branch/missing': 1897,
 'atp/field/housenumber/missing': 1897,
 'atp/field/opening_hours/missing': 23,
 'atp/field/operator/missing': 1897,
 'atp/field/operator_wikidata/missing': 1897,
 'atp/field/postcode/missing': 1897,
 'atp/field/state/missing': 1897,
 'atp/field/street/missing': 1897,
 'atp/field/twitter/missing': 1897,
 'atp/field/unit/missing': 1897,
 'atp/item_scraped_host_count/www.invitro.ru': 1897,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 1897,
 'downloader/exception_count': 17,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 17,
 'downloader/request_bytes': 2035797,
 'downloader/request_count': 2545,
 'downloader/request_method_count/GET': 2545,
 'downloader/response_bytes': 572024368,
 'downloader/response_count': 2528,
 'downloader/response_status_count/200': 2524,
 'downloader/response_status_count/301': 4,
 'dupefilter/filtered': 174,
 'elapsed_time_seconds': 4017.1720000000005,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 8, 13, 39, 8, 452819, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 4061066909,
 'httpcompression/response_count': 2523,
 'item_scraped_count': 1897,
 'items_per_minute': 28.334578043315908,
 'log_count/DEBUG': 4443,
 'log_count/INFO': 1703,
 'request_depth_max': 2,
 'response_received_count': 2524,
 'responses_per_minute': 37.69977595220313,
 'retry/count': 17,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 17,
 'scheduler/dequeued': 2545,
 'scheduler/dequeued/memory': 2545,
 'scheduler/enqueued': 2545,
 'scheduler/enqueued/memory': 2545,
 'start_time': datetime.datetime(2026, 6, 8, 12, 32, 11, 275008, tzinfo=datetime.timezone.utc)}
```