### PR TITLE
UCC Coffee House (JP) create spider

### DIFF
--- a/locations/spiders/ucc_jp.py
+++ b/locations/spiders/ucc_jp.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class UccJPSpider(LocationCloudSpider):
+    name = "ucc_jp"
+    item_attributes = {"brand": "上島珈琲店", "brand_wikidata": "Q96152143"}
+    api_endpoint = "https://shop.ufs.co.jp/ufs/api/proxy2/shop/list"
+    website_formatter = "https://shop.ufs.co.jp/ufs/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+
+        item["branch"] = source_feature["name"].removeprefix("上島珈琲店　")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby").removeprefix("UESHIMA COFFEE ")
+
+        apply_category(Categories.COFFEE_SHOP, item)
+
+        yield item


### PR DESCRIPTION
closes #16931
{'atp/brand/上島珈琲店': 162,
 'atp/brand_wikidata/Q96152143': 162,
 'atp/category/amenity/cafe': 162,
 'atp/country/JP': 162,
 'atp/field/city/missing': 162,
 'atp/field/country/from_spider_name': 162,
 'atp/field/email/missing': 162,
 'atp/field/housenumber/missing': 162,
 'atp/field/opening_hours/missing': 162,
 'atp/field/operator/missing': 162,
 'atp/field/operator_wikidata/missing': 162,
 'atp/field/phone/missing': 162,
 'atp/field/state/missing': 162,
 'atp/field/street/missing': 162,
 'atp/field/street_address/missing': 162,
 'atp/field/twitter/missing': 162,
 'atp/field/unit/missing': 162,
 'atp/item_scraped_host_count/shop.ufs.co.jp': 162,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 162,
 'downloader/request_bytes': 709,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 18171,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.9059999999990396,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 4, 46, 21, 814144, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 111045,
 'httpcompression/response_count': 2,
 'item_scraped_count': 162,
 'items_per_minute': 4860.0,
 'log_count/DEBUG': 164,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 20, 4, 46, 18, 898785, tzinfo=datetime.timezone.utc)}