### PR TITLE
[dm] Improve search areas

### DIFF
--- a/locations/spiders/dm.py
+++ b/locations/spiders/dm.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import scrapy
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -9,11 +12,10 @@ class DmSpider(scrapy.Spider):
     name = "dm"
     item_attributes = {"brand": "dm", "brand_wikidata": "Q266572"}
     start_urls = [
-        "https://store-data-service.services.dmtech.com/stores/bbox/49.27562530004775%2C10.195245519081993%2C47.019140477949975%2C24.043815030918438",
-        "https://store-data-service.services.dmtech.com/stores/bbox/53.81734501171468%2C-0.8184878281186911%2C46.98695695433199%2C16.603367890508224",
-        "https://store-data-service.services.dmtech.com/stores/bbox/47.786865948031554,14.70566557769028,42.709273836666,24.75120274749999",
-        "https://store-data-service.services.dmtech.com/stores/bbox/47.786865948031554,14.70566557769028,45.21501355698323,16.19156309497206",
-        "https://store-data-service.services.dmtech.com/stores/bbox/47.786865948031554,14.70566557769028,41.78413678399999,21.484047576",
+        "https://store-data-service.services.dmtech.com/stores/bbox/55.2791403,5.4052295,48.5166335,17.5121631",
+        "https://store-data-service.services.dmtech.com/stores/bbox/55.2791403,17.5121631,48.5166335,29.6190967",
+        "https://store-data-service.services.dmtech.com/stores/bbox/48.5166335,5.4052295,40.7139891,17.5121631",
+        "https://store-data-service.services.dmtech.com/stores/bbox/48.5166335,17.5121631,40.7139891,29.6190967",
     ]
 
     @staticmethod
@@ -22,14 +24,11 @@ class DmSpider(scrapy.Spider):
 
         for store_day in store_hours:
             for times in store_day["timeRanges"]:
-                open_time = times["opening"]
-                close_time = times["closing"]
-
-                opening_hours.add_range(DAYS[store_day["weekDay"] - 1], open_time, close_time)
+                opening_hours.add_range(DAYS[store_day["weekDay"] - 1], times["opening"], times["closing"])
 
         return opening_hours
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["stores"]:
             location["address"]["street_address"] = location["address"].pop("street")
             location["address"]["country"] = location["countryCode"]
@@ -42,7 +41,7 @@ class DmSpider(scrapy.Spider):
                 item["website"] = f'https://www.mojadm.sk/store{location["storeUrlPath"]}'
             else:
                 item["website"] = f'https://www.dm.{location["countryCode"].lower()}/store{location["storeUrlPath"]}'
-            item["extras"]["check_date"] = location["updateTimeStamp"]
+            item["extras"]["check_date"] = location["updateTimeStamp"].split("T", 1)[0]
             if location.get("openingHours"):
                 item["opening_hours"] = self.parse_hours(location.get("openingHours"))
 


### PR DESCRIPTION
Fixes #11036

```python
{'atp/brand/dm': 4221,
 'atp/brand_wikidata/Q266572': 4221,
 'atp/category/shop/chemist': 4221,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/housenumber': 4,
 'atp/country/AT': 376,
 'atp/country/BA': 93,
 'atp/country/BG': 118,
 'atp/country/CZ': 263,
 'atp/country/DE': 2172,
 'atp/country/HR': 178,
 'atp/country/HU': 252,
 'atp/country/IT': 98,
 'atp/country/MK': 24,
 'atp/country/PL': 75,
 'atp/country/RO': 172,
 'atp/country/RS': 135,
 'atp/country/SI': 97,
 'atp/country/SK': 168,
 'atp/field/branch/missing': 4221,
 'atp/field/email/missing': 4221,
 'atp/field/housenumber/missing': 6,
 'atp/field/operator/missing': 4221,
 'atp/field/operator_wikidata/missing': 4221,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 4221,
 'atp/field/twitter/missing': 4221,
 'atp/field/unit/missing': 4221,
 'atp/item_scraped_host_count/store-data-service.services.dmtech.com': 4221,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/cc_match': 4221,
 'downloader/request_bytes': 1958,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 2424360,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 4,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 7.237974085999667,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 9, 10, 27, 9, 706098, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 4,
 'httpcache/hit': 1,
 'httpcache/miss': 4,
 'httpcache/store': 4,
 'httpcompression/response_bytes': 50266567,
 'httpcompression/response_count': 4,
 'item_scraped_count': 4221,
 'items_per_minute': 36180.0,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 300859392,
 'memusage/startup': 300859392,
 'response_received_count': 5,
 'responses_per_minute': 42.857142857142854,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2026, 6, 9, 10, 27, 2, 468123, tzinfo=datetime.timezone.utc)}
```