### PR TITLE
Use Mazda dealer names as POI names

### DIFF
--- a/locations/spiders/mazda_de.py
+++ b/locations/spiders/mazda_de.py
@@ -31,8 +31,7 @@ class MazdaDESpider(Spider):
                     continue
                 feature["contact"]["phoneNumber"] = feature["contact"]["phoneNumber"]["e164"]
                 item = DictParser.parse(feature["contact"])
-                item["branch"] = feature_group["name"]
-                item.pop("name", None)
+                item["name"] = feature_group["name"]
                 match feature["name"]:
                     case "Car Sales":
                         apply_category(Categories.SHOP_CAR, item)
@@ -64,6 +63,6 @@ class MazdaDESpider(Spider):
                 yield from self.post_process_item(item, feature, feature_group)
 
     def post_process_item(self, item: Feature, feature: dict, feature_group: dict) -> Iterable[Feature]:
-        if "Test & Training" in item["branch"]:
+        if "Test & Training" in item["name"]:
             return
         yield item

--- a/locations/spiders/mazda_fi.py
+++ b/locations/spiders/mazda_fi.py
@@ -28,7 +28,7 @@ class MazdaFISpider(Spider):
         for dealer in dealers:
             services = dealer.get("dealerServices", [])
             base = {
-                "branch": dealer["title"],
+                "name": dealer["title"],
                 "lat": dealer.get("latitude"),
                 "lon": dealer.get("longitude"),
                 "street_address": merge_address_lines([dealer.get("address1"), dealer.get("address2")]),

--- a/locations/spiders/mazda_gr.py
+++ b/locations/spiders/mazda_gr.py
@@ -50,7 +50,7 @@ class MazdaGRSpider(Spider):
 
     def _make_item(self, dealer: dict) -> Feature:
         item = Feature()
-        item["branch"] = dealer.get("Title")
+        item["name"] = dealer.get("Title")
         item["lat"] = dealer.get("Latitude")
         item["lon"] = dealer.get("Longitude")
         item["addr_full"] = dealer.get("Address")

--- a/locations/spiders/mazda_id.py
+++ b/locations/spiders/mazda_id.py
@@ -23,7 +23,7 @@ class MazdaIDSpider(Spider):
         dealers = {}
         variable_map = {
             "dealerId": "ref",
-            "dealerName": "branch",
+            "dealerName": "name",
             "dealerAddress": "address",
             "dealerPhone": "phone",
             "dealersalesOperationalHour": "hours_sales",
@@ -56,7 +56,6 @@ class MazdaIDSpider(Spider):
 
         for dealer in dealers.values():
             item = DictParser.parse(dealer)
-            item["branch"] = dealer["branch"].removeprefix("Mazda ")
             hours_sales_text = " ".join(Selector(text=dealer["hours_sales"]).xpath("//text()").getall())
             hours_service_text = " ".join(Selector(text=dealer["hours_service"]).xpath("//text()").getall())
             if hours_sales_text:

--- a/locations/spiders/mazda_my.py
+++ b/locations/spiders/mazda_my.py
@@ -19,7 +19,6 @@ class MazdaMYSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(item["ref"])
-        item["branch"] = item.pop("name", None)
         item["addr_full"] = merge_address_lines([feature["addressOne"], feature["addressTwo"]])
         if item["email"]:
             item["email"] = item["email"].split()[0]

--- a/locations/spiders/mazda_th.py
+++ b/locations/spiders/mazda_th.py
@@ -32,8 +32,6 @@ class MazdaTHSpider(JSONBlobSpider):
         feature.update(feature.pop("detail"))
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["branch"] = item.pop("name", None)
-
         if feature["ServiceTypeID"] and len(feature["ServiceTypeID"]) > 0:
             service_item = item.deepcopy()
             service_item["ref"] = service_item["ref"] + "_Service"


### PR DESCRIPTION
Summary
- Keep Mazda dealer titles in name instead of moving them to branch.
- Apply the same treatment across the Mazda dealer spiders that were using dealer title/name fields as branch.
- This PR was created with Codex.

Rationale
I want to propose keeping Mazda dealer titles in name instead of branch. Codex analysis of the Mazda output found that 397 of 3,893 POIs with branch values, or 10.2%, already had Mazda in the branch; including Thai มาสด้า, that rises to 536 POIs, or 13.8%. Examples like Arnold Clark Mazda - Aberdeen, Boland Mazda, and MAZDA MILANO - MOCAUTOGROUP S.R.L. read as dealership names, not branch labels.

The source field appears to be the dealer business name, so name=<dealer name> with brand=Mazda better represents the POI. Car dealerships are a little different from ordinary chain stores because the real-world place is usually an independently named authorized dealer, while the marque relationship belongs in brand. This also matches comparable dealer spiders such as Cadillac, Mercedes-Benz, and Maserati, which keep dealer names in name while storing the marque in brand.

Verification
- uv run pytest tests/test_spider_imports.py tests/test_item_attributes.py
- uv run python -m py_compile locations/spiders/mazda_de.py locations/spiders/mazda_fi.py locations/spiders/mazda_gr.py locations/spiders/mazda_id.py locations/spiders/mazda_my.py locations/spiders/mazda_th.py
- git diff --check