### PR TITLE
[Southern Railway GB] Fix spider

### DIFF
--- a/locations/spiders/southern_railway_gb.py
+++ b/locations/spiders/southern_railway_gb.py
@@ -1,6 +1,8 @@
+import json
 from typing import Any, AsyncIterator
+from urllib.parse import urlencode
 
-from scrapy import FormRequest, Request, Spider
+from scrapy import Request, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
@@ -12,25 +14,30 @@ from locations.user_agents import BROWSER_DEFAULT
 class SouthernRailwayGBSpider(Spider):
     name = "southern_railway_gb"
     item_attributes = {"operator": "Southern Railway", "operator_wikidata": "Q1258373"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     async def start(self) -> AsyncIterator[Any]:
-        yield Request(
-            "https://www.southernrailway.com/travel-information/station-information",
-            headers={"User-Agent": BROWSER_DEFAULT},
-        )
+        yield Request("https://www.southernrailway.com/travel-information/station-information")
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for link in response.xpath('//a[contains(@href, "/travel-information/station-information/")]/@href').getall():
             website = response.urljoin(link)
-            yield FormRequest(
-                "https://stationpages.fabdigital.uk/api/index.php?api_public/get_station_data",
-                formdata={"page": "api_public", "action": "get_station_data", "crs": website.split("/")[5]},
+            # URL is .../station-information/<CRS>/<Station-Name>, so the CRS
+            # code is the second-to-last path segment.
+            params = urlencode({"page": "api_public", "action": "get_station_data", "crs": website.split("/")[-2]})
+            yield Request(
+                f"https://stationpages.fabdigital.uk/api/index.php?api_public/get_station_data&{params}",
                 callback=self.parse_station,
                 cb_kwargs={"website": website},
             )
 
     def parse_station(self, response: Response, **kwargs: Any) -> Any:
-        station = response.json()["response"]["stationData"]
+        # The upstream API is unreliable and occasionally returns a malformed/empty
+        # body. Skip those so a single bad response can't abort the whole crawl.
+        try:
+            station = response.json()["response"]["stationData"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return
 
         if station["stationInfo"]["stationOperatorCode"] != "SN":
             return


### PR DESCRIPTION
The spider was intermittently returning 0 items with JSONDecodeError.

Stats produced on US network:

```
{'atp/category/railway/station': 154,
 'atp/country/GB': 154,
 'atp/field/branch/missing': 154,
 'atp/field/brand/missing': 154,
 'atp/field/brand_wikidata/missing': 154,
 'atp/field/city/missing': 154,
 'atp/field/country/from_spider_name': 154,
 'atp/field/email/missing': 154,
 'atp/field/housenumber/missing': 154,
 'atp/field/opening_hours/missing': 154,
 'atp/field/phone/missing': 154,
 'atp/field/state/missing': 154,
 'atp/field/street/missing': 154,
 'atp/field/street_address/missing': 154,
 'atp/field/twitter/missing': 154,
 'atp/field/unit/missing': 154,
 'atp/item_scraped_host_count/stationpages.fabdigital.uk': 154,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 154,
 'atp/nsi/operator_unknown': 154,
 'atp/operator/Southern Railway': 154,
 'atp/operator_wikidata/Q1258373': 154,
 'downloader/request_bytes': 142756,
 'downloader/request_count': 324,
 'downloader/request_method_count/GET': 324,
 'downloader/response_bytes': 1040711,
 'downloader/response_count': 324,
 'downloader/response_status_count/200': 323,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 395.1869999999999,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 6, 6, 1, 1, 509958, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3676887,
 'httpcompression/response_count': 323,
 'item_scraped_count': 154,
 'items_per_minute': 23.39240506329114,
 'log_count/DEBUG': 479,
 'log_count/INFO': 9,
 'request_depth_max': 1,
 'response_received_count': 324,
 'responses_per_minute': 49.21518987341772,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 322,
 'scheduler/dequeued/memory': 322,
 'scheduler/enqueued': 322,
 'scheduler/enqueued/memory': 322,
 'start_time': datetime.datetime(2026, 7, 6, 5, 54, 26, 318665, tzinfo=datetime.timezone.utc)}
```