### PR TITLE
[Victorian Government Department of Education] Add public schools

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -24,9 +24,12 @@ class Categories(Enum):
     PARKING = {"amenity": "parking"}
     PARKING_SPACE = {"amenity": "parking_space"}
 
-    SCHOOL = {"amenity": "school"}
-    UNIVERSITY = {"amenity": "university"}
-    COLLEGE = {"amenity": "college"}
+    KINDERGARTEN = {"amenity": "kindergarten", "education": "kindergarten"}
+    SCHOOL = {"amenity": "school", "education": "school"}
+    COLLEGE = {"amenity": "college", "education": "college"}
+    UNIVERSITY = {"amenity": "university", "education": "university"}
+    LANGUAGE_SCHOOL = {"amenity": "school", "education": "language_school"}
+    NATURE_SCHOOL = {"amenity": "school", "education": "nature_school"}
 
     BUS_STOP = {"highway": "bus_stop", "public_transport": "platform"}
     BUS_STATION = {"amenity": "bus_station", "public_transport": "station"}
@@ -317,7 +320,6 @@ class Categories(Enum):
     HOTEL = {"tourism": "hotel"}
     INTERNET_CAFE = {"amenity": "internet_cafe"}
     ICE_CREAM = {"amenity": "ice_cream"}
-    KINDERGARTEN = {"amenity": "kindergarten"}
     LIBRARY = {"amenity": "library"}
     MANHOLE = {"man_made": "manhole"}
     MARKETPLACE = {"amenity": "marketplace"}
@@ -496,6 +498,7 @@ top_level_tags = [
     "club",
     "craft",
     "dark_store",
+    "education",
     "emergency",
     "healthcare",
     "highway",
@@ -542,6 +545,12 @@ def get_category_tags(source: Feature | Enum | Mapping) -> dict:
             categories[top_level_tag] = v
     if len(categories.keys()) > 1 and categories.get("shop") == "yes":
         categories.pop("shop")
+    if "amenity" in categories.keys() and "education" in categories.keys():
+        # amenity=school is being replaced within OSM by education=*
+        # Whilst ATP still sets amenity=school for backwards compatibility
+        # it is "education" not "amenity" which is the intended top level
+        # category.
+        categories.pop("amenity")
     return categories
 
 

--- a/locations/spiders/infrastructure/victorian_government_schools_au.py
+++ b/locations/spiders/infrastructure/victorian_government_schools_au.py
@@ -11,9 +11,7 @@ class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
     name = "victorian_government_schools_au"
     item_attributes = {"operator": "Department of Education", "operator_wikidata": "Q5260272"}
     allowed_domains = ["www.vic.gov.au"]
-    start_urls = [
-        "https://www.vic.gov.au/api/tide/elasticsearch/content-vic__production__sapi_node/_search"
-    ]
+    start_urls = ["https://www.vic.gov.au/api/tide/elasticsearch/content-vic__production__sapi_node/_search"]
     locations_key = ["hits", "hits"]
 
     async def start(self) -> AsyncIterator[JsonRequest]:
@@ -21,34 +19,12 @@ class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
             "from": 0,
             "query": {
                 "bool": {
-                    "filter": [
-                        {
-                            "terms": {
-                                "type": ["det_150_content"]
-                            }
-                        },
-                        {
-                            "terms": {
-                                "field_node_site": [4]
-                            }
-                        }
-                    ],
-                    "must": [
-                        {
-                            "match_all": {}
-                        }
-                    ]
+                    "filter": [{"terms": {"type": ["det_150_content"]}}, {"terms": {"field_node_site": [4]}}],
+                    "must": [{"match_all": {}}],
                 }
             },
             "size": 10000,
-            "sort": [
-                {
-                    "_score": "desc"
-                },
-                {
-                    "title.keyword": "asc"
-                }
-            ]
+            "sort": [{"_score": "desc"}, {"title.keyword": "asc"}],
         }
         yield JsonRequest(url=self.start_urls[0], data=data, method="POST")
 
@@ -62,7 +38,11 @@ class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
             case "Closed":
                 return
             case _:
-                self.logger.warning("Unknown school status '{}' for school '{}'.".format(feature["field_school_status_name"][0], feature["field_school_number"][0]))
+                self.logger.warning(
+                    "Unknown school status '{}' for school '{}'.".format(
+                        feature["field_school_status_name"][0], feature["field_school_number"][0]
+                    )
+                )
 
         item["ref"] = feature["field_school_number"][0]
         item["name"] = feature["title"][0].split(" - ", 1)[0]
@@ -122,4 +102,8 @@ class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
             case "Camp":
                 apply_category(Categories.NATURE_SCHOOL, item)
             case _:
-                self.logger.warning("Unknown school type '{}' for school '{}'.".format(feature["field_school_type_name"][0], feature["field_school_number"][0]))
+                self.logger.warning(
+                    "Unknown school type '{}' for school '{}'.".format(
+                        feature["field_school_type_name"][0], feature["field_school_number"][0]
+                    )
+                )

