### PR TITLE
[Ito-Yokado and Heiwado JP] add 2 spiders

### DIFF
--- a/locations/spiders/heiwado_jp.py
+++ b/locations/spiders/heiwado_jp.py
@@ -1,0 +1,30 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class HeiwadoJPSpider(CanlySpider):
+    name = "heiwado_jp"
+    item_attributes = {
+        "brand": "平和堂",
+        "brand_wikidata": "Q11060757",
+    }
+    api_endpoint = "https://api.site.can-ly.com/v2/directories/6/shops/search"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # Skip any non-open locations
+        if feature.get("openStatus") != "IS_ALREADY_OPEN":
+            return
+
+        item["name"] = feature.get("brand").get("name")
+        item["branch"] = feature.get("nameKanji")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
+        item["website"] = f"https://shoplist.heiwado.jp/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/spiders/itoyokado_jp.py
+++ b/locations/spiders/itoyokado_jp.py
@@ -1,0 +1,29 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class ItoyokadoJPSpider(CanlySpider):
+    name = "itoyokado_jp"
+    item_attributes = {
+        "brand": "イトーヨーカドー",
+        "brand_wikidata": "Q3088746",
+    }
+    api_endpoint = "https://api.site.can-ly.com/v2/directories/55/shops/search"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # Skip any non-open locations
+        if feature.get("openStatus") != "IS_ALREADY_OPEN":
+            return
+
+        item["branch"] = feature.get("nameKanji").removeprefix("イトーヨーカドー ")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana").removeprefix("イトーヨーカドー ")
+        item["website"] = f"https://stores.itoyokado.co.jp/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/storefinders/canly.py
+++ b/locations/storefinders/canly.py
@@ -23,7 +23,7 @@ class CanlySpider(Spider):
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         if self.api_endpoint == "" and self.brand_key != "":
-           yield JsonRequest(url=f"https://g9ey9rioe.api.hp.can-ly.com/v2/companies/{self.brand_key}/shops/search") 
+            yield JsonRequest(url=f"https://g9ey9rioe.api.hp.can-ly.com/v2/companies/{self.brand_key}/shops/search")
         else:
             yield JsonRequest(url=self.api_endpoint)
 

--- a/locations/storefinders/canly.py
+++ b/locations/storefinders/canly.py
@@ -36,8 +36,9 @@ class CanlySpider(Spider):
             item["ref"] = feature.get("storeCode")
 
             oh = OpeningHours()
-            for day_hours in feature.get("businessHours", []):
-                oh.add_range(day_hours["name"], day_hours["openTime"], day_hours["closeTime"], "%H:%M:%S")
+            if item_hours := feature.get("businessHours"):
+                for day_hours in item_hours:
+                    oh.add_range(day_hours["name"], day_hours["openTime"], day_hours["closeTime"], "%H:%M:%S")
             item["opening_hours"] = oh
 
             yield from self.post_process_item(item, response, feature) or []

--- a/locations/storefinders/canly.py
+++ b/locations/storefinders/canly.py
@@ -17,11 +17,15 @@ class CanlySpider(Spider):
     locator which is hosted by Can-ly. Brand keys are numerical.
     """
 
+    api_endpoint: str = ""
     dataset_attributes: dict = {"source": "api", "api": "can-ly.com"}
-    brand_key: str
+    brand_key: str = ""
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        yield JsonRequest(url=f"https://g9ey9rioe.api.hp.can-ly.com/v2/companies/{self.brand_key}/shops/search")
+        if self.api_endpoint == "" and self.brand_key != "":
+           yield JsonRequest(url=f"https://g9ey9rioe.api.hp.can-ly.com/v2/companies/{self.brand_key}/shops/search") 
+        else:
+            yield JsonRequest(url=self.api_endpoint)
 
     def parse(self, response: TextResponse, **kwargs: Any) -> Iterable[Feature]:
         for feature in response.json()["shops"]:


### PR DESCRIPTION
edit: found another supermarket that also needs the updated canly storefinder so I decided to add it to this PR.

{'atp/brand/イトーヨーカドー': 91,
 'atp/brand_wikidata/Q3088746': 91,
 'atp/category/shop/supermarket': 91,
 'atp/country/JP': 91,
 'atp/field/city/missing': 91,
 'atp/field/country/from_spider_name': 91,
 'atp/field/email/missing': 91,
 'atp/field/housenumber/missing': 91,
 'atp/field/operator/missing': 91,
 'atp/field/operator_wikidata/missing': 91,
 'atp/field/state/missing': 91,
 'atp/field/street/missing': 91,
 'atp/field/street_address/missing': 91,
 'atp/field/twitter/missing': 91,
 'atp/field/unit/missing': 91,
 'atp/item_scraped_host_count/api.site.can-ly.com': 91,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 91,
 'downloader/request_bytes': 709,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 28583,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 2.2339999999999236,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 4, 23, 50, 10, 137939, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 428049,
 'httpcompression/response_count': 1,
 'item_scraped_count': 91,
 'items_per_minute': 2730.0,
 'log_count/DEBUG': 94,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 4, 23, 50, 7, 916254, tzinfo=datetime.timezone.utc)}