### PR TITLE
[Ringer Hut JP] Add spider (~548 locations)

### DIFF
--- a/locations/spiders/ringer_hut_jp.py
+++ b/locations/spiders/ringer_hut_jp.py
@@ -1,0 +1,40 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class RingerHutJPSpider(CanlySpider):
+    name = "ringer_hut_jp"
+    item_attributes = {
+        "brand": "リンガーハット",
+        "brand_wikidata": "Q7334856",
+    }
+    brand_key = "946"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        name = feature.get("nameKanji", "")
+
+        # Skip vending machine entries (store codes starting with VM)
+        if feature.get("storeCode", "").startswith("VM"):
+            return
+
+        # Skip any non-open locations
+        if feature.get("businessStatus") != "OPEN":
+            return
+
+        item["branch"] = name.removeprefix("リンガーハット").strip()
+        item["website"] = f"https://shop.ringerhut.jp/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.FAST_FOOD, item)
+
+        oh = OpeningHours()
+        for day_hours in feature.get("businessHours", []):
+            oh.add_range(day_hours["name"], day_hours["openTime"], day_hours["closeTime"], "%H:%M:%S")
+        item["opening_hours"] = oh
+
+        yield item


### PR DESCRIPTION
New spider for Ringer Hut (リンガーハット) Japanese champon noodle restaurants.

Data source: Canly API (brand key 946) returning ~548 locations with coords, address, phone, and opening hours. Vending machine entries (VM prefix store codes) are filtered out.

Closes #14121