### PR TITLE
Fix websites in British Garden Centres spider

### DIFF
--- a/locations/spiders/british_garden_centres_gb.py
+++ b/locations/spiders/british_garden_centres_gb.py
@@ -15,9 +15,8 @@ class BritishGardenCentresGBSpider(JSONBlobSpider):
     ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request]:
-        if not item["website"].startswith("http"):
-            item["website"] = "https://www.britishgardencentres.com" + item["website"]
         item["name"] = feature["store"]
+        item["website"] = feature["permalink"]
         item["street_address"] = item.pop("addr_full")
         apply_category(Categories.SHOP_GARDEN_CENTRE, item)
 


### PR DESCRIPTION
BGC seems to have changed its URL format to include a /centres/ level before the branch slug. Rather than constructing the URLs manually and risk breakage on future changes, we can instead make use of the 'permalink' field in the JSON which contains the whole URL.