### PR TITLE
[Benesse Be-Studio JP] Add spider

### DIFF
--- a/locations/spiders/benesse_bestudio_jp.py
+++ b/locations/spiders/benesse_bestudio_jp.py
@@ -1,0 +1,42 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class BenesseBestudioJPSpider(Spider):
+    name = "benesse_bestudio_jp"
+    item_attributes = {"brand": "ベネッセビースタジオ", "brand_wikidata": "Q817123"}
+    start_urls = ["https://school.benesse-bestudio.com/bbs/api/proxy2/shop/list"]
+
+    def make_request(self, offset: int, limit: int = 500) -> JsonRequest:
+        return JsonRequest(
+            f"https://school.benesse-bestudio.com/bbs/api/proxy2/shop/list?limit={limit}&offset={offset}"
+        )
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield self.make_request(0)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = response.json()
+        for location in data["items"]:
+            item = Feature()
+            item["ref"] = location["code"]
+            item["branch"] = location["name"]
+            item["phone"] = location.get("phone")
+            item["addr_full"] = location.get("address_name")
+            item["postcode"] = location.get("postal_code")
+            item["country"] = "JP"
+            if coord := location.get("coord"):
+                item["lat"] = coord.get("lat")
+                item["lon"] = coord.get("lon")
+            item["website"] = "https://school.benesse-bestudio.com/bbs/spot/detail?code={}".format(location["code"])
+            apply_category(Categories.LANGUAGE_SCHOOL, item)
+            yield item
+
+        pager = data["count"]
+        if pager["offset"] + pager["limit"] < pager["total"]:
+            yield self.make_request(pager["offset"] + pager["limit"], pager["limit"])


### PR DESCRIPTION
Adds a spider for Benesse Be-Studio (ベネッセビースタジオ), the children's English language learning classroom network operated by Benesse in Japan.

## Data source

Paginated JSON API: `https://school.benesse-bestudio.com/bbs/api/proxy2/shop/list?limit=500&offset=0`

This is a NAVITIME/LocationCloud-powered store locator (same platform as `super_hotel_jp` and similar JP spiders).

## Coverage

~1563 locations across Japan (ホーム校 home schools, プラザ校 plaza schools, 提携校 partner schools, グローバル思考力特化校 global thinking schools).

## Fields parsed

- `ref` (store code)
- `branch` (location name in Japanese)
- `phone`
- `addr_full` (full Japanese address)
- `postcode`
- `lat`/`lon` (coordinates)
- `website` (per-store detail URL)
- Category: `LANGUAGE_SCHOOL`

Closes #16940