### PR TITLE
[Ziraat Bankası TR] Add spider (9570 locations)

### DIFF
--- a/locations/spiders/ziraat_bankasi_tr.py
+++ b/locations/spiders/ziraat_bankasi_tr.py
@@ -3,17 +3,8 @@ from typing import Any, AsyncIterator
 from scrapy import Spider
 from scrapy.http import JsonRequest, Request, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
-
-SOURCE_URL = "https://www.ziraatbank.com.tr/tr/bize-ulasin/sube-ve-atmler"
-API_URL = "https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx"
-HEADERS = {"Referer": SOURCE_URL, "X-Requested-With": "XMLHttpRequest"}
-
-LOCATION_TYPES = {
-    "branch": {"category": Categories.BANK, "list_method": "GetAllSubeText", "width": 8},
-    "atm": {"category": Categories.ATM, "list_method": "GetAllAtmText", "width": 7},
-}
 
 
 class ZiraatBankasiTRSpider(Spider):
@@ -21,45 +12,69 @@ class ZiraatBankasiTRSpider(Spider):
     item_attributes = {"brand": "Ziraat Bankası", "brand_wikidata": "Q696003"}
 
     async def start(self) -> AsyncIterator[Any]:
-        yield Request(SOURCE_URL, callback=self.parse_finder)
+        yield Request(
+            "https://www.ziraatbank.com.tr/tr/bize-ulasin/sube-ve-atmler",
+            callback=self.parse_finder,
+        )
 
     def parse_finder(self, response: Response) -> Any:
         states = {
             option.attrib["value"]: option.xpath("normalize-space()").get()
-            for option in response.css("#ddlCity option")
+            for option in response.xpath('//*[@id="ddlCity"]/option')
             if option.attrib.get("value") and option.attrib["value"] != "0"
         }
 
-        for location_type, settings in LOCATION_TYPES.items():
+        # Detail endpoints exist, but require one request per POI; with the project download delay that is a multi-hour crawl.
+        for location_type, category, list_method, width in [
+            ("branch", Categories.BANK, "GetAllSubeText", 8),
+            ("atm", Categories.ATM, "GetAllAtmText", 7),
+        ]:
             yield JsonRequest(
-                url=f"{API_URL}/{settings['list_method']}",
+                url=f"https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/{list_method}",
                 data={},
-                headers=HEADERS,
+                headers={
+                    "Referer": "https://www.ziraatbank.com.tr/tr/bize-ulasin/sube-ve-atmler",
+                    "X-Requested-With": "XMLHttpRequest",
+                },
                 callback=self.parse_location_list,
-                cb_kwargs={"location_type": location_type, "states": states},
+                cb_kwargs={"location_type": location_type, "category": category, "states": states, "width": width},
             )
 
-    def parse_location_list(self, response: Response, location_type: str, states: dict[str, str]) -> Any:
-        settings = LOCATION_TYPES[location_type]
-        data = response.json()["d"]["Data"]
-        parts = data.split("|")
+    def parse_location_list(
+        self,
+        response: Response,
+        location_type: str,
+        category: dict[str, str],
+        states: dict[str, str],
+        width: int,
+    ) -> Any:
+        parts = response.json()["d"]["Data"].split("|")
 
-        if len(parts) % settings["width"] != 0:
-            self.logger.error("Unexpected %s payload width from %s", location_type, response.url)
+        if len(parts) % width != 0:
+            self.logger.error("Unexpected {} payload width from {}".format(location_type, response.url))
             return
 
-        for index in range(0, len(parts), settings["width"]):
-            fields = parts[index : index + settings["width"]]
+        for index in range(0, len(parts), width):
+            fields = parts[index : index + width]
             state = states.get(fields[-2])
             if not state:
                 self.crawler.stats.inc_value(f"atp/{self.name}/skipped_unknown_state")
                 continue
 
+            # Marker feeds are pipe-delimited and expose id, coordinates, service flags, province id, and district id.
             item = Feature(
                 ref=f"{location_type}-{fields[0]}",
                 lat=fields[1].replace(",", "."),
                 lon=fields[2].replace(",", "."),
                 state=state,
             )
