### PR TITLE
[Vpz GB] Fix spider

### DIFF
--- a/locations/spiders/vpz_gb.py
+++ b/locations/spiders/vpz_gb.py
@@ -13,6 +13,7 @@ class VpzGBSpider(UberallSpider):
     key = "GTKUBZglSKHUX6xr99T8FQfxPyHfa5"
 
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["image"] = None
         item["ref"] = location.get("id")
         apply_category(Categories.SHOP_E_CIGARETTE, item)
         yield item

--- a/locations/spiders/vpz_gb.py
+++ b/locations/spiders/vpz_gb.py
@@ -1,17 +1,18 @@
-from locations.storefinders.storemapper import StoremapperSpider
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
 
 
-class VpzGBSpider(StoremapperSpider):
+class VpzGBSpider(UberallSpider):
     name = "vpz_gb"
     item_attributes = {"brand": "VPZ", "brand_wikidata": "Q107300487"}
-    company_id = "14072-3UOwEWhgZ0NnwVEo"
+    key = "GTKUBZglSKHUX6xr99T8FQfxPyHfa5"
 
-    def parse_item(self, item, location):
-        for custom_field in location["store_custom_fields"]:
-            if custom_field["custom_field_id"] == 42770:
-                item["city"] = custom_field["value"]
-            if custom_field["custom_field_id"] == 42771:
-                item["state"] = custom_field["value"]
-        item.pop("website")
-        item.pop("email")
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["ref"] = location.get("id")
+        apply_category(Categories.SHOP_E_CIGARETTE, item)
         yield item


### PR DESCRIPTION
```
{'atp/brand/VPZ': 200,
 'atp/brand_wikidata/Q107300487': 200,
 'atp/category/shop/e-cigarette': 200,
 'atp/country/GB': 200,
 'atp/field/branch/missing': 200,
 'atp/field/email/missing': 200,
 'atp/field/housenumber/missing': 200,
 'atp/field/operator/missing': 200,
 'atp/field/operator_wikidata/missing': 200,
 'atp/field/phone/missing': 3,
 'atp/field/street/missing': 200,
 'atp/field/twitter/missing': 200,
 'atp/field/unit/missing': 200,
 'atp/item_scraped_host_count/uberall.com': 200,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 200,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 22395,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.8899999999998727,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 26, 12, 0, 52, 279811, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 163622,
 'httpcompression/response_count': 2,
 'item_scraped_count': 200,
 'items_per_minute': 4000.0,
 'log_count/DEBUG': 202,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 26, 12, 0, 48, 388260, tzinfo=datetime.timezone.utc)}
```