### PR TITLE
[Depil Tech] Drop generic image

### DIFF
--- a/locations/spiders/depil_tech.py
+++ b/locations/spiders/depil_tech.py
@@ -10,3 +10,7 @@ class DepilTechSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.depiltech.com/sitemap.xml"]
     sitemap_rules = [(r"/fr/[\w-]+/[\w-]+/\d+", "parse_sd")]
     wanted_types = ["HealthAndBeautyBusiness"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image", None)  # Generic brand image, not per-location
+        yield item


### PR DESCRIPTION
12/12 stores had the same generic image. Pop the image field since it is not per-location.\n\nCloses #10952