### PR TITLE
[Dominos Pizza BH] Pop duplicate addr:state

### DIFF
--- a/locations/spiders/dominos_pizza_bh.py
+++ b/locations/spiders/dominos_pizza_bh.py
@@ -16,4 +16,7 @@ class DominosPizzaBHSpider(DominosPizzaInternationalSpider):
                 item["addr_full"] = location["LocationInfo"]
         if branch_ar := item["extras"].get("branch:ar"):
             item["branch"] = branch_ar
+        # Bahrain has no states; DictParser maps the country code into state — drop it
+        if item.get("state") == item.get("country"):
+            item["state"] = None
         yield item


### PR DESCRIPTION
Bahrain has no administrative states; `DictParser` maps the country code into `addr:state` resulting in `addr:state = addr:country = BH`. Pop `state` when it equals `country`.\n\nCloses #11160