### PR TITLE
Fix hallucinated brand_wikidata IDs for V-Markt, Vomar, and Liquor Mart CA

### DIFF
--- a/locations/spiders/liquor_mart_ca.py
+++ b/locations/spiders/liquor_mart_ca.py
@@ -13,7 +13,7 @@ class LiquorMartCASpider(Spider):
     """
 
     name = "liquor_mart_ca"
-    item_attributes = {"brand": "Liquor Mart", "brand_wikidata": "Q29467564"}
+    item_attributes = {"brand": "Liquor Mart", "brand_wikidata": "Q124030913"}
     start_urls = ["https://www.liquormarts.ca/liquormarts"]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
@@ -26,7 +26,7 @@ class LiquorMartCASpider(Spider):
             name = location.css("div.views-field-field-store-name .field-content::text").get("").strip()
             if "Express" in name:
                 item["brand"] = "Liquor Mart Express"
-                item["brand_wikidata"] = "Q29467564"
+                item["brand_wikidata"] = "Q124030913"
             item["branch"] = name.removeprefix("Liquor Mart Express").removeprefix("Liquor Mart").strip() or None
 
             item["street_address"] = (

--- a/locations/spiders/v_markt_de.py
+++ b/locations/spiders/v_markt_de.py
@@ -14,7 +14,7 @@ class VMarktDESpider(Spider):
     """
 
     name = "v_markt_de"
-    item_attributes = {"brand": "V-Markt", "brand_wikidata": "Q2523915"}
+    item_attributes = {"brand": "V-Markt", "brand_wikidata": "Q1504903"}
     start_urls = ["https://www.v-markt.de/standorte_vmarkt"]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:

--- a/locations/spiders/v_markt_de.py
+++ b/locations/spiders/v_markt_de.py
@@ -14,7 +14,7 @@ class VMarktDESpider(Spider):
     """
 
     name = "v_markt_de"
-    item_attributes = {"brand": "V-Markt", "brand_wikidata": "Q1504903"}
+    item_attributes = {"brand": "V-MARKT", "brand_wikidata": "Q1504903"}
     start_urls = ["https://www.v-markt.de/standorte_vmarkt"]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
@@ -79,7 +79,7 @@ class VMarktDESpider(Spider):
             item = Feature()
             item["ref"] = store_id
             # Strip brand prefix from name to get branch name
-            item["branch"] = re.sub(r"^V-Markt\s*", "", name).strip() or None
+            item["branch"] = re.sub(r"^V-MARKT\s*", "", name, flags=re.IGNORECASE).strip() or None
             item["street_address"] = street_address
             item["city"] = city
             item["postcode"] = postcode

--- a/locations/spiders/vomar_nl.py
+++ b/locations/spiders/vomar_nl.py
@@ -14,7 +14,7 @@ class VomarNLSpider(SitemapSpider):
     """
 
     name = "vomar_nl"
-    item_attributes = {"brand": "Vomar", "brand_wikidata": "Q2410271"}
+    item_attributes = {"brand": "Vomar", "brand_wikidata": "Q3202837"}
     sitemap_urls = ["https://www.vomar.nl/sitemap.xml"]
     sitemap_rules = [(r"https://www\.vomar\.nl/winkels/vomar-[^/]+\.htm$", "parse_store")]
 


### PR DESCRIPTION
Three brand_wikidata IDs from yesterday's new spiders were incorrect:

- **V-Markt** Q2523915 → was *Dicronychus sahlbergi* (a beetle 🐞) → correct: Q1504903
- **Vomar** Q2410271 → was *Chelonus iranicus* (a parasitic wasp 🐝) → correct: Q3202837
- **Liquor Mart** Q29467564 → was *Manitoba Liquor & Lotteries Corporation* (parent co.) → correct: Q124030913

Verified via the Wikidata API.