### PR TITLE
[Denmans GB] Remove spider (domain redirects to Rexel)

### DIFF
--- a/locations/spiders/denmans_gb.py
+++ b/locations/spiders/denmans_gb.py
@@ -1,9 +1,0 @@
-from locations.storefinders.rexel import RexelSpider
-
-
-class DenmansGBSpider(RexelSpider):
-    name = "denmans_gb"
-    item_attributes = {"brand": "Denmans", "brand_wikidata": "Q116508855"}
-    base_url = "www.denmans.co.uk/den"
-    search_lat = 51
-    search_lon = -0


### PR DESCRIPTION
denmans.co.uk permanently redirects (301) to rexel.co.uk/uki/. The `rexel_gb` spider already covers these locations.\n\nCloses #16100