### PR TITLE
[Beisia JP] add spider, goga storefinder, update dict_parser dictionary

### DIFF
--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -42,6 +42,7 @@ class DictParser:
         "BranchID",
         "branchID",
         "branch-code",
+        "key",
         # ES
         "id-tienda",
         "ID-tienda",
@@ -233,6 +234,8 @@ class DictParser:
         "branch-telephone",
         # ES
         "telefono",  # "phone"
+        # JP
+        "電話番号",
     ]
 
     lat_keys = [
@@ -302,6 +305,8 @@ class DictParser:
         # IT
         "orario",
         "orari",
+        # JP
+        "営業時間",
     ]
 
     twitter_keys = [

--- a/locations/dict_parser.py
+++ b/locations/dict_parser.py
@@ -42,7 +42,6 @@ class DictParser:
         "BranchID",
         "branchID",
         "branch-code",
-        "key",
         # ES
         "id-tienda",
         "ID-tienda",
@@ -234,8 +233,6 @@ class DictParser:
         "branch-telephone",
         # ES
         "telefono",  # "phone"
-        # JP
-        "電話番号",
     ]
 
     lat_keys = [
@@ -305,8 +302,6 @@ class DictParser:
         # IT
         "orario",
         "orari",
-        # JP
-        "営業時間",
     ]
 
     twitter_keys = [

--- a/locations/spiders/beisia_jp.py
+++ b/locations/spiders/beisia_jp.py
@@ -1,0 +1,24 @@
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.goga_store_locator import GogaStoreLocatorSpider
+
+
+class BeisiaJPSpider(GogaStoreLocatorSpider):
+    name = "beisia_jp"
+
+    start_urls = ["https://map.beisia.co.jp/api/points"]
+    item_attributes = {
+        "brand": "ベイシア",
+        "brand_wikidata": "Q11336776",
+    }
+    website_formatter = "https://map.beisia.co.jp/map/{}"
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = "ベイシア"
+        item["branch"] = source_feature.get("name")
+        item["extras"]["branch:ja-Hira"] = source_feature.get("ふりがな")
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/storefinders/goga_store_locator.py
+++ b/locations/storefinders/goga_store_locator.py
@@ -1,0 +1,51 @@
+from typing import Any, AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.dict_parser import DictParser
+from locations.items import Feature
+
+
+class GogaStoreLocatorSpider(Spider):
+    """
+    Goga Store Locator is a software-as-a-service store locator API with an official homepage of https://www.goga.co.jp/products/storelocator/.
+
+    To use this spider, specify a URL in the 'start_urls' list attribute.
+    Usually the expected URL is similar to
+    "https://map.beisia.co.jp/api/points".
+
+    Optionally, provide a list of geohashes if the base URL does not return all locations.
+    
+    Also, you can provide a website formatter, which should be needed for most chains.
+    Some of them will provide their own URLs in the JSON response.
+    """   
+    
+    dataset_attributes: dict = {"source": "api"}
+
+    start_urls: list[str] = []
+    geohashes: list[str] = []
+    website_formatter: str = ""
+
+    async def start(self) -> AsyncIterator[Request]:
+        if len(self.start_urls) == 1 and len(self.geohashes) == 0:
+            yield Request(url=self.start_urls[0])
+        elif len(self.start_urls) == 1 and len(self.geohashes) != 0:
+            for geohash in self.geohashes:
+                yield Request(url=f"{self.start_urls[0]}/{geohash}") # make sure to leave out trailing slash on start_urls
+        else:
+            raise ValueError("Specify one URL in the start_urls list attribute.")
+            return
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for location in response.json()["items"]:
+            location.update(location.pop("extra_fields"))
+            item = DictParser.parse(location)
+            if self.website_formatter:
+                item["website"] = self.website_formatter.format(location.get("key"))
+            item["ref"] = location.get("key")
+
+            yield from self.post_process_feature(item, location)
+
+    def post_process_feature(self, item: Feature, source_feature: dict, **kwargs) -> Iterable[Feature]:
+        yield item

--- a/locations/storefinders/goga_store_locator.py
+++ b/locations/storefinders/goga_store_locator.py
@@ -46,6 +46,7 @@ class GogaStoreLocatorSpider(Spider):
             if self.website_formatter:
                 item["website"] = self.website_formatter.format(location.get("key"))
             item["ref"] = location.get("key")
+            item["phone"] = location.get("電話番号")
 
             yield from self.post_process_feature(item, location)
 

--- a/locations/storefinders/goga_store_locator.py
+++ b/locations/storefinders/goga_store_locator.py
@@ -16,11 +16,11 @@ class GogaStoreLocatorSpider(Spider):
     "https://map.beisia.co.jp/api/points".
 
     Optionally, provide a list of geohashes if the base URL does not return all locations.
-    
+
     Also, you can provide a website formatter, which should be needed for most chains.
     Some of them will provide their own URLs in the JSON response.
-    """   
-    
+    """
+
     dataset_attributes: dict = {"source": "api"}
 
     start_urls: list[str] = []
@@ -32,7 +32,9 @@ class GogaStoreLocatorSpider(Spider):
             yield Request(url=self.start_urls[0])
         elif len(self.start_urls) == 1 and len(self.geohashes) != 0:
             for geohash in self.geohashes:
-                yield Request(url=f"{self.start_urls[0]}/{geohash}") # make sure to leave out trailing slash on start_urls
+                yield Request(
+                    url=f"{self.start_urls[0]}/{geohash}"
+                )  # make sure to leave out trailing slash on start_urls
         else:
             raise ValueError("Specify one URL in the start_urls list attribute.")
             return

--- a/locations/storefinders/goga_store_locator.py
+++ b/locations/storefinders/goga_store_locator.py
@@ -40,7 +40,7 @@ class GogaStoreLocatorSpider(Spider):
             return
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        for location in response.json()["items"]: # ty: ignore[unresolved-attribute]
+        for location in response.json()["items"]:  # ty: ignore[unresolved-attribute]
             location.update(location.pop("extra_fields"))
             item = DictParser.parse(location)
             if self.website_formatter:

--- a/locations/storefinders/goga_store_locator.py
+++ b/locations/storefinders/goga_store_locator.py
@@ -40,7 +40,7 @@ class GogaStoreLocatorSpider(Spider):
             return
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        for location in response.json()["items"]:
+        for location in response.json()["items"]: # ty: ignore[unresolved-attribute]
             location.update(location.pop("extra_fields"))
             item = DictParser.parse(location)
             if self.website_formatter:


### PR DESCRIPTION
{'atp/brand/ベイシア': 140,
 'atp/brand_wikidata/Q11336776': 140,
 'atp/category/shop/supermarket': 140,
 'atp/clean_strings/phone': 1,
 'atp/country/JP': 140,
 'atp/field/city/missing': 140,
 'atp/field/country/from_spider_name': 140,
 'atp/field/email/missing': 140,
 'atp/field/housenumber/missing': 140,
 'atp/field/opening_hours/missing': 140,
 'atp/field/operator/missing': 140,
 'atp/field/operator_wikidata/missing': 140,
 'atp/field/phone/invalid': 1,
 'atp/field/state/missing': 140,
 'atp/field/street/missing': 140,
 'atp/field/street_address/missing': 140,
 'atp/field/twitter/missing': 140,
 'atp/field/unit/missing': 140,
 'atp/item_scraped_host_count/map.beisia.co.jp': 140,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 140,
 'atp/nsi/match_failed': 140,
 'downloader/request_bytes': 668,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 31249,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.5780000000013388,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 5, 10, 43, 58, 360558, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 282550,
 'httpcompression/response_count': 1,
 'item_scraped_count': 140,
 'items_per_minute': 4200.0,
 'log_count/DEBUG': 142,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 5, 10, 43, 55, 778718, tzinfo=datetime.timezone.utc)}