### PR TITLE
[Raiffeisen bank HR] Add spider (373 locations)

### DIFF
--- a/locations/spiders/raiffeisen_bank_hr.py
+++ b/locations/spiders/raiffeisen_bank_hr.py
@@ -1,0 +1,39 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class RaiffeisenBankHRSpider(Spider):
+    name = "raiffeisen_bank_hr"
+    item_attributes = {"brand": "Raiffeisen bank", "brand_wikidata": "Q125756787"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(
+            url="https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati?p_p_id=poslovnice_WAR_poslovniceportlet&p_p_lifecycle=2&p_p_resource_id=loadLocations&p_p_cacheability=cacheLevelPage"
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            if street_address := item.pop("addr_full", None):
+                item["street_address"] = street_address
+
+            location_type = location.get("type", {})
+            has_branch = any(location_type.get(key) for key in ("branch", "premium", "business"))
+            has_atm = location_type.get("atmWithdrawal") or location_type.get("atmDeposit")
+
+            if has_branch:
+                apply_category(Categories.BANK, item)
+                apply_yes_no(Extras.ATM, item, has_atm)
+            elif has_atm:
+                apply_category(Categories.ATM, item)
+                apply_yes_no(Extras.CASH_IN, item, location_type.get("atmDeposit"))
+            else:
+                self.logger.warning("Skipping location with unexpected type: {}".format(location_type))
+                continue
+
+            yield item


### PR DESCRIPTION
Data source: https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati

The spider uses the RBA bulk marker feed (single Liferay portlet resource):
https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati?p_p_id=poslovnice_WAR_poslovniceportlet&p_p_lifecycle=2&p_p_resource_id=loadLocations&p_p_cacheability=cacheLevelPage

Category mapping:
BRANCH (`type.branch` / `type.premium` / `type.business`) -> Categories.BANK, with `atm=yes` (every branch carries an ATM)
ATM (`type.atmWithdrawal` / `type.atmDeposit` only) -> Categories.ATM
Records that are neither branch nor ATM are logged and skipped (0 in current data).

ATM capability note:
The source marks all ATM records with withdrawal capability (`atmWithdrawal=true` on 313/313 ATMs), so the spider does not emit a redundant `cash_out` tag — `amenity=atm` already implies withdrawal in practice, and tagging it on every record would be uninformative noise.

`atmDeposit`, by contrast, is discriminating: it is true on only 35 of 313 ATMs (deposit/recycling machines). Those 35 get `cash_in=yes` via `apply_yes_no(Extras.CASH_IN, ...)`; the remaining 278 are left untagged (positive-only), so absence of `cash_in` is not asserted as `no`. `cash_in` is applied only to standalone `amenity=atm` records — branch records carry `atm=yes` and are split into a separate ATM node downstream, so ATM-level cash attributes are intentionally not duplicated onto the bank node.

Coverage note:
The locator UI requires entering a city, but the unfiltered `loadLocations` resource returns the complete national set in one request — verified that `city` / `lat` / `lng` params do not change the count (373 with no params, 373 for Zagreb, 373 for Split). Coverage spans the whole country (Zagreb 90, Rijeka 13, Zadar 13, Split 12, Osijek 11, Varaždin 10, Pula 7, Dubrovnik 4, + 143 more towns; bbox lat 42.56→46.52, lon 13.52→19.00).

Notes:
- There are no usable detail endpoints (`loadLocation?id=` returns an empty body, the `urlAddress` detail page 404s), so the bulk feed is the only source. It provides stable IDs, coordinates, street address, city, and branch/ATM type flags in a single request.
- The source `address` is street + house number only (city is a separate field, no postcode/country), so it is mapped to `addr:street_address` rather than `addr:full`.
- Opening hours are not parsed: the feed's `open` field is only "open now / open this weekend" status booleans, not access hours.
- No per-location phone/email/website is exposed by the source.
- robots.txt is `Disallow:` (empty), so no robots override, custom headers, or proxy are used.

Stats summary:
373 total items, 60 banks, 313 ATMs (35 with `cash_in=yes`). NSI: 373 match_perfect. Country derived from spider name: 373.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "id": "bc_H4Wv9uwra3bzltFe9aBEJ07A=",
    "properties": {
      "ref": "4",
      "amenity": "bank",
      "atm": "yes",
      "@source_uri": "https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati?p_p_id=poslovnice_WAR_poslovniceportlet&p_p_lifecycle=2&p_p_resource_id=loadLocations&p_p_cacheability=cacheLevelPage",
      "@spider": "raiffeisen_bank_hr",
      "addr:street_address": "Trg Eugena Kvaternika 9",
      "addr:city": "Bjelovar",
      "addr:country": "HR",
      "name": "Raiffeisen bank",
      "brand": "Raiffeisen bank",
      "brand:wikidata": "Q125756787",
      "nsi_id": "raiffeisenbank-6f3d3b"
    },
    "geometry": { "type": "Point", "coordinates": [16.84212, 45.8979] }
  },
  {
    "type": "Feature",
    "id": "ldroJyE-xieSIBJ__cmGgQh3otU=",
    "properties": {
      "ref": "8649",
      "amenity": "atm",
      "@source_uri": "https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati?p_p_id=poslovnice_WAR_poslovniceportlet&p_p_lifecycle=2&p_p_resource_id=loadLocations&p_p_cacheability=cacheLevelPage",
      "@spider": "raiffeisen_bank_hr",
      "addr:street_address": "Kamik 24",
      "addr:city": "Banjole",
      "addr:country": "HR",
      "brand": "Raiffeisen bank",
      "brand:wikidata": "Q125756787",
      "operator": "Raiffeisen bank",
      "operator:wikidata": "Q125756787",
      "nsi_id": "raiffeisenbank-4d8c03"
    },
    "geometry": { "type": "Point", "coordinates": [13.87903, 44.82648] }
  },
  {
    "type": "Feature",
    "id": "ZOvVKgtMWWfGi289mPkOJkjy45c=",
    "properties": {
      "ref": "17293",
      "amenity": "atm",
      "cash_in": "yes",
      "@source_uri": "https://www.rba.hr/hr_HR/lokacije-poslovnice-bankomati?p_p_id=poslovnice_WAR_poslovniceportlet&p_p_lifecycle=2&p_p_resource_id=loadLocations&p_p_cacheability=cacheLevelPage",
      "@spider": "raiffeisen_bank_hr",
      "addr:street_address": "DR. FRANJE TUĐMANA 19",
      "addr:city": "Biograd na Moru",
      "addr:country": "HR",
      "brand": "Raiffeisen bank",
      "brand:wikidata": "Q125756787",
      "operator": "Raiffeisen bank",
      "operator:wikidata": "Q125756787",
      "nsi_id": "raiffeisenbank-254ed3"
    },
    "geometry": { "type": "Point", "coordinates": [15.445271, 43.938022] }
  }
]
```
Stats:
```
{
  "atp/brand/Raiffeisen bank": 373,
  "atp/brand_wikidata/Q125756787": 373,
  "atp/category/amenity/atm": 313,
  "atp/category/amenity/bank": 60,
  "atp/country/HR": 373,
  "atp/field/country/from_spider_name": 373,
  "atp/field/opening_hours/missing": 373,
  "atp/item_scraped_host_count/www.rba.hr": 373,
  "atp/nsi/match_perfect": 373,
  "downloader/request_count": 2,
  "downloader/response_status_count/200": 2,
  "elapsed_time_seconds": 7.297,
  "finish_reason": "finished",
  "item_scraped_count": 373
}
```