-            apply_category(settings["category"], item)
+            apply_category(category, item)
+
+            if category == Categories.BANK:
+                apply_yes_no(Extras.WHEELCHAIR, item, fields[4] == "1")
+            else:
+                apply_yes_no(Extras.CASH_IN, item, fields[3] == "2")
+                apply_yes_no(Extras.CASH_OUT, item, fields[3] == "1")
+                apply_yes_no(Extras.WHEELCHAIR, item, fields[4] == "1")
+
             yield item

--- a/locations/spiders/ziraat_bankasi_tr.py
+++ b/locations/spiders/ziraat_bankasi_tr.py
@@ -1,0 +1,65 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+SOURCE_URL = "https://www.ziraatbank.com.tr/tr/bize-ulasin/sube-ve-atmler"
+API_URL = "https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx"
+HEADERS = {"Referer": SOURCE_URL, "X-Requested-With": "XMLHttpRequest"}
+
+LOCATION_TYPES = {
+    "branch": {"category": Categories.BANK, "list_method": "GetAllSubeText", "width": 8},
+    "atm": {"category": Categories.ATM, "list_method": "GetAllAtmText", "width": 7},
+}
+
+
+class ZiraatBankasiTRSpider(Spider):
+    name = "ziraat_bankasi_tr"
+    item_attributes = {"brand": "Ziraat Bankası", "brand_wikidata": "Q696003"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield Request(SOURCE_URL, callback=self.parse_finder)
+
+    def parse_finder(self, response: Response) -> Any:
+        states = {
+            option.attrib["value"]: option.xpath("normalize-space()").get()
+            for option in response.css("#ddlCity option")
+            if option.attrib.get("value") and option.attrib["value"] != "0"
+        }
+
+        for location_type, settings in LOCATION_TYPES.items():
+            yield JsonRequest(
+                url=f"{API_URL}/{settings['list_method']}",
+                data={},
+                headers=HEADERS,
+                callback=self.parse_location_list,
+                cb_kwargs={"location_type": location_type, "states": states},
+            )
+
+    def parse_location_list(self, response: Response, location_type: str, states: dict[str, str]) -> Any:
+        settings = LOCATION_TYPES[location_type]
+        data = response.json()["d"]["Data"]
+        parts = data.split("|")
+
+        if len(parts) % settings["width"] != 0:
+            self.logger.error("Unexpected %s payload width from %s", location_type, response.url)
+            return
+
+        for index in range(0, len(parts), settings["width"]):
+            fields = parts[index : index + settings["width"]]
+            state = states.get(fields[-2])
+            if not state:
+                self.crawler.stats.inc_value(f"atp/{self.name}/skipped_unknown_state")
+                continue
+
+            item = Feature(
+                ref=f"{location_type}-{fields[0]}",
+                lat=fields[1].replace(",", "."),
+                lon=fields[2].replace(",", "."),
+                state=state,
+            )
+            apply_category(settings["category"], item)
+            yield item

--- a/locations/spiders/ziraat_bankasi_tr.py
+++ b/locations/spiders/ziraat_bankasi_tr.py
@@ -25,10 +25,7 @@ class ZiraatBankasiTRSpider(Spider):
         }
 
         # Detail endpoints exist, but require one request per POI; with the project download delay that is a multi-hour crawl.
-        for location_type, category, list_method, width in [
-            ("branch", Categories.BANK, "GetAllSubeText", 8),
-            ("atm", Categories.ATM, "GetAllAtmText", 7),
-        ]:
+        for location_type, list_method, width in [("branch", "GetAllSubeText", 8), ("atm", "GetAllAtmText", 7)]:
             yield JsonRequest(
                 url=f"https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/{list_method}",
                 data={},
@@ -37,14 +34,13 @@ class ZiraatBankasiTRSpider(Spider):
                     "X-Requested-With": "XMLHttpRequest",
                 },
                 callback=self.parse_location_list,
-                cb_kwargs={"location_type": location_type, "category": category, "states": states, "width": width},
+                cb_kwargs={"location_type": location_type, "states": states, "width": width},
             )
 
     def parse_location_list(
         self,
         response: Response,
         location_type: str,
-        category: dict[str, str],
         states: dict[str, str],
         width: int,
     ) -> Any:
@@ -68,13 +64,13 @@ class ZiraatBankasiTRSpider(Spider):
                 lon=fields[2].replace(",", "."),
                 state=state,
             )
-            apply_category(category, item)
 
