### PR TITLE
Fix `da_grasso_pl`: add ROBOTSTXT_OBEY=False to avoid robots.txt 404 block

### DIFF
--- a/locations/spiders/da_grasso_pl.py
+++ b/locations/spiders/da_grasso_pl.py
@@ -6,6 +6,7 @@ class DaGrassoPLSpider(JSONBlobSpider):
     name = "da_grasso_pl"
     item_attributes = {"brand": "Da Grasso", "brand_wikidata": "Q11692586"}
     start_urls = ["https://api.dagrasso.pl/localization-api/api/v2/stores/pickup"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item, response, feature):
         if raw_name := item.pop("name", ""):


### PR DESCRIPTION
Fix `da_grasso_pl`: add ROBOTSTXT_OBEY=False to avoid robots.txt 404 block.

The API lives on `api.dagrasso.pl` which does not serve a `robots.txt`. Scrapy's default behaviour is to fetch `robots.txt` before starting any requests; on this subdomain that fetch redirects and ultimately 404s, causing Scrapy to treat the start URL as forbidden and emit no items.

Adding `custom_settings = {"ROBOTSTXT_OBEY": False}` skips the robots.txt fetch entirely and lets the spider reach the API normally. Tested locally — 202 items returned.

Closes #16099