### PR TITLE
[Paul BE] Drop generic image

### DIFF
--- a/locations/spiders/paul_be.py
+++ b/locations/spiders/paul_be.py
@@ -27,7 +27,6 @@ class PaulBESpider(Spider):
             item["postcode"] = location.xpath('.//span[@class="postal-code"]/text()').get()
             item["country"] = location.xpath('.//span[@class="country"]/text()').get()
 
-            item["image"] = "https://www.paul-belgium.be/" + response.xpath('.//div[@itemprop="image"]/img/@src').get()
             item["phone"] = location.xpath('.//a[contains(@href, "tel:")]/@href').get()
 
             item["opening_hours"] = OpeningHours()


### PR DESCRIPTION
22/22 stores had the same generic image. Pop the image field since it is not per-location.\n\nCloses #10952