### PR TITLE
[Novák CZ] Add brand name

### DIFF
--- a/locations/spiders/novak_cz.py
+++ b/locations/spiders/novak_cz.py
@@ -10,7 +10,7 @@ from locations.items import Feature
 
 class NovakCZSpider(Spider):
     name = "novak_cz"
-    item_attributes = {"brand_wikidata": "Q58490605"}
+    item_attributes = {"brand": "NOVÁK", "brand_wikidata": "Q58490605"}
     start_urls = ["https://masonovak.cz/o-nas/kde-nas-najdete"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
Adds missing `brand: "NOVÁK"` to item_attributes. The spider was merged in #16962 without it. Closes #16944.