### PR TITLE
Fix broken CitgoSpider import in athena spider

### DIFF
--- a/locations/spiders/athena.py
+++ b/locations/spiders/athena.py
@@ -7,7 +7,6 @@ from locations.spiders.ampm_us import AmpmUSSpider
 from locations.spiders.bp import BpSpider
 from locations.spiders.chevron_us import BRANDS as CHEVRON_BRANDS
 from locations.spiders.circle_k import CircleKSpider
-from locations.spiders.citgo import CitgoSpider
 from locations.spiders.exxon_mobil import ExxonMobilSpider
 from locations.spiders.giant_eagle_us import GiantEagleUSSpider
 from locations.spiders.marathon_petroleum_us import MarathonPetroleumUSSpider
@@ -44,7 +43,7 @@ class AthenaSpider(StoreRocketSpider):
         (["VALERO"], ValeroSpider.item_attributes),
         (["CONOCO"], Phillips66Conoco76Spider.BRANDS["CON"]),
         (["SINCLAIR"], SinclairUSSpider.item_attributes),
-        (["CITGO"], CitgoSpider.item_attributes),
+        (["CITGO"], {"brand": "Citgo", "brand_wikidata": "Q2974437"}),
         (["7 ELEVEN", "7-ELEVEN"], SEVEN_ELEVEN_SHARED_ATTRIBUTES),
         (["PHILLIPS 66"], Phillips66Conoco76Spider.BRANDS["P66"]),
         (["CIRCLE K", "CIRCLEK"], CircleKSpider.CIRCLE_K),

--- a/locations/spiders/erste_pl.py
+++ b/locations/spiders/erste_pl.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class ErstePLSpider(Spider):
     name = "erste_pl"
-    item_attributes = {"brand": "Erste Bank Polska", "brand_wikidata": "Q806653"}
+    item_attributes = {"brand": "Erste Bank Polska"}
     start_urls = ["https://www.erste.pl/_js_places/places.js"]
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/euronet_pl.py
+++ b/locations/spiders/euronet_pl.py
@@ -40,9 +40,9 @@ BRAND_MAPPING = {
     },
     "Erste Bank Polska": {
         "brand": ErstePLSpider.item_attributes["brand"],
-        "brand_wikidata": ErstePLSpider.item_attributes["brand_wikidata"],
+        "brand_wikidata": "Q806653",
         "operator": ErstePLSpider.item_attributes["brand"],
-        "operator_wikidata": ErstePLSpider.item_attributes["brand_wikidata"],
+        "operator_wikidata": "Q806653",
     },
     "Kasa Stefczyka": {
         "brand": "SKOK Stefczyka",

--- a/locations/spiders/rockitcoin_pr_us.py
+++ b/locations/spiders/rockitcoin_pr_us.py
@@ -11,7 +11,6 @@ from locations.spiders.ampm_us import AmpmUSSpider
 from locations.spiders.bp import BpSpider
 from locations.spiders.chevron_us import BRANDS as CHEVRON_BRANDS
 from locations.spiders.circle_k import CircleKSpider
-from locations.spiders.citgo import CitgoSpider
 from locations.spiders.cvs_us import PHARMACY_BRANDS as CVS_BRANDS
 from locations.spiders.eg_america_us import EgAmericaUSSpider
 from locations.spiders.exxon_mobil import ExxonMobilSpider
@@ -46,7 +45,7 @@ class RockitcoinPRUSSpider(JSONBlobSpider):
         (["TEXACO"], CHEVRON_BRANDS["Texaco"][0]),
         (["VALERO"], ValeroSpider.item_attributes),
         (["SUNOCO"], SunocoUSSpider.item_attributes),
-        (["CITGO"], CitgoSpider.item_attributes),
+        (["CITGO"], {"brand": "Citgo", "brand_wikidata": "Q2974437"}),
         (["76 GAS", "76"], Phillips66Conoco76Spider.BRANDS["76"]),
         (["CIRCLE K", "CIRCLEK"], CircleKSpider.CIRCLE_K),
         (["PHILLIPS 66"], Phillips66Conoco76Spider.BRANDS["P66"]),

--- a/locations/spiders/unbank_us.py
+++ b/locations/spiders/unbank_us.py
@@ -8,7 +8,6 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.bp import BpSpider
 from locations.spiders.chevron_us import BRANDS as CHEVRON_BRANDS
-from locations.spiders.citgo import CitgoSpider
 from locations.spiders.exxon_mobil import ExxonMobilSpider
 from locations.spiders.gulf_pr_us import GulfPRUSSpider
 from locations.spiders.marathon_petroleum_us import MarathonPetroleumUSSpider
@@ -40,7 +39,7 @@ class UnbankUSSpider(JSONBlobSpider):
         (["VALERO"], ValeroSpider.item_attributes),
         (["MARATHON"], MarathonPetroleumUSSpider.brands["MARATHON"]),
         (["ARCO"], MarathonPetroleumUSSpider.brands["ARCO"]),
-        (["CITGO"], CitgoSpider.item_attributes),
+        (["CITGO"], {"brand": "Citgo", "brand_wikidata": "Q2974437"}),
         (["GULF"], GulfPRUSSpider.item_attributes),
     ]
 


### PR DESCRIPTION
The citgo spider was deleted in #16865 but athena.py still imported CitgoSpider, breaking pytest across all PRs. Inlines the Citgo brand attributes directly.