### PR TITLE
[Extended Stay America] Fix Spider

### DIFF
--- a/locations/spiders/extended_stay_america.py
+++ b/locations/spiders/extended_stay_america.py
@@ -1,17 +1,30 @@
-from scrapy.spiders import SitemapSpider
+import json
+import re
+from typing import Any
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class ExtendedStayAmericaSpider(SitemapSpider, StructuredDataSpider):
+class ExtendedStayAmericaSpider(Spider):
     name = "extended_stay_america"
     item_attributes = {
         "brand": "Extended Stay America",
         "brand_wikidata": "Q5421850",
         "country": "US",
     }
-    sitemap_urls = ["https://api.prod.bws.esa.com/cms-proxy-api/sitemap/property"]
-    sitemap_rules = [("/hotels/", "parse_sd")]
+    start_urls = ["https://www.extendedstayamerica.com/hotels"]
     custom_settings = {"AUTOTHROTTLE_ENABLED": True, "USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = True
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw_data = json.loads(re.search(r"hotelsData\s*=\s*(\[.*\]);", response.text).group(1))
+        for location in raw_data:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["ref"] = location["siteId"]
+            item["website"] = response.urljoin(location["urlMap"])
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Extended Stay America': 746,
 'atp/brand_wikidata/Q5421850': 746,
 'atp/category/tourism/hotel': 746,
 'atp/cdn/cloudfront/response_count': 2,
 'atp/cdn/cloudfront/response_status_count/200': 2,
 'atp/country/US': 746,
 'atp/field/email/missing': 746,
 'atp/field/housenumber/missing': 746,
 'atp/field/opening_hours/missing': 746,
 'atp/field/operator/missing': 746,
 'atp/field/operator_wikidata/missing': 746,
 'atp/field/phone/missing': 746,
 'atp/field/street_address/missing': 746,
 'atp/field/twitter/missing': 746,
 'atp/field/unit/missing': 746,
 'atp/item_scraped_host_count/www.extendedstayamerica.com': 746,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 746,
 'downloader/request_bytes': 828,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 106073,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 10.875,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 10, 8, 51, 6, 739009, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1079286,
 'httpcompression/response_count': 1,
 'item_scraped_count': 746,
 'items_per_minute': 4476.0,
 'log_count/DEBUG': 748,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 12.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 10, 8, 50, 55, 853821, tzinfo=datetime.timezone.utc)}
```