### PR TITLE
[Ecbo Cloak] add more details from API, use city locations

### DIFF
--- a/locations/spiders/ecbo_cloak.py
+++ b/locations/spiders/ecbo_cloak.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator, Iterable
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.geo import city_locations
 from locations.items import Feature
 
@@ -58,9 +58,9 @@ class EcboCloakSpider(Spider):
 
             location_type = location.get("type")
             if location_type == "space":
-                item["extras"]["amenity"] = "left_luggage"
+                apply_category(Categories.LEFT_LUGGAGE, item)
             else:
                 # pudo and locker_cluster types are luggage lockers
-                item["extras"]["amenity"] = "luggage_locker"
+                apply_category(Categories.LUGGAGE_LOCKER, item)
 
             yield item

--- a/locations/spiders/ecbo_cloak.py
+++ b/locations/spiders/ecbo_cloak.py
@@ -18,11 +18,11 @@ class EcboCloakSpider(Spider):
         self._seen: set[str] = set()
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for city in city_locations("JP", 10000):
+        for city in city_locations("JP", 15000):
             yield JsonRequest(
                 url=f"https://search.ecbo.io/api/v1/search?latitude={city['latitude']}&longitude={city['longitude']}",
             )
-        for city in city_locations("TW", 10000):
+        for city in city_locations("TW", 15000):
             yield JsonRequest(
                 url=f"https://search.ecbo.io/api/v1/search?latitude={city['latitude']}&longitude={city['longitude']}",
             )

--- a/locations/spiders/ecbo_cloak.py
+++ b/locations/spiders/ecbo_cloak.py
@@ -3,23 +3,28 @@ from typing import AsyncIterator, Iterable
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
-from locations.geo import country_iseadgg_centroids
-from locations.hours import DAYS, OpeningHours
+from locations.categories import Extras, apply_yes_no
+from locations.geo import city_locations
 from locations.items import Feature
 
 
-class EcboCloakJPSpider(Spider):
-    name = "ecbo_cloak_jp"
+class EcboCloakSpider(Spider):
+    name = "ecbo_cloak"
     item_attributes = {"brand": "ecbo cloak"}
+    skip_auto_cc_domain = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._seen: set[str] = set()
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for lat, lon in country_iseadgg_centroids(["JP", "TW"], 24):
+        for city in city_locations("JP", 10000):
             yield JsonRequest(
-                url=f"https://search.ecbo.io/api/v1/search?latitude={lat}&longitude={lon}",
+                url=f"https://search.ecbo.io/api/v1/search?latitude={city['latitude']}&longitude={city['longitude']}",
+            )
+        for city in city_locations("TW", 10000):
+            yield JsonRequest(
+                url=f"https://search.ecbo.io/api/v1/search?latitude={city['latitude']}&longitude={city['longitude']}",
             )
 
     def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
@@ -32,17 +37,24 @@ class EcboCloakJPSpider(Spider):
             loc = location.get("location", {})
             item = Feature()
             item["ref"] = ref
-            item["name"] = location.get("en_name") or location.get("name")
+            item["name"] = location.get("name") or location.get("en_name")
+            item["extras"]["name:en"] = location.get("en_name")
             item["lat"] = loc.get("latitude")
             item["lon"] = loc.get("longitude")
             item["website"] = f"https://cloak.ecbo.io/ja/space/{ref}"
+            item["extras"]["website:en"] = f"https://cloak.ecbo.io/en/space/{ref}"
+            item["extras"]["website:ja"] = f"https://cloak.ecbo.io/ja/space/{ref}"
+            item["extras"]["website:zh-TW"] = f"https://cloak.ecbo.io/zh-TW/space/{ref}"
+            item["image"] = location.get("main_image_url")
 
             basic = location.get("basic_info", {})
 
-            oh = OpeningHours()
             if basic.get("available_24_hour"):
-                oh.add_days_range(DAYS, "00:00", "23:59")
-            item["opening_hours"] = oh
+                item["opening_hours"] = "24/7"
+            apply_yes_no("elevator", item, basic.get("has_elevator"))
+            apply_yes_no("socket:nema_1_15", item, basic.get("has_charge"))
+            apply_yes_no("language:en", item, basic.get("available_in_english"))
+            apply_yes_no(Extras.WIFI, item, basic.get("has_wifi"))
 
             location_type = location.get("type")
             if location_type == "space":


### PR DESCRIPTION
To get more locations this uses city locations rather than iseadgg centroids. It works better for dense cities like Tokyo. Also, I renamed the spider so it accurately displays the country name.

{'atp/brand/ecbo cloak': 2537,
 'atp/category/amenity/left_luggage': 2489,
 'atp/category/amenity/luggage_locker': 48,
 'atp/clean_strings/name': 11,
 'atp/country/JP': 2519,
 'atp/country/TW': 18,
 'atp/field/branch/missing': 2537,
 'atp/field/brand_wikidata/missing': 2537,
 'atp/field/city/missing': 2537,
 'atp/field/country/from_reverse_geocoding': 2537,
 'atp/field/email/missing': 2537,
 'atp/field/housenumber/missing': 2537,
 'atp/field/opening_hours/missing': 2390,
 'atp/field/operator/missing': 2537,
 'atp/field/operator_wikidata/missing': 2537,
 'atp/field/phone/missing': 2537,
 'atp/field/postcode/missing': 2537,
 'atp/field/street/missing': 2537,
 'atp/field/street_address/missing': 2537,
 'atp/field/twitter/missing': 2537,
 'atp/field/unit/missing': 2537,
 'atp/item_scraped_host_count/search.ecbo.io': 2537,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 2537,
 'atp/nsi/match_failed': 2537,
 'downloader/request_bytes': 525190,
 'downloader/request_count': 1357,
 'downloader/request_method_count/GET': 1357,
 'downloader/response_bytes': 3162073,
 'downloader/response_count': 1357,
 'downloader/response_status_count/200': 1356,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 1642.5940000000046,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 22, 21, 52, 32, 564135, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2537,
 'items_per_minute': 92.70401948842874,
 'log_count/DEBUG': 3896,
 'log_count/INFO': 30,
 'response_received_count': 1357,
 'responses_per_minute': 49.58587088915956,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1356,
 'scheduler/dequeued/memory': 1356,
 'scheduler/enqueued': 1356,
 'scheduler/enqueued/memory': 1356,
 'start_time': datetime.datetime(2026, 6, 22, 21, 25, 9, 967573, tzinfo=datetime.timezone.utc)}