### PR TITLE
[Wsp] Fix spider

### DIFF
--- a/locations/spiders/wsp.py
+++ b/locations/spiders/wsp.py
@@ -1,4 +1,7 @@
+from typing import AsyncIterator, Iterable
+
 import scrapy
+from scrapy.http import Request, Response
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
@@ -6,8 +9,9 @@ from locations.items import Feature
 from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 COUNTRY_MAP = {
-    "Greater China": "CN",
-    "Viet Nam": "VN",
+    "greater-china": "CN",
+    "korea": "KR",
+    "viet-nam": "VN",
 }
 
 
@@ -19,33 +23,30 @@ class WspSpider(CamoufoxSpider):
     captcha_type = "cloudflare_turnstile"
     captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
 
-    async def start(self):
+    async def start(self) -> AsyncIterator[Request]:
         yield scrapy.Request("https://www.wsp.com/en-gl/contact-us/offices")
 
-    def parse(self, response):
-        current_country = ""
+    def parse(self, response: Response) -> Iterable[Feature]:
         for office in response.css("div.offices-address"):
-            country_heading = office.css("h2.title-h2::text").get("").strip()
-            if country_heading:
-                current_country = country_heading
-
-            name = office.css("h4.title-h4 a.news-title::attr(title)").get("").strip()
             href = office.css("h4.title-h4 a.news-title::attr(href)").get("")
             ref = href.rstrip("/").split("/")[-1]
-            website = response.urljoin(href)
 
             if not ref:
                 continue
 
+            country = ""
+            if "/offices/" in href:
+                slug = href.split("/offices/")[1].split("/")[0]
+                country = COUNTRY_MAP.get(slug) or slug.replace("-", " ").title()
+
             texts = [t.strip() for t in office.css("div.office-address div.text::text").getall() if t.strip()]
-            addr_full = ", ".join(texts) if texts else None
 
             properties = {
                 "ref": ref,
-                "name": name,
-                "addr_full": addr_full,
-                "country": COUNTRY_MAP.get(current_country, current_country),
-                "website": website,
+                "branch": office.css("h4.title-h4 a.news-title::attr(title)").get("").strip(),
+                "addr_full": ", ".join(texts) if texts else None,
+                "country": country or None,
+                "website": response.urljoin(href),
             }
 
             apply_category(Categories.OFFICE_ENGINEER, properties)


### PR DESCRIPTION
The previous code of the spider derived each office's country from h2 section headings on the page. These headings are not present for several regions, so when run locally the crawl completed but produced 254 Invalid value for attribute "country" errors. Offices in the US, Sweden, Switzerland, China, and Korea received invalid country values such as "Our Offices" and were rejected by the country pipeline.

Resolved by deriving the country from the country slug in each office's detail URL which is present and consistent across all 562 offices. This reduces the error count from 254 to 0.

Stats produced by the spider when run on the US network:

```
{'atp/brand/WSP': 562,
 'atp/brand_wikidata/Q1333162': 562,
 'atp/category/office/engineer': 562,
 'atp/country/AE': 3,
 'atp/country/AR': 1,
 'atp/country/AU': 16,
 'atp/country/BD': 1,
 'atp/country/BE': 1,
 'atp/country/BR': 3,
 'atp/country/CA': 110,
 'atp/country/CH': 14,
 'atp/country/CL': 3,
 'atp/country/CM': 1,
 'atp/country/CN': 7,
 'atp/country/CO': 2,
 'atp/country/DE': 10,
 'atp/country/DK': 6,
 'atp/country/ES': 4,
 'atp/country/FI': 13,
 'atp/country/FR': 11,
 'atp/country/GB': 31,
 'atp/country/GN': 1,
 'atp/country/HU': 2,
 'atp/country/ID': 1,
 'atp/country/IE': 2,
 'atp/country/IN': 5,
 'atp/country/IT': 8,
 'atp/country/KR': 1,
 'atp/country/MX': 5,
 'atp/country/MZ': 1,
 'atp/country/NL': 9,
 'atp/country/NO': 12,
 'atp/country/NZ': 25,
 'atp/country/OM': 1,
 'atp/country/PA': 1,
 'atp/country/PE': 1,
 'atp/country/PH': 2,
 'atp/country/PL': 1,
 'atp/country/PT': 1,
 'atp/country/QA': 1,
 'atp/country/RO': 1,
 'atp/country/SA': 2,
 'atp/country/SE': 29,
 'atp/country/SG': 1,
 'atp/country/TH': 1,
 'atp/country/TR': 1,
 'atp/country/TT': 1,
 'atp/country/US': 203,
 'atp/country/VN': 1,
 'atp/country/ZA': 5,
 'atp/field/city/missing': 562,
 'atp/field/email/missing': 562,
 'atp/field/geometry/missing': 562,
 'atp/field/housenumber/missing': 562,
 'atp/field/opening_hours/missing': 562,
 'atp/field/operator/missing': 562,
 'atp/field/operator_wikidata/missing': 562,
 'atp/field/phone/missing': 562,
 'atp/field/postcode/missing': 562,
 'atp/field/state/missing': 562,
 'atp/field/street/missing': 562,
 'atp/field/street_address/missing': 562,
 'atp/field/twitter/missing': 562,
 'atp/field/unit/missing': 562,
 'atp/item_scraped_host_count/www.wsp.com': 562,
 'atp/lineage': 'S_?',
 'atp/nsi/perfect_match': 562,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 30,
 'camoufox/request_count/aborted': 27,
 'camoufox/request_count/method/GET': 30,
 'camoufox/request_count/navigation': 1,
 'camoufox/request_count/resource_type/document': 1,
 'camoufox/request_count/resource_type/image': 17,
 'camoufox/request_count/resource_type/script': 8,
 'camoufox/request_count/resource_type/stylesheet': 4,
 'camoufox/response_count': 3,
 'camoufox/response_count/method/GET': 3,
 'camoufox/response_count/resource_type/document': 1,
 'camoufox/response_count/resource_type/script': 2,
 'downloader/request_bytes': 343,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1354063,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 72.15599999999995,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 12, 34, 43, 343411, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 562,
 'items_per_minute': 468.33333333333337,
 'log_count/DEBUG': 625,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.8333333333333334,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 3, 12, 33, 31, 184182, tzinfo=datetime.timezone.utc)}
```