### PR TITLE
[Otsuka JP] Fix Spider

### DIFF
--- a/locations/spiders/otsuka_jp.py
+++ b/locations/spiders/otsuka_jp.py
@@ -10,7 +10,7 @@ from locations.dict_parser import DictParser
 class OtsukaJPSpider(Spider):
     name = "otsuka_jp"
 
-    start_urls = ["https://shop-eql.otsuka.co.jp/api/points/xn7"]
+    start_urls = ["https://shop-eql.otsuka.co.jp/api/points"]
     allowed_domains = ["shop-eql.otsuka.co.jp"]
     country_code = "JP"
     SKIP_BRANDS = [
@@ -33,7 +33,7 @@ class OtsukaJPSpider(Spider):
             item = DictParser.parse(store)
             item["ref"] = store["key"]
             item["website"] = f"https://shop-eql.otsuka.co.jp/map/{store['key']}"
-            if store["markers"]["ja"] == 1:
+            if store["markers"]["ja"] == "1":
                 apply_category(Categories.PHARMACY, item)
                 item["extras"]["dispensing"] = "yes"
             else:

--- a/locations/spiders/otsuka_jp.py
+++ b/locations/spiders/otsuka_jp.py
@@ -10,7 +10,7 @@ from locations.dict_parser import DictParser
 class OtsukaJPSpider(Spider):
     name = "otsuka_jp"
 
-    start_urls = ["https://shop-eql.otsuka.co.jp/api/poi"]
+    start_urls = ["https://shop-eql.otsuka.co.jp/api/points/xn7"]
     allowed_domains = ["shop-eql.otsuka.co.jp"]
     country_code = "JP"
     SKIP_BRANDS = [
@@ -26,14 +26,14 @@ class OtsukaJPSpider(Spider):
     ]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in response.json():
+        for store in response.json()["items"]:
             if any(i in store["name"] for i in self.SKIP_BRANDS):
                 item = {}
                 yield item
             item = DictParser.parse(store)
             item["ref"] = store["key"]
             item["website"] = f"https://shop-eql.otsuka.co.jp/map/{store['key']}"
-            if store["marker_index"] == 1:
+            if store["markers"]["ja"] == 1:
                 apply_category(Categories.PHARMACY, item)
                 item["extras"]["dispensing"] = "yes"
             else:


### PR DESCRIPTION
```python
{'atp/category/amenity/clinic': 8226,
 'atp/category/multiple': 8226,
 'atp/clean_strings/name': 7,
 'atp/country/JP': 8226,
 'atp/field/branch/missing': 8226,
 'atp/field/brand/missing': 8226,
 'atp/field/brand_wikidata/missing': 8226,
 'atp/field/city/missing': 8226,
 'atp/field/country/from_spider_name': 8226,
 'atp/field/email/missing': 8226,
 'atp/field/housenumber/missing': 8226,
 'atp/field/opening_hours/missing': 8226,
 'atp/field/operator/missing': 8226,
 'atp/field/operator_wikidata/missing': 8226,
 'atp/field/phone/missing': 8226,
 'atp/field/postcode/missing': 8226,
 'atp/field/state/missing': 8226,
 'atp/field/street/missing': 8226,
 'atp/field/street_address/missing': 8226,
 'atp/field/twitter/missing': 8226,
 'atp/field/unit/missing': 8226,
 'atp/item_scraped_host_count/shop-eql.otsuka.co.jp': 8226,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 8226,
 'atp/nsi/match_failed': 8226,
 'downloader/request_bytes': 682,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 449455,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 28.812000000005355,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 23, 11, 13, 42, 798798, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3033114,
 'httpcompression/response_count': 1,
 'item_scraped_count': 8226,
 'items_per_minute': 17627.142857142855,
 'log_count/DEBUG': 8228,
 'log_count/ERROR': 154,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 4.285714285714286,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 23, 11, 13, 13, 994153, tzinfo=datetime.timezone.utc)}
```