### PR TITLE
[Seattle Coffee Company] Fix and extend hours parsing

### DIFF
--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -23,7 +23,7 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for day_time in response.xpath('//div[contains(@class, "trading")]').xpath("normalize-space()").getall():
-            if "Church Services" in day_time:
+            if "church services" in day_time.lower():
                 continue
             if "24/7" in day_time:
                 item["opening_hours"] = "24/7"
@@ -49,7 +49,7 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
                         item["opening_hours"].add_days_range(
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
-                except Exception as e:
+                except:
                     item["opening_hours"] = ""
                     break
 

--- a/locations/spiders/seattle_coffee_company.py
+++ b/locations/spiders/seattle_coffee_company.py
@@ -23,26 +23,34 @@ class SeattleCoffeeCompanySpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for day_time in response.xpath('//div[contains(@class, "trading")]').xpath("normalize-space()").getall():
-            if ("Closed" in day_time) or ("Church Services" in day_time):
+            if "Church Services" in day_time:
                 continue
             if "24/7" in day_time:
                 item["opening_hours"] = "24/7"
             else:
                 try:
-                    day, time = day_time.replace(" - ", "-").split(" ")
+                    day, time = day_time.replace(" - ", "-").split(" ", 1)
                     if "-" in day:
                         start_day, end_day = day.split("-")
+                        if "holidays" in end_day.lower():
+                            end_day = start_day
+                    else:
+                        start_day = day
+                        end_day = day
+
+                    if "closed" in time.lower():
+                        item["opening_hours"].set_closed(day_range(start_day, end_day))
+                    elif "-" in time:
                         open_time, close_time = time.split("-")
                         if ":" not in open_time:
                             open_time = open_time.replace("am", ":00AM")
                         if ":" not in close_time:
                             close_time = close_time.replace("pm", ":00PM")
-                        if end_day == "Holidays":
-                            end_day = start_day
                         item["opening_hours"].add_days_range(
                             day_range(start_day, end_day), open_time, close_time, time_format="%I:%M%p"
                         )
-                except:
+                except Exception as e:
                     item["opening_hours"] = ""
+                    break
 
         yield item


### PR DESCRIPTION
Locations like https://www.seattlecoffeecompany.co.za/store/belvedere/ were parsing to `Mo-Fr 06:30-17:00; Su 07:00-14:00`, skipping Saturday as it was not a range. This fixes that and adds explicit parsing for locations that are closed on certain days, such as https://www.seattlecoffeecompany.co.za/store/liberty/ which did simply have `Mo-Fr 06:30-16:00` (not wrong, but not explicit).

Anything that can't be parsed is totally skipped.