### PR TITLE
[National Bank of Kuwait] Add spider (509 locations)

### DIFF
--- a/locations/spiders/national_bank_of_kuwait.py
+++ b/locations/spiders/national_bank_of_kuwait.py
@@ -1,0 +1,167 @@
+import re
+
+from scrapy import Request, Spider
+
+from locations.brand_utils import extract_located_in
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import DAYS, OpeningHours, day_range
+from locations.items import Feature
+from locations.spiders.carrefour_fr import CARREFOUR_SUPERMARKET
+from locations.spiders.circle_k import CircleKSpider
+from locations.spiders.fairmont import FairmontSpider
+from locations.spiders.ikea import IkeaSpider
+from locations.spiders.total_energies import TotalEnergiesSpider
+from locations.spiders.vodafone_de import VODAFONE_SHARED_ATTRIBUTES
+from locations.user_agents import BROWSER_DEFAULT
+
+API_URL = "https://www.nbk.com/.rest/nbk/locations?lang={lang}&path={site}"
+ARABIC_TEXT = re.compile(r"[؀-ۿ]")
+
+
+class NationalBankOfKuwaitSpider(Spider):
+    name = "national_bank_of_kuwait"
+    item_attributes = {"brand": "National Bank of Kuwait", "brand_wikidata": "Q4045072"}
+    # Venues hosting offsite machines, eg "The Avenues - IKEA - ATM" or "Circle K Almaza".
+    LOCATED_IN_MAPPINGS = [
+        (["IKEA"], IkeaSpider.item_attributes),
+        (["Carrefour"], CARREFOUR_SUPERMARKET),
+        (["Lulu Hypermarket"], {"brand": "Lulu Hypermarket", "brand_wikidata": "Q6702930"}),
+        (["Four Points by Sheraton"], {"brand": "Four Points by Sheraton", "brand_wikidata": "Q1439966"}),
+        (["Sheraton"], {"brand": "Sheraton", "brand_wikidata": "Q634831"}),
+        (["Four Seasons"], {"brand": "Four Seasons", "brand_wikidata": "Q1424786"}),
+        (["Hilton"], {"brand": "Hilton", "brand_wikidata": "Q598884"}),
+        (["Marriott"], {"brand": "Marriott", "brand_wikidata": "Q3918608"}),
+        (["Fairmont"], FairmontSpider.FAIRMONT),
+        (["Westin"], {"brand": "The Westin", "brand_wikidata": "Q1969162"}),
+        (["Vodafone"], VODAFONE_SHARED_ATTRIBUTES),
+        (["Circle K"], CircleKSpider.CIRCLE_K),
+        (["Mobil"], {"brand": "Mobil", "brand_wikidata": "Q109676002"}),
+        (["Total"], TotalEnergiesSpider.BRANDS["tot"]),
+        (["Eni"], {"brand": "Eni", "brand_wikidata": "Q565594"}),
+        (["Misr Petroleum"], {"brand": "Misr Petroleum", "brand_wikidata": "Q10982617"}),
+    ]
+    # The bank's WAF blocks requests without a full browser user agent.
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    # API backing the map on https://www.nbk.com/<site>/find-us.html, one site per country.
+    SITES = {
+        "kuwait": "KW",
+        "egypt": "EG",
+        "uae": "AE",
+        "ksa": "SA",
+        "bahrain": "BH",
+        "jordan": "JO",
+        "lebanon": "LB",
+        "london": "GB",
+        "iraq": "IQ",
+    }
+
+    async def start(self):
+        for site, country in self.SITES.items():
+            yield Request(API_URL.format(lang="en", site=site), cb_kwargs={"country": country, "site": site})
+
+    def parse(self, response, country, site):
+        items = {}
+        for location in response.xpath("//BranchItem"):
+            item = Feature()
+            item["ref"] = location.xpath("id/text()").get()
+            item["lat"] = location.xpath("latitudes/text()").get()
+            item["lon"] = location.xpath("longitudes/text()").get()
+            item["addr_full"] = location.xpath("address/text()").get()
+            item["city"] = location.xpath("AreasList/Areaitem/Atitle/text()").get()
+            item["country"] = country
+            item["phone"] = location.xpath("phone_no/text()").get()
+            item["extras"]["fax"] = location.xpath("fax_no/text()").get()
+
+            name = location.xpath("name/text()").get("").strip()
+            facilities = location.xpath("FacilitiesList/Facilityitem/Ftitle/text()").getall()
+            # The "pinImage" branch/ATM marker is unreliable (in Egypt most offsite ATMs carry the
+            # branch marker), so classify by the facility list instead.
+            is_branch = "Branch" in facilities or ("ATM" not in facilities and "branch" in name.lower())
+            if is_branch:
+                item["branch"] = name
+                apply_category(Categories.BANK, item)
+                apply_yes_no(Extras.ATM, item, "ATM" in facilities)
+            else:
+                # Machines are named after their venue or host branch, eg "The Avenues - IKEA - ATM"
+                # or "Madinaty Branch - ATM II".
+                item["branch"] = re.sub(r"\s*-?\s*\b(ATM|ITM|CDM)\b[^-]*$", "", name)
+                apply_category(Categories.ATM, item)
+                item["located_in"], item["located_in_wikidata"] = extract_located_in(
+                    name, self.LOCATED_IN_MAPPINGS, self
+                )
+            item["opening_hours"] = self.parse_opening_hours(
+                location.xpath("workingHoursLabels/text()").get(), is_branch
+            )
+            apply_yes_no(Extras.CASH_IN, item, "CDM" in facilities or "Cash Deposit" in facilities)
+            apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive Through" in facilities or "Drive-Through" in facilities)
+
+            items[item["ref"]] = item
+
+        # The same locations are also published in Arabic, the local language everywhere but London.
+        yield Request(
+            API_URL.format(lang="ar", site=site),
+            callback=self.parse_arabic,
+            cb_kwargs={"items": items},
+            errback=self.parse_arabic_failed,
+        )
+
+    def parse_arabic(self, response, items):
+        for location in response.xpath("//BranchItem"):
+            item = items.get(location.xpath("id/text()").get())
+            if item is None:
+                continue
+            name = location.xpath("name/text()").get("").strip()
+            if ARABIC_TEXT.search(name):
+                # Machine names carry a descriptive suffix, eg "جهاز سحب آلي" (ATM).
+                name = re.sub(r"\s*-\s*جهاز\s[^-]*$", "", name)
+                item["extras"]["branch:en"] = item["branch"]
+                item["branch"] = item["extras"]["branch:ar"] = name
+            address = location.xpath("address/text()").get()
+            if address and ARABIC_TEXT.search(address):
+                item["extras"]["addr:full:en"] = item["addr_full"]
+                item["addr_full"] = item["extras"]["addr:full:ar"] = address
+        yield from items.values()
+
+    def parse_arabic_failed(self, failure):
+        # Don't lose a whole country over the Arabic feed: yield the English-only items.
+        yield from failure.request.cb_kwargs["items"].values()
+
+    @staticmethod
+    def parse_opening_hours(label, is_branch):
+        if not label:
+            return None
+        if label.strip().lower() == "24 hours":
+            return "24/7"
+        oh = OpeningHours()
+        # Eg "8:30 AM - 3 PM | Sunday - Thursday", "9 AM - 1 PM | Sunday - Thursday,5 PM - 7 PM | Sunday - Wednesday",
+        # "09.30 AM to 04.30 PM", or just "9 AM - 8:30 PM" for machines available daily.
+        for rule in label.replace("–", "-").replace(" to ", " - ").split(","):
+            if match := re.fullmatch(
+                r"(\d{1,2})(?:[:.](\d{2}))?\s*([AP]M)\s*-\s*(\d{1,2})(?:[:.](\d{2}))?\s*([AP]M)"
+                r"(?:\s*\|\s*(\w+)(?:\s*-\s*(\w+))?)?",
+                rule.strip(),
+                re.IGNORECASE,
+            ):
+                open_h, open_m, open_ap, close_h, close_m, close_ap, day_start, day_end = match.groups()
+                try:
+                    if day_start and day_end:
+                        days = day_range(day_start, day_end)
+                    elif day_start:
+                        days = [day_start]
+                    elif not is_branch:
+                        # Machine hours without days, eg mall opening times, apply daily.
+                        days = DAYS
+                    else:
+                        # Branch hours without days (most Egypt branches): the open days are unknown,
+                        # so don't guess.
+                        continue
+                    oh.add_days_range(
+                        days,
+                        f"{open_h}:{open_m or '00'} {open_ap.upper()}",
+                        f"{close_h}:{close_m or '00'} {close_ap.upper()}",
+                        "%I:%M %p",
+                    )
+                except ValueError:
+                    # Eg an unrecognised day word or a nonsense time: skip the rule, keep the item.
+                    continue
+        return oh


