### PR TITLE
Add requires_proxy to fix bot-blocked spiders: adairs, blaze_pizza, carters_us

### DIFF
--- a/locations/spiders/adairs.py
+++ b/locations/spiders/adairs.py
@@ -11,24 +11,19 @@ from locations.hours import DAYS_FULL, OpeningHours
 class AdairsSpider(Spider):
     name = "adairs"
     item_attributes = {"brand": "Adairs", "brand_wikidata": "Q109626904"}
-    allowed_domains = ["www.adairs.com.au", "www.adairs.co.nz"]
+    allowed_domains = ["www.adairs.com.au"]
     start_urls = [
         "https://www.adairs.com.au/api/store/search-store",
-        "https://www.adairs.co.nz/api/store/search-store",
     ]
+    requires_proxy = "AU"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        data = {
-            "pageId": 665,
-            "pageNumber": 1,
-            "pageSize": 1000,
-        }
-        for url in self.start_urls:
-            if "adairs.com.au" in url:
-                data["marketId"] = "AUS"
-            elif "adairs.co.nz" in url:
-                data["marketId"] = "NEZ"
-            yield JsonRequest(url=url, method="POST", data=data, callback=self.parse)
+        yield JsonRequest(
+            url=self.start_urls[0],
+            method="POST",
+            data={"pageId": 665, "pageNumber": 1, "pageSize": 1000, "marketId": "AUS"},
+            callback=self.parse,
+        )
 
     def parse(self, response):
         if not response.json()["success"]:

--- a/locations/spiders/blaze_pizza.py
+++ b/locations/spiders/blaze_pizza.py
@@ -6,5 +6,6 @@ from locations.structured_data_spider import StructuredDataSpider
 class BlazePizzaSpider(SitemapSpider, StructuredDataSpider):
     name = "blaze_pizza"
     item_attributes = {"brand": "Blaze Pizza", "brand_wikidata": "Q23016666"}
+    requires_proxy = True
     sitemap_urls = ["https://locations.blazepizza.com/sitemap.xml"]
     sitemap_rules = [(r"https://locations.blazepizza.com/[^/]+/[^/]+/[a-zA-z0-9-]+", "parse_sd")]

--- a/locations/spiders/carters_us.py
+++ b/locations/spiders/carters_us.py
@@ -12,6 +12,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class CartersUSSpider(SitemapSpider, StructuredDataSpider):
     name = "carters_us"
     item_attributes = {"brand": "Carter's", "brand_wikidata": "Q5047083"}
+    requires_proxy = True
     allowed_domains = ["www.carters.com"]
     sitemap_urls = ["https://www.carters.com/sitemap_index.xml"]
     sitemap_follow = ["store-page"]


### PR DESCRIPTION
Three spiders failing due to bot protection with no proxy configured:

**adairs** (issue #16670): The AU API was returning 403 from CI IPs. Adding `requires_proxy = "AU"`. Also removes the NZ endpoint since Adairs NZ is shutting down end of June (issue #16642) and simplifies `start()`.

**blaze_pizza** (issue #16672): Getting Cloudflare 429 on the sitemap fetch at `locations.blazepizza.com`. Adding `requires_proxy = True`.

**carters_us** (issue #16673): Getting Cloudflare 429 on the sitemap fetch at `www.carters.com`. Adding `requires_proxy = True`.

Closes #16670
Closes #16642
Closes #16672
Closes #16673

(feedback by Claude 🤖)