### PR TITLE
[FineWineGoodSpirits] Fix spider

### DIFF
--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -7,7 +7,8 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, DAYS_FULL
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -55,15 +56,10 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
             item["image"] = img_url
 
         oh = OpeningHours()
-        for element in response.xpath('//div[@class="storeHoursInformation"]//dl/div'):
-            day = element.xpath("./dt/text()").get()
-            hours_text = element.xpath("./dd/text()").get()
-            if not day or not hours_text or day.strip() == "Today":
-                continue
-
-            oh.add_ranges_from_string(f"{day.strip()} {hours_text.strip()}")
-
+        for day in map(str.lower, DAYS_FULL):
+            oh.add_range(day, location["b2cStore_{}OpenTime".format(day)], location["b2cStore_{}CloseTime".format(day)])
         item["opening_hours"] = oh
+
         apply_category(Categories.SHOP_ALCOHOL, item)
 
         yield item

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -1,66 +1,57 @@
-from scrapy import Spider
+from typing import Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class FineWineGoodSpiritsSpider(Spider):
+class FineWineGoodSpiritsSpider(SitemapSpider):
     name = "fine_wine_good_spirits"
     item_attributes = {
         "name": "Fine Wine & Good Spirits",
         "brand": "Fine Wine & Good Spirits",
         "brand_wikidata": "Q64514776",
     }
