### PR TITLE
[Exxon Mobil] Fix spider

### DIFF
--- a/locations/middlewares/playwright_middleware.py
+++ b/locations/middlewares/playwright_middleware.py
@@ -1,3 +1,4 @@
+from scrapy import Selector
 from scrapy.crawler import Crawler
 from scrapy.http import Request, Response, TextResponse
 from scrapy.spiders import SitemapSpider, XMLFeedSpider
@@ -86,15 +87,19 @@ class PlaywrightMiddleware:
             # middleware and do nothing to the response.
             return response
 
-        if isinstance(response, TextResponse):
-            # Response object is JSON format and therefore doesn't need to be
+        if not isinstance(response, TextResponse):
+            # Skip binary responses such as .gz sitemaps, ZIP archives etc.
+            return response
+
+        if Selector(response).type not in ("html", "xml"):
+            # Response object is JSON format in general, and therefore doesn't need to be
             # processed further.
             return response
 
         # If a Playwright or Camoufox request is for a plaintext-type file
         # (for ATP, this is mostly JSON files), the browser may internally
         # render this plaintext-type file using a lightweight HTML wrapper.
-        # Thus Scrapy's Response.body would contain HTML not plaintext/JSON
+        # Thus, Scrapy's Response.body would contain HTML not plaintext/JSON
         # data that was requested. We have to strip the HTML wrapping and
         # return the raw plaintext in Response.body.
         #
@@ -106,7 +111,7 @@ class PlaywrightMiddleware:
             plaintext = response.xpath("//body/pre/text()").get("")
             return response.replace(body=plaintext.encode("utf-8"))
 
-        # If a Playwright or Camoufox request is for a XML document (for ATP,
+        # If a Playwright or Camoufox request is for an XML document (for ATP,
         # this is mostly sitemap.xml for websites) and this XML document
         # contains a <?xml-stylesheet type="text/xsl" href="//style.xsl"?>
         # type of XML comment, the browser may attempt to transform the XML
@@ -129,8 +134,4 @@ class PlaywrightMiddleware:
                     setattr(self.crawler.spider, "_last_observed_xml_document", None)
                     return response.replace(body=xml_document.encode("utf-8"))
 
-        # At this point the response should be a HTML document or binary
-        # file which has been downloaded by the browser (for example, ZIP
-        # archive) and both HTML and binary files should be returned as-is
-        # without modification.
         return response

--- a/locations/middlewares/playwright_middleware.py
+++ b/locations/middlewares/playwright_middleware.py
@@ -106,9 +106,8 @@ class PlaywrightMiddleware:
         # Note this is probably browser specific for how a text document is
         # rendered by a browser as HTML. The list of cases below may need to
         # be expanded to accomodate different browsers.
-        if response.xpath('//link[@href="resource://content-accessible/plaintext.css"]').get():
-            # Rendering by Firefox-based web browsers
-            plaintext = response.xpath("//body/pre/text()").get("")
+        plaintext = response.xpath("//body/pre/text()").get()
+        if plaintext:
             return response.replace(body=plaintext.encode("utf-8"))
 
         # If a Playwright or Camoufox request is for an XML document (for ATP,

--- a/locations/spiders/albert_heijn_nl.py
+++ b/locations/spiders/albert_heijn_nl.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from urllib.parse import urljoin
 
@@ -63,7 +62,7 @@ class AlbertHeijnNLSpider(PlaywrightSpider):
         )
 
     def parse_api(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get())["data"]["storesSearch"]["result"]:
+        for location in response.json()["data"]["storesSearch"]["result"]:
             item = DictParser.parse(location)
             self.parse_hours(item, location)
             item.update(self.brand_map.get(location["storeType"]))

--- a/locations/spiders/banco_mercantil_br.py
+++ b/locations/spiders/banco_mercantil_br.py
@@ -1,20 +1,18 @@
-import json
 from typing import Any, AsyncIterator
 
