### PR TITLE
[QNB QA] Add spider (273 locations)

### DIFF
--- a/locations/spiders/qnb_qa.py
+++ b/locations/spiders/qnb_qa.py
@@ -18,7 +18,7 @@ INFO_WINDOW_RE = re.compile(r"locationsDetail\s*=\s*'(<div class=\"info-window-c
 class QnbQASpider(Spider):
     name = "qnb_qa"
     item_attributes = {"brand": "QNB", "brand_wikidata": "Q1136759"}
-    requires_proxy = True  # Cloudflare 403s datacenter IPs (confirmed in CI)
+    requires_proxy = "QA"  # Qatar-only site; other-country IPs can't reach it (Zyte returns 421)
 
     async def start(self) -> AsyncIterator[Any]:
         yield FormRequest(

--- a/locations/spiders/qnb_qa.py
+++ b/locations/spiders/qnb_qa.py
@@ -1,0 +1,101 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Selector, Spider
+from scrapy.http import FormRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+ENDPOINT = "https://www.qnb.com/sites/Satellite/"
+LATITUDE_RE = re.compile(r'var latitude\s*=\s*"([0-9.-]+)"')
+LONGITUDE_RE = re.compile(r'var longitude\s*=\s*"([0-9.-]+)"')
+# Each map marker's info window is emitted separately from its coordinates, so
+# coordinates are matched back to the nearest preceding lat/lon assignment.
+INFO_WINDOW_RE = re.compile(r"locationsDetail\s*=\s*'(<div class=\"info-window-content\".*?)'", re.S)
+
+
+class QnbQASpider(Spider):
+    name = "qnb_qa"
+    item_attributes = {"brand": "QNB", "brand_wikidata": "Q1136759"}
+    requires_proxy = True  # Cloudflare 403s datacenter IPs (confirmed in CI)
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield FormRequest(
+            url=ENDPOINT,
+            formdata={
+                "pagename": "GetATMBranchResult",
+                "site": "QNBQatar",
+                "locale": "ar",
+                "isatm": "false",
+                "hasCity": "true",
+                "countryId": "قطر",
+                "cityId": "",
+            },
+            callback=self.parse_cities,
+        )
+
+    def parse_cities(self, response: Response, **kwargs: Any) -> Any:
+        for city in response.xpath("//option/@value").getall():
+            if not (city := city.strip()):
+                continue
+            for location_type in ("branch", "atm"):
+                yield FormRequest(
+                    url=ENDPOINT,
+                    formdata={
+                        "pagename": "GetATMBranchResult",
+                        "site": "QNBQatar",
+                        "locale": "ar",
+                        "isatm": "true" if location_type == "atm" else "false",
+                        "hasBranch": "true",
+                        "cityId": city,
+                    },
+                    callback=self.parse_locations,
+                    cb_kwargs={"city": city, "location_type": location_type},
+                )
+
+    def parse_locations(self, response: Response, city: str, location_type: str, **kwargs: Any) -> Any:
+        text = response.text
+        latitudes = [(m.start(), m.group(1)) for m in LATITUDE_RE.finditer(text)]
+        longitudes = [(m.start(), m.group(1)) for m in LONGITUDE_RE.finditer(text)]
+
+        # Map markers hold name/coordinates; the address list is rendered in a
+        # separate block in the same order, so it is joined back positionally.
+        windows = list(INFO_WINDOW_RE.finditer(text))
+        address_spans = response.xpath('//span[strong[contains(text(), "العنوان")]]/following-sibling::span[1]')
+        addresses = [" ".join("".join(span.xpath(".//text()").getall()).split()) for span in address_spans]
+        if len(addresses) != len(windows):
+            addresses = []
+
+        for index, window in enumerate(windows):
+            lat = self.value_before(latitudes, window.start())
+            lon = self.value_before(longitudes, window.start())
+            if not (lat and lon):
+                continue
+
+            name = Selector(text=window.group(1)).xpath("//h3/text()").get()
+
+            item = Feature(
+                ref="/".join([lat, lon, name or ""]),
+                lat=lat,
+                lon=lon,
+                city=city,
+                addr_full=addresses[index] if addresses else None,
+            )
+            if location_type == "atm":
+                item["name"] = name
+                apply_category(Categories.ATM, item)
+            else:
+                item["branch"] = name
+                apply_category(Categories.BANK, item)
+
+            yield item
+
+    @staticmethod
+    def value_before(positions: list[tuple[int, str]], offset: int) -> str | None:
+        value = None
+        for start, candidate in positions:
+            if start >= offset:
+                break
+            value = candidate
+        return value

--- a/locations/spiders/qnb_qa.py
+++ b/locations/spiders/qnb_qa.py
@@ -55,6 +55,8 @@ class QnbQASpider(Spider):
                 )
 
     def parse_locations(self, response: Response, city: str, location_type: str, **kwargs: Any) -> Any:
+        # The endpoint returns HTML with coordinates in inline JavaScript and details in separate HTML
+        # blocks (no JSON API), so fields are extracted individually and DictParser does not apply.
         text = response.text
         latitudes = [(m.start(), m.group(1)) for m in LATITUDE_RE.finditer(text)]
         longitudes = [(m.start(), m.group(1)) for m in LONGITUDE_RE.finditer(text)]


### PR DESCRIPTION
Data source: https://www.qnb.com/sites/qnb/qnbqatar/page/ar/aratmbranches.html

The locator posts to a shared endpoint that returns HTML fragments with an embedded Google-Maps script:
`POST https://www.qnb.com/sites/Satellite/` with `pagename=GetATMBranchResult`, `site=QNBQatar`, `locale=ar`, `isatm=true|false`, and either `hasCity=true` (city list) or `hasBranch=true`+`cityId=<city>` (locations). The spider iterates the city list, then requests branches and ATMs per city, and parses each marker's info window (`<h3>` name + coordinates from the nearest `var latitude`/`var longitude`).

Category mapping:
- branch results (`isatm=false`) -> `Categories.BANK`
- ATM results (`isatm=true`) -> `Categories.ATM`

### Scope: Qatar only
`Q1136759` is used by the existing `qnb_tr` (Turkey, separate site `qnb.com.tr`). This locator's country dropdown lists 18 countries, but NSI only recognises QNB (`Q1136759`) in `eg, om, qa, sy` (+ `tr`). Of those, only Qatar/Oman/Syria are on this endpoint (Egypt/Tunisia have separate sites), and Oman/Syria are tiny (2 and 8 locations) and prone to being dropped by the site's intermittent Cloudflare 403s. This PR is therefore scoped to Qatar; Oman/Syria can be separate follow-ups if wanted.

Notes:
- `qnb.com` is Cloudflare-fronted and returns intermittent HTTP 403 to direct requests (rate-limiting); since `alltheplaces-fetch` runs from datacenter IPs, `requires_proxy = True` is set for reliable fetching.
- `addr:city` uses the source's district grouping (e.g. "West Bay", "Al Sadd").
- Opening hours and street address are not present in the marker feed; `phone` is omitted because it is a shared call-centre number, not location-specific.
- Standalone ATMs keep the source display label as `name`; branches move it to `branch` (brand name comes from NSI).
- `ref` is a coordinate + name composite (the feed has no stable branch id for branches).
- The source's location text is free-form (landmark/complex + district, e.g. "مجمع اللاجونا التجاري- الخليج الغربي" = Laguna Commercial Complex – West Bay), not a street + house number, so it's mapped to addr:full rather than addr:street_address per the playbook. It sometimes repeats the district that also appears in addr:city; it's kept verbatim (free-form isn't split).

Stats summary (local direct run; a proxied CI run will be steadier):
273 items — 37 banks, 236 ATMs. NSI: 273 match_perfect. Country from spider name: 273.

JSON stats :
```
{
  "atp/brand/QNB": 273,
  "atp/brand_wikidata/Q1136759": 273,
  "atp/category/amenity/atm": 236,
  "atp/category/amenity/bank": 37,
  "atp/country/QA": 273,
  "atp/field/country/from_spider_name": 273,
  "atp/nsi/match_perfect": 273,
  "downloader/request_count": 74,
  "item_scraped_count": 273,
  "finish_reason": "finished"
}
```
Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "25.324/51.52969444/فرع QNB سيتي سنتر",
      "amenity": "bank",
      "branch": "فرع QNB سيتي سنتر",
      "name": "QNB",
      "addr:full": "مجمع سيتي سنتر- الدفنة",
      "addr:city": "West Bay",
      "addr:country": "QA",
      "brand": "QNB",
      "brand:wikidata": "Q1136759",
      "nsi_id": "qnb-1ee5d6"
    },
    "geometry": { "type": "Point", "coordinates": [51.52969444, 25.324] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "25.37977778/51.53152778/فندق الرتز كارلتون - الدوحة",
      "amenity": "atm",
      "name": "فندق الرتز كارلتون - الدوحة",
      "addr:full": "فندق الريتز كارلتون- الدوحة, ردهة الفندق الخليج الغربي",
      "addr:city": "West Bay",
      "addr:country": "QA",
      "brand": "QNB",
      "brand:wikidata": "Q1136759",
      "operator": "QNB",
      "operator:wikidata": "Q1136759",
      "nsi_id": "qnb-8b9bb3"
    },
    "geometry": { "type": "Point", "coordinates": [51.53152778, 25.37977778] }
  }
]
```