### PR TITLE
Fix jacks_us spider

### DIFF
--- a/locations/spiders/jacks_us.py
+++ b/locations/spiders/jacks_us.py
@@ -1,0 +1,19 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class JacksUSSpider(CrawlSpider, StructuredDataSpider):
+    name = "jacks_us"
+    item_attributes = {"brand": "Jack's", "brand_wikidata": "Q6110826"}
+    drop_attributes = {"name"}
+    start_urls = ["https://locations.eatatjacks.com/locations-list/"]
+    rules = [
+        Rule(LinkExtractor(r"/locations-list/\w\w/$")),
+        Rule(LinkExtractor(r"/locations-list/\w\w/[^/]+/$")),
+        Rule(LinkExtractor(r"com/\w\w/[^/]+/[^/]+/$"), "parse"),
+    ]
+    wanted_types = ["Restaurant"]
+    search_for_facebook = False
+    search_for_twitter = False


### PR DESCRIPTION
The spider was producing 0 results for 5 consecutive runs despite the site being fully alive at https://locations.eatatjacks.com/locations-list/.

Two bugs:

**1. Wrong `wanted_types`**: The spider set `wanted_types = ["LocalBusiness"]` but the JSON-LD on location pages uses `@type: "Restaurant"`. Since `Restaurant` is not in the list, `StructuredDataSpider` skipped every location page. Earlier run stats (e.g. June 6: 534 requests, depth 3, 0 items) show the spider was successfully crawling but extracting nothing.

**2. State URL regex missing trailing slash**: Rule 1 `r"/locations-list/\w\w$"` did not match the actual state URLs like `/locations-list/al/` (which have a trailing slash). This was masked by the item extraction bug — the spider was still reaching city and location pages because Scrapy also follows links encountered on the start page via rules 2 and 3.

The fix changes rule 1 to `r"/locations-list/\w\w/$"` and `wanted_types` to `["Restaurant"]`.

Tested locally: `uv run scrapy crawl jacks_us --set CLOSESPIDER_ITEMCOUNT=5` scraped 19 items, reaching depth 3 with 46 requests.

Closes #16866