### PR TITLE
[NLB Banka Podgorica ME] Add spider (158 locations)

### DIFF
--- a/locations/spiders/nlb_me.py
+++ b/locations/spiders/nlb_me.py
@@ -33,6 +33,10 @@ class NlbMESpider(Spider):
             if facility_url := poi.get("facilityPageUrl"):
                 item["website"] = f"https://www.nlb.me{facility_url}"
 
+            # Drop generic corporate contact details — not location-specific
+            item.pop("phone", None)
+            item.pop("email", None)
+
             oh = OpeningHours()
             for avail in poi.get("availabilities") or []:
                 day = DAYS_HR.get(avail["dayOfWeek"])

--- a/locations/spiders/nlb_me.py
+++ b/locations/spiders/nlb_me.py
@@ -1,0 +1,60 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_HR, OpeningHours
+
+
+class NlbMESpider(Spider):
+    name = "nlb_me"
+    item_attributes = {"brand": "NLB", "brand_wikidata": "Q6428302"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for kind in ("atm", "branch"):
+            yield Request(
+                url=f"https://www.nlb.me/content/nlbbanks/nlbme/sr_me/stanovnistvo/lokacije/jcr:content/root/container/container/branchsearch.facilities.json?kind={kind}"
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json():
+            item = DictParser.parse(poi)
+
+            # DictParser does not flatten nested address objects, so override
+            # the geo/address fields from the nested "location" dict manually.
+            loc = poi.get("location") or {}
+            item["lat"] = loc.get("latitude")
+            item["lon"] = loc.get("longitude")
+            item["street_address"] = loc.get("street")
+            item["city"] = loc.get("city")
+
+            if facility_url := poi.get("facilityPageUrl"):
+                item["website"] = f"https://www.nlb.me{facility_url}"
+
+            oh = OpeningHours()
+            for avail in poi.get("availabilities") or []:
+                day = DAYS_HR.get(avail["dayOfWeek"])
+                if not day:
+                    continue
+                for r in avail.get("range") or []:
+                    if r.get("closed") or r.get("from") is None:
+                        continue
+                    # Times are formatted as "8.00" / "24.00" — normalise to "HH:MM"
+                    open_time = r["from"].replace(".", ":").zfill(5)
+                    close_time = r["to"].replace(".", ":").zfill(5)
+                    oh.add_range(day, open_time, close_time)
+            item["opening_hours"] = oh.as_opening_hours()
+
+            kind = poi.get("kind")
+            if kind == "atm":
+                apply_category(Categories.ATM, item)
+            elif kind == "branch":
+                item["branch"] = (item.pop("name", "") or "").removeprefix("Filijala ").strip() or None
+                apply_category(Categories.BANK, item)
+            else:
+                self.logger.error("Unexpected NLB kind: %s", kind)
+                continue
+
+            yield item


### PR DESCRIPTION
NLB Banka Podgorica (Montenegro) — NLB's AEM `facilities.json` endpoint, one GET per `kind`:

- `?kind=branch` → 20 branches
- `?kind=atm` → 138 ATMs

`DictParser` handles `id`→`ref`, `name`, `phoneNumber`→`phone`, `email`; the nested `location` dict is flattened manually (lat/lon/street/city); `website` from `facilityPageUrl`.

**Type mapping**: `kind=="branch"` → `Categories.BANK` (name popped to `branch` with `"Filijala "` prefix stripped); `kind=="atm"` → `Categories.ATM` (DictParser name kept as venue label).

**Opening hours**: parsed from the `availabilities` array using `DAYS_HR` (Croatian/Montenegrin day names — `Ponedjeljak`/`Utorak`/`Srijeda`/`Četvrtak`/`Petak`/`Subota`/`Nedjelja`, verified 7/7 match). Times `"8.15"`/`"24.00"` normalised to `HH:MM`. Branches render `Mo-Fr 08:15-15:45`; ATMs are 24/7 (`Mo-Su 00:00-24:00`). 2 ATMs with empty API `availabilities` correctly have no hours.

**Stats**:

```json
{
 "atp/brand/NLB": 158,
 "atp/brand_wikidata/Q6428302": 158,
 "atp/category/amenity/atm": 138,
 "atp/category/amenity/bank": 20,
 "atp/clean_strings/city": 43,
 "atp/clean_strings/name": 2,
 "atp/clean_strings/street_address": 11,
 "atp/country/ME": 158,
 "atp/field/branch/missing": 138,
 "atp/field/country/from_spider_name": 158,
 "atp/field/email/missing": 138,
 "atp/field/housenumber/missing": 158,
 "atp/field/opening_hours/invalid": 2,
 "atp/field/operator/missing": 20,
 "atp/field/operator_wikidata/missing": 20,
 "atp/field/phone/invalid": 20,
 "atp/field/phone/missing": 138,
 "atp/field/postcode/missing": 158,
 "atp/field/state/missing": 158,
 "atp/field/street/missing": 158,
 "atp/field/twitter/missing": 158,
 "atp/field/unit/missing": 158,
 "atp/item_scraped_host_count/www.nlb.me": 158,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 158,
 "atp/operator/NLB": 138,
 "atp/operator_wikidata/Q6428302": 138,
 "downloader/request_bytes": 1217,
 "downloader/request_count": 3,
 "downloader/request_method_count/GET": 3,
 "downloader/response_bytes": 30678,
 "downloader/response_count": 3,
 "downloader/response_status_count/200": 3,
 "elapsed_time_seconds": 8.125,
 "finish_reason": "finished",
 "finish_time": "2026-06-15T14:31:47.321273+00:00",
 "httpcompression/response_bytes": 441494,
 "httpcompression/response_count": 2,
 "item_scraped_count": 158,
 "items_per_minute": 1185.0,
 "response_received_count": 3,
 "responses_per_minute": 22.5,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2026-06-15T14:31:39.192250+00:00"
}
```

**Sample POIs**:

Branch (Bar):
```json
{
  "ref": "95200001",
  "amenity": "bank",
  "name": "NLB banka Podgorica",
  "branch": "Bar",
  "addr:street_address": "Maršala Tita 24",
  "addr:city": "Bar",
  "phone": "+382 19888",
  "email": "info@nlb.me",
  "opening_hours": "Mo-Fr 08:15-15:45",
  "brand": "NLB",
  "brand:wikidata": "Q6428302"
}
```

ATM (24/7 venue):
```json
{
  "ref": "95200021",
  "amenity": "atm",
  "name": "Butik Olimpik",
  "addr:city": "Budva",
  "opening_hours": "Mo-Su 00:00-24:00",
  "brand": "NLB",
  "brand:wikidata": "Q6428302"
}
```

**Wikidata**:

```
$ uv run scrapy nsi --code Q6428302
"NLB Banka Podgorica", "Q6428302"
  -> Montenegrin banking and financial services company
  -> {amenity:atm,  brand:NLB, ...}    [me]
  -> {amenity:bank, brand:NLB, ...}    [me]
```