### PR TITLE
[enseignement_premier_second_degre_fr] Fix licensing metadata

### DIFF
--- a/locations/licenses.py
+++ b/locations/licenses.py
@@ -26,6 +26,13 @@ class Licenses(Enum):
         "license:wikidata": "Q18199165",
         "attribution": "required",
     }
+    ETALAB2 = {
+        "license": "Etalab Open License 2.0",
+        "license:website": "https://www.etalab.gouv.fr/wp-content/uploads/2018/11/open-licence.pdf",
+        "license:wikidata": "Q80939351",
+        "attribution": "required",
+        "use:commercial": "permit",
+    }
     GB_OGLv3 = {
         "license": "Open Government Licence v3.0",
         "license:website": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/locations/spiders/government/enseignement_premier_second_degre_fr.py
+++ b/locations/spiders/government/enseignement_premier_second_degre_fr.py
@@ -4,6 +4,7 @@ from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.licenses import Licenses
 from locations.storefinders.opendatasoft_explore import OpendatasoftExploreSpider
 
 # https://www.data.gouv.fr/datasets/adresse-et-geolocalisation-des-etablissements-denseignement-des-premier-et-second-degres
@@ -47,13 +48,14 @@ NATURE_UAI_CATEGORY_MAP = {
 
 class EnseignementPremierSecondDegreFRSpider(OpendatasoftExploreSpider):
     name = "enseignement_premier_second_degre_fr"
-    dataset_attributes = OpendatasoftExploreSpider.dataset_attributes | {
-        "license": "Licence Ouverte / Open Licence version 2.0",
-        "license:website": "https://www.etalab.gouv.fr/licence-ouverte-open-licence/",
-        "license:wikidata": "Q29949417",
-        "attribution": "required",
-        "attribution:name": "Ministere de l'Education Nationale - data.education.gouv.fr",
-    }
+    dataset_attributes = (
+        OpendatasoftExploreSpider.dataset_attributes
+        | Licenses.ETALAB2.value
+        | {
+            "attribution:name": "Ministère de l’Éducation Nationale",
+            "attribution:website": "https://data.education.gouv.fr/",
+        }
+    )
     api_endpoint = "https://data.education.gouv.fr/api/explore/v2.1/"
     dataset_id = "fr-en-adresse-et-geolocalisation-etablissements-premier-et-second-degre"
 


### PR DESCRIPTION
Before this change, the licensing metadata was declared within the spider, with `license:wikidata` pointing to a [Stone setting in Södermanland, Sweden](https://www.wikidata.org/wiki/Q29949417).

After this change, the licensing metadata for this dataset is taken from `locations/licenses.py`. Also corrected French accents in the attribution string.
