### PR TITLE
[Standard Bank ZA] Reject incomplete hours

### DIFF
--- a/locations/spiders/standard_bank_za.py
+++ b/locations/spiders/standard_bank_za.py
@@ -140,7 +140,7 @@ class StandardBankZASpider(scrapy.Spider):
                                 times = times.strip()
                                 oh.add_range(day, times.split("-")[0].strip(), times.split("-")[1].strip(), "%HH%M")
                         except ValueError:
-                            pass
+                            return None
                 elif "-" in day_time[0]:
                     try:
                         for times in day_time[1].split("&"):
@@ -154,7 +154,7 @@ class StandardBankZASpider(scrapy.Spider):
                                 "%HH%M",
                             )
                     except ValueError:
-                        pass
+                        return None
             except:
                 pass
         return oh.as_opening_hours()


### PR DESCRIPTION
Some locations have unparseable hours for some days of the week. This leads to incomplete hours, such as `Sa 08:30-13:00; Su closed` (missing times for Mo-Fr, because of a failed parse). I think it is better to drop such times than return incomplete values like this.

Parsing can't really be improved easily, since it is basically free text, and issues are things like "MON - FRI: 09H00 - 15H30, FIRST AND LAST BUSINESS DAY OF THE MONTH 08H30 - 16H00", which is beyond ATP opening hours and possibly also beyond OSM opening hours. Also, this only affects a few locations.