### PR TITLE
[Starbucks BR] Fix spider

### DIFF
--- a/locations/spiders/starbucks_br.py
+++ b/locations/spiders/starbucks_br.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Any
 
@@ -5,7 +6,8 @@ from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.hours import OpeningHours
+from locations.items import Feature, set_closed
 from locations.spiders.starbucks_us import STARBUCKS_SHARED_ATTRIBUTES
 
 
@@ -16,16 +18,64 @@ class StarbucksBRSpider(Spider):
     requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        # Using xpath we only get few POIs
-        for ref, address, lat, lon, slug in re.findall(
-            r"\"([0-9a-f]+)\"[,\s]+\"(.+?)\"[,\s]+.*?\"([-.\d]+)\"[,\s]+\"([-.\d]+)\"[,\s]+.*?\"(starbucks-[-\w]+)\"",
-            response.xpath('//*[@id="__NUXT_DATA__"]/text()').get(""),
-        ):
+        for location in self.nuxt_state(response)["config"]["locations"]:
             item = Feature()
-            item["ref"] = ref
-            item["addr_full"] = address
-            item["lat"] = lat
-            item["lon"] = lon
-            item["website"] = response.urljoin(slug)
+            item["ref"] = location["establishment_id"]
+            item["addr_full"] = location["display_address"]
+            item["website"] = response.urljoin(location["slug"])
+
+            if (lat := location.get("address_latitude")) not in (None, "", "0") and (
+                lon := location.get("address_longitude")
+            ) not in (None, "", "0"):
+                item["lat"] = lat
+                item["lon"] = lon
+
+            if location.get("openinfo_status") == "CLOSED_PERMANENTLY":
+                set_closed(item)
+            else:
+                item["opening_hours"] = self.parse_hours(location.get("regular_hours", {}).get("periods", []))
+
             apply_category(Categories.COFFEE_SHOP, item)
-            yield item
+
+            if item.get("lat") and item.get("lon"):
+                yield item
+            else:
+                # The listing has no coordinates for this store, and neither does
+                # its detail page. Visit the page only to capture the Google Place ID
+                yield response.follow(item["website"], callback=self.parse_place_id, cb_kwargs={"item": item})
+
+    def parse_place_id(self, response: Response, item: Feature) -> Any:
+        if place_id := re.search(r"placeid=([\w-]+)", response.text):
+            item["extras"]["ref:google:place_id"] = place_id.group(1)
+        yield item
+
+    def resolve_nuxt(self, idx: int, payload: list, seen: frozenset = None) -> Any:
+        if seen is None:
+            seen = frozenset()
+
+        if not isinstance(idx, int) or idx < 0 or idx >= len(payload) or idx in seen:
+            return None
+
+        seen = seen | {idx}
+        node = payload[idx]
+
+        if isinstance(node, list):
+            if len(node) == 2 and node[0] in ("ShallowReactive", "Reactive", "Ref"):
+                return self.resolve_nuxt(node[1], payload, seen)
+            return [self.resolve_nuxt(x, payload, seen) if isinstance(x, int) else x for x in node]
+
+        if isinstance(node, dict):
+            return {k: self.resolve_nuxt(v, payload, seen) if isinstance(v, int) else v for k, v in node.items()}
+
+        return node
+
+    def nuxt_state(self, response: Response) -> dict:
+        return self.resolve_nuxt(1, json.loads(response.xpath('//script[@id="__NUXT_DATA__"]/text()').get()))["state"][
+            "$sstore"
+        ]
+
+    def parse_hours(self, periods: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for period in periods:
+            oh.add_range(period["openDay"].title(), period["openTime"], period["closeTime"])
+        return oh

--- a/locations/spiders/starbucks_br.py
+++ b/locations/spiders/starbucks_br.py
@@ -15,7 +15,6 @@ class StarbucksBRSpider(Spider):
     name = "starbucks_br"
     item_attributes = STARBUCKS_SHARED_ATTRIBUTES
     start_urls = ["https://starbucks.harmo.me/"]  # Locator found on https://starbucks.com.br/
-    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in self.nuxt_state(response)["config"]["locations"]:


### PR DESCRIPTION
Fixes the spider, which was previously only extracting a partial list of locations. Increase the count from 19 to 50.
The main directory's Nuxt state only provides geographic coordinates (`lat`/`lon`) for a subset of stores; the rest default to `"0"`. If a location is missing valid geometry in the main array, the spider now yields a secondary request to the individual store's page to fetch google place id.

Note: Removed proxy because spider is working fine on US network.

```
{'atp/brand/Starbucks': 50,
 'atp/brand_wikidata/Q37158': 50,
 'atp/category/amenity/cafe': 50,
 'atp/closed_poi': 2,
 'atp/country/BR': 50,
 'atp/field/branch/missing': 50,
 'atp/field/city/missing': 50,
 'atp/field/country/from_spider_name': 50,
 'atp/field/email/missing': 50,
 'atp/field/geometry/missing': 31,
 'atp/field/housenumber/missing': 50,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 50,
 'atp/field/operator_wikidata/missing': 50,
 'atp/field/phone/missing': 50,
 'atp/field/postcode/missing': 50,
 'atp/field/state/missing': 50,
 'atp/field/street/missing': 50,
 'atp/field/street_address/missing': 50,
 'atp/field/twitter/missing': 50,
 'atp/field/unit/missing': 50,
 'atp/item_scraped_host_count/starbucks.harmo.me': 50,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 50,
 'downloader/request_bytes': 12867,
 'downloader/request_count': 33,
 'downloader/request_method_count/GET': 33,
 'downloader/response_bytes': 985774,
 'downloader/response_count': 33,
 'downloader/response_status_count/200': 33,
 'elapsed_time_seconds': 40.51499999999987,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 18, 19, 42, 51, 162342, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 12019960,
 'httpcompression/response_count': 32,
 'item_scraped_count': 50,
 'items_per_minute': 75.0,
 'log_count/DEBUG': 83,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 33,
 'responses_per_minute': 49.5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 32,
 'scheduler/dequeued/memory': 32,
 'scheduler/enqueued': 32,
 'scheduler/enqueued/memory': 32,
 'start_time': datetime.datetime(2026, 6, 18, 19, 42, 10, 647905, tzinfo=datetime.timezone.utc)}
```