### PR TITLE
[Ōita Bank JP] Add spider

### DIFF
--- a/locations/spiders/oita_bank_jp.py
+++ b/locations/spiders/oita_bank_jp.py
@@ -1,0 +1,41 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class OitaBankJPSpider(LocationCloudSpider):
+    name = "oita_bank_jp"
+    item_attributes = {
+        "brand": "大分銀行",
+        "brand_wikidata": "Q10933745",
+        "extras": {"brand:en": "Ōita Bank", "brand:ja": "大分銀行"},
+    }
+    api_endpoint = "https://store.oitabank.co.jp/oitabank/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03.04.05.06"
+    website_formatter = "https://store.oitabank.co.jp/oitabank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02" | "04" | "05":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case "03":
+                apply_category(Categories.ATM, item)
+            case "06":
+                apply_category(Categories.OFFICE_COWORKING, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+
+        yield item


### PR DESCRIPTION
Adds a spider for Ōita Bank (大分銀行), a regional bank in Ōita Prefecture, Japan.

**Data source:** `https://store.oitabank.co.jp/oitabank/api/proxy2/shop/list` (LocationCloud/Navitime platform)

**Location count:** 202 locations:
- 70 branches (`amenity=bank`, `atm=yes`)
- 114 off-premise ATMs (`amenity=atm`)
- 12 loan plazas and insurance/asset management offices (`office=financial`)
- 1 coworking space (`office=coworking`)

**Fields parsed:** coordinates, address, postcode, phone, branch name, category, website URL

Closes #16925