### PR TITLE
[Bank Hapoalim IL] Add spider

### DIFF
--- a/locations/spiders/bank_hapoalim_il.py
+++ b/locations/spiders/bank_hapoalim_il.py
@@ -1,0 +1,106 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
+
+
+class BankHapoalimILSpider(Spider):
+    name = "bank_hapoalim_il"
+    item_attributes = {"brand": "בנק הפועלים", "brand_wikidata": "Q2666775"}
+    requires_proxy = True  # Incapsula blocks direct requests.
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url="https://www.bankhapoalim.co.il/he/api/branches/data")
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = self.parse_location(location)
+            if not item:
+                continue
+
+            if opening_hours := self.parse_opening_hours(location):
+                item["opening_hours"] = opening_hours
+
+            if location.get("channelsGroupCode") == 19:
+                if branch := item.pop("name", None):
+                    item["branch"] = branch
+                apply_yes_no(Extras.ATM, item, self.has_service(location, 11))
+                apply_yes_no(Extras.WHEELCHAIR, item, self.has_accessibility(location, 2))
+                apply_category(Categories.BANK, item)
+            elif location.get("channelsGroupCode") == 899:
+                apply_yes_no(Extras.CASH_IN, item, self.has_service(location, 11))
+                apply_yes_no(Extras.CASH_OUT, item, self.has_service(location, 11))
+                apply_category(Categories.ATM, item)
+            else:
+                self.logger.error("Unexpected channelsGroupCode: {}".format(location.get("channelsGroupCode")))
+                continue
+
+            yield item
+
+    def parse_location(self, location: dict[str, Any]) -> Feature | None:
+        address = (location.get("geographicAddress") or [{}])[0] or {}
+        coordinates = address.get("geographicCoordinate") or {}
+        if not (coordinates.get("geoCoordinateX") and coordinates.get("geoCoordinateY")):
+            return None
+
+        item = DictParser.parse(location)
+        item["ref"] = str(location.get("branchNumber"))
+        item["lon"] = coordinates.get("geoCoordinateX")
+        item["lat"] = coordinates.get("geoCoordinateY")
+        item["street_address"] = self.build_street_address(address)
+        item["city"] = address.get("cityName")
+
+        if postcode := address.get("zipCode"):
+            item["postcode"] = str(postcode)
+
+        item.pop("phone", None)
+        item.pop("email", None)
+        item.pop("website", None)
+
+        return item
+
+    def parse_opening_hours(self, location: dict[str, Any]) -> OpeningHours | None:
+        opening_hours = OpeningHours()
+
+        try:
+            for day_name, day in (
+                ((location.get("availability") or {}).get("availabilityStandard") or {})
+                .get("weekDaysSpecification", {})
+                .items()
+            ):
+                osm_day = DAYS_EN.get(day_name.title())
+                if not osm_day:
+                    continue
+
+                for rule in (day or {}).get("branchOpeningHours") or []:
+                    if rule.get("startHour") and rule.get("endHour"):
+                        opening_hours.add_range(osm_day, rule["startHour"], rule["endHour"])
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            self.logger.warning("Could not parse opening hours for {}: {}".format(location.get("branchNumber"), e))
+            return None
+
+        return opening_hours or None
+
+    @staticmethod
+    def build_street_address(address: dict[str, Any]) -> str | None:
+        return " ".join(filter(None, [address.get("streetName"), address.get("buildingNumber")])) or None
+
+    @staticmethod
+    def has_service(location: dict[str, Any], service_code: int) -> bool:
+        return any(
+            service.get("branchServiceTypeCode") == service_code and service.get("serviceSwitch") == "yes"
+            for service in location.get("branchService") or []
+        )
+
+    @staticmethod
+    def has_accessibility(location: dict[str, Any], accessibility_code: int) -> bool:
+        return any(
+            accessibility.get("accessibilityTypeCode") == accessibility_code
+            and accessibility.get("accessibilityTypeSwitch") == "1"
+            for accessibility in location.get("accessibility") or []
+        )

--- a/locations/spiders/bank_hapoalim_il.py
+++ b/locations/spiders/bank_hapoalim_il.py
@@ -45,13 +45,18 @@ class BankHapoalimILSpider(Spider):
     def parse_location(self, location: dict[str, Any]) -> Feature | None:
         address = (location.get("geographicAddress") or [{}])[0] or {}
         coordinates = address.get("geographicCoordinate") or {}
-        if not (coordinates.get("geoCoordinateX") and coordinates.get("geoCoordinateY")):
+        try:
+            lon, lat = float(coordinates["geoCoordinateX"]), float(coordinates["geoCoordinateY"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        # Some records carry Israeli ITM grid values (or garbage) instead of WGS84; drop those.
+        if not (34.0 < lon < 36.0 and 29.0 < lat < 33.6):
             return None
 
         item = DictParser.parse(location)
         item["ref"] = str(location.get("branchNumber"))
-        item["lon"] = coordinates.get("geoCoordinateX")
-        item["lat"] = coordinates.get("geoCoordinateY")
+        item["lon"] = lon
+        item["lat"] = lat
         item["street_address"] = self.build_street_address(address)
         item["city"] = address.get("cityName")
 


### PR DESCRIPTION
Data source: https://www.bankhapoalim.co.il/he (branch & ATM finder)
API endpoint: https://www.bankhapoalim.co.il/he/api/branches/data

Category mapping:
branch (channelsGroupCode 19) -> Categories.BANK ; ATM (channelsGroupCode 899) -> Categories.ATM

### No duplicated POIs
Branches and ATMs are separate source records emitted 1:1. A branch is tagged `atm=yes` from an explicit per-branch service flag — code 11, `בנקט למשיכות והפקדות מזומנים` ("ATM for cash withdrawals and deposits") — and the standalone ATMs are their own `amenity=atm` POIs. Only 2 of the ATMs share a branch's exact coordinates; the rest are at distinct locations, so this is not duplication.

### Coordinates cleaned
Some ATM records carry Israeli ITM grid values (or garbage) instead of WGS84; those are dropped (coordinates outside Israel are skipped), so no invalid geometry is emitted.

### Other
`requires_proxy = True` — the site is behind Incapsula and blocks direct/datacenter requests. `DictParser` maps the record; coordinates come from `geographicCoordinate` (X=lon, Y=lat); `cash_in`/`cash_out` on ATMs and `wheelchair` on branches come from the service/accessibility codes. Opening hours are parsed from the structured per-weekday specification (Israeli Sun–Fri patterns). Generic phone/email/website are dropped.

Stats summary:
258 total items 
208 branches 
50 ATMs 
NSI: 258 match_perfect Country derived from spider name: 258

Sample POIs:

```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "144",
      "atm": "yes",
      "amenity": "bank",
      "@spider": "bank_hapoalim_il",
      "branch": "פועלים INVEST חיפה",
      "name": "בנק הפועלים",
      "addr:street_address": "הנביאים 18",
      "addr:city": "חיפה",
      "addr:postcode": "35501",
      "addr:country": "IL",
      "brand": "בנק הפועלים",
      "brand:wikidata": "Q2666775"
    },
    "geometry": { "type": "Point", "coordinates": [34.995827, 32.813406] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "9128",
      "amenity": "atm",
      "@spider": "bank_hapoalim_il",
      "name": "בנקט - מתנ”ס ירוחם",
      "addr:street_address": "צבי בורשטיין",
      "addr:city": "ירוחם",
      "addr:country": "IL",
      "brand": "בנק הפועלים",
      "brand:wikidata": "Q2666775",
      "operator": "בנק הפועלים",
      "operator:wikidata": "Q2666775"
    },
    "geometry": { "type": "Point", "coordinates": [34.92826, 30.98794] }
  }
]
```

Json stats : 
```
{
  "atp/brand/בנק הפועלים": 258,
  "atp/brand_wikidata/Q2666775": 258,
  "atp/category/amenity/atm": 50,
  "atp/category/amenity/bank": 208,
  "atp/country/IL": 258,
  "atp/field/branch/missing": 50,
  "atp/field/country/from_spider_name": 258,
  "atp/field/opening_hours/missing": 44,
  "atp/field/operator/missing": 208,
  "atp/field/operator_wikidata/missing": 208,
  "atp/field/phone/missing": 258,
  "atp/field/postcode/missing": 79,
  "atp/item_scraped_host_count/www.bankhapoalim.co.il": 258,
  "atp/lineage": "S_ATP_BRANDS",
  "atp/nsi/match_perfect": 258,
  "atp/operator/בנק הפועלים": 50,
  "atp/operator_wikidata/Q2666775": 50,
  "downloader/response_status_count/200": 2,
  "finish_reason": "finished",
  "item_scraped_count": 258
}
```