### PR TITLE
[Privredna banka Zagreb HR] Add spider (791 locations)

### DIFF
--- a/locations/spiders/privredna_banka_zagreb_hr.py
+++ b/locations/spiders/privredna_banka_zagreb_hr.py
@@ -1,0 +1,63 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+
+class PrivrednaBankaZagrebHRSpider(Spider):
+    name = "privredna_banka_zagreb_hr"
+    item_attributes = {"brand": "Privredna banka Zagreb", "brand_wikidata": "Q7246343"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for location_type in ["BRANCH", "ATM"]:
+            yield JsonRequest(
+                url=(
+                    "https://www.pbz.hr/digitalServicesServlet/?operation=fetchMarkers&headers=lbsHeader"
+                    "&endpointName=fetchMarkers&bank=PBZ&locale=en"
+                ),
+                data={"locationType": location_type},
+                cb_kwargs={"location_type": location_type},
+            )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for location in response.json().get("locationDetails", []):
+            item = self.parse_location(location)
+
+            if location_type == "BRANCH":
+                apply_category(Categories.BANK, item)
+            elif location_type == "ATM":
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item
+
+    def parse_location(self, location: dict[str, Any]) -> Feature:
+        item = DictParser.parse(location)
+
+        if position := location.get("locationPosition", {}):
+            item["lat"] = position.get("lat")
+            item["lon"] = position.get("lon")
+
+        if branch := item.pop("name", None):
+            item["branch"] = re.sub(
+                r"\s+\([^)]*\)$", "", branch.removeprefix("PBZ ").removeprefix("POSLOVNICA ")
+            ).strip()
+
+        # PBZ provides address parts only as a flat fullAddress string.
+        if match := re.match(
+            r"(?P<street_address>.+)\s+(?P<postcode>\d{5})\s+(?P<city>.+?)(?:\s+Hrvatska)?\s*$",
+            location.get("fullAddress", ""),
+            flags=re.IGNORECASE,
+        ):
+            item["street_address"] = match.group("street_address")
+            item["postcode"] = match.group("postcode")
+            item["city"] = match.group("city")
+
+        return item


### PR DESCRIPTION
Data source:
https://www.pbz.hr/gradjani/poslovnice-i-bankomati.html

The spider uses the PBZ marker API:
https://www.pbz.hr/digitalServicesServlet/?operation=fetchMarkers&headers=lbsHeader&endpointName=fetchMarkers&bank=PBZ&locale=en

Category mapping:
- `BRANCH` -> `Categories.BANK`
- `ATM` -> `Categories.ATM`

Stats summary:
- 791 total items
- 134 banks
- 657 ATMs
- NSI: 791 `cc_match`
- Country derived from spider name: 791

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "0714000",
      "amenity": "bank",
      "addr:street_address": "PALINOVEČKA 19B",
      "addr:city": "ZAGREB",
      "addr:postcode": "10000",
      "addr:country": "HR",
      "name": "Privredna banka Zagreb",
      "branch": "140 VRBANI III",
      "brand": "Privredna banka Zagreb",
      "brand:wikidata": "Q7246343"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [15.91378480196, 45.790504791872]
    }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "0780153",
      "amenity": "atm",
      "addr:street_address": "Ilica 335",
      "addr:city": "ZAGREB",
      "addr:postcode": "10000",
      "addr:country": "HR",
      "branch": "MUP",
      "brand": "Privredna banka Zagreb",
      "brand:wikidata": "Q7246343",
      "operator": "Privredna banka Zagreb",
      "operator:wikidata": "Q7246343"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [15.92265321, 45.81240957]
    }
  }
]
```

Notes:
The API provides ATMs as separate records, so the spider yields both branch and ATM records directly. Two ATM source addresses lack a normal five-digit postcode, so those fields are left unforced rather than guessed.

```json
{
 "atp/brand/Privredna banka Zagreb": 791,
 "atp/brand_wikidata/Q7246343": 791,
 "atp/category/amenity/atm": 657,
 "atp/category/amenity/bank": 134,
 "atp/clean_strings/addr_full": 791,
 "atp/country/HR": 791,
 "atp/field/city/missing": 2,
 "atp/field/country/from_spider_name": 791,
 "atp/field/email/missing": 791,
 "atp/field/housenumber/missing": 791,
 "atp/field/name/missing": 657,
 "atp/field/opening_hours/missing": 791,
 "atp/field/operator/missing": 134,
 "atp/field/operator_wikidata/missing": 134,
 "atp/field/phone/missing": 791,
 "atp/field/postcode/missing": 2,
 "atp/field/state/missing": 791,
 "atp/field/street/missing": 791,
 "atp/field/street_address/missing": 2,
 "atp/field/twitter/missing": 791,
 "atp/field/unit/missing": 791,
 "atp/item_scraped_host_count/www.pbz.hr": 791,
 "atp/lineage": "S_?",
 "atp/nsi/cc_match": 791,
 "atp/operator/Privredna banka Zagreb": 657,
 "atp/operator_wikidata/Q7246343": 657,
 "downloader/request_bytes": 1743,
 "downloader/request_count": 3,
 "downloader/request_method_count/GET": 1,
 "downloader/request_method_count/POST": 2,
 "downloader/response_bytes": 37847,
 "downloader/response_count": 3,
 "downloader/response_status_count/200": 3,
 "elapsed_time_seconds": 7.51600000000326,
 "finish_reason": "finished",
 "finish_time": "2026-06-16T15:52:20.857175+00:00",
 "httpcompression/response_bytes": 288585,
 "httpcompression/response_count": 2,
 "item_scraped_count": 791,
 "items_per_minute": 6780.0,
 "response_received_count": 3,
 "responses_per_minute": 25.714285714285715,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2026-06-16T15:52:13.342456+00:00"
}