### PR TITLE
[Luminor LT] Add spider (365 locations)

### DIFF
--- a/locations/spiders/luminor_lt.py
+++ b/locations/spiders/luminor_lt.py
@@ -32,7 +32,7 @@ class LuminorLTSpider(Spider):
             # Source map settings nest coordinates and town names, so DictParser cannot map the useful fields.
             item = Feature(
                 ref=ref,
-                branch=self.clean_branch(location.get("title")),
+                name=self.clean_branch(location.get("title")),
                 lat=location.get("geolocation", {}).get("lat"),
                 lon=location.get("geolocation", {}).get("lng"),
                 street_address=location.get("address"),
@@ -40,6 +40,7 @@ class LuminorLTSpider(Spider):
             )
 
             if has_branch:
+                item["branch"] = item.pop("name")
                 apply_yes_no(Extras.ATM, item, has_atm)
                 apply_category(Categories.BANK, item)
             else:

--- a/locations/spiders/luminor_lt.py
+++ b/locations/spiders/luminor_lt.py
@@ -1,0 +1,85 @@
+import json
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+
+
+class LuminorLTSpider(Spider):
+    name = "luminor_lt"
+    item_attributes = {"brand": "Luminor Bank", "brand_wikidata": "Q28966957"}
+    requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.luminor.lt/en/bank-network"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if not (contacts := self.extract_page_contacts(response)):
+            self.logger.error("Unable to find Luminor contacts data")
+            return
+
+        for ref, location in contacts.get("map_objects", {}).items():
+            object_types = {str(object_type) for object_type in location.get("object_types", [])}
+            has_branch = "74" in object_types
+            has_atm = location.get("pin_icon") in ["cash-out", "cash-in-out", "partner"] or bool(
+                {"70", "71", "75"} & object_types
+            )
+            if not (has_branch or has_atm):
+                continue
+
+            # Source map settings nest coordinates and town names, so DictParser cannot map the useful fields.
+            item = Feature(
+                ref=ref,
+                branch=self.clean_branch(location.get("title")),
+                lat=location.get("geolocation", {}).get("lat"),
+                lon=location.get("geolocation", {}).get("lng"),
+                street_address=location.get("address"),
+                city=self.get_city(location, contacts),
+            )
+
+            if has_branch:
+                apply_yes_no(Extras.ATM, item, has_atm)
+                apply_category(Categories.BANK, item)
+            else:
+                apply_category(Categories.ATM, item)
+
+            yield item
+
+    def extract_page_contacts(self, response: Response) -> dict[str, Any] | None:
+        settings_marker = "jQuery.extend(Drupal.settings,"
+        if (settings_start := response.text.find(settings_marker)) == -1:
+            return None
+        data_start = response.text.find("{", settings_start)
+        if data_start == -1:
+            return None
+
+        settings, _ = json.JSONDecoder().raw_decode(response.text[data_start:])
+        return settings.get("dnb_contacts")
+
+    def clean_branch(self, branch: str | None) -> str | None:
+        if not branch:
+            return None
+        return branch.split("|", 1)[0].strip()
+
+    def get_city(self, location: dict[str, Any], contacts: dict[str, Any]) -> str | None:
+        town = location.get("town", {})
+        towns = contacts.get("towns_tree") or contacts.get("towns") or {}
+        county = self.get_town(towns, town.get("county"))
+        if not county:
+            return None
+        if child := self.get_town(county.get("children", []), town.get("town")):
+            return child.get("name")
+        return None
+
+    def get_town(self, towns: Any, town_id: Any) -> dict[str, Any] | None:
+        if town_id is None:
+            return None
+        if isinstance(towns, dict):
+            return towns.get(str(town_id)) or towns.get(town_id)
+        if isinstance(towns, list):
+            for town in towns:
+                if str(town.get("id")) == str(town_id):
+                    return town
+        return None


### PR DESCRIPTION
Data source:
https://www.luminor.lt/en/bank-network

I first tested a single multi-country `luminor` spider for LT/LV/EE because NSI covers all three countries. In CodeBuild, the multi-country version fetched Lithuania but then timed out before Latvia/Estonia completed. To keep this PR reviewable and avoid a long-running proxy-dependent spider, this PR is intentionally scoped to Lithuania only as `luminor_lt`.

Latvia and Estonia are left for separate follow-up spiders because their live pages/API behavior needs separate validation under CodeBuild.

NSI:
```text
"Luminor Bank", "Q28966957"
-> {amenity:atm, brand:Luminor Bank, ...} [ee, lt, lv]
-> {amenity:bank, brand:Luminor Bank, ...} [ee, lt, lv]
```

Category mapping:

- object type `74` -> `Categories.BANK`
- object types `70`, `71`, `75` and cash pin icons -> `Categories.ATM`
- branch locations with ATM availability -> `atm=yes`

Stats summary:

- 365 total items
- 356 ATMs
- 9 banks
- NSI: 365 perfect matches
- Country derived from spider name: 365

Notes:

- The site is Cloudflare-protected, so the spider uses `requires_proxy = True`.
- No item-specific `website` is emitted because no verified stable POI detail URLs were found.
- Generic contact details are not emitted.
- Opening hours are intentionally skipped in v1.
- The source URL uses the English Lithuanian page (`/en/bank-network`), but it is the official Lithuania locator and exposes the same embedded `dnb_contacts` location data for Lithuanian branches and ATMs. Addresses and cities are still sourced from the Lithuanian locator data.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "id": "WWXJoSVTg34LvZDWkDXEE0jaWtw=",
    "dataset_attributes": {
      "spider:robots_txt": "ignored",
      "spider:lineage": "S_ATP_BRANDS",
      "@spider": "luminor_lt",
      "spider:collection_time": "2026-06-23T08:33:07.379533"
    },
    "properties": {
      "ref": "15421",
      "amenity": "atm",
      "@source_uri": "https://www.luminor.lt/en/bank-network",
      "@spider": "luminor_lt",
      "addr:street_address": "Antakalnio g. 71",
      "addr:city": "Vilnius",
      "addr:country": "LT",
      "branch": "PC IKI",
      "brand": "Luminor Bank",
      "brand:wikidata": "Q28966957",
      "operator": "Luminor Bank",
      "operator:wikidata": "Q28966957",
      "nsi_id": "luminorbank-82bd77"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [25.3162376, 54.7139969]
    }
  },
  {
    "type": "Feature",
    "id": "8RAzzKEvqfdN4OGeq3buaTT_l0E=",
    "properties": {
      "ref": "14842",
      "atm": "yes",
      "amenity": "bank",
      "@source_uri": "https://www.luminor.lt/en/bank-network",
      "@spider": "luminor_lt",
      "addr:street_address": "Aukštaičių g. 7",
      "addr:city": "Vilnius",
      "addr:country": "LT",
      "name": "Luminor Bank",
      "branch": "Paupio konsultavimo centras",
      "brand": "Luminor Bank",
      "brand:wikidata": "Q28966957",
      "nsi_id": "luminorbank-3ce14c"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [25.3035121664093, 54.67909287095725]
    }
  }
]
```
Json stats :

{
  "atp/brand/Luminor Bank": 365,
  "atp/brand_wikidata/Q28966957": 365,
  "atp/category/amenity/atm": 356,
  "atp/category/amenity/bank": 9,
  "atp/cdn/cloudflare/response_count": 1,
  "atp/cdn/cloudflare/response_status_count/200": 1,
  "atp/clean_strings/street_address": 4,
  "atp/country/LT": 365,
  "atp/field/country/from_spider_name": 365,
  "atp/field/email/missing": 365,
  "atp/field/housenumber/missing": 365,
  "atp/field/name/missing": 356,
  "atp/field/opening_hours/missing": 365,
  "atp/field/operator/missing": 9,
  "atp/field/operator_wikidata/missing": 9,
  "atp/field/phone/missing": 365,
  "atp/field/postcode/missing": 365,
  "atp/field/state/missing": 365,
  "atp/field/street/missing": 365,
  "atp/field/twitter/missing": 365,
  "atp/field/unit/missing": 365,
  "atp/item_scraped_host_count/www.luminor.lt": 365,
  "atp/lineage": "S_ATP_BRANDS",
  "atp/nsi/match_perfect": 365,
  "atp/operator/Luminor Bank": 356,
  "atp/operator_wikidata/Q28966957": 356,
  "downloader/request_count": 1,
  "downloader/response_status_count/200": 1,
  "elapsed_time_seconds": 4.577498131000027,
  "finish_reason": "finished",
  "item_scraped_count": 365,
  "scrapy-zyte-api/success": 1
}