### PR TITLE
First Bank of Toyama (JP) add spider

### DIFF
--- a/locations/spiders/first_bank_toyama_jp.py
+++ b/locations/spiders/first_bank_toyama_jp.py
@@ -7,7 +7,11 @@ from locations.storefinders.location_cloud import LocationCloudSpider
 
 class FirstBankToyamaJPSpider(LocationCloudSpider):
     name = "first_bank_toyama_jp"
-    item_attributes = {"brand": "富山第一銀行", "brand_wikidata": "Q11456838", "extras": {"brand:en": "First Bank of Toyama"},}
+    item_attributes = {
+        "brand": "富山第一銀行",
+        "brand_wikidata": "Q11456838",
+        "extras": {"brand:en": "First Bank of Toyama"},
+    }
     api_endpoint = "https://pkg.navitime.co.jp/first-bank/api/proxy2/shop/list"
     additional_args = "&category=01.02.03.04"
     website_formatter = "https://pkg.navitime.co.jp/first-bank/spot/detail?code={}"

--- a/locations/spiders/first_bank_toyama_jp.py
+++ b/locations/spiders/first_bank_toyama_jp.py
@@ -1,0 +1,31 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class FirstBankToyamaJPSpider(LocationCloudSpider):
+    name = "first_bank_toyama_jp"
+    item_attributes = {"brand": "富山第一銀行", "brand_wikidata": "Q11456838", "extras": {"brand:en": "First Bank of Toyama"},}
+    api_endpoint = "https://pkg.navitime.co.jp/first-bank/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03.04"
+    website_formatter = "https://pkg.navitime.co.jp/first-bank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case "03":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "no"
+            case _:
+                apply_category(Categories.BANK, item)
+
+        item["branch"] = source_feature["name"]
+
+        yield item

--- a/locations/spiders/first_bank_toyama_jp.py
+++ b/locations/spiders/first_bank_toyama_jp.py
@@ -17,18 +17,20 @@ class FirstBankToyamaJPSpider(LocationCloudSpider):
     website_formatter = "https://pkg.navitime.co.jp/first-bank/spot/detail?code={}"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
-
-        match source_feature["categories"][0]["code"]:
-            case "01":
-                apply_category(Categories.BANK, item)
-                item["extras"]["atm"] = "yes"
-            case "02":
-                apply_category(Categories.ATM, item)
-            case "03":
-                apply_category(Categories.BANK, item)
-                item["extras"]["atm"] = "no"
-            case _:
-                apply_category(Categories.BANK, item)
+        if not source_feature.get("categories"):
+            apply_category(Categories.BANK, item)
+        else:
+            match source_feature["categories"][0]["code"]:
+                case "01":
+                    apply_category(Categories.BANK, item)
+                    item["extras"]["atm"] = "yes"
+                case "02":
+                    apply_category(Categories.ATM, item)
+                case "03":
+                    apply_category(Categories.BANK, item)
+                    item["extras"]["atm"] = "no"
+                case _:
+                    apply_category(Categories.BANK, item)
 
         item["branch"] = source_feature["name"]
 


### PR DESCRIPTION
closes #16906 
{'atp/brand/富山第一銀行': 91,
 'atp/brand_wikidata/Q11456838': 91,
 'atp/category/amenity/atm': 22,
 'atp/category/amenity/bank': 69,
 'atp/country/JP': 91,
 'atp/field/city/missing': 91,
 'atp/field/country/from_spider_name': 91,
 'atp/field/email/missing': 91,
 'atp/field/housenumber/missing': 91,
 'atp/field/name/missing': 91,
 'atp/field/opening_hours/missing': 91,
 'atp/field/operator/missing': 91,
 'atp/field/operator_wikidata/missing': 91,
 'atp/field/phone/missing': 91,
 'atp/field/state/missing': 91,
 'atp/field/street/missing': 91,
 'atp/field/street_address/missing': 91,
 'atp/field/twitter/missing': 91,
 'atp/field/unit/missing': 91,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 91,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 91,
 'atp/nsi/match_failed': 91,
 'downloader/request_bytes': 745,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 7389,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.2189999999991414,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 20, 23, 54, 2, 838339, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 54129,
 'httpcompression/response_count': 2,
 'item_scraped_count': 91,
 'items_per_minute': 2730.0,
 'log_count/DEBUG': 93,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 20, 23, 54, 0, 613103, tzinfo=datetime.timezone.utc)}