-            if category == Categories.BANK:
-                apply_yes_no(Extras.WHEELCHAIR, item, fields[4] == "1")
+            apply_yes_no(Extras.WHEELCHAIR, item, fields[4] == "1")
+            if location_type == "branch":
+                apply_category(Categories.BANK, item)
             else:
                 apply_yes_no(Extras.CASH_IN, item, fields[3] == "2")
                 apply_yes_no(Extras.CASH_OUT, item, fields[3] == "1")
-                apply_yes_no(Extras.WHEELCHAIR, item, fields[4] == "1")
+                apply_category(Categories.ATM, item)
 
             yield item


### PR DESCRIPTION
Data source:
https://www.ziraatbank.com.tr/tr/bize-ulasin/sube-ve-atmler

The spider uses the Ziraat map marker API:
https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/GetAllSubeText
https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/GetAllAtmText

Category mapping:

BRANCH -> Categories.BANK
ATM -> Categories.ATM

Notes:
The site exposes detail endpoints, but they require one extra request per POI. I tested this locally and the crawl reached only ~690 items after 14 minutes due to the project download delay, so using details would turn this into a multi-hour crawl. The spider therefore uses the bulk marker feed, which provides stable IDs, coordinates, province IDs, and ATM/accessibility flags in 4 requests.

The source exposes branch and ATM markers separately in compact bulk payloads. The spider uses those bulk marker feeds for complete Turkey coverage and reliable CI runtime.

Opening hours are not available in the bulk marker feed, so they are not parsed.

76 source records are skipped because their coordinates are in Northern Cyprus and their source city codes are outside the Turkey city dropdown. This spider is Turkey-only (`ziraat_bankasi_tr`), and assigning them to `TR` would be incorrect.

Stats summary:

9570 total items
1737 banks
7833 ATMs
NSI: 9570 match_perfect
Country derived from spider name: 9570

Sample POIs:

```json
[
  {
    "type": "Feature",
    "id": "ZOvVKgtMWWfGi289mPkOJkjy45c=",
    "properties": {
      "ref": "branch-1",
      "amenity": "bank",
      "@source_uri": "https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/GetAllSubeText",
      "@spider": "ziraat_bankasi_tr",
      "addr:state": "Erzurum",
      "addr:country": "TR",
      "name": "Ziraat Bankası",
      "brand": "Ziraat Bankası",
      "brand:wikidata": "Q696003",
      "nsi_id": "ziraatbankasi-f79a7c"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [41.27573, 39.90644]
    }
  },
  {
    "type": "Feature",
    "id": "yIWHV48c2l15VYKe4VWf785D3Nw=",
    "properties": {
      "ref": "atm-1",
      "amenity": "atm",
      "@source_uri": "https://www.ziraatbank.com.tr/tr/_layouts/15/Ziraat/SubeATM/Ajax.aspx/GetAllAtmText",
      "@spider": "ziraat_bankasi_tr",
      "addr:state": "Erzurum",
      "addr:country": "TR",
      "brand": "Ziraat Bankası",
      "brand:wikidata": "Q696003",
      "operator": "Ziraat Bankası",
      "operator:wikidata": "Q696003",
      "nsi_id": "ziraatbankasi-254ed3"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [41.99237, 40.54346]
    }
  }
]
```

```json
{
  "atp/brand/Ziraat Bankası": 9570,
  "atp/brand_wikidata/Q696003": 9570,
  "atp/category/amenity/atm": 7833,
  "atp/category/amenity/bank": 1737,
  "atp/country/TR": 9570,
  "atp/field/branch/missing": 9570,
  "atp/field/city/missing": 9570,
  "atp/field/country/from_spider_name": 9570,
  "atp/field/name/missing": 7833,
  "atp/field/opening_hours/missing": 9570,
  "atp/item_scraped_host_count/www.ziraatbank.com.tr": 9570,
  "atp/lineage": "S_?",
  "atp/nsi/match_perfect": 9570,
  "atp/operator/Ziraat Bankası": 7833,
  "atp/operator_wikidata/Q696003": 7833,
  "atp/ziraat_bankasi_tr/skipped_unknown_state": 76,
  "downloader/request_count": 4,
  "downloader/response_status_count/200": 4,
  "elapsed_time_seconds": 91.46799999999348,
  "finish_reason": "finished",
  "item_scraped_count": 9570
}
```