### PR TITLE
[Carrefour PL] Fix spider

### DIFF
--- a/locations/spiders/carrefour_pl.py
+++ b/locations/spiders/carrefour_pl.py
@@ -1,95 +1,48 @@
-import binascii
-import os
-from typing import AsyncIterator
+import json
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import TextResponse
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_EN, OpeningHours
-from locations.spiders.carrefour_fr import (
-    CARREFOUR_EXPRESS,
-    CARREFOUR_MARKET,
-    CARREFOUR_SUPERMARKET,
-    parse_brand_and_category_from_mapping,
-)
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.spiders.carrefour_fr import CARREFOUR_EXPRESS, CARREFOUR_MARKET, CARREFOUR_SUPERMARKET
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class CarrefourPLSpider(Spider):
+class CarrefourPLSpider(JSONBlobSpider, PlaywrightSpider):
     name = "carrefour_pl"
-    # Taken from mobile app
-    start_urls = ["https://c4webservice.carrefour.pl:8080/MobileWebService/v3/Bootstrap.svc/App/Bootstrap"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    start_urls = ["https://www.carrefour.pl/sklepy"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False} | DEFAULT_PLAYWRIGHT_SETTINGS
+    requires_proxy = True
 
     brands = {
-        "Express (Zielony)": CARREFOUR_EXPRESS,
-        "Express (Pomarańczowy)": CARREFOUR_EXPRESS,
+        "Carrefour Express Zielony ": CARREFOUR_EXPRESS,
+        "Carrefour Express": CARREFOUR_EXPRESS,
         "Hipermarket": CARREFOUR_SUPERMARKET,
-        "Market": CARREFOUR_MARKET,
-        "Globi": {"brand": "Globi", "category": Categories.SHOP_CONVENIENCE},
+        "Carrefour Market": CARREFOUR_MARKET,
+        "Supermarket Franczyzowy": CARREFOUR_MARKET,
+        "Globi": {"brand": "Globi", "brand_wikidata": "Q11751761", "category": Categories.SHOP_CONVENIENCE},
+        "Carrefour": CARREFOUR_SUPERMARKET,
     }
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield Request(
-            self.start_urls[0],
-            headers={
-                # random 16 hex
-                "device-key": binascii.b2a_hex(os.urandom(8)).decode("utf-8"),
-                "customerid": "-1",
-                "os-type-id": "1",
-                "version-name": "3.7.2616",
-                "version-number": "309616001",
-            },
-            method="POST",
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        return DictParser.get_nested_key(
+            json.loads(response.xpath('//script[@id="__NEXT_DATA__"]//text()').get()), "shops"
         )
 
-    def parse(self, response):
-        brand_ids_to_brands = {}
-        for brand in response.json()["shopTypes"]:
-            brand_ids_to_brands[str(brand["shopTypeForMobile"])] = brand["displayName"]
-
-        for location in response.json()["shops"]:
-            item = DictParser.parse(location)
-
-            brand_key = brand_ids_to_brands.get(str(location["shopTypeForMobile"]))
-            if not parse_brand_and_category_from_mapping(item, brand_key, self.brands):
-                continue  # bad brand
-
-            item.pop("street")
-            item["ref"] = location["shopId"]
-            item["street_address"] = location["street"]
-            opening_hours = OpeningHours()
-            for day in DAYS_EN:
-                if ("shop" + day) not in location:
-                    continue
-                opening_str = location["shop" + day]
-
-                opening_str = (
-                    opening_str.strip()
-                    .replace(",", "")
-                    .replace(".", ":")
-                    .replace("-:", "-")
-                    .replace(":-", "-")
-                    .replace("- ", "-")
-                    .replace(" -", "-")
-                    .split(" ")[0]
-                )
-                if opening_str.lower() in ["nieczynny", "nieczynne", "zamkniete", "nd"]:
-                    continue
-                elif opening_str.lower() in ["24h", "całodobowy"]:
-                    opening_hours.add_range(day=day, open_time="00:00", close_time="23:59")
-                else:
-                    segments = opening_str.split("-")
-                    # add :00 if missing
-                    segments = [segment + ":00" if ":" not in segment else segment for segment in segments]
-                    # cap at 5 characters
-                    segments = [segment[:5] for segment in segments]
-                    try:
-                        opening_hours.add_range(day=day, open_time=segments[0], close_time=segments[1])
-                    except ValueError:
-                        # The opening hours are hot garbage, so we'll just skip the most problematic ones
-                        pass
-            item["opening_hours"] = opening_hours
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["uuid"]
+        item.pop("name", None)
+        for brand_key in self.brands:
+            if feature["displayName"].startswith(brand_key):
+                brand_info = self.brands[brand_key]
+                item["brand"] = brand_info["brand"]
+                item["brand_wikidata"] = brand_info["brand_wikidata"]
+                apply_category(brand_info["category"], item)
+                break
+        item["website"] = f'https://www.carrefour.pl/sklep/{feature["slug"].strip("/")}'
+        yield item

--- a/locations/spiders/carrefour_pl.py
+++ b/locations/spiders/carrefour_pl.py
@@ -5,6 +5,7 @@ from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.playwright_spider import PlaywrightSpider
@@ -44,5 +45,21 @@ class CarrefourPLSpider(JSONBlobSpider, PlaywrightSpider):
                 item["brand_wikidata"] = brand_info["brand_wikidata"]
                 apply_category(brand_info["category"], item)
                 break
+
         item["website"] = f'https://www.carrefour.pl/sklep/{feature["slug"].strip("/")}'
+
+        if opening_times := feature.get("openTimes", {}):
+            try:
+                item["opening_hours"] = self.parse_opening_hours(opening_times)
+            except Exception as e:
+                self.logger.error(f"Error parsing opening hours: {opening_times} {e}")
+
         yield item
+
+    def parse_opening_hours(self, opening_times: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day, hours in opening_times.items():
+            start_time = f'{hours["startHour"]:02d}:{hours["startMinute"]:02d}'
+            end_time = f'{hours["endHour"]:02d}:{hours["endMinute"]:02d}'.replace("00:00", "23:59")
+            opening_hours.add_range(day, start_time, end_time)
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/Carrefour': 95,
 'atp/brand/Carrefour Express': 341,
 'atp/brand/Carrefour Market': 137,
 'atp/brand/Globi': 117,
 'atp/brand_wikidata/Q11751761': 117,
 'atp/brand_wikidata/Q217599': 95,
 'atp/brand_wikidata/Q2689639': 137,
 'atp/brand_wikidata/Q2940190': 341,
 'atp/category/shop/convenience': 458,
 'atp/category/shop/supermarket': 232,
 'atp/clean_strings/housenumber': 10,
 'atp/clean_strings/street': 2,
 'atp/country/PL': 690,
 'atp/field/branch/missing': 690,
 'atp/field/country/from_spider_name': 690,
 'atp/field/email/missing': 690,
 'atp/field/housenumber/missing': 10,
 'atp/field/opening_hours/missing': 18,
 'atp/field/operator/missing': 690,
 'atp/field/operator_wikidata/missing': 690,
 'atp/field/phone/missing': 10,
 'atp/field/state/missing': 690,
 'atp/field/street_address/missing': 690,
 'atp/field/twitter/missing': 690,
 'atp/field/unit/missing': 690,
 'atp/item_scraped_host_count/www.carrefour.pl': 690,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 690,
 'downloader/request_bytes': 262,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1158918,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 7.766000000001441,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 3, 15, 25, 41, 623892, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 690,
 'items_per_minute': 5914.285714285714,
 'log_count/DEBUG': 775,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 41,
 'playwright/request_count/aborted': 40,
 'playwright/request_count/method/GET': 41,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/request_count/resource_type/font': 4,
 'playwright/request_count/resource_type/image': 9,
 'playwright/request_count/resource_type/script': 27,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 8.571428571428571,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 3, 15, 25, 33, 861981, tzinfo=datetime.timezone.utc)}
```