### PR TITLE
[Erste Bank HR] Add spider (772 locations)

### DIFF
--- a/locations/spiders/erste_banka_hr.py
+++ b/locations/spiders/erste_banka_hr.py
@@ -1,0 +1,74 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+
+class ErsteBankaHRSpider(Spider):
+    name = "erste_banka_hr"
+    item_attributes = {"brand": "Erste Bank", "brand_wikidata": "Q696867"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(
+            url="https://local.erstebank.hr/api/v1/branches",
+            cb_kwargs={"location_type": "branch"},
+        )
+        yield JsonRequest(
+            url="https://local.erstebank.hr/api/v1/atms",
+            cb_kwargs={"location_type": "atm"},
+        )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for location in response.json()["items"]:
+            item = self.parse_location(location)
+
+            if location_type == "branch":
+                if branch := item.pop("name", None):
+                    item["branch"] = re.sub(
+                        r"^(?:Poslovnica|Filijala|Savjetodavni centar|Stambeni centar)\s+", "", branch
+                    ).strip()
+                apply_category(Categories.BANK, item)
+            elif location_type == "atm":
+                item.pop("name", None)
+                if (branch := location.get("location", "").strip()) and branch.upper() not in {
+                    "BANKA",
+                    "KIOSK",
+                    "POSLOVNI PROSTOR",
+                    "SAMOSTOJEĆI KIOSK",
+                    "SAMOUSLUŽNA ZONA",
+                    "STAMBENA ZGRADA",
+                }:
+                    item["branch"] = branch
+                apply_yes_no(
+                    Extras.CASH_IN,
+                    item,
+                    location.get("features", {}).get("atmDeposit") in (True, "true", "True", "TRUE"),
+                    False,
+                )
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item
+
+    @staticmethod
+    def parse_location(location: dict[str, Any]) -> Feature:
+        item = DictParser.parse(location)
+
+        if position := location.get("position", {}):
+            item["lat"] = position.get("lat")
+            item["lon"] = position.get("lng")
+
+        if address := location.get("address", {}):
+            item["street_address"] = address.get("street")
+            item["city"] = address.get("city")
+            item["postcode"] = str(postcode) if (postcode := address.get("postcode")) else None
+
+        return item


### PR DESCRIPTION
Data source:
https://www.erstebank.hr/hr/poslovnice-i-bankomati#/poslovnice
https://www.erstebank.hr/hr/poslovnice-i-bankomati#/bankomati

The spider uses the Erste locator APIs:
https://local.erstebank.hr/api/v1/branches
https://local.erstebank.hr/api/v1/atms

Category mapping:

/api/v1/branches -> Categories.BANK
/api/v1/atms -> Categories.ATM

Stats summary:

772 total items
108 banks
664 ATMs
198 ATMs with cash_in=yes
466 ATMs with cash_in=no
NSI: 772 match_perfect

Sample POIs:

```json
[
  {
    "type": "Feature",
    "id": "LMU_oFvtBxcthTNjhKAxRGDWnas=",
    "properties": {
      "ref": "170",
      "amenity": "bank",
      "@source_uri": "https://local.erstebank.hr/api/v1/branches",
      "@spider": "erste_banka_hr",
      "addr:street": "Kralja Zvonimira 114",
      "addr:street_address": "Kralja Zvonimira 114",
      "addr:city": "Baška",
      "addr:postcode": "51523",
      "addr:country": "HR",
      "name": "Erste Bank",
      "branch": "Baška",
      "brand": "Erste Bank",
      "brand:wikidata": "Q696867",
      "nsi_id": "erstebank-d01b30"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [14.7523, 44.9702]
    }
  },
  {
    "type": "Feature",
    "id": "KMiGzIP06FWW6Y-_44QXpDo_Mo8=",
    "properties": {
      "ref": "A146344",
      "cash_in": "yes",
      "amenity": "atm",
      "@source_uri": "https://local.erstebank.hr/api/v1/atms",
      "@spider": "erste_banka_hr",
      "addr:street": "Martinkovac 127",
      "addr:street_address": "Martinkovac 127",
      "addr:city": "Rijeka",
      "addr:postcode": "51000",
      "addr:country": "HR",
      "branch": "TC MARTI RETAIL PARK",
      "brand": "Erste Bank",
      "brand:wikidata": "Q696867",
      "operator": "Erste Bank",
      "operator:wikidata": "Q696867",
      "nsi_id": "erstebank-1343ca"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [14.362991, 45.355081]
    }
  },
  {
    "type": "Feature",
    "id": "UeFRJC0Il3444C5DraZvTCTNH-I=",
    "properties": {
      "ref": "A130607",
      "cash_in": "no",
      "amenity": "atm",
      "@source_uri": "https://local.erstebank.hr/api/v1/atms",
      "@spider": "erste_banka_hr",
      "addr:street": "Lanište 17",
      "addr:street_address": "Lanište 17",
      "addr:city": "Zagreb",
      "addr:postcode": "10020",
      "addr:country": "HR",
      "branch": "SUPER SPORT",
      "brand": "Erste Bank",
      "brand:wikidata": "Q696867",
      "operator": "Erste Bank",
      "operator:wikidata": "Q696867",
      "nsi_id": "erstebank-1343ca"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [15.944711, 45.772629]
    }
  }
]
```
json stats :

```json
{
 "atp/brand/Erste Bank": 772,
 "atp/brand_wikidata/Q696867": 772,
 "atp/category/amenity/atm": 664,
 "atp/category/amenity/bank": 108,
 "atp/country/HR": 772,
 "atp/field/branch/missing": 250,
 "atp/field/email/missing": 772,
 "atp/field/housenumber/missing": 772,
 "atp/field/name/missing": 664,
 "atp/field/opening_hours/missing": 772,
 "atp/field/operator/missing": 108,
 "atp/field/operator_wikidata/missing": 108,
 "atp/field/phone/missing": 772,
 "atp/field/state/missing": 772,
 "atp/field/twitter/missing": 772,
 "atp/field/unit/missing": 772,
 "atp/item_scraped_host_count/local.erstebank.hr": 772,
 "atp/lineage": "S_?",
 "atp/nsi/match_perfect": 772,
 "atp/operator/Erste Bank": 664,
 "atp/operator_wikidata/Q696867": 664,
 "downloader/request_bytes": 708,
 "downloader/request_count": 2,
 "downloader/request_method_count/GET": 2,
 "downloader/response_bytes": 480442,
 "downloader/response_count": 2,
 "downloader/response_status_count/200": 2,
 "elapsed_time_seconds": 5.8439999999827705,
 "finish_reason": "finished",
 "finish_time": "2026-06-17T07:35:02.644937+00:00",
 "item_scraped_count": 772,
 "items_per_minute": 9264.0,
 "response_received_count": 2,
 "responses_per_minute": 24.0,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2026-06-17T07:34:56.795577+00:00"
}
```

Notes:
The API provides branches and ATMs as separate records, so the spider yields both directly. ATM deposit support is mapped to cash_in=yes/no.

Opening hours were checked but intentionally not mapped. Branch hours are service-specific rather than branch-level, and some ATM records have unclear/empty hour values, so leaving opening_hours unmapped is the safer conservative choice.

Generic ATM location placeholders such as BANKA, POSLOVNI PROSTOR, KIOSK, SAMOSTOJEĆI KIOSK, SAMOUSLUŽNA ZONA, and STAMBENA ZGRADA are not used as branch values.