### PR TITLE
[ZG Raiffeisen DE] Add spider

### DIFF
--- a/locations/spiders/zg_raiffeisen_de.py
+++ b/locations/spiders/zg_raiffeisen_de.py
@@ -1,0 +1,16 @@
+from locations.categories import Categories, apply_category
+from locations.storefinders.uberall import UberallSpider
+
+
+class ZgRaiffeisenDESpider(UberallSpider):
+    """Spider for ZG Raiffeisen agrarian stores (Germany).
+    Closes #7034
+    """
+
+    name = "zg_raiffeisen_de"
+    item_attributes = {"brand": "ZG Raiffeisen", "brand_wikidata": "Q136135"}
+    key = "ooHwNN7SQvTWSMqR5bn1F1G0aGuTSu"
+
+    def post_process_item(self, item, response, location):
+        apply_category(Categories.SHOP_AGRARIAN, item)
+        yield item


### PR DESCRIPTION
Adds spider for ZG Raiffeisen agrarian cooperative stores in Germany (198 locations).

Data source: Uberall storefinder API, key extracted from `data-key` attribute of the store finder widget on `https://www.zg-raiffeisen.de/standorte`.

Category: `shop=agrarian`.

Closes #7034