### PR TITLE
[NLB SI] Add spider

### DIFF
--- a/locations/spiders/nlb_si.py
+++ b/locations/spiders/nlb_si.py
@@ -1,0 +1,45 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class NlbSISpider(Spider):
+    name = "nlb_si"
+    item_attributes = {"brand": "NLB", "brand_wikidata": "Q1481509"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for kind in ("atm", "branch"):
+            yield Request(
+                url=f"https://www.nlb.si/content/nlbbanks/nlbsi/sl/osebno/poslovalnice-in-bankomati/jcr:content/root/container/container/branchsearch.facilities.json?kind={kind}"
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json():
+            item = DictParser.parse(poi)
+
+            # DictParser does not flatten nested address objects, so override
+            # the geo/address fields from the nested "location" dict manually.
+            loc = poi.get("location") or {}
+            item["lat"] = loc.get("latitude")
+            item["lon"] = loc.get("longitude")
+            item["street_address"] = loc.get("street")
+            item["city"] = loc.get("city")
+
+            if facility_url := poi.get("facilityPageUrl"):
+                item["website"] = f"https://www.nlb.si{facility_url}"
+
+            kind = poi.get("kind")
+            if kind == "atm":
+                apply_category(Categories.ATM, item)
+            elif kind == "branch":
+                item["branch"] = (item.pop("name", "") or "").removeprefix("Poslovalnica ").strip() or None
+                apply_category(Categories.BANK, item)
+            else:
+                self.logger.error("Unexpected NLB kind: %s", kind)
+                continue
+
+            yield item

--- a/locations/spiders/nlb_si.py
+++ b/locations/spiders/nlb_si.py
@@ -5,6 +5,7 @@ from scrapy.http import Request, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_SI, OpeningHours
 
 
 class NlbSISpider(Spider):
@@ -31,6 +32,20 @@ class NlbSISpider(Spider):
 
             if facility_url := poi.get("facilityPageUrl"):
                 item["website"] = f"https://www.nlb.si{facility_url}"
+
+            oh = OpeningHours()
+            for avail in poi.get("availabilities") or []:
+                day = DAYS_SI.get(avail["dayOfWeek"])
+                if not day:
+                    continue
+                for r in avail.get("range") or []:
+                    if r.get("closed") or r.get("from") is None:
+                        continue
+                    # Times are formatted as "8.00" / "24.00" — normalise to "HH:MM"
+                    open_time = r["from"].replace(".", ":").zfill(5)
+                    close_time = r["to"].replace(".", ":").zfill(5)
+                    oh.add_range(day, open_time, close_time)
+            item["opening_hours"] = oh.as_opening_hours()
 
             kind = poi.get("kind")
             if kind == "atm":


### PR DESCRIPTION
Two GET requests to NLB's AEM facility-search endpoint, one per `kind`:

- `?kind=atm` → 525 ATMs (~2 MB JSON)
- `?kind=branch` → 77 branches (~410 KB JSON)

Both return a top-level JSON array; no pagination, auth, or rate limiting. `DictParser.parse(poi)` handles `id` → `ref`, `phoneNumber` → `phone`, `email`, and `name`. The nested `location` dict is manually flattened (lat/lng/street/city). `website` is built from `facilityPageUrl`.

**Type mapping**

- `kind == "atm"` → `Categories.ATM`. DictParser-set `name` is preserved (venue labels like `OMV`, `Spar`, `Pasaža`...) — playbook *"if DictParser sets name from API data, leave it as-is"*.
- `kind == "branch"` → `Categories.BANK`, name popped to `branch` with `"Poslovalnica "` (Slovenian for "branch") prefix stripped.

NSI splits bank+atm via the two `Q1481509` registry entries.

**Notes**

- Opening hours (`availabilities` field) are present in the API but not parsed.
- NLB Group operates in BA and XK as well per NSI `locationSet`, but those subsidiaries use different domains (`nlbbanka.ba`, `nlbbanka.com`) — separate spiders for follow-up.

**Stats**

```json
{
 "atp/brand/NLB": 602,
 "atp/brand_wikidata/Q1481509": 602,
 "atp/category/amenity/atm": 525,
 "atp/category/amenity/bank": 77,
 "atp/country/SI": 602,
 "atp/field/branch/missing": 525,
 "atp/field/city/missing": 2,
 "atp/field/country/from_spider_name": 602,
 "atp/field/email/missing": 532,
 "atp/field/housenumber/missing": 602,
 "atp/field/opening_hours/missing": 602,
 "atp/field/operator/missing": 77,
 "atp/field/operator_wikidata/missing": 77,
 "atp/field/phone/missing": 530,
 "atp/field/postcode/missing": 602,
 "atp/field/state/missing": 602,
 "atp/field/street/missing": 602,
 "atp/field/twitter/missing": 602,
 "atp/field/unit/missing": 602,
 "atp/item_scraped_host_count/www.nlb.si": 602,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 602,
 "atp/operator/NLB": 525,
 "atp/operator_wikidata/Q1481509": 525,
 "downloader/request_bytes": 1233,
 "downloader/request_count": 3,
 "downloader/request_method_count/GET": 3,
 "downloader/response_bytes": 73775,
 "downloader/response_count": 3,
 "downloader/response_status_count/200": 3,
 "elapsed_time_seconds": 6.311999999990803,
 "finish_reason": "finished",
 "finish_time": "2026-06-12T14:17:08.547264+00:00",
 "httpcompression/response_bytes": 2498788,
 "httpcompression/response_count": 2,
 "item_scraped_count": 602,
 "items_per_minute": 6020.0,
 "response_received_count": 3,
 "responses_per_minute": 30.0,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2026-06-12T14:17:02.233670+00:00"
}
```

**Sample POIs**

ATM at a venue (Ljubljana city centre):
```json
{
  "ref": "10000075",
  "amenity": "atm",
  "name": "Pasaža, službeni vhod NLB",
  "addr:street_address": "Trg republike 2",
  "addr:city": "Ljubljana",
  "brand": "NLB",
  "brand:wikidata": "Q1481509",
  "operator": "NLB",
  "operator:wikidata": "Q1481509",
  "website": "https://www.nlb.si/poslovalnice-in-bankomati/poslovalnica/pasaza,-sluzbeni-vhod-nlb"
}
```

Branch (Ljubljana, prefix-stripped):
```json
{
  "ref": "10000001",
  "amenity": "bank",
  "name": "NLB",                              // added by NSI registry, not by spider
  "branch": "Mestna hranilnica ljubljanska",
  "addr:street_address": "Čopova ulica 3",
  "addr:city": "Ljubljana",
  "phone": "01 477 2000",
  "email": "info@nlb.si",
  "brand": "NLB",
  "brand:wikidata": "Q1481509"
}
```

ATM with empty city (small town):
```json
{
  "ref": "10000241",
  "amenity": "atm",
  "name": "Ig",
  "addr:street_address": "Banija 4",
  "brand": "NLB",
  "brand:wikidata": "Q1481509"
}
```

**Wikidata verification**

```
$ uv run scrapy nsi --code Q1481509
"NLB Group", "Q1481509"
  -> Slovenian banking and financial services company
  -> {amenity:atm,  brand:NLB, ...}    (nlb-cf7091)    [ba, si, xk]
  -> {amenity:bank, brand:NLB, ...}    (nlb-155ab9)    [ba, si, xk]
```