### PR TITLE
[Arcelik Global TR] Fix Spider

### DIFF
--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -1,8 +1,7 @@
-from scrapy import Spider
-
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -12,10 +11,9 @@ BRANDS = {
 }
 
 
-class ArcelikGlobalTRSpider(Spider):
+class ArcelikGlobalTRSpider(PlaywrightSpider):
     name = "arcelik_global_tr"
     start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = True
 

--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -4,6 +4,7 @@ from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 BRANDS = {
     "arcelik": {"brand": "Arçelik", "brand_wikidata": "Q640497"},
@@ -15,7 +16,7 @@ class ArcelikGlobalTRSpider(Spider):
     name = "arcelik_global_tr"
     start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
     is_playwright_spider = True
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = True
 
     def parse(self, response, **kwargs):


### PR DESCRIPTION
```python
{'atp/brand/Arçelik': 500,
 'atp/brand/Beko': 500,
 'atp/brand_wikidata/Q631792': 500,
 'atp/brand_wikidata/Q640497': 500,
 'atp/category/shop/appliance': 1000,
 'atp/country/TR': 1000,
 'atp/field/branch/missing': 1000,
 'atp/field/city/missing': 1000,
 'atp/field/country/from_spider_name': 1000,
 'atp/field/email/missing': 1000,
 'atp/field/housenumber/missing': 1000,
 'atp/field/opening_hours/missing': 1000,
 'atp/field/operator/missing': 1000,
 'atp/field/operator_wikidata/missing': 1000,
 'atp/field/postcode/missing': 1000,
 'atp/field/state/missing': 1000,
 'atp/field/street/missing': 1000,
 'atp/field/street_address/missing': 1000,
 'atp/field/twitter/missing': 1000,
 'atp/field/unit/missing': 1000,
 'atp/item_scraped_host_count/www.arcelik.com.tr': 500,
 'atp/item_scraped_host_count/www.beko.com.tr': 500,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 1000,
 'downloader/request_bytes': 1162,
 'downloader/request_count': 4,
 'downloader/request_method_count/GET': 4,
 'downloader/response_bytes': 3503091,
 'downloader/response_count': 4,
 'downloader/response_status_count/200': 4,
 'elapsed_time_seconds': 28.35899999999674,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 24, 5, 50, 13, 226736, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1000,
 'items_per_minute': 2142.8571428571427,
 'log_count/DEBUG': 1175,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 4,
 'playwright/page_count/closed': 4,
 'playwright/page_count/max_concurrent': 2,
 'playwright/request_count': 33,
 'playwright/request_count/aborted': 29,
 'playwright/request_count/method/GET': 33,
 'playwright/request_count/navigation': 4,
 'playwright/request_count/resource_type/document': 4,
 'playwright/request_count/resource_type/image': 3,
 'playwright/request_count/resource_type/other': 4,
 'playwright/request_count/resource_type/script': 18,
 'playwright/request_count/resource_type/stylesheet': 4,
 'playwright/response_count': 4,
 'playwright/response_count/method/GET': 4,
 'playwright/response_count/resource_type/document': 4,
 'response_received_count': 4,
 'responses_per_minute': 8.571428571428571,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 6, 24, 5, 49, 44, 858921, tzinfo=datetime.timezone.utc)}
```