### PR TITLE
[kenya_commercial_bank_ke] Add spider

### DIFF
--- a/locations/spiders/kenya_commercial_bank_ke.py
+++ b/locations/spiders/kenya_commercial_bank_ke.py
@@ -1,0 +1,40 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class KenyaCommercialBankKESpider(JSONBlobSpider):
+    name = "kenya_commercial_bank_ke"
+    item_attributes = {"brand": "KCB", "brand_wikidata": "Q7193999"}
+    start_urls = ["https://ke.kcbgroup.com/api/branches"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        apply_category(Categories.BANK, item)
+        item.pop("email")
+        item["branch"] = item.pop("name").removeprefix("KCB ")
+
+        try:
+            item["opening_hours"] = self.parse_opening_hours(feature.get("working_hours", ""))
+        except Exception as e:
+            self.logger.error(f'Error parsing opening hours for {feature.get("working_hours")}: {e}')
+        yield item
+
+    def parse_opening_hours(self, hours: str) -> OpeningHours | None:
+        if not hours:
+            return None
+        opening_hours = OpeningHours()
+        for rule in hours.split("\n"):
+            day, times = rule.split(":")
+
+            day = day.lower().replace("and public holidays", "")
+            times = times.replace("noon", "pm")
+
+            for result in OpeningHours.extract_hours_from_string(f"{day} {times}"):
+                opening_hours.add_days_range(result[0], result[1], result[2])
+
+        return opening_hours

--- a/locations/spiders/kenya_commercial_bank_ke.py
+++ b/locations/spiders/kenya_commercial_bank_ke.py
@@ -15,7 +15,10 @@ class KenyaCommercialBankKESpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         apply_category(Categories.BANK, item)
+
         item.pop("email")
+        item.pop("phone")
+
         item["branch"] = item.pop("name").removeprefix("KCB ")
 
         try:

--- a/locations/spiders/kenya_commercial_bank_ke.py
+++ b/locations/spiders/kenya_commercial_bank_ke.py
@@ -16,8 +16,8 @@ class KenyaCommercialBankKESpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         apply_category(Categories.BANK, item)
 
-        item.pop("email")
-        item.pop("phone")
+        item.pop("email", None)
+        item.pop("phone", None)
 
         item["branch"] = item.pop("name").removeprefix("KCB ")
 
@@ -32,7 +32,9 @@ class KenyaCommercialBankKESpider(JSONBlobSpider):
             return None
         opening_hours = OpeningHours()
         for rule in hours.split("\n"):
-            day, times = rule.split(":")
+            if ":" not in rule:
+                continue
+            day, times = rule.split(":", 1)
 
             day = day.lower().replace("and public holidays", "")
             times = times.replace("noon", "pm")


### PR DESCRIPTION
Lat and lon not available

They also have ATMs, but with even less location info

```
{'atp/brand/KCB': 222,
 'atp/brand_wikidata/Q7193999': 222,
 'atp/category/amenity/bank': 222,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/KE': 222,
 'atp/field/city/missing': 222,
 'atp/field/country/from_spider_name': 222,
 'atp/field/email/missing': 222,
 'atp/field/geometry/invalid': 1,
 'atp/field/geometry/missing': 221,
 'atp/field/housenumber/missing': 222,
 'atp/field/name/missing': 222,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 222,
 'atp/field/operator_wikidata/missing': 222,
 'atp/field/postcode/missing': 222,
 'atp/field/state/missing': 221,
 'atp/field/street/missing': 222,
 'atp/field/street_address/missing': 222,
 'atp/field/twitter/missing': 222,
 'atp/field/unit/missing': 222,
 'atp/item_scraped_host_count/ke.kcbgroup.com': 222,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 222,
 'atp/nsi/match_failed': 222,
 'downloader/request_bytes': 668,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 19486,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.457871710881591,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 21, 17, 56, 8, 527627, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 101960,
 'httpcompression/response_count': 2,
 'item_scraped_count': 222,
 'items_per_minute': 2664.0,
 'log_count/DEBUG': 224,
 'log_count/ERROR': 1,
 'log_count/INFO': 3,
 'memusage/max': 134377472,
 'memusage/startup': 134377472,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 21, 17, 56, 3, 69756, tzinfo=datetime.timezone.utc)}
```