-from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.geo import city_locations
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import FIREFOX_LATEST
 
 
-class BancoMercantilBRSpider(Spider):
+class BancoMercantilBRSpider(PlaywrightSpider):
     name = "banco_mercantil_br"
     item_attributes = {"brand": "Banco Mercantil do Brasil", "brand_wikidata": "Q9645252"}
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": FIREFOX_LATEST, "ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[Any]:
@@ -35,7 +33,7 @@ class BancoMercantilBRSpider(Spider):
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        locations = json.loads(response.xpath("//pre/text()").get()).get("d", {}).get("agencias") or []
+        locations = response.json().get("d", {}).get("agencias") or []
         for location in locations:
             item = Feature()
             item["branch"] = location["nomeAgencia"]

--- a/locations/spiders/barnardos_gb.py
+++ b/locations/spiders/barnardos_gb.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import AsyncIterator
 from urllib.parse import unquote
@@ -29,7 +28,7 @@ class BarnardosGBSpider(PlaywrightSpider):
         )
 
     def parse(self, response, **kwargs):
-        for poi in json.loads(response.xpath("//pre/text()").get()):
+        for poi in response.json():
             item = Feature()
             item["ref"] = poi.get("yourId")
             item["branch"] = poi.get("name").replace("+", " ")

--- a/locations/spiders/bottlemart_au.py
+++ b/locations/spiders/bottlemart_au.py
@@ -1,20 +1,17 @@
-import json
-
 import scrapy
-from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
-class BottlemartAUSpider(Spider):
+class BottlemartAUSpider(PlaywrightSpider):
     name = "bottlemart_au"
     item_attributes = {"brand": "Bottlemart", "brand_wikidata": "Q102863175"}
-    is_playwright_spider = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     async def start(self):
@@ -27,18 +24,17 @@ class BottlemartAUSpider(Spider):
             )
 
     def parse(self, response, **kwargs):
-        if response.xpath("//pre/text()").get():
-            for city in json.loads(response.xpath("//pre/text()").get()):
-                yield JsonRequest(
-                    url=f"https://bottlemart.com.au/api/members/search/{city['locality']}/{city['postal_code']}/{city['lat']}/{city['lon']}?maxDistance=200",
-                    headers={
-                        "tenant": "BM",
-                    },
-                    callback=self.parse_details,
-                )
+        for city in response.json():
+            yield JsonRequest(
+                url=f"https://bottlemart.com.au/api/members/search/{city['locality']}/{city['postal_code']}/{city['lat']}/{city['lon']}?maxDistance=200",
+                headers={
+                    "tenant": "BM",
+                },
+                callback=self.parse_details,
+            )
 
     def parse_details(self, response):
-        for location in json.loads(response.xpath("//pre/text()").get()):
+        for location in response.json():
             item = DictParser.parse(location)
             item["ref"] = location["store_number"]
             item["state"] = location["address"].get("administrative_area")

