### PR TITLE
[Yapı Kredi] Add spider (5555 locations)

### DIFF
--- a/locations/spiders/yapi_kredi_tr.py
+++ b/locations/spiders/yapi_kredi_tr.py
@@ -1,0 +1,131 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+API_URL = "https://www.yapikredi.com.tr/_ajaxproxy/general.aspx"
+PAGE_SIZE = 10
+
+
+class YapiKrediTRSpider(Spider):
+    name = "yapi_kredi_tr"
+    item_attributes = {"brand": "Yapı Kredi", "brand_wikidata": "Q8049138"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url=f"{API_URL}/FetchCity", data={}, callback=self.parse_cities)
+
+    def parse_cities(self, response: Response, **kwargs: Any) -> Any:
+        for city in response.json()["d"]["Data"].get("Parameters", []):
+            city_id = city["Key"]
+            city_name = city["Value"]
+
+            yield JsonRequest(
+                url=f"{API_URL}/FetchBranchByFilter",
+                data={
+                    "cityId": city_id,
+                    "districtId": None,
+                    "keyword": None,
+                    "branchTypes": None,
+                    "functions": [],
+                    "page": 1,
+                },
+                callback=self.parse_branches,
+                cb_kwargs={"city_id": city_id, "city_name": city_name, "page": 1},
+            )
+            yield JsonRequest(
+                url=f"{API_URL}/FetchAtmByFilter",
+                data={
+                    "cityId": city_id,
+                    "town": None,
+                    "keyword": None,
+                    "properties": [],
+                    "page": 1,
+                },
+                callback=self.parse_atms,
+                cb_kwargs={"city_id": city_id, "city_name": city_name, "page": 1},
+            )
+
+    def parse_branches(self, response: Response, city_id: str, city_name: str, page: int, **kwargs: Any) -> Any:
+        data = response.json()["d"]["Data"]
+        locations = data.get("BranchList") or []
+
+        for location in locations:
+            item = self.parse_branch(location, city_name)
+            apply_category(Categories.BANK, item)
+            yield item
+
+        if locations and page * PAGE_SIZE < data.get("TotalCount", 0):
+            yield JsonRequest(
+                url=f"{API_URL}/FetchBranchByFilter",
+                data={
+                    "cityId": city_id,
+                    "districtId": None,
+                    "keyword": None,
+                    "branchTypes": None,
+                    "functions": [],
+                    "page": page + 1,
+                },
+                callback=self.parse_branches,
+                cb_kwargs={"city_id": city_id, "city_name": city_name, "page": page + 1},
+            )
+
+    def parse_atms(self, response: Response, city_id: str, city_name: str, page: int, **kwargs: Any) -> Any:
+        data = response.json()["d"]["Data"]
+        locations = data.get("NearestATM") or []
+
+        for location in locations:
+            if location.get("NotPublic"):
+                continue
+
+            item = self.parse_atm(location, city_name)
+            apply_yes_no(Extras.CASH_IN, item, location.get("DepositNotAvailable") is False)
+            apply_yes_no(
+                Extras.CASH_OUT,
+                item,
+                bool(location.get("WithdrawalDefinedCurrencies") or location.get("WithdrawalAvailableCurrencies")),
+            )
+            apply_yes_no(Extras.WHEELCHAIR, item, location.get("DisabledCompatible") is True)
+            apply_category(Categories.ATM, item)
+            yield item
+
+        if locations and page * PAGE_SIZE < data.get("TotalCount", 0) and len(locations) == PAGE_SIZE:
+            yield JsonRequest(
+                url=f"{API_URL}/FetchAtmByFilter",
+                data={
+                    "cityId": city_id,
+                    "town": None,
+                    "keyword": None,
+                    "properties": [],
+                    "page": page + 1,
+                },
+                callback=self.parse_atms,
+                cb_kwargs={"city_id": city_id, "city_name": city_name, "page": page + 1},
+            )
+
+    def parse_branch(self, location: dict[str, Any], city_name: str) -> Feature:
+        item = DictParser.parse(location)
+        item["ref"] = location.get("BranchCode")
+        item["addr_full"] = location.get("Address")
+        item["city"] = city_name
+
+        if branch := item.pop("name", None):
+            item["branch"] = branch.removesuffix(" ŞUBESİ").strip()
+
+        item.pop("fax", None)
+
+        return item
+
+    def parse_atm(self, location: dict[str, Any], city_name: str) -> Feature:
+        item = DictParser.parse(location)
+        item["ref"] = location.get("TerminalID")
+        item["addr_full"] = location.get("Address")
+        item["city"] = city_name
+
+        if location.get("StartWorkingHour") and location.get("EndWorkingHour"):
+            item["opening_hours"] = "Mo-Su {}-{}".format(location["StartWorkingHour"], location["EndWorkingHour"])
+
+        return item


