### PR TITLE
Add requires_proxy to fix big_c_th spider

### DIFF
--- a/locations/spiders/big_c_th.py
+++ b/locations/spiders/big_c_th.py
@@ -19,6 +19,7 @@ def decode_phones(data_item: dict) -> list[str]:
 class BigCTHSpider(scrapy.Spider):
     name = "big_c_th"
     item_attributes = {"brand": "Big C", "brand_wikidata": "Q858665"}
+    requires_proxy = True
     start_urls = ["https://corporate.bigc.co.th/include/get_store.php"]
 
     def parse(self, response, **kwargs):


### PR DESCRIPTION
The `corporate.bigc.co.th` API endpoint is behind a Cloudflare Managed Challenge. Adding `requires_proxy = True` routes requests through Zyte to bypass it.

Closes #16870