### PR TITLE
Fix stars field being set as a float instead of an integer string

### DIFF
--- a/locations/linked_data_parser.py
+++ b/locations/linked_data_parser.py
@@ -328,7 +328,8 @@ class LinkedDataParser:
             if isinstance(stars, str):
                 item["extras"]["stars"] = stars
             elif isinstance(stars, dict):
-                item["extras"]["stars"] = LinkedDataParser.get_case_insensitive(stars, "ratingValue")
+                if rating_value := LinkedDataParser.get_case_insensitive(stars, "ratingValue"):
+                    item["extras"]["stars"] = str(rating_value).removesuffix(".0")
 
     @staticmethod
     def parse_same_as(ld: dict, item: Feature):


### PR DESCRIPTION
Fixes #14646.

When `starRating` in JSON-LD is a dict with a numeric `ratingValue` (e.g. `5.0`), `linked_data_parser` was storing the raw float. Cast to `str` and strip the trailing `.0` so values like `5.0` become `"5"` as expected.