### PR TITLE
[Erste Bank Polska] Rename from santander_pl and fix

### DIFF
--- a/locations/spiders/erste_pl.py
+++ b/locations/spiders/erste_pl.py
@@ -7,10 +7,10 @@ from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 
-class SantanderPLSpider(Spider):
-    name = "santander_pl"
-    item_attributes = {"brand": "Santander", "brand_wikidata": "Q806653"}
-    start_urls = ["https://www.santander.pl/_js_places/places.js"]
+class ErstePLSpider(Spider):
+    name = "erste_pl"
+    item_attributes = {"brand": "Erste Bank Polska", "brand_wikidata": "Q806653"}
+    start_urls = ["https://www.erste.pl/_js_places/places.js"]
 
     def parse(self, response, **kwargs):
         data = chompjs.parse_js_object(response.text)
@@ -39,9 +39,11 @@ class SantanderPLSpider(Spider):
 
         if category == Categories.ATM:
             item["name"] = None
+            item["operator"] = "Erste Bank Polska"
+            item["operator_wikidata"] = "Q806653"
         else:
             item["branch"] = item.get("name")
-            item["name"] = None
+            item["name"] = "Erste Bank Polska"
 
         apply_category(category, item)
 

--- a/locations/spiders/euronet_pl.py
+++ b/locations/spiders/euronet_pl.py
@@ -9,8 +9,8 @@ from locations.categories import Categories, Extras, apply_category, apply_yes_n
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.spiders.alior_bank_pl import AliorBankPLSpider
+from locations.spiders.erste_pl import ErstePLSpider
 from locations.spiders.millennium_bank_pl import MillenniumBankPLSpider
-from locations.spiders.santander_pl import SantanderPLSpider
 from locations.spiders.unicredit_bank_it import UnicreditBankITSpider
 
 BRAND_MAPPING = {
@@ -38,11 +38,11 @@ BRAND_MAPPING = {
         "operator": "mBank",
         "operator_wikidata": "Q1160928",
     },
-    "Santander Bank Polska": {
-        "brand": SantanderPLSpider.item_attributes["brand"],
-        "brand_wikidata": SantanderPLSpider.item_attributes["brand_wikidata"],
-        "operator": SantanderPLSpider.item_attributes["brand"],
-        "operator_wikidata": SantanderPLSpider.item_attributes["brand_wikidata"],
+    "Erste Bank Polska": {
+        "brand": ErstePLSpider.item_attributes["brand"],
+        "brand_wikidata": ErstePLSpider.item_attributes["brand_wikidata"],
+        "operator": ErstePLSpider.item_attributes["brand"],
+        "operator_wikidata": ErstePLSpider.item_attributes["brand_wikidata"],
     },
     "Kasa Stefczyka": {
         "brand": "SKOK Stefczyka",


### PR DESCRIPTION
Santander Bank Polska was acquired by Erste Group (completed 9 January
2026) and rebranded to Erste Bank Polska. santander.pl now redirects to
erste.pl, and the site, the store feed and Wikidata (Q806653) all use
the Erste name.

Rename santander_pl -> erste_pl, set brand to "Erste Bank Polska" (same
Q806653), and read the erste.pl store feed — recovering all ATMs and
branches (was 0). NSI still labels Q806653 "Santander", so name and the
ATM operator are set explicitly to stop the stale value back-filling.

Also update euronet_pl: the Euronet ATM list already labels these
machines "Erste Bank Polska", so its brand mapping is repointed — these
ATMs were going unbranded under the old "Santander Bank Polska" key.