### PR TITLE
[Parkbee] Add spider

### DIFF
--- a/locations/spiders/parkbee.py
+++ b/locations/spiders/parkbee.py
@@ -12,7 +12,7 @@ from locations.items import Feature
 
 class ParkbeeSpider(Spider):
     name = "parkbee"
-    item_attributes = {"brand": "ParkBee", "brand_wikidata": "Q121536325"}
+    item_attributes = {"operator": "ParkBee", "operator_wikidata": "Q121536325"}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         # Force the search to next Wednesday at 12:00 PM UTC to ensure max availability

--- a/locations/spiders/parkbee.py
+++ b/locations/spiders/parkbee.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+from typing import AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
+from locations.items import Feature
+
+
+class ParkbeeSpider(Spider):
+    name = "parkbee"
+    item_attributes = {"brand": "ParkBee", "brand_wikidata": "Q121536325"}
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        # Force the search to next Wednesday at 12:00 PM UTC to ensure max availability
+        # and to bypass night/weekend closures
+        now = datetime.now(timezone.utc)
+        target_date = (now + timedelta(days=7 - (now.weekday() - 2) % 7)).replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
+        start_t = target_date.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        end_t = (target_date + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+        # Radius 24 is the closest ISEADGG radius to the 25km search radius
+        for lat, lon in country_iseadgg_centroids(["NL", "BE", "GB"], 24):
+            yield JsonRequest(
+                url="https://maps-api.parkbee.net/v1/garages/search",
+                data={
+                    "latitude": str(lat),
+                    "longitude": str(lon),
+                    "searchRadius": "25",
+                    "product": "go",
+                    "startTime": start_t,
+                    "endTime": end_t,
+                },
+                headers={"Origin": "https://maps-web.parkbee.com"},
+                callback=self.parse,
+            )
+
+    def parse(self, response: Response) -> Iterable[Feature]:
+        for garage in response.json():
+            if garage.get("isSuspended"):
+                continue
+
+            # the API returns "state": "None"
+            garage.pop("state", None)
+
+            item = DictParser.parse(garage)
+            item["ref"] = garage.get("garageId")
+
+            apply_category(Categories.PARKING, item)
+            item["extras"]["fee"] = "yes"
+            item["extras"]["access"] = "customers"
+
+            if garage.get("isOutdoor"):
+                item["extras"]["parking"] = "surface"
+
+            if garage.get("maximumHeadSpaceInMeters"):
+                item["extras"]["maxheight"] = garage["maximumHeadSpaceInMeters"]
+            if garage.get("widthRestrictionInMeters"):
+                item["extras"]["maxwidth"] = garage["widthRestrictionInMeters"]
+
+            if (
+                capacity := (garage.get("garageComprehensiveInfo") or {})
+                .get("availability", {})
+                .get("currentTotalCapacity")
+            ):
+                item["extras"]["capacity"] = capacity
+
+            apply_yes_no("wheelchair", item, garage.get("wheelChairAccessible"))
+            apply_yes_no(Fuel.ELECTRIC, item, garage.get("evCharging"))
+            apply_yes_no("supervised", item, garage.get("manned"))
+            apply_yes_no("surveillance", item, garage.get("closedCircuitTelevision"))
+
+            yield item


### PR DESCRIPTION
```
{'atp/brand/ParkBee': 529,
 'atp/brand_wikidata/Q121536325': 529,
 'atp/category/amenity/parking': 529,
 'atp/clean_strings/city': 10,
 'atp/clean_strings/name': 30,
 'atp/clean_strings/postcode': 22,
 'atp/clean_strings/street_address': 48,
 'atp/country/BE': 140,
 'atp/country/GB': 126,
 'atp/country/NL': 263,
 'atp/duplicate_count': 273,
 'atp/field/branch/missing': 529,
 'atp/field/email/missing': 529,
 'atp/field/housenumber/missing': 529,
 'atp/field/opening_hours/missing': 529,
 'atp/field/phone/missing': 529,
 'atp/field/state/missing': 529,
 'atp/field/street/missing': 529,
 'atp/field/twitter/missing': 529,
 'atp/field/unit/missing': 529,
 'atp/item_scraped_host_count/maps-api.parkbee.net': 802,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 529,
 'atp/operator/ParkBee': 529,
 'atp/operator_wikidata/Q121536325': 529,
 'downloader/request_bytes': 197724,
 'downloader/request_count': 347,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 346,
 'downloader/response_bytes': 2194278,
 'downloader/response_count': 347,
 'downloader/response_status_count/200': 346,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 429.1099999999997,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 14, 20, 4, 0, 611867, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 273,
 'item_dropped_reasons_count/DropItem': 273,
 'item_scraped_count': 529,
 'items_per_minute': 73.98601398601399,
 'log_count/DEBUG': 1149,
 'log_count/INFO': 18,
 'response_received_count': 347,
 'responses_per_minute': 48.531468531468526,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 346,
 'scheduler/dequeued/memory': 346,
 'scheduler/enqueued': 346,
 'scheduler/enqueued/memory': 346,
 'start_time': datetime.datetime(2026, 6, 14, 19, 56, 51, 496830, tzinfo=datetime.timezone.utc)}
```