### PR TITLE
Fix `chetyre_lapy_ru`: handle stale buildId causing 302 redirect to non-JSON page

### DIFF
--- a/locations/spiders/chetyre_lapy_ru.py
+++ b/locations/spiders/chetyre_lapy_ru.py
@@ -28,6 +28,13 @@ class ChetyreLapyRUSpider(scrapy.Spider):
         )
 
     def parse_pois(self, response):
+        if "application/json" not in response.headers.get("Content-Type", b"").decode():
+            self.logger.error(
+                "Expected JSON from %s but got non-JSON response (stale buildId?); status=%s",
+                response.url,
+                response.status,
+            )
+            return
         for poi in list(response.json()["pageProps"]["fallback"].values())[0]["items"]:
             item = Feature()
             item["ref"] = poi["id"]


### PR DESCRIPTION
Fix `chetyre_lapy_ru`: handle stale buildId causing 302 redirect to non-JSON page.

The spider extracts the Next.js `buildId` from the `__NEXT_DATA__` script tag on the shops page, then constructs a `/_next/data/{buildId}/shops.json` URL. When the site re-deploys and the `buildId` changes, that URL responds with a 302 redirect to an HTML error page. Calling `response.json()` on that HTML body raises a `JSONDecodeError` and the spider crashes with no output.

This fix adds a `Content-Type` check at the top of `parse_pois`: if the response is not `application/json`, a clear error is logged and the method returns cleanly instead of raising an exception. The fix has no impact on the happy path — when the buildId is current and the API responds with JSON, the check passes and processing continues as before.

Tested locally — 641 items returned with no errors.

Closes #16021