### PR TITLE
[Effia] Add spider

### DIFF
--- a/locations/spiders/effia.py
+++ b/locations/spiders/effia.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any
 
 from scrapy.http import Response

--- a/locations/spiders/effia.py
+++ b/locations/spiders/effia.py
@@ -1,0 +1,42 @@
+import re
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class EffiaSpider(SitemapSpider):
+    name = "effia"
+    item_attributes = {"brand": "EFFIA", "brand_wikidata": "Q3045894"}
+    sitemap_urls = ["https://www.effia.com/sitemap.xml"]
+    sitemap_rules = [(r"/parking/parking-", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        car_park = response.css("div.car-park")
+        if not car_park:
+            return
+
+        item = Feature()
+        item["ref"] = car_park.attrib.get("data-poche-id") or car_park.attrib.get("data-product-id")
+        item["branch"] = re.sub(r"\s*[-–]\s*EFFIA\s*$", "", car_park.attrib.get("data-title", "")).strip()
+        item["lat"] = car_park.attrib.get("data-lat")
+        item["lon"] = car_park.attrib.get("data-lon")
+        item["website"] = response.url.split("?")[0]
+
+        if raw_address := car_park.attrib.get("data-address", ""):
+            parts = [p.strip() for p in raw_address.split(",")]
+            if len(parts) >= 3:
+                item["city"] = parts[-1].title()
+                item["postcode"] = parts[-2]
+                item["street_address"] = ", ".join(parts[:-2])
+
+            # To prevent border-snapping anomaly for Hendaye
+            if "Hendaye" in item.get("city", ""):
+                item["country"] = "FR"
+
+        apply_category(Categories.PARKING, item)
+
+        yield item

--- a/locations/spiders/effia.py
+++ b/locations/spiders/effia.py
@@ -7,10 +7,11 @@ from scrapy.spiders import SitemapSpider
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 
+EFFIA = {"brand": "Effia", "brand_wikidata": "Q3045894"}
+
 
 class EffiaSpider(SitemapSpider):
     name = "effia"
-    item_attributes = {"brand": "Effia", "brand_wikidata": "Q3045894"}
     sitemap_urls = ["https://www.effia.com/sitemap.xml"]
     sitemap_rules = [(r"/parking/parking-", "parse")]
 
@@ -21,10 +22,15 @@ class EffiaSpider(SitemapSpider):
 
         item = Feature()
         item["ref"] = car_park.attrib.get("data-poche-id") or car_park.attrib.get("data-product-id")
-        item["branch"] = re.sub(r"\s*[-–]\s*EFFIA\s*$", "", car_park.attrib.get("data-title", "")).strip()
+        item["name"] = car_park.attrib["data-title"].strip()
         item["lat"] = car_park.attrib.get("data-lat")
         item["lon"] = car_park.attrib.get("data-lon")
         item["website"] = response.url.split("?")[0]
+
+        if item["name"].endswith("EFFIA"):
+            item["name"] = item["name"].removesuffix(" EFFIA").strip(" -–")
+            item.update(EFFIA)
+        # else  NAOLIB + ALFAPARK
 
         if raw_address := car_park.attrib.get("data-address", ""):
             parts = [p.strip() for p in raw_address.split(",")]

--- a/locations/spiders/effia.py
+++ b/locations/spiders/effia.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 
 class EffiaSpider(SitemapSpider):
     name = "effia"
-    item_attributes = {"brand": "EFFIA", "brand_wikidata": "Q3045894"}
+    item_attributes = {"brand": "Effia", "brand_wikidata": "Q3045894"}
     sitemap_urls = ["https://www.effia.com/sitemap.xml"]
     sitemap_rules = [(r"/parking/parking-", "parse")]
 


### PR DESCRIPTION
```
{'atp/brand/Effia': 501,
 'atp/brand_wikidata/Q3045894': 501,
 'atp/category/amenity/parking': 501,
 'atp/clean_strings/street_address': 395,
 'atp/country/BE': 1,
 'atp/country/FR': 500,
 'atp/field/country/from_reverse_geocoding': 500,
 'atp/field/email/missing': 501,
 'atp/field/housenumber/missing': 501,
 'atp/field/name/missing': 501,
 'atp/field/opening_hours/missing': 501,
 'atp/field/operator/missing': 501,
 'atp/field/operator_wikidata/missing': 501,
 'atp/field/phone/missing': 501,
 'atp/field/state/missing': 1,
 'atp/field/street/missing': 501,
 'atp/field/twitter/missing': 501,
 'atp/field/unit/missing': 501,
 'atp/item_scraped_host_count/www.effia.com': 501,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 501,
 'downloader/request_bytes': 338389,
 'downloader/request_count': 503,
 'downloader/request_method_count/GET': 503,
 'downloader/response_bytes': 9402695,
 'downloader/response_count': 503,
 'downloader/response_status_count/200': 503,
 'elapsed_time_seconds': 617.3899999999994,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 12, 10, 13, 39, 250494, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 41006988,
 'httpcompression/response_count': 503,
 'item_scraped_count': 501,
 'items_per_minute': 48.719611021069696,
 'log_count/DEBUG': 1004,
 'log_count/INFO': 13,
 'request_depth_max': 1,
 'response_received_count': 503,
 'responses_per_minute': 48.91410048622366,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 502,
 'scheduler/dequeued/memory': 502,
 'scheduler/enqueued': 502,
 'scheduler/enqueued/memory': 502,
 'start_time': datetime.datetime(2026, 6, 12, 10, 3, 21, 853649, tzinfo=datetime.timezone.utc)}
```