### PR TITLE
[Burger King UY] Fix 403 by using browser User-Agent

### DIFF
--- a/locations/spiders/burger_king_uy.py
+++ b/locations/spiders/burger_king_uy.py
@@ -2,12 +2,14 @@ from scrapy import Spider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BurgerKingUYSpider(Spider):
     name = "burger_king_uy"
     item_attributes = {"brand": "Burger King", "brand_wikidata": "Q177054"}
     start_urls = ["https://www.burgerking.com.uy/restaurantes/"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
 
     def parse(self, response):
         for location in response.xpath("//div[@data-lat]"):


### PR DESCRIPTION
## Summary

The `burger_king_uy` spider was getting 403 responses in CI because the Microsoft IIS/ASP.NET server at `burgerking.com.uy` blocks Scrapy's default User-Agent. Additionally, the site has no `robots.txt` (returns a 404 HTML error page), which was causing spurious blocking.

## Root Cause

Run stats showed `downloader/response_status_count/403: 1` for the main page request. Testing locally confirmed:
- Scrapy's default UA → 403
- Browser UA → 200 with all 28 locations

The site is a static Microsoft IIS/ASP.NET site that was rebuilt; it now serves location data directly in the HTML with `data-lat`/`data-lon` attributes (which the spider's XPath already handles correctly).

## Fix

Added `custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}` to bypass the UA block and skip the broken robots.txt check.

## Testing

Tested locally — returns all 28 Burger King Uruguay locations with coordinates, addresses, and phone numbers.

Closes #15951