### PR TITLE
[CEF GB] Drop generic image

### DIFF
--- a/locations/spiders/cef_gb.py
+++ b/locations/spiders/cef_gb.py
@@ -18,5 +18,6 @@ class CefGBSpider(CrawlSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data):
         item["lat"], item["lon"] = url_to_coords(ld_data["hasmap"])
+        item.pop("image", None)  # Generic branch icon, not per-location
 
         yield item


### PR DESCRIPTION
397/397 stores had the same generic branch icon. Pop the image field since it is not per-location.\n\nCloses #10952