### PR TITLE
[Marks & Spencer] Include Compass UK and LondonRetailPartner stores

### DIFF
--- a/locations/spiders/marks_and_spencer.py
+++ b/locations/spiders/marks_and_spencer.py
@@ -23,7 +23,7 @@ class MarksAndSpencerSpider(scrapy.Spider):
     def parse_stores(self, response):
         stores = response.json()
         for store in stores["results"]:
-            if store.get("locationTypeName") in [None, "Applegreen", "LondonRetailPartner", "Event", "Compass UK"]:
+            if store.get("locationTypeName") in [None, "Applegreen", "Event"]:
                 continue
 
             properties = {
@@ -77,6 +77,14 @@ class MarksAndSpencerSpider(scrapy.Spider):
             elif store["locationTypeName"] in ["Full Line", "Ireland - Full Line"]:
                 properties["name"] = "Marks & Spencer"
                 apply_category(Categories.SHOP_DEPARTMENT_STORE, properties)
+            elif store["locationTypeName"] == "Compass UK":
+                properties["operator"] = "Compass Group"
+                properties["operator_wikidata"] = "Q1074937"
+                properties["name"] = "M&S Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
+            elif store["locationTypeName"] == "LondonRetailPartner":
+                properties["name"] = "M&S Simply Food"
+                apply_category(Categories.SHOP_CONVENIENCE, properties)
             else:
                 if name.endswith("foodhall") or name.endswith(" fh"):
                     properties["name"] = "M&S Foodhall"


### PR DESCRIPTION
Two store types were being incorrectly filtered out of the M&S spider output:

- **Compass UK** (20 stores): M&S Food concessions in NHS hospitals, operated by Compass Group. These are M&S branded with regular pages on the M&S website (e.g. [Birmingham Heartlands NHS Hospital](https://www.marksandspencer.com/stores/birmingham-heartlands-nhs-hospital-2068)), valid coordinates and opening hours.
- **LondonRetailPartner** (2 stores): Standard M&S Simply Food stores at [Shaftesbury Avenue](https://www.marksandspencer.com/stores/shaftesbury-ave-1725) and [Queensway](https://www.marksandspencer.com/stores/queensway-1726). Google Streetview confirms both are regular M&S Food stores.

Fix: remove these two types from the exclusion list and add handling in the elif chain (Compass UK gets `operator=Compass Group` with Wikidata Q1074937, both categorised as `SHOP_CONVENIENCE`).

This increases the output count from ~1056 to ~1078 (22 additional stores).

Closes #14133