### PR TITLE
[Kita-Nippon Bank JP] Add spider

### DIFF
--- a/locations/spiders/kita_nippon_bank_jp.py
+++ b/locations/spiders/kita_nippon_bank_jp.py
@@ -1,0 +1,39 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class KitaNipponBankJPSpider(LocationCloudSpider):
+    name = "kita_nippon_bank_jp"
+    item_attributes = {
+        "brand": "北日本銀行",
+        "brand_wikidata": "Q11401871",
+        "extras": {"brand:en": "Kita-Nippon Bank", "brand:ja": "北日本銀行"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/kitagin/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03"
+    website_formatter = "https://pkg.navitime.co.jp/kitagin/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.ATM, item)
+            case "03":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+
+        yield item


### PR DESCRIPTION
Data source: https://pkg.navitime.co.jp/kitagin/api/proxy2/shop/list (Navitime LocationCloud API)

~193 locations (branches, off-site ATMs, and loan/insurance plazas across Iwate Prefecture and Miyagi Prefecture).

Fields parsed: branch name, coordinates, address, postcode, phone, website URL, category (bank/ATM/financial office).

Category mapping:
- `01` 店舗 (branch) → `amenity=bank` + `atm=yes`
- `02` 店舗外ATM (off-site ATM) → `amenity=atm`
- `03` ローン・保険プラザ (loan/insurance plaza) → `office=financial`

Closes #16922