--- a/locations/spiders/infrastructure/victorian_government_schools_au.py
+++ b/locations/spiders/infrastructure/victorian_government_schools_au.py
@@ -9,7 +9,7 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
     name = "victorian_government_schools_au"
-    item_attributes = {"operator": "Department of Education", "operator_wikidata": "Q5260272"}
+    item_attributes = {"operator": "Victorian Department of Education", "operator_wikidata": "Q5260272"}
     allowed_domains = ["www.vic.gov.au"]
     start_urls = ["https://www.vic.gov.au/api/tide/elasticsearch/content-vic__production__sapi_node/_search"]
     locations_key = ["hits", "hits"]

--- a/locations/spiders/infrastructure/victorian_government_schools_au.py
+++ b/locations/spiders/infrastructure/victorian_government_schools_au.py
@@ -1,0 +1,125 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class VictorianGovernmentSchoolsAUSpider(JSONBlobSpider):
+    name = "victorian_government_schools_au"
+    item_attributes = {"operator": "Department of Education", "operator_wikidata": "Q5260272"}
+    allowed_domains = ["www.vic.gov.au"]
+    start_urls = [
+        "https://www.vic.gov.au/api/tide/elasticsearch/content-vic__production__sapi_node/_search"
+    ]
+    locations_key = ["hits", "hits"]
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        data = {
+            "from": 0,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "terms": {
+                                "type": ["det_150_content"]
+                            }
+                        },
+                        {
+                            "terms": {
+                                "field_node_site": [4]
+                            }
+                        }
+                    ],
+                    "must": [
+                        {
+                            "match_all": {}
+                        }
+                    ]
+                }
+            },
+            "size": 10000,
+            "sort": [
+                {
+                    "_score": "desc"
+                },
+                {
+                    "title.keyword": "asc"
+                }
+            ]
+        }
+        yield JsonRequest(url=self.start_urls[0], data=data, method="POST")
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("_source"))
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        match feature["field_school_status_name"][0]:
+            case "Open":
+                pass
+            case "Closed":
+                return
+            case _:
+                self.logger.warning("Unknown school status '{}' for school '{}'.".format(feature["field_school_status_name"][0], feature["field_school_number"][0]))
+
+        item["ref"] = feature["field_school_number"][0]
+        item["name"] = feature["title"][0].split(" - ", 1)[0]
+        item["lat"] = float(feature["field_latitude_value"][0])
+        item["lon"] = float(feature["field_longitude_value"][0])
+        if feature.get("field_street_address"):
+            item["street_address"] = feature["field_street_address"][0]
+        if feature.get("field_suburb"):
+            item["city"] = feature["field_suburb"][0]
+        if feature.get("field_postcode"):
+            item["postcode"] = feature["field_postcode"][0]
+        if feature.get("field_email"):
+            item["email"] = feature["field_email"][0]
+        item.pop("website", None)
+
+        self.extract_school_type(item, feature)
+
+        if feature.get("field_open_date"):
+            item["extras"]["start_date"] = feature["field_open_date"][0].split("T", 1)[0]
+
+        yield item
+
+    def extract_school_type(self, item: Feature, feature: dict) -> None:
+        match feature["field_school_type_name"][0]:
+            case "Primary":
+                apply_category(Categories.SCHOOL, item)
+                item["extras"]["school"] = "primary"
+                item["extras"]["grades"] = "0-6"
+                item["extras"]["isced:level:2011"] = "1"
+            case "Primary and secondary":
+                apply_category(Categories.SCHOOL, item)
+                item["extras"]["school"] = "primary;secondary"
+                if "P-9" in item["name"]:
+                    item["extras"]["grades"] = "0-9"
+                    item["extras"]["isced:level:2011"] = "1;2"
+                else:
+                    # Sometimes (but not always) containing P-12 in name
+                    item["extras"]["grades"] = "0-12"
+                    item["extras"]["isced:level:2011"] = "1;2;3"
+            case "Secondary":
+                apply_category(Categories.SCHOOL, item)
+                item["extras"]["school"] = "secondary"
+                if "Senior College" in item["name"]:
+                    item["extras"]["grades"] = "10-12"
+                    item["extras"]["isced:level:2011"] = "3"
+                elif "Middle Years" in item["name"]:
+                    item["extras"]["grades"] = "7-9"
+                    item["extras"]["isced:level:2011"] = "2"
+                else:
+                    item["extras"]["grades"] = "7-12"
+                    item["extras"]["isced:level:2011"] = "2;3"
+            case "Special":
+                apply_category(Categories.SCHOOL, item)
+                item["extras"]["school"] = "special_education_needs"
+            case "Language":
+                apply_category(Categories.LANGUAGE_SCHOOL, item)
+            case "Camp":
+                apply_category(Categories.NATURE_SCHOOL, item)
+            case _:
+                self.logger.warning("Unknown school type '{}' for school '{}'.".format(feature["field_school_type_name"][0], feature["field_school_number"][0]))


### PR DESCRIPTION
1621 schools returned.

Also fix up ATPs categories to accomodate OSM's migration from amenity=school to education=* tags. This new spider requires use of more specific tagging introduced by education=*, even though it also keeps amenity=school for backwards compatibility with older OSM client software.