### PR TITLE
[mtn_za] Fix spider

### DIFF
--- a/locations/spiders/mtn_za.py
+++ b/locations/spiders/mtn_za.py
@@ -1,27 +1,28 @@
+from typing import Iterable
+
+from scrapy.http import Request, Response
+
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS, OpeningHours
-from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.storefinders.go_review_api import GoReviewApiSpider
 
 
-class MtnZASpider(JSONBlobSpider):
+class MtnZASpider(GoReviewApiSpider):
     name = "mtn_za"
     item_attributes = {"brand": "MTN", "brand_wikidata": "Q1813361"}
-    start_urls = [
-        "https://www.mtn.co.za/api/cms/v1/store-location/1725724280978268358/coverage-map-store-app?storeCount=10000&latitude=-29&longitude=24"
-    ]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 60}
+    domain = "stores.mtn.co.za"
 
-    def post_process_item(self, item, response, location):
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request]:
+        item["branch"] = item.pop("name").removeprefix("MTN ")
+        item["website"] = "https://stores.mtn.co.za/" + feature["slug"]
         apply_category(Categories.SHOP_MOBILE_PHONE, item)
-        item["branch"] = item.pop("name").replace("MTN Store - ", "").replace("MTN Lite - ", "")
-        item["street_address"] = clean_address([location["addressExtra"], location["streetAndNumber"]])
-        item["website"] = "https://www.mtn.co.za/home/coverage/store/" + location["slug"]
+        yield Request(url=item["website"], meta={"item": item}, callback=self.parse_opening_hours)
 
+    def parse_opening_hours(self, response: Response) -> Iterable[Feature]:
+        item = response.meta["item"]
+        hours_string = " ".join(response.xpath('//div[contains(@class, "operating-hours")]//text()').getall())
+        hours_string = hours_string.replace("|", "-").replace("day ", ":")
         item["opening_hours"] = OpeningHours()
-        for day_hours in location["openingHours"]:
-            if day_hours["closed"]:
-                item["opening_hours"].set_closed(DAYS[day_hours["dayOfWeek"] - 1])
-            item["opening_hours"].add_range(DAYS[day_hours["dayOfWeek"] - 1], day_hours["from1"], day_hours["to1"])
-
+        item["opening_hours"].add_ranges_from_string(hours_string)
         yield item


### PR DESCRIPTION
Switch to GoReviewApiSpider to fix spider

```
{'atp/brand/MTN': 414,
 'atp/brand_wikidata/Q1813361': 414,
 'atp/category/shop/mobile_phone': 414,
 'atp/country/ZA': 414,
 'atp/field/city/missing': 414,
 'atp/field/email/missing': 414,
 'atp/field/housenumber/missing': 414,
 'atp/field/operator/missing': 414,
 'atp/field/operator_wikidata/missing': 414,
 'atp/field/postcode/missing': 414,
 'atp/field/state/missing': 414,
 'atp/field/street/missing': 414,
 'atp/field/street_address/missing': 414,
 'atp/field/twitter/missing': 414,
 'atp/field/unit/missing': 414,
 'atp/item_scraped_host_count/stores.mtn.co.za': 414,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 414,
 'downloader/request_bytes': 178676,
 'downloader/request_count': 415,
 'downloader/request_method_count/GET': 414,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 48985140,
 'downloader/response_count': 415,
 'downloader/response_status_count/200': 415,
 'elapsed_time_seconds': 507.1846394557506,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 13, 7, 31, 748737, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 425603,
 'httpcompression/response_count': 1,
 'item_scraped_count': 414,
 'items_per_minute': 48.99408284023669,
 'log_count/DEBUG': 829,
 'log_count/INFO': 11,
 'memusage/max': 282939392,
 'memusage/startup': 134352896,
 'request_depth_max': 1,
 'response_received_count': 415,
 'responses_per_minute': 49.11242603550296,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'start_time': datetime.datetime(2026, 6, 20, 12, 59, 4, 564152, tzinfo=datetime.timezone.utc)}
```