--- a/locations/spiders/dfs_gb.py
+++ b/locations/spiders/dfs_gb.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from scrapy.http import Response
@@ -18,7 +17,7 @@ class DfsGBSpider(PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = json.loads(response.xpath("//pre/text()").get())
+        data = response.json()
         for location in data["stores"]:
             item = DictParser.parse(location)
             item["phone"] = None

--- a/locations/spiders/dollar_curtains_and_blinds_au.py
+++ b/locations/spiders/dollar_curtains_and_blinds_au.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from scrapy.http import Response
@@ -19,7 +18,7 @@ class DollarCurtainsAndBlindsAUSpider(PlaywrightSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get("")):
+        for location in response.json():
             location.update(location.pop("map_location"))
             item = DictParser.parse(location)
             item["branch"] = item.pop("name").removeprefix("dollar curtains + blinds ")

--- a/locations/spiders/essex_us.py
+++ b/locations/spiders/essex_us.py
@@ -1,4 +1,3 @@
-import json
 from typing import Iterable
 
 from scrapy.http import TextResponse
@@ -21,7 +20,7 @@ class EssexUSSpider(JSONBlobSpider, PlaywrightSpider):
     requires_proxy = True
 
     def extract_json(self, response: TextResponse) -> dict | list[dict]:
-        return json.loads(response.xpath("//pre/text()").get())["communities"]
+        return response.json()["communities"]
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         item["image"] = feature["imagelist"].split("|")[0]

--- a/locations/spiders/exxon_mobil.py
+++ b/locations/spiders/exxon_mobil.py
@@ -5,19 +5,22 @@ from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMet
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
+
 
 # We can get the first 250 from the API, but can't find a way to get the next 250 :(
 # So instead get the ids from the sitemap and call the individual api endpoint
 # "https://www.exxon.com/en/api/locator/Locations?DataSource=RetailGasStations",
 
 
-# This data is also in Microsofts Virtual Earth, but we don't have a key with read access :(
+# This data is also in Microsoft's Virtual Earth, but we don't have a key with read access :(
 # dataset_id = "5857976ca2ae4a8c9a546777ed33c1cd"
 # dataset_name = "WEP2_Retail_PROD/RetailGasStations"
 
 
-class ExxonMobilSpider(SitemapSpider):
+class ExxonMobilSpider(SitemapSpider, PlaywrightSpider):
     name = "exxon_mobil"
     sitemap_urls = [
         "https://www.esso.co.uk/robots.txt",
@@ -45,7 +48,7 @@ class ExxonMobilSpider(SitemapSpider):
         "USER_AGENT": BROWSER_DEFAULT,
         "RETRY_HTTP_CODES": [403],  # Sometimes server blocks and sometimes allows
         "RETRY_TIMES": 5,
-    }
+    } | DEFAULT_PLAYWRIGHT_SETTINGS
 
     brands = {
         "Exxon": {"brand": "Exxon", "brand_wikidata": "Q109675651"},

--- a/locations/spiders/exxon_mobil.py
+++ b/locations/spiders/exxon_mobil.py
@@ -13,7 +13,6 @@ from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
-
 # We can get the first 250 from the API, but can't find a way to get the next 250 :(
 # So instead get the ids from the sitemap and call the individual api endpoint
 # "https://www.exxon.com/en/api/locator/Locations?DataSource=RetailGasStations",

--- a/locations/spiders/exxon_mobil.py
+++ b/locations/spiders/exxon_mobil.py
@@ -1,4 +1,8 @@
-from scrapy.http import JsonRequest
+from typing import Any, Iterable
+
+from chompjs import chompjs
+from scrapy import Request
+from scrapy.http import JsonRequest, Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no
@@ -74,7 +78,7 @@ class ExxonMobilSpider(SitemapSpider, PlaywrightSpider):
     }
 
     # Rewrite the request to the API
-    def _parse_sitemap(self, response):
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
         for request in super()._parse_sitemap(response):
             if request.callback == self.parse:
                 domain = request.url.split("/")[2]
@@ -88,8 +92,9 @@ class ExxonMobilSpider(SitemapSpider, PlaywrightSpider):
 
             yield request
 
-    def parse(self, response, **kwargs):
-        for location in response.json()["Locations"]:
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Extract JSON content wrapped in an HTML body
+        for location in chompjs.parse_js_object(response.text)["Locations"]:
             if location["Brand"] == "Mobilcard":
                 continue  # 170 NZ POIs that seem to third party ones that accept there loyalty cards
 

--- a/locations/spiders/ford_dealers_us.py
+++ b/locations/spiders/ford_dealers_us.py
@@ -1,4 +1,3 @@
-import json
 import re
 from copy import deepcopy
 
@@ -47,7 +46,7 @@ class FordDealersUSSpider(PlaywrightSpider):
                 )
 
     def parse_details(self, response: Response, **kwargs):
-        if data := json.loads(response.xpath("//pre/text()").get()).get("Response").get("Dealer"):
+        if data := response.json().get("Response").get("Dealer"):
             for dealer in data:
                 item = DictParser.parse(dealer)
                 item["ref"] = f"{dealer.get('PACode')}-{kwargs['brand']}"

--- a/locations/spiders/forever_new_au_nz.py
+++ b/locations/spiders/forever_new_au_nz.py
@@ -22,7 +22,7 @@ class ForeverNewAUNZSpider(JSONBlobSpider, PlaywrightSpider):
     requires_proxy = True
 
     def extract_json(self, response: TextResponse):
-        data = json.loads(response.xpath("//pre/text()").get())["results"]["results"]
+        data = response.json()["results"]["results"]
         return data
 
     def post_process_item(self, item, response, location):

--- a/locations/spiders/hornbach.py
+++ b/locations/spiders/hornbach.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import chompjs
@@ -44,7 +43,7 @@ class HornbachSpider(PlaywrightSpider):
             )
 
     def parse_locations(self, response: TextResponse) -> Any:
