### PR TITLE
[Coinstar] Apply vending_machine category and coin_change_machine vending tag

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -924,6 +924,7 @@ class Vending(Enum):
     BICYCLE_TUBE = "bicycle_tube"
     BOTTLE_RETURN = "bottle_return"
     COFFEE = "coffee"
+    COIN_CHANGE_MACHINE = "coin_change_machine"
     DRINKS = "drinks"
     FOOD = "food"
     KEYS = "key"

--- a/locations/spiders/coinstar.py
+++ b/locations/spiders/coinstar.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, Vending, add_vending, apply_category
 from locations.dict_parser import DictParser
 from locations.geo import country_iseadgg_centroids
 
@@ -43,4 +44,6 @@ class CoinstarSpider(Spider):
             item["street_address"] = kiosk["street_address_text"]
             item["state"] = kiosk["state_province_code"]
             item["website"] = f"https://coinstar.com/kiosk-info?KioskId={kiosk['machine_placement_id']}"
+            apply_category(Categories.VENDING_MACHINE, item)
+            add_vending(Vending.COIN_CHANGE_MACHINE, item)
             yield item


### PR DESCRIPTION
Fixes #15031.

Coinstar kiosks were emitting no category at all. OSM tagging for these is `amenity=vending_machine` + `vending=coin_change_machine`. Added `COIN_CHANGE_MACHINE` to the `Vending` enum and applied both tags in the spider.