### PR TITLE
[Geox] Fix Spider

### DIFF
--- a/locations/spiders/geox.py
+++ b/locations/spiders/geox.py
@@ -1,46 +1,55 @@
-import re
+from typing import Any, AsyncIterator
 
 import scrapy
+from scrapy import Selector
+from scrapy.http import Response
 
-from locations.hours import OpeningHours
 from locations.items import Feature
 
 
 class GeoxSpider(scrapy.Spider):
     name = "geox"
     item_attributes = {"brand": "Geox", "brand_wikidata": "Q588001"}
-    start_urls = ["https://www.geox.com/int/stores"]
 
-    def parse(self, response):
-        url = "https://www.geox.com/on/demandware.store/Sites-international-Site/en_GB/Stores-FindStoresAjax?countryCode={country_code}&page=storelocator&format=ajax"
-        country_codes = response.xpath('//*[@id="dwfrm_storelocator_country"]/option/@value').getall()
-        for code in country_codes:
-            yield scrapy.Request(url=url.format(country_code=code), callback=self.parse_country)
+    async def start(self) -> AsyncIterator[Any]:
+        for country in [
+            "AT",
+            "BE",
+            "BG",
+            "CA",
+            "CH",
+            "CN",
+            "CZ",
+            "DE",
+            "ES",
+            "FR",
+            "GB",
+            "GR",
+            "HR",
+            "HU",
+            "IT",
+            "LT",
+            "LU",
+            "LV",
+            "NL",
+            "PL",
+            "PT",
+            "RO",
+            "RU",
+        ]:
+            yield scrapy.Request(
+                url=f"https://www.geox.com/on/demandware.store/Sites-xcom-international-Site/en_GL/Stores-FindAjax?country={country}"
+            )
 
-    def parse_country(self, response):
-        data = response.json()
-        if data["stores"]:
-            for store in data["stores"]:
-                item = Feature()
-                item["ref"] = store["storeId"]
-                item["name"] = ("Geox " + (store.get("name") or "")).strip()
-                item["street_address"] = store["address"]
-                item["city"] = store["city"]
-                item["email"] = store["email"]
-                item["phone"] = store["phone"]
-                item["postcode"] = store["postalCode"].strip()
-                item["country"] = store["countryCode"]
-                item["lat"] = store["lat"]
-                item["lon"] = store["long"]
-                item["website"] = "https://www.geox.com/int/storedetails?StoreID=" + store["storeId"]
-                item["opening_hours"] = self.parse_opening_hours(store)
-                yield item
-
-    @staticmethod
-    def parse_opening_hours(store: dict) -> OpeningHours:
-        oh = OpeningHours()
-        store_oh = store["storeHours"]
-        get_list = re.findall("(<p>)(.+?)(</p>)", store_oh)
-        for elmt in get_list:
-            oh.add_ranges_from_string(ranges_string=elmt[1], delimiters=[" - "])
-        return oh
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        html_data = Selector(text=response.json()["storesTilesHtml"])
+        for location in html_data.xpath('.//*[@class="custom-infowindow"]'):
+            item = Feature()
+            item["branch"] = location.xpath('.//*[contains(@class,"sl-store-name")]//text()').get()
+            item["addr_full"] = location.xpath('.//*[contains(@class,"sl-store-address")]//text()').get()
+            item["phone"] = location.xpath('.//*[contains(@title,"Phone number")]//text()').get()
+            item["website"] = item["ref"] = response.urljoin(
+                location.xpath('.//*[contains(@href,"/int/storedetails/")]/@href').get()
+            )
+            item["lat"], item["lon"] = location.xpath(".//@data-loc").get().split(",")
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Geox': 467,
 'atp/brand_wikidata/Q588001': 467,
 'atp/category/shop/shoes': 467,
 'atp/cdn/cloudflare/response_count': 24,
 'atp/cdn/cloudflare/response_status_count/200': 24,
 'atp/clean_strings/phone': 2,
 'atp/country/AT': 10,
 'atp/country/BE': 9,
 'atp/country/BG': 1,
 'atp/country/CA': 13,
 'atp/country/CH': 2,
 'atp/country/CN': 40,
 'atp/country/CZ': 8,
 'atp/country/DE': 6,
 'atp/country/ES': 32,
 'atp/country/FR': 72,
 'atp/country/GB': 6,
 'atp/country/GR': 8,
 'atp/country/HR': 2,
 'atp/country/HU': 2,
 'atp/country/IT': 153,
 'atp/country/LT': 1,
 'atp/country/LU': 2,
 'atp/country/LV': 1,
 'atp/country/NL': 1,
 'atp/country/PL': 4,
 'atp/country/PT': 11,
 'atp/country/RO': 2,
 'atp/country/RU': 78,
 'atp/country/VA': 3,
 'atp/field/city/missing': 467,
 'atp/field/country/from_reverse_geocoding': 467,
 'atp/field/email/missing': 467,
 'atp/field/housenumber/missing': 467,
 'atp/field/opening_hours/missing': 467,
 'atp/field/operator/missing': 467,
 'atp/field/operator_wikidata/missing': 467,
 'atp/field/phone/invalid': 8,
 'atp/field/phone/missing': 37,
 'atp/field/postcode/missing': 464,
 'atp/field/state/missing': 3,
 'atp/field/street/missing': 467,
 'atp/field/street_address/missing': 467,
 'atp/field/twitter/missing': 467,
 'atp/field/unit/missing': 467,
 'atp/item_scraped_host_count/www.geox.com': 467,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 467,
 'atp/nsi/match_imperfect': 467,
 'downloader/request_bytes': 16186,
 'downloader/request_count': 24,
 'downloader/request_method_count/GET': 24,
 'downloader/response_bytes': 107429,
 'downloader/response_count': 24,
 'downloader/response_status_count/200': 24,
 'elapsed_time_seconds': 30.01600000000326,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 17, 8, 6, 41, 747662, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1531625,
 'httpcompression/response_count': 24,
 'item_scraped_count': 467,
 'items_per_minute': 934.0,
 'log_count/DEBUG': 491,
 'log_count/INFO': 3,
 'response_received_count': 24,
 'responses_per_minute': 48.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 23,
 'scheduler/dequeued/memory': 23,
 'scheduler/enqueued': 23,
 'scheduler/enqueued/memory': 23,
 'start_time': datetime.datetime(2026, 6, 17, 8, 6, 11, 724796, tzinfo=datetime.timezone.utc)}
```