-    start_urls = [
-        "https://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?storeId=10051&langId=-1&catalogId=10051&pageNum=1&listSize=1000&category=&city=&zip_code=&county=All+Stores&storeNO="
-    ]
-    allowed_domains = ["www.finewineandgoodspirits.com"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    sitemap_urls = ["https://www.finewineandgoodspirits.com/productSitemap.xml"]
+    sitemap_rules = [(r"/product/store-\d+", "parse")]
 
-    def parse(self, response):
-        for row in response.css(".tabContentRow"):
-            column_address = row.css(".columnAddress")
-            address_phone_fax = [s.strip() for s in column_address.xpath('*[@class="normalText"]//text()').extract()]
-            if "Fax:" in address_phone_fax:
-                i = address_phone_fax.index("Fax:")
-                fax = address_phone_fax[i + 1]
-                address_phone_fax[i:] = []
-            else:
-                fax = None
-            i = address_phone_fax.index("Phone:")
-            phone = address_phone_fax[i + 1]
-            address_phone_fax[i:] = []
-            address = "\n".join(address_phone_fax).strip().replace("\xa0", " ")
+    def parse(self, response: Response) -> Iterable[Feature]:
+        item = Feature()
+        item["ref"] = response.url.split("-")[-1]
+        item["website"] = response.url
+        item["country"] = "US"
 
-            ref = column_address.xpath('*[@class="boldMaroonText"]/text()').get().strip()
+        street = response.xpath('//h1[@class="heading_1"]/text()').get()
+        item["addr_full"] = merge_address_lines(
+            [street, response.xpath('string(//h1[@class="heading_1"]/following-sibling::p)').get()]
+        )
+        item["branch"] = street.strip() if street else None
+        item["phone"] = response.xpath('//a[contains(@href, "tel:")]/@href').get("").replace("tel:", "")
+        item["email"] = response.xpath('//a[contains(@href, "mailto:")]/text()').get()
 
-            type_text = [s.strip() for s in row.xpath('*[@class="columnTypeOfStore"]//text()').extract()]
-            type_of_store = [s for s in type_text if s]
+        img_url = response.urljoin(
+            response.xpath('//div[contains(@class, "storeDetailsCard_image")]/@style')
+            .re_first(r"url\((.*?)\)")
+            .strip("'\"")
+        )
+        # Only save the image if it is an actual photo, not a placeholder
+        if "/placeholders/" not in img_url:
+            item["image"] = img_url
 
-            hours_txt = row.xpath('*[@class="columnHoursOfOprn"]/div/*/text()').extract()
-            opening_hours = [
-                f"{hours_txt[i]} {hours_txt[i + 1]}"
-                for i in range(0, len(hours_txt) // 2, 2)
-                if hours_txt[i + 1] != "Closed"
-            ]
-            oh = LinkedDataParser.parse_opening_hours({"openingHours": opening_hours}, "%I:%M %p")
+        oh = OpeningHours()
+        for element in response.xpath('//div[@class="storeHoursInformation"]//dl/div'):
+            day = element.xpath("./dt/text()").get()
+            hours_text = element.xpath("./dd/text()").get()
+            if not day or not hours_text or day.strip() == "Today":
+                continue
 
-            [lat, lon] = row.xpath("*/form/input").re('name=".*itude" value="(.*)"')
-            if float(lat) == 0 and float(lon) == 0:
-                lat, lon = None, None
+            oh.add_ranges_from_string(f"{day.strip()} {hours_text.strip()}")
 
-            properties = {
-                "lat": lat,
-                "lon": lon,
-                "addr_full": address,
-                "phone": phone,
-                "extras": {
-                    "fax": fax,
-                    "type_of_store": type_of_store,
-                },
-                "ref": ref,
-                "opening_hours": oh,
-            }
-            apply_category(Categories.SHOP_ALCOHOL, properties)
-            yield Feature(**properties)
+        item["opening_hours"] = oh
+        apply_category(Categories.SHOP_ALCOHOL, item)
+
+        yield item

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -37,18 +37,20 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
         )
 
         item = Feature()
-        item["ref"] = response.url.split("-")[-1]
+        item["ref"] = location["b2cStore_id"]
         item["lat"] = location["b2cStore_latitude"]
         item["lon"] = location["b2cStore_longitude"]
         item["website"] = response.url
         item["country"] = "US"
 
-        item["street_address"] = response.xpath('//h1[@class="heading_1"]/text()').get()
-        item["addr_full"] = merge_address_lines(
-            [item["street_address"], response.xpath('string(//h1[@class="heading_1"]/following-sibling::p)').get()]
+        item["street_address"] = merge_address_lines(
+            [location["b2cStore_address1"], location["b2cStore_address2"], location["b2cStore_address3"]]
         )
-        item["phone"] = response.xpath('//a[contains(@href, "tel:")]/@href').get("").replace("tel:", "")
-        item["email"] = response.xpath('//a[contains(@href, "mailto:")]/text()').get()
+        item["city"] = location["b2cStore_city"]
+        item["state"] = location["b2cStore_state"]
+        item["postcode"] = location["b2cStore_zip"]
+        item["phone"] = location["b2cStore_phoneNumber"]
+        item["email"] = location["b2cStore_contactEmail"]
 
         img_url = response.urljoin(location["primaryFullImageURL"])
         # Only save the image if it is an actual photo, not a placeholder

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -29,7 +29,6 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
         item["addr_full"] = merge_address_lines(
             [street, response.xpath('string(//h1[@class="heading_1"]/following-sibling::p)').get()]
         )
-        item["branch"] = street.strip() if street else None
         item["phone"] = response.xpath('//a[contains(@href, "tel:")]/@href').get("").replace("tel:", "")
         item["email"] = response.xpath('//a[contains(@href, "mailto:")]/text()').get()
 

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -25,9 +25,9 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
         item["website"] = response.url
         item["country"] = "US"
 
-        street = response.xpath('//h1[@class="heading_1"]/text()').get()
+        item["street_address"] = response.xpath('//h1[@class="heading_1"]/text()').get()
         item["addr_full"] = merge_address_lines(
-            [street, response.xpath('string(//h1[@class="heading_1"]/following-sibling::p)').get()]
+            [item["street_address"], response.xpath('string(//h1[@class="heading_1"]/following-sibling::p)').get()]
         )
         item["phone"] = response.xpath('//a[contains(@href, "tel:")]/@href').get("").replace("tel:", "")
         item["email"] = response.xpath('//a[contains(@href, "mailto:")]/text()').get()

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -1,4 +1,7 @@
+import json
+import re
 from typing import Iterable
+from urllib.parse import unquote
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
@@ -11,17 +14,31 @@ from locations.pipelines.address_clean_up import merge_address_lines
 
 class FineWineGoodSpiritsSpider(SitemapSpider):
     name = "fine_wine_good_spirits"
-    item_attributes = {
-        "name": "Fine Wine & Good Spirits",
-        "brand": "Fine Wine & Good Spirits",
-        "brand_wikidata": "Q64514776",
-    }
+    item_attributes = {"brand": "Fine Wine & Good Spirits", "brand_wikidata": "Q64514776"}
     sitemap_urls = ["https://www.finewineandgoodspirits.com/productSitemap.xml"]
     sitemap_rules = [(r"/product/store-\d+", "parse")]
 
     def parse(self, response: Response) -> Iterable[Feature]:
+        location = next(
+            iter(
+                DictParser.get_nested_key(
+                    json.loads(
+                        unquote(
+                            re.match(
+                                r"window\.state = JSON\.parse\(decodeURI\(\"(.+?)\"\)\)",
+                                response.xpath('//script[contains(text(), "window.state = ")]/text()').get(),
+                            ).group(1)
+                        )
+                    ),
+                    "products",
+                ).values()
+            )
+        )
+
         item = Feature()
         item["ref"] = response.url.split("-")[-1]
+        item["lat"] = location["b2cStore_latitude"]
+        item["lon"] = location["b2cStore_longitude"]
         item["website"] = response.url
         item["country"] = "US"
 

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -8,7 +8,7 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, DAYS_FULL
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 

--- a/locations/spiders/fine_wine_good_spirits.py
+++ b/locations/spiders/fine_wine_good_spirits.py
@@ -49,13 +49,9 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
         item["phone"] = response.xpath('//a[contains(@href, "tel:")]/@href').get("").replace("tel:", "")
         item["email"] = response.xpath('//a[contains(@href, "mailto:")]/text()').get()
 
-        img_url = response.urljoin(
-            response.xpath('//div[contains(@class, "storeDetailsCard_image")]/@style')
-            .re_first(r"url\((.*?)\)")
-            .strip("'\"")
-        )
+        img_url = response.urljoin(location["primaryFullImageURL"])
         # Only save the image if it is an actual photo, not a placeholder
-        if "/placeholders/" not in img_url:
+        if "img/no-image" not in img_url:
             item["image"] = img_url
 
         oh = OpeningHours()

--- a/locations/spiders/fine_wine_good_spirits_us.py
+++ b/locations/spiders/fine_wine_good_spirits_us.py
@@ -13,8 +13,8 @@ from locations.items import Feature
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class FineWineGoodSpiritsSpider(SitemapSpider):
-    name = "fine_wine_good_spirits"
+class FineWineGoodSpiritsUSSpider(SitemapSpider):
+    name = "fine_wine_good_spirits_us"
     item_attributes = {"brand": "Fine Wine & Good Spirits", "brand_wikidata": "Q64514776"}
     sitemap_urls = ["https://www.finewineandgoodspirits.com/productSitemap.xml"]
     sitemap_rules = [(r"/product/store-\d+", "parse")]
@@ -41,7 +41,6 @@ class FineWineGoodSpiritsSpider(SitemapSpider):
         item["lat"] = location["b2cStore_latitude"]
         item["lon"] = location["b2cStore_longitude"]
         item["website"] = response.url
-        item["country"] = "US"
 
         item["street_address"] = merge_address_lines(
             [location["b2cStore_address1"], location["b2cStore_address2"], location["b2cStore_address3"]]


### PR DESCRIPTION
Opted for the sitemap approach because the new store API is gated by strict Akamai bot protection.
```
{'atp/brand/Fine Wine & Good Spirits': 565,
 'atp/brand_wikidata/Q64514776': 565,
 'atp/category/shop/alcohol': 565,
 'atp/country/US': 565,
 'atp/field/city/missing': 565,
 'atp/field/geometry/missing': 565,
 'atp/field/housenumber/missing': 565,
 'atp/field/operator/missing': 565,
 'atp/field/operator_wikidata/missing': 565,
 'atp/field/postcode/missing': 565,
 'atp/field/state/missing': 565,
 'atp/field/street/missing': 565,
 'atp/field/street_address/missing': 565,
 'atp/field/twitter/missing': 565,
 'atp/field/unit/missing': 565,
 'atp/item_scraped_host_count/www.finewineandgoodspirits.com': 565,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 565,
 'downloader/request_bytes': 1052831,
 'downloader/request_count': 567,
 'downloader/request_method_count/GET': 567,
 'downloader/response_bytes': 42563063,
 'downloader/response_count': 567,
 'downloader/response_status_count/200': 567,
 'elapsed_time_seconds': 694.9380000000001,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 11, 19, 18, 1, 444144, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 272623272,
 'httpcompression/response_count': 567,
 'item_scraped_count': 565,
 'items_per_minute': 48.847262247838614,
 'log_count/DEBUG': 1132,
 'log_count/INFO': 15,
 'request_depth_max': 1,
 'response_received_count': 567,
 'responses_per_minute': 49.02017291066282,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 566,
 'scheduler/dequeued/memory': 566,
 'scheduler/enqueued': 566,
 'scheduler/enqueued/memory': 566,
 'start_time': datetime.datetime(2026, 6, 11, 19, 6, 26, 496606, tzinfo=datetime.timezone.utc)}
```