### PR TITLE
[ApplyNSICategoriesPipeline] Remove depricated function

### DIFF
--- a/locations/pipelines/apply_nsi_categories.py
+++ b/locations/pipelines/apply_nsi_categories.py
@@ -1,4 +1,4 @@
-from scrapy import Spider
+from scrapy.crawler import Crawler
 
 from locations.categories import get_category_tags
 from locations.items import Feature
@@ -9,9 +9,15 @@ class ApplyNSICategoriesPipeline:
     nsi = NSI()
     wikidata_cache = {}
 
-    def process_item(self, item: Feature, spider: Spider) -> Feature:
-        stats = spider.crawler.stats
-        if stats is None:
+    def __init__(self, crawler: Crawler):
+        self.crawler = crawler
+
+    @classmethod
+    def from_crawler(cls, crawler: Crawler):
+        return cls(crawler)
+
+    def process_item(self, item: Feature):
+        if self.crawler.stats is None:
             return item
         if item.get("nsi_id"):
             # Skip NSI matching and tag synchronisation upon spider request. A
@@ -26,8 +32,8 @@ class ApplyNSICategoriesPipeline:
             # Failure to match due to missing brand_wikidata or
             # operator_wikidata fields on the item. One or both of these
             # fields must be supplied.
-            stats.inc_value("atp/nsi/match_failed")
-            stats.inc_value("atp/nsi/brand_or_operator_missing")
+            self.crawler.stats.inc_value("atp/nsi/match_failed")
+            self.crawler.stats.inc_value("atp/nsi/brand_or_operator_missing")
             return item
 
         if not get_category_tags(item) and item.get("brand_wikidata"):
@@ -50,7 +56,7 @@ class ApplyNSICategoriesPipeline:
             #   of "Costco" in the US with Wikidata item Q715583 being both
             #   shop/warehouse and amenity/car_wash. The only field different
             #   in NSI entries is the category.
-            stats.inc_value("atp/nsi/category_missing")
+            self.crawler.stats.inc_value("atp/nsi/category_missing")
         elif not get_category_tags(item):
             # Failure to match due to missing top level category tags on the
             # ATP item, preventing matching with NSI operator entries. Most
@@ -65,15 +71,15 @@ class ApplyNSICategoriesPipeline:
             #   of knowing which of numerous NSI entries associated with the
             #   local government organisation is applicable if no category is
             #   specified.
-            stats.inc_value("atp/nsi/match_failed")
-            stats.inc_value("atp/nsi/category_missing")
+            self.crawler.stats.inc_value("atp/nsi/match_failed")
+            self.crawler.stats.inc_value("atp/nsi/category_missing")
             return item
 
         if not item.has_valid_country_code():
             # Not a fatal condition for NSI matching because both the ATP and
             # NSI items may have global applicability (e.g. "001" for NSI).
             # However, it's still worth collecting statistics.
-            stats.inc_value("atp/nsi/country_missing")
+            self.crawler.stats.inc_value("atp/nsi/country_missing")
 
         if brand_operator_qcode not in self.wikidata_cache:
             # wikidata_cache will usually only hold one thing, but can contain
@@ -88,16 +94,16 @@ class ApplyNSICategoriesPipeline:
             # for a brand, but NSI does not know of this Wikidata item.
             # It is suggested that a change be submitted to:
             # https://github.com/osmlab/name-suggestion-index
-            stats.inc_value("atp/nsi/match_failed")
-            stats.inc_value("atp/nsi/brand_unknown")
+            self.crawler.stats.inc_value("atp/nsi/match_failed")
+            self.crawler.stats.inc_value("atp/nsi/brand_unknown")
             return item
         elif len(nsi_matches) == 0 and item.get("operator_wikidata"):
             # Failure to match due to the ATP item specifying a Wikidata item
             # for an operator, but NSI does not know of this Wikidata item.
             # It is suggested that a change be submitted to:
             # https://github.com/osmlab/name-suggestion-index
-            stats.inc_value("atp/nsi/match_failed")
-            stats.inc_value("atp/nsi/operator_unknown")
+            self.crawler.stats.inc_value("atp/nsi/match_failed")
+            self.crawler.stats.inc_value("atp/nsi/operator_unknown")
             return item
 
         # Sometimes a brand and operator are the same across both NSI's
