### PR TITLE
[Ace Hardware] Fix Spider

### DIFF
--- a/locations/spiders/ace_hardware.py
+++ b/locations/spiders/ace_hardware.py
@@ -6,5 +6,4 @@ class AceHardwareSpider(KiboSpider):
     name = "ace_hardware"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
-    requires_proxy = True
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}

--- a/locations/spiders/ace_hardware_us.py
+++ b/locations/spiders/ace_hardware_us.py
@@ -1,9 +1,11 @@
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.storefinders.kibo import KiboSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AceHardwareUSSpider(KiboSpider):
+class AceHardwareUSSpider(KiboSpider, PlaywrightSpider):
     name = "ace_hardware_us"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}

--- a/locations/spiders/ace_hardware_us.py
+++ b/locations/spiders/ace_hardware_us.py
@@ -2,8 +2,8 @@ from locations.storefinders.kibo import KiboSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class AceHardwareSpider(KiboSpider):
-    name = "ace_hardware"
+class AceHardwareUSSpider(KiboSpider):
+    name = "ace_hardware_us"
     item_attributes = {"brand": "Ace Hardware", "brand_wikidata": "Q4672981"}
     start_urls = ["https://www.acehardware.com/api/commerce/storefront/locationUsageTypes/SP/locations"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}

--- a/locations/storefinders/kibo.py
+++ b/locations/storefinders/kibo.py
@@ -1,3 +1,4 @@
+import json
 from typing import AsyncIterator, Iterable
 
 from scrapy import Spider
@@ -44,7 +45,11 @@ class KiboSpider(Spider):
             yield JsonRequest(url=f"{self.start_urls[0]}?pageSize={self.page_size}")
 
     def parse(self, response: TextResponse) -> Iterable[Feature | JsonRequest]:
-        for location in response.json()["items"]:
+        try:
+            data = response.json()
+        except Exception:
+            data = json.loads(response.xpath("//pre//text()").get())
+        for location in data.get("items", []):
             self.pre_process_data(location)
             item = DictParser.parse(location)
 
@@ -73,10 +78,10 @@ class KiboSpider(Spider):
 
             yield from self.parse_item(item, location) or []
 
-            self.page_size = response.json()["pageSize"]
-            locations_remaining = response.json()["totalCount"] - (response.json()["startIndex"] + self.page_size)
+            self.page_size = data["pageSize"]
+            locations_remaining = data["totalCount"] - (data["startIndex"] + self.page_size)
             if locations_remaining > 0:
-                next_start_index = response.json()["startIndex"] + self.page_size
+                next_start_index = data["startIndex"] + self.page_size
                 yield JsonRequest(url=f"{self.start_urls[0]}?pageSize={self.page_size}&startIndex={next_start_index}")
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:

--- a/locations/storefinders/kibo.py
+++ b/locations/storefinders/kibo.py
@@ -47,8 +47,8 @@ class KiboSpider(Spider):
     def parse(self, response: TextResponse) -> Iterable[Feature | JsonRequest]:
         try:
             data = response.json()
-        except Exception:
-            data = json.loads(response.xpath("//pre//text()").get())
+        except:
+            data = json.loads(response.xpath("//pre//text()").get() or "{}")
         for location in data.get("items", []):
             self.pre_process_data(location)
             item = DictParser.parse(location)


### PR DESCRIPTION
```python
{'atp/brand/Ace Hardware': 4889,
 'atp/brand_wikidata/Q4672981': 4889,
 'atp/category/shop/doityourself': 4889,
 'atp/country/US': 4889,
 'atp/field/branch/missing': 4889,
 'atp/field/email/missing': 1258,
 'atp/field/housenumber/missing': 4889,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 4889,
 'atp/field/operator_wikidata/missing': 4889,
 'atp/field/phone/missing': 9,
 'atp/field/street/missing': 4889,
 'atp/field/twitter/missing': 4889,
 'atp/field/unit/missing': 4889,
 'atp/item_scraped_host_count/www.acehardware.com': 4889,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 4889,
 'atp/nsi/match_imperfect': 4889,
 'downloader/request_bytes': 4693,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 25919515,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'dupefilter/filtered': 3996,
 'elapsed_time_seconds': 52.71800000000803,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 23, 7, 59, 43, 396425, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 4889,
 'items_per_minute': 5641.153846153846,
 'log_count/DEBUG': 4917,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 6,
 'playwright/page_count/closed': 6,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 6,
 'playwright/request_count/method/GET': 6,
 'playwright/request_count/navigation': 6,
 'playwright/request_count/resource_type/document': 6,
 'playwright/response_count': 6,
 'playwright/response_count/method/GET': 6,
 'playwright/response_count/resource_type/document': 6,
 'request_depth_max': 4,
 'response_received_count': 6,
 'responses_per_minute': 6.9230769230769225,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 5,
 'scheduler/dequeued/memory': 5,
 'scheduler/enqueued': 5,
 'scheduler/enqueued/memory': 5,
 'start_time': datetime.datetime(2026, 6, 23, 7, 58, 50, 681641, tzinfo=datetime.timezone.utc)}
```