### PR TITLE
[Commerzbank DE] Emit ATM instead of BANK for self-service-only locations

### DIFF
--- a/locations/spiders/commerzbank_de.py
+++ b/locations/spiders/commerzbank_de.py
@@ -105,7 +105,13 @@ class CommerzbankDESpider(CrawlSpider):
 
                 properties["opening_hours"] = self.parse_hours(branch)
 
-                apply_category(Categories.BANK, properties)
-                apply_yes_no(Extras.ATM, properties, bool(branch.get("geldautomat")))
+                # Locations with orgTyp="SB" (Selbstbedienung / self-service) and
+                # no cashier (kasse=False) are standalone ATM kiosks, not branches.
+                is_atm_only = branch.get("orgTyp") == "SB" or not branch.get("kasse")
+                if is_atm_only:
+                    apply_category(Categories.ATM, properties)
+                else:
+                    apply_category(Categories.BANK, properties)
+                    apply_yes_no(Extras.ATM, properties, bool(branch.get("geldautomat")))
 
                 yield Feature(**properties)


### PR DESCRIPTION
Fixes #7600.

Standalone Commerzbank ATM kiosks (SB-Standorte) were being emitted as `amenity=bank`, which is incorrect — they have no teller, no cashier, and are self-service only.

The API data includes `orgTyp` (e.g. `"SB"` for Selbstbedienung) and `kasse` (boolean, whether a cashier is present). Locations where `orgTyp == "SB"` or `kasse == False` are now emitted as `amenity=atm`. Full branches with cashier services continue to emit `amenity=bank` with `atm=yes/no` as before.

Closes #7600