### PR TITLE
[Francescas US] Delete spider for defunct brand

### DIFF
--- a/locations/spiders/francescas_us.py
+++ b/locations/spiders/francescas_us.py
@@ -1,7 +1,0 @@
-from locations.storefinders.storemapper import StoremapperSpider
-
-
-class FrancescasUSSpider(StoremapperSpider):
-    name = "francescas_us"
-    item_attributes = {"brand": "Francesca's", "brand_wikidata": "Q72982331"}
-    company_id = "16784"


### PR DESCRIPTION
Closure of all stores announced earlier this year per example of [1].

Their Facebook post of 30 March indicated it was their last day of trading per [2].

Currently the website is still live (still reporting "last day") but the storefinder at https://francescas.com/store-locator is broken and/or not returning any stores.

It looks like no stores remain open and those being extracted by ATP since April (or before) are from a SaaS API endpoint which has not yet been disabled (e.g. might be paid in advance for a year).

[1] https://www.usatoday.com/story/money/shopping/2026/02/12/francescas-stores-closing-sales-locations/88641048007/

[2] https://www.facebook.com/francescascollectionsboutique/posts/pfbid02bbkb8SKcXXAe359n9btd8cEhzXnDu5d2CkqV7h3CDbvbjTHRHdXFJQ2zygvtn72kl