### PR TITLE
[Skyline Chili] Drop generic image

### DIFF
--- a/locations/spiders/skyline_chili.py
+++ b/locations/spiders/skyline_chili.py
@@ -12,3 +12,7 @@ class SkylineChiliSpider(SitemapSpider, StructuredDataSpider):
     }
 
     sitemap_urls = ["https://locations.skylinechili.com/sitemap.xml"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image", None)  # Generic brand image, not per-location
+        yield item


### PR DESCRIPTION
161/161 stores had the same generic brand image. Pop the image field since it is not per-location.\n\nCloses #10952