### PR TITLE
[Cracker Barrel] Clean name

### DIFF
--- a/locations/spiders/cracker_barrel.py
+++ b/locations/spiders/cracker_barrel.py
@@ -26,24 +26,21 @@ class CrackerBarrelSpider(SitemapSpider):
 
         hours = OpeningHours()
         for day in DAYS_FULL:
-            start_time = data[f"{day}_Open"]["value"]
-            end_time = data[f"{day}_Close"]["value"]
-            hours.add_range(day[:2], start_time, end_time, "%I:%M %p")
+            hours.add_range(day, data[f"{day}_Open"]["value"], data[f"{day}_Close"]["value"], "%I:%M %p")
 
         properties = {
             "ref": data["Store Number"]["value"],
             "lat": data["Latitude"]["value"],
             "lon": data["Longitude"]["value"],
             "website": response.url,
-            "name": data["Alternate Name"]["value"],
+            "branch": data["Alternate Name"]["value"],
             "street_address": data["Address 1"]["value"],
             "city": data["City"]["value"],
             "state": data["State"]["value"],
             "postcode": data["Zip"]["value"],
             "country": data["Country"]["value"],
             "phone": data["Phone"]["value"],
-            "opening_hours": hours.as_opening_hours(),
+            "opening_hours": hours,
         }
         apply_category(Categories.RESTAURANT, properties)
-        apply_category({"cuisine": "american"}, properties)
         yield Feature(**properties)


### PR DESCRIPTION
```python
{'atp/brand/Cracker Barrel': 657,
 'atp/brand_wikidata/Q4492609': 657,
 'atp/category/amenity/restaurant': 657,
 'atp/country/US': 657,
 'atp/field/email/missing': 657,
 'atp/field/housenumber/missing': 657,
 'atp/field/operator/missing': 657,
 'atp/field/operator_wikidata/missing': 657,
 'atp/field/street/missing': 657,
 'atp/field/twitter/missing': 657,
 'atp/field/unit/missing': 657,
 'atp/item_scraped_host_count/www.crackerbarrel.com': 657,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 657,
 'downloader/request_bytes': 272637,
 'downloader/request_count': 659,
 'downloader/request_method_count/GET': 659,
 'downloader/response_bytes': 11593599,
 'downloader/response_count': 659,
 'downloader/response_status_count/200': 659,
 'elapsed_time_seconds': 807.9672506719999,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 23, 11, 17, 57, 654154, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 659,
 'httpcache/miss': 659,
 'httpcache/store': 659,
 'httpcompression/response_bytes': 68762796,
 'httpcompression/response_count': 659,
 'item_scraped_count': 657,
 'items_per_minute': 48.84758364312268,
 'log_count/DEBUG': 1317,
 'log_count/INFO': 16,
 'log_count/WARNING': 1,
 'memusage/max': 444657664,
 'memusage/startup': 302481408,
 'request_depth_max': 1,
 'response_received_count': 659,
 'responses_per_minute': 48.99628252788104,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 658,
 'scheduler/dequeued/memory': 658,
 'scheduler/enqueued': 658,
 'scheduler/enqueued/memory': 658,
 'start_time': datetime.datetime(2026, 6, 23, 11, 4, 29, 686898, tzinfo=datetime.timezone.utc)}
```