### PR TITLE
[Pase MX] Fix spider

### DIFF
--- a/locations/spiders/pase_mx.py
+++ b/locations/spiders/pase_mx.py
@@ -1,21 +1,28 @@
-import scrapy
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
-class PaseMXSpider(scrapy.Spider):
+class PaseMXSpider(Spider):
     name = "pase_mx"
     start_urls = ["https://apps.pase.com.mx/sp-web/api/cobertura/estacionamientos"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response):
-        data = response.json()
-        for lot in data:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for lot in response.xpath("//item"):
             item = Feature()
-            item["ref"] = lot["id"]
-            item["name"] = lot["nombre"]
-            item["addr_full"] = lot["descripcion"]
-            item["lat"] = lot.get("ubicacion", {}).get("coords", [{}])[0].get("y")
-            item["lon"] = lot.get("ubicacion", {}).get("coords", [{}])[0].get("x")
+            item["ref"] = lot.xpath("id/text()").get()
+            item["branch"] = lot.xpath("nombre/text()").get()
+            item["addr_full"] = lot.xpath("descripcion/text()").get()
+            item["lat"] = lot.xpath("ubicacion/coords/y/text()").get()
+            item["lon"] = lot.xpath("ubicacion/coords/x/text()").get()
+
+            if operator := lot.xpath(".//nombreoperador/text()").get():
+                item["operator"] = operator.strip()
+
             apply_category(Categories.PARKING, item)
             yield item


### PR DESCRIPTION
```
{'atp/category/amenity/parking': 49,
 'atp/clean_strings/addr_full': 2,
 'atp/country/MX': 49,
 'atp/field/brand/missing': 49,
 'atp/field/brand_wikidata/missing': 49,
 'atp/field/city/missing': 49,
 'atp/field/country/from_spider_name': 49,
 'atp/field/email/missing': 49,
 'atp/field/housenumber/missing': 49,
 'atp/field/name/missing': 49,
 'atp/field/opening_hours/missing': 49,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 49,
 'atp/field/phone/missing': 49,
 'atp/field/postcode/missing': 49,
 'atp/field/state/missing': 49,
 'atp/field/street/missing': 49,
 'atp/field/street_address/missing': 49,
 'atp/field/twitter/missing': 49,
 'atp/field/unit/missing': 49,
 'atp/item_scraped_host_count/apps.pase.com.mx': 49,
 'atp/lineage': 'S_?',
 'atp/operator/DRIVE': 35,
 'atp/operator/PASE': 5,
 'downloader/request_bytes': 361,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 38272,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.7659999999996217,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 9, 6, 23, 4, 802591, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 49,
 'items_per_minute': 1470.0,
 'log_count/DEBUG': 50,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 9, 6, 23, 2, 28063, tzinfo=datetime.timezone.utc)}
```