### PR TITLE
[RidleysFamilyMarkets] Fix spider

### DIFF
--- a/locations/spiders/ridleys_family_markets.py
+++ b/locations/spiders/ridleys_family_markets.py
@@ -1,33 +1,31 @@
-import scrapy
+from typing import AsyncIterator, Iterable
 
-from locations.categories import Categories
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class RidleysFamilyMarketsSpider(scrapy.Spider):
+class RidleysFamilyMarketsSpider(JSONBlobSpider):
     name = "ridleys_family_markets"
-    item_attributes = {
-        "brand": "Ridley's Family Markets",
-        "brand_wikidata": "Q7332999",
-        "extras": Categories.SHOP_SUPERMARKET.value,
-    }
-    start_urls = ["https://shopridleys.com/_ajax_map.php"]
+    item_attributes = {"brand": "Ridley's Family Markets", "brand_wikidata": "Q7332999"}
 
-    def parse(self, response):
-        results = response.json()
-        for data in results:
-            props = {
-                "ref": data.get("storeNumber"),
-                "street_address": data.get("streetAddress"),
-                "name": data.get("storeName"),
-                "city": data.get("city"),
-                "postcode": data.get("zip"),
-                "state": data.get("state"),
-                "website": data.get("rio_url"),
-                "phone": data.get("phone"),
-                "lat": data.get("lat"),
-                "lon": data.get("lon"),
-                "country": "US",
-            }
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
+            url="https://shopridleys.com/wp-admin/admin-ajax.php",
+            body="action=imm_sections_get_stores_ajax&nonce=43299e3cf7&lat=41.3080357&lng=-105.5557724&city=&count=100&all_store=yes",
+            method="POST",
+        )
 
-            yield Feature(**props)
+    def extract_json(self, response: Response) -> list[dict]:
+        return response.json().get("data", {}).get("data", {}).get("message", [])
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["country"] = "US"
+        item["street_address"] = item.pop("addr_full")
+        item["branch"] = feature.get("DisplayName")
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item


### PR DESCRIPTION
The primary WordPress AJAX endpoint (admin-ajax.php) provides comprehensive store data including full physical addresses, but it does not return latitude and longitude coordinates. The Ridley's website relies on a secondary client-side call to the Google Maps Geocode API to drop map pins.

```
{"atp/brand/Ridley's Family Markets": 35,
 'atp/brand_wikidata/Q7332999': 35,
 'atp/category/shop/supermarket': 35,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/US': 35,
 'atp/field/email/missing': 35,
 'atp/field/geometry/missing': 35,
 'atp/field/housenumber/missing': 35,
 'atp/field/opening_hours/missing': 35,
 'atp/field/operator/missing': 35,
 'atp/field/operator_wikidata/missing': 35,
 'atp/field/street/missing': 35,
 'atp/field/twitter/missing': 35,
 'atp/field/unit/missing': 35,
 'atp/item_scraped_host_count/shopridleys.com': 35,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_missing': 35,
 'downloader/request_bytes': 1011,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 5444,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.9220000000000255,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 17, 12, 47, 22, 701911, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 31165,
 'httpcompression/response_count': 2,
 'item_scraped_count': 35,
 'items_per_minute': 1050.0,
 'log_count/DEBUG': 37,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 17, 12, 47, 19, 773343, tzinfo=datetime.timezone.utc)}
```