### PR TITLE
Fix `casa_do_pao_de_queijo_br`: guard re.search() None for stale bundle filename

### DIFF
--- a/locations/spiders/casa_do_pao_de_queijo_br.py
+++ b/locations/spiders/casa_do_pao_de_queijo_br.py
@@ -21,7 +21,11 @@ class CasaDoPaoDeQueijoBRSpider(Spider):
         )
 
     def parse_location(self, response: Response, **kwargs: Any) -> Any:
-        for location in chompjs.parse_js_object(re.search(r"dP\s*=\s*(\[.+\]),\s*fP=\(\)", response.text).group(1)):
+        match = re.search(r"dP\s*=\s*(\[.+\]),\s*fP=\(\)", response.text)
+        if not match:
+            self.logger.error("Could not find dP=[...] data in bundle at %s", response.url)
+            return
+        for location in chompjs.parse_js_object(match.group(1)):
             item = Feature()
             item["branch"] = location["nome"].removeprefix("CPQ ")
             item["addr_full"] = item["ref"] = location["endereco"]


### PR DESCRIPTION
Fix `casa_do_pao_de_queijo_br`: guard re.search() None for stale bundle filename.

The spider fetches the Vite bundle JS file and extracts location data with a `re.search(r"dP=([...]),...")`. When the bundle filename rotates (Vite content-hashes the filename), the pattern can still match the right file, but if Vite restructures or minifies the variable assignments differently the regex returns `None` — causing an `AttributeError: 'NoneType' object has no attribute 'group'`.

This fix captures the `re.search()` result in a variable, checks it for `None`, and logs a clear error before returning instead of crashing with a traceback.

Tested locally — 207 items returned with no errors.

Closes #16097