### PR TITLE
[Prima banka SK] Add spider

### DIFF
--- a/locations/spiders/prima_banka_sk.py
+++ b/locations/spiders/prima_banka_sk.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+from chompjs import parse_js_object
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+REGIONS = [
+    "banskobystricky-kraj",
+    "bratislavsky-kraj",
+    "kosicky-kraj",
+    "nitriansky-kraj",
+    "presovsky-kraj",
+    "trenciansky-kraj",
+    "trnavsky-kraj",
+    "zilinsky-kraj",
+]
+
+
+class PrimaBankaSKSpider(Spider):
+    name = "prima_banka_sk"
+    item_attributes = {"brand": "Prima banka", "brand_wikidata": "Q13538661"}
+    start_urls = [f"https://www.primabanka.sk/pobocky-a-bankomaty/{region}" for region in REGIONS]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Each region page embeds its locations as a `var markers = [...]` JS array.
+        raw = response.text.split("var markers =", 1)[1]
+        for location in parse_js_object(raw[raw.index("[") :]):
+            location_type = location["type"]
+
+            item = DictParser.parse(location)
+            item.pop("state", None)  # source "state" is a status flag, not a region
+            item.pop("email", None)  # a single generic address, not location-specific
+            item["lat"] = location["gps_lat"]
+            item["lon"] = location["gps_lon"]
+            item["addr_full"] = location.get("adresa")  # free-form (landmarks/districts), so not street_address
+            item["city"] = location.get("mesto")
+            item["postcode"] = location.get("psc")
+
+            if location_type == "bankomat":
+                apply_category(Categories.ATM, item)
+            elif location_type in ("pobocka", "firemne_centrum"):
+                item["branch"] = item.pop("name", None)
+                apply_yes_no(Extras.ATM, item, location.get("ma_bankomat") == "1")
+                apply_category(Categories.BANK, item)
+            else:
+                self.logger.error("Unexpected location type: {}".format(location_type))
+                continue
+
+            yield item


### PR DESCRIPTION
Data source: https://www.primabanka.sk/pobocky-a-bankomaty

The public `filter.php` POST endpoint is WAF-gated and session-stateful (returns empty/blocked to non-browser clients), so the spider instead reads the **8 regional pages**, each of which embeds all of its locations server-side as a `var markers = [...]` JSON array (parsed with `chompjs`).

Category mapping (`type` field):
- `pobocka` / `firemne_centrum` -> `Categories.BANK`
- `bankomat` -> `Categories.ATM`
- branches with `ma_bankomat == "1"` -> `atm=yes` (single item; no duplicate ATM POI)

Notes:
- `robots.txt` allows the location pages; no proxy, custom headers, or robots override.
- `addr:full` is used because `adresa` is free-form (landmarks/districts, e.g. "OC Campo di Martin", "COOP Jednota"), not a clean street+number; `city`/`postcode` are separate structured fields.
- `phone` omitted: the feed exposes a single call-centre number, not location-specific.
- Standalone ATMs keep their source label as `name`; branches use `branch` (brand name comes from NSI).
- Opening hours (`otvaracie_hodiny`) are free-text Slovak and are not parsed in v1.
- `country=SK` derived from the spider name.

NSI: `Q13538661` (Prima banka) has both `amenity=bank` and `amenity=atm` in `sk`.

Stats summary: 341 items — 118 banks, 223 ATMs (114 `atm=yes`). NSI: 341 match_perfect. Country from spider name: 341. No errors.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "253",
      "amenity": "bank",
      "name": "Prima banka",
      "atm": "yes",
      "addr:full": "Svätotrojičné námestie 9",
      "addr:city": "Krupina",
      "addr:postcode": "963 01",
      "addr:country": "SK",
      "brand": "Prima banka",
      "brand:wikidata": "Q13538661",
      "nsi_id": "primabanka-6a1dfb"
    },
    "geometry": { "type": "Point", "coordinates": [19.067051, 48.355094] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "769",
      "amenity": "atm",
      "addr:full": "T.G. Masaryka 17",
      "addr:city": "Lučenec",
      "addr:postcode": "984 01",
      "addr:country": "SK",
      "brand": "Prima banka",
      "brand:wikidata": "Q13538661",
      "operator": "Prima banka",
      "operator:wikidata": "Q13538661",
      "nsi_id": "primabanka-6843ee"
    },
    "geometry": { "type": "Point", "coordinates": [19.66668, 48.32941] }
  }
]
```

```json
{
  "atp/brand/Prima banka": 341,
  "atp/brand_wikidata/Q13538661": 341,
  "atp/category/amenity/atm": 223,
  "atp/category/amenity/bank": 118,
  "atp/country/SK": 341,
  "atp/field/country/from_spider_name": 341,
  "atp/nsi/match_perfect": 341,
  "item_scraped_count": 341,
  "finish_reason": "finished"
}
```