### PR TITLE
[Slovenská sporiteľňa SK] Add spider (792 locations)

### DIFF
--- a/locations/spiders/slovenska_sporitelna_sk.py
+++ b/locations/spiders/slovenska_sporitelna_sk.py
@@ -1,0 +1,71 @@
+from collections import Counter
+from datetime import datetime
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+
+class SlovenskaSporitelnaSKSpider(Spider):
+    name = "slovenska_sporitelna_sk"
+    item_attributes = {"brand": "Slovenská sporiteľňa", "brand_wikidata": "Q7541907"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for poi_type in ("pobocka", "bankomat", "firemnecentrum", "vkladomat"):
+            yield Request(
+                url=f"https://www.slsp.sk/bin/erstegroup/gemesgapi/locations/gem_site_location_locations-sk-slsp?types={poi_type}&items=1000&page=0&longitude=17.1071553&latitude=48.1477745"
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json():
+            # title is always the brand and address/location are nested, so build manually
+            item = Feature()
+            item["ref"] = poi["ouId"]
+            item["branch"] = poi.get("description")
+            address = poi.get("address") or {}
+            item["street_address"] = address.get("street")
+            item["city"] = address.get("city")
+            item["postcode"] = address.get("zipCode")
+            location = poi.get("location") or {}
+            item["lat"] = location.get("latitude")
+            item["lon"] = location.get("longitude")
+            service_ids = {s.get("id") for s in poi.get("services", [])}
+
+            if poi["types"][1] == "BRANCH":
+                apply_category(Categories.BANK, item)
+                apply_yes_no(Extras.ATM, item, "atmInBranch" in service_ids)
+            elif poi["types"][1] == "ATM":
+                apply_category(Categories.ATM, item)
+                apply_yes_no(Extras.CASH_IN, item, "banknoteDeposit" in service_ids)
+            else:
+                self.logger.error("Unexpected SLSP category: %s", poi["types"][1])
+                continue
+
+            if hours := poi.get("openingHoursWithDates"):
+                try:
+                    item["opening_hours"] = self.parse_opening_hours(hours)
+                except Exception:
+                    self.logger.warning("Failed to parse hours for %s", item["ref"])
+
+            yield item
+
+    def parse_opening_hours(self, opening_hours_with_dates: list) -> OpeningHours:
+        by_day: dict[int, Counter] = {}
+        for entry in opening_hours_with_dates:
+            day_index = datetime.strptime(entry["date"], "%d.%m.%Y").weekday()
+            periods = tuple((p["open"], p["close"]) for p in entry.get("periods", []))
+            by_day.setdefault(day_index, Counter())[periods] += 1
+
+        oh = OpeningHours()
+        for day_index, counter in by_day.items():
+            most_common_periods = counter.most_common(1)[0][0]
+            if not most_common_periods:
+                oh.set_closed(DAYS[day_index])
+            else:
+                for open_time, close_time in most_common_periods:
+                    oh.add_range(DAYS[day_index], open_time, close_time)
+        return oh


### PR DESCRIPTION
Erste Group `gemesgapi` endpoint, 4 GET requests (one per Slovak facility type). `items=1000` returns ALL records of each type regardless of the lat/lon origin (verified: identical 452-record set from Bratislava and Košice), so no geo-iteration needed. Pipeline dedups overlap by `ref` (`ouId`).

**Types queried**: `pobocka` (branches), `bankomat` (ATMs), `firemnecentrum` (corporate centres), `vkladomat` (deposit ATMs).

**Category mapping** (via `types[1]`):
- `BRANCH` → `Categories.BANK`; `atmInBranch` service → `atm=yes`
- `ATM` → `Categories.ATM`; `banknoteDeposit` service → `cash_in=yes`

**Opening hours** — the API exposes `openingHoursWithDates` as specific calendar dates over a 14-day window. Parsed to weekday-based OSM hours by converting each date → weekday and taking the **most-common schedule per weekday** (via `collections.Counter`), so a single public holiday in the window can't contaminate the regular schedule. 67 of 792 items carry hours (50 branches + 17 in-store ATMs); standalone ATMs have no published hours and are correctly left unset.

**Stats**:

```json
{
 "atp/brand/Slovensk\u00e1 sporite\u013e\u0148a": 792,
 "atp/brand_wikidata/Q7541907": 792,
 "atp/category/amenity/atm": 741,
 "atp/category/amenity/bank": 51,
 "atp/country/SK": 792,
 "atp/field/country/from_spider_name": 792,
 "atp/field/email/missing": 792,
 "atp/field/housenumber/missing": 792,
 "atp/field/name/missing": 741,
 "atp/field/opening_hours/missing": 725,
 "atp/field/operator/missing": 51,
 "atp/field/operator_wikidata/missing": 51,
 "atp/field/phone/missing": 792,
 "atp/field/state/missing": 792,
 "atp/field/street/missing": 792,
 "atp/field/twitter/missing": 792,
 "atp/field/unit/missing": 792,
 "atp/item_scraped_host_count/www.slsp.sk": 792,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 792,
 "atp/operator/Slovensk\u00e1 sporite\u013e\u0148a": 741,
 "atp/operator_wikidata/Q7541907": 741,
 "downloader/request_bytes": 2187,
 "downloader/request_count": 5,
 "downloader/request_method_count/GET": 5,
 "downloader/response_bytes": 1523510,
 "downloader/response_count": 5,
 "downloader/response_status_count/200": 5,
 "elapsed_time_seconds": 6.813000000023749,
 "finish_reason": "finished",
 "finish_time": "2026-06-15T10:16:17.079426+00:00",
 "httpcompression/response_bytes": 211,
 "httpcompression/response_count": 1,
 "item_scraped_count": 792,
 "items_per_minute": 7920.0,
 "response_received_count": 5,
 "responses_per_minute": 50.0,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 4,
 "scheduler/dequeued/memory": 4,
 "scheduler/enqueued": 4,
 "scheduler/enqueued/memory": 4,
 "start_time": "2026-06-15T10:16:10.272037+00:00"
}
```

**Sample POIs**:

Branch with hours (AUPARK mall):
```json
{
  "ref": "45001331",
  "amenity": "bank",
  "branch": "BRATISLAVA, AUPARK, EINSTEINOVA 18",
  "opening_hours": "Mo-Su 10:00-21:00",
  "addr:city": "Bratislava",
  "brand": "Slovenská sporiteľňa",
  "brand:wikidata": "Q7541907"
}
```

In-store ATM with hours (APOLLO NIVY):
```json
{
  "ref": "297",
  "amenity": "atm",
  "branch": "Bankomat, APOLLO NIVY",
  "opening_hours": "Mo-Fr 08:00-19:00; Sa-Su closed",
  "brand": "Slovenská sporiteľňa",
  "brand:wikidata": "Q7541907"
}
```

Deposit ATM (vkladomat, cash_in):
```json
{
  "ref": "307",
  "amenity": "atm",
  "branch": "Vkladový bankomat, hotel CROWNE PLAZA",
  "extras": {"cash_in": "yes"},
  "addr:city": "Bratislava",
  "brand": "Slovenská sporiteľňa",
  "brand:wikidata": "Q7541907"
}
```

**Wikidata**:

```
$ uv run scrapy nsi --code Q7541907
"Slovenská sporiteľňa", "Q7541907"
  -> largest commercial bank in Slovakia
  -> {amenity:atm,  brand:Slovenská sporiteľňa, ...}    [sk]
  -> {amenity:bank, brand:Slovenská sporiteľňa, ...}    [sk]
```