### PR TITLE
[Academy US] Drop generic image

### DIFF
--- a/locations/spiders/academy_us.py
+++ b/locations/spiders/academy_us.py
@@ -10,3 +10,7 @@ class AcademyUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_follow = ["storelocator"]
     sitemap_rules = [(r"/store-\d+$", "parse_sd")]
     wanted_types = ["SportingGoodsStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image", None)  # Generic Yext CDN thumbnails, not per-location
+        yield item


### PR DESCRIPTION
333 of 333 stores had only 2 distinct Yext CDN thumbnails. Filter or pop the image field.\n\nCloses #10952