### PR TITLE
[LOOP Fitness] Fix spider

### DIFF
--- a/locations/spiders/loop_fitness_dk.py
+++ b/locations/spiders/loop_fitness_dk.py
@@ -1,18 +1,30 @@
+from typing import Any
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
 
 
-class LoopFitnessDKSpider(SitemapSpider, StructuredDataSpider):
+class LoopFitnessDKSpider(SitemapSpider):
     name = "loop_fitness_dk"
     item_attributes = {"brand": "LOOP Fitness", "brand_wikidata": "Q18647221"}
     sitemap_urls = ["https://loopfitness.dk/fitness-center-sitemap.xml"]
-    sitemap_rules = [(r"/centre/loop-fitness", "parse_sd")]
-    wanted_types = ["Place"]
+    sitemap_rules = [(r"/centre/[^/]+/$", "parse")]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("LOOP Fitness ")
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        info = response.xpath('//div[@class="loop-center-info"]')
+        if not info:
+            return
 
+        item = Feature()
+        item["ref"] = response.url
+        item["website"] = response.url
+        item["branch"] = response.xpath('//h1[starts-with(@id, "h-")]/text()').get("").strip()
+        item["addr_full"] = " ".join(info.xpath('.//*[@itemprop="address"]//text()').getall()).strip()
+        item["phone"] = info.xpath('.//*[@itemprop="telephone"]//text()').get()
+        item["email"] = info.xpath('.//*[@itemprop="email"]//text()').get()
+
+        apply_category(Categories.GYM, item)
         yield item


### PR DESCRIPTION
The centre pages no longer emit a `Place` ld+json entity (only `WebPage`/`Organization`), so the `StructuredDataSpider` with `wanted_types=["Place"]` matched the sitemap pages but parsed zero items.

Parse each `/centre/<slug>/` page's `loop-center-info` block directly (SitemapSpider) — branch from the `<h1>`, plus address / telephone / email from the schema.org microdata — and apply the gym category.