-        for store in json.loads(response.xpath("//pre/text()").get()):
+        for store in response.json():
             item = DictParser.parse(store)
             item["street_address"] = item.pop("street")
             item["branch"] = item.pop("name", "").removeprefix("BODENHAUS ").removeprefix("HORNBACH ").strip()

--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import Any, AsyncIterator
 
@@ -45,8 +44,7 @@ class HowardHannaSpider(PlaywrightSpider):
         yield scrapy.FormRequest(url=url, method="POST", formdata=formdata, callback=self.parse)
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        # This fixes the JSONDecodeError by stripping the <pre> tag
-        for office in json.loads(response.xpath("//pre/text()").get()).get("Properties", []):
+        for office in response.json().get("Properties", []):
             branch = office.get("OfficeName")
             mls_number = office.get("MlsNumber")
 

--- a/locations/spiders/inditex.py
+++ b/locations/spiders/inditex.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Iterable
 
 import scrapy
@@ -33,7 +32,7 @@ class InditexSpider(PlaywrightSpider):
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        config = json.loads(response.xpath("//pre/text()").get())["seoParamMap"]
+        config = response.json()["seoParamMap"]
         for store_id, country in config["storeId"].items():
             for brand in config["brandId"].values():
                 if brand == "dutti":
@@ -49,7 +48,7 @@ class InditexSpider(PlaywrightSpider):
                 yield scrapy.http.JsonRequest(url, callback=self.parse_stores, cb_kwargs=dict(brand=brand))
 
     def parse_stores(self, response: Response, brand: str) -> Iterable[Feature]:
-        for store in json.loads(response.xpath("//pre/text()").get())["stores"]:
+        for store in response.json()["stores"]:
             item = DictParser.parse(store)
             item["website"] = "https://www.{}.com/".format(brand) + item["country"].lower()
             item.update(self.my_brands.get(brand))

--- a/locations/spiders/lietuvos_pastas_lt.py
+++ b/locations/spiders/lietuvos_pastas_lt.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, AsyncIterator
 
 from scrapy import FormRequest
@@ -25,7 +24,7 @@ class LietuvosPastasLTSpider(PlaywrightSpider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get()):
+        for location in response.json():
             item = DictParser.parse(location)
             item["housenumber"] = location["addressDetails"]["houseNumber"]
             item["street"] = location["addressDetails"]["streetName"]

--- a/locations/spiders/louvre_hotels.py
+++ b/locations/spiders/louvre_hotels.py
@@ -1,4 +1,3 @@
-import json
 from json import dumps
 from typing import Any, AsyncIterator
 
@@ -57,7 +56,7 @@ class LouvreHotelsSpider(Spider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        resorts = json.loads(response.xpath("//pre/text()").get())["data"]["resortsSearchByBrandsV2"]
+        resorts = response.json()["data"]["resortsSearchByBrandsV2"]
 
         for resort in resorts:
             item = DictParser.parse(resort)

--- a/locations/spiders/mcdonalds_be.py
+++ b/locations/spiders/mcdonalds_be.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import Any
 
@@ -21,7 +20,7 @@ class McdonaldsBESpider(PlaywrightSpider):
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get()):
+        for location in response.json():
             item = DictParser.parse(location)
             item["branch"] = re.sub(r"\(\s*(Drive|Mall|In-Store)\s*\)", "", item.pop("name"), re.IGNORECASE).strip()
             item["housenumber"] = location.get("nr")

--- a/locations/spiders/mcdonalds_it.py
+++ b/locations/spiders/mcdonalds_it.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from urllib.parse import urljoin
 
