### PR TITLE
[Zdrofit] Fix spider: add Playwright for AWS WAF JS challenge

### DIFF
--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -1,8 +1,7 @@
-from scrapy import Spider
-
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -12,10 +11,9 @@ BRANDS = {
 }
 
 
-class ArcelikGlobalTRSpider(Spider):
+class ArcelikGlobalTRSpider(PlaywrightSpider):
     name = "arcelik_global_tr"
     start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = True
 

--- a/locations/spiders/arcelik_global_tr.py
+++ b/locations/spiders/arcelik_global_tr.py
@@ -4,6 +4,7 @@ from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 BRANDS = {
     "arcelik": {"brand": "Arçelik", "brand_wikidata": "Q640497"},
@@ -15,7 +16,7 @@ class ArcelikGlobalTRSpider(Spider):
     name = "arcelik_global_tr"
     start_urls = ["https://www.arcelik.com.tr/arcelik-magazalari", "https://www.beko.com.tr/beko-magazalari"]
     is_playwright_spider = True
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = True
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/zdrofit_pl.py
+++ b/locations/spiders/zdrofit_pl.py
@@ -5,16 +5,19 @@ from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class ZdrofitPLSpider(SitemapSpider, StructuredDataSpider):
+class ZdrofitPLSpider(SitemapSpider, PlaywrightSpider, StructuredDataSpider):
     name = "zdrofit_pl"
     item_attributes = {"brand": "Zdrofit", "brand_wikidata": "Q113457353"}
     time_format = "%H:%M:%S"
     sitemap_urls = ["https://zdrofit.pl/sitemaps/clubs-1.xml"]
     sitemap_rules = [(r"https://zdrofit.pl/kluby-fitness/[a-z0-9-]+/$", "parse_sd")]
-    proxy_required = True
+    requires_proxy = "PL"
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name")


### PR DESCRIPTION
- Fix `proxy_required = True` typo to `requires_proxy = "PL"` so the Polish proxy actually activates
- Add `PlaywrightSpider` base class and `DEFAULT_PLAYWRIGHT_SETTINGS` to handle the AWS WAF JS challenge (site returns 202 + `x-amzn-waf-action: challenge` on all requests including robots.txt)
- Add `ROBOTSTXT_OBEY: False` since robots.txt is also behind the WAF challenge

Seen in #17054