### PR TITLE
Origin Toshu (JP) create spider

### DIFF
--- a/locations/spiders/origin_toshu.py
+++ b/locations/spiders/origin_toshu.py
@@ -11,35 +11,37 @@ class OriginToshuSpider(LocationCloudSpider):
     website_formatter = "https://shop.toshu.co.jp/toshu/spot/detail?code={}"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        name = source_feature.get("name") or ""
         match source_feature["categories"][0]["name"]:
             case "キッチンオリジン":
                 item["brand_wikidata"] = "Q92658990"
-                item["branch"] = source_feature.get("name").removeprefix("キッチンオリジン ")
+                item["branch"] = name.removeprefix("キッチンオリジン ") or None
                 if ruby := source_feature.get("ruby"):
                     item["extras"]["branch:ja-Hira"] = ruby.removeprefix("きっちんおりじん ")
                 apply_category(Categories.FAST_FOOD, item)
             case "れんげ食堂Toshu":
                 item["brand_wikidata"] = "Q92662226"
-                item["branch"] = source_feature.get("name").removeprefix("れんげ食堂Toshu ")
+                item["branch"] = name.removeprefix("れんげ食堂Toshu ") or None
                 if ruby := source_feature.get("ruby"):
                     item["extras"]["branch:ja-Hira"] = ruby.removeprefix("れんげしょくどうとうしゅう ")
                 apply_category(Categories.RESTAURANT, item)
             case "オリジンデリカ":
                 item["brand"] = "オリジンデリカ"
-                item["branch"] = source_feature.get("name").removeprefix("オリジンデリカ ")
+                item["branch"] = name.removeprefix("オリジンデリカ ") or None
                 if ruby := source_feature.get("ruby"):
                     item["extras"]["branch:ja-Hira"] = ruby.removeprefix("おりじんでりか ")
                 apply_category(Categories.FAST_FOOD, item)
             case "オリジン弁当":
                 item["brand_wikidata"] = "Q11292632"
-                item["branch"] = source_feature.get("name").removeprefix("オリジン弁当 ")
+                item["branch"] = name.removeprefix("オリジン弁当 ") or None
                 if ruby := source_feature.get("ruby"):
                     item["extras"]["branch:ja-Hira"] = ruby.removeprefix("おりじんべんとう ")
                 apply_category(Categories.FAST_FOOD, item)
             case _:
                 item["brand"] = source_feature["categories"][0]["name"]
-                item["branch"] = source_feature.get("name")
-                item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+                item["branch"] = name or None
+                if ruby := source_feature.get("ruby"):
+                    item["extras"]["branch:ja-Hira"] = ruby
                 apply_category(Categories.RESTAURANT, item)
 
         yield item

--- a/locations/spiders/origin_toshu.py
+++ b/locations/spiders/origin_toshu.py
@@ -1,0 +1,45 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class OriginToshuSpider(LocationCloudSpider):
+    name = "origin_toshu"
+    api_endpoint = "https://shop.toshu.co.jp/toshu/api/proxy2/shop/list"
+    website_formatter = "https://shop.toshu.co.jp/toshu/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        match source_feature["categories"][0]["name"]:
+            case "キッチンオリジン":
+                item["brand_wikidata"] = "Q92658990"
+                item["branch"] = source_feature.get("name").removeprefix("キッチンオリジン ")
+                if ruby := source_feature.get("ruby"):
+                    item["extras"]["branch:ja-Hira"] = ruby.removeprefix("きっちんおりじん ")
+                apply_category(Categories.FAST_FOOD, item)
+            case "れんげ食堂Toshu":
+                item["brand_wikidata"] = "Q92662226"
+                item["branch"] = source_feature.get("name").removeprefix("れんげ食堂Toshu ")
+                if ruby := source_feature.get("ruby"):
+                    item["extras"]["branch:ja-Hira"] = ruby.removeprefix("れんげしょくどうとうしゅう ")
+                apply_category(Categories.RESTAURANT, item)
+            case "オリジンデリカ":
+                item["brand"] = "オリジンデリカ"
+                item["branch"] = source_feature.get("name").removeprefix("オリジンデリカ ")
+                if ruby := source_feature.get("ruby"):
+                    item["extras"]["branch:ja-Hira"] = ruby.removeprefix("おりじんでりか ")
+                apply_category(Categories.FAST_FOOD, item)
+            case "オリジン弁当":
+                item["brand_wikidata"] = "Q11292632"
+                item["branch"] = source_feature.get("name").removeprefix("オリジン弁当 ")
+                if ruby := source_feature.get("ruby"):
+                    item["extras"]["branch:ja-Hira"] = ruby.removeprefix("おりじんべんとう ")
+                apply_category(Categories.FAST_FOOD, item)
+            case _:
+                item["brand"] = source_feature["categories"][0]["name"]
+                item["branch"] = source_feature.get("name")
+                item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+                apply_category(Categories.RESTAURANT, item)
+
+        yield item


### PR DESCRIPTION
closes #16905
{'atp/brand/れんげ食堂Toshu': 80,
 'atp/brand/オリジンデリカ': 56,
 'atp/brand/オリジン弁当': 16,
 'atp/brand/キッチンオリジン': 395,
 'atp/brand/武蔵野うどん小麦晴れ': 4,
 'atp/brand/鉄鍋焼きスパ ゲッティ': 2,
 'atp/brand_wikidata/Q11292632': 16,
 'atp/brand_wikidata/Q92658990': 395,
 'atp/brand_wikidata/Q92662226': 80,
 'atp/category/amenity/fast_food': 467,
 'atp/category/amenity/restaurant': 86,
 'atp/country/JP': 553,
 'atp/field/brand_wikidata/missing': 62,
 'atp/field/city/missing': 553,
 'atp/field/country/from_website_url': 553,
 'atp/field/email/missing': 553,
 'atp/field/housenumber/missing': 553,
 'atp/field/name/missing': 62,
 'atp/field/opening_hours/missing': 553,
 'atp/field/operator/missing': 553,
 'atp/field/operator_wikidata/missing': 553,
 'atp/field/phone/missing': 553,
 'atp/field/state/missing': 553,
 'atp/field/street/missing': 553,
 'atp/field/street_address/missing': 553,
 'atp/field/twitter/missing': 553,
 'atp/field/unit/missing': 553,
 'atp/item_scraped_host_count/shop.toshu.co.jp': 553,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 62,
 'atp/nsi/match_failed': 62,
 'atp/nsi/match_perfect': 491,
 'downloader/request_bytes': 1277,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 46451,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 4.35899999999674,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 8, 26, 33, 140574, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 375886,
 'httpcompression/response_count': 3,
 'item_scraped_count': 553,
 'items_per_minute': 8295.0,
 'log_count/DEBUG': 556,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 45.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 6, 20, 8, 26, 28, 777363, tzinfo=datetime.timezone.utc)}