@@ -123,8 +129,8 @@ class ApplyNSICategoriesPipeline:
                 # match to NSI is not possible as NSI first needs updating to
                 # reflect the brand "Costco" opening pubs adjoining their
                 # warehouses.
-                stats.inc_value("atp/nsi/match_failed")
-                stats.inc_value("atp/nsi/category_unknown")
+                self.crawler.stats.inc_value("atp/nsi/match_failed")
+                self.crawler.stats.inc_value("atp/nsi/category_unknown")
                 return item
 
         location_code = item.get_iso_3166_2_code()
@@ -137,8 +143,8 @@ class ApplyNSICategoriesPipeline:
             # operating within the ATP items designated country and first
             # level subdivision. For example, "Chick-fil-A" is known in NSI
             # to operate in 3 countries, but Andorra ("AD") is not one them.
-            stats.inc_value("atp/nsi/match_failed")
-            stats.inc_value("atp/nsi/location_unknown")
+            self.crawler.stats.inc_value("atp/nsi/match_failed")
+            self.crawler.stats.inc_value("atp/nsi/location_unknown")
             return item
 
         if len(nsi_matches) == 1 and (not get_category_tags(item) or not location_code):
@@ -146,13 +152,13 @@ class ApplyNSICategoriesPipeline:
             # match wasn't possible so there is a remaining risk that a
             # mismatch has occurred. Alternatively or additionally, a location
             # match wasn't possible.
-            stats.inc_value("atp/nsi/match_imperfect")
+            self.crawler.stats.inc_value("atp/nsi/match_imperfect")
             self.apply_nsi_tags(nsi_matches[0], item)
             return item
         elif len(nsi_matches) == 1:
             # Perfect match where only one NSI entry is returned matching the
             # ATP item.
-            stats.inc_value("atp/nsi/match_perfect")
+            self.crawler.stats.inc_value("atp/nsi/match_perfect")
             self.apply_nsi_tags(nsi_matches[0], item)
             return item
 
@@ -164,8 +170,8 @@ class ApplyNSICategoriesPipeline:
         # country and first level subvision, both of the two KFC NSI entries
         # could be returned at this point. Matching fails here because it's
         # unknown which of the multiple NSI matches to apply.
-        stats.inc_value("atp/nsi/match_failed")
-        stats.inc_value("atp/nsi/multiple_matches")
+        self.crawler.stats.inc_value("atp/nsi/match_failed")
+        self.crawler.stats.inc_value("atp/nsi/multiple_matches")
         return item
 
     @staticmethod

--- a/locations/spiders/erste_pl.py
+++ b/locations/spiders/erste_pl.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class ErstePLSpider(Spider):
     name = "erste_pl"
-    item_attributes = {"brand": "Erste Bank Polska", "brand_wikidata": "Q806653"}
+    item_attributes = {"brand": "Erste Bank Polska"}
     start_urls = ["https://www.erste.pl/_js_places/places.js"]
 
     def parse(self, response, **kwargs):

