### PR TITLE
[king_pie_za] Fix spider

### DIFF
--- a/locations/spiders/king_pie_za.py
+++ b/locations/spiders/king_pie_za.py
@@ -10,6 +10,7 @@ class KingPieZASpider(JSONBlobSpider):
     item_attributes = {"brand": "King Pie", "brand_wikidata": "Q116619039"}
     start_urls = ["https://www.kingpie.co.za/wp-content/uploads/ssf-wp-uploads/ssf-data.json"]
     locations_key = "item"
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item, response, location):
         if item["website"] == "https://www.kingpie.co.za/":

--- a/locations/spiders/king_pie_za.py
+++ b/locations/spiders/king_pie_za.py
@@ -16,6 +16,9 @@ class KingPieZASpider(JSONBlobSpider):
         if item["website"] == "https://www.kingpie.co.za/":
             item.pop("website")
 
+        if item["phone"] and item["phone"].replace(" ", "") == "0823350236":
+            item.pop("phone")
+
         item["opening_hours"] = oh = OpeningHours()
         oh.add_ranges_from_string(
             re.sub(r"<[^>]*>|&nbsp;", " ", location["operatingHours"]).replace("24hrs", "00:00 - 23:59")


### PR DESCRIPTION
Ignore robots.txt to fix spider. There is only 1 file being fetched.

```
{'atp/brand/King Pie': 281,
 'atp/brand_wikidata/Q116619039': 281,
 'atp/category/amenity/fast_food': 281,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/clean_strings/addr_full': 9,
 'atp/country/ZA': 281,
 'atp/field/branch/missing': 281,
 'atp/field/city/missing': 281,
 'atp/field/country/from_spider_name': 27,
 'atp/field/email/missing': 250,
 'atp/field/housenumber/missing': 281,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 281,
 'atp/field/operator_wikidata/missing': 281,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 281,
 'atp/field/state/missing': 281,
 'atp/field/street/missing': 281,
 'atp/field/street_address/missing': 281,
 'atp/field/twitter/missing': 281,
 'atp/field/unit/missing': 281,
 'atp/item_scraped_host_count/www.kingpie.co.za': 281,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 281,
 'atp/nsi/match_imperfect': 281,
 'downloader/request_bytes': 372,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 25418,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.1574098020792007,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 12, 31, 26, 89294, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 260422,
 'httpcompression/response_count': 1,
 'item_scraped_count': 281,
 'items_per_minute': 8430.0,
 'log_count/DEBUG': 282,
 'log_count/INFO': 3,
 'memusage/max': 134438912,
 'memusage/startup': 134438912,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 20, 12, 31, 23, 931884, tzinfo=datetime.timezone.utc)}
```