### PR TITLE
[Auto Nation US] Fix Spider 

### DIFF
--- a/locations/spiders/auto_nation_us.py
+++ b/locations/spiders/auto_nation_us.py
@@ -7,17 +7,17 @@ from locations.categories import Categories, Extras, apply_category, apply_yes_n
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class AutoNationUSSpider(SitemapSpider, StructuredDataSpider):
+class AutoNationUSSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "auto_nation_us"
     allowed_domains = ["autonation.com"]
     item_attributes = {"brand": "AutoNation", "brand_wikidata": "Q784804"}
     sitemap_urls = ["https://www.autonation.com/robots.txt"]
     sitemap_rules = [(r"https://www.autonation.com/dealers/[^/]+$", "parse")]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000}
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):

--- a/locations/spiders/auto_nation_us.py
+++ b/locations/spiders/auto_nation_us.py
@@ -26,6 +26,7 @@ class AutoNationUSSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
         item["lat"] = store_info.get("latitude")
         item["lon"] = store_info.get("longitude")
         item["ref"] = store_info.get("hyperionId")
+        item.pop("image", None)  # Same brand logo on every location, not per-location
         # ld_data has opening hours of sales and services all merged, difficult to differentiate.
         item["opening_hours"] = self.parse_opening_hours(store_info.get("detailedHours") or [])
         departments = [department.get("name") for department in store_info.get("departments", [])]


### PR DESCRIPTION
```python
{'atp/brand/AutoNation': 245,
 'atp/brand_wikidata/Q784804': 245,
 'atp/category/shop/car': 243,
 'atp/category/shop/car_repair': 2,
 'atp/country/US': 245,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 245,
 'atp/field/email/missing': 245,
 'atp/field/housenumber/missing': 245,
 'atp/field/operator/missing': 245,
 'atp/field/operator_wikidata/missing': 245,
 'atp/field/street/missing': 245,
 'atp/field/unit/missing': 245,
 'atp/item_scraped_host_count/www.autonation.com': 246,
 'atp/lineage': 'S_?',
 'atp/nsi/category_unknown': 2,
 'atp/nsi/match_failed': 2,
 'atp/nsi/match_perfect': 243,
 'downloader/request_bytes': 226821,
 'downloader/request_count': 278,
 'downloader/request_method_count/GET': 278,
 'downloader/response_bytes': 149984899,
 'downloader/response_count': 278,
 'downloader/response_status_count/200': 269,
 'downloader/response_status_count/404': 3,
 'downloader/response_status_count/500': 6,
 'elapsed_time_seconds': 344.0779999999795,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 29, 11, 59, 29, 756589, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 5,
 'httperror/response_ignored_status_count/404': 3,
 'httperror/response_ignored_status_count/500': 2,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 245,
 'items_per_minute': 42.73255813953488,
 'log_count/DEBUG': 29608,
 'log_count/ERROR': 2,
 'log_count/INFO': 17,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 278,
 'playwright/page_count/closed': 278,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 14402,
 'playwright/request_count/aborted': 14118,
 'playwright/request_count/method/GET': 14155,
 'playwright/request_count/method/POST': 247,
 'playwright/request_count/navigation': 283,
 'playwright/request_count/resource_type/document': 283,
 'playwright/request_count/resource_type/fetch': 248,
 'playwright/request_count/resource_type/image': 6339,
 'playwright/request_count/resource_type/script': 6038,
 'playwright/request_count/resource_type/stylesheet': 1494,
 'playwright/response_count': 283,
 'playwright/response_count/method/GET': 283,
 'playwright/response_count/resource_type/document': 283,
 'request_depth_max': 2,
 'response_received_count': 274,
 'responses_per_minute': 47.7906976744186,
 'retry/count': 4,
 'retry/max_reached': 2,
 'retry/reason_count/500 Internal Server Error': 4,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 277,
 'scheduler/dequeued/memory': 277,
 'scheduler/enqueued': 277,
 'scheduler/enqueued/memory': 277,
 'start_time': datetime.datetime(2026, 6, 29, 11, 53, 45, 662219, tzinfo=datetime.timezone.utc)}
```