### PR TITLE
Fix `desa_tr`: add browser User-Agent — server returns 405 for Scrapy default UA

### DIFF
--- a/locations/spiders/desa_tr.py
+++ b/locations/spiders/desa_tr.py
@@ -4,6 +4,7 @@ import scrapy
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class DesaTRSpider(scrapy.Spider):
@@ -13,6 +14,7 @@ class DesaTRSpider(scrapy.Spider):
         "brand_wikidata": "Q17513880",
     }
     start_urls = ["https://www.desa.com.tr/api/Store/GetStoriesLite"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["magazalar"]:


### PR DESCRIPTION
Fix `desa_tr`: add browser User-Agent — server returns 405 for Scrapy default UA.

The `desa.com.tr` API endpoint returns HTTP 405 when the request is made with Scrapy's default `Scrapy/...` User-Agent string. Adding `custom_settings = {"USER_AGENT": BROWSER_DEFAULT}` (Firefox ESR UA) allows the request to succeed.

Tested locally — 38 items returned with HTTP 200.

Closes #16101