### PR TITLE
[Hyundai TH] Split sales and service into separate POIs

### DIFF
--- a/locations/spiders/hyundai_th.py
+++ b/locations/spiders/hyundai_th.py
@@ -63,4 +63,3 @@ class HyundaiTHSpider(JSONBlobSpider):
             service_item["ref"] = f"{item['ref']}-service"
             apply_category(Categories.SHOP_CAR_REPAIR, service_item)
             yield service_item
-

--- a/locations/spiders/hyundai_th.py
+++ b/locations/spiders/hyundai_th.py
@@ -1,8 +1,9 @@
+from copy import deepcopy
 from typing import AsyncIterator, Iterable
 
 from scrapy.http import FormRequest, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.hyundai_kr import HYUNDAI_SHARED_ATTRIBUTES
@@ -45,5 +46,21 @@ class HyundaiTHSpider(JSONBlobSpider):
         item["addr_full"] = feature.get("dealer_address")
         item["postcode"] = feature.get("dealer_post_code")
         item["phone"] = feature.get("dealer_phone1", "").removeprefix("Tel ")
-        apply_category(Categories.SHOP_CAR, item)
-        yield item
+
+        services = feature.get("dealer_service_nm", "")
+        has_showroom = "โชว์รูม" in services  # showroom
+        has_service = "ศูนย์ซ่อมบริการ" in services  # service centre
+
+        if has_showroom:
+            sales_item = deepcopy(item)
+            sales_item["ref"] = f"{item['ref']}-sales"
+            apply_category(Categories.SHOP_CAR, sales_item)
+            apply_yes_no(Extras.CAR_REPAIR, sales_item, has_service)
+            yield sales_item
+
+        if has_service:
+            service_item = deepcopy(item)
+            service_item["ref"] = f"{item['ref']}-service"
+            apply_category(Categories.SHOP_CAR_REPAIR, service_item)
+            yield service_item
+


### PR DESCRIPTION
## Summary
- Refactors `hyundai_th.py` to yield separate `SHOP_CAR` and `SHOP_CAR_REPAIR` POIs using the `dealer_service_nm` field (Thai: โชว์รูม = showroom, ศูนย์ซ่อมบริการ = service centre)
- Sales item retains `CAR_REPAIR` yes/no tag when service is also present
- Ref suffixes (`-sales`, `-service`) follow the same pattern used across other Hyundai spiders

## Test plan
- [ ] Run spider and confirm locations yield two items with correct categories and `-sales`/`-service` ref suffixes
- [ ] Confirm `dealer_service_nm` values are being parsed correctly for all service type combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)