### PR DESCRIPTION
Branches and ATMs/ITMs across KW, EG, AE, SA, BH, LB, GB and IQ from the XML API behind the find-us map, merging the English and Arabic feeds so branch and addr_full carry the local language with :en/:ar variants. Classifies by facility list (the pinImage marker is unreliable in Egypt) and maps host venues of offsite ATMs to located_in via NSI brands.

{'atp/brand/National Bank of Kuwait': 509,
 'atp/brand_wikidata/Q4045072': 509,
 'atp/category/amenity/atm': 379,
 'atp/category/amenity/bank': 130,
 'atp/clean_strings/addr_full': 25,
 'atp/clean_strings/lat': 79,
 'atp/clean_strings/lon': 82,
 'atp/country/AE': 3,
 'atp/country/BH': 5,
 'atp/country/EG': 292,
 'atp/country/GB': 1,
 'atp/country/IQ': 3,
 'atp/country/KW': 200,
 'atp/country/LB': 2,
 'atp/country/SA': 3,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 509,
 'atp/field/geometry/invalid': 1,
 'atp/field/housenumber/missing': 509,
 'atp/field/name/missing': 382,
 'atp/field/opening_hours/missing': 69,
 'atp/field/operator/missing': 130,
 'atp/field/operator_wikidata/missing': 130,
 'atp/field/phone/invalid': 38,
 'atp/field/phone/missing': 382,
 'atp/field/postcode/missing': 508,
 'atp/field/state/missing': 509,
 'atp/field/street/missing': 509,
 'atp/field/street_address/missing': 509,
 'atp/field/twitter/missing': 509,
 'atp/field/unit/missing': 509,
 'atp/item_scraped_host_count/www.nbk.com': 509,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/located_in/Carrefour': 1,
 'atp/located_in/Circle K': 8,
 'atp/located_in/Eni': 2,
 'atp/located_in/Fairmont': 1,
 'atp/located_in/Four Points by Sheraton': 1,
 'atp/located_in/Four Seasons': 1,
 'atp/located_in/Hilton': 1,
 'atp/located_in/IKEA': 1,
 'atp/located_in/Lulu Hypermarket': 3,
 'atp/located_in/Marriott': 1,
 'atp/located_in/Misr Petroleum': 5,
 'atp/located_in/Mobil': 2,
 'atp/located_in/Sheraton': 1,
 'atp/located_in/The Westin': 1,
 'atp/located_in/TotalEnergies': 5,
 'atp/located_in/Vodafone': 6,
 'atp/located_in_wikidata/Q109676002': 2,
 'atp/located_in_wikidata/Q10982617': 5,
 'atp/located_in_wikidata/Q122141': 6,
 'atp/located_in_wikidata/Q1393345': 1,
 'atp/located_in_wikidata/Q1424786': 1,
 'atp/located_in_wikidata/Q1439966': 1,
 'atp/located_in_wikidata/Q154037': 5,
 'atp/located_in_wikidata/Q1969162': 1,
 'atp/located_in_wikidata/Q217599': 1,
 'atp/located_in_wikidata/Q3268010': 8,
 'atp/located_in_wikidata/Q3918608': 1,
 'atp/located_in_wikidata/Q54078': 1,
 'atp/located_in_wikidata/Q565594': 2,
 'atp/located_in_wikidata/Q598884': 1,
 'atp/located_in_wikidata/Q634831': 1,
 'atp/located_in_wikidata/Q6702930': 3,
 'atp/nsi/cc_match': 506,
 'atp/nsi/match_failed': 3,
 'atp/operator/National Bank of Kuwait': 379,
 'atp/operator_wikidata/Q4045072': 379,
 'downloader/request_bytes': 16996,
 'downloader/request_count': 19,
 'downloader/request_method_count/GET': 19,
 'downloader/response_bytes': 128579,
 'downloader/response_count': 19,
 'downloader/response_status_count/200': 19,
 'elapsed_time_seconds': 23.493887791992165,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 10, 15, 38, 1, 394836, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 910022,
 'httpcompression/response_count': 18,
 'item_scraped_count': 509,
 'items_per_minute': 1327.8260869565217,
 'log_count/DEBUG': 528,
 'log_count/INFO': 3,
 'memusage/max': 284295168,
 'memusage/startup': 284295168,
 'request_depth_max': 1,
 'response_received_count': 19,
 'responses_per_minute': 49.565217391304344,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 18,
 'scheduler/dequeued/memory': 18,
 'scheduler/enqueued': 18,
 'scheduler/enqueued/memory': 18,
 'start_time': datetime.datetime(2026, 6, 10, 15, 37, 37, 900897, tzinfo=datetime.timezone.utc)}