### PR TITLE
[naivas_ke] Add spider

### DIFF
--- a/locations/spiders/naivas_ke.py
+++ b/locations/spiders/naivas_ke.py
@@ -1,0 +1,34 @@
+from typing import Iterable
+
+import chompjs
+from scrapy import FormRequest
+from scrapy.http import Response, TextResponse
+
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class NaivasKESpider(JSONBlobSpider):
+    name = "naivas_ke"
+    item_attributes = {"brand": "Naivas", "brand_wikidata": "Q18379067"}
+    start_urls = ["https://corporate.naivas.info/our-stores/"]
+    locations_key = "data"
+
+    def parse(self, response: TextResponse) -> Iterable[Feature]:
+        data_raw = response.xpath("//script[@id='naivas-map-js-js-extra']/text()").get()
+        data_raw = data_raw.split("store_locator_ajax =", 1)[1]
+        store_locator_ajax = chompjs.parse_js_object(data_raw)
+
+        ajax_url = store_locator_ajax["ajax_url"]
+        nonce = store_locator_ajax["nonce"]
+        form_data = {"action": "get_stores", "nonce": nonce}
+
+        yield FormRequest(url=ajax_url, formdata=form_data, callback=self.parse_stores)
+
+    def parse_stores(self, response: TextResponse) -> Iterable[Feature]:
+        features = self.extract_json(response)
+        yield from self.parse_feature_array(response, features) or []
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        yield item


### PR DESCRIPTION
```
{'atp/brand/Naivas': 109,
 'atp/brand_wikidata/Q18379067': 109,
 'atp/category/shop/supermarket': 109,
 'atp/country/KE': 109,
 'atp/field/city/missing': 109,
 'atp/field/country/from_spider_name': 109,
 'atp/field/email/missing': 109,
 'atp/field/housenumber/missing': 109,
 'atp/field/opening_hours/missing': 109,
 'atp/field/operator/missing': 109,
 'atp/field/operator_wikidata/missing': 109,
 'atp/field/phone/missing': 107,
 'atp/field/postcode/missing': 109,
 'atp/field/state/missing': 109,
 'atp/field/street/missing': 109,
 'atp/field/street_address/missing': 109,
 'atp/field/twitter/missing': 109,
 'atp/field/unit/missing': 109,
 'atp/item_scraped_host_count/corporate.naivas.info': 109,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 109,
 'atp/nsi/match_imperfect': 109,
 'downloader/request_bytes': 1167,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 2,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 29585,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 5.109218632802367,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 25, 12, 58, 13, 580808, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 141946,
 'httpcompression/response_count': 3,
 'item_scraped_count': 109,
 'items_per_minute': 1308.0,
 'log_count/DEBUG': 112,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'memusage/max': 134787072,
 'memusage/startup': 134787072,
 'request_depth_max': 1,
 'response_received_count': 3,
 'responses_per_minute': 36.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 6, 25, 12, 58, 8, 471587, tzinfo=datetime.timezone.utc)}
```