### PR TITLE
[V-Markt DE, Vomar NL] Add spiders

### DIFF
--- a/locations/spiders/v_markt_de.py
+++ b/locations/spiders/v_markt_de.py
@@ -1,0 +1,93 @@
+import re
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class VMarktDESpider(Spider):
+    """Spider for V-Markt supermarkets in Germany.
+    Closes #9084
+    """
+
+    name = "v_markt_de"
+    item_attributes = {"brand": "V-Markt", "brand_wikidata": "Q2523915"}
+    start_urls = ["https://www.v-markt.de/standorte_vmarkt"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # Each store has a tab block keyed by data-id.
+        # Extract all blocks between consecutive data-id attributes.
+        blocks = re.findall(
+            r'data-id="(\d+)"[^>]*>(.*?)(?=data-id="\d+"|$)',
+            response.text,
+            re.DOTALL,
+        )
+        # Build a map of data-id -> coords from the Google Maps direction links
+        coords_map = {
+            m.group(1): (m.group(2), m.group(3))
+            for m in re.finditer(
+                r'data-id="(\d+)".*?destination=\(([0-9.-]+),\s*([0-9.-]+)\)',
+                response.text,
+                re.DOTALL,
+            )
+        }
+        # Build a map of data-id -> store name from tab-label divs
+        names_map = {
+            m.group(1): m.group(2).strip()
+            for m in re.finditer(
+                r'<div class="tab-label"[^>]*data-id="(\d+)"[^>]*>(.*?)</div>',
+                response.text,
+            )
+        }
+
+        seen = set()
+        for store_id, content in blocks:
+            if store_id in seen:
+                continue
+            seen.add(store_id)
+
+            name = names_map.get(store_id, "")
+            if not name:
+                continue
+
+            # Extract address paragraph (first <p>): "Street\nPostcode City"
+            paras = [re.sub(r"<[^>]+>", "", p).strip() for p in re.findall(r"<p[^>]*>(.*?)</p>", content, re.DOTALL)]
+
+            street_address = None
+            city = None
+            postcode = None
+            phone = None
+
+            for para in paras:
+                if not para:
+                    continue
+                # Phone paragraph starts with "Telefon:"
+                phone_m = re.match(r"Telefon:\s*(.+)", para)
+                if phone_m:
+                    phone = phone_m.group(1).strip()
+                    continue
+                # Address paragraph: "Street\nPostcode City"
+                addr_m = re.match(r"(.+)\n(\d{5})\s+(.+)", para, re.DOTALL)
+                if addr_m:
+                    street_address = addr_m.group(1).strip()
+                    postcode = addr_m.group(2)
+                    city = addr_m.group(3).strip()
+
+            item = Feature()
+            item["ref"] = store_id
+            # Strip brand prefix from name to get branch name
+            item["branch"] = re.sub(r"^V-Markt\s*", "", name).strip() or None
+            item["street_address"] = street_address
+            item["city"] = city
+            item["postcode"] = postcode
+            item["country"] = "DE"
+            item["phone"] = phone
+
+            if store_id in coords_map:
+                item["lat"], item["lon"] = coords_map[store_id]
+
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+            yield item

--- a/locations/spiders/vomar_nl.py
+++ b/locations/spiders/vomar_nl.py
@@ -1,0 +1,44 @@
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class VomarNLSpider(SitemapSpider):
+    """Spider for Vomar supermarkets in the Netherlands.
+    Closes #9086
+    """
+
+    name = "vomar_nl"
+    item_attributes = {"brand": "Vomar", "brand_wikidata": "Q2410271"}
+    sitemap_urls = ["https://www.vomar.nl/sitemap.xml"]
+    sitemap_rules = [(r"https://www\.vomar\.nl/winkels/vomar-[^/]+\.htm$", "parse_store")]
+
+    def parse_store(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # Store data is embedded in the window.__NUXT__ blob as alias->value pairs.
+        data: dict[str, str] = {}
+        for m in re.finditer(r'alias:"([^"]+)"[^}]*value:"([^"]+)"', response.text):
+            data[m.group(1)] = m.group(2)
+
+        lat = data.get("latitude")
+        lon = data.get("longitude")
+        if not lat or not lon:
+            return
+
+        item = Feature()
+        item["ref"] = data.get("shop_nr") or response.url.split("/")[-1].replace(".htm", "")
+        item["street_address"] = data.get("street_and_number")
+        item["postcode"] = data.get("zipcode")
+        item["city"] = data.get("city")
+        item["country"] = "NL"
+        item["phone"] = data.get("telephone") or None
+        item["lat"] = lat
+        item["lon"] = lon
+        item["website"] = response.url
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item


### PR DESCRIPTION
## V-Markt DE (`v_markt_de`)

German supermarket chain with 39 stores, all in Bavaria and surrounding region.

**Data source**: All stores are listed on a single page (https://www.v-markt.de/standorte_vmarkt) with coordinates embedded as Google Maps direction URL `destination=(lat, lon)` parameters and store details in accordion blocks keyed by `data-id`.

**Fields**: ref (data-id), branch (store name without brand prefix), street_address, postcode, city, phone, lat/lon.

## Vomar NL (`vomar_nl`)

Dutch supermarket chain with ~102 stores in Noord-Holland, Utrecht and surrounding provinces.

**Data source**: Sitemap at https://www.vomar.nl/sitemap.xml lists individual store pages. Each page contains a `window.__NUXT__` SSR blob with store data encoded as `alias/value` pairs (shop_nr, street_and_number, zipcode, city, telephone, latitude, longitude).

**Fields**: ref (shop_nr), street_address, postcode, city, phone, lat/lon. Pages without latitude data (empty/placeholder stores) are skipped.

Closes #9084
Closes #9086