### PR TITLE
[Jd Sports PT] Fix spider

### DIFF
--- a/locations/spiders/jd_sports_pt.py
+++ b/locations/spiders/jd_sports_pt.py
@@ -1,6 +1,11 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,3 +14,8 @@ class JdSportsPTSpider(CrawlSpider, StructuredDataSpider):
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.pt/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow=r"store-locator/[^/]+/\d+/$"), callback="parse_sd")]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item

--- a/locations/spiders/jd_sports_pt.py
+++ b/locations/spiders/jd_sports_pt.py
@@ -8,5 +8,4 @@ class JdSportsPTSpider(CrawlSpider, StructuredDataSpider):
     name = "jd_sports_pt"
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.pt/store-locator/all-stores/"]
-    rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
-    requires_proxy = True
+    rules = [Rule(LinkExtractor(allow=r"store-locator/[^/]+/\d+/$"), callback="parse_sd")]


### PR DESCRIPTION
```
{'atp/brand/JD Sports': 35,
 'atp/brand_wikidata/Q6108019': 35,
 'atp/category/shop/clothes': 35,
 'atp/country/PT': 35,
 'atp/field/branch/missing': 35,
 'atp/field/email/missing': 35,
 'atp/field/housenumber/missing': 35,
 'atp/field/image/dropped': 35,
 'atp/field/operator/missing': 35,
 'atp/field/operator_wikidata/missing': 35,
 'atp/field/phone/missing': 9,
 'atp/field/state/missing': 34,
 'atp/field/street/missing': 35,
 'atp/field/twitter/missing': 35,
 'atp/field/unit/missing': 35,
 'atp/item_scraped_host_count/www.jdsports.pt': 35,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 35,
 'atp/nsi/match_imperfect': 35,
 'downloader/request_bytes': 16262,
 'downloader/request_count': 37,
 'downloader/request_method_count/GET': 37,
 'downloader/response_bytes': 2483222,
 'downloader/response_count': 37,
 'downloader/response_status_count/200': 37,
 'elapsed_time_seconds': 47.4220000000023,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 25, 17, 22, 54, 59413, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9505720,
 'httpcompression/response_count': 37,
 'item_scraped_count': 35,
 'items_per_minute': 44.680851063829785,
 'log_count/DEBUG': 72,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 37,
 'responses_per_minute': 47.23404255319149,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 36,
 'scheduler/dequeued/memory': 36,
 'scheduler/enqueued': 36,
 'scheduler/enqueued/memory': 36,
 'start_time': datetime.datetime(2026, 6, 25, 17, 22, 6, 622527, tzinfo=datetime.timezone.utc)}
```