### PR TITLE
[JackWills GB] Fix spider

### DIFF
--- a/locations/spiders/jack_wills_gb.py
+++ b/locations/spiders/jack_wills_gb.py
@@ -56,10 +56,11 @@ class JackWillsGBSpider(JSONBlobSpider):
         item["branch"] = item.pop("name", "").removesuffix(" JWO").removesuffix(" JW")
         item["phone"] = feature.get("phoneNumber")
         item["website"] = "https://www.jackwills.com" + feature["slug"]
-        item["street_address"] = feature.get("address").get("address")
+        if address := feature.get("address"):
+            item["street_address"] = address.get("address")
 
         item["opening_hours"] = OpeningHours()
-        for rule in feature.get("openingHours"):
+        for rule in feature.get("openingHours") or []:
             item["opening_hours"].add_range(DAYS[int(rule["day"])], rule["openingTime"], rule["closingTime"])
 
         yield item

--- a/locations/spiders/jack_wills_gb.py
+++ b/locations/spiders/jack_wills_gb.py
@@ -1,30 +1,65 @@
-import chompjs
+from typing import AsyncIterator, Iterable
+
+from scrapy.http import JsonRequest, Response
 
 from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
 class JackWillsGBSpider(JSONBlobSpider):
     name = "jack_wills_gb"
-    item_attributes = {
-        "brand": "Jack Wills",
-        "brand_wikidata": "Q6115814",
-    }
-    start_urls = [
-        "https://www.jackwills.com/stores/search?countryName=United%20Kingdom&countryCode=GB&lat=0&long=0&sd=40"
-    ]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,
-    }
-    requires_proxy = True
+    item_attributes = {"brand": "Jack Wills", "brand_wikidata": "Q6115814"}
+    locations_key = ["data", "getStoresByLocation"]
 
-    def extract_json(self, response):
-        return chompjs.parse_js_object(response.xpath('//script[contains(text(),"var stores = ")]/text()').get())
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        graphql_query = """
+        query getStoresByLocation($countryCode: String!, $distanceUnit: DistanceUnit!, $latitude: String!, $longitude: String!, $maxDistance: Int!, $storeKey: String!) {
+          getStoresByLocation(
+            countryCode: $countryCode
+            distanceUnit: $distanceUnit
+            latitude: $latitude
+            longitude: $longitude
+            maxDistance: $maxDistance
+            storeKey: $storeKey
+          ) {
+            address { country countryCode postCode town address }
+            code
+            latitude
+            longitude
+            name
+            openingHours { day openingTime closingTime }
+            phoneNumber
+            slug
+          }
+        }
+        """
 
-    def post_process_item(self, item, response, location):
-        item["ref"] = location["code"]
-        item["website"] = "https://www.jackwills.com/" + location["storeUrl"]
+        yield JsonRequest(
+            url="https://api-prem.prd.frasersgroup.services/graphql?op=getStoresByLocation",
+            method="POST",
+            data={
+                "query": graphql_query,
+                "variables": {
+                    "countryCode": "GB",
+                    "distanceUnit": "Miles",
+                    "latitude": "51.5072178",
+                    "longitude": "-0.1275862",
+                    "maxDistance": 500,
+                    "storeKey": "JACK",
+                },
+            },
+        )
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["code"]
+        item["branch"] = item.pop("name", "").removesuffix(" JWO").removesuffix(" JW")
+        item["phone"] = feature.get("phoneNumber")
+        item["website"] = "https://www.jackwills.com" + feature["slug"]
+        item["street_address"] = feature.get("address").get("address")
+
         item["opening_hours"] = OpeningHours()
-        for rule in location["openingTimes"]:
-            item["opening_hours"].add_range(DAYS[rule["dayOfWeek"]], rule["openingTime"], rule["closingTime"])
+        for rule in feature.get("openingHours"):
+            item["opening_hours"].add_range(DAYS[int(rule["day"])], rule["openingTime"], rule["closingTime"])
+
         yield item


### PR DESCRIPTION
Note: Removed proxy as the spider is working fine on US network.

```
{'atp/brand/Jack Wills': 9,
 'atp/brand_wikidata/Q6115814': 9,
 'atp/category/shop/clothes': 9,
 'atp/country/GB': 9,
 'atp/field/email/missing': 9,
 'atp/field/housenumber/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/state/missing': 9,
 'atp/field/street/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/unit/missing': 9,
 'atp/item_scraped_host_count/api-prem.prd.frasersgroup.services': 9,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 9,
 'atp/nsi/match_imperfect': 9,
 'downloader/request_bytes': 1628,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 2352,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.2650000000001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 19, 12, 34, 9, 246653, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6432,
 'httpcompression/response_count': 1,
 'item_scraped_count': 9,
 'items_per_minute': 270.0,
 'log_count/DEBUG': 11,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 19, 12, 34, 6, 985578, tzinfo=datetime.timezone.utc)}
```