### PR TITLE
[QNB TR] Add spider (3961 locations)

### DIFF
--- a/locations/spiders/qnb_tr.py
+++ b/locations/spiders/qnb_tr.py
@@ -1,0 +1,55 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import set_closed
+
+
+class QnbTRSpider(Spider):
+    name = "qnb_tr"
+    item_attributes = {"brand": "QNB", "brand_wikidata": "Q1136759"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        for location_type, query in [("branch", "hasBranch=true"), ("atm", "hasAtm=true")]:
+            yield JsonRequest(
+                url=f"https://www.qnb.com.tr/api/City?{query}",
+                cb_kwargs={"location_type": location_type},
+            )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for city in response.json():
+            yield JsonRequest(
+                url=f"https://www.qnb.com.tr/api/{location_type}?cityId={city.get('Id')}",
+                data={},
+                callback=self.parse_locations,
+                cb_kwargs={"location_type": location_type, "city": city.get("Name")},
+            )
+
+    def parse_locations(self, response: Response, location_type: str, city: str, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["lon"] = location.get("Longtitude")
+            item["city"] = city
+
+            if location_type == "branch":
+                item["branch"] = location.get("OrganizationName")
+                item["phone"] = location.get("Phone1")
+                if location.get("IsTemporaryClosed"):
+                    set_closed(item)
+                apply_category(Categories.BANK, item)
+            elif location_type == "atm":
+                item["addr_full"] = location.get("Adress")
+                apply_yes_no(Extras.CASH_IN, item, location.get("BuyingTL") == 1)
+                apply_yes_no(Extras.CASH_OUT, item, location.get("SellingTL") == 1)
+                apply_yes_no(Extras.WHEELCHAIR, item, location.get("Enable") in (1, 3))
+                if location.get("IsActive") is not True:
+                    set_closed(item)
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item


### PR DESCRIPTION
Data source:
https://www.qnb.com.tr/yasal/sube-ve-atm

The spider uses the QNB locator APIs:
https://www.qnb.com.tr/api/City?hasBranch=true
https://www.qnb.com.tr/api/City?hasAtm=true
https://www.qnb.com.tr/api/branch?cityId={city_id}
https://www.qnb.com.tr/api/atm?cityId={city_id}

Category mapping:

branch -> Categories.BANK
atm -> Categories.ATM

Notes:

Robots.txt is obeyed and returned 200 during the crawl. No robots bypass is used.

The branch and ATM list endpoints require POST with JSON content type; `JsonRequest(data={})` supplies that without custom headers.

The branch API has no working countrywide endpoint (`cityId=all` returns 0), so the spider follows the site’s city-level lookup. The ATM API has an all-data endpoint, but using city-level requests preserves `addr:city` for every ATM.

Opening hours are not parsed. The API exposes `StartHour` consistently, but does not provide reliable closing times/weekdays for all branches.

The source marks 2 branches as temporarily closed and 254 ATMs as inactive; these are mapped with `set_closed()`.

Stats summary:

3961 total items
409 banks
3552 ATMs
NSI: 3961 match_perfect
Country derived from spider name: 3961

Stats JSON:
```
{
  "atp/brand/QNB": 3961,
  "atp/brand_wikidata/Q1136759": 3961,
  "atp/category/amenity/atm": 3552,
  "atp/category/amenity/bank": 409,
  "atp/clean_strings/addr_full": 241,
  "atp/clean_strings/street_address": 44,
  "atp/closed_poi": 256,
  "atp/country/TR": 3961,
  "atp/field/branch/missing": 3552,
  "atp/field/country/from_spider_name": 3961,
  "atp/field/email/missing": 3961,
  "atp/field/housenumber/missing": 3961,
  "atp/field/opening_hours/missing": 3961,
  "atp/field/operator/missing": 409,
  "atp/field/operator_wikidata/missing": 409,
  "atp/field/phone/missing": 3552,
  "atp/field/postcode/missing": 3961,
  "atp/field/state/missing": 3961,
  "atp/field/street/missing": 3961,
  "atp/field/street_address/missing": 3552,
  "atp/field/twitter/missing": 3961,
  "atp/field/unit/missing": 3961,
  "atp/item_scraped_host_count/www.qnb.com.tr": 3961,
  "atp/lineage": "S_?",
  "atp/nsi/match_perfect": 3961,
  "atp/operator/QNB": 3552,
  "atp/operator_wikidata/Q1136759": 3552,
  "downloader/request_count": 144,
  "downloader/request_method_count/GET": 3,
  "downloader/request_method_count/POST": 141,
  "downloader/response_count": 144,
  "downloader/response_status_count/200": 144,
  "item_scraped_count": 3961,
  "robotstxt/response_status_count/200": 1
}
```

Sample POIs:
```
[
  {
    "type": "Feature",
    "id": "Mux6AcoiQAUZpxDM_nq5NqKwafI=",
    "properties": {
      "ref": "19162",
      "amenity": "bank",
      "addr:street_address": "MÜFTÜ MAH. MEYDANBAŞI CAD. AY CİTY ALIŞVERİŞ VE YAŞAM MERK. NO:30",
      "addr:city": "Zonguldak",
      "addr:country": "TR",
      "name": "QNB",
      "branch": "Karadeniz ereğli",
      "phone": "+90 372 333 09 00",
      "brand": "QNB",
      "brand:wikidata": "Q1136759",
      "nsi_id": "qnb-a30806"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [31.424335, 41.278036]
    }
  },
  {
    "type": "Feature",
    "id": "Fg4rAyBNM4Sck7vaaMyKXPZniTw=",
    "properties": {
      "ref": "126241",
      "cash_in": "yes",
      "cash_out": "yes",
      "wheelchair": "yes",
      "amenity": "atm",
      "addr:full": "Acılık Camii Derneği Dükkanları, 10 Temmuz Mah. Belediye Bulvarı No:2, Merkez/Acılık",
      "addr:city": "Zonguldak",
      "addr:country": "TR",
      "name": "MERKEZ ACILIK",
      "brand": "QNB",
      "brand:wikidata": "Q1136759",
      "operator": "QNB",
      "operator:wikidata": "Q1136759",
      "nsi_id": "qnb-6f1d1d"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [31.78973968, 41.44937951]
    }
  },
  {
    "type": "Feature",
    "id": "g5Tfe02UID9G1grfrBOu1mwDCLk=",
    "properties": {
      "ref": "130417",
      "cash_out": "yes",
      "end_date": "yes",
      "amenity": "atm",
      "addr:full": "MİMAR SİNAN MAHALLESİ BAĞDAT CADDESİ NO:95 /A OVAM TIP MERKEZİ",
      "addr:city": "Kocaeli",
      "addr:country": "TR",
      "name": "DILOVASI MERKEZ",
      "brand": "QNB",
      "brand:wikidata": "Q1136759",
      "operator": "QNB",
      "operator:wikidata": "Q1136759",
      "nsi_id": "qnb-6f1d1d"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [29.539916, 40.785735]
    }
  }
]
```