### PR TITLE
[Musashino Bank JP] Add spider

### DIFF
--- a/locations/spiders/musashino_bank_jp.py
+++ b/locations/spiders/musashino_bank_jp.py
@@ -1,0 +1,39 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class MusashinoBankJPSpider(LocationCloudSpider):
+    name = "musashino_bank_jp"
+    item_attributes = {
+        "brand": "武蔵野銀行",
+        "brand_wikidata": "Q11546449",
+        "extras": {"brand:en": "Musashino Bank", "brand:ja": "武蔵野銀行"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/musashinobank/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03"
+    website_formatter = "https://pkg.navitime.co.jp/musashinobank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case "03":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+
+        yield item


### PR DESCRIPTION
Data source: https://pkg.navitime.co.jp/musashinobank/api/proxy2/shop/list (LocationCloud/Navitime API)

Scrapes 231 locations across three categories:
- `01` — 店舗 (branch offices with ATM, 100 locations) → `amenity=bank` + `atm=yes`
- `02` — 店舗外ATM (off-premises ATMs, 123 locations) → `amenity=atm`
- `03` — 住宅ローンセンター (home loan centers, 8 locations) → `office=financial`

Fields parsed: coordinates, branch name, phone, address, postcode, website URL.

Closes #16929