### PR TITLE
[DC Traffic Signals] Fix spider: INTERSECTIONID removed, use ACISA

### DIFF
--- a/locations/spiders/infrastructure/district_department_of_transportation_traffic_signals_us.py
+++ b/locations/spiders/infrastructure/district_department_of_transportation_traffic_signals_us.py
@@ -21,7 +21,7 @@ class DistrictDepartmentOfTransportationTrafficSignalsUSSpider(ArcGISFeatureServ
     layer_id = "170"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["ref"] = feature["INTERSECTIONID"]
+        item["ref"] = feature["ACISA"]
         item["name"] = feature["INTERSECTIONNAME"]
         apply_category(Categories.HIGHWAY_TRAFFIC_SIGNALS, item)
         yield item


### PR DESCRIPTION
The DDOT ArcGIS MapServer layer 170 removed the `INTERSECTIONID` field. The spider was crashing trying to read it.\n\nFix: use the `ACISA` field instead, which is stable and unique.\n\nCloses #16104