### PR TITLE
[Tesco EU] Fix Spider

### DIFF
--- a/locations/spiders/tesco_eu.py
+++ b/locations/spiders/tesco_eu.py
@@ -22,7 +22,7 @@ class TescoEUSpider(SitemapSpider, StructuredDataSpider):
         (r"/(prodejny|aruhazak)/[^/]+/[^/]+/?$", "parse_sd"),
         (r"/obchody/[^/]+/[^/]+/[^/]+/?$", "parse_sd"),
     ]
-    requires_proxy = True
+    requires_proxy = "CZ"
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         if "Extra" in item["name"].title():

--- a/locations/spiders/tesco_eu.py
+++ b/locations/spiders/tesco_eu.py
@@ -22,6 +22,7 @@ class TescoEUSpider(SitemapSpider, StructuredDataSpider):
         (r"/(prodejny|aruhazak)/[^/]+/[^/]+/?$", "parse_sd"),
         (r"/obchody/[^/]+/[^/]+/[^/]+/?$", "parse_sd"),
     ]
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         if "Extra" in item["name"].title():

--- a/locations/spiders/tesco_eu.py
+++ b/locations/spiders/tesco_eu.py
@@ -1,64 +1,36 @@
-from json import loads
-from typing import AsyncIterator
-from urllib.parse import urlparse
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
 from locations.spiders.tesco_gb import TescoGBSpider
+from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-# TODO: modernize spider to use https://www.tesco.sk/obchody/directory pages + structured data
-class TescoEUSpider(Spider):
+class TescoEUSpider(SitemapSpider, StructuredDataSpider):
     name = "tesco_eu"
-    COUNTRY_WEBSITE_MAP = {
-        "cz": "https://www.itesco.cz/prodejny/",
-        "hu": "https://www.tesco.hu/aruhazak/",
-        "sk": "https://www.tesco.sk/obchody/",
-    }
-    BRANDING_WORDS = ["tesco", "expres", "extra", "expressz"]  # lowercase
-    requires_proxy = "CZ"
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    sitemap_urls = [
+        "https://www.itesco.cz/prodejny/sitemap.xml",
+        "https://www.tesco.hu/aruhazak/sitemap.xml",
+        "https://www.tesco.sk/obchody/sitemap.xml",
+    ]
+    sitemap_rules = [
+        (r"/(prodejny|aruhazak)/[^/]+/[^/]+/?$", "parse_sd"),
+        (r"/obchody/[^/]+/[^/]+/[^/]+/?$", "parse_sd"),
+    ]
 
-    async def start(self) -> AsyncIterator[Request]:
-        for country, website in self.COUNTRY_WEBSITE_MAP.items():
-            yield Request(
-                url=f"https://{urlparse(website).hostname}/Ajax?type=fetch-stores-for-area&bounds[nw][lat]=90&bounds[nw][lng]=-180&bounds[ne][lat]=90&bounds[ne][lng]=180&bounds[sw][lat]=-90&bounds[sw][lng]=-180&bounds[se][lat]=-90&bounds[se][lng]=180",
-                cb_kwargs=dict(country=country),
-            )
-
-    def parse(self, response, country):
-        for store in response.json()["stores"]:
-            store["street-address"] = store.pop("address", "")
-            item = DictParser.parse(store)
-            if name := item.pop("name"):
-                item["branch"] = " ".join([word for word in name.split(" ") if word.lower() not in self.BRANDING_WORDS])
-            item["ref"] = store["goldid"]
-            item["lat"] = store.get("gpslat")
-            item["lon"] = store.get("gpslng")
-            item["country"] = country
-            item["opening_hours"] = OpeningHours()
-            item["website"] = self.COUNTRY_WEBSITE_MAP.get(
-                country
-            )  # There is 'urlname' attribute, but it's not leading to the store page
-            if timing_text := store.get("opening"):
-                for day, hours in loads(timing_text).items():
-                    open_time, close_time = hours if hours else [None, None]
-                    item["opening_hours"].add_range(DAYS[int(day) - 1], open_time, close_time)
-
-            # typeid is not consistent across countries, also sometimes not reliable to determine a brand
-            store_names = [name.title() for name in [store.get("name", ""), store.get("webname", "")]]
-            if any("Extra" in name for name in store_names):
-                apply_category(Categories.SHOP_SUPERMARKET, item)
-                item.update(TescoGBSpider.TESCO_EXTRA)
-            elif any("Expres" in name for name in store_names):
-                apply_category(Categories.SHOP_CONVENIENCE, item)
-                item.update(TescoGBSpider.TESCO_EXPRESS)
-            else:
-                apply_category(Categories.SHOP_SUPERMARKET, item)
-                item.update(TescoGBSpider.TESCO)
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if "Extra" in item["name"].title():
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+            item.update(TescoGBSpider.TESCO_EXTRA)
+        elif "Expres" in item["name"].title():
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+            item.update(TescoGBSpider.TESCO_EXPRESS)
+        else:
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+            item.update(TescoGBSpider.TESCO)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Tesco': 299,
 'atp/brand/Tesco Express': 84,
 'atp/brand_wikidata/Q487494': 299,
 'atp/brand_wikidata/Q98456772': 84,
 'atp/category/shop/convenience': 84,
 'atp/category/shop/supermarket': 299,
 'atp/country/CZ': 126,
 'atp/country/HU': 179,
 'atp/country/SK': 78,
 'atp/field/branch/missing': 383,
 'atp/field/city/missing': 383,
 'atp/field/country/from_website_url': 383,
 'atp/field/email/missing': 383,
 'atp/field/housenumber/missing': 383,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 383,
 'atp/field/operator_wikidata/missing': 383,
 'atp/field/phone/missing': 383,
 'atp/field/state/missing': 383,
 'atp/field/street/missing': 383,
 'atp/field/twitter/missing': 383,
 'atp/field/unit/missing': 383,
 'atp/item_scraped_host_count/www.itesco.cz': 126,
 'atp/item_scraped_host_count/www.tesco.hu': 179,
 'atp/item_scraped_host_count/www.tesco.sk': 78,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 383,
 'downloader/request_bytes': 143742,
 'downloader/request_count': 389,
 'downloader/request_method_count/GET': 389,
 'downloader/response_bytes': 5590716,
 'downloader/response_count': 389,
 'downloader/response_status_count/200': 389,
 'elapsed_time_seconds': 215.1869999999908,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 25, 5, 5, 44, 374746, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 30408644,
 'httpcompression/response_count': 389,
 'item_scraped_count': 383,
 'items_per_minute': 106.88372093023256,
 'log_count/DEBUG': 807,
 'log_count/INFO': 6,
 'log_count/WARNING': 7,
 'request_depth_max': 1,
 'response_received_count': 389,
 'responses_per_minute': 108.55813953488372,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 386,
 'scheduler/dequeued/memory': 386,
 'scheduler/enqueued': 386,
 'scheduler/enqueued/memory': 386,
 'start_time': datetime.datetime(2026, 6, 25, 5, 2, 9, 164747, tzinfo=datetime.timezone.utc)}
```