### PR TITLE
[SpPlusParking] Add spider (2378 locations)

### DIFF
--- a/locations/spiders/sp_plus_parking.py
+++ b/locations/spiders/sp_plus_parking.py
@@ -1,0 +1,71 @@
+import re
+from typing import Any, Iterable, Optional
+
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class SpPlusParkingSpider(SitemapSpider):
+    name = "sp_plus_parking"
+    item_attributes = {"brand": "SP+", "brand_wikidata": "Q7598289"}
+    sitemap_urls = ["https://parking.com/sitemap.xml"]
+    sitemap_rules = [(r"/lot/[^/]+$", "parse_lot_page")]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
+
+    def parse_lot_page(self, response: Response) -> Iterable[Request]:
+        yield Request(
+            response.url.rstrip("/") + ".json",
+            callback=self.parse_lot_json,
+            cb_kwargs={"page_url": response.url},
+        )
+
+    def parse_lot_json(self, response: Response, page_url: str = "", **kwargs: Any) -> Iterable[Feature]:
+        data = response.json()
+        lot = data.get("lot") or data
+        item = DictParser.parse(lot)
+        item["website"] = page_url
+        item["street_address"] = item.pop("addr_full", None)
+
+        name = (item.pop("name") or "").strip()
+        if name.startswith("(") and ") " in name:
+            item["branch"] = name.split(") ", 1)[1].strip()
+        else:
+            item["branch"] = name
+
+        if addr2 := lot.get("addressLine2"):
+            parts = addr2.rsplit(",", 1)
+            item["city"] = parts[0].strip() if len(addr2.rsplit(",", 1)) == 2 else addr2
+            if len(parts) == 2:
+                sp = parts[1].strip().split()
+                item["state"] = sp[0] if sp else None
+                item["postcode"] = sp[1] if len(sp) > 1 else None
+
+        features = lot.get("features") or {}
+        raw_hours = features.get("hoursOfOperation")
+
+        if parsed_hours := self.parse_opening_hours(raw_hours):
+            item["opening_hours"] = parsed_hours
+
+        apply_category(Categories.PARKING, item)
+        apply_yes_no(Fuel.ELECTRIC, item, (lot.get("features") or {}).get("electricVehicleCharging", False))
+
+        yield item
+
+    def parse_opening_hours(self, hours_string: Optional[str]) -> OpeningHours | str | None:
+        if not hours_string:
+            return None
+
+        hours_string = hours_string.strip()
+        if "24 / 7" in hours_string or "24/7" in hours_string:
+            return "24/7"
+
+        oh = OpeningHours()
+        oh.add_ranges_from_string(re.sub(r"(?i)\bopen\b", "", re.sub(r"(?i)24\s*hours?", "00:00-23:59", hours_string)))
+
+        return oh or None


### PR DESCRIPTION
Initially tried using the iseadgg grid approach with their internal map API. However, that approach yielded far fewer locations than expected, missing hundreds of lots due to hidden API limits and returning heavy 404 errors for empty coordinates.

Therefore, swtiched to Sitemap approach.

```
{'atp/brand/SP+': 2378,
 'atp/brand_wikidata/Q7598289': 2378,
 'atp/category/amenity/parking': 2378,
 'atp/clean_strings/street_address': 191,
 'atp/country/CA': 46,
 'atp/country/US': 2332,
 'atp/field/city/missing': 3,
 'atp/field/email/missing': 2378,
 'atp/field/housenumber/missing': 2378,
 'atp/field/opening_hours/missing': 185,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 2,
 'atp/field/state/from_reverse_geocoding': 2,
 'atp/field/street/missing': 2378,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2378,
 'atp/field/unit/missing': 2378,
 'atp/item_scraped_host_count/parking.com': 2378,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 2378,
 'atp/operator/SP+': 2378,
 'atp/operator_wikidata/Q7598289': 2378,
 'downloader/exception_count': 11,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 11,
 'downloader/request_bytes': 3203406,
 'downloader/request_count': 4871,
 'downloader/request_method_count/GET': 4871,
 'downloader/response_bytes': 153496091,
 'downloader/response_count': 4860,
 'downloader/response_status_count/200': 4838,
 'downloader/response_status_count/301': 4,
 'downloader/response_status_count/302': 13,
 'downloader/response_status_count/404': 3,
 'downloader/response_status_count/502': 2,
 'dupefilter/filtered': 17,
 'elapsed_time_seconds': 6125.938000000002,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 15, 17, 45, 51, 185290, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 768176544,
 'httpcompression/response_count': 4841,
 'httperror/response_ignored_count': 3,
 'httperror/response_ignored_status_count/404': 3,
 'item_scraped_count': 2378,
 'items_per_minute': 23.294693877551023,
 'log_count/DEBUG': 7249,
 'log_count/ERROR': 2,
 'log_count/INFO': 233,
 'log_count/WARNING': 1,
 'request_depth_max': 3,
 'response_received_count': 4841,
 'responses_per_minute': 47.422040816326536,
 'retry/count': 12,
 'retry/max_reached': 1,
 'retry/reason_count/502 Bad Gateway': 2,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 10,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 4870,
 'scheduler/dequeued/memory': 4870,
 'scheduler/enqueued': 4870,
 'scheduler/enqueued/memory': 4870,
 'start_time': datetime.datetime(2026, 6, 15, 16, 3, 45, 247850, tzinfo=datetime.timezone.utc)}
```