### PR TITLE
[outdoor_warehouse_na_za] Try requires_proxy to fix spider

### DIFF
--- a/locations/spiders/outdoor_warehouse_na_za.py
+++ b/locations/spiders/outdoor_warehouse_na_za.py
@@ -13,6 +13,7 @@ class OutdoorWarehouseNAZASpider(JSONBlobSpider):
     }
     start_urls = ["https://www.outdoorwarehouse.co.za/store-locator"]
     skip_auto_cc_domain = True
+    requires_proxy = "ZA"
 
     def extract_json(self, response):
         return chompjs.parse_js_object(response.xpath("//store-selector").get())


### PR DESCRIPTION
```
{'atp/brand/Outdoor Warehouse': 38,
 'atp/brand_wikidata/Q130485369': 38,
 'atp/category/missing': 1,
 'atp/category/shop/outdoor': 37,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/NA': 1,
 'atp/country/ZA': 37,
 'atp/field/country/from_reverse_geocoding': 38,
 'atp/field/housenumber/missing': 31,
 'atp/field/name/missing': 1,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/street/missing': 31,
 'atp/field/twitter/missing': 38,
 'atp/field/unit/missing': 38,
 'atp/item_scraped_host_count/www.outdoorwarehouse.co.za': 38,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 38,
 'atp/nsi/location_unknown': 1,
 'atp/nsi/match_failed': 1,
 'atp/nsi/match_imperfect': 37,
 'downloader/request_bytes': 691,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 36749,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.02674753498286,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 12, 39, 31, 284099, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 277782,
 'httpcompression/response_count': 2,
 'item_scraped_count': 38,
 'items_per_minute': 456.0,
 'log_count/DEBUG': 48,
 'log_count/INFO': 3,
 'memusage/max': 134541312,
 'memusage/startup': 134541312,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 20, 12, 39, 26, 257350, tzinfo=datetime.timezone.utc)}
2026-06-20 14:39:31 [scrapy.core.engine] INFO: Spider closed (finished)
```