### PR TITLE
[Dr. Max] Remove generic brand email

### DIFF
--- a/locations/spiders/dr_max.py
+++ b/locations/spiders/dr_max.py
@@ -43,7 +43,7 @@ class DrMaxSpider(Spider):
             item["street_address"] = item.pop("street")
             item.pop("name")
             item["phone"] = "; ".join([n["number"] for n in location["phoneNumbers"]])
-            item["email"] = location.get("additionalParams").get("email")
+            item.pop("email", None)  # generic brand email, not location-specific
             item["image"] = location["pharmacyImage"]
             item["country"] = country = response.meta["country"]
             service_ids = [service["serviceId"] for service in location["services"]]


### PR DESCRIPTION
The source API returns `drmax@drmax.sk` for every pharmacy — the same address across all ~435 stores. Pop it rather than setting it.\n\nCloses #10951