### PR TITLE
[Mitsubishi BO] Add Bolivia spider

### DIFF
--- a/locations/spiders/mitsubishi_bo.py
+++ b/locations/spiders/mitsubishi_bo.py
@@ -1,0 +1,6 @@
+from locations.spiders.mitsubishi_cl import MitsubishiCLSpider
+
+
+class MitsubishiBOSpider(MitsubishiCLSpider):
+    name = "mitsubishi_bo"
+    start_urls = ["https://mitsubishi-motors.bo/red"]


### PR DESCRIPTION
## Summary
- Adds a new spider for Mitsubishi Motors Bolivia
- Inherits from `MitsubishiCLSpider` with `start_urls` pointing to `https://mitsubishi-motors.bo/red`

## Test plan
- [ ] Run spider and verify locations are returned
- [ ] Check that dealership categories (sales, service, parts) are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)