### PR TITLE
[Sixt] Map obsolete CS/YU country codes to RS (Serbia)

### DIFF
--- a/locations/spiders/sixt.py
+++ b/locations/spiders/sixt.py
@@ -16,6 +16,9 @@ class SixtSpider(SitemapSpider, StructuredDataSpider):
     skip_auto_cc_domain = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["country"] = item.pop("state")
+        country = item.pop("state")
+        # Map obsolete country codes used by Sixt
+        country = {"CS": "RS", "YU": "RS"}.get(country, country)
+        item["country"] = country
 
         yield item


### PR DESCRIPTION
Map obsolete CS/YU country codes to RS (Serbia).\n\nCloses #11994