### PR TITLE
[Colonial Parking US] Add spider (286 locations)

### DIFF
--- a/locations/spiders/colonial_parking_us.py
+++ b/locations/spiders/colonial_parking_us.py
@@ -1,0 +1,30 @@
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+
+class ColonialParkingUSSpider(Spider):
+    name = "colonial_parking_us"
+    item_attributes = {"brand": "Colonial Parking", "brand_wikidata": "Q121494114"}
+    start_urls = [
+        "https://www.ecolonial.com/wp-admin/admin-ajax.php?action=mapmarkers&ne_lat=90&ne_lng=180&sw_lat=-90&sw_lng=-180"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            apply_category(Categories.PARKING, item)
+            yield Request(
+                url=f'https://www.ecolonial.com/wp-admin/admin-ajax.php?action=facility&id={item["ref"]}',
+                callback=self.parse_location_details,
+                cb_kwargs={"item": item},
+            )
+
+    def parse_location_details(self, response: Response, item: Feature) -> Iterable[Feature]:
+        item["addr_full"] = response.xpath('//*[@class="adresse"]/span/text()').get()
+        yield item

--- a/locations/spiders/colonial_parking_us.py
+++ b/locations/spiders/colonial_parking_us.py
@@ -27,4 +27,5 @@ class ColonialParkingUSSpider(Spider):
 
     def parse_location_details(self, response: Response, item: Feature) -> Iterable[Feature]:
         item["addr_full"] = response.xpath('//*[@class="adresse"]/span/text()').get()
+        item["phone"] = response.xpath('//*[contains(text(), "Phone")]/following-sibling::span/text()').get()
         yield item

--- a/locations/spiders/colonial_parking_us.py
+++ b/locations/spiders/colonial_parking_us.py
@@ -5,6 +5,7 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.items import Feature
 
 
@@ -28,4 +29,15 @@ class ColonialParkingUSSpider(Spider):
     def parse_location_details(self, response: Response, item: Feature) -> Iterable[Feature]:
         item["addr_full"] = response.xpath('//*[@class="adresse"]/span/text()').get()
         item["phone"] = response.xpath('//*[contains(text(), "Phone")]/following-sibling::span/text()').get()
+        item["opening_hours"] = self.parse_opening_hours(response)
         yield item
+
+    def parse_opening_hours(self, response: Response) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for rule in (
+            response.xpath('//*[contains(@class, "openhours")]//p[@class="intend"]')
+            .xpath("normalize-space(.)")
+            .getall()
+        ):
+            opening_hours.add_ranges_from_string(rule.replace("from 12:00 AM to 12:00 AM", "from 12:00 AM to 11:59 PM"))
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/Colonial Parking': 286,
 'atp/brand_wikidata/Q121494114': 286,
 'atp/category/amenity/parking': 286,
 'atp/cdn/cloudflare/response_count': 288,
 'atp/cdn/cloudflare/response_status_count/200': 288,
 'atp/clean_strings/addr_full': 2,
 'atp/country/US': 286,
 'atp/field/branch/missing': 286,
 'atp/field/city/missing': 286,
 'atp/field/country/from_spider_name': 286,
 'atp/field/email/missing': 286,
 'atp/field/housenumber/missing': 286,
 'atp/field/opening_hours/missing': 7,
 'atp/field/phone/invalid': 10,
 'atp/field/phone/missing': 111,
 'atp/field/postcode/missing': 286,
 'atp/field/state/from_reverse_geocoding': 286,
 'atp/field/state/missing': 3,
 'atp/field/street/missing': 286,
 'atp/field/street_address/missing': 286,
 'atp/field/twitter/missing': 286,
 'atp/field/unit/missing': 286,
 'atp/item_scraped_host_count/www.ecolonial.com': 286,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 286,
 'atp/operator/Colonial Parking': 286,
 'atp/operator_wikidata/Q121494114': 286,
 'downloader/request_bytes': 155162,
 'downloader/request_count': 288,
 'downloader/request_method_count/GET': 288,
 'downloader/response_bytes': 1063669,
 'downloader/response_count': 288,
 'downloader/response_status_count/200': 288,
 'elapsed_time_seconds': 5.28099999999904,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 16, 12, 24, 56, 213468, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 288,
 'httpcompression/response_bytes': 3680763,
 'httpcompression/response_count': 288,
 'item_scraped_count': 286,
 'items_per_minute': 3432.0,
 'log_count/DEBUG': 575,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 288,
 'responses_per_minute': 3456.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 287,
 'scheduler/dequeued/memory': 287,
 'scheduler/enqueued': 287,
 'scheduler/enqueued/memory': 287,
 'start_time': datetime.datetime(2026, 6, 16, 12, 24, 50, 928735, tzinfo=datetime.timezone.utc)}


```