### PR TITLE
[SDI Broker BG] Add spider; [Hobbyco AU] Add spider

### DIFF
--- a/locations/spiders/hobbyco_au.py
+++ b/locations/spiders/hobbyco_au.py
@@ -1,0 +1,66 @@
+import re
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class HobbycoAUSpider(Spider):
+    """Spider for Hobbyco hobby stores (Australia).
+    Closes #6546
+    """
+
+    name = "hobbyco_au"
+    item_attributes = {"brand": "Hobbyco", "brand_wikidata": "Q124003864"}
+    start_urls = ["https://www.hobbyco.com.au/pages/stores"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # The page embeds a JS FeatureCollection using single-quoted syntax.
+        # Extract the features array and convert to JSON-parseable form.
+        m = re.search(r"const stores\s*=\s*\{.*?'features'\s*:\s*(\[.*?\])\s*\}", response.text, re.DOTALL)
+        if not m:
+            return
+
+        # Convert single-quoted JS object to valid JSON
+        raw = m.group(1)
+        raw = re.sub(r"'([^']*)'", lambda mo: '"' + mo.group(1).replace('"', '\\"') + '"', raw)
+        raw = re.sub(r",\s*\}", "}", raw)
+        raw = re.sub(r",\s*\]", "]", raw)
+
+        import json
+
+        try:
+            features = json.loads(raw)
+        except json.JSONDecodeError:
+            self.logger.error("Failed to parse Hobbyco store JSON")
+            return
+
+        for feature in features:
+            props = feature.get("properties", {})
+            coords = feature.get("geometry", {}).get("coordinates", [])
+
+            item = Feature()
+            item["ref"] = props.get("email", "").split("@")[0] or props.get("address")
+            item["branch"] = props.get("address")
+            item["city"] = props.get("city")
+            item["postcode"] = props.get("postalCode")
+            item["country"] = "AU"
+            item["phone"] = props.get("phone") or None
+            item["email"] = props.get("email") or None
+            item["website"] = props.get("maps") or None
+            if len(coords) == 2:
+                item["lon"], item["lat"] = coords
+
+            if hours_raw := props.get("hours"):
+                oh = OpeningHours()
+                # Format: "Monday 10am - 6pm<br>Tuesday 10am - 6pm<br>..."
+                for line in re.split(r"<br\s*/?>", hours_raw, flags=re.IGNORECASE):
+                    oh.add_ranges_from_string(line.strip())
+                item["opening_hours"] = oh
+
+            apply_category(Categories.SHOP_TOYS, item)
+            yield item

--- a/locations/spiders/hobbyco_au.py
+++ b/locations/spiders/hobbyco_au.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Any, Iterable
 
@@ -20,26 +21,41 @@ class HobbycoAUSpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         # The page embeds a JS FeatureCollection using single-quoted syntax.
-        # Extract the features array and convert to JSON-parseable form.
-        m = re.search(r"const stores\s*=\s*\{.*?'features'\s*:\s*(\[.*?\])\s*\}", response.text, re.DOTALL)
-        if not m:
+        # Use brace-counting to extract the full object reliably.
+        idx = response.text.find("const stores =")
+        if idx < 0:
+            self.logger.error("Could not find 'const stores' in page")
             return
 
+        start = response.text.find("{", idx)
+        if start < 0:
+            return
+
+        depth = 0
+        end = start
+        for i, c in enumerate(response.text[start:], start):
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+
+        raw = response.text[start:end]
+
         # Convert single-quoted JS object to valid JSON
-        raw = m.group(1)
-        raw = re.sub(r"'([^']*)'", lambda mo: '"' + mo.group(1).replace('"', '\\"') + '"', raw)
+        raw = re.sub(r"'([^']*?)'", lambda mo: '"' + mo.group(1).replace('"', '\\"') + '"', raw)
         raw = re.sub(r",\s*\}", "}", raw)
         raw = re.sub(r",\s*\]", "]", raw)
 
-        import json
-
         try:
-            features = json.loads(raw)
-        except json.JSONDecodeError:
-            self.logger.error("Failed to parse Hobbyco store JSON")
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            self.logger.error("Failed to parse Hobbyco store JSON: %s", e)
             return
 
-        for feature in features:
+        for feature in data.get("features", []):
             props = feature.get("properties", {})
             coords = feature.get("geometry", {}).get("coordinates", [])
 
@@ -57,7 +73,6 @@ class HobbycoAUSpider(Spider):
 
             if hours_raw := props.get("hours"):
                 oh = OpeningHours()
-                # Format: "Monday 10am - 6pm<br>Tuesday 10am - 6pm<br>..."
                 for line in re.split(r"<br\s*/?>", hours_raw, flags=re.IGNORECASE):
                     oh.add_ranges_from_string(line.strip())
                 item["opening_hours"] = oh

--- a/locations/spiders/sdi_broker_bg.py
+++ b/locations/spiders/sdi_broker_bg.py
@@ -20,7 +20,7 @@ class SdiBrokerBGSpider(Spider):
     start_urls = ["https://www.sdi.bg/sitemap.xml"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for url in response.xpath("//url/loc/text()").getall():
+        for url in response.xpath("//url/loc/text() | //*[local-name()='loc']/text()").getall():
             if re.match(r"https://www\.sdi\.bg/offices/[a-z].*\.html$", url):
                 yield response.follow(url, callback=self.parse_city)
 

--- a/locations/spiders/sdi_broker_bg.py
+++ b/locations/spiders/sdi_broker_bg.py
@@ -1,0 +1,50 @@
+import json
+import re
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class SdiBrokerBGSpider(Spider):
+    """Spider for SDI Broker (Bulgaria) insurance offices.
+    Closes #5915
+    """
+
+    name = "sdi_broker_bg"
+    item_attributes = {"brand": "SDI Broker", "brand_wikidata": "Q65224484"}
+    start_urls = ["https://www.sdi.bg/sitemap.xml"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for url in response.xpath("//url/loc/text()").getall():
+            if re.match(r"https://www\.sdi\.bg/offices/[a-z].*\.html$", url):
+                yield response.follow(url, callback=self.parse_city)
+
+    def parse_city(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        m = re.search(r"var offices\s*=\s*(\[[\s\S]*?\]);", response.text)
+        if not m:
+            return
+        for office in json.loads(m.group(1)):
+            if office.get("office_status") != "2":
+                continue
+            item = Feature()
+            item["ref"] = office["office_id"]
+            item["branch"] = office.get("office_name", "").replace("Офис ", "").strip() or None
+            item["street_address"] = office.get("office_address")
+            item["lat"] = office.get("office_gps_lat")
+            item["lon"] = office.get("office_gps_lon")
+            item["phone"] = office.get("office_phones") or None
+            item["email"] = office.get("office_email") or None
+
+            # office_working_hours_rich is already in OSM opening_hours format
+            if hours_str := office.get("office_working_hours_rich", "").strip().strip('"'):
+                oh = OpeningHours()
+                oh.add_ranges_from_string(hours_str)
+                item["opening_hours"] = oh
+
+            apply_category(Categories.OFFICE_INSURANCE, item)
+            yield item


### PR DESCRIPTION
Two new spiders from the issue backlog.

**SDI Broker BG** (Closes #5915)
Bulgarian insurance broker with ~100+ offices. Data source: per-city HTML pages discovered via sitemap (e.g. `/offices/sofia.html`), each containing a `var offices = [...]` JSON array. Fields parsed: ref, branch name, street address, coordinates, phone, email, opening hours (`office_working_hours_rich` is already in OSM format). Filters out non-active offices (`office_status != 2`). Category: `office=insurance`.

**Hobbyco AU** (Closes #6546)
Australian hobby store chain with 6 locations. Data source: GeoJSON FeatureCollection embedded as a JS object in the `/pages/stores` Shopify page. Fields parsed: branch, city, postcode, coordinates, phone, email, opening hours (HTML day/time strings). Category: `shop=toys`.