### PR TITLE
Fix Steiger-Stiftung Wikidata item

### DIFF
--- a/locations/spiders/steiger_stiftung_aed.py
+++ b/locations/spiders/steiger_stiftung_aed.py
@@ -11,7 +11,7 @@ class SteigerStiftungAedSpider(CSVFeedSpider):
     name = "steiger_stiftung_aed"
     item_attributes = {
         "operator": "Steiger-Stiftung",
-        "operator_wikidata": "Q112899405",
+        "operator_wikidata": "Q879521",
         "nsi_id": "N/A",
     }
     start_urls = ["https://www.steiger-stiftung.de/download/page/maps/data/aeds.csv"]


### PR DESCRIPTION
The spider was added in https://github.com/alltheplaces/alltheplaces/pull/16828 but didn't use the correct Wikidata item suggested in #14800 ([Q879521](https://www.wikidata.org/wiki/Q879521)) but instead a completely different one ([Q112899405](https://www.wikidata.org/wiki/Q112899405)). This PR fixes the spider to use the correct one.