### PR TITLE
[Lee's Sandwiches US] Fix spider

### DIFF
--- a/locations/spiders/lees_sandwiches_us.py
+++ b/locations/spiders/lees_sandwiches_us.py
@@ -1,32 +1,51 @@
 import re
+from typing import Any
 
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.storefinders.store_locator_plus_self import StoreLocatorPlusSelfSpider
 
-branch_separator = re.compile(r"^\s*-\s*Lee&#039;s Sandwiches\s+")
+branch_separator = re.compile(r"^\s*-\s*Lee's Sandwiches\s+")
 
 
-class LeesSandwichesUSSpider(StoreLocatorPlusSelfSpider):
+class LeesSandwichesUSSpider(Spider):
     name = "lees_sandwiches_us"
     item_attributes = {
         "brand_wikidata": "Q6512823",
         "brand": "Lee's Sandwiches",
     }
     allowed_domains = ["leesandwiches.com"]
-    iseadgg_countries_list = ["US"]
-    search_radius = 158
-    max_results = 50
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://leesandwiches.com/wp-json/store-locator-plus/v2/locations"]
 
-    def parse_item(self, item, location, **kwargs):
-        if "Coming Soon" in item["name"]:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            yield JsonRequest(
+                url=f"{self.start_urls[0]}/{location['sl_id']}",
+                callback=self.parse_location,
+            )
+
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        location = response.json()
+        if "Coming Soon" in location["sl_store"]:
             return
-        item["extras"]["fax"] = location["fax"]
-        item["image"] = location["image"]
-        item["branch"] = branch_separator.sub("", item.pop("name").removeprefix(location["city"]))
+
+        item = DictParser.parse({key.removeprefix("sl_"): value for key, value in location.items()})
+        item["ref"] = location["sl_id"]
+        item.pop("addr_full", None)
+        item["street_address"] = ", ".join(filter(None, [location.get("sl_address"), location.get("sl_address2")]))
+        item["website"] = None
+        item["image"] = location["sl_image"]
+        item["extras"]["fax"] = location["sl_fax"]
+        item.pop("name", None)
+        item["branch"] = branch_separator.sub("", location["sl_store"].removeprefix(location["sl_city"]))
 
         oh = OpeningHours()
-        oh.add_ranges_from_string(location["hours"])
+        oh.add_ranges_from_string(location["sl_hours"])
         item["opening_hours"] = oh
+
+        apply_category(Categories.FAST_FOOD, item)
 
         yield item


### PR DESCRIPTION
The StoreLocatorPlus admin-ajax endpoint the spider relied on now
returns HTTP 500. Switch to the site's SLP REST API — the locations
list, then per-store detail. Category set to FAST_FOOD.