### PR TITLE
[SPACER JP] Add spider

### DIFF
--- a/locations/spiders/spacer_jp.py
+++ b/locations/spiders/spacer_jp.py
@@ -1,0 +1,37 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class SpacerJPSpider(JSONBlobSpider):
+    name = "spacer_jp"
+    item_attributes = {"brand": "SPACER"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = [
+        "https://locker-c5f2c.firebaseio.com/spacersLocations.json?auth=AIzaSyCt9HAVOsFXvd0bXRlFcUE093mR9T82tmk"
+    ]
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature.get("isHiddenMap"):
+            return
+        if not feature.get("lat") or not feature.get("lng"):
+            return
+
+        item["branch"] = item.pop("name", None)
+        item["country"] = "JP"
+        item["extras"]["amenity"] = "left_luggage"
+
+        oh = OpeningHours()
+        open_time = feature.get("open")
+        close_time = feature.get("close")
+        if open_time and close_time:
+            oh.add_days_range(DAYS, open_time, close_time)
+        else:
+            oh.add_days_range(DAYS, "00:00", "23:59")
+        item["opening_hours"] = oh
+
+        yield item


### PR DESCRIPTION
Data source: Firebase Realtime Database at `https://locker-c5f2c.firebaseio.com/spacersLocations.json` (API key from the map page's bundled JS at `https://wp-maps.spacer.co.jp/js/main.js`)

Approximately 216 locations (filtered from 419 total — hidden/test locations excluded, locations without coordinates excluded).

Fields parsed: coordinates, full address, branch name, opening hours (all-week range using `open`/`close` fields; defaults to 24/7 when absent), country (JP).

Category: `amenity=left_luggage` (smart coin lockers, not a parcel delivery service).

Wikidata: no entry found for SPACER (スペースアール).

Closes #16975