### PR TITLE
[Wilson Parking AU NZ][Wilson Parking HK] Add Spiders (854 locations)(407 locations)

### DIFF
--- a/locations/spiders/wilson_parking_au_nz.py
+++ b/locations/spiders/wilson_parking_au_nz.py
@@ -1,0 +1,24 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy import Request
+from scrapy.http import JsonRequest, TextResponse
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class WilsonParkingAUNZSpider(JSONBlobSpider):
+    name = "wilson_parking_au_nz"
+    item_attributes = {"brand": "Wilson Parking", "brand_wikidata": "Q28448427"}
+    locations_key = "carParks"
+
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
+        for domain in ["wilsonparking.co.nz", "www.wilsonparking.com.au"]:
+            yield JsonRequest(
+                url=f"https://{domain}/api/v2/GetParkingByLocation?latitude=0&longitude=0&sort=undefined&distance=200000000"
+            )
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["website"] = item["ref"] = response.urljoin(item["website"])
+        item["addr_full"] = feature["location"]["address"]
+        yield item

--- a/locations/spiders/wilson_parking_hk.py
+++ b/locations/spiders/wilson_parking_hk.py
@@ -1,0 +1,28 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy import Request
+from scrapy.http import JsonRequest, TextResponse
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class WilsonParkingHKSpider(JSONBlobSpider):
+    name = "wilson_parking_hk"
+    item_attributes = {"brand": "Wilson Parking", "brand_wikidata": "Q28448427"}
+    locations_key = "data"
+
+    async def start(self) -> AsyncIterator[JsonRequest | Request]:
+        yield JsonRequest(url="https://web-api.wilsonparking.com.hk/carPark")
+
+    def pre_process_data(self, feature: dict) -> None:
+        if feature.get("coordinates"):
+            feature.update(feature.pop("coordinates"))
+        feature.update(feature.pop("Location"))
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["code"]
+        item["city"] = feature["chineseDistrict"]
+        item["state"] = feature["chineseRegion"]
+        item["addr_full"] = feature["chineseAddress"]
+        yield item


### PR DESCRIPTION
**_Countries: AU & NZ_**

```python
{'atp/brand/Wilson Parking': 854,
 'atp/brand_wikidata/Q28448427': 854,
 'atp/category/amenity/parking': 854,
 'atp/cdn/cloudflare/response_count': 5,
 'atp/cdn/cloudflare/response_status_count/200': 5,
 'atp/clean_strings/addr_full': 104,
 'atp/clean_strings/name': 18,
 'atp/clean_strings/phone': 5,
 'atp/country/AU': 554,
 'atp/country/NZ': 300,
 'atp/field/branch/missing': 854,
 'atp/field/city/missing': 854,
 'atp/field/country/from_website_url': 854,
 'atp/field/email/missing': 854,
 'atp/field/housenumber/missing': 854,
 'atp/field/opening_hours/missing': 854,
 'atp/field/phone/invalid': 460,
 'atp/field/phone/missing': 51,
 'atp/field/postcode/missing': 854,
 'atp/field/state/missing': 198,
 'atp/field/street/missing': 854,
 'atp/field/street_address/missing': 854,
 'atp/field/twitter/missing': 854,
 'atp/field/unit/missing': 854,
 'atp/item_scraped_host_count/www.wilsonparking.co.nz': 300,
 'atp/item_scraped_host_count/www.wilsonparking.com.au': 554,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 854,
 'atp/operator/Wilson Parking': 854,
 'atp/operator_wikidata/Q28448427': 854,
 'downloader/request_bytes': 3745,
 'downloader/request_count': 7,
 'downloader/request_method_count/GET': 7,
 'downloader/response_bytes': 682705,
 'downloader/response_count': 7,
 'downloader/response_status_count/200': 5,
 'downloader/response_status_count/301': 2,
 'elapsed_time_seconds': 10.577999999979511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 15, 13, 1, 14, 399647, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3650361,
 'httpcompression/response_count': 5,
 'item_scraped_count': 854,
 'items_per_minute': 5124.0,
 'log_count/DEBUG': 861,
 'log_count/INFO': 3,
 'response_received_count': 5,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 6, 15, 13, 1, 3, 833142, tzinfo=datetime.timezone.utc)}
```

**_Country : HK_**
```
{'atp/brand/Wilson Parking': 407,
 'atp/brand_wikidata/Q28448427': 407,
 'atp/category/amenity/parking': 407,
 'atp/clean_strings/addr_full': 7,
 'atp/clean_strings/lon': 1,
 'atp/clean_strings/name': 21,
 'atp/clean_strings/phone': 10,
 'atp/clean_strings/ref': 2,
 'atp/closed_check': 210,
 'atp/country/HK': 407,
 'atp/field/branch/missing': 407,
 'atp/field/country/from_spider_name': 407,
 'atp/field/email/missing': 385,
 'atp/field/geometry/missing': 8,
 'atp/field/housenumber/missing': 407,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 407,
 'atp/field/phone/invalid': 19,
 'atp/field/phone/missing': 8,
 'atp/field/postcode/missing': 407,
 'atp/field/street/missing': 407,
 'atp/field/street_address/missing': 407,
 'atp/field/twitter/missing': 407,
 'atp/field/unit/missing': 407,
 'atp/item_scraped_host_count/web-api.wilsonparking.com.hk': 407,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 407,
 'atp/operator/威信停車場 Wilson Parking': 407,
 'atp/operator_wikidata/Q28448427': 407,
 'downloader/request_bytes': 838,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 148722,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 8.39100000000326,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 15, 13, 19, 32, 738603, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2085019,
 'httpcompression/response_count': 1,
 'item_scraped_count': 407,
 'items_per_minute': 3052.5,
 'log_count/DEBUG': 409,
 'log_count/INFO': 3,
 'log_count/WARNING': 210,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 15, 13, 19, 24, 355858, tzinfo=datetime.timezone.utc)}
```