### PR TITLE
[Towa Bank JP] Add spider

### DIFF
--- a/locations/spiders/towa_bank_jp.py
+++ b/locations/spiders/towa_bank_jp.py
@@ -1,0 +1,39 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class TowaBankJPSpider(LocationCloudSpider):
+    name = "towa_bank_jp"
+    item_attributes = {
+        "brand": "東和銀行",
+        "brand_wikidata": "Q11526364",
+        "extras": {"brand:en": "Towa Bank", "brand:ja": "東和銀行"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/towabank/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03"
+    website_formatter = "https://pkg.navitime.co.jp/towabank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case "03":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+
+        yield item


### PR DESCRIPTION
Data source: `https://pkg.navitime.co.jp/towabank/api/proxy2/shop/list` (LocationCloud/Navitime API)

Scrapes Towa Bank's own locations using `category=01.02.03` filter to exclude the ~53,000 third-party shared ATMs at convenience stores:
- Category 01 (店舗): 88 bank branches
- Category 02 (店舗外ATM): 74 standalone ATMs
- Category 03 (マイホームセンター): 6 financial consultation offices

Total: 168 locations. Fields parsed: coordinates, address, postcode, phone, branch name, website.

Closes #16926