### PR TITLE
[Zagrebačka banka HR] Add spider

### DIFF
--- a/locations/spiders/zagrebacka_banka_hr.py
+++ b/locations/spiders/zagrebacka_banka_hr.py
@@ -1,0 +1,85 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.geo import point_locations
+from locations.hours import DAYS, OpeningHours
+
+
+class ZagrebackaBankaHRSpider(Spider):
+    name = "zagrebacka_banka_hr"
+    item_attributes = {"brand": "Zagrebačka banka", "brand_wikidata": "Q140381"}
+
+    # The endpoint returns the POIs nearest to a query point, distance-limited,
+    # so a grid of points covering Croatia (overlapping reach) is queried and the
+    # pipeline deduplicates by ref. "vrstaPoi" lists the categories to fully
+    # enumerate; it must include BOTH "Poslovnica" (branches) and "Bankomat"
+    # (ATMs), otherwise the omitted category is only returned as sparse nearby
+    # context rather than exhaustively. Note the payload swaps the usual order:
+    # "lb" carries latitude and "mb" longitude. The "vrsta*" arrays select
+    # function sub-types within each category:
+    #   vrstaPoslovnice: 2=retail branch, 3=branch, 4=business centre
+    #   vrstaBankomata:  0=withdrawal ATM, 1=deposit/withdrawal ATM
+    async def start(self) -> AsyncIterator[Any]:
+        for lat, lon in point_locations("eu_centroids_40km_radius_country.csv", "HR"):
+            yield JsonRequest(
+                url="https://www.zaba.hr/home/mapa/nbLokacija",
+                data={
+                    "lb": lat,
+                    "mb": lon,
+                    "filter": {
+                        "broj": 99999,
+                        "vrstaPoslovnice": [2, 3, 4],
+                        "vrstaBankomata": [0, 1],
+                        "vrstaPoi": ["Poslovnica", "Bankomat"],
+                    },
+                },
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for cluster in response.json()["obj"]:
+            for poi in cluster.get("pois", []):
+                if not poi["idZupanija"]:
+                    continue  # foreign UniCredit-group POIs carry no Croatian county id
+
+                if poi["vrsta"] == "Poslovnica":
+                    category = Categories.BANK
+                elif poi["vrsta"] == "Bankomat":
+                    category = Categories.ATM
+                elif poi["vrsta"] in ("DNT", "Uređaj za zaprimanje naloga", "Uređaj za deponiranje kovanica"):
+                    continue  # day/night safes, order-intake and coin-deposit devices, not mapped
+                else:
+                    self.logger.error("Unexpected vrsta: {}".format(poi["vrsta"]))
+                    continue
+
+                item = DictParser.parse(poi)
+                # Croatian API keys: DictParser only maps ref/lat, rest set manually.
+                item["lon"] = poi["geolon"]
+                item["street_address"] = poi.get("adresa")
+                item["city"] = poi.get("grad")
+                item["postcode"] = str(poi["postanskiBroj"]) if poi.get("postanskiBroj") else None
+                item["phone"] = poi.get("telefon")
+
+                if poi["vrsta"] == "Poslovnica":
+                    self.parse_hours(item, poi.get("radnoVrijeme"))
+
+                apply_category(category, item)
+                yield item
+
+    def parse_hours(self, item: dict, rules: list[dict] | None) -> None:
+        if not rules:
+            return
+        oh = OpeningHours()
+        try:
+            for rule in rules:
+                day = DAYS[rule["dan"]]
+                if rule["t1h"] or rule["t1m"]:
+                    oh.add_range(day, f"{rule['f1h']:02d}:{rule['f1m']:02d}", f"{rule['t1h']:02d}:{rule['t1m']:02d}")
+                if rule["t2h"] or rule["t2m"]:
+                    oh.add_range(day, f"{rule['f2h']:02d}:{rule['f2m']:02d}", f"{rule['t2h']:02d}:{rule['t2m']:02d}")
+            item["opening_hours"] = oh
+        except Exception:  # TODO: revisit if hours parsing proves unreliable
+            self.logger.warning("Failed to parse hours for {}".format(item.get("ref")))


### PR DESCRIPTION
Source: https://www.zaba.hr/home/mapa → POST nbLokacija, grid-driven
(eu_centroids_40km_radius_country.csv, HR) + pipeline dedup.

Counts: 175 banks (amenity=bank) + 662 ATMs (amenity=atm) = 837.

Categories: vrsta field — Poslovnica→BANK, Bankomat→ATM; device types
(day/night safe, coin-deposit, order-intake) skipped; unknown vrsta
logged as error.

Completeness: verified by grid convergence — 40km (66 pts) and 20km
(201 pts) grids both yield identical 837. Foreign UniCredit-group
partner ATMs (AT/HU/BA/RS), different than Zagrebačka banka,  excluded via idZupanija == 0.

Hours: branches only (ATMs have radnoVrijeme: null), parsed from the
structured numeric schedule.

NSI: all items cc_match for Q140381.

Samples:
1) Standalone bank — Zadar (ref 1358)

