### PR TITLE
[Tesco GB] Fix Spider

### DIFF
--- a/locations/spiders/tesco_gb.py
+++ b/locations/spiders/tesco_gb.py
@@ -3,6 +3,8 @@ import json
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -25,7 +27,7 @@ def set_located_in(brand: {}, item):
         item["located_in_wikidata"] = brand.get("brand_wikidata")
 
 
-class TescoGBSpider(SitemapSpider, StructuredDataSpider):
+class TescoGBSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "tesco_gb"
     TESCO = {"brand": "Tesco", "brand_wikidata": "Q487494"}
     TESCO_EXTRA = {"brand": "Tesco Extra", "brand_wikidata": "Q25172225"}
@@ -34,7 +36,7 @@ class TescoGBSpider(SitemapSpider, StructuredDataSpider):
     TESCO_METRO = {"brand": "Tesco Metro", "brand_wikidata": "Q57551648"}
     item_attributes = TESCO
     sitemap_urls = ["https://www.tesco.com/store-locator/sitemap.xml"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
     requires_proxy = True
     strip_names = [
         "Tesco Café",


### PR DESCRIPTION
```python
{'atp/brand/Tesco': 1740,
 'atp/brand/Tesco Express': 2188,
 'atp/brand/Tesco Extra': 257,
 'atp/brand_wikidata/Q25172225': 257,
 'atp/brand_wikidata/Q487494': 1740,
 'atp/brand_wikidata/Q98456772': 2188,
 'atp/category/amenity/cafe': 316,
 'atp/category/amenity/fuel': 493,
 'atp/category/amenity/pharmacy': 371,
 'atp/category/multiple': 371,
 'atp/category/shop/convenience': 2188,
 'atp/category/shop/supermarket': 817,
 'atp/country/GB': 4185,
 'atp/duplicate_count': 2,
 'atp/field/city/missing': 4184,
 'atp/field/country/from_spider_name': 4185,
 'atp/field/email/missing': 4185,
 'atp/field/housenumber/missing': 4185,
 'atp/field/name/missing': 257,
 'atp/field/opening_hours/missing': 24,
 'atp/field/operator/missing': 4185,
 'atp/field/operator_wikidata/missing': 4185,
 'atp/field/phone/missing': 1,
 'atp/field/state/missing': 4185,
 'atp/field/street/missing': 4185,
 'atp/field/unit/missing': 4185,
 'atp/item_scraped_host_count/www.tesco.com': 4187,
 'atp/ld_type/ClothingStore/ignore': 502,
 'atp/ld_type/LocalBusiness/ignore': 330,
 'atp/lineage': 'S_?',
 'atp/located_in/Tesco': 546,
 'atp/located_in/Tesco Express': 1,
 'atp/located_in/Tesco Extra': 632,
 'atp/located_in_wikidata/Q25172225': 632,
 'atp/located_in_wikidata/Q487494': 546,
 'atp/located_in_wikidata/Q98456772': 1,
 'atp/nsi/location_unknown': 257,
 'atp/nsi/match_failed': 257,
 'atp/nsi/match_perfect': 3928,
 'downloader/request_bytes': 2179060,
 'downloader/request_count': 6140,
 'downloader/request_method_count/GET': 6140,
 'downloader/response_bytes': 894290305,
 'downloader/response_count': 6140,
 'downloader/response_status_count/200': 6140,
 'elapsed_time_seconds': 7536.188000000009,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 23, 14, 22, 1, 433549, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 4185,
 'items_per_minute': 33.32006369426752,
 'log_count/DEBUG': 244528,
 'log_count/INFO': 141,
 'log_count/WARNING': 23,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 6140,
 'playwright/page_count/closed': 6140,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 114030,
 'playwright/request_count/aborted': 107889,
 'playwright/request_count/method/GET': 114030,
 'playwright/request_count/navigation': 6141,
 'playwright/request_count/resource_type/document': 6141,
 'playwright/request_count/resource_type/image': 74589,
 'playwright/request_count/resource_type/other': 3986,
 'playwright/request_count/resource_type/script': 23175,
 'playwright/request_count/resource_type/stylesheet': 6139,
 'playwright/response_count': 6141,
 'playwright/response_count/method/GET': 6141,
 'playwright/response_count/resource_type/document': 6141,
 'request_depth_max': 1,
 'response_received_count': 6140,
 'responses_per_minute': 48.88535031847134,
 'scheduler/dequeued': 6140,
 'scheduler/dequeued/memory': 6140,
 'scheduler/enqueued': 6140,
 'scheduler/enqueued/memory': 6140,
 'start_time': datetime.datetime(2026, 6, 23, 12, 16, 25, 149088, tzinfo=datetime.timezone.utc)}
```