### PR TITLE
Daikokuya (JP) create spider

### DIFF
--- a/locations/spiders/daikokuya_jp.py
+++ b/locations/spiders/daikokuya_jp.py
@@ -1,5 +1,5 @@
-from typing import Iterable
 import re
+from typing import Iterable
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
@@ -16,7 +16,7 @@ class DaikokuyaJPSpider(LocationCloudSpider):
 
         item["branch"] = source_feature["name"].removesuffix("大黒屋 ")
         item["extras"]["branch:en"] = source_feature.get("ruby").removesuffix("Daikokuya ")
-        item["addr_full"] = re.sub(r'<\/?.*>', '', source_feature.get("address_name")) # removes HTML
+        item["addr_full"] = re.sub(r"<\/?.*>", "", source_feature.get("address_name"))  # removes HTML
 
         apply_category(Categories.SHOP_PAWNBROKER, item)
 

--- a/locations/spiders/daikokuya_jp.py
+++ b/locations/spiders/daikokuya_jp.py
@@ -14,8 +14,8 @@ class DaikokuyaJPSpider(LocationCloudSpider):
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
 
-        item["branch"] = source_feature["name"].removesuffix("大黒屋 ")
-        item["extras"]["branch:en"] = source_feature.get("ruby").removesuffix("Daikokuya ")
+        item["branch"] = source_feature["name"].removeprefix("大黒屋 ")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby").removeprefix("だいこくや ")
         item["addr_full"] = re.sub(r"<\/?.*>", "", source_feature.get("address_name"))  # removes HTML
 
         apply_category(Categories.SHOP_PAWNBROKER, item)

--- a/locations/spiders/daikokuya_jp.py
+++ b/locations/spiders/daikokuya_jp.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+import re
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class DaikokuyaJPSpider(LocationCloudSpider):
+    name = "daikokuya_jp"
+    item_attributes = {"brand": "大黒屋", "brand_wikidata": "Q11442068"}
+    api_endpoint = "https://shop.e-daikoku.com/info/api/proxy2/shop/list"
+    website_formatter = "https://shop.e-daikoku.com/info/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+
+        item["branch"] = source_feature["name"].removesuffix("大黒屋 ")
+        item["extras"]["branch:en"] = source_feature.get("ruby").removesuffix("Daikokuya ")
+        item["addr_full"] = re.sub(r'<\/?.*>', '', source_feature.get("address_name")) # removes HTML
+
+        apply_category(Categories.SHOP_PAWNBROKER, item)
+
+        yield item


### PR DESCRIPTION
closes #16904 

{'atp/brand/大黒屋': 217,
 'atp/brand_wikidata/Q11442068': 217,
 'atp/category/shop/pawnbroker': 217,
 'atp/clean_strings/addr_full': 38,
 'atp/country/JP': 217,
 'atp/field/city/missing': 217,
 'atp/field/country/from_spider_name': 217,
 'atp/field/email/missing': 217,
 'atp/field/housenumber/missing': 217,
 'atp/field/opening_hours/missing': 217,
 'atp/field/operator/missing': 217,
 'atp/field/operator_wikidata/missing': 217,
 'atp/field/phone/missing': 217,
 'atp/field/state/missing': 217,
 'atp/field/street/missing': 217,
 'atp/field/street_address/missing': 217,
 'atp/field/twitter/missing': 217,
 'atp/field/unit/missing': 217,
 'atp/item_scraped_host_count/shop.e-daikoku.com': 217,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 217,
 'downloader/request_bytes': 718,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 55041,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.1410000000032596,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 4, 21, 37, 767931, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 297029,
 'httpcompression/response_count': 2,
 'item_scraped_count': 217,
 'items_per_minute': 4340.0,
 'log_count/DEBUG': 219,
 'log_count/ERROR': 1,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'spider_exceptions/AttributeError': 1,
 'spider_exceptions/count': 1,
 'start_time': datetime.datetime(2026, 6, 20, 4, 21, 34, 622377, tzinfo=datetime.timezone.utc)}