@@ -19,7 +18,7 @@ class McdonaldsITSpider(PlaywrightSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in json.loads(response.xpath("//pre/text()").get())["sites"]:
+        for store in response.json()["sites"]:
             store["street_address"] = store.pop("address")
             item = DictParser.parse(store)
             item["branch"] = item.pop("name")

--- a/locations/spiders/motel6.py
+++ b/locations/spiders/motel6.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import scrapy
@@ -19,7 +18,7 @@ class Motel6Spider(scrapy.Spider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for hotel_id in json.loads(response.xpath("//pre/text()").get()).keys():  # JSON embedded within HTML
+        for hotel_id in response.json().keys():
             try:
                 url = "https://www.motel6.com/bin/g6/propertydata.{}.json".format(int(hotel_id))
                 yield scrapy.Request(url, callback=self.parse_hotel)
@@ -27,7 +26,7 @@ class Motel6Spider(scrapy.Spider):
                 continue
 
     def parse_hotel(self, response: Response, **kwargs: Any) -> Any:
-        data = json.loads(response.xpath("//pre/text()").get())
+        data = response.json()
         if not data:
             return
         data.update(data.pop("address", {}))

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, AsyncIterator
 
 from scrapy.http import JsonRequest, Response
@@ -39,7 +38,7 @@ class RadissonHotelsSpider(PlaywrightSpider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for hotel in json.loads(response.xpath("//pre/text()").get())["hotels"]:
+        for hotel in response.json()["hotels"]:
             hotel.update(hotel.pop("contactInfo"))
             item = DictParser.parse(hotel)
             item["ref"] = hotel.get("code")

--- a/locations/spiders/ron_jon_surf_shop_us.py
+++ b/locations/spiders/ron_jon_surf_shop_us.py
@@ -1,6 +1,4 @@
-import json
-
-from locations.categories import Categories, apply_category
+from locations.categories import apply_category
 from locations.dict_parser import DictParser
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
@@ -15,11 +13,11 @@ class RonJonSurfShopUSSpider(PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response):
-        for data in json.loads(response.xpath("//pre/text()").get())["results"]:
+        for data in response.json()["results"]:
             item = DictParser.parse(data)
             item["branch"] = item.pop("name")
             item["website"] = response.urljoin(data["url"])
 
-            apply_category(Categories.SHOP_SURF, item)
+            apply_category({"shop": "surf"}, item)
 
             yield item

--- a/locations/spiders/santander_br.py
+++ b/locations/spiders/santander_br.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import chompjs
@@ -30,7 +29,7 @@ class SantanderBRSpider(PlaywrightSpider):
             )
 
     def parse_locations(self, response: Response, **kwargs: Any) -> Any:
-        if locations := json.loads(response.xpath("//pre/text()").get()).get("agencias"):
+        if locations := response.json().get("agencias"):
             for location in locations:
                 item = Feature()
                 item["ref"] = location.get("codigo")

--- a/locations/spiders/superdrug.py
+++ b/locations/spiders/superdrug.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, AsyncIterator
 from urllib.parse import urljoin
 
@@ -32,7 +31,7 @@ class SuperdrugSpider(PlaywrightSpider):
         yield self.make_request(0)
 
     def parse_api(self, response: Response, **kwargs: Any) -> Any:
-        results = json.loads(response.xpath("//pre/text()").get())
+        results = response.json()
         for location in results["stores"]:
             if location["address"]["country"]["isocode"] == "AZ":
                 location["address"]["country"]["isocode"] = None  # Null island

--- a/locations/spiders/total_tools_au.py
+++ b/locations/spiders/total_tools_au.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Iterable
 
 import scrapy
@@ -20,7 +19,7 @@ class TotalToolsAUSpider(PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in json.loads(response.xpath("//pre/text()").get())["storesjson"]:
+        for store in response.json()["storesjson"]:
             item = DictParser.parse(store)
             item["branch"] = item.pop("name").removeprefix("Total Tools ")
             item["ref"] = store["storelocator_id"]

--- a/locations/spiders/toyota_au.py
+++ b/locations/spiders/toyota_au.py
@@ -1,4 +1,3 @@
-import json
 from typing import Iterable
 
 from scrapy.http import Response, TextResponse
@@ -30,7 +29,7 @@ class ToyotaAUSpider(JSONBlobSpider, PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS_WITH_EXT_JS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def extract_json(self, response: TextResponse) -> list[dict]:
-        return json.loads(response.xpath("//pre/text()").get())["results"]
+        return response.json()["results"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["lat"] = feature["refY"]

--- a/locations/spiders/woolworths_au.py
+++ b/locations/spiders/woolworths_au.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import scrapy
@@ -23,7 +22,7 @@ class WoolworthsAUSpider(scrapy.Spider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get())["Stores"]:
+        for location in response.json()["Stores"]:
             item = DictParser.parse(location)
             item["branch"] = item.pop("name")
             item["street_address"] = merge_address_lines([location["AddressLine1"], location["AddressLine2"]])


### PR DESCRIPTION
Updated `playwright_middleware` to fix the bug when handling binary responses like `.gz` sitemap urls. Also, now html embedded json when using `playwright`, will no longer needed to handle manually for most of the spiders.

```python
{'atp/brand/Esso': 6049,
 'atp/brand/Exxon': 6087,
 'atp/brand/Mobil': 5613,
 'atp/brand_wikidata/Q109675651': 6087,
 'atp/brand_wikidata/Q109676002': 5613,
 'atp/brand_wikidata/Q867662': 6049,
 'atp/category/amenity/fuel': 17757,
 'atp/clean_strings/name': 527,
 'atp/closed_check': 3,
 'atp/country/BE': 430,
 'atp/country/CA': 2477,
 'atp/country/DE': 1155,
 'atp/country/GB': 1453,
 'atp/country/GU': 20,
 'atp/country/HK': 39,
 'atp/country/LU': 35,
 'atp/country/MP': 11,
 'atp/country/NL': 481,
 'atp/country/NO': 236,
 'atp/country/NZ': 150,
 'atp/country/SG': 58,
 'atp/country/US': 11212,
 'atp/exxonmobil/unknown_brand/': 8,
 'atp/field/branch/missing': 17757,
 'atp/field/brand/missing': 8,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/city/missing': 4,
 'atp/field/country/from_website_url': 39,
 'atp/field/email/missing': 17757,
 'atp/field/housenumber/missing': 17757,
 'atp/field/opening_hours/missing': 94,
 'atp/field/operator/missing': 17757,
 'atp/field/operator_wikidata/missing': 17757,
 'atp/field/phone/invalid': 287,
 'atp/field/phone/missing': 1965,
 'atp/field/postcode/missing': 41,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/state/missing': 3918,
 'atp/field/street/missing': 17757,
 'atp/field/street_address/missing': 3,
 'atp/field/twitter/missing': 17757,
 'atp/field/unit/missing': 17757,
 'atp/item_scraped_host_count/guam.mobil.com': 20,
 'atp/item_scraped_host_count/www.esso.be': 430,
 'atp/item_scraped_host_count/www.esso.com.hk': 39,
 'atp/item_scraped_host_count/www.esso.com.sg': 58,
 'atp/item_scraped_host_count/www.esso.de': 1155,
 'atp/item_scraped_host_count/www.esso.lu': 35,
 'atp/item_scraped_host_count/www.esso.nl': 481,
 'atp/item_scraped_host_count/www.esso.no': 236,
 'atp/item_scraped_host_count/www.exxon.com': 15153,
 'atp/item_scraped_host_count/www.mobil.co.nz': 150,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 8,
 'atp/nsi/match_failed': 8,
 'atp/nsi/match_perfect': 17749,
 'downloader/request_bytes': 19777755,
 'downloader/request_count': 18044,
 'downloader/request_method_count/GET': 18044,
 'downloader/response_bytes': 134367846,
 'downloader/response_count': 18044,
 'downloader/response_status_count/200': 18043,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 3915,
 'elapsed_time_seconds': 166.0,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 6, 10, 27, 627862, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 9,
 'httpcache/hit': 18035,
 'httpcache/miss': 9,
 'httpcache/store': 9,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 17757,
 'items_per_minute': 6418.192771084337,
 'log_count/DEBUG': 35831,
 'log_count/INFO': 10,
 'log_count/WARNING': 8,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 9,
 'playwright/page_count/closed': 9,
 'playwright/page_count/max_concurrent': 5,
 'playwright/request_count': 9,
 'playwright/request_count/method/GET': 9,
 'playwright/request_count/navigation': 9,
 'playwright/request_count/resource_type/document': 9,
 'playwright/response_count': 9,
 'playwright/response_count/method/GET': 9,
 'playwright/response_count/resource_type/document': 9,
 'request_depth_max': 3,
 'response_received_count': 18044,
 'responses_per_minute': 6521.9277108433735,
 'scheduler/dequeued': 18044,
 'scheduler/dequeued/memory': 18044,
 'scheduler/enqueued': 18044,
 'scheduler/enqueued/memory': 18044,
 'start_time': datetime.datetime(2026, 7, 3, 6, 7, 41, 618568, tzinfo=datetime.timezone.utc)}
```