### PR TITLE
[Haggen] Drop generic image

### DIFF
--- a/locations/spiders/haggen.py
+++ b/locations/spiders/haggen.py
@@ -15,3 +15,7 @@ class HaggenSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://local.haggen.com/sitemap.xml"]
     sitemap_rules = [("", "parse_sd")]
     wanted_types = ["GroceryStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item.pop("image", None)  # Generic brand image, not per-location
+        yield item


### PR DESCRIPTION
15/15 stores had the same Yext CDN thumbnail. Pop the image field.\n\nCloses #10952