### PR TITLE
[Mazda] Add spiders for EE, LV, FI, GR, MT, ME, MK, MD

### DIFF
--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -84,6 +84,7 @@ COUNTRYCODE_COMPONENTS = {
     "LU",
     "LV",
     "MA",
+    "MD",
     "ME",
     "MK",
     "MN",

--- a/locations/spiders/mazda_ee.py
+++ b/locations/spiders/mazda_ee.py
@@ -1,0 +1,7 @@
+from locations.spiders.mazda_fi import MazdaFISpider
+
+
+class MazdaEESpider(MazdaFISpider):
+    name = "mazda_ee"
+    start_urls = ["https://www.mazda.ee/edasimuujad"]
+    country = "EE"

--- a/locations/spiders/mazda_fi.py
+++ b/locations/spiders/mazda_fi.py
@@ -1,0 +1,77 @@
+import html
+import json
+import re
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+from locations.spiders.mazda_jp import MAZDA_SHARED_ATTRIBUTES
+
+
+class MazdaFISpider(Spider):
+    """Base spider for Mazda dealer finders using embedded JSON in a data-dealers attribute."""
+
+    name = "mazda_fi"
+    item_attributes = MAZDA_SHARED_ATTRIBUTES
+    start_urls = ["https://www.mazda.fi/jalleenmyyjat"]
+    country = "FI"
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        raw = response.xpath('//*[@id="find-dealer-app"]/@data-dealers').get()
+        if not raw:
+            return
+        dealers = json.loads(html.unescape(raw))
+        for dealer in dealers:
+            services = dealer.get("dealerServices", [])
+            base = {
+                "branch": dealer["title"],
+                "lat": dealer.get("latitude"),
+                "lon": dealer.get("longitude"),
+                "street_address": merge_address_lines([dealer.get("address1"), dealer.get("address2")]),
+                "phone": self._clean_phone(dealer.get("phone")),
+                "email": self._clean_email(dealer.get("email")),
+                "website": (dealer.get("rightLink") or {}).get("url") or None,
+                "country": self.country,
+            }
+            if not base["phone"]:
+                base.pop("phone", None)
+            if not base["email"]:
+                base.pop("email", None)
+            if not base["website"] or base["website"].startswith("mailto:"):
+                base.pop("website", None)
+            ref_base = str(dealer["id"])
+            if "Sales" in services:
+                item = Feature(**base)
+                item["ref"] = ref_base + "_Sales"
+                apply_category(Categories.SHOP_CAR, item)
+                yield item
+            if "Service" in services or "Parts" in services:
+                item = Feature(**base)
+                item["ref"] = ref_base + "_Service"
+                apply_category(Categories.SHOP_CAR_REPAIR, item)
+                yield item
+            if not services:
+                item = Feature(**base)
+                item["ref"] = ref_base
+                yield item
+
+    def _clean_phone(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        # Some entries have multiple phone numbers separated by ; or newlines
+        # Return just the first one
+        first = re.split(r"[;\t\n]", value)[0].strip()
+        # Strip any label prefix like "Automyynti puhelin: "
+        first = re.sub(r"^[^:+0-9]*:", "", first).strip()
+        return first or None
+
+    def _clean_email(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        # Some entries have multiple emails - return just the first valid one
+        m = re.search(r"[\w.+-]+@[\w.-]+\.\w+", value)
+        return m.group(0) if m else None

--- a/locations/spiders/mazda_gr.py
+++ b/locations/spiders/mazda_gr.py
@@ -1,0 +1,59 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.spiders.mazda_jp import MAZDA_SHARED_ATTRIBUTES
+
+
+class MazdaGRSpider(Spider):
+    """Base spider for Mazda dealer finders using the DNN 2sxc API."""
+
+    name = "mazda_gr"
+    item_attributes = MAZDA_SHARED_ATTRIBUTES
+
+    # Subclasses must set these:
+    api_url: str = "https://www.mazda.gr/api/2sxc/app/auto/query/DealerListByPortalAlias/Default"
+    module_id: str = "22432"
+    tab_id: str = "1527"
+    country: str = "GR"
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(
+            url=self.api_url,
+            headers={
+                "ModuleId": self.module_id,
+                "ContentBlockId": self.module_id,
+                "TabId": self.tab_id,
+                "PageId": self.tab_id,
+            },
+        )
+
+    def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
+        for dealer in response.json().get("Default", []):
+            if dealer.get("HasSales"):
+                item = self._make_item(dealer)
+                item["ref"] = str(dealer["Id"]) + "_Sales"
+                apply_category(Categories.SHOP_CAR, item)
+                yield item
+            if dealer.get("HasRepair"):
+                item = self._make_item(dealer)
+                item["ref"] = str(dealer["Id"]) + "_Service"
+                apply_category(Categories.SHOP_CAR_REPAIR, item)
+                yield item
+            if not dealer.get("HasSales") and not dealer.get("HasRepair"):
+                item = self._make_item(dealer)
+                item["ref"] = str(dealer["Id"])
+                yield item
+
+    def _make_item(self, dealer: dict) -> Feature:
+        item = Feature()
+        item["branch"] = dealer.get("Title")
+        item["lat"] = dealer.get("Latitude")
+        item["lon"] = dealer.get("Longitude")
+        item["addr_full"] = dealer.get("Address")
+        item["website"] = dealer.get("Website") or None
+        item["country"] = self.country
+        return item

--- a/locations/spiders/mazda_lv.py
+++ b/locations/spiders/mazda_lv.py
@@ -1,0 +1,7 @@
+from locations.spiders.mazda_fi import MazdaFISpider
+
+
+class MazdaLVSpider(MazdaFISpider):
+    name = "mazda_lv"
+    start_urls = ["https://www.mazda.lv/atrast-parstavi"]
+    country = "LV"

--- a/locations/spiders/mazda_md.py
+++ b/locations/spiders/mazda_md.py
@@ -1,0 +1,9 @@
+from locations.spiders.mazda_gr import MazdaGRSpider
+
+
+class MazdaMDSpider(MazdaGRSpider):
+    name = "mazda_md"
+    api_url = "https://www.mazda.md/api/2sxc/app/auto/query/DealerListByPortalAlias/Default"
+    module_id = "22362"
+    tab_id = "1421"
+    country = "MD"

--- a/locations/spiders/mazda_me.py
+++ b/locations/spiders/mazda_me.py
@@ -1,0 +1,9 @@
+from locations.spiders.mazda_gr import MazdaGRSpider
+
+
+class MazdaMESpider(MazdaGRSpider):
+    name = "mazda_me"
+    api_url = "https://www.mazda.co.me/api/2sxc/app/auto/query/DealerListByPortalAlias/Default"
+    module_id = "2702"
+    tab_id = "1258"
+    country = "ME"

--- a/locations/spiders/mazda_mk.py
+++ b/locations/spiders/mazda_mk.py
@@ -1,0 +1,9 @@
+from locations.spiders.mazda_gr import MazdaGRSpider
+
+
+class MazdaMKSpider(MazdaGRSpider):
+    name = "mazda_mk"
+    api_url = "https://www.mazda.mk/api/2sxc/app/auto/query/DealerListByPortalAlias/Default"
+    module_id = "22416"
+    tab_id = "2406"
+    country = "MK"

--- a/locations/spiders/mazda_mt.py
+++ b/locations/spiders/mazda_mt.py
@@ -1,0 +1,9 @@
+from locations.spiders.mazda_gr import MazdaGRSpider
+
+
+class MazdaMTSpider(MazdaGRSpider):
+    name = "mazda_mt"
+    api_url = "https://www.mazda.com.mt/api/2sxc/app/auto/query/DealerListByPortalAlias/Default"
+    module_id = "10025"
+    tab_id = "2559"
+    country = "MT"


### PR DESCRIPTION
Adds 8 new Mazda dealer spiders for small European countries that were missing coverage.

**Two base spiders** handle the two different data sources:
- `mazda_fi` — reads embedded JSON from a `data-dealers` attribute on the dealer-finder page, shared by EE/LV/FI
- `mazda_gr` — hits a DNN 2sxc API with country-specific module ID headers, shared by GR/MT/ME/MK/MD

**Country subclasses:**
| Spider | Country | Items |
|--------|---------|-------|
| `mazda_fi` | Finland | 45 |
| `mazda_ee` | Estonia | 6 |
| `mazda_lv` | Latvia | 4 |
| `mazda_gr` | Greece | 25 |
| `mazda_mt` | Malta | 3 |
| `mazda_me` | Montenegro | 2 |
| `mazda_mk` | North Macedonia | 2 |
| `mazda_md` | Moldova | 2 |

Each dealer yields both a Sales (`shop=car`) and Service (`shop=car_repair`) item where applicable.

Also adds `MD` to the known country-code components in the naming consistency check.

Closes #13784
Closes #13785
Closes #13786
Closes #13787
Closes #13788
Closes #13789
Closes #13790
Closes #13791