### PR TITLE
[Edible Arrangements] Fix Spider

### DIFF
--- a/locations/spiders/edible_arrangements.py
+++ b/locations/spiders/edible_arrangements.py
@@ -1,52 +1,25 @@
-import json
-from typing import AsyncIterator
+from typing import Iterable
+from urllib.parse import urljoin
 
-from scrapy import Spider
-from scrapy.http import FormRequest
+from scrapy.http import TextResponse
 
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours, day_range
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class EdibleArrangementsSpider(Spider):
+class EdibleArrangementsSpider(JSONBlobSpider):
     name = "edible_arrangements"
     item_attributes = {"brand": "Edible Arrangements", "brand_wikidata": "Q5337996"}
     allowed_domains = ["www.ediblearrangements.com"]
+    start_urls = ["https://www.ediblearrangements.com/api/stores/store-finder/get-stores?latitude=0&longitude=0"]
+    locations_key = "storeData"
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        yield FormRequest(
-            "https://www.ediblearrangements.com/stores/store-locator.aspx/GetStoresByCurrentLocation",
-            method="POST",
-            headers={
-                "accept": "application/json, text/javascript, */*; q=0.01",
-                "accept-language": "en-US,en;q=0.9",
-                "content-type": "application/json; charset=UTF-8",
-                "origin": "https://www.ediblearrangements.com",
-                "referer": "https://www.ediblearrangements.com/stores/store-locator.aspx",
-                "x-requested-with": "XMLHttpRequest",
-            },
-            body="{'Latitude' : '37.09024' , 'Longitude': '-95.712891','Distance':'5000'}",
-            callback=self.parse,
-        )
-
-    def parse(self, response):
-        d = json.loads(response.json()["d"])
-        for shop in d["_Data"]:
-            item = DictParser.parse(shop)
-            oh = OpeningHours()
-            for day_time in shop["TimingsShort"]:
-                day = day_time["Days"]
-                time = day_time["Timing"]
-                if time == "Closed":
-                    oh.set_closed(day)
-                else:
-                    start_day, end_day = day.split("-") if "-" in day else (day, day)
-                    open_time, close_time = time.split("-")
-                    oh.add_days_range(
-                        day_range(start_day, end_day),
-                        open_time=open_time.strip(),
-                        close_time=close_time.strip(),
-                        time_format="%I:%M %p",
-                    )
-                item["opening_hours"] = oh
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["website"] = urljoin("https://www.ediblearrangements.com/stores/", feature.get("pageFriendlyUrl"))
+        oh = OpeningHours()
+        for day_time in feature["timingsShort"]:
+            day_time_text = " ".join(list(day_time.values()))
+            oh.add_ranges_from_string(day_time_text)
+        item["opening_hours"] = oh
+        yield item

--- a/locations/spiders/edible_arrangements_us.py
+++ b/locations/spiders/edible_arrangements_us.py
@@ -9,7 +9,7 @@ from locations.json_blob_spider import JSONBlobSpider
 
 
 class EdibleArrangementsUSSpider(JSONBlobSpider):
-    name = "edible_arrangements"
+    name = "edible_arrangements_us"
     item_attributes = {"brand": "Edible Arrangements", "brand_wikidata": "Q5337996"}
     allowed_domains = ["www.ediblearrangements.com"]
     start_urls = ["https://www.ediblearrangements.com/api/stores/store-finder/get-stores?latitude=0&longitude=0"]

--- a/locations/spiders/edible_arrangements_us.py
+++ b/locations/spiders/edible_arrangements_us.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class EdibleArrangementsSpider(JSONBlobSpider):
+class EdibleArrangementsUSSpider(JSONBlobSpider):
     name = "edible_arrangements"
     item_attributes = {"brand": "Edible Arrangements", "brand_wikidata": "Q5337996"}
     allowed_domains = ["www.ediblearrangements.com"]


### PR DESCRIPTION
```python
{'atp/brand/Edible Arrangements': 571,
 'atp/brand_wikidata/Q5337996': 571,
 'atp/category/shop/gift': 571,
 'atp/country/US': 571,
 'atp/field/branch/missing': 571,
 'atp/field/housenumber/missing': 571,
 'atp/field/operator/missing': 571,
 'atp/field/operator_wikidata/missing': 571,
 'atp/field/postcode/missing': 571,
 'atp/field/street/missing': 571,
 'atp/field/twitter/missing': 571,
 'atp/field/unit/missing': 571,
 'atp/item_scraped_host_count/www.ediblearrangements.com': 571,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 571,
 'atp/nsi/match_imperfect': 571,
 'downloader/request_bytes': 929,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 154281,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.515999999999622,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 11, 19, 40, 737545, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 715640,
 'httpcompression/response_count': 2,
 'item_scraped_count': 571,
 'items_per_minute': 5710.0,
 'log_count/DEBUG': 573,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 3, 11, 19, 34, 222623, tzinfo=datetime.timezone.utc)}
```