### PR TITLE
[Accenture] Fix spider

### DIFF
--- a/locations/spiders/accenture.py
+++ b/locations/spiders/accenture.py
@@ -1,35 +1,35 @@
 import html
 import json
+from typing import Any, Iterable
 
-import scrapy
-from scrapy.http import JsonRequest
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
-class AccentureSpider(scrapy.Spider):
+class AccentureSpider(Spider):
     name = "accenture"
     item_attributes = {"brand": "Accenture", "brand_wikidata": "Q338825"}
     start_urls = ["https://www.accenture.com/us-en/about/location"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
     no_refs = True
 
-    def parse(self, response, **kwargs):
-        for country in response.xpath('//a[contains(@class, "cmp-text__link")]/text()').getall():
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[JsonRequest]:
+        for country in response.xpath('//a[contains(@class, "rad-office-location-country__link")]//text()').getall():
             yield JsonRequest(
                 url=f"https://www.accenture.com/us-en/about/locations/office-details/jcr:content/root/container_main/locationhero_copy.result.html?query={country}&from=0&size=1500",
-                callback=self.parse_country,
+                callback=self.parse_office,
             )
 
-    def parse_country(self, response, **kwargs):
+    def parse_office(self, response: Response, **kwargs: Any) -> Iterable[Any]:
         for office in json.loads(html.unescape(response.text)):
             item = DictParser.parse(office)
             item.pop("state")
             item["branch"] = item.pop("name")
-            item["name"] = self.item_attributes["brand"]
             item["street_address"] = item.pop("addr_full")
             item["postcode"] = office.get("postalZipCode", "")
             item["phone"] = office.get("contactTel", "")
             apply_category(Categories.OFFICE_CONSULTING, item)
+
             yield item


### PR DESCRIPTION
```
{'atp/brand/Accenture': 334,
 'atp/brand_wikidata/Q338825': 334,
 'atp/category/office/consulting': 334,
 'atp/country/AE': 2,
 'atp/country/AR': 4,
 'atp/country/AT': 1,
 'atp/country/AU': 6,
 'atp/country/BE': 1,
 'atp/country/BG': 2,
 'atp/country/BR': 11,
 'atp/country/CA': 13,
 'atp/country/CH': 9,
 'atp/country/CL': 1,
 'atp/country/CN': 12,
 'atp/country/CO': 3,
 'atp/country/CR': 1,
 'atp/country/CZ': 2,
 'atp/country/DE': 20,
 'atp/country/DK': 3,
 'atp/country/ES': 13,
 'atp/country/FI': 2,
 'atp/country/FR': 6,
 'atp/country/GB': 8,
 'atp/country/GR': 2,
 'atp/country/HK': 1,
 'atp/country/HU': 2,
 'atp/country/ID': 2,
 'atp/country/IE': 4,
 'atp/country/IL': 2,
 'atp/country/IN': 43,
 'atp/country/IT': 16,
 'atp/country/JP': 12,
 'atp/country/LT': 1,
 'atp/country/LU': 1,
 'atp/country/LV': 1,
 'atp/country/MA': 1,
 'atp/country/MU': 4,
 'atp/country/MX': 4,
 'atp/country/MY': 10,
 'atp/country/NL': 2,
 'atp/country/NO': 3,
 'atp/country/NZ': 2,
 'atp/country/PH': 8,
 'atp/country/PL': 9,
 'atp/country/PR': 1,
 'atp/country/PT': 3,
 'atp/country/RO': 6,
 'atp/country/SA': 3,
 'atp/country/SE': 4,
 'atp/country/SG': 2,
 'atp/country/SK': 3,
 'atp/country/TH': 3,
 'atp/country/TR': 1,
 'atp/country/TW': 1,
 'atp/country/US': 54,
 'atp/country/VN': 1,
 'atp/country/ZA': 2,
 'atp/field/country/from_reverse_geocoding': 14,
 'atp/field/email/missing': 334,
 'atp/field/housenumber/missing': 334,
 'atp/field/opening_hours/missing': 334,
 'atp/field/operator/missing': 334,
 'atp/field/operator_wikidata/missing': 334,
 'atp/field/postcode/missing': 4,
 'atp/field/state/from_reverse_geocoding': 67,
 'atp/field/state/missing': 253,
 'atp/field/street/missing': 334,
 'atp/field/twitter/missing': 334,
 'atp/field/unit/missing': 334,
 'atp/item_scraped_host_count/www.accenture.com': 334,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 334,
 'downloader/request_bytes': 30705,
 'downloader/request_count': 56,
 'downloader/request_method_count/GET': 56,
 'downloader/response_bytes': 767423,
 'downloader/response_count': 56,
 'downloader/response_status_count/200': 56,
 'dupefilter/filtered': 154,
 'elapsed_time_seconds': 66.96900000000005,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 26, 5, 33, 26, 510809, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3317445,
 'httpcompression/response_count': 53,
 'item_scraped_count': 334,
 'items_per_minute': 303.6363636363636,
 'log_count/DEBUG': 391,
 'log_count/INFO': 4,
 'request_depth_max': 1,
 'response_received_count': 56,
 'responses_per_minute': 50.90909090909091,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 55,
 'scheduler/dequeued/memory': 55,
 'scheduler/enqueued': 55,
 'scheduler/enqueued/memory': 55,
 'start_time': datetime.datetime(2026, 6, 26, 5, 32, 19, 542546, tzinfo=datetime.timezone.utc)}
```