### PR TITLE
[KeyFood US] Guard None in name removesuffix

### DIFF
--- a/locations/spiders/key_food_us.py
+++ b/locations/spiders/key_food_us.py
@@ -45,7 +45,7 @@ class KeyFoodUSSpider(Spider):
             location = store.get("location", {})
             item = DictParser.parse(location)
             item["ref"] = store.get("storeId")
-            item["name"] = store.get("displayName").removesuffix(item.get("street_address")).strip()
+            item["name"] = (store.get("displayName") or "").removesuffix(item.get("street_address") or "").strip()
 
             if phones := store.get("phoneNumbers", []):
                 item["phone"] = phones[0].get("value")


### PR DESCRIPTION
Fixes a latent crash where `store.get("displayName")` or `item.get("street_address")` returns None, causing `AttributeError`/`TypeError` on the `.removesuffix()` call. Seen in #16903.