### PR TITLE
[Tokyo Higashi Shinkin Bank JP] Add spider

### DIFF
--- a/locations/spiders/tokyo_higashi_shinkin_bank_jp.py
+++ b/locations/spiders/tokyo_higashi_shinkin_bank_jp.py
@@ -1,0 +1,44 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class TokyoHigashiShinkinBankJPSpider(LocationCloudSpider):
+    name = "tokyo_higashi_shinkin_bank_jp"
+    item_attributes = {
+        "brand": "東京東信用金庫",
+        "brand_wikidata": "Q11524925",
+        "extras": {"brand:en": "Tokyo Higashi Shinkin Bank"},
+    }
+    api_endpoint = "https://pkg.navitime.co.jp/higashin/api/proxy2/shop/list"
+    additional_args = "&category=01.02.03.04"
+    website_formatter = "https://pkg.navitime.co.jp/higashin/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if not source_feature.get("categories"):
+            return
+
+        if phone := source_feature.get("phone"):
+            if phone != "－":
+                item["phone"] = phone
+
+        match source_feature["categories"][0]["code"]:
+            case "01":
+                apply_category(Categories.BANK, item)
+                item["extras"]["atm"] = "yes"
+            case "02":
+                apply_category(Categories.BANK, item)
+            case "03":
+                apply_category(Categories.ATM, item)
+            case "04":
+                apply_category(Categories.OFFICE_FINANCIAL, item)
+            case _:
+                return
+
+        item["branch"] = source_feature.get("name", "")
+        if ruby := source_feature.get("ruby"):
+            item["extras"]["branch:ja-Hira"] = ruby
+
+        yield item


### PR DESCRIPTION
Data source: `https://pkg.navitime.co.jp/higashin/api/proxy2/shop/list` (Navitime LocationCloud API)

Approximately 90 locations, covering categories:
- 01 店舗 (branches): BANK + atm=yes (~62 items)
- 02 出張所 (branch offices): BANK (~11 items)
- 03 ATM: ATM (~15 items)
- 04 本部 (headquarters): OFFICE_FINANCIAL (~1 item)

Fields parsed: coordinates, address, postcode, phone, branch name, branch name in hiragana (branch:ja-Hira), website URL.

Closes #16920