### PR DESCRIPTION
Data source:
https://www.yapikredi.com.tr/kendim-icin/sinirsiz-bankacilik/atm/sube-ve-atm-arama

The spider uses the Yapı Kredi API endpoints:
https://www.yapikredi.com.tr/_ajaxproxy/general.aspx/FetchCity
https://www.yapikredi.com.tr/_ajaxproxy/general.aspx/FetchBranchByFilter
https://www.yapikredi.com.tr/_ajaxproxy/general.aspx/FetchAtmByFilter

Category mapping:

Branch records -> Categories.BANK
ATM records -> Categories.ATM

Notes:
The spider iterates all 81 Turkish cities from `FetchCity`, then requests city-level branch and ATM data.

ATM opening hours are only emitted when the source provides explicit `StartWorkingHour` and `EndWorkingHour` values. Null hour fields are left blank rather than treated as 24/7.

Branch phone numbers are location-specific: 736 unique branch phone numbers for 736 branch records.

No item-specific `website` field is emitted.

Stats summary:

```json
{
  "item_scraped_count": 5555,
  "atp/category/amenity/bank": 736,
  "atp/category/amenity/atm": 4819,
  "atp/brand/Yapı Kredi": 5555,
  "atp/brand_wikidata/Q8049138": 5555,
  "atp/country/TR": 5555,
  "atp/nsi/match_perfect": 5555,
  "atp/operator/Yapı Kredi": 4819,
  "atp/operator_wikidata/Q8049138": 4819,
  "atp/field/country/from_spider_name": 5555,
  "atp/field/opening_hours/missing": 5338,
  "item_dropped_count": 0,
  "downloader/request_count": 213,
  "downloader/response_status_count/200": 213,
  "robotstxt/response_status_count/200": 1
}
```

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "147",
      "amenity": "bank",
      "addr:full": "Kültür Mahallesi İstanbul Caddesi No:110 MERKEZ/DÜZCE",
      "addr:city": "DÜZCE",
      "addr:postcode": "81010",
      "addr:country": "TR",
      "name": "Yapı Kredi",
      "branch": "DÜZCE",
      "phone": "+90 380 514 13 61",
      "brand": "Yapı Kredi",
      "brand:wikidata": "Q8049138",
      "nsi_id": "yapikredi-a30806"
    },
    "geometry": {"type": "Point", "coordinates": [31.158, 40.8398]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "106025",
      "amenity": "atm",
      "cash_in": "yes",
      "cash_out": "yes",
      "wheelchair": "yes",
      "addr:full": "Kültür Mh İstanbul Cd No:1 Merkez/DÜZCE",
      "addr:city": "DÜZCE",
      "addr:country": "TR",
      "name": "Krempark AVM",
      "opening_hours": "Mo-Su 10:00-22:00",
      "brand": "Yapı Kredi",
      "brand:wikidata": "Q8049138",
      "operator": "Yapı Kredi",
      "operator:wikidata": "Q8049138",
      "nsi_id": "yapikredi-6f1d1d"
    },
    "geometry": {"type": "Point", "coordinates": [31.162109, 40.838684]}
  }
]
```