### PR TITLE
[Greene King Inns GB] Fix spider

### DIFF
--- a/locations/spiders/greene_king_inns_gb.py
+++ b/locations/spiders/greene_king_inns_gb.py
@@ -14,6 +14,7 @@ class GreeneKingInnsGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Greene King", "brand_wikidata": "Q5564162"}
     sitemap_urls = ["https://www.greenekinginns.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.greenekinginns\.co\.uk\/hotels\/[\w\-]+\/[\w\-]+$", "parse_sd")]
+    wanted_types = ["Hotel"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:

--- a/locations/spiders/greene_king_inns_gb.py
+++ b/locations/spiders/greene_king_inns_gb.py
@@ -1,7 +1,12 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class GreeneKingInnsGBSpider(SitemapSpider, StructuredDataSpider):
@@ -9,8 +14,9 @@ class GreeneKingInnsGBSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Greene King", "brand_wikidata": "Q5564162"}
     sitemap_urls = ["https://www.greenekinginns.co.uk/sitemap.xml"]
     sitemap_rules = [(r"https:\/\/www\.greenekinginns\.co\.uk\/hotels\/[\w\-]+\/[\w\-]+$", "parse_sd")]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def post_process_item(self, item, response, ld_data):
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["ref"] = item["ref"].replace("gki-", "")
 
         apply_category(Categories.HOTEL, item)


### PR DESCRIPTION
```
{'atp/brand/Greene King': 104,
 'atp/brand_wikidata/Q5564162': 104,
 'atp/category/tourism/hotel': 104,
 'atp/country/GB': 104,
 'atp/duplicate_count': 104,
 'atp/field/branch/missing': 104,
 'atp/field/country/from_spider_name': 104,
 'atp/field/housenumber/missing': 104,
 'atp/field/opening_hours/missing': 104,
 'atp/field/operator/missing': 104,
 'atp/field/operator_wikidata/missing': 104,
 'atp/field/state/missing': 104,
 'atp/field/street/missing': 104,
 'atp/field/twitter/missing': 104,
 'atp/field/unit/missing': 104,
 'atp/item_scraped_host_count/www.greenekinginns.co.uk': 208,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 104,
 'downloader/request_bytes': 102670,
 'downloader/request_count': 106,
 'downloader/request_method_count/GET': 106,
 'downloader/response_bytes': 5741971,
 'downloader/response_count': 106,
 'downloader/response_status_count/200': 106,
 'elapsed_time_seconds': 130.0,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 6, 30, 9, 50, 33, 690015, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 21384697,
 'httpcompression/response_count': 106,
 'item_dropped_count': 104,
 'item_dropped_reasons_count/DropItem': 104,
 'item_scraped_count': 104,
 'items_per_minute': 48.0,
 'log_count/DEBUG': 314,
 'log_count/INFO': 5,
 'request_depth_max': 1,
 'response_received_count': 106,
 'responses_per_minute': 48.92307692307693,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 105,
 'scheduler/dequeued/memory': 105,
 'scheduler/enqueued': 105,
 'scheduler/enqueued/memory': 105,
 'start_time': datetime.datetime(2026, 6, 30, 9, 48, 23, 688473, tzinfo=datetime.timezone.utc)}
```