### PR TITLE
Fix parquet OOM: parameterize DuckDB memory limit and close connection before pyarrow

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = babel,boto3,botocore,chompjs,cryptography,duckdb,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,pandas,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_zyte_api,shapefile,shapely,tldextract,twisted,unidecode,w3lib,xmltodict
+known_third_party = babel,boto3,botocore,chompjs,cryptography,duckdb,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,pandas,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,psutil,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_zyte_api,shapefile,shapely,tldextract,twisted,unidecode,w3lib,xmltodict

--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import sys
 import traceback
 from argparse import ArgumentParser
@@ -8,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import duckdb
+import psutil
 import pyarrow.parquet as pq
 
 logger = getLogger(__name__)
@@ -20,6 +22,15 @@ logging.basicConfig(
         logging.StreamHandler(sys.stderr),
     ],
 )
+
+
+def duckdb_memory_limit() -> str:
+    total_bytes = psutil.virtual_memory().total
+    # Reserve 2 GB for Python, pyarrow, and OS overhead
+    reserved_bytes = 2 * 1024**3
+    duckdb_bytes = max(total_bytes - reserved_bytes, reserved_bytes)
+    duckdb_gb = math.floor(duckdb_bytes / 1024**3)
+    return f"{duckdb_gb}GB"
 
 
 def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
@@ -41,8 +52,10 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             logger.info("Spatial extension loaded successfully")
 
             logger.info("Configuring DuckDB settings...")
+            memory_limit = duckdb_memory_limit()
+            logger.info(f"Setting DuckDB memory limit to {memory_limit} (total system RAM: {psutil.virtual_memory().total / 1024**3:.1f} GB)")
             con.execute(f"SET temp_directory='{temp_dir}'")
-            con.execute("SET memory_limit='8GB'")
+            con.execute(f"SET memory_limit='{memory_limit}'")
             con.execute("SET threads=2")
             con.execute("SET preserve_insertion_order=false")
 
@@ -105,30 +118,31 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             """)
             logger.info("Parquet file written successfully")
 
-            logger.info("Adding GeoParquet metadata...")
-            table = pq.read_table(str(output_file_path))
+        # DuckDB connection is now closed; release its memory before loading with pyarrow
+        logger.info("Adding GeoParquet metadata...")
+        table = pq.read_table(str(output_file_path))
 
-            if bbox_res is None:
-                xmin, ymin, xmax, ymax = None, None, None, None
-            else:
-                xmin, ymin, xmax, ymax = bbox_res
-            geo_meta = {
-                "version": "1.1.0",
-                "primary_column": "geom",
-                "columns": {
-                    "geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"], "crs": "EPSG:4326"}
-                },
-                "bbox": [xmin, ymin, xmax, ymax],
-            }
+        if bbox_res is None:
+            xmin, ymin, xmax, ymax = None, None, None, None
+        else:
+            xmin, ymin, xmax, ymax = bbox_res
+        geo_meta = {
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"], "crs": "EPSG:4326"}
+            },
+            "bbox": [xmin, ymin, xmax, ymax],
+        }
 
-            existing_md = table.schema.metadata or {}
-            new_md = dict(existing_md)
-            new_md[b"geo"] = json.dumps(geo_meta, ensure_ascii=False).encode("utf-8")
+        existing_md = table.schema.metadata or {}
+        new_md = dict(existing_md)
+        new_md[b"geo"] = json.dumps(geo_meta, ensure_ascii=False).encode("utf-8")
 
-            table = table.replace_schema_metadata(new_md)
+        table = table.replace_schema_metadata(new_md)
 
-            logger.info("Writing final parquet file with metadata...")
-            pq.write_table(table, str(output_file_path), compression="ZSTD")
+        logger.info("Writing final parquet file with metadata...")
+        pq.write_table(table, str(output_file_path), compression="ZSTD")
 
     file_size = output_file_path.stat().st_size
     logger.info(f"✓ Created {output_file_path} ({file_size:,} bytes)")

--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -53,7 +53,9 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
 
             logger.info("Configuring DuckDB settings...")
             memory_limit = duckdb_memory_limit()
-            logger.info(f"Setting DuckDB memory limit to {memory_limit} (total system RAM: {psutil.virtual_memory().total / 1024**3:.1f} GB)")
+            logger.info(
+                f"Setting DuckDB memory limit to {memory_limit} (total system RAM: {psutil.virtual_memory().total / 1024**3:.1f} GB)"
+            )
             con.execute(f"SET temp_directory='{temp_dir}'")
             con.execute(f"SET memory_limit='{memory_limit}'")
             con.execute("SET threads=2")
@@ -129,9 +131,7 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
         geo_meta = {
             "version": "1.1.0",
             "primary_column": "geom",
-            "columns": {
-                "geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"], "crs": "EPSG:4326"}
-            },
+            "columns": {"geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"], "crs": "EPSG:4326"}},
             "bbox": [xmin, ymin, xmax, ymax],
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "phonenumbers",
     "phpserialize",
     "playwright_captcha",
+    "psutil",
     "pyarrow",
     "pycountry",
     "pygeohash<4",

--- a/uv.lock
+++ b/uv.lock
@@ -103,6 +103,7 @@ dependencies = [
     { name = "phonenumbers" },
     { name = "phpserialize" },
     { name = "playwright-captcha" },
+    { name = "psutil" },
     { name = "pyarrow" },
     { name = "pycountry" },
     { name = "pygeohash" },
@@ -155,6 +156,7 @@ requires-dist = [
     { name = "phonenumbers" },
     { name = "phpserialize" },
     { name = "playwright-captcha" },
+    { name = "psutil" },
     { name = "pyarrow" },
     { name = "pycountry" },
     { name = "pygeohash", specifier = "<4" },
@@ -1345,6 +1347,22 @@ source = { registry = "https://pypi.python.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/9b/9c3a649167c7e43a0818df515d515e66d95a261fdfdf2a6afd45be9db696/protego-0.5.0.tar.gz", hash = "sha256:225dee0acfcc71de8c6f7cef9c618e5a9d3e7baa7ae1470b8d076a064033c463", size = 3137494, upload-time = "2025-06-24T13:58:45.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/cb/4347985f89ca3e4beb5d0cb85f8b951c9e339564bd2a3f388d6fb78382cc/protego-0.5.0-py3-none-any.whl", hash = "sha256:4237227840a67fdeec289a9b89652455b5657806388c17e1a556e160435f8fc5", size = 10356, upload-time = "2025-06-24T13:58:44.08Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.python.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The parquet output has been 0 bytes since the 2026-02-21 run (issues #14341, #16158), broken by commit c26dec8a3 which changed `SET memory_limit` from `'1GB'` to `'8GB'`.

The ECS task has 8 GB total RAM. With DuckDB claiming all 8 GB for the `ORDER BY ST_Hilbert` sort across ~30M rows, there is no headroom for the Python process or OS, causing the Linux OOM killer to terminate the process silently — no Python traceback is logged, and the output file is left at 0 bytes.

A second compounding issue: `pq.read_table()` was called while the DuckDB connection was still open, so both DuckDB and pyarrow held the full dataset in RAM simultaneously.

## Fix

- Add `duckdb_memory_limit()` which reads total system RAM via `psutil` and reserves 2 GB for Python/pyarrow/OS overhead. On the 8 GB ECS task this gives DuckDB 6 GB; scales automatically on larger hosts.
- Move `pq.read_table()`/`pq.write_table()` outside the `with duckdb.connect()` block so DuckDB fully releases memory before pyarrow loads the file.
- Add `psutil` dependency.