### PR TITLE
[plumblink_na_za] Add spider

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = babel,boto3,botocore,chompjs,cryptography,duckdb,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,pandas,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,psutil,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_zyte_api,shapefile,shapely,tldextract,twisted,unidecode,w3lib,xmltodict
+known_third_party = babel,boto3,botocore,chompjs,cryptography,duckdb,geonamescache,geopandas,h2,ijson,json5,lxml,openpyxl,pandas,parsel,pdfplumber,phonenumbers,phpserialize,playwright,playwright_captcha,psutil,pyarrow,pycountry,pygeohash,pyproj,pytest,requests,requests_cache,reverse_geocoder,scrapy,scrapy_camoufox,scrapy_playwright,scrapy_zyte_api,shapefile,shapely,tldextract,twisted,unidecode,w3lib,xmltodict

--- a/locations/spiders/plumblink_na_za.py
+++ b/locations/spiders/plumblink_na_za.py
@@ -39,6 +39,8 @@ class PlumblinkNAZASpider(JSONBlobSpider):
             await page.close()
 
         auth_cookie = next((c for c in cookies if c["name"] == "_ng_eslv_token"), None)
+        if not auth_cookie:
+            return
 
         yield FormRequest(url=self.start_urls[0], headers={"authorization": auth_cookie["value"]})
 

--- a/locations/spiders/plumblink_na_za.py
+++ b/locations/spiders/plumblink_na_za.py
@@ -10,8 +10,8 @@ from locations.json_blob_spider import JSONBlobSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS
 
 
-class PlumblinkZASpider(JSONBlobSpider):
-    name = "plumblink_za"
+class PlumblinkNAZASpider(JSONBlobSpider):
+    name = "plumblink_na_za"
     item_attributes = {"brand": "Plumblink", "brand_wikidata": "Q127596751"}
     start_urls = ["https://api.esolve.co.za/get-locations.php?is_active=true&ws_id=PLNK01"]
     locations_key = "records"

--- a/locations/spiders/plumblink_za.py
+++ b/locations/spiders/plumblink_za.py
@@ -1,0 +1,70 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy.http import FormRequest, Request, Response
+from scrapy_playwright.page import PageMethod
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS_FULL, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS
+
+
+class PlumblinkZASpider(JSONBlobSpider):
+    name = "plumblink_za"
+    item_attributes = {"brand": "Plumblink", "brand_wikidata": "Q127596751"}
+    start_urls = ["https://api.esolve.co.za/get-locations.php?is_active=true&ws_id=PLNK01"]
+    locations_key = "records"
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
+            url="https://www.plumblink.co.za/store-locator",
+            meta={
+                "playwright": True,
+                "playwright_include_page": True,
+                "playwright_page_methods": [
+                    PageMethod("wait_for_load_state", "networkidle"),
+                ],
+            },
+            callback=self.parse_cookie,
+        )
+
+    async def parse_cookie(self, response) -> AsyncIterator[FormRequest]:
+        page = response.meta["playwright_page"]
+
+        try:
+            cookies = await page.context.cookies()
+        finally:
+            await page.close()
+
+        auth_cookie = next((c for c in cookies if c["name"] == "_ng_eslv_token"), None)
+
+        yield FormRequest(url=self.start_urls[0], headers={"authorization": auth_cookie["value"]})
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature["head_office"] == 1:
+            return
+
+        item["branch"] = feature.pop("description", "").removeprefix("Plumblink ")
+        item["website"] = "https://www.plumblink.co.za/store/" + feature.pop("identifier", "")
+
+        item["street_address"] = item.pop("street", "")
+
+        item["phone"] = feature.pop("branch_telnumber", "")
+        item["email"] = feature.pop("branch_email", "")
+        item["extras"]["contact:whatsapp"] = feature.pop("branch_whatsapp_number", "")
+        item["extras"]["fax"] = feature.pop("branch_fax", "")
+
+        item["opening_hours"] = OpeningHours()
+        for day in DAYS_FULL:
+            open_time = feature.get(f"{day.lower()}_open_time")
+            close_time = feature.get(f"{day.lower()}_close_time")
+            if open_time == close_time:
+                item["opening_hours"].set_closed(day)
+            else:
+                item["opening_hours"].add_range(day, open_time, close_time)
+
+        apply_category(Categories.SHOP_HARDWARE, item)
+
+        yield item


### PR DESCRIPTION
Waiting on https://github.com/osmlab/name-suggestion-index/commit/123ba4264fae02ae4703d1900b26226278d7c905 for NSI matching

```
{'atp/brand/Plumblink': 158,
 'atp/brand_wikidata/Q127596751': 158,
 'atp/category/shop/hardware': 158,
 'atp/country/NA': 1,
 'atp/country/ZA': 157,
 'atp/field/city/missing': 3,
 'atp/field/housenumber/missing': 158,
 'atp/field/name/missing': 158,
 'atp/field/operator/missing': 158,
 'atp/field/operator_wikidata/missing': 158,
 'atp/field/postcode/missing': 18,
 'atp/field/street/missing': 158,
 'atp/field/street_address/missing': 14,
 'atp/field/twitter/missing': 158,
 'atp/field/unit/missing': 158,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/api.esolve.co.za': 158,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 158,
 'atp/nsi/match_failed': 158,
 'downloader/request_bytes': 2448,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 137603,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 3,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 18.007878311909735,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 18, 43, 15, 292795, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 214165,
 'httpcompression/response_count': 1,
 'item_scraped_count': 158,
 'items_per_minute': 526.6666666666667,
 'log_count/DEBUG': 518,
 'log_count/INFO': 7,
 'log_count/WARNING': 1,
 'memusage/max': 139456512,
 'memusage/startup': 139456512,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 177,
 'playwright/request_count/aborted': 48,
 'playwright/request_count/method/GET': 166,
 'playwright/request_count/method/POST': 11,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/request_count/resource_type/fetch': 7,
 'playwright/request_count/resource_type/font': 9,
 'playwright/request_count/resource_type/image': 46,
 'playwright/request_count/resource_type/other': 1,
 'playwright/request_count/resource_type/script': 90,
 'playwright/request_count/resource_type/stylesheet': 4,
 'playwright/request_count/resource_type/xhr': 19,
 'playwright/response_count': 129,
 'playwright/response_count/method/GET': 124,
 'playwright/response_count/method/POST': 5,
 'playwright/response_count/resource_type/document': 1,
 'playwright/response_count/resource_type/fetch': 1,
 'playwright/response_count/resource_type/font': 2,
 'playwright/response_count/resource_type/image': 24,
 'playwright/response_count/resource_type/other': 1,
 'playwright/response_count/resource_type/script': 90,
 'playwright/response_count/resource_type/stylesheet': 3,
 'playwright/response_count/resource_type/xhr': 7,
 'request_depth_max': 1,
 'response_received_count': 4,
 'responses_per_minute': 13.333333333333334,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 6, 20, 18, 42, 57, 284915, tzinfo=datetime.timezone.utc)}
```