### PR TITLE
[Garanti BBVA TR] Add spider (7204 locations)

### DIFF
--- a/locations/spiders/garanti_bbva_tr.py
+++ b/locations/spiders/garanti_bbva_tr.py
@@ -2,7 +2,7 @@ from typing import Any, AsyncIterator
 from uuid import uuid4
 
 from scrapy import Request, Spider
-from scrapy.http import Response
+from scrapy.http import Response, JsonRequest
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -12,28 +12,29 @@ from locations.items import Feature
 class GarantiBbvaTRSpider(Spider):
     name = "garanti_bbva_tr"
     item_attributes = {"brand": "Garanti Bankası", "brand_wikidata": "Q322962"}
-    custom_settings = {"ROBOTSTXT_OBEY": False}  # API host robots.txt returns HTTP 500
 
     async def start(self) -> AsyncIterator[Request]:
-        yield Request(
+        yield JsonRequest(
             url="https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/branches",
             headers=self.api_headers(),
-            cb_kwargs={"ref_prefix": "branch", "category": Categories.BANK},
+            cb_kwargs={"ref_prefix": "branch"},
         )
-        yield Request(
+        yield JsonRequest(
             url="https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/atms",
             headers=self.api_headers(),
-            cb_kwargs={"ref_prefix": "atm", "category": Categories.ATM},
+            cb_kwargs={"ref_prefix": "atm"},
         )
 
-    def parse(self, response: Response, ref_prefix: str, category: dict[str, str], **kwargs: Any) -> Any:
+    def parse(self, response: Response, ref_prefix: str, **kwargs: Any) -> Any:
         for location in response.json():
             item = self.parse_location(location, ref_prefix)
-            apply_category(category, item)
 
-            if category == Categories.ATM:
+            if ref_prefix == "atm":
                 apply_yes_no(Extras.CASH_IN, item, bool(location.get("deposit")))
                 apply_yes_no(Extras.CASH_OUT, item, bool(location.get("withdraw")))
+                apply_category(Categories.ATM, item)
+            else:
+                apply_category(Categories.BANK, item)
 
             if "orthopedic" in location.get("accessible", []):
                 apply_yes_no(Extras.WHEELCHAIR, item, True)

--- a/locations/spiders/garanti_bbva_tr.py
+++ b/locations/spiders/garanti_bbva_tr.py
@@ -2,7 +2,7 @@ from typing import Any, AsyncIterator
 from uuid import uuid4
 
 from scrapy import Request, Spider
-from scrapy.http import Response, JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser

--- a/locations/spiders/garanti_bbva_tr.py
+++ b/locations/spiders/garanti_bbva_tr.py
@@ -1,0 +1,74 @@
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+API_BASE = "https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0"
+
+
+class GarantiBbvaTRSpider(Spider):
+    name = "garanti_bbva_tr"
+    item_attributes = {"brand": "Garanti Bankası", "brand_wikidata": "Q322962"}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    async def start(self) -> AsyncIterator[Request]:
+        for endpoint, ref_prefix, category in [
+            ("branches", "branch", Categories.BANK),
+            ("atms", "atm", Categories.ATM),
+        ]:
+            yield Request(
+                url=f"{API_BASE}/{endpoint}",
+                headers=self.api_headers(),
+                cb_kwargs={"ref_prefix": ref_prefix, "category": category},
+            )
+
+    def parse(self, response: Response, ref_prefix: str, category: dict[str, str], **kwargs: Any) -> Any:
+        for location in response.json():
+            item = self.parse_location(location, ref_prefix)
+            apply_category(category, item)
+
+            if category == Categories.ATM:
+                apply_yes_no(Extras.CASH_IN, item, bool(location.get("deposit")))
+                apply_yes_no(Extras.CASH_OUT, item, bool(location.get("withdraw")))
+
+            if "orthopedic" in location.get("accessible", []):
+                apply_yes_no(Extras.WHEELCHAIR, item, True)
+
+            yield item
+
+    def parse_location(self, location: dict[str, Any], ref_prefix: str) -> Feature:
+        item = DictParser.parse(location)
+        item["ref"] = f"{ref_prefix}-{location['id']}"
+
+        if name := item.pop("name", None):
+            item["branch"] = name.removeprefix(f"{location['id']} - ").strip()
+
+        item["street_address"] = item.pop("addr_full", None)
+        item["lat"] = location.get("latitude")
+        item["lon"] = location.get("longitude")
+        item.pop("fax", None)
+
+        return item
+
+    def api_headers(self) -> dict[str, str]:
+        guid = uuid4().hex
+        return {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "channel": "Internet",
+            "ip": "127.0.0.1",
+            "dialect": "TR",
+            "guid": guid,
+            "tenant-company-id": "GAR",
+            "x-client-trace-id": guid,
+            "client-session-id": uuid4().hex[:20],
+            "client-type": "ArkClient",
+            "client-id": "DslahJXaDW59ibNZppCm",
+            "tenant-geolocation": "TUR",
+            "Referer": "https://webforms.garantibbva.com.tr/public-atm-branch-app/?lang=en",
+        }

--- a/locations/spiders/garanti_bbva_tr.py
+++ b/locations/spiders/garanti_bbva_tr.py
@@ -8,24 +8,23 @@ from locations.categories import Categories, Extras, apply_category, apply_yes_n
 from locations.dict_parser import DictParser
 from locations.items import Feature
 
-API_BASE = "https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0"
-
 
 class GarantiBbvaTRSpider(Spider):
     name = "garanti_bbva_tr"
     item_attributes = {"brand": "Garanti Bankası", "brand_wikidata": "Q322962"}
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False}  # API host robots.txt returns HTTP 500
 
     async def start(self) -> AsyncIterator[Request]:
-        for endpoint, ref_prefix, category in [
-            ("branches", "branch", Categories.BANK),
-            ("atms", "atm", Categories.ATM),
-        ]:
-            yield Request(
-                url=f"{API_BASE}/{endpoint}",
-                headers=self.api_headers(),
-                cb_kwargs={"ref_prefix": ref_prefix, "category": category},
-            )
+        yield Request(
+            url="https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/branches",
+            headers=self.api_headers(),
+            cb_kwargs={"ref_prefix": "branch", "category": Categories.BANK},
+        )
+        yield Request(
+            url="https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/atms",
+            headers=self.api_headers(),
+            cb_kwargs={"ref_prefix": "atm", "category": Categories.ATM},
+        )
 
     def parse(self, response: Response, ref_prefix: str, category: dict[str, str], **kwargs: Any) -> Any:
         for location in response.json():


### PR DESCRIPTION
Data source:
https://www.garantibbva.com.tr/en/contacts/branch-atm-finder

The spider uses the Garanti BBVA public branch/ATM API used by the finder iframe:

https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/branches
https://customers.garantibbva.com.tr/digital-public/public-atm-branch-ch/v0/atms

Category mapping:

BRANCH -> Categories.BANK
ATM -> Categories.ATM

Notes:
The source exposes branches and ATMs as separate records, so the spider yields both directly.

The API provides stable IDs, coordinates, address, city, branch/ATM display labels, and branch-specific phone numbers. ATM records include explicit deposit and withdrawal arrays, so the spider maps `cash_in=yes` and `cash_out=yes` for ATMs.

No per-location opening hours are returned by the branch/ATM API. I also checked the related CMS info-box asset used by the finder, and it only contains UI text, not structured hours.

Transient ATM status fields such as `offline` and `faultyList` are intentionally not mapped because they describe temporary operational state rather than stable POI attributes.

The API host returns HTTP 500 for `robots.txt`, while both data endpoints return 200. The spider disables robots.txt for this API host to avoid retry noise and keep the crawl stable.

Stats summary:

7204 total items
793 banks
6411 ATMs
NSI: 7204 match_perfect
Country derived from spider name: 7204

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "branch-186",
      "amenity": "bank",
      "addr:street_address": "Levent Mahallesi Cömert Sokak No:1/C/9-10",
      "addr:city": "İSTANBUL",
      "addr:country": "TR",
      "name": "Garanti Bankası",
      "branch": "1. LEVENT TİCARİ",
      "phone": "+90 212 385 39 50",
      "brand": "Garanti Bankası",
      "brand:wikidata": "Q322962",
      "nsi_id": "garantibankasi-4dfec6"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [29.01182, 41.08088]
    }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "atm-00922CRS043",
      "amenity": "atm",
      "cash_in": "yes",
      "cash_out": "yes",
      "addr:street_address": "AHMET REMZİ YÜREĞİR ERDAL ACET CD. 5-1",
      "addr:city": "ADANA",
      "addr:country": "TR",
      "branch": "01 BURDA AVM",
      "brand": "Garanti Bankası",
      "brand:wikidata": "Q322962",
      "operator": "Garanti Bankası",
      "operator:wikidata": "Q322962",
      "nsi_id": "garantibankasi-3780b1"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [35.306907362069, 36.994015655172]
    }
  }
]
```

JSON stats:

```json
{
  "atp/brand/Garanti Bankası": 7204,
  "atp/brand_wikidata/Q322962": 7204,
  "atp/category/amenity/atm": 6411,
  "atp/category/amenity/bank": 793,
  "atp/country/TR": 7204,
  "atp/field/country/from_spider_name": 7204,
  "atp/field/name/missing": 6411,
  "atp/field/opening_hours/missing": 7204,
  "atp/field/phone/missing": 6419,
  "atp/item_scraped_host_count/customers.garantibbva.com.tr": 7204,
  "atp/lineage": "S_?",
  "atp/nsi/match_perfect": 7204,
  "atp/operator/Garanti Bankası": 6411,
  "atp/operator_wikidata/Q322962": 6411,
  "downloader/request_count": 2,
  "downloader/response_status_count/200": 2,
  "item_scraped_count": 7204,
  "finish_reason": "finished"
}
```