### PR TITLE
[Monteroza JP] create spider

### DIFF
--- a/locations/spiders/monteroza_jp.py
+++ b/locations/spiders/monteroza_jp.py
@@ -15,7 +15,14 @@ class MonterozaJPSpider(CanlySpider):
         if feature.get("businessStatus") != "OPEN":
             return
 
-        brand = feature.get("selectBrand", {}).get("selectBrand", {}).get("selected", {}).get("item", {}).get("brand", {}).get("label")
+        brand = (
+            feature.get("selectBrand", {})
+            .get("selectBrand", {})
+            .get("selected", {})
+            .get("item", {})
+            .get("brand", {})
+            .get("label")
+        )
         if not brand:
             return
         match brand:

--- a/locations/spiders/monteroza_jp.py
+++ b/locations/spiders/monteroza_jp.py
@@ -1,0 +1,38 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class MonterozaJPSpider(CanlySpider):
+    name = "monteroza_jp"
+    brand_key = "478"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature.get("businessStatus") != "OPEN":
+            return
+
+        brand = feature.get("selectBrand").get("selectBrand").get("selected").get("item").get("brand").get("label")
+        match brand:
+            case "白木屋":
+                item["brand_wikidata"] = "Q489746"
+            case "目利きの銀次":
+                item["brand_wikidata"] = "Q109653557"
+            case "笑笑":
+                item["brand_wikidata"] = "Q87214327"
+            case "魚民":
+                item["brand_wikidata"] = "Q11673981"
+            case _:
+                pass
+
+        item["branch"] = feature.get("nameKanji")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
+        item["brand"] = brand
+        item["website"] = f"https://shop.monteroza.co.jp/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.PUB, item)
+
+        yield item

--- a/locations/spiders/monteroza_jp.py
+++ b/locations/spiders/monteroza_jp.py
@@ -15,7 +15,9 @@ class MonterozaJPSpider(CanlySpider):
         if feature.get("businessStatus") != "OPEN":
             return
 
-        brand = feature.get("selectBrand").get("selectBrand").get("selected").get("item").get("brand").get("label")
+        brand = feature.get("selectBrand", {}).get("selectBrand", {}).get("selected", {}).get("item", {}).get("brand", {}).get("label")
+        if not brand:
+            return
         match brand:
             case "白木屋":
                 item["brand_wikidata"] = "Q489746"


### PR DESCRIPTION
closes #17181 

{'atp/brand/かば屋': 7,
 'atp/brand/かみふうせん': 4,
 'atp/brand/からあげの鉄人': 1,
 'atp/brand/くろ○': 2,
 'atp/brand/しゃぶ食べ': 3,
 'atp/brand/すしざむらい': 1,
 'atp/brand/すし魚銀': 1,
 'atp/brand/みつえちゃん': 4,
 'atp/brand/カミナリステーキ': 1,
 'atp/brand/キタノイチバ': 5,
 'atp/brand/バリヤスサカバ': 2,
 'atp/brand/ホルモンおいで屋': 8,
 'atp/brand/俺の串かつ黒田': 1,
 'atp/brand/俺の店': 4,
 'atp/brand/千年の宴': 46,
 'atp/brand/四十五縁家': 1,
 'atp/brand/大衆酒場 銀次': 3,
 'atp/brand/寿司と居酒屋魚民': 14,
 'atp/brand/山内農場': 78,
 'atp/brand/月の宴': 5,
 'atp/brand/横濱魚萬': 9,
 'atp/brand/濱焼北海道魚萬': 7,
 'atp/brand/濱焼魚萬': 4,
 'atp/brand/炭火焼鳥めでた家': 1,
 'atp/brand/焼肉ホルモン おいで屋': 1,
 'atp/brand/白木屋': 58,
 'atp/brand/白木屋×バリヤス酒場': 17,
 'atp/brand/目利きの銀次': 155,
 'atp/brand/福福屋': 11,
 'atp/brand/竹取酒物語': 1,
 'atp/brand/笑笑': 21,
 'atp/brand/豊後高田どり酒場': 1,
 'atp/brand/魚民': 322,
 'atp/brand/魚民のすし': 8,
 'atp/brand_wikidata/Q109653557': 155,
 'atp/brand_wikidata/Q11673981': 322,
 'atp/brand_wikidata/Q489746': 58,
 'atp/brand_wikidata/Q87214327': 21,
 'atp/category/amenity/pub': 807,
 'atp/country/JP': 807,
 'atp/field/brand_wikidata/missing': 251,
 'atp/field/city/missing': 807,
 'atp/field/country/from_spider_name': 807,
 'atp/field/email/missing': 807,
 'atp/field/housenumber/missing': 807,
 'atp/field/name/missing': 251,
 'atp/field/operator/missing': 807,
 'atp/field/operator_wikidata/missing': 807,
 'atp/field/state/missing': 807,
 'atp/field/street/missing': 807,
 'atp/field/street_address/missing': 807,
 'atp/field/twitter/missing': 807,
 'atp/field/unit/missing': 807,
 'atp/item_scraped_host_count/g9ey9rioe.api.hp.can-ly.com': 807,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 251,
 'atp/nsi/match_failed': 251,
 'atp/nsi/match_perfect': 556,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 446480,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.688000000000102,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 12, 20, 55, 983842, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 13337478,
 'httpcompression/response_count': 1,
 'item_scraped_count': 807,
 'items_per_minute': 9684.0,
 'log_count/DEBUG': 810,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 3, 12, 20, 50, 294098, tzinfo=datetime.timezone.utc)}