{
 "ref": "1358", "amenity": "bank",
 "short_name": "ZaBa", "name": "Zagrebačka banka",
 "addr:street_address": "Dr. Franje Tuđmana 17",
 "addr:city": "Zadar", "addr:postcode": "23000", "addr:country": "HR",
 "phone": "+385 23 208 313",
 "brand": "Zagrebačka banka", "brand:wikidata": "Q140381",
 "nsi_id": "zagrebackabanka-6f3d3b"
}

2) Standalone ATM — Crikvenica (ref 1496)

{
 "ref": "1496", "amenity": "atm",
 "addr:street_address": "Trg S. Radića 1",
 "addr:city": "Crikvenica", "addr:postcode": "51260", "addr:country": "HR",
 "brand": "Zagrebačka banka", "brand:wikidata": "Q140381",
 "operator": "Zagrebačka banka", "operator:wikidata": "Q140381",
 "nsi_id": "zagrebackabanka-4d8c03"
}

 json stats

{
 "atp/brand/Zagreba\u010dka banka": 837,
 "atp/brand_wikidata/Q140381": 837,
 "atp/category/amenity/atm": 662,
 "atp/category/amenity/bank": 175,
 "atp/clean_strings/phone": 18,
 "atp/country/HR": 837,
 "atp/duplicate_count": 14526,
 "atp/field/branch/missing": 837,
 "atp/field/country/from_spider_name": 837,
 "atp/field/email/missing": 837,
 "atp/field/housenumber/missing": 837,
 "atp/field/name/missing": 662,
 "atp/field/opening_hours/missing": 670,
 "atp/field/operator/missing": 175,
 "atp/field/operator_wikidata/missing": 175,
 "atp/field/phone/invalid": 122,
 "atp/field/phone/missing": 671,
 "atp/field/state/missing": 837,
 "atp/field/street/missing": 837,
 "atp/field/twitter/missing": 837,
 "atp/field/unit/missing": 837,
 "atp/item_scraped_host_count/www.zaba.hr": 15363,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 837,
 "atp/operator/Zagreba\u010dka banka": 662,
 "atp/operator_wikidata/Q140381": 662,
 "downloader/request_bytes": 58541,
 "downloader/request_count": 68,
 "downloader/request_method_count/GET": 1,
 "downloader/request_method_count/POST": 67,
 "downloader/response_bytes": 1335340,
 "downloader/response_count": 68,
 "downloader/response_status_count/200": 67,
 "downloader/response_status_count/503": 1,
 "elapsed_time_seconds": 84.93799999996554,
 "finish_reason": "finished",
 "finish_time": "2026-06-16T07:41:23.591112+00:00",
 "httpcompression/response_bytes": 25399627,
 "httpcompression/response_count": 66,
 "item_dropped_count": 14526,
 "item_dropped_reasons_count/DropItem": 14526,
 "item_scraped_count": 837,
 "items_per_minute": 597.8571428571429,
 "response_received_count": 67,
 "responses_per_minute": 47.85714285714286,
 "retry/count": 1,
 "retry/reason_count/503 Service Unavailable": 1,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 67,
 "scheduler/dequeued/memory": 67,
 "scheduler/enqueued": 67,
 "scheduler/enqueued/memory": 67,
 "start_time": "2026-06-16T07:39:58.650672+00:00"
}