--- a/tests/test_pipeline_apply_nsi_categories.py
+++ b/tests/test_pipeline_apply_nsi_categories.py
@@ -26,7 +26,7 @@ def get_test_objects(
     if isinstance(categories, list):
         for category in categories:
             apply_category(category, feature)
-    return feature, ApplyNSICategoriesPipeline(), spider
+    return feature, ApplyNSICategoriesPipeline.from_crawler(get_crawler()), spider
 
 
 def test_skip_nsi_matching():
@@ -38,7 +38,7 @@ def test_skip_nsi_matching():
         categories=[Categories.FAST_FOOD.value],
     )
     item["nsi_id"] = "-1"
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item["nsi_id"] == "-1"
 
     item, pipeline, spider = get_test_objects(
@@ -49,25 +49,25 @@ def test_skip_nsi_matching():
         categories=[Categories.FAST_FOOD.value],
     )
     item["nsi_id"] = "1234567"
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item["nsi_id"] == "1234567"
 
 
 def test_brand_missing():
     item, pipeline, spider = get_test_objects(spider_name="kfc_us", operator_wikidata="Q668737")
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
 def test_operator_missing():
     item, pipeline, spider = get_test_objects(spider_name="city_of_darwin_cctv_au", brand_wikidata="Q125673118")
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
 def test_brand_and_operator_missing():
     item, pipeline, spider = get_test_objects(spider_name="failing_spider")
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -80,7 +80,7 @@ def test_brand_category_missing():
     # convenience store, with no difference in branding or labelling of each
     # feature.
     item, pipeline, spider = get_test_objects(spider_name="kfc_us", brand_wikidata="Q524757", country="US", state="TX")
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item.get("nsi_id")
 
 
@@ -95,7 +95,7 @@ def test_brand_category_required():
         state="TX",
         categories=[Categories.CAR_WASH.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item.get("nsi_id")
 
     # Is this Costco feature shop=wholesale, amenity=car_wash...? No match is
@@ -103,7 +103,7 @@ def test_brand_category_required():
     item, pipeline, spider = get_test_objects(
         spider_name="costco_us", brand_wikidata="Q715583", country="US", state="TX"
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -118,7 +118,7 @@ def test_operator_category_missing():
     item, pipeline, spider = get_test_objects(
         spider_name="city_of_darwin_cctv_au", operator_wikidata="Q125673118", country="AU", state="NT"
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -132,7 +132,7 @@ def test_brand_country_missing():
         state="NSW",
         categories=[Categories.SHOP_SUPERMARKET.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # A match fails if the country is specified as a blank string (not just
@@ -144,7 +144,7 @@ def test_brand_country_missing():
         state="NSW",
         categories=[Categories.SHOP_SUPERMARKET.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -157,7 +157,7 @@ def test_brand_country_invalid():
         country="GB",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Brand is not known by NSI to operate in a specific country.
@@ -168,7 +168,7 @@ def test_brand_country_invalid():
         country="United Kingdom",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Specified country is entirely invalid.
@@ -178,7 +178,7 @@ def test_brand_country_invalid():
         country="ZZ",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -188,7 +188,7 @@ def test_brand_country_not_required():
     item, pipeline, spider = get_test_objects(
         spider_name="kfc_us", brand_wikidata="Q524757", categories=[Categories.FAST_FOOD.value]
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item.get("nsi_id")
 
 
@@ -198,7 +198,7 @@ def test_brand_country_required():
     item, pipeline, spider = get_test_objects(
         spider_name="woolworths_au", brand_wikidata="Q3249145", categories=[Categories.SHOP_SUPERMARKET.value]
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Another failure to specify a country is the country being a blank string
@@ -209,7 +209,7 @@ def test_brand_country_required():
         country="",
         categories=[Categories.SHOP_SUPERMARKET.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -223,7 +223,7 @@ def test_brand_state_missing():
         country="US",
         categories=[Categories.BANK.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # A match fails if the state is specified as a blank string (not just
@@ -236,7 +236,7 @@ def test_brand_state_missing():
         state="",
         categories=[Categories.BANK.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Failure to match one of multiple specific regions identified.
@@ -246,7 +246,7 @@ def test_brand_state_missing():
         country="US",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -260,7 +260,7 @@ def test_brand_state_invalid():
         state="AL",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Brand is not known by NSI to operate in a specific region.
@@ -272,7 +272,7 @@ def test_brand_state_invalid():
         state="Alabama",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Specified region is entirely invalid.
@@ -283,7 +283,7 @@ def test_brand_state_invalid():
         state="ZZ",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
     # Specified region is a blank string (not the default of None).
@@ -294,7 +294,7 @@ def test_brand_state_invalid():
         state="",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert not item.get("nsi_id")
 
 
@@ -308,5 +308,5 @@ def test_brand_state_not_required():
         state="TX",
         categories=[Categories.FAST_FOOD.value],
     )
-    pipeline.process_item(item, spider)
+    pipeline.process_item(item)
     assert item.get("nsi_id")


### PR DESCRIPTION
`def process_item(self, item: Feature, spider: Spider) -> Feature:` was deprecated a while ago, #11672 reintroduced it and is causing warnings.