### PR TITLE
[Daito Bank JP] add spider

### DIFF
--- a/locations/spiders/daito_jp.py
+++ b/locations/spiders/daito_jp.py
@@ -1,0 +1,33 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class DaitoJPSpider(LocationCloudSpider):
+    name = "daito_jp"
+    item_attributes = {
+        "brand": "大東銀行",
+        "brand_wikidata": "Q11436170",
+        "extras": {"brand:en": "Daito Bank"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/daitobank/api/proxy2/shop/list"
+    additional_args = "&category=01.02"
+    website_formatter = "https://pkg.navitime.co.jp/daitobank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name").removesuffix("出張所")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+
+        yield item

--- a/locations/spiders/daito_jp.py
+++ b/locations/spiders/daito_jp.py
@@ -17,6 +17,8 @@ class DaitoJPSpider(LocationCloudSpider):
     website_formatter = "https://pkg.navitime.co.jp/daitobank/spot/detail?code={}"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
 
         match source_feature["categories"][0]["code"]:
             case "01":
@@ -27,7 +29,8 @@ class DaitoJPSpider(LocationCloudSpider):
             case _:
                 return
 
-        item["branch"] = source_feature.get("name").removesuffix("出張所")
-        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby")
+        item["branch"] = (source_feature.get("name") or "").removesuffix("出張所")
+        if ruby := source_feature.get("ruby"):
+            item["extras"]["branch:ja-Hira"] = ruby
 
         yield item


### PR DESCRIPTION
closes #16908
{'atp/brand/大東銀行': 104,
 'atp/brand_wikidata/Q11436170': 104,
 'atp/category/amenity/atm': 48,
 'atp/category/amenity/bank': 56,
 'atp/country/JP': 104,
 'atp/field/city/missing': 104,
 'atp/field/country/from_spider_name': 104,
 'atp/field/email/missing': 104,
 'atp/field/housenumber/missing': 104,
 'atp/field/name/missing': 104,
 'atp/field/opening_hours/missing': 104,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/phone/missing': 104,
 'atp/field/state/missing': 104,
 'atp/field/street/missing': 104,
 'atp/field/street_address/missing': 104,
 'atp/field/twitter/missing': 104,
 'atp/field/unit/missing': 104,
 'atp/item_scraped_host_count/pkg.navitime.co.jp': 104,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 104,
 'atp/nsi/match_failed': 104,
 'downloader/request_bytes': 738,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 9236,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.4680000000007567,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 21, 1, 13, 40, 840440, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 56073,
 'httpcompression/response_count': 2,
 'item_scraped_count': 104,
 'items_per_minute': 3120.0,
 'log_count/DEBUG': 106,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 21, 1, 13, 38, 375672, tzinfo=datetime.timezone.utc)}