### PR TITLE
[Slovenská pošta SK] Add spider (1,638 locations)

### DIFF
--- a/locations/spiders/slovenska_posta_sk.py
+++ b/locations/spiders/slovenska_posta_sk.py
@@ -1,0 +1,66 @@
+from typing import Any, AsyncIterator
+from urllib.parse import urlencode
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+SLOVENSKA_POSTA = {"operator": "Slovenská pošta", "operator_wikidata": "Q1191849"}
+BALIKOBOX = {"brand": "BalíkoBOX", "brand_wikidata": "Q131136953", **SLOVENSKA_POSTA}
+
+
+class SlovenskaPostaSKSpider(Spider):
+    name = "slovenska_posta_sk"
+    start_urls = ["https://www.posta.sk/pobocky-a-balikoboxy"]
+    api_url = "https://api.posta.sk/private/web/branches"
+    page_size = 100
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield self.request_page(0)
+
+    def request_page(self, offset: int) -> Request:
+        return Request(
+            url="{}?{}".format(
+                self.api_url, urlencode({"include": "detail", "limit": self.page_size, "offset": offset})
+            ),
+            cb_kwargs={"offset": offset},
+        )
+
+    def parse(self, response: Response, offset: int, **kwargs: Any) -> Any:
+        locations = response.json().get("branches", [])
+        for location in locations:
+            item = self.parse_location(location)
+
+            if location.get("kind") == "office":
+                item.update(SLOVENSKA_POSTA)
+                apply_yes_no(Extras.ATM, item, "atm" in location.get("services", []))
+                apply_category(Categories.POST_OFFICE, item)
+            elif location.get("kind") == "bbox" and location.get("name", "").startswith("BalíkoBOX"):
+                item.update(BALIKOBOX)
+                apply_category(Categories.PARCEL_LOCKER, item)
+            else:
+                continue
+
+            yield item
+
+        if len(locations) == self.page_size:
+            yield self.request_page(offset + self.page_size)
+
+    def parse_location(self, location: dict[str, Any]) -> Feature:
+        item = DictParser.parse(location)
+
+        item["ref"] = location["id"]
+        item["lat"], item["lon"] = location["gps"]
+        item["name"] = location.get("dname") or location.get("name")
+        item["street_address"] = item.pop("street", None)
+        item["city"] = location.get("city")
+        item["postcode"] = location.get("zip")
+        item["website"] = "https://www.posta.sk/pobocky-a-balikoboxy?{}".format(urlencode({"n": location["nsk"]}))
+
+        if phones := location.get("phones"):
+            item["phone"] = "; ".join(phones)
+
+        return item

--- a/locations/spiders/slovenska_posta_sk.py
+++ b/locations/spiders/slovenska_posta_sk.py
@@ -6,6 +6,7 @@ from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 
 SLOVENSKA_POSTA = {"operator": "Slovenská pošta", "operator_wikidata": "Q1191849"}
@@ -63,4 +64,29 @@ class SlovenskaPostaSKSpider(Spider):
         if phones := location.get("phones"):
             item["phone"] = "; ".join(phones)
 
+        if opening_hours := self.parse_opening_hours(location.get("oh", [])):
+            item["opening_hours"] = opening_hours
+
         return item
+
+    def parse_opening_hours(self, days: list[dict[str, Any]]) -> str | None:
+        try:
+            day_hours = {}
+            for day in days:
+                if not day.get("std"):
+                    continue
+                # The API repeats today's row before the standard week; keep the later weekly row.
+                day_hours[DAYS_EN[day["day"].title()]] = day["std"]
+
+            opening_hours = OpeningHours()
+            for day, hours in day_hours.items():
+                for open_seconds, close_seconds in hours:
+                    opening_hours.add_range(day, self.format_seconds(open_seconds), self.format_seconds(close_seconds))
+            return opening_hours.as_opening_hours() or None
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def format_seconds(seconds: int) -> str:
+        hours, remainder = divmod(seconds, 3600)
+        return f"{hours:02}:{remainder // 60:02}"

--- a/locations/spiders/slovenska_posta_sk.py
+++ b/locations/spiders/slovenska_posta_sk.py
@@ -59,7 +59,7 @@ class SlovenskaPostaSKSpider(Spider):
         item["street_address"] = item.pop("street", None)
         item["city"] = location.get("city")
         item["postcode"] = location.get("zip")
-        item["website"] = "https://www.posta.sk/pobocky-a-balikoboxy?{}".format(urlencode({"n": location["nsk"]}))
+        item["website"] = "https://www.posta.sk/pobocky-a-balikoboxy#{}".format(urlencode({"n": location["nsk"]}))
 
         if phones := location.get("phones"):
             item["phone"] = "; ".join(phones)


### PR DESCRIPTION
Description: 

Data source:
https://www.posta.sk/pobocky-a-balikoboxy

The spider uses the Slovenská pošta branches API:
https://api.posta.sk/private/web/branches?include=detail&limit=100&offset=0

The locator UI searches this endpoint with limit and offset; the spider paginates the blank search until the final partial page.

Category mapping:

- kind=office -> Categories.POST_OFFICE
- kind=bbox and name starts with BalíkoBOX -> Categories.PARCEL_LOCKER
- services contains atm on a post office -> atm=yes

Brand / operator mapping:

- Post offices use operator=Slovenská pošta and operator:wikidata=Q1191849
- BalíkoBOX lockers use brand=BalíkoBOX, brand:wikidata=Q131136953, plus operator=Slovenská pošta, operator:wikidata=Q1191849

Scope note:
The same endpoint also returns AlzaBox lockers and PoštaPOINT partner locations. They are intentionally out of scope for this PR because the verified NSI entries here are Slovenská pošta post offices and BalíkoBOX parcel lockers. The spider therefore yields 1,394 post offices and 244 true BalíkoBOX lockers.

Opening hours:
The API provides structured oh data as weekly std ranges in seconds from midnight. The spider converts those ranges to OSM-style opening hours. The API also repeats the current day before the standard week and can include temporary temp overrides; the spider keeps the later standard weekly row and does not encode temporary overrides. One post office has no standard opening-hours range in the source, so it is left without opening_hours.

Stats summary:

- 1,638 total items
- 1,394 post offices
- 244 BalíkoBOX parcel lockers
- 59 post offices with atm=yes
- 1,637 items with opening_hours
- NSI: 1,638 match_perfect
- Country derived from spider name: 1,638

Sample POIs:
```[
  {
    "type": "Feature",
    "id": "YPlifPlR248akf74cMZcVj7muv0=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "slovenska_posta_sk",
      "spider:collection_time": "2026-06-19T12:15:46.306790"
    },
    "properties": {
      "ref": "291645",
      "atm": "yes",
      "amenity": "post_office",
      "@source_uri": "https://api.posta.sk/private/web/branches?include=detail&limit=100&offset=0",
      "@spider": "slovenska_posta_sk",
      "addr:street_address": "Janka Jesenského 2",
      "addr:city": "Bánovce nad Bebravou",
      "addr:postcode": "95701",
      "addr:country": "SK",
      "name": "Pošta Bánovce nad Bebravou 1",
      "phone": "+421 38 760 22 00",
      "website": "https://www.posta.sk/pobocky-a-balikoboxy?n=banovcenadbebravou1",
      "opening_hours": "Mo-Tu 08:00-18:00; We 08:00-19:00; Th-Fr 08:00-18:00",
      "operator": "Slovenská pošta",
      "operator:wikidata": "Q1191849",
      "nsi_id": "slovenskaposta-e92a45"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [18.256532302714, 48.7205049532285]
    }
  },
  {
    "type": "Feature",
    "id": "qZg4bN1LarXP0fPhaOVbso6fSlY=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "slovenska_posta_sk",
      "spider:collection_time": "2026-06-19T12:15:46.306790"
    },
    "properties": {
      "ref": "292481",
      "amenity": "post_office",
      "@source_uri": "https://api.posta.sk/private/web/branches?include=detail&limit=100&offset=0",
      "@spider": "slovenska_posta_sk",
      "addr:street_address": "Ábelová 94",
      "addr:city": "Ábelová",
      "addr:postcode": "98513",
      "addr:country": "SK",
      "name": "Pošta Ábelová",
      "phone": "+421 47 437 95 28",
      "website": "https://www.posta.sk/pobocky-a-balikoboxy?n=abelova",
      "opening_hours": "Mo-Fr 11:00-13:30",
      "operator": "Slovenská pošta",
      "operator:wikidata": "Q1191849",
      "nsi_id": "slovenskaposta-e92a45"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [19.4326164069571, 48.4111601519231]
    }
  },
  {
    "type": "Feature",
    "id": "2o9wwlk7_CvDryfQyuezsw8SqKE=",
    "dataset_attributes": {
      "spider:lineage": "S_?",
      "@spider": "slovenska_posta_sk",
      "spider:collection_time": "2026-06-19T12:15:46.306790"
    },
    "properties": {
      "ref": "309361",
      "amenity": "parcel_locker",
      "@source_uri": "https://api.posta.sk/private/web/branches?include=detail&limit=100&offset=0",
      "@spider": "slovenska_posta_sk",
      "addr:street_address": "Svätoplukova 1",
      "addr:city": "Bánovce nad Bebravou",
      "addr:postcode": "95991",
      "addr:country": "SK",
      "name": "BalíkoBOX LIDL",
      "phone": "+421 48 437 87 70",
      "website": "https://www.posta.sk/pobocky-a-balikoboxy?n=banovcenadbebravoubalikoboxlidl",
      "opening_hours": "Mo-Su 00:00-24:00",
      "brand": "BalíkoBOX",
      "brand:wikidata": "Q131136953",
      "operator": "Slovenská pošta",
      "operator:wikidata": "Q1191849",
      "nsi_id": "balikobox-cda9c4"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [18.252219, 48.726301]
    }
  }
]
```

JSON stats:

```{
  "atp/brand/BalíkoBOX": 244,
  "atp/brand_wikidata/Q131136953": 244,
  "atp/category/amenity/parcel_locker": 244,
  "atp/category/amenity/post_office": 1394,
  "atp/clean_strings/name": 4,
  "atp/country/SK": 1638,
  "atp/field/branch/missing": 1638,
  "atp/field/brand/missing": 1394,
  "atp/field/brand_wikidata/missing": 1394,
  "atp/field/country/from_spider_name": 1638,
  "atp/field/email/missing": 1638,
  "atp/field/housenumber/missing": 1638,
  "atp/field/opening_hours/missing": 1,
  "atp/field/phone/missing": 17,
  "atp/field/state/missing": 1638,
  "atp/field/street/missing": 1638,
  "atp/field/twitter/missing": 1638,
  "atp/field/unit/missing": 1638,
  "atp/item_scraped_host_count/api.posta.sk": 1638,
  "atp/lineage": "S_?",
  "atp/nsi/match_perfect": 1638,
  "atp/operator/Slovenská pošta": 1638,
  "atp/operator_wikidata/Q1191849": 1638,
  "downloader/request_bytes": 15042,
  "downloader/request_count": 26,
  "downloader/request_method_count/GET": 26,
  "downloader/response_bytes": 1780733,
  "downloader/response_count": 26,
  "downloader/response_status_count/200": 25,
  "downloader/response_status_count/404": 1,
  "elapsed_time_seconds": 33.625,
  "finish_reason": "finished",
  "finish_time": "2026-06-19T10:16:16.289264+00:00",
  "item_scraped_count": 1638,
  "items_per_minute": 2978.181818181818,
  "request_depth_max": 24,
  "response_received_count": 26,
  "responses_per_minute": 47.272727272727266,
  "robotstxt/request_count": 1,
  "robotstxt/response_count": 1,
  "robotstxt/response_status_count/404": 1,
  "scheduler/dequeued": 25,
  "scheduler/dequeued/memory": 25,
  "scheduler/enqueued": 25,
  "scheduler/enqueued/memory": 25,
  "start_time": "2026-06-19T10:15:42.669862+00:00"
}```