### PR TITLE
[365.bank SK] Add spider

### DIFF
--- a/locations/spiders/365_bank_sk.py
+++ b/locations/spiders/365_bank_sk.py
@@ -1,0 +1,73 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+# API weekday field prefixes (e.g. "pondelok_od"/"pondelok_do") mapped to OSM days.
+DAYS = {
+    "pondelok": "Mo",
+    "utorok": "Tu",
+    "streda": "We",
+    "stvrtok": "Th",
+    "piatok": "Fr",
+    "sobota": "Sa",
+    "nedela": "Su",
+}
+
+
+class ThreehundredsixtyfiveBankSKSpider(Spider):
+    name = "365_bank_sk"
+    item_attributes = {"brand": "365.bank", "brand_wikidata": "Q7237158"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url="https://365.bank/api/branch/", data={})
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            location_type = location["type"]
+            if location_type == "posta":
+                continue  # Slovak Post offices, not 365.bank locations
+
+            item = DictParser.parse(location)
+            # DictParser maps name/lat/lon; the remaining fields use Slovak keys and are set explicitly.
+            item["ref"] = location["ident"]
+            item["street_address"] = location.get("ulica")
+            item["city"] = location.get("mesto")
+            item["postcode"] = location.get("psc")
+            item["state"] = location.get("kraj")
+            item.pop("phone", None)  # a single generic call-centre number, not location-specific
+            apply_yes_no(Extras.WHEELCHAIR, item, location.get("bezbarierovy_pristup") == 1)
+
+            if location_type == "bankomat":
+                apply_category(Categories.ATM, item)
+            elif location_type in ("pobocka", "bankaNaPoste"):
+                item["branch"] = item.pop("name", None)
+                apply_yes_no(Extras.ATM, item, location.get("bankomat") == 1)
+                item["opening_hours"] = self.parse_hours(location)
+                apply_category(Categories.BANK, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item
+
+    def parse_hours(self, location: dict[str, Any]) -> OpeningHours | None:
+        hours = OpeningHours()
+        has_lunch_break = location.get("obedna_prestavka") == 1
+        try:
+            for day, osm_day in DAYS.items():
+                if not (open_time := location.get(f"{day}_od")) or not (close_time := location.get(f"{day}_do")):
+                    continue
+                if has_lunch_break and location.get("obedna_prestavka_od") and location.get("obedna_prestavka_do"):
+                    hours.add_range(osm_day, open_time, location["obedna_prestavka_od"])
+                    hours.add_range(osm_day, location["obedna_prestavka_do"], close_time)
+                else:
+                    hours.add_range(osm_day, open_time, close_time)
+        except (KeyError, ValueError) as error:
+            self.logger.warning("Could not parse hours for {}: {}".format(location.get("ident"), error))
+            return None
+        return hours or None


### PR DESCRIPTION
Data source: https://365.bank/mapa/

The spider uses the branch/ATM JSON API: `POST https://365.bank/api/branch/` (empty JSON body returns all locations).

### Scope: 365.bank locations only
The endpoint returns 1661 records across 4 `type`s. The **1347 `posta` records are Slovak Post offices** (a different operator) and are **filtered out**. The spider keeps only the 365.bank types:

| `type` | Label | Count | Mapping |
|---|---|---|---|
| `pobocka` | 365.bank branch | 53 | `Categories.BANK` |
| `bankaNaPoste` | Bank counter at post office | 87 | `Categories.BANK` |
| `bankomat` | ATM | 174 | `Categories.ATM` |
| `posta` | Post office | 1347 | skipped (not 365.bank) |

- Branches with an on-site ATM (`bankomat == 1`) get `atm=yes` on the single bank item (no duplicate ATM POI).
- `bezbarierovy_pristup == 1` → `wheelchair=yes`.
- Opening hours are parsed from the per-day fields, including the shared lunch break (`obedna_prestavka`), e.g. `Mo-Fr 09:00-12:00,12:30-17:00`.

Notes:
- `robots.txt` allows `/api/`; no proxy, custom headers, or robots override.
- `phone` is omitted: the feed exposes only two call-centre numbers (one for branches, one for bank-at-post), not location-specific.
- Standalone ATMs keep their source label as `name`; branches use `branch` (brand name comes from NSI).
- `country=SK` is derived from the spider name.

NSI: `Q7237158` (365.bank) has both `amenity=bank` and `amenity=atm` entries in `sk`.

Stats summary:
314 items — 140 banks, 174 ATMs (138 with opening_hours, 49 `atm=yes`, 109 `wheelchair=yes`). NSI: 314 match_perfect. Country from spider name: 314. No errors.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "pobocka-365bank-Banovce-nad-bebravou",
      "amenity": "bank",
      "branch": "Bánovce nad Bebravou",
      "name": "365.bank",
      "atm": "yes",
      "wheelchair": "yes",
      "opening_hours": "Mo-We 09:00-12:00,13:00-17:00; Fr 09:00-12:00,13:00-17:00",
      "addr:street_address": "Námestie Ľudovíta Štúra 8/8B",
      "addr:city": "Bánovce nad Bebravou",
      "addr:postcode": "957 01",
      "addr:state": "Trenčiansky kraj",
      "addr:country": "SK",
      "brand": "365.bank",
      "brand:wikidata": "Q7237158",
      "nsi_id": "365bank-6a1dfb"
    },
    "geometry": { "type": "Point", "coordinates": [18.256819, 48.719089] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "Bankomat-365-bank-1maja4-Zilina",
      "amenity": "atm",
      "name": "1.mája 4, Žilina",
      "addr:street_address": "1.mája 4",
      "addr:city": "Žilina",
      "addr:postcode": "010 01",
      "addr:state": "Žilinský kraj",
      "addr:country": "SK",
      "brand": "365.bank",
      "brand:wikidata": "Q7237158",
      "operator": "365.bank",
      "operator:wikidata": "Q7237158",
      "nsi_id": "365bank-6843ee"
    },
    "geometry": { "type": "Point", "coordinates": [18.74695, 49.221337] }
  }
]
```

```json
{
  "atp/brand/365.bank": 314,
  "atp/brand_wikidata/Q7237158": 314,
  "atp/category/amenity/atm": 174,
  "atp/category/amenity/bank": 140,
  "atp/country/SK": 314,
  "atp/field/country/from_spider_name": 314,
  "atp/nsi/match_perfect": 314,
  "item_scraped_count": 314,
  "finish_reason": "finished"
}
```