### PR TITLE
Fix Blaze Pizza spider robots.txt timeout

### DIFF
--- a/locations/spiders/blaze_pizza.py
+++ b/locations/spiders/blaze_pizza.py
@@ -7,5 +7,6 @@ class BlazePizzaSpider(SitemapSpider, StructuredDataSpider):
     name = "blaze_pizza"
     item_attributes = {"brand": "Blaze Pizza", "brand_wikidata": "Q23016666"}
     requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False}
     sitemap_urls = ["https://locations.blazepizza.com/sitemap.xml"]
     sitemap_rules = [(r"https://locations.blazepizza.com/[^/]+/[^/]+/[a-zA-z0-9-]+", "parse_sd")]


### PR DESCRIPTION
The robots.txt fetch at locations.blazepizza.com hangs indefinitely when routed through Zyte proxy, causing the spider to produce no output. Adding ROBOTSTXT_OBEY: False so the sitemap fetch proceeds directly.

Closes #16871