### PR TITLE
[Vancouver Coastal Health CA] Filter generic placeholder images

### DIFF
--- a/locations/spiders/vancouver_coastal_health_ca.py
+++ b/locations/spiders/vancouver_coastal_health_ca.py
@@ -37,7 +37,10 @@ class VancouverCoastalHealthCASpider(Spider):
             location["url"] = f'https://www.vch.ca{location["url"]}'
 
             item = DictParser.parse(location)
-            item["image"] = location["image"]
+            if img := location.get("image"):
+                # Filter generic placeholder images that appear on most locations
+                if "Mountains_pattern" not in img and "VCH_pattern" not in img:
+                    item["image"] = img
 
             if cat := self.CATEGORIES.get(location["type"]["id"]):
                 apply_category(cat, item)


### PR DESCRIPTION
Two generic VCH pattern images appear on 107+22 out of 234 locations. Skip known placeholder URL substrings; only emit per-location photos.\n\nCloses #10952