### PR TITLE
[Ace Parking US] Add  spider (418 locations)

### DIFF
--- a/locations/spiders/ace_parking_us.py
+++ b/locations/spiders/ace_parking_us.py
@@ -1,0 +1,54 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy.http import JsonRequest, TextResponse
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.geo import country_iseadgg_centroids
+from locations.hours import OpeningHours, sanitise_day
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class AceParkingUSSpider(JSONBlobSpider):
+    name = "ace_parking_us"
+    item_attributes = {"brand": "Ace Parking", "brand_wikidata": "Q108274179"}
+    locations_key = "results"
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for lat, lon in country_iseadgg_centroids("US", 158):
+            yield JsonRequest(
+                url=f"https://aceparking.com/wp-json/ace-parking/v1/find-parking?lat={lat}&lng={lon}",
+            )
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("address"))
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full", None)
+        item["website"] = None
+        try:
+            item["opening_hours"] = self.parse_opening_hours(feature.get("hours", {}))
+        except Exception as e:
+            self.logger.error(f'Error parsing opening hours for {feature.get("hours")}: {e}')
+        apply_category(Categories.PARKING, item)
+        apply_yes_no(Fuel.ELECTRIC, item, feature.get("evChargers"))
+        yield item
+
+    def parse_opening_hours(self, rules: dict) -> OpeningHours | None:
+        if not rules:
+            return None
+        opening_hours = OpeningHours()
+        for rule in rules:
+            if day := sanitise_day(rule):
+                hours = rules[rule]
+                if not hours:
+                    continue
+                elif "Closed" in hours:
+                    opening_hours.set_closed(day)
+                    continue
+                elif "2400" in hours:
+                    open_time, close_time = "00:00", "23:59"
+                else:
+                    open_time, close_time = [f"{t[:-2]}:{t[-2:]}" for t in hours]
+                opening_hours.add_range(day, open_time, close_time)
+        return opening_hours


### PR DESCRIPTION
Tried `country_iseadgg_centroids("US", 24)` as well but count is saturated at `418`.

```python
{'atp/brand/Ace Parking': 418,
 'atp/brand_wikidata/Q108274179': 418,
 'atp/category/amenity/parking': 418,
 'atp/country/US': 418,
 'atp/duplicate_count': 81,
 'atp/field/branch/missing': 418,
 'atp/field/country/from_spider_name': 418,
 'atp/field/email/missing': 418,
 'atp/field/housenumber/missing': 418,
 'atp/field/opening_hours/missing': 28,
 'atp/field/phone/missing': 362,
 'atp/field/street/missing': 418,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 418,
 'atp/field/unit/missing': 418,
 'atp/item_scraped_host_count/aceparking.com': 499,
 'atp/lineage': 'S_?',
 'atp/nsi/cc_match': 418,
 'atp/operator/Ace Parking': 418,
 'atp/operator_wikidata/Q108274179': 418,
 'downloader/request_bytes': 91055,
 'downloader/request_count': 226,
 'downloader/request_method_count/GET': 226,
 'downloader/response_bytes': 223281,
 'downloader/response_count': 226,
 'downloader/response_status_count/200': 226,
 'elapsed_time_seconds': 2.6569999999992433,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 15, 14, 22, 42, 222045, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 226,
 'httpcompression/response_bytes': 289391,
 'httpcompression/response_count': 226,
 'item_dropped_count': 81,
 'item_dropped_reasons_count/DropItem': 81,
 'item_scraped_count': 418,
 'items_per_minute': 12540.0,
 'log_count/DEBUG': 726,
 'log_count/ERROR': 7,
 'log_count/INFO': 3,
 'response_received_count': 226,
 'responses_per_minute': 6780.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 225,
 'scheduler/dequeued/memory': 225,
 'scheduler/enqueued': 225,
 'scheduler/enqueued/memory': 225,
 'start_time': datetime.datetime(2026, 6, 15, 14, 22, 39, 571079, tzinfo=datetime.timezone.utc)}
```