### PR TITLE
[Fastrak ZA] Add requires proxy to fix the spider

### DIFF
--- a/locations/spiders/fastrak_za.py
+++ b/locations/spiders/fastrak_za.py
@@ -12,11 +12,9 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class FastrakZASpider(JSONBlobSpider):
     name = "fastrak_za"
-    item_attributes = {
-        "brand": "Fastrak",
-        "brand_wikidata": "Q120799603",
-    }
+    item_attributes = {"brand": "Fastrak", "brand_wikidata": "Q120799603"}
     locations_key = ["data", "mapData"]
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[FormRequest]:
         yield FormRequest(


### PR DESCRIPTION
The spider runs successfully on my local setup. Added the requires_proxy configuration to ensure consistent functionality across networks.

```
{'atp/brand/Fastrak': 86,
 'atp/brand_wikidata/Q120799603': 86,
 'atp/category/shop/hifi': 86,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/ZA': 86,
 'atp/field/email/missing': 9,
 'atp/field/housenumber/missing': 86,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 86,
 'atp/field/operator_wikidata/missing': 86,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 3,
 'atp/field/street/missing': 86,
 'atp/field/street_address/missing': 86,
 'atp/field/twitter/missing': 86,
 'atp/field/unit/missing': 86,
 'atp/item_scraped_host_count/msl.cirkleinc.com': 86,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 86,
 'downloader/request_bytes': 769,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 20078,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.1409999999996217,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 10, 13, 16, 46, 718360, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 93648,
 'httpcompression/response_count': 2,
 'item_scraped_count': 86,
 'items_per_minute': 2580.0,
 'log_count/DEBUG': 88,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 10, 13, 16, 44, 580404, tzinfo=datetime.timezone.utc)}
```