### PR TITLE
[Pandora] Fix website URL construction for empty/http indy_url

### DIFF
--- a/locations/spiders/pandora.py
+++ b/locations/spiders/pandora.py
@@ -29,6 +29,10 @@ class PandoraSpider(RioSeoSpider):
             postcode = None  # Placeholder like "0000" or "00000"
         feature["postcode"] = postcode
         feature["country"] = feature["ref"][:2].upper()
-        feature["website"] = "https:" + location["indy_url"]
+        if indy_url := location.get("indy_url"):
+            if indy_url.startswith("//"):
+                indy_url = "https:" + indy_url
+            if indy_url.startswith("http"):
+                feature["website"] = indy_url
         feature["branch"] = feature.pop("name").removeprefix("Pandora ").removeprefix("Store ").removeprefix("@ ")
         yield feature


### PR DESCRIPTION
The `indy_url` field in the RioSeo API can be empty or already start with `http://`. The previous code unconditionally prepended `"https:"`, which produced invalid URLs like `"https:"` (empty) or `"https:http://..."`.

Fix: only set `website` when `indy_url` is non-empty; prepend `https:` only for protocol-relative `//` URLs; pass through already-absolute `http://` or `https://` URLs as-is.

Spotted as a pre-existing issue noted during review of #16801.