### PR TITLE
[Walmart US] Add requires_proxy to fix collapsed output

### DIFF
--- a/locations/spiders/walmart_us.py
+++ b/locations/spiders/walmart_us.py
@@ -16,6 +16,7 @@ class WalmartUSSpider(SitemapSpider):
     allowed_domains = ["www.walmart.com"]
     sitemap_urls = ["https://www.walmart.com/sitemap_store_main.xml"]
     sitemap_rules = [(r"/store/\d+-", "parse")]
+    requires_proxy = True
     custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,


### PR DESCRIPTION
Spider output dropped from ~4,600 stores to just 4 (issue #16706). Root cause: Walmart store pages now return 21 bytes (empty bot-block response) without a proxy, even with a browser UA.

The sitemap is healthy — sitemap_store_main_supercenter.xml.gz alone has 3,577 store URLs. Adding `requires_proxy = True` so page fetches go through Zyte should restore full coverage.

Fixes #16706

(feedback by Claude 🤖)