### PR TITLE
[Hrvatska poštanska banka HR] Add spider

### DIFF
--- a/locations/spiders/hpb_hr.py
+++ b/locations/spiders/hpb_hr.py
@@ -1,0 +1,39 @@
+import re
+from typing import Any
+
+from chompjs import parse_js_object
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class HpbHRSpider(Spider):
+    name = "hpb_hr"
+    item_attributes = {"brand": "Hrvatska poštanska banka", "brand_wikidata": "Q5923981"}
+    start_urls = ["https://www.hpb.hr/en/map/2752"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # The map page embeds all locations as a `var markers = [...]` JS array.
+        raw = response.text.split("var markers =", 1)[1]
+        for location in parse_js_object(raw[raw.index("[") :]):
+            if location.get("type") == "POSTA":
+                continue  # Croatian Post offices, not HPB locations
+            if not (location.get("latitude") and location.get("longitude")):
+                continue
+
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full", None)
+            # The city field embeds the postcode, e.g. "10 000 Zagreb".
+            if postcode_city := re.match(r"\s*(\d[\d ]*\d)\s+(.+)", item.get("city") or ""):
+                item["postcode"] = postcode_city.group(1).replace(" ", "")  # "10 000" -> "10000"
+                item["city"] = postcode_city.group(2)
+
+            if location["type"] == "BANKOMAT":
+                apply_category(Categories.ATM, item)
+            else:  # POSLOVNICA, PODRUŽNICA, ISPOSTAVA
+                item["branch"] = item.pop("name", None)
+                apply_category(Categories.BANK, item)
+
+            yield item


### PR DESCRIPTION
Data source: https://www.hpb.hr/en/map/2752

The map page embeds all locations as a `var markers = [...]` JS array (parsed with `chompjs`).

Category mapping (`type` field):
- `POSLOVNICA` / `PODRUŽNICA` / `ISPOSTAVA` -> `Categories.BANK`
- `BANKOMAT` -> `Categories.ATM`
- `POSTA` -> skipped (Croatian Post offices — a different operator, not HPB locations)

Notes:
- No WAF; `robots.txt` allows the page; no proxy/headers/robots override.
- The source `city` field embeds the postcode (e.g. "10 000 Zagreb"); it is split into `addr:postcode` (normalized to "10000") and `addr:city` ("Zagreb"). The separate `zipcode` field is always empty.
- `phone` is kept where present (per-branch, location-specific); ATMs generally have none.
- Standalone ATMs keep their source label as `name`; branches use `branch` (brand name from NSI).
- Opening hours (`working_hours.nonstructured_time`) are free-text Croatian (`structured:false`) and are not parsed in v1.
- 39 branch records have no coordinates in the source and are skipped.
- `country=HR` derived from the spider name.

NSI: `Q5923981` (Hrvatska poštanska banka) has both `amenity=bank` and `amenity=atm` in `hr`.

Stats summary: 506 items — 82 banks, 424 ATMs. NSI: 506 match_perfect. Country from spider name: 506. No errors.

Sample POIs:

```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "264",
      "amenity": "bank",
      "branch": "Centar Gajnice",
      "name": "Hrvatska poštanska banka",
      "phone": "+385 1 3466 930",
      "addr:street_address": "Argentinska 4",
      "addr:city": "Zagreb",
      "addr:postcode": "10000",
      "addr:country": "HR",
      "brand": "Hrvatska poštanska banka",
      "brand:wikidata": "Q5923981",
      "nsi_id": "hrvatskapostanskabanka-6f3d3b"
    },
    "geometry": { "type": "Point", "coordinates": [15.8760978, 45.8149158] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "91",
      "amenity": "atm",
      "name": "Poštanski ured (eGotovina)",
      "addr:street_address": "Artura Turkulina 48",
      "addr:city": "Petrinja",
      "addr:country": "HR",
      "brand": "Hrvatska poštanska banka",
      "brand:wikidata": "Q5923981",
      "operator": "Hrvatska poštanska banka",
      "operator:wikidata": "Q5923981",
      "nsi_id": "hrvatskapostanskabanka-4d8c03"
    },
    "geometry": { "type": "Point", "coordinates": [16.283665, 45.44183] }
  }
]
```

```json
{
  "atp/brand_wikidata/Q5923981": 506,
  "atp/category/amenity/atm": 424,
  "atp/category/amenity/bank": 82,
  "atp/country/HR": 506,
  "atp/field/country/from_spider_name": 506,
  "atp/nsi/match_perfect": 506,
  "item_scraped_count": 506,
  "finish_reason": "finished"
}
```