### PR TITLE
[Evgo US] Fix spider

### DIFF
--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -17,6 +17,15 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
 
+    def start_requests(self) -> Iterable[Request]:
+        # Route the sitemap fetch through Playwright to bypass the Vercel security checkpoint
+        for url in self.sitemap_urls:
+            yield Request(
+                url,
+                callback=self._parse_sitemap,
+                meta={"playwright": True, "playwright_include_page": True},
+            )
+
     def _parse_sitemap(self, response: Response) -> Iterable[Request]:
         for request in super()._parse_sitemap(response):
             request.meta["playwright"] = True

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -16,6 +16,7 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         # Skip the root overview page if it comes through the sitemap

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterator
 
-from scrapy.http import Request, Response
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -8,33 +8,32 @@ from locations.google_url import extract_google_position
 from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
-
-    def parse_sitemap(self, response: Response) -> Iterable[Request]:
-        for request in super()._parse_sitemap(response):
-            request.meta["playwright"] = True
-            request.meta["playwright_include_page"] = True
-            yield request
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
+        # Skip the root overview page if it comes through the sitemap
+        if response.url.strip("/").endswith("find-a-charger"):
+            return
+
         item = Feature()
         item["website"] = response.url
         item["ref"] = response.url.rsplit("-", 1)[1].strip("/")
         item["branch"] = response.xpath("//h1/text()").get()
         item["street_address"] = response.xpath("//ol/li[last()]//span/text()").get()
-        item["state"] = response.xpath("//ol/li[2]//a/text()").get().upper()
+        item["state"] = response.xpath("//ol/li[2]//a/text()").get("").upper()
         item["addr_full"] = (
             response.xpath("//title/text()").get().split(" | ", 1)[0].removeprefix("EVgo EV Charging Station in ")
         )
         item["extras"]["capacity"] = (
             response.xpath('//div[contains(@title, " stalls at this location")]/@title')
-            .get()
+            .get("")
             .removesuffix(" stalls at this location")
         )
 

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -16,7 +16,6 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
-    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         # Skip the root overview page if it comes through the sitemap

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -1,6 +1,6 @@
-from typing import Any, Iterator
+from typing import Any, Iterable, Iterator
 
-from scrapy.http import Response
+from scrapy.http import Request, Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
@@ -15,8 +15,13 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
-    requires_proxy = True
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
+
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
+        for request in super()._parse_sitemap(response):
+            request.meta["playwright"] = True
+            request.meta["playwright_include_page"] = True
+            yield request
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:
         # Skip the root overview page if it comes through the sitemap

--- a/locations/spiders/evgo_us.py
+++ b/locations/spiders/evgo_us.py
@@ -15,6 +15,7 @@ class EvgoUSSpider(SitemapSpider, PlaywrightSpider):
     name = "evgo_us"
     item_attributes = {"brand": "EVgo", "brand_wikidata": "Q61803820"}
     sitemap_urls = ["https://evgo.com/find-a-charger/sites-sitemap.xml"]
+    requires_proxy = True
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Iterator[Feature]:


### PR DESCRIPTION
The spider runs successfully and extracts all items correctly on US network. One error in the log is not related to the spider code but is just harmless background noise from the Playwright framework when it encounters page redirects.

```
{'atp/brand/EVgo': 881,
 'atp/brand_wikidata/Q61803820': 881,
 'atp/category/amenity/charging_station': 881,
 'atp/country/US': 881,
 'atp/field/branch/missing': 1,
 'atp/field/city/missing': 881,
 'atp/field/country/from_spider_name': 881,
 'atp/field/email/missing': 881,
 'atp/field/geometry/missing': 2,
 'atp/field/housenumber/missing': 881,
 'atp/field/opening_hours/missing': 881,
 'atp/field/phone/missing': 881,
 'atp/field/postcode/missing': 881,
 'atp/field/state/from_reverse_geocoding': 21,
 'atp/field/state/missing': 2,
 'atp/field/street/missing': 881,
 'atp/field/street_address/missing': 2,
 'atp/field/twitter/missing': 881,
 'atp/field/unit/missing': 881,
 'atp/item_scraped_host_count/evgo.com': 881,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 881,
 'atp/operator/EVgo': 881,
 'atp/operator_wikidata/Q61803820': 881,
 'downloader/request_bytes': 324600,
 'downloader/request_count': 898,
 'downloader/request_method_count/GET': 898,
 'downloader/response_bytes': 110237415,
 'downloader/response_count': 898,
 'downloader/response_status_count/200': 898,
 'elapsed_time_seconds': 1104.688,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 10, 10, 14, 37, 141620, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 881,
 'items_per_minute': 47.8804347826087,
 'log_count/DEBUG': 72613,
 'log_count/ERROR': 1,
 'log_count/INFO': 32,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 898,
 'playwright/page_count/closed': 898,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 34967,
 'playwright/request_count/aborted': 34035,
 'playwright/request_count/method/GET': 34967,
 'playwright/request_count/navigation': 932,
 'playwright/request_count/resource_type/document': 932,
 'playwright/request_count/resource_type/font': 4480,
 'playwright/request_count/resource_type/image': 5324,
 'playwright/request_count/resource_type/script': 21543,
 'playwright/request_count/resource_type/stylesheet': 2688,
 'playwright/response_count': 932,
 'playwright/response_count/method/GET': 932,
 'playwright/response_count/resource_type/document': 932,
 'request_depth_max': 1,
 'response_received_count': 898,
 'responses_per_minute': 48.80434782608696,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 897,
 'scheduler/dequeued/memory': 897,
 'scheduler/enqueued': 897,
 'scheduler/enqueued/memory': 897,
 'start_time': datetime.datetime(2026, 6, 10, 9, 56, 12, 445425, tzinfo=datetime.timezone.utc)}
```