### PR TITLE
[Athena] Drop invalid placeholder phone number

### DIFF
--- a/locations/spiders/athena.py
+++ b/locations/spiders/athena.py
@@ -60,6 +60,8 @@ class AthenaSpider(StoreRocketSpider):
         item.pop("name", None)
         item.pop("facebook", None)
         item["extras"].pop("contact:instagram", None)
+        if item.get("phone") == "-4844":
+            item["phone"] = None
 
         for field in location.get("fields", {}):
             if field["name"] == "Located Inside:":


### PR DESCRIPTION
Fixes #16284.

The StoreRocket API returns `-4844` as the phone value for many locations — a placeholder for the corporate extension rather than a real per-location number. Drop it so it doesn't pass through as an invalid phone.