### PR TITLE
[Nitori JP] add spider

### DIFF
--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -19,6 +19,6 @@ class NitoriJPSpider(LocationCloudSpider):
 
         item["branch"] = source_feature.get("name", "")
         item["extras"]["branch:ja-Hira"] = source_feature.get("ruby", "")
-        item["phone"] = f"+81 {source_feature.get('phone', '')}"
+        item["phone"] = None
 
         yield item

--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -19,6 +19,5 @@ class NitoriJPSpider(LocationCloudSpider):
 
         item["branch"] = source_feature.get("name", "")
         item["extras"]["branch:ja-Hira"] = source_feature.get("ruby", "")
-        item["phone"] = None
 
         yield item

--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -1,6 +1,5 @@
 from typing import Iterable
 
-from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.location_cloud import LocationCloudSpider
 

--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -16,7 +16,7 @@ class NitoriJPSpider(LocationCloudSpider):
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
         if source_feature["categories"][0]["code"] == "03":
             return  # skip logistics centers
-        
+
         item["branch"] = source_feature.get("name", "")
         item["extras"]["branch:ja-Hira"] = source_feature.get("ruby", "")
         item["phone"] = f"+81 {source_feature.get('phone', '')}"

--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.location_cloud import LocationCloudSpider
+
+
+class NitoriJPSpider(LocationCloudSpider):
+    name = "nitori_jp"
+    item_attributes = {
+        "brand": "ニトリ",
+        "brand_wikidata": "Q10801453",
+    }
+    api_endpoint = "https://shop.nitori-net.jp/nitori/api/proxy2/shop/list"
+    website_formatter = "https://shop.nitori-net.jp/nitori/spot/detail?code={}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = source_feature.get("name", "")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ruby", "")
+
+        yield item

--- a/locations/spiders/nitori_jp.py
+++ b/locations/spiders/nitori_jp.py
@@ -14,7 +14,11 @@ class NitoriJPSpider(LocationCloudSpider):
     website_formatter = "https://shop.nitori-net.jp/nitori/spot/detail?code={}"
 
     def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        if source_feature["categories"][0]["code"] == "03":
+            return  # skip logistics centers
+        
         item["branch"] = source_feature.get("name", "")
         item["extras"]["branch:ja-Hira"] = source_feature.get("ruby", "")
+        item["phone"] = f"+81 {source_feature.get('phone', '')}"
 
         yield item


### PR DESCRIPTION
{'atp/brand/ニトリ': 919,
 'atp/brand_wikidata/Q10801453': 919,
 'atp/category/shop/furniture': 919,
 'atp/country/JP': 919,
 'atp/field/city/missing': 919,
 'atp/field/country/from_spider_name': 919,
 'atp/field/email/missing': 919,
 'atp/field/housenumber/missing': 919,
 'atp/field/opening_hours/missing': 919,
 'atp/field/operator/missing': 919,
 'atp/field/operator_wikidata/missing': 919,
 'atp/field/phone/missing': 919,
 'atp/field/state/missing': 919,
 'atp/field/street/missing': 919,
 'atp/field/street_address/missing': 919,
 'atp/field/twitter/missing': 919,
 'atp/field/unit/missing': 919,
 'atp/item_scraped_host_count/shop.nitori-net.jp': 919,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 919,
 'atp/nsi/match_imperfect': 919,
 'downloader/request_bytes': 1284,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 74544,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 5.546999999999571,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 23, 11, 31, 57, 883661, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 527825,
 'httpcompression/response_count': 3,
 'item_scraped_count': 919,
 'items_per_minute': 11028.0,
 'log_count/DEBUG': 922,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 36.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 6, 23, 11, 31, 52, 331311, tzinfo=datetime.timezone.utc)}