### PR TITLE
[Bank of Kyoto JP] Add spider

### DIFF
--- a/locations/spiders/bank_of_kyoto_jp.py
+++ b/locations/spiders/bank_of_kyoto_jp.py
@@ -1,0 +1,39 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class BankOfKyotoJPSpider(LocationCloudSpider):
+    name = "bank_of_kyoto_jp"
+    item_attributes = {
+        "brand": "京都銀行",
+        "brand_wikidata": "Q11375713",
+        "extras": {"brand:en": "Bank of Kyoto", "brand:ja": "京都銀行"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/kyotobank/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03"
+    website_formatter = "https://pkg.navitime.co.jp/kyotobank/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.ATM, item)
+            case "02":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "03":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+
+        yield item


### PR DESCRIPTION
Data source: `https://pkg.navitime.co.jp/kyotobank/api/proxy2/shop/list` (LocationCloud / Navitime API)

Scrapes 397 locations in 2 requests (500 per page limit). Locations include:
- Staffed bank branches (有人店舗, category `02`) tagged as `amenity=bank` + `atm=yes`
- Stand-alone ATMs (店舗外ATM, category `01`) tagged as `amenity=atm`
- Loan consultation offices (休日ローン相談, category `03`) tagged as `office=financial`

Fields parsed: `ref`, coordinates, address, postcode, phone, branch name, website, opening hours (not available in API response).

Closes #16921