### PR TITLE
[Enterprise] Remove int1 staging server - only use prd production server

### DIFF
--- a/locations/spiders/enterprise.py
+++ b/locations/spiders/enterprise.py
@@ -12,20 +12,15 @@ from locations.pipelines.address_clean_up import clean_address
 class EnterpriseSpider(Spider):
     name = "enterprise"
     item_attributes = {"brand": "Enterprise", "brand_wikidata": "Q17085454"}
-    allowed_domains = ["prd.location.enterprise.com", "int1.location.enterprise.com"]
+    allowed_domains = ["prd.location.enterprise.com"]
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         gc = geonamescache.GeonamesCache()
         countries = gc.get_countries()
         for country_code in countries.keys():
-            # It appears that countries are sharded between two
-            # servers. Other servers are int2, xqa1, xqa2, xqa3
-            # but search of these servers reveals no additional
-            # locations on top of just prd and int1.
-            for subdomain in ["prd", "int1"]:
-                yield JsonRequest(
-                    url=f"https://{subdomain}.location.enterprise.com/enterprise-sls/search/location/enterprise/web/country/{country_code}"
-                )
+            yield JsonRequest(
+                url=f"https://prd.location.enterprise.com/enterprise-sls/search/location/enterprise/web/country/{country_code}"
+            )
 
     def parse(self, response):
         for location in response.json():


### PR DESCRIPTION
The `int1` server appears to be a staging/internal server that returns locations no longer active in production. Investigation found that for the UK alone, `int1` adds 57 unique locations that don't appear in the `prd` (production) server — these appear to be old/closed branches (e.g. Downtown Birmingham on Suffolk Street Queensway, which closed between 2019 and 2021).

Enterprise's own website lists ~420 UK branches, consistent with the ~453 returned by `prd` alone — not the ~510 that result from combining `prd` + `int1`.

Fix: remove `int1` from the subdomains list; use only `prd`.

Closes #14128