### PR TITLE
Improve category handling for the Feature class

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -454,21 +454,83 @@ class Categories(Enum):
     NATURAL_TREE = {"natural": "tree"}
 
 
-def apply_category(category: Mapping | Enum, item: Feature | dict) -> None:
+def apply_category(category: Mapping | Categories, item: Feature | dict) -> None:
     """
-    Apply categories to a Feature, where categories can be supplied as a
-    single Enum, or dictionary of key-value strings.
-    :param category: Either an Enum member representing a single category to
-                     add, or a dictionary of key-value strings representing
-                     a category to add.
-    :param item: Feature to which categories should be added to.
+    This 'apply_category' method has been replaced by use of the 'categories'
+    property of the 'Feature' class. It is preferred for a spider to set this
+    category property with either of:
+    1. item_attributes = {"brand": "ACME", "category": Categories.SHOP_WINE}
+    2. item["category"] = Categories.SHOP_WINE
+
+    For older spiders which still rely on this function, current behaviour of
+    this function is documented below.
+
+    A 'category' in ATP corresponds to categories defined in NSI
+    (see https://nsi.guide for list of categories). ATP uses this 'category'
+    to look up an entry in NSI for the Feature extracted to allow additional
+    attributes for the Feature to be automatically populated for the Feature.
+    For example, setting a category of 'amenity=fast_food' in ATP will allow
+    ATP to match a feature with the relevant brand in NSI and then additional
+    attributes such as 'cuisine=chicken' can automatically be added to the ATP
+    feature.
+
+    It's important to note this primary intended use of NSI matching because
+    if there exists a conflict between tagging in OSM and NSI, it is
+    preferred to use the NSI tagging scheme. This issue is seen, for example,
+    with deprecation of amenity=school on OSM and replacement with a new
+    tol level category tag of education=school. If NSI has not yet migrated
+    to use of education=school then it is preferred to follow whatever scheme
+    NSI is currently using.
+
+    This function will apply a 'category' to a Feature. A Feature should only
+    ever have one 'category' declared. Historically, ATP didn't enforce this
+    contraint because ATP stored the category in the 'extras' dictionary which
+    is a property of the Feature class. Spiders were free to add any number of
+    category tags into this 'extras' dictionary, such as:
+      item["extras"] = {"shop": "wine", "amenity": "parking"}
+    For this example, a spider may have set these tags for a single POI that
+    corresponds to a wine cellar shop at a vineyard, as well as customer
+    parking at the vineyard. The correct expectation for ATP spiders is the
+    shop and the parking area should be extracted as two separate features,
+    each with one top level category tag only.
+
+    A 'category' property has more recently been added to the Feature class in
+    ATP to ensure that only one top level category is applied at a time. By
+    passing a member of the Categories Enum member to this function, the
+    'category' property will be replaced with the supplied Categories Enum
+    member. No change is made the 'extras' property of the Feature.
+
+    If a Mapping (dict) is instead supplied to this function, a top level
+    category supplied in this dictionary, such as shop=wine, will be added
+    to the supplied Feature within the 'extras' property (a dictionary). This
+    function will do nothing if the supplied Mapping does not contain a top
+    level category. Do not add two top level categories to the Mapping
+    supplied. Refer to the documentation for the get_category_tags function
+    for more detail on how top level categories are decided. It is always
+    preferred to create a new member of the Categories Enum instead of
+    passing a Mapping (dict) to this function.
+
+    ATP will automatically attempt to use the 'category' property of each
+    Feature class to find a matching entry in NSI, and tags for that entry
+    in NSI will then be added to the 'extras' property of the Feature class.
+    If the Feature has not defined a value for the 'category' property, the
+    get_category_tags function will instead be used to read the 'extras'
+    property of the Feature to determine a top level category to use for
+    matching to an entry in NSI.
+
+    :param category: Either a Categories Enum member representing a single
+                     category to add, or a Mapping (e.g. dictionary) with a
+                     single key-value pair of strings representing a category
+                     to add.
+    :param item: Feature to which the category should be added to.
     """
-    if isinstance(category, Enum):
-        tags = category.value
+    if isinstance(category, Categories):
+        tags = {}
+        item["category"] = category
     elif isinstance(category, Mapping):
-        tags = category
+        tags = get_category_tags(category)
     else:
-        raise TypeError("dict or Enum required")
+        raise TypeError("Supplied top level categories must be a Categories Enum member (preferred) or Mapping (dict).")
 
     if not item.get("extras"):
         item["extras"] = {}
@@ -545,7 +607,10 @@ def get_category_tags(source: Feature | Enum | Mapping) -> dict:
              which are not top-level are ignored.
     """
     if isinstance(source, Feature):
-        tags = source.get("extras", {})
+        if isinstance(source.get("category"), Categories):
+            tags = source["category"].value
+        else:
+            tags = source.get("extras", {})
     elif isinstance(source, Enum):
         tags = source.value
     elif isinstance(source, Mapping):

--- a/locations/items.py
+++ b/locations/items.py
@@ -48,6 +48,7 @@ class Feature(scrapy.Item):
     located_in_wikidata = scrapy.Field()
     nsi_id = scrapy.Field()
     extras = scrapy.Field()
+    category = scrapy.Field()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -251,6 +252,7 @@ KEYS_THAT_SHOULD_MATCH = [
     "located_in",
     "located_in_wikidata",
     "nsi_id",
+    "category",
 ]
 
 TRANSLATABLE_EXTRA_KEYS = [

--- a/locations/pipelines/apply_nsi_categories.py
+++ b/locations/pipelines/apply_nsi_categories.py
@@ -1,6 +1,6 @@
 from scrapy.crawler import Crawler
 
-from locations.categories import get_category_tags
+from locations.categories import Categories, get_category_tags
 from locations.items import Feature
 from locations.name_suggestion_index import NSI
 
@@ -25,6 +25,13 @@ class ApplyNSICategoriesPipeline:
             # nsi_id is NOT a stable identifier and should not be set manually
             # by a spider unless it does so by lookup of the current NSI
             # database.
+
+            # If the Feature has a Categories Enum member supplied as a value
+            # in the 'category' property, tags need to be copied into the
+            # 'extras' property of the Feature.
+            if isinstance(item.get("category"), Categories):
+               self.copy_feature_category_to_extras_dict(item)
+
             return item
 
         brand_operator_qcode = item.get("brand_wikidata", item.get("operator_wikidata"))
@@ -34,6 +41,13 @@ class ApplyNSICategoriesPipeline:
             # fields must be supplied.
             self.crawler.stats.inc_value("atp/nsi/match_failed")
             self.crawler.stats.inc_value("atp/nsi/brand_or_operator_missing")
+
+            # If the Feature has a Categories Enum member supplied as a value
+            # in the 'category' property, tags need to be copied into the
+            # 'extras' property of the Feature.
+            if isinstance(item.get("category"), Categories):
+               self.copy_feature_category_to_extras_dict(item)
+
             return item
 
         if not get_category_tags(item) and item.get("brand_wikidata"):
@@ -73,6 +87,11 @@ class ApplyNSICategoriesPipeline:
             #   specified.
             self.crawler.stats.inc_value("atp/nsi/match_failed")
             self.crawler.stats.inc_value("atp/nsi/category_missing")
+
+            # Even though the match failed, there is no need to copy tags from
+            # a Categories Enum member supplied as a value in the 'category'
+            # property of the Feature to the 'extras' property of the Feature.
+            # There are no useful top level tags to copy.
             return item
 
         if not item.has_valid_country_code():
@@ -96,7 +115,15 @@ class ApplyNSICategoriesPipeline:
             # https://github.com/osmlab/name-suggestion-index
             self.crawler.stats.inc_value("atp/nsi/match_failed")
             self.crawler.stats.inc_value("atp/nsi/brand_unknown")
+
+            # If the Feature has a Categories Enum member supplied as a value
+            # in the 'category' property, tags need to be copied into the
+            # 'extras' property of the Feature.
+            if isinstance(item.get("category"), Categories):
+               self.copy_feature_category_to_extras_dict(item)
+
             return item
+
         elif len(nsi_matches) == 0 and item.get("operator_wikidata"):
             # Failure to match due to the ATP item specifying a Wikidata item
             # for an operator, but NSI does not know of this Wikidata item.
@@ -104,6 +131,13 @@ class ApplyNSICategoriesPipeline:
             # https://github.com/osmlab/name-suggestion-index
             self.crawler.stats.inc_value("atp/nsi/match_failed")
             self.crawler.stats.inc_value("atp/nsi/operator_unknown")
+
+            # If the Feature has a Categories Enum member supplied as a value
+            # in the 'category' property, tags need to be copied into the
+            # 'extras' property of the Feature.
+            if isinstance(item.get("category"), Categories):
+               self.copy_feature_category_to_extras_dict(item)
+
             return item
 
         # Sometimes a brand and operator are the same across both NSI's
@@ -131,6 +165,13 @@ class ApplyNSICategoriesPipeline:
                 # warehouses.
                 self.crawler.stats.inc_value("atp/nsi/match_failed")
                 self.crawler.stats.inc_value("atp/nsi/category_unknown")
+
+                # If the Feature has a Categories Enum member supplied as a value
+                # in the 'category' property, tags need to be copied into the
+                # 'extras' property of the Feature.
+                if isinstance(item.get("category"), Categories):
+                    self.copy_feature_category_to_extras_dict(item)
+
                 return item
 
         location_code = item.get_iso_3166_2_code()
@@ -145,6 +186,13 @@ class ApplyNSICategoriesPipeline:
             # to operate in 3 countries, but Andorra ("AD") is not one them.
             self.crawler.stats.inc_value("atp/nsi/match_failed")
             self.crawler.stats.inc_value("atp/nsi/location_unknown")
+
+            # If the Feature has a Categories Enum member supplied as a value
+            # in the 'category' property, tags need to be copied into the
+            # 'extras' property of the Feature.
+            if isinstance(item.get("category"), Categories):
+               self.copy_feature_category_to_extras_dict(item)
+
             return item
 
         if len(nsi_matches) == 1 and (not get_category_tags(item) or not location_code):
@@ -172,6 +220,13 @@ class ApplyNSICategoriesPipeline:
         # unknown which of the multiple NSI matches to apply.
         self.crawler.stats.inc_value("atp/nsi/match_failed")
         self.crawler.stats.inc_value("atp/nsi/multiple_matches")
+
+        # If the Feature has a Categories Enum member supplied as a value
+        # in the 'category' property, tags need to be copied into the
+        # 'extras' property of the Feature.
+        if isinstance(item.get("category"), Categories):
+            self.copy_feature_category_to_extras_dict(item)
+
         return item
 
     @staticmethod
@@ -290,3 +345,33 @@ class ApplyNSICategoriesPipeline:
                 if extras.get(key) is None:
                     extras[key] = value
         item["extras"] = extras
+
+    @staticmethod
+    def copy_feature_category_to_extras_dict(item: Feature) -> None:
+        """
+        For a Feature with a Categories Enum member supplied in the 'category'
+        property, copy the tags of this Categories Enum member to the 'extras'
+        property of the Feature.
+
+        If NSI matching is successful, this function would not be called and
+        the 'extras' property of the Feature is instead populated with tags
+        retrieved from the successfully matched NSI entry.
+
+        If NSI matching is not possible, the spider may have set the
+        'category' property and been hopeful for an NSI match, which has not
+        been able to occur successfully. The spider's setting of the
+        'category' property allows tags of this Categories Enum member to be
+        used instead of the tags that would have been otherwise retrieved
+        from a matching NSI entry.
+        :param item: Feature that will, if possible, have tags from the
+                     'category' property (Categories Enum member) copied to
+                     the Feature's 'extras' property.
+        """
+        if category := item.get("category"):
+            if not isinstance(category, Categories):
+                return
+            tags = category.value
+            if not item.get("extras"):
+                item["extras"] = {}
+            for key, value in tags.items():
+                item["extras"][key] = value

--- a/locations/pipelines/apply_nsi_categories.py
+++ b/locations/pipelines/apply_nsi_categories.py
@@ -30,7 +30,7 @@ class ApplyNSICategoriesPipeline:
             # in the 'category' property, tags need to be copied into the
             # 'extras' property of the Feature.
             if isinstance(item.get("category"), Categories):
-               self.copy_feature_category_to_extras_dict(item)
+                self.copy_feature_category_to_extras_dict(item)
 
             return item
 
@@ -46,7 +46,7 @@ class ApplyNSICategoriesPipeline:
             # in the 'category' property, tags need to be copied into the
             # 'extras' property of the Feature.
             if isinstance(item.get("category"), Categories):
-               self.copy_feature_category_to_extras_dict(item)
+                self.copy_feature_category_to_extras_dict(item)
 
             return item
 
@@ -120,7 +120,7 @@ class ApplyNSICategoriesPipeline:
             # in the 'category' property, tags need to be copied into the
             # 'extras' property of the Feature.
             if isinstance(item.get("category"), Categories):
-               self.copy_feature_category_to_extras_dict(item)
+                self.copy_feature_category_to_extras_dict(item)
 
             return item
 
@@ -136,7 +136,7 @@ class ApplyNSICategoriesPipeline:
             # in the 'category' property, tags need to be copied into the
             # 'extras' property of the Feature.
             if isinstance(item.get("category"), Categories):
-               self.copy_feature_category_to_extras_dict(item)
+                self.copy_feature_category_to_extras_dict(item)
 
             return item
 
@@ -191,7 +191,7 @@ class ApplyNSICategoriesPipeline:
             # in the 'category' property, tags need to be copied into the
             # 'extras' property of the Feature.
             if isinstance(item.get("category"), Categories):
-               self.copy_feature_category_to_extras_dict(item)
+                self.copy_feature_category_to_extras_dict(item)
 
             return item
 

--- a/locations/spiders/first_national_bank_us.py
+++ b/locations/spiders/first_national_bank_us.py
@@ -1,5 +1,5 @@
 from locations.brand_utils import extract_located_in
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, apply_yes_no
 from locations.spiders.eatn_park_us import EatnParkUSSpider
 from locations.spiders.exxon_mobil import ExxonMobilSpider
 from locations.spiders.food_lion_us import FoodLionUSSpider
@@ -36,12 +36,12 @@ class FirstNationalBankUSSpider(YextAnswersSpider):
 
     def parse_item(self, location, item):
         if location["type"] == "atm":
-            apply_category(Categories.ATM, item)
+            item["category"] = Categories.ATM
             item["located_in"], item["located_in_wikidata"] = extract_located_in(
                 item.get("branch", ""), self.LOCATED_IN_MAPPINGS, self
             )
         elif location["type"] == "location":
-            apply_category(Categories.BANK, item)
+            item["category"] = Categories.BANK
             if amenities := location.get("c_branchFilters"):
                 apply_yes_no(Extras.ATM, item, "ATM" in amenities, False)
                 apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive-Thru" in amenities, False)

--- a/locations/spiders/infrastructure/barwon_water_potable_pump_stations_au.py
+++ b/locations/spiders/infrastructure/barwon_water_potable_pump_stations_au.py
@@ -9,7 +9,11 @@ from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpid
 
 class BarwonWaterPotablePumpStationsAUSpider(ArcGISFeatureServerSpider):
     name = "barwon_water_potable_pump_stations_au"
-    item_attributes = {"operator": "Barwon Water", "operator_wikidata": "Q4865988", "category": Categories.PUMPING_STATION_WATER}
+    item_attributes = {
+        "operator": "Barwon Water",
+        "operator_wikidata": "Q4865988",
+        "category": Categories.PUMPING_STATION_WATER,
+    }
     host = "services8.arcgis.com"
     context_path = "uLK1YQYKdEhgFHsx/ArcGIS"
     service_id = "Barwon_Water_Water_Assets"

--- a/locations/spiders/infrastructure/barwon_water_potable_pump_stations_au.py
+++ b/locations/spiders/infrastructure/barwon_water_potable_pump_stations_au.py
@@ -2,14 +2,14 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories
 from locations.items import Feature
 from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
 
 
 class BarwonWaterPotablePumpStationsAUSpider(ArcGISFeatureServerSpider):
     name = "barwon_water_potable_pump_stations_au"
-    item_attributes = {"operator": "Barwon Water", "operator_wikidata": "Q4865988"}
+    item_attributes = {"operator": "Barwon Water", "operator_wikidata": "Q4865988", "category": Categories.PUMPING_STATION_WATER}
     host = "services8.arcgis.com"
     context_path = "uLK1YQYKdEhgFHsx/ArcGIS"
     service_id = "Barwon_Water_Water_Assets"
@@ -19,5 +19,4 @@ class BarwonWaterPotablePumpStationsAUSpider(ArcGISFeatureServerSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(feature["BW_ASSET_ID"])
         item["name"] = feature.get("GENERAL_TEXT")
-        apply_category(Categories.PUMPING_STATION_WATER, item)
         yield item

--- a/locations/spiders/kfc_us.py
+++ b/locations/spiders/kfc_us.py
@@ -1,10 +1,10 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, apply_yes_no
 from locations.items import set_closed
 from locations.structured_data_spider import StructuredDataSpider
 
-KFC_SHARED_ATTRIBUTES = {"brand": "KFC", "brand_wikidata": "Q524757", "extras": Categories.FAST_FOOD.value}
+KFC_SHARED_ATTRIBUTES = {"brand": "KFC", "brand_wikidata": "Q524757", "category": Categories.FAST_FOOD}
 
 
 class KfcUSSpider(SitemapSpider, StructuredDataSpider):
@@ -26,7 +26,5 @@ class KfcUSSpider(SitemapSpider, StructuredDataSpider):
         apply_yes_no(Extras.DRIVE_THROUGH, item, "Drive Thru" in services)
         # apply_yes_no(, item, "Gift Cards" in services)
         apply_yes_no(Extras.WIFI, item, "WiFi" in services)
-
-        apply_category(Categories.FAST_FOOD, item)
 
         yield item


### PR DESCRIPTION
Currently a 'category' in ATP is primarily used for the purpose of matching a feature to one in NSI, and applying additional tags from the matched NSI entry. There are some auxillary uses too--such as compiling statistics at the end of each spider run, which is particularly useful for spiders which extract multiple types of features, such as bank branches and ATMs.

The primary method expected to be used today by a spider to set a category for a feature is use of the 'apply_category' function. This function has had a messy historical history, having changed in functionality a few times, and been used in differing ways by spiders. This is largely due to the historical lack of strict definition for the 'apply_category' function and the ad-hoc way in which ATP has historically wanted spiders to specify a category.

It is now clear from PR #16911 and other changes in the past year:
- A category is an NSI "category", which is based on https://wiki.openstreetmap.org/wiki/Top-level_tag
- A feature extracted by ATP should only have a single NSI "category" applicable. That is, a spider extracting a shop=supermarket and amenity=parking as a single feature for a supermarket that also has a nearby customer carpark should extract two separate features, each with only one category (either shop=supermarket or amenity=parking).
- Spiders should provide minimum tags necessary to permit a feature to be matched to an NSI entry. For example, a spider shouldn't need to specify cuisine=chicken for spider kfc_us because this tag can be obtained from (and centrally managed) through the NSI database. Extras tags should only be supplied where they differ between different features being extracted. If tags apply to all features extracted by a spider, a change request should be made to NSI to update tags in the NSI database.
- If there is a conflict between NSI categories and OSM top-level keys (https://wiki.openstreetmap.org/wiki/Top-level_tag) as is the case for the example of amenity=school/education=school (OSM is transitioning to new education= top level key) then the NSI category is preferred to be used by ATP, because ATP primarily cares about categories just to allow an NSI match to occur.

This change introduces a new 'category' property to the Feature class which expects a type only of a single member of the Categories Enum (from categories.py). This presents a number of benefits to help prevent spiders from messing up categories, and also to make spiders simpler and easier to read and develop:
- `item_attributes = {"brand": "..", "brand_wikidata": "..", "category": Categories.SHOP_WINE}` can be used as the preferred method for specifying a single common category for all features extracted by a spider. It's not possible to accidentally specify two categories for the same feature. It also places all the information NSI uses to perform matching in a single line (single dictionary) so on a quick glance at spider code it's possible to see how it intends NSI matching to occur.
- `item["category"] = Categories.ATM` can be used within a spider to specify/override the category of an individual feature, if the spider is able to extract different feature types such as bank branches and ATMs.
- There is no longer a need to add single line post_process_item functions into spiders which only call `apply_category(Categories.ATM, item)`. This can significantly reduce the number of imports the spider needs and makes spiders faster to develop and easier to read.
- There is no need to use the `apply_category` function--it is now deprecated (and could be decorated as @deprecated when ATP specifies a more recent minimum Python version).

By setting the 'category' property on a Feature,
ApplyNSICategoriesPipeline will use this 'category' when finding a suitable NSI entry to match the Feature against. The 'extras' dictionary of the Feature will then be populated with any tags contained in the NSI entry. For example, if `item["category"] = Categories.FAST_FOOD` and an NSI match is successful, ApplyNSICategoriesPipeline may set `item["extras"] = {"amenity": "fast_food", "cuisine": "chicken"}`.

If an NSI match is unsuccessful (e.g. NSI doesn't yet contain an entry for the feature) then ApplyNSICategoriesPipeline will fall back to copying tags from the 'category' of a Feature into the 'extras' dictionary. For example, if `item["category"] = Categories.FAST_FOOD` but an NSI match is not possible, ApplyNSICategoriesPipeline would set `item["extras"] = {"amenity": "fast_food"}`.