### PR TITLE
[The Big Biscuit US] Fix spider — rewrite to scrape HTML instead of removed JS variable

### DIFF
--- a/locations/spiders/the_big_biscuit_us.py
+++ b/locations/spiders/the_big_biscuit_us.py
@@ -1,31 +1,67 @@
-from chompjs import parse_js_object
+import re
+
+from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
-from locations.json_blob_spider import JSONBlobSpider
+from locations.items import Feature
 
 
-class TheBigBiscuitUSSpider(JSONBlobSpider):
+class TheBigBiscuitUSSpider(Spider):
     name = "the_big_biscuit_us"
     item_attributes = {"brand": "The Big Biscuit", "brand_wikidata": "Q124125449"}
-    allowed_domains = ["www.bigbiscuit.com"]
     start_urls = ["https://bigbiscuit.com/locations/"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def extract_json(self, response):
-        js_blob = response.xpath('//script[contains(text(), "var mapLocations = ")]/text()').get()
-        js_blob = "[" + js_blob.split("var mapLocations = [", 1)[1].split("}];", 1)[0] + "}]"
-        return parse_js_object(js_blob)
+    def parse(self, response: Response, **kwargs):
+        for block in response.css("div.col.w-full.mb-8.lg\\:w-1\\/3"):
+            texts = [t.strip() for t in block.css("p, h4").xpath("normalize-space()").getall() if t.strip()]
+            if not texts or "coming soon" in " ".join(texts).lower():
+                continue
 
-    def post_process_item(self, item, response, location):
-        if "COMING SOON" in location["name"].upper():
-            return
-        item["ref"] = location["permalink"]
-        # Opening hours are the same for all stores per FAQ at:
-        # https://bigbiscuit.com/contact-the-big-biscuit/
-        item["opening_hours"] = OpeningHours()
-        item["opening_hours"].add_days_range(DAYS, "06:30", "14:30")
+            item = Feature()
 
-        apply_category(Categories.RESTAURANT, item)
-        item["extras"]["cuisine"] = "american"
+            # Branch name is in an h4
+            item["branch"] = block.css("h4").xpath("normalize-space()").get("").strip().title()
 
-        yield item
+            # Phone from tel: link
+            if phone := block.css("a[href^='tel:']::attr(href)").get():
+                item["phone"] = phone.replace("tel:", "")
+
+            # Website from detail link if present
+            if detail := block.css("a[href*='bigbiscuit.com']::attr(href)").get():
+                item["website"] = detail
+
+            # Coords from Google Maps link
+            if maps_url := block.css("a[href*='google.com/maps']::attr(href)").get():
+                if m := re.search(r"/@(-?\d+\.\d+),(-?\d+\.\d+)", maps_url):
+                    item["lat"], item["lon"] = m.group(1), m.group(2)
+
+            # Address: first non-empty <p> that's not a phone/link
+            addr_lines = []
+            for p in block.css("p"):
+                text = p.xpath("normalize-space()").get("").strip()
+                if text and not p.css("a") and text not in (item.get("branch", ""),):
+                    addr_lines.append(text)
+            if addr_lines:
+                # First line is street, second is city/state
+                item["street_address"] = addr_lines[0] if len(addr_lines) > 0 else None
+                if len(addr_lines) > 1:
+                    city_state = addr_lines[1].split(",")
+                    item["city"] = city_state[0].strip()
+                    if len(city_state) > 1:
+                        item["state"] = city_state[1].strip()
+                item["country"] = "US"
+
+            item["ref"] = item.get("website") or item["branch"]
+
+            # Opening hours are the same for all stores per FAQ
+            oh = OpeningHours()
+            oh.add_days_range(DAYS, "06:30", "14:30")
+            item["opening_hours"] = oh
+
+            apply_category(Categories.RESTAURANT, item)
+            item["extras"]["cuisine"] = "american"
+
+            yield item


### PR DESCRIPTION
The `mapLocations` JS variable previously used to extract location data has been removed from the page. However, the site is still live at https://bigbiscuit.com/locations/ and all location data is available as server-rendered HTML.

The new spider scrapes the HTML directly:
- Branch name from `<h4>` elements
- Street address and city/state from `<p>` elements
- Phone from `tel:` links
- Coordinates from Google Maps direction links (/@lat,lon pattern)
- Opening hours are unchanged (06:30–14:30 daily, per the brand FAQ)
- Filters out "coming soon" entries

31 locations found, 29 with coordinates (2 missing coords in Google Maps links in source).

Closes #16668

(feedback by Claude 🤖)