### PR TITLE
[Mcdonalds HK] Try proxy to fix spider

### DIFF
--- a/locations/spiders/mcdonalds_hk.py
+++ b/locations/spiders/mcdonalds_hk.py
@@ -11,6 +11,7 @@ class McdonaldsHKSpider(Spider):
     name = "mcdonalds_hk"
     item_attributes = McdonaldsSpider.item_attributes
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[FormRequest]:
         url = "https://www.mcdonalds.com.hk/wp-admin/admin-ajax.php?action=get_restaurants"


### PR DESCRIPTION
Try with proxy to bypass both the geo and datacenter-IP blocks. The spider is returning 403 Forbidden from awselb/2.0 (AWS WAF) on every request to admin-ajax.php.