### PR TITLE
[Valor JP] create spider

### DIFF
--- a/locations/spiders/valor_jp.py
+++ b/locations/spiders/valor_jp.py
@@ -1,0 +1,28 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class ValorJPSpider(CanlySpider):
+    name = "valor_jp"
+    item_attributes = {
+        "brand": "バロー",
+        "brand_wikidata": "Q11328346",
+    }
+    brand_key = "1245"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # Skip any non-open locations
+        if feature.get("businessStatus") != "OPEN":
+            return
+        
+        item["branch"] = feature.get("nameKanji").removeprefix("スーパーマーケットバロー").strip()
+        item["website"] = f"https://stores.valor.jp/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/spiders/valor_jp.py
+++ b/locations/spiders/valor_jp.py
@@ -19,7 +19,7 @@ class ValorJPSpider(CanlySpider):
         # Skip any non-open locations
         if feature.get("businessStatus") != "OPEN":
             return
-        
+
         item["branch"] = feature.get("nameKanji").removeprefix("スーパーマーケットバロー").strip()
         item["website"] = f"https://stores.valor.jp/detail/{feature.get('storeCode')}/"
 


### PR DESCRIPTION
{'atp/brand/バロー': 247,
 'atp/brand_wikidata/Q11328346': 247,
 'atp/category/shop/supermarket': 247,
 'atp/country/JP': 247,
 'atp/field/city/missing': 247,
 'atp/field/country/from_spider_name': 247,
 'atp/field/email/missing': 247,
 'atp/field/housenumber/missing': 247,
 'atp/field/name/missing': 247,
 'atp/field/opening_hours/missing': 247,
 'atp/field/operator/missing': 247,
 'atp/field/operator_wikidata/missing': 247,
 'atp/field/state/missing': 247,
 'atp/field/street/missing': 247,
 'atp/field/street_address/missing': 247,
 'atp/field/twitter/missing': 247,
 'atp/field/unit/missing': 247,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 247,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 247,
 'atp/nsi/match_failed': 247,
 'downloader/request_bytes': 725,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 53531,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 3.375,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 27, 9, 10, 49, 939997, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1205224,
 'httpcompression/response_count': 1,
 'item_scraped_count': 247,
 'items_per_minute': 4940.0,
 'log_count/DEBUG': 250,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 6, 27, 9, 10, 46, 566810, tzinfo=datetime.timezone.utc)}