### PR TITLE
[OTP banka HR] Add spider (554 locations)

### DIFF
--- a/locations/spiders/otp_banka_hr.py
+++ b/locations/spiders/otp_banka_hr.py
@@ -1,0 +1,83 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+
+
+class OtpBankaHRSpider(Spider):
+    name = "otp_banka_hr"
+    item_attributes = {"brand": "OTP banka", "brand_wikidata": "Q31198593"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield Request(
+            url="https://www.otpbanka.hr/poslovnice/print",
+            cb_kwargs={"location_type": "branch"},
+        )
+        yield Request(
+            url="https://www.otpbanka.hr/atms/print",
+            cb_kwargs={"location_type": "atm"},
+        )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for row in response.xpath('//table[contains(@class, "views-table")]//tbody/tr'):
+            item = self.parse_location(row, response)
+
+            if location_type == "branch":
+                apply_yes_no(
+                    Extras.WHEELCHAIR,
+                    item,
+                    row.xpath('normalize-space(.//*[contains(@class, "views-field-field-pristup-za-invalide")])')
+                    .get("")
+                    .strip()
+                    == "Pristup za invalide",
+                    False,
+                )
+                apply_category(Categories.BANK, item)
+            elif location_type == "atm":
+                apply_yes_no(
+                    Extras.CASH_IN,
+                    item,
+                    row.xpath('normalize-space(.//*[contains(@class, "views-field-field-vrsta-bankomata-tablica")])')
+                    .get("")
+                    .strip()
+                    == "Uplatno-isplatni bankomat",
+                    False,
+                )
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item
+
+    @staticmethod
+    def parse_location(row: Any, response: Response) -> Feature:
+        # Source rows are HTML tables rather than JSON, so DictParser is not applicable.
+        item = Feature()
+
+        if href := row.xpath('.//a[contains(@href, "/offices-atms/")]/@href').get():
+            if match := re.search(r"/offices-atms/(\d+)", href):
+                item["ref"] = match.group(1)
+            item["website"] = response.urljoin(href)
+
+        if branch := row.xpath("normalize-space(./td[2])").get():
+            item["branch"] = branch.removeprefix("Poslovnica ").strip()
+        item["street_address"] = row.xpath('normalize-space(.//*[contains(@class, "street-address")])').get()
+        item["city"] = row.xpath('normalize-space(.//*[contains(@class, "views-field-city")]//a)').get()
+        if phone := row.xpath(
+            'normalize-space(.//*[contains(@class, "views-field-field-telefon")]//a[contains(@href, "tel:")])'
+        ).get():
+            item["phone"] = phone
+
+        if match := re.match(
+            r"(?P<lat>-?\d+(?:\.\d+)?)\s*,\s*(?P<lon>-?\d+(?:\.\d+)?)",
+            row.xpath('normalize-space(.//*[contains(@class, "views-field-coordinates")]//a)').get(""),
+        ):
+            item["lat"] = match.group("lat")
+            item["lon"] = match.group("lon")
+
+        return item

--- a/locations/spiders/otp_banka_hr.py
+++ b/locations/spiders/otp_banka_hr.py
@@ -5,6 +5,7 @@ from scrapy import Spider
 from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import DAYS_HR, OpeningHours
 from locations.items import Feature
 
 
@@ -27,6 +28,7 @@ class OtpBankaHRSpider(Spider):
             item = self.parse_location(row, response)
 
             if location_type == "branch":
+                self.parse_hours(item, row)
                 apply_yes_no(
                     Extras.WHEELCHAIR,
                     item,
@@ -53,6 +55,51 @@ class OtpBankaHRSpider(Spider):
                 continue
 
             yield item
+
+    def parse_hours(self, item: Feature, row: Any) -> None:
+        rules = row.xpath(
+            './/*[contains(@class, "views-field-field-radno-vrijeme")]'
+            '//*[contains(concat(" ", normalize-space(@class), " "), " oh-display ")]'
+        )
+        if not rules:
+            return
+
+        days_hr = DAYS_HR | {
+            "Pon": "Mo",
+            "Uto": "Tu",
+            "Sri": "We",
+            "\u010cet": "Th",
+            "Pet": "Fr",
+            "Sub": "Sa",
+            "Ned": "Su",
+        }
+        oh = OpeningHours()
+        try:
+            for rule in rules:
+                day = days_hr[
+                    rule.xpath(
+                        'normalize-space(.//*[contains(concat(" ", normalize-space(@class), " "), " oh-display-label ")])'
+                    )
+                    .get("")
+                    .rstrip(":")
+                    .strip()
+                ]
+                hours = (
+                    rule.xpath(
+                        'normalize-space(.//*[contains(concat(" ", normalize-space(@class), " "), " oh-display-times ")])'
+                    )
+                    .get("")
+                    .strip()
+                )
+                if hours == "Zatvoreno":
+                    oh.set_closed(day)
+                elif "-" in hours:
+                    oh.add_range(day, *hours.split("-", 1))
+                else:
+                    raise ValueError("Unexpected opening hours value: {}".format(hours))
+            item["opening_hours"] = oh
+        except Exception:
+            self.logger.warning("Failed to parse hours for {}".format(item.get("ref")))
 
     @staticmethod
     def parse_location(row: Any, response: Response) -> Feature:


### PR DESCRIPTION
Data source:
https://www.otpbanka.hr/offices-atms

The spider uses OTP banka's public print tables:
https://www.otpbanka.hr/poslovnice/print
https://www.otpbanka.hr/atms/print

Category mapping:

BRANCH rows from `/poslovnice/print` -> `Categories.BANK`
ATM rows from `/atms/print` -> `Categories.ATM`
`Uplatno-isplatni bankomat` -> `cash_in=yes`
`Isplatni bankomat` -> `cash_in=no`
`Pristup za invalide` / `Bez pristupa za invalide` -> `wheelchair=yes/no` for branch records
Structured branch opening-hours rows -> `opening_hours` for branch records only

Stats summary:

554 total items
99 banks
455 ATMs
99 branches with opening hours
92 cash-in ATMs
363 withdrawal-only ATMs
83 branches with wheelchair access
16 branches without wheelchair access
NSI: 554 match_perfect
Country derived from spider name: 554

Sample POIs:

```json
[
  {
    "type": "Feature",
    "id": "3yE82z8L4YULMWjYrkZHX_VkaK4=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "otp_banka_hr",
      "spider:collection_time": "2026-06-17T11:36:21.277700"
    },
    "properties": {
      "ref": "49422",
      "wheelchair": "no",
      "amenity": "bank",
      "@source_uri": "https://www.otpbanka.hr/poslovnice/print",
      "@spider": "otp_banka_hr",
      "addr:street_address": "Trg.kralja Tomislava 4",
      "addr:city": "Crikvenica",
      "addr:country": "HR",
      "name": "OTP banka",
      "branch": "Crikvenica",
      "phone": "+385 72 206 393",
      "website": "https://www.otpbanka.hr/offices-atms/49422?type_1=office",
      "opening_hours": "Mo 08:00-15:00; Tu 12:00-19:00; We-Fr 08:00-15:00; Sa-Su closed",
      "brand": "OTP banka",
      "brand:wikidata": "Q31198593",
      "nsi_id": "otpbanka-6f3d3b"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [14.69083, 45.1736]
    }
  },
  {
    "type": "Feature",
    "id": "eDdUQpKrifsXuvIj64ck4XKzv7o=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "otp_banka_hr",
      "spider:collection_time": "2026-06-17T11:36:21.277700"
    },
    "properties": {
      "ref": "48629",
      "cash_in": "yes",
      "amenity": "atm",
      "@source_uri": "https://www.otpbanka.hr/atms/print",
      "@spider": "otp_banka_hr",
      "addr:street_address": "Vukovarska ulica 2",
      "addr:city": "Benkovac",
      "addr:country": "HR",
      "branch": "Benkovac (ATM 2)",
      "website": "https://www.otpbanka.hr/offices-atms/48629?city=&type_1=atm",
      "brand": "OTP banka",
      "brand:wikidata": "Q31198593",
      "operator": "OTP banka",
      "operator:wikidata": "Q31198593",
      "nsi_id": "otpbanka-4d8c03"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [15.614299, 44.032144]
    }
  },
  {
    "type": "Feature",
    "id": "D_0gVkaGVFi_hGscpt04uZAfVN8=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "otp_banka_hr",
      "spider:collection_time": "2026-06-17T11:36:21.277700"
    },
    "properties": {
      "ref": "48623",
      "cash_in": "no",
      "amenity": "atm",
      "@source_uri": "https://www.otpbanka.hr/atms/print",
      "@spider": "otp_banka_hr",
      "addr:street_address": "Trg La Musa 11",
      "addr:city": "Bale",
      "addr:country": "HR",
      "branch": "Multimedijalni centar Ulika",
      "website": "https://www.otpbanka.hr/offices-atms/48623?city=&type_1=atm",
      "brand": "OTP banka",
      "brand:wikidata": "Q31198593",
      "operator": "OTP banka",
      "operator:wikidata": "Q31198593",
      "nsi_id": "otpbanka-4d8c03"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [13.783361, 45.040444]
    }
  }
]
```

```json
{
 "atp/brand/OTP banka": 554,
 "atp/brand_wikidata/Q31198593": 554,
 "atp/category/amenity/atm": 455,
 "atp/category/amenity/bank": 99,
 "atp/country/HR": 554,
 "atp/field/country/from_spider_name": 554,
 "atp/field/email/missing": 554,
 "atp/field/housenumber/missing": 554,
 "atp/field/name/missing": 455,
 "atp/field/opening_hours/missing": 455,
 "atp/field/operator/missing": 99,
 "atp/field/operator_wikidata/missing": 99,
 "atp/field/phone/missing": 455,
 "atp/field/postcode/missing": 554,
 "atp/field/state/missing": 554,
 "atp/field/street/missing": 554,
 "atp/field/twitter/missing": 554,
 "atp/field/unit/missing": 554,
 "atp/item_scraped_host_count/www.otpbanka.hr": 554,
 "atp/lineage": "S_?",
 "atp/nsi/match_perfect": 554,
 "atp/operator/OTP banka": 455,
 "atp/operator_wikidata/Q31198593": 455,
 "downloader/request_bytes": 1005,
 "downloader/request_count": 3,
 "downloader/request_method_count/GET": 3,
 "downloader/response_bytes": 58151,
 "downloader/response_count": 3,
 "downloader/response_status_count/200": 3,
 "elapsed_time_seconds": 5.389999999955762,
 "finish_reason": "finished",
 "finish_time": "2026-06-17T09:36:23.705051+00:00",
 "httpcompression/response_bytes": 837022,
 "httpcompression/response_count": 2,
 "item_scraped_count": 554,
 "items_per_minute": 6648.0,
 "response_received_count": 3,
 "responses_per_minute": 36.0,
 "robotstxt/request_count": 1,
 "robotstxt/response_count": 1,
 "robotstxt/response_status_count/200": 1,
 "scheduler/dequeued": 2,
 "scheduler/dequeued/memory": 2,
 "scheduler/enqueued": 2,
 "scheduler/enqueued/memory": 2,
 "start_time": "2026-06-17T09:36:18.327466+00:00"
}
```
Notes:

The source provides branches and ATMs as separate table rows, so the spider yields both directly. The source pages do not provide postcodes, so postcodes are left unset rather than guessed. Branch opening hours are captured from structured day/time spans; ATM rows do not provide opening hours.
