### PR TITLE
[Israel Discount Bank IL] Add spider

### DIFF
--- a/locations/spiders/discount_bank_il.py
+++ b/locations/spiders/discount_bank_il.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+
+
+class DiscountBankILSpider(Spider):
+    name = "discount_bank_il"
+    item_attributes = {"brand": "בנק דיסקונט לישראל", "brand_wikidata": "Q250362"}
+    start_urls = ["https://www.discountbank.co.il/branches/"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for branch in response.xpath("//div[@data-branchnumber]"):
+            attributes = branch.attrib
+            item = Feature()
+            item["ref"] = attributes["data-branchnumber"]
+            item["branch"] = attributes.get("data-name")
+            item["lat"] = attributes.get("data-lat")
+            item["lon"] = attributes.get("data-lng")
+            item["street_address"] = (
+                " ".join(filter(None, [attributes.get("data-street"), attributes.get("data-streetnumber")])) or None
+            )
+            item["city"] = attributes.get("data-city")
+            item["phone"] = attributes.get("data-phone")
+
+            services = {code.strip() for code in (attributes.get("data-field_branch_services") or "").split(",")}
+            apply_yes_no(Extras.ATM, item, "1720" in services)  # 1720 = כספומט (ATM)
+            apply_yes_no(Extras.WHEELCHAIR, item, "1756" in services)  # 1756 = סניף נגיש (accessible branch)
+
+            apply_category(Categories.BANK, item)
+
+            yield item


### PR DESCRIPTION
Description

Data source: https://www.discountbank.co.il/branches/

The branch data is embedded server-side in the `/branches/` page as `data-*` attributes on each `.branch-item` card (id, name, city, street, coordinates, phone, and a `data-field_branch_services` code list). The spider parses that single robots-allowed page — no API/AJAX call is needed (the per-branch popup loads via a `/umbraco/` endpoint that `robots.txt` disallows, so it is not used).

Category mapping:
BRANCH -> Categories.BANK

Branch services (`data-field_branch_services`): codes were resolved against the on-page service-filter legend and only OSM-standard ones are mapped:

| Code | Label | Mapped |
|---|---|---|
| `1720` | כספומט (ATM) | `atm=yes` |
| `1756` | סניף נגיש (accessible) | `wheelchair=yes` |
| `1726`/`1735` | FX ATM (EUR/USD) | not mapped |
| `1740`/`1744`/`1751`/`1753` | mortgage/pension advice, teller, business deposit | not mapped |
| `50240`/`50241` | open Sunday/Friday | not mapped (partial flag, not real hours, and inconsistent vs the popup) |

Notes:
- `robots.txt` allows `/branches/` (only `/umbraco/`, `/media/`, etc. are disallowed); no proxy, custom headers, or robots override.
- Opening hours are not available on the branches page (they load from the robots-disallowed `/umbraco/` popup), so they are not parsed.
- `phone` is per-branch (96 distinct of 99 present), so it is kept; no generic contact is emitted.
- `branch` uses the location label (`data-name`); brand name comes from NSI.
- Single-country spider; `country=IL` is derived from the spider name.

Stats summary:
102 total items, all `amenity=bank` (98 `atm=yes`, 101 `wheelchair=yes`). NSI: 102 match_perfect. Country derived from spider name: 102.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "85",
      "amenity": "bank",
      "atm": "yes",
      "wheelchair": "yes",
      "branch": "כיכר רבין",
      "name": "בנק דיסקונט",
      "addr:street_address": "אבן גבירול 66/68",
      "addr:city": "תל אביב יפו",
      "addr:country": "IL",
      "phone": "+972 76-805-3830",
      "brand": "בנק דיסקונט לישראל",
      "brand:wikidata": "Q250362",
      "nsi_id": "bankdiscount-563f7f"
    },
    "geometry": { "type": "Point", "coordinates": [34.781357, 32.080023] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "2",
      "amenity": "bank",
      "atm": "yes",
      "wheelchair": "yes",
      "branch": "עפולה",
      "name": "בנק דיסקונט",
      "addr:street_address": "הכורם 1",
      "addr:city": "עפולה",
      "addr:country": "IL",
      "phone": "+972 76-805-2170",
      "brand": "בנק דיסקונט לישראל",
      "brand:wikidata": "Q250362",
      "nsi_id": "bankdiscount-563f7f"
    },
    "geometry": { "type": "Point", "coordinates": [35.284688, 32.611069] }
  }
]
```

Stats:

```json
{
  "item_scraped_count": 102,
  "atp/category/amenity/bank": 102,
  "atp/nsi/match_perfect": 102,
  "atp/field/country/from_spider_name": 102,
  "downloader/request_count": 2,
  "downloader/response_status_count/200": 2,
  "finish_reason": "finished"
}
```