### PR TITLE
[Credit Union US] Drop spurious state for overseas locations

### DIFF
--- a/locations/spiders/credit_union_us.py
+++ b/locations/spiders/credit_union_us.py
@@ -27,6 +27,9 @@ class CreditUnionUSSpider(CSVFeedSpider):
         item = DictParser.parse(row)
         item["country"] = item["country"].strip()
         item["street_address"] = item.pop("addr_full")
+        # For overseas locations the State column is a query artefact, not a real state
+        if item.get("country") != "US":
+            item["state"] = None
 
         item["opening_hours"] = OpeningHours()
         for day in DAYS_3_LETTERS:


### PR DESCRIPTION
The spider queries by US state code (e.g. `state=DE` for Delaware), but some returned rows are US military bases physically in Germany etc. The `State` column for these is the query parameter, not a real US state. Pop `state` when `country != US`.\n\nCloses #11185