### PR TITLE
[Verizon US] Fix spider to cover all consumer stores

### DIFF
--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -3,6 +3,7 @@ from typing import AsyncIterator, Iterable
 from scrapy.http import JsonRequest, TextResponse
 
 from locations.geo import country_iseadgg_centroids
+from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -49,9 +50,26 @@ class VerizonUSSpider(JSONBlobSpider):
             item["website"] = (
                 f'https://www.verizon.com/nextgendigital/nos/storelocator/detail/{website.removeprefix("/stores/")}'
             )
+
         if business_name := feature.get("businessName"):
             if operator_info := self.operators.get(business_name):
                 item["operator"], item["operator_wikidata"] = operator_info
             else:
                 self.logger.warning(f"Unknown operator for business name: {business_name}")
+
+        try:
+            item["opening_hours"] = self.parse_opening_hours(feature)
+        except Exception as e:
+            self.logger.error(f"Error parsing opening hours: {e}")
+
         yield item
+
+    def parse_opening_hours(self, feature: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day in DAYS_3_LETTERS:
+            if hours := feature.get(f"hours{day}"):
+                if "Closed" in hours:
+                    opening_hours.set_closed(day)
+                    continue
+                opening_hours.add_range(day, *hours.strip().replace("M ", "M-").split("-"), "%I:%M %p")
+        return opening_hours

--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -47,6 +47,7 @@ class VerizonUSSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         item["ref"] = feature["storeNumber"]
+        item["branch"] = item.pop("name", None)
         if website := item.get("website"):
             item["website"] = (
                 f'https://www.verizon.com/nextgendigital/nos/storelocator/detail/{website.removeprefix("/stores/")}'

--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -2,6 +2,7 @@ from typing import AsyncIterator, Iterable
 
 from scrapy.http import JsonRequest, TextResponse
 
+from locations.categories import Categories, apply_category
 from locations.geo import country_iseadgg_centroids
 from locations.hours import DAYS_3_LETTERS, OpeningHours
 from locations.items import Feature
@@ -54,6 +55,8 @@ class VerizonUSSpider(JSONBlobSpider):
         if business_name := feature.get("businessName"):
             if operator_info := self.operators.get(business_name):
                 item["operator"], item["operator_wikidata"] = operator_info
+                if item["operator"] in ["Victra", "The Cellular Connection"]:  # Covered by Victra & Tcc US Spiders
+                    return
             else:
                 self.logger.warning(f"Unknown operator for business name: {business_name}")
 
@@ -61,7 +64,7 @@ class VerizonUSSpider(JSONBlobSpider):
             item["opening_hours"] = self.parse_opening_hours(feature)
         except Exception as e:
             self.logger.error(f"Error parsing opening hours: {e}")
-
+        apply_category(Categories.SHOP_MOBILE_PHONE, item)
         yield item
 
     def parse_opening_hours(self, feature: dict) -> OpeningHours:

--- a/locations/spiders/verizon_us.py
+++ b/locations/spiders/verizon_us.py
@@ -1,47 +1,57 @@
-import json
+from typing import AsyncIterator, Iterable
 
-from scrapy.http import TextResponse
-from scrapy.spiders import SitemapSpider
+from scrapy.http import JsonRequest, TextResponse
 
-from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.geo import country_iseadgg_centroids
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
-from locations.structured_data_spider import StructuredDataSpider
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class VerizonUSSpider(SitemapSpider, StructuredDataSpider):
+class VerizonUSSpider(JSONBlobSpider):
     name = "verizon_us"
     item_attributes = {"brand": "Verizon", "brand_wikidata": "Q919641"}
-    sitemap_urls = ["https://www.verizon.com/business/locations/sitemap.xml"]
-    sitemap_rules = [(r"https://www.verizon.com/business/locations/[^/]+/[^/]+/[^/]+/$", "parse")]
+    operators = {
+        "ABC Phones of North Carolina, Inc.": ("Victra", "Q118402656"),
+        "BeMobile, Inc": ("BeMobile", None),
+        "Cellular Sales Management Group LLC via its affili": ("Cellular Sales", "Q5058345"),
+        "Credico (USA) LLC": ("Credico", None),
+        "Cydcor LLC": ("Cydcor", None),
+        "Gee Papa Enterprises, Inc.": ("Team Wireless", None),
+        "LCM Enterprises Inc.": ("Smartmart", None),
+        "Mobile Generation, LLC": ("Mobile Generation", None),
+        "R Wireless Inc": ("R Wireless", None),
+        "Russell Cellular, Inc.": ("Russell Cellular", "Q125523800"),
+        "The Cellular Connection, LLC": ("The Cellular Connection", "Q121336519"),
+        "UNITED TELECOM USA, INC. DBA YOUR WIRELESS": ("Your Wireless", None),
+        "Verizon Wireless": ("Verizon", "Q919641"),
+        "Wireless Plus, Inc.": ("Wireless Plus", None),
+        "Wireless Zone, LLC": ("Wireless Zone", "Q122517436"),
+    }
+    locations_key = ["body", "data", "stores"]
 
-    def parse(self, response: TextResponse, **kwargs):
-        if street_address := response.xpath('//*[@class="vbg-address-text"]/strong/text()').get():
-            item = Feature()
-            item["branch"] = (
-                response.xpath("//title//text()")
-                .get()
-                .removeprefix("Verizon Business Services - ")
-                .removesuffix("| Verizon")
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for lat, lon in country_iseadgg_centroids("US", 458):
+            yield JsonRequest(
+                url="https://www.verizon.com/digital/nsa/nos/gw/retail/searchresultsdata",
+                data={
+                    "latitude": lat,
+                    "longitude": lon,
+                    "range": 10000,
+                    "noOfStores": 2500,
+                    "excludeIndirect": False,
+                    "retrieveBy": "GEO",
+                },
             )
-            item["street_address"] = street_address
-            item["addr_full"] = merge_address_lines(
-                response.xpath('//*[@class="vbg-address-text"]//text()').getall()
-            ).replace("Address, ", "")
-            item["lat"] = response.xpath("//@data-lat").get()
-            item["lon"] = response.xpath("//@data-lng").get()
-            item["ref"] = item["website"] = response.url
-            apply_category(Categories.SHOP_MOBILE_PHONE, item)
-            day_time_data = response.xpath("//@data-hours-json").get()
-            oh = OpeningHours()
-            if data := json.loads(day_time_data):
-                for day, time in data.items():
-                    day = day
-                    if time in ["Closed", "Closed Closed"]:
-                        oh.set_closed(day)
-                    else:
-                        open_time, close_time = time.split("-")
-                        oh.add_range(day, open_time.strip(), close_time.strip(), "%I:%M %p")
-            item["opening_hours"] = oh
-            yield item
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["storeNumber"]
+        if website := item.get("website"):
+            item["website"] = (
+                f'https://www.verizon.com/nextgendigital/nos/storelocator/detail/{website.removeprefix("/stores/")}'
+            )
+        if business_name := feature.get("businessName"):
+            if operator_info := self.operators.get(business_name):
+                item["operator"], item["operator_wikidata"] = operator_info
+            else:
+                self.logger.warning(f"Unknown operator for business name: {business_name}")
+        yield item


### PR DESCRIPTION
Spider was scraping [Verizon Business](https://en.wikipedia.org/wiki/Verizon_Business) locations only which serve for enterprise, small business and government. Now, it is refactored to cover locations for normal consumers (directly operated by Verizon plus Authorized Retailers).

```python
{'atp/brand/Verizon': 4302,
 'atp/brand_wikidata/Q919641': 4302,
 'atp/category/shop/mobile_phone': 4302,
 'atp/clean_strings/name': 11,
 'atp/clean_strings/street_address': 14,
 'atp/country/US': 4302,
 'atp/duplicate_count': 63123,
 'atp/field/branch/missing': 4302,
 'atp/field/country/from_spider_name': 4302,
 'atp/field/email/missing': 4302,
 'atp/field/housenumber/missing': 4302,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator_wikidata/missing': 681,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 5,
 'atp/field/state/from_reverse_geocoding': 4302,
 'atp/field/state/missing': 2,
 'atp/field/street/missing': 4302,
 'atp/field/twitter/missing': 4302,
 'atp/field/unit/missing': 4302,
 'atp/item_scraped_host_count/www.verizon.com': 67425,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 4302,
 'atp/operator/BeMobile': 117,
 'atp/operator/Cellular Sales': 842,
 'atp/operator/Credico': 3,
 'atp/operator/Cydcor': 3,
 'atp/operator/Mobile Generation': 51,
 'atp/operator/R Wireless': 37,
 'atp/operator/Russell Cellular': 701,
 'atp/operator/Smartmart': 10,
 'atp/operator/Team Wireless': 212,
 'atp/operator/Verizon': 1275,
 'atp/operator/Wireless Plus': 36,
 'atp/operator/Wireless Zone': 803,
 'atp/operator/Your Wireless': 212,
 'atp/operator_wikidata/Q122517436': 803,
 'atp/operator_wikidata/Q125523800': 701,
 'atp/operator_wikidata/Q5058345': 842,
 'atp/operator_wikidata/Q919641': 1275,
 'downloader/request_bytes': 112356,
 'downloader/request_count': 43,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 42,
 'downloader/response_bytes': 21063384,
 'downloader/response_count': 43,
 'downloader/response_status_count/200': 43,
 'elapsed_time_seconds': 65.29699999999866,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 10, 13, 19, 14, 876451, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 250883442,
 'httpcompression/response_count': 43,
 'item_dropped_count': 63123,
 'item_dropped_reasons_count/DropItem': 63123,
 'item_scraped_count': 4302,
 'items_per_minute': 3971.0769230769233,
 'log_count/DEBUG': 67468,
 'log_count/INFO': 4,
 'response_received_count': 43,
 'responses_per_minute': 39.69230769230769,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 42,
 'scheduler/dequeued/memory': 42,
 'scheduler/enqueued': 42,
 'scheduler/enqueued/memory': 42,
 'start_time': datetime.datetime(2026, 6, 10, 13, 18, 9, 575775, tzinfo=datetime.timezone.utc)}
```