### PR TITLE
Seibu Shinkin Bank (JP) add spider

### DIFF
--- a/locations/spiders/seibu_shinkin_jp.py
+++ b/locations/spiders/seibu_shinkin_jp.py
@@ -1,0 +1,33 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class SeibuShinkinJPSpider(LocationCloudSpider):
+    name = "seibu_shinkin_jp"
+    item_attributes = {
+        "brand": "西武信用金庫",
+        "brand_wikidata": "Q11628905",
+        "extras": {"brand:en": "Seibu Shinkin Bank"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/seibushinkin/api/proxy2/shop/list"
+    additional_args = "&category=01.02"
+    website_formatter = "https://pkg.navitime.co.jp/seibushinkin/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name").removesuffix("出張所")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+
+        yield item

--- a/locations/spiders/seibu_shinkin_jp.py
+++ b/locations/spiders/seibu_shinkin_jp.py
@@ -17,6 +17,8 @@ class SeibuShinkinJPSpider(LocationCloudSpider):
     website_formatter = "https://pkg.navitime.co.jp/seibushinkin/spot/detail?code={}"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
 
         match source_feature["categories"][0]["code"]:
             case "01":
@@ -27,7 +29,8 @@ class SeibuShinkinJPSpider(LocationCloudSpider):
             case _:
                 return
 
-        item["branch"] = source_feature.get("name").removesuffix("出張所")
-        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+        item["branch"] = (source_feature.get("name") or "").removesuffix("出張所")
+        if ruby := source_feature.get("ruby"):
+            item["extras"]["branch:ja-Hira"] = ruby
 
         yield item


### PR DESCRIPTION
closes #16907
{'atp/brand/西武信用金庫': 105,
 'atp/brand_wikidata/Q11628905': 105,
 'atp/category/amenity/atm': 30,
 'atp/category/amenity/bank': 75,
 'atp/country/JP': 105,
 'atp/field/city/missing': 105,
 'atp/field/country/from_spider_name': 105,
 'atp/field/email/missing': 105,
 'atp/field/housenumber/missing': 105,
 'atp/field/name/missing': 105,
 'atp/field/opening_hours/missing': 105,
 'atp/field/operator/missing': 105,
 'atp/field/operator_wikidata/missing': 105,
 'atp/field/phone/missing': 105,
 'atp/field/state/missing': 105,
 'atp/field/street/missing': 105,
 'atp/field/street_address/missing': 105,
 'atp/field/twitter/missing': 105,
 'atp/field/unit/missing': 105,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 105,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 105,
 'atp/nsi/match_failed': 105,
 'downloader/request_bytes': 741,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 8881,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.375,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 21, 0, 32, 21, 584631, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 54534,
 'httpcompression/response_count': 2,
 'item_scraped_count': 105,
 'items_per_minute': 3150.0,
 'log_count/DEBUG': 107,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 21, 0, 32, 19, 203237, tzinfo=datetime.timezone.utc)}