### PR TITLE
[Mitsubishi CH] Fix spider

### DIFF
--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -1,12 +1,10 @@
-import re
 from copy import deepcopy
 from typing import Any
 
-import chompjs
-from scrapy import Request
 from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -14,48 +12,36 @@ from locations.json_blob_spider import JSONBlobSpider
 class MitsubishiCHSpider(JSONBlobSpider):
     name = "mitsubishi_ch"
     item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
-    start_urls = ["https://www.mitsubishi-motors.ch/haendler/"]
-
-    def extract_json(self, response: Response) -> list[dict]:
-        return [
-            chompjs.parse_js_object(location)
-            for location in re.findall(
-                r"locations\[\d+\]\s*=\s*(.+?}\));",
-                response.xpath('//script[contains(text(), "locationData")]/text()').get(""),
-                re.DOTALL,
-            )
-        ]
-
-    def pre_process_data(self, feature: dict) -> None:
-        feature.update(feature.pop("marker", {}) | feature.pop("locationData", {}))
-        feature["id"] = feature.get("externalId")
+    start_urls = ["https://dealcore.slapwl.ch/de/mitsubishi/ch/corporate/dealer-list?filter=all"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Any:
-        item["street_address"] = item.pop("addr_full", None)
-        item["name"] = feature.get("organisation")
-        item["website"] = response.urljoin(feature.get("www"))
+        mitsubishi = next((brand for brand in feature.get("brands", []) if brand.get("code") == "MIT"), None)
+        if not mitsubishi:
+            return
 
-        # hasSales, hasService fields are always false. Hence, we need to determine category from the POI pages.
+        item["website"] = "https://www.mitsubishi-motors.ch/de/haendler/" + feature["slug"]
+        opening_hours = feature.get("dealerOpenings", {}).get("openingHours", {})
 
-        yield Request(url=item["website"], callback=self.parse_location, cb_kwargs=dict(item=item))
-
-    def parse_location(self, response: Response, item: Feature) -> Any:
-        location_type = (
-            response.xpath('//*[@class="haendler-heading-details"]//*[@class="haendler-icon-text"]').get("").lower()
-        )
-
-        has_sales = "verkauf" in location_type
-        has_service = "service" in location_type
-
-        if has_sales:
+        if mitsubishi.get("sell"):
             sales_item = deepcopy(item)
             sales_item["ref"] = f"{item['ref']}-sales"
             apply_category(Categories.SHOP_CAR, sales_item)
-            apply_yes_no(Extras.CAR_REPAIR, sales_item, has_service)
+            apply_yes_no(Extras.CAR_REPAIR, sales_item, mitsubishi.get("service", False))
+            sales_item["opening_hours"] = self.parse_hours(opening_hours.get("sales"))
             yield sales_item
 
-        if has_service:
+        if mitsubishi.get("service"):
             service_item = deepcopy(item)
             service_item["ref"] = f"{item['ref']}-service"
             apply_category(Categories.SHOP_CAR_REPAIR, service_item)
+            service_item["opening_hours"] = self.parse_hours(opening_hours.get("service"))
             yield service_item
+
+    @staticmethod
+    def parse_hours(rules: list[dict] | None) -> OpeningHours | None:
+        if not rules:
+            return None
+        oh = OpeningHours()
+        for rule in rules:
+            oh.add_range(rule["openDay"], rule["openTime"], rule["closeTime"])
+        return oh

--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -19,7 +19,7 @@ class MitsubishiCHSpider(JSONBlobSpider):
         if not mitsubishi:
             return
 
-        item["website"] = "https://www.mitsubishi-motors.ch/de/haendler/" + feature["slug"]
+        item["website"] = "https://www.mitsubishi-motors.ch/de/haendler/" + feature.get("slug", "")
         opening_hours = feature.get("dealerOpenings", {}).get("openingHours", {})
 
         if mitsubishi.get("sell"):


### PR DESCRIPTION
The spider fails when run locally. This fix ensures it will remain stable during the next weekly run.

```
{'atp/brand/Mitsubishi': 180,
 'atp/brand_wikidata/Q36033': 180,
 'atp/category/shop/car': 78,
 'atp/category/shop/car_repair': 102,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/street': 4,
 'atp/country/CH': 180,
 'atp/field/branch/missing': 180,
 'atp/field/housenumber/missing': 180,
 'atp/field/opening_hours/missing': 16,
 'atp/field/operator/missing': 180,
 'atp/field/operator_wikidata/missing': 180,
 'atp/field/phone/missing': 4,
 'atp/field/state/missing': 180,
 'atp/field/street_address/missing': 180,
 'atp/field/twitter/missing': 180,
 'atp/field/unit/missing': 180,
 'atp/item_scraped_host_count/dealcore.slapwl.ch': 180,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 180,
 'downloader/request_bytes': 711,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28134,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.530999999999949,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 7, 16, 3, 869920, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 453907,
 'httpcompression/response_count': 2,
 'item_scraped_count': 180,
 'items_per_minute': 5400.0,
 'log_count/DEBUG': 182,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 3, 7, 16, 1, 347953, tzinfo=datetime.timezone.utc)}
```