### PR TITLE
[Seattle Coffee Company] Fix and extend hours parsing

### DIFF
--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.google_url import extract_google_position
-from locations.hours import OpeningHours, day_range
+from locations.hours import OpeningHours, day_range, days_in_day_range
 from locations.items import Feature
 
 
@@ -23,7 +23,7 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for day_time in response.xpath('//div[contains(@class, "trading")]').xpath("normalize-space()").getall():
-            if ("Closed" in day_time) or ("Church Services" in day_time):
+            if ("Church Services" in day_time):
                 continue
             if "24/7" in day_time:
                 item["opening_hours"] = "24/7"
@@ -46,8 +46,8 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                         item["opening_hours"].add_days_range(
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
-                    elif time.lower().strip() == "closed":
-                        item["opening_hours"].set_closed(day_range(start_day, end_day))
+                    elif "closed" in time.lower():
+                        item["opening_hours"].set_closed(days_in_day_range(start_day, end_day))
                 except:
                     item["opening_hours"] = ""
                     break

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -32,22 +32,23 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                     day, time = day_time.replace(" - ", "-").split(" ")
                     if "-" in day:
                         start_day, end_day = day.split("-")
+                        if end_day == "Holidays":
+                            end_day = start_day
                     else:
                         start_day = day
                         end_day = day
-                    if "-" in time:
+
+                    if "closed" in time.lower():
+                        item["opening_hours"].set_closed(OpeningHours.days_in_day_range(start_day, end_day))
+                    elif "-" in time:
                         open_time, close_time = time.split("-")
                         if ":" not in open_time:
                             open_time = open_time.replace("am", ":00AM")
                         if ":" not in close_time:
                             close_time = close_time.replace("pm", ":00PM")
-                        if end_day == "Holidays":
-                            end_day = start_day
                         item["opening_hours"].add_days_range(
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
-                    elif "closed" in time.lower():
-                        item["opening_hours"].set_closed(OpeningHours.days_in_day_range(start_day, end_day))
                 except:
                     item["opening_hours"] = ""
                     break

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -23,7 +23,7 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for day_time in response.xpath('//div[contains(@class, "trading")]').xpath("normalize-space()").getall():
-            if ("Church Services" in day_time):
+            if "Church Services" in day_time:
                 continue
             if "24/7" in day_time:
                 item["opening_hours"] = "24/7"

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -35,16 +35,19 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                     else:
                         start_day = day
                         end_day = day
-                    open_time, close_time = time.split("-")
-                    if ":" not in open_time:
-                        open_time = open_time.replace("am", ":00AM")
-                    if ":" not in close_time:
-                        close_time = close_time.replace("pm", ":00PM")
-                    if end_day == "Holidays":
-                        end_day = start_day
-                    item["opening_hours"].add_days_range(
-                        day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
-                    )
+                    if "-" in time:
+                        open_time, close_time = time.split("-")
+                        if ":" not in open_time:
+                            open_time = open_time.replace("am", ":00AM")
+                        if ":" not in close_time:
+                            close_time = close_time.replace("pm", ":00PM")
+                        if end_day == "Holidays":
+                            end_day = start_day
+                        item["opening_hours"].add_days_range(
+                            day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
+                        )
+                    elif time.lower().strip() == "closed":
+                        item["opening_hours"].set_closed(day_range(start_day, end_day))
                 except:
                     item["opening_hours"] = ""
                     break

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -29,17 +29,17 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                 item["opening_hours"] = "24/7"
             else:
                 try:
-                    day, time = day_time.replace(" - ", "-").split(" ")
+                    day, time = day_time.replace(" - ", "-").split(" ", 1)
                     if "-" in day:
                         start_day, end_day = day.split("-")
-                        if end_day == "Holidays":
+                        if "holidays" in end_day.lower():
                             end_day = start_day
                     else:
                         start_day = day
                         end_day = day
 
                     if "closed" in time.lower():
-                        item["opening_hours"].set_closed(OpeningHours.days_in_day_range(start_day, end_day))
+                        item["opening_hours"].set_closed(day_range(start_day, end_day))
                     elif "-" in time:
                         open_time, close_time = time.split("-")
                         if ":" not in open_time:
@@ -49,7 +49,8 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                         item["opening_hours"].add_days_range(
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
-                except:
+                except Exception as e:
+                    print(e)
                     item["opening_hours"] = ""
                     break
 

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.google_url import extract_google_position
-from locations.hours import OpeningHours, day_range, days_in_day_range
+from locations.hours import OpeningHours, day_range
 from locations.items import Feature
 
 
@@ -47,7 +47,7 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
                     elif "closed" in time.lower():
-                        item["opening_hours"].set_closed(days_in_day_range(start_day, end_day))
+                        item["opening_hours"].set_closed(OpeningHours.days_in_day_range(start_day, end_day))
                 except:
                     item["opening_hours"] = ""
                     break

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -32,17 +32,21 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                     day, time = day_time.replace(" - ", "-").split(" ")
                     if "-" in day:
                         start_day, end_day = day.split("-")
-                        open_time, close_time = time.split("-")
-                        if ":" not in open_time:
-                            open_time = open_time.replace("am", ":00AM")
-                        if ":" not in close_time:
-                            close_time = close_time.replace("pm", ":00PM")
-                        if end_day == "Holidays":
-                            end_day = start_day
-                        item["opening_hours"].add_days_range(
-                            day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
-                        )
+                    else:
+                        start_day = day
+                        end_day = day
+                    open_time, close_time = time.split("-")
+                    if ":" not in open_time:
+                        open_time = open_time.replace("am", ":00AM")
+                    if ":" not in close_time:
+                        close_time = close_time.replace("pm", ":00PM")
+                    if end_day == "Holidays":
+                        end_day = start_day
+                    item["opening_hours"].add_days_range(
+                        day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
+                    )
                 except:
                     item["opening_hours"] = ""
+                    break
 
         yield item


### PR DESCRIPTION
Locations like https://www.seattlecoffeecompany.co.za/store/belvedere/ were parsing to `Mo-Fr 06:30-17:00; Su 07:00-14:00`, skipping Saturday as it was not a range. This fixes that and adds explicit parsing for locations that are closed on certain days, such as https://www.seattlecoffeecompany.co.za/store/liberty/ which did simply have `Mo-Fr 06:30-16:00` (not wrong, but not explicit).

Anything that can't be parsed is totally skipped.