### PR TITLE
[Extended Stay America] Fix addr:street -> addr:street_address

### DIFF
--- a/locations/spiders/extended_stay_america.py
+++ b/locations/spiders/extended_stay_america.py
@@ -27,4 +27,8 @@ class ExtendedStayAmericaSpider(Spider):
             item["branch"] = item.pop("name")
             item["ref"] = location["siteId"]
             item["website"] = response.urljoin(location["urlMap"])
+            # DictParser maps "street" -> addr:street (street name only), but the source
+            # field contains the full address line including house number, so use street_address.
+            if street := item.pop("street", None):
+                item["street_address"] = street
             yield item


### PR DESCRIPTION
Follow-up to #16663. The source `street` field contains the full address line including house number (e.g. `217 West Osborn Road`), but DictParser maps `street` to `addr:street` which in OSM is the street name only (without house number). Moving it to `street_address` so it maps correctly to `addr:street_address`.

(feedback by Claude 🤖)