### PR TITLE
[Delhaize] Drop duplicates and improve attributes

### DIFF
--- a/locations/spiders/delhaize.py
+++ b/locations/spiders/delhaize.py
@@ -18,9 +18,12 @@ class DelhaizeSpider(SitemapSpider, StructuredDataSpider):
         "https://magasins.delhaize.lu/robots.txt",
     ]
     sitemap_rules = [(r"/fr/([^/]+)$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    custom_settings = {"REDIRECT_ENABLED": False, "METAREFRESH_ENABLED": False}
+    search_for_facebook = False
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["website"] = item["website"].replace("http://", "https://")
+        item["website"] = item["website"].replace("http://", "https://").lower()
 
         if "/ad-delhaize-" in item["website"] or "/ad-" in item["website"]:
             item["branch"] = item.pop("name").removeprefix("AD ").removeprefix("Delhaize ")
@@ -48,10 +51,30 @@ class DelhaizeSpider(SitemapSpider, StructuredDataSpider):
         else:
             self.logger.error("Unexpected shop type: {}".format(item["website"]))
 
+        if item.get("image") in {
+            "http://magasins.delhaize.lu/image/mobilosoft-testing?apiPath=rehab/delhaize-lu/images/location/proxy&imageSize=h_500",
+            "http://magasins.delhaize.lu/image/mobilosoft-testing?apiPath=rehab/delhaize-lu/images/location/shop-n-go&imageSize=h_500",
+            "https://stores.delhaize.be/image/mobilosoft-testing?apiPath=rehab/delhaize-be/images/location/mobilosoft-testing%20%281%29&imageSize=h_500",
+            "http://magasins.delhaize.lu/image/mobilosoft-testing?apiPath=rehab/delhaize-lu/images/location/mobilosoft-testing%20%284%29&imageSize=h_500",
+            "https://stores.delhaize.be/image/mobilosoft-testing?apiPath=rehab/delhaize-be/images/location/Proxy%20photo%20ge%CC%81ne%CC%81rique%201674480128409&imageSize=h_500",
+            "https://stores.delhaize.be/image/mobilosoft-testing?apiPath=rehab/delhaize-be/images/location/ShopGo%201674480562182&imageSize=h_500",
+            "http://magasins.delhaize.lu/image/mobilosoft-testing?apiPath=rehab/delhaize-lu/images/location/index&imageSize=h_500",
+        }:
+            del item["image"]
+        if item.get("email") in {
+            "klantendienst@delhaize.be",
+            "serviceclients@delhaize.be",
+            "serviceclients@delhaize.lu",
+        }:
+            del item["email"]
+
         if "delhaize.be" in response.url:
+            item["website"] = item["extras"]["website:fr"] = response.url
+            item["extras"]["website:nl"] = response.xpath('//link[@rel="alternate"][@hreflang="nl"]/@href').get()
             if fb := response.xpath('//a[@class="fb-btn"][contains(@href, "facebook.com")]/@href').get():
                 set_social_media(item, SocialMedia.FACEBOOK, fb)
         else:
+            item["website"] = response.url
             if fb := response.xpath('//ul[@class="socials"]//a[contains(@href, "facebook.com")]/@href').get():
                 set_social_media(item, SocialMedia.FACEBOOK, fb)
 


### PR DESCRIPTION
```python
{'atp/brand/AD Delhaize': 6,
 'atp/brand/Delhaize': 798,
 'atp/brand_wikidata/Q1184173': 804,
 'atp/category/shop/convenience': 184,
 'atp/category/shop/supermarket': 620,
 'atp/clean_strings/branch': 2,
 'atp/country/BE': 737,
 'atp/country/LU': 67,
 'atp/field/email/missing': 723,
 'atp/field/geometry/missing': 4,
 'atp/field/housenumber/missing': 804,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 804,
 'atp/field/operator_wikidata/missing': 804,
 'atp/field/phone/missing': 23,
 'atp/field/state/missing': 804,
 'atp/field/street/missing': 804,
 'atp/field/twitter/missing': 804,
 'atp/field/unit/missing': 804,
 'atp/item_scraped_host_count/magasins.delhaize.lu': 67,
 'atp/item_scraped_host_count/stores.delhaize.be': 737,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_failed': 620,
 'atp/nsi/match_perfect': 184,
 'atp/nsi/multiple_matches': 620,
 'downloader/request_bytes': 372751,
 'downloader/request_count': 823,
 'downloader/request_method_count/GET': 823,
 'downloader/response_bytes': 15166128,
 'downloader/response_count': 823,
 'downloader/response_status_count/200': 810,
 'downloader/response_status_count/301': 11,
 'downloader/response_status_count/403': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 7.202427420997992,
 'feedexport/success_count/FileFeedStorage': 2,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 1, 11, 52, 13, 951264, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 823,
 'httpcompression/response_bytes': 99321326,
 'httpcompression/response_count': 809,
 'httperror/response_ignored_count': 13,
 'httperror/response_ignored_status_count/301': 11,
 'httperror/response_ignored_status_count/403': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 804,
 'items_per_minute': 6891.428571428572,
 'log_count/INFO': 16,
 'log_count/WARNING': 1,
 'memusage/max': 307941376,
 'memusage/startup': 307941376,
 'request_depth_max': 2,
 'response_received_count': 823,
 'responses_per_minute': 7054.285714285714,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 821,
 'scheduler/dequeued/memory': 821,
 'scheduler/enqueued': 821,
 'scheduler/enqueued/memory': 821,
 'start_time': datetime.datetime(2026, 7, 1, 11, 52, 6, 748838, tzinfo=datetime.timezone.utc)}
```