### PR TITLE
Only scrape company-owned BRW stores, not independent dealers

### DIFF
--- a/locations/spiders/black_red_white_pl.py
+++ b/locations/spiders/black_red_white_pl.py
@@ -7,6 +7,7 @@ class BlackRedWhitePLSpider(SitemapSpider, StructuredDataSpider):
     name = "black_red_white_pl"
     item_attributes = {"brand": "Black Red White", "brand_wikidata": "Q4921546"}
     sitemap_urls = ["https://www.brw.pl/sitemap/salony.xml"]
+    sitemap_rules = [(r"/salon,salon-firmowy-black-red-white,", "parse_sd")]
 
     def pre_process_data(self, ld_data, **kwargs):
         ld_data["@id"] = None


### PR DESCRIPTION
The BRW store locator includes ~297 independent furniture dealers alongside ~70 company-owned stores. All were being tagged `brand=Black Red White`, but the independent dealers have their own brand identities (e.g. PSB Mrówka, Centrum Meblowe Stollido, etc.).

Adding `sitemap_rules` to filter only `salon-firmowy-black-red-white` URLs, which are the actual company-branded stores.

Closes #12013