### PR TITLE
[Erste PL] Fix brand_wikidata to use Erste Group QID

### DIFF
--- a/locations/spiders/erste_pl.py
+++ b/locations/spiders/erste_pl.py
@@ -9,7 +9,7 @@ from locations.items import Feature
 
 class ErstePLSpider(Spider):
     name = "erste_pl"
-    item_attributes = {"brand": "Erste Bank Polska"}
+    item_attributes = {"brand": "Erste Bank Polska", "brand_wikidata": "Q696867"}
     start_urls = ["https://www.erste.pl/_js_places/places.js"]
 
     def parse(self, response, **kwargs):
@@ -40,7 +40,7 @@ class ErstePLSpider(Spider):
         if category == Categories.ATM:
             item["name"] = None
             item["operator"] = "Erste Bank Polska"
-            item["operator_wikidata"] = "Q806653"
+            item["operator_wikidata"] = "Q696867"
         else:
             item["branch"] = item.get("name")
             item["name"] = "Erste Bank Polska"


### PR DESCRIPTION
- PR #16915 set `brand_wikidata: "Q806653"` but that QID is used in NSI for **Santander (Polska)** — the Polish Santander entity whose parent org on Wikidata is Banco Santander. Wrong QID for this spider.
- The correct QID is `Q696867` (Erste Bank, the Austrian group), matching `erste_banka_hr.py` and all NSI Erste Bank entries.
- Also fixes `operator_wikidata` in the ATM branch from Q806653 to Q696867.
- Keeps `brand: "Erste Bank Polska"` — the live site title is "Erste Bank Polska - przedtem Santander Bank" (formerly Santander Bank), so the brand name is correct.

seen in #16915