### PR TITLE
[Skoringen DK/NO] Drop generic image

### DIFF
--- a/locations/spiders/skoringen_dk_no.py
+++ b/locations/spiders/skoringen_dk_no.py
@@ -17,4 +17,5 @@ class SkoringenDKNOSpider(SitemapSpider, StructuredDataSpider):
         apply_category(Categories.SHOP_SHOES, item)
         extract_google_position(item, response)
         item.pop("opening_hours")
+        item.pop("image", None)  # Generic placeholder image, not per-location
         yield item


### PR DESCRIPTION
151/158 stores had the same placeholder image. Pop the image field since it is not per-location.\n\nCloses #10952