### PR TITLE
[Justpark GB] Add spider

### DIFF
--- a/locations/spiders/justpark_gb.py
+++ b/locations/spiders/justpark_gb.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class JustparkGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "justpark_gb"
+    item_attributes = {"brand": "JustPark", "brand_wikidata": "Q17143517"}
+    allowed_domains = ["justpark.com"]
+    sitemap_urls = ["https://www.justpark.com/sitemap.xml"]
+    sitemap_follow = ["uk_listings_"]
+    sitemap_rules = [("/uk/parking/", "parse_sd")]
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.PARKING, item)
+        yield item


### PR DESCRIPTION
Initially, tested an API-based spider using JustPark's internal GraphQL endpoint. While the GraphQL approach was incredibly fast (pulling over 20,000 locations in 17 minutes), the API returns severely truncated data. Most notably, the address field is returned as null.

Because data completeness is prioritized over raw crawling speed, I opted for a SitemapSpider approach instead.
Below is the stats when ran the spider with CLOSESPIDER_ITEMCOUNT=3000.

```
{'atp/brand/JustPark': 3016,
 'atp/brand_wikidata/Q17143517': 3016,
 'atp/category/amenity/parking': 3016,
 'atp/country/GB': 3016,
 'atp/field/branch/missing': 3016,
 'atp/field/email/missing': 3016,
 'atp/field/housenumber/missing': 3016,
 'atp/field/opening_hours/missing': 3016,
 'atp/field/operator/missing': 3016,
 'atp/field/operator_wikidata/missing': 3016,
 'atp/field/phone/missing': 3016,
 'atp/field/state/missing': 3016,
 'atp/field/street/missing': 3016,
 'atp/field/street_address/missing': 5,
 'atp/field/twitter/missing': 3016,
 'atp/field/unit/missing': 3016,
 'atp/item_scraped_host_count/www.justpark.com': 3016,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 3016,
 'downloader/request_bytes': 2964807,
 'downloader/request_count': 3174,
 'downloader/request_method_count/GET': 3174,
 'downloader/response_bytes': 190821401,
 'downloader/response_count': 3174,
 'downloader/response_status_count/200': 3171,
 'downloader/response_status_count/500': 2,
 'downloader/response_status_count/503': 1,
 'elapsed_time_seconds': 3884.219000000001,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2026, 6, 16, 15, 20, 58, 8341, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 809485430,
 'httpcompression/response_count': 3173,
 'item_scraped_count': 3016,
 'items_per_minute': 46.59114315139032,
 'log_count/DEBUG': 6190,
 'log_count/INFO': 913,
 'request_depth_max': 2,
 'response_received_count': 3171,
 'responses_per_minute': 48.985581874356335,
 'retry/count': 3,
 'retry/reason_count/500 Internal Server Error': 2,
 'retry/reason_count/503 Service Unavailable': 1,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3173,
 'scheduler/dequeued/memory': 3173,
 'scheduler/enqueued': 5529,
 'scheduler/enqueued/memory': 5529,
 'start_time': datetime.datetime(2026, 6, 16, 14, 16, 13, 797065, tzinfo=datetime.timezone.utc)}
```