### PR TITLE
[DHL Express US/CA] Drop generic image

### DIFF
--- a/locations/spiders/dhl_express_us_ca.py
+++ b/locations/spiders/dhl_express_us_ca.py
@@ -20,4 +20,5 @@ class DhlExpressUSCASpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data):
         item["country"] = re.findall(r"\.ca|\.us", response.url)[0][1:].upper()
         apply_category(Categories.POST_OFFICE, item)
+        item.pop("image", None)  # Generic brand icon, not per-location
         yield item


### PR DESCRIPTION
317/318 stores had the same generic brand icon. Pop the image field since it is not per-location.\n\nCloses #10952