### PR TITLE
Remove stale ty: ignore directive in react_server_components

### DIFF
--- a/locations/react_server_components.py
+++ b/locations/react_server_components.py
@@ -36,7 +36,7 @@ def parse_rsc(data_raw: Iterable[int]) -> Iterator[tuple[int, Any]]:
                 row_data = row_tag.encode() + row_data
                 row_tag = b"\0"
 
-        if array_type := ARRAY_TYPES.get(row_tag):  # ty: ignore[invalid-argument-type]
+        if array_type := ARRAY_TYPES.get(row_tag):
             yield row_id, array.array(array_type, row_data)
         else:
             row_str = row_data.decode()


### PR DESCRIPTION
Removes a `# ty: ignore[invalid-argument-type]` directive that ty 0.0.55 now flags as unused (the type narrowing was apparently improved and the suppression is no longer needed).

Related to #17123 