### PR TITLE
[CKB ME] Add spider

### DIFF
--- a/locations/spiders/ckb_me.py
+++ b/locations/spiders/ckb_me.py
@@ -1,0 +1,69 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import FormRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+
+GMARKER_RE = re.compile(
+    r"gmarkers\[\d+\]\s*=\s*new\s+Array\(\s*"
+    r"'([^']+)'\s*,\s*"  # lat
+    r"'\s*([^']+?)\s*'\s*,\s*"  # lng (strip whitespace inside quotes)
+    r"'([PZN])'\s*,\s*"  # type
+    r"'(\d+)'"  # id
+)
+
+
+class CkbMESpider(Spider):
+    name = "ckb_me"
+    item_attributes = {"brand": "Crnogorska Komercijalna Banka", "brand_wikidata": "Q869855"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield FormRequest(
+            url="https://www.ckb.me/site/locations/map.aspx",
+            formdata={},
+            headers={"Origin": "https://www.ckb.me", "Referer": "https://www.ckb.me/site/locations/map.aspx"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for lat, lng, marker_type, marker_id in GMARKER_RE.findall(response.text):
+            yield FormRequest(
+                url="https://www.ckb.me/site/locations/get_details.aspx",
+                formdata={"id": marker_id},
+                cb_kwargs={"lat": lat, "lng": lng, "marker_type": marker_type, "marker_id": marker_id},
+                callback=self.parse_detail,
+            )
+
+    def parse_detail(
+        self, response: Response, lat: str, lng: str, marker_type: str, marker_id: str, **kwargs: Any
+    ) -> Any:
+        # Source is HTML, no DictParser
+        item = Feature()
+        item["ref"] = marker_id
+        item["lat"] = lat
+        item["lon"] = lng
+
+        name = response.xpath('normalize-space(//*[contains(@class, "location-name")])').get()
+        if " - " in name:
+            item["city"], item["street_address"] = name.split(" - ", 1)
+        item["branch"] = name
+
+        phones = [p.strip() for p in response.xpath('//*[contains(@class, "location-phone")]/text()').getall()]
+        phones = [p for p in phones if p]
+        if phones:
+            item["phone"] = phones[-1]
+
+        if marker_type == "P":
+            apply_category(Categories.ATM, item)
+        elif marker_type == "Z":
+            apply_category(Categories.BANK, item)
+            apply_yes_no(Extras.ATM, item, True)
+        elif marker_type == "N":
+            apply_category(Categories.BANK, item)
+        else:
+            self.logger.error("Unexpected CKB marker type: %s", marker_type)
+            return
+
+        yield item

--- a/locations/spiders/ckb_me.py
+++ b/locations/spiders/ckb_me.py
@@ -39,7 +39,6 @@ class CkbMESpider(Spider):
     def parse_detail(
         self, response: Response, lat: str, lng: str, marker_type: str, marker_id: str, **kwargs: Any
     ) -> Any:
-        # Source is HTML, no DictParser
         item = Feature()
         item["ref"] = marker_id
         item["lat"] = lat
@@ -48,7 +47,6 @@ class CkbMESpider(Spider):
         name = response.xpath('normalize-space(//*[contains(@class, "location-name")])').get()
         if " - " in name:
             item["city"], item["street_address"] = name.split(" - ", 1)
-        item["branch"] = name
 
         phones = [p.strip() for p in response.xpath('//*[contains(@class, "location-phone")]/text()').getall()]
         phones = [p for p in phones if p]


### PR DESCRIPTION
2-step ASP.NET scrape:

1. `POST /site/locations/map.aspx` → parses inline `gmarkers[N] = new Array('lat','lng','TYPE','id','icon');` JS array (112 markers).
2. `POST /site/locations/get_details.aspx` per marker ID → parses HTML fragment for branch name, address (split from `<city> - <street>` format), and optional phone.

**Type → category mapping**:

- `P` (`pin_atm.png`) → `Categories.ATM` (86 items)
- `Z` (`pin_bank_atm.png`) → `Categories.BANK` + `apply_yes_no(Extras.ATM, item, True)` (24 items)
- `N` (`pin_bank.png`) → `Categories.BANK` (1 item)

**Notes**

- 111/112 items: 1 marker ID returned 404 on `get_details.aspx`; Scrapy's httperror middleware drops it.
- 2 ATMs returned empty `location-name`; their `branch` is empty but coordinates are valid.

**Stats**:

```json
{
 "atp/brand/Crnogorska Komercijalna Banka": 111,
 "atp/brand_wikidata/Q869855": 111,
 "atp/category/amenity/atm": 86,
 "atp/category/amenity/bank": 25,
 "atp/country/ME": 111,
 "atp/field/branch/missing": 2,
 "atp/field/city/missing": 2,
 "atp/field/country/from_spider_name": 111,
 "atp/field/email/missing": 111,
 "atp/field/housenumber/missing": 111,
 "atp/field/name/missing": 86,
 "atp/field/opening_hours/missing": 111,
 "atp/field/operator/missing": 25,
 "atp/field/operator_wikidata/missing": 25,
 "atp/field/phone/missing": 86,
 "atp/field/postcode/missing": 111,
 "atp/field/state/missing": 111,
 "atp/field/street/missing": 111,
 "atp/field/street_address/missing": 2,
 "atp/field/twitter/missing": 111,
 "atp/field/unit/missing": 111,
 "atp/item_scraped_host_count/www.ckb.me": 111,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 111,
 "atp/operator/Crnogorska Komercijalna Banka": 86,
 "atp/operator_wikidata/Q869855": 86,
 "downloader/request_bytes": 130602,
 "downloader/request_count": 114,
 "downloader/request_method_count/GET": 2,
 "downloader/request_method_count/POST": 112,
 "downloader/response_bytes": 151645,
 "downloader/response_count": 114,
 "downloader/response_status_count/200": 113,
 "downloader/response_status_count/404": 1,
 "elapsed_time_seconds": 137.86000000000058,
 "finish_reason": "finished",
 "finish_time": "2026-06-12T13:47:14.481660+00:00",
 "httperror/response_ignored_count": 1,
 "httperror/response_ignored_status_count/404": 1,
 "item_scraped_count": 111,
 "items_per_minute": 48.61313868613139,
 "request_depth_max": 1,
 "response_received_count": 114,
 "responses_per_minute": 49.92700729927007,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 113,
 "scheduler/dequeued/memory": 113,
 "scheduler/enqueued": 113,
 "scheduler/enqueued/memory": 113,
 "start_time": "2026-06-12T13:44:56.622279+00:00"
}
```

**Sample POIs**:

ATM (`P`):
```json
{
  "ref": "81",
  "amenity": "atm",
  "branch": "Žabljak - Vuka Karadžića bb",
  "addr:city": "Žabljak",
  "addr:street_address": "Vuka Karadžića bb",
  "brand": "Crnogorska Komercijalna Banka",
  "brand:wikidata": "Q869855",
  "operator": "Crnogorska Komercijalna Banka",
  "operator:wikidata": "Q869855"
}
```

Bank+ATM (`Z`):
```json
{
  "ref": "84",
  "amenity": "bank",
  "extras": {"atm": "yes"},
  "branch": "Ulcinj - ...",
  "name": "Crnogorska Komercijalna Banka",
  "brand": "Crnogorska Komercijalna Banka",
  "brand:wikidata": "Q869855"
}
```

Bank-only (`N`):
```json
{
  "ref": "139",
  "amenity": "bank",
  "branch": "Podgorica - Big Fashion, Cetinjski put bb",
  "addr:city": "Podgorica",
  "addr:street_address": "Big Fashion, Cetinjski put bb",
  "name": "Crnogorska Komercijalna Banka",
  "brand": "Crnogorska Komercijalna Banka",
  "brand:wikidata": "Q869855"
}
```

**Wikidata**:

```
$ uv run scrapy nsi --code Q869855
"Crnogorska komercijalna banka", "Q869855"
  -> Montenegrin subsidiary of OTP Bank
  -> {amenity:atm,  brand:Crnogorska Komercijalna Banka, ...}    [me]
  -> {amenity:bank, brand:Crnogorska Komercijalna Banka, ...}    [me]
```