### PR TITLE
[Unimoni IN] Remove redundant zero-coord filter

### DIFF
--- a/locations/spiders/unimoni_in.py
+++ b/locations/spiders/unimoni_in.py
@@ -52,6 +52,4 @@ class UnimoniINSpider(scrapy.Spider):
         item["state"] = kwargs["state"]
         item["addr_full"] = ", ".join(filter(None, [data.get("address1"), data.get("address2"), data.get("address3")]))
         apply_category(Categories.BUREAU_DE_CHANGE, item)
-        if not item["lat"] or not item["lon"] or float(item["lat"]) == 0 or float(item["lon"]) == 0:
-            return
         yield item


### PR DESCRIPTION
The pipeline's `check_item_properties` already handles lat/lon = 0 via a null-island check (`fabs(lat) < 3 and fabs(lon) < 3`), recording an `atp/geometry/null_island` stat and dropping those coordinates. The explicit filter added in the original PR was redundant. (feedback by Claude 🤖)