### PR TITLE
[Yespark] Add spider (7548 locations)

### DIFF
--- a/locations/spiders/yespark.py
+++ b/locations/spiders/yespark.py
@@ -11,7 +11,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class YesparkSpider(SitemapSpider, StructuredDataSpider):
     name = "yespark"
-    item_attributes = {"brand": "Yespark", "brand_wikidata": "Q109046724"}
+    item_attributes = {"operator": "Yespark", "operator_wikidata": "Q109046724"}
     sitemap_urls = [
         "https://www.yespark.fr/sitemap/parkings.xml",
     ]

--- a/locations/spiders/yespark.py
+++ b/locations/spiders/yespark.py
@@ -1,0 +1,33 @@
+from typing import Iterable
+
+from scrapy import Selector
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class YesparkSpider(SitemapSpider, StructuredDataSpider):
+    name = "yespark"
+    item_attributes = {"brand": "Yespark", "brand_wikidata": "Q109046724"}
+    sitemap_urls = [
+        "https://www.yespark.fr/sitemap/parkings.xml",
+    ]
+    sitemap_rules = [(r"/parkings/(\d+)-[-\w]+/?$", "parse_sd")]  # capture parking_id as reference
+    wanted_types = ["ParkingFacility"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.PARKING, item)
+        apply_yes_no("fee", item, ld_data.get("isAccessibleForFree") is False, apply_positive_only=True)
+        yield item
+
+    def extract_amenity_features(self, item: Feature | dict, selector: Selector, ld_item: dict) -> None:
+        for service in ld_item.get("amenityFeature", []):
+            if service["name"].lower() == "underground parking" and service["value"] is True:
+                item["extras"]["parking"] = "underground"
+            elif service["name"].lower() == "cctv surveillance":
+                apply_yes_no("surveillance", item, service["value"])
+            elif service["name"].lower() == "electric vehicle charging":
+                apply_yes_no(Fuel.ELECTRIC, item, service["value"])


### PR DESCRIPTION
```python
{'atp/category/amenity/parking': 7548,
 'atp/cdn/cloudflare/response_count': 7560,
 'atp/cdn/cloudflare/response_status_count/200': 7549,
 'atp/cdn/cloudflare/response_status_count/410': 11,
 'atp/country/FR': 7512,
 'atp/country/IT': 36,
 'atp/field/branch/missing': 7548,
 'atp/field/brand/missing': 7548,
 'atp/field/brand_wikidata/missing': 7548,
 'atp/field/email/missing': 7548,
 'atp/field/housenumber/missing': 7548,
 'atp/field/image/dropped': 1,
 'atp/field/phone/missing': 7548,
 'atp/field/state/missing': 7548,
 'atp/field/street/missing': 7548,
 'atp/field/twitter/missing': 7548,
 'atp/field/unit/missing': 7548,
 'atp/item_scraped_host_count/www.yespark.fr': 7548,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 7548,
 'atp/operator/Yespark': 7548,
 'atp/operator_wikidata/Q109046724': 7548,
 'downloader/request_bytes': 7529492,
 'downloader/request_count': 7563,
 'downloader/request_method_count/GET': 7563,
 'downloader/response_bytes': 437956121,
 'downloader/response_count': 7563,
 'downloader/response_status_count/200': 7550,
 'downloader/response_status_count/301': 1,
 'downloader/response_status_count/403': 1,
 'downloader/response_status_count/410': 11,
 'elapsed_time_seconds': 207.96900000001187,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 12, 14, 5, 4, 327602, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 1,
 'httpcache/hit': 7562,
 'httpcache/miss': 1,
 'httpcache/uncacheable': 1,
 'httpcompression/response_bytes': 1986921872,
 'httpcompression/response_count': 7549,
 'httperror/response_ignored_count': 11,
 'httperror/response_ignored_status_count/410': 11,
 'item_scraped_count': 7548,
 'items_per_minute': 2187.8260869565215,
 'log_count/DEBUG': 15112,
 'log_count/INFO': 17,
 'request_depth_max': 1,
 'response_received_count': 7562,
 'responses_per_minute': 2191.8840579710145,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 7561,
 'scheduler/dequeued/memory': 7561,
 'scheduler/enqueued': 7561,
 'scheduler/enqueued/memory': 7561,
 'start_time': datetime.datetime(2026, 6, 12, 14, 1, 36, 354327, tzinfo=datetime.timezone.utc)}
```