### PR TITLE
[Zizzi GB IE] Fix and rename spider

### DIFF
--- a/locations/spiders/zizzi_gb.py
+++ b/locations/spiders/zizzi_gb.py
@@ -1,25 +1,34 @@
-import scrapy
+from typing import Iterable
 
-from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import clean_address
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class ZizziGBSpider(scrapy.Spider):
+class ZizziGBSpider(SitemapSpider, StructuredDataSpider):
     name = "zizzi_gb"
     item_attributes = {"brand": "Zizzi", "brand_wikidata": "Q8072944"}
-    start_urls = ["https://www.zizzi.co.uk/wp-json/locations/get_venues"]
+    sitemap_urls = ["https://www.zizzi.co.uk/sitemap.xml"]
+    sitemap_rules = [
+        (r"/italian-restaurants/((?!.*/(?:poi|offers|news|menus)(?:/|$))[^/]+/[^/]+(?:/[^/]+)?)$", "parse")
+    ]
+    wanted_types = ["Restaurant"]
 
-    def parse(self, response):
-        for store in response.json()["data"]:
-            item = DictParser.parse(store)
-            item["addr_full"] = clean_address(store["address"].split("\r\n"))
-            item["image"] = store["featured_image"]
-            item["website"] = store["link"]
-            item["branch"] = item.pop("name")
-            if store["region"] == "Ireland":
-                item.pop("state")
-                item["country"] = "IE"
-            else:
-                item["country"] = "GB"
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        # Each page carries two Restaurant blocks, skip the "#restaurant" duplicate.
+        if ld_data.get("@id", "").endswith("#restaurant"):
+            return
 
-            yield item
+        item["branch"] = item.pop("name")
+
+        # The site reports every location as GB, so correct Republic of Ireland.
+        if response.url.split("/italian-restaurants/", 1)[1].split("/", 1)[0] == "ireland":
+            item["country"] = "IE"
+            item.pop("state", None)
+
+        apply_category(Categories.RESTAURANT, item)
+
+        yield item

--- a/locations/spiders/zizzi_gb_ie.py
+++ b/locations/spiders/zizzi_gb_ie.py
@@ -8,8 +8,8 @@ from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class ZizziGBSpider(SitemapSpider, StructuredDataSpider):
-    name = "zizzi_gb"
+class ZizziGBIESpider(SitemapSpider, StructuredDataSpider):
+    name = "zizzi_gb_ie"
     item_attributes = {"brand": "Zizzi", "brand_wikidata": "Q8072944"}
     sitemap_urls = ["https://www.zizzi.co.uk/sitemap.xml"]
     sitemap_rules = [


### PR DESCRIPTION
```
{'atp/brand/Zizzi': 133,
 'atp/brand_wikidata/Q8072944': 133,
 'atp/category/amenity/restaurant': 133,
 'atp/country/GB': 130,
 'atp/country/IE': 3,
 'atp/field/email/missing': 133,
 'atp/field/housenumber/missing': 133,
 'atp/field/operator/missing': 133,
 'atp/field/operator_wikidata/missing': 133,
 'atp/field/state/missing': 133,
 'atp/field/street/missing': 133,
 'atp/field/twitter/missing': 133,
 'atp/field/unit/missing': 133,
 'atp/item_scraped_host_count/www.zizzi.co.uk': 133,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 133,
 'downloader/request_bytes': 55871,
 'downloader/request_count': 135,
 'downloader/request_method_count/GET': 135,
 'downloader/response_bytes': 7863202,
 'downloader/response_count': 135,
 'downloader/response_status_count/200': 135,
 'elapsed_time_seconds': 162.28099999999995,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 29, 13, 40, 49, 381924, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 59779457,
 'httpcompression/response_count': 135,
 'item_scraped_count': 133,
 'items_per_minute': 49.25925925925926,
 'log_count/DEBUG': 268,
 'log_count/INFO': 5,
 'request_depth_max': 1,
 'response_received_count': 135,
 'responses_per_minute': 50.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 134,
 'scheduler/dequeued/memory': 134,
 'scheduler/enqueued': 134,
 'scheduler/enqueued/memory': 134,
 'start_time': datetime.datetime(2026, 6, 29, 13, 38, 7, 92136, tzinfo=datetime.timezone.utc)}
```