### PR TITLE
[Redtag Fashion AE SA] Fix spider

### DIFF
--- a/locations/spiders/redtag_fashion_ae_sa.py
+++ b/locations/spiders/redtag_fashion_ae_sa.py
@@ -10,16 +10,13 @@ from locations.hours import OpeningHours
 
 class RedtagFashionAESASpider(Spider):
     name = "redtag_fashion_ae_sa"
-    item_attributes = {
-        "brand": "Red Tag",
-        "brand_wikidata": "Q132891092",
-    }
+    item_attributes = {"brand": "Red Tag", "brand_wikidata": "Q132891092"}
 
     async def start(self) -> AsyncIterator[Request]:
         countries = ["Saudi Arabia", "UAE"]
         for country in countries:
             yield Request(
-                url=f"https://redtagfashion.com/locations/locations.php?country={country}",
+                url=f"https://www.redtagfashion.com/locations/locations.php?country={country}",
                 meta={"country": country},
             )
 

--- a/locations/spiders/redtag_fashion_ae_sa.py
+++ b/locations/spiders/redtag_fashion_ae_sa.py
@@ -11,6 +11,7 @@ from locations.hours import OpeningHours
 class RedtagFashionAESASpider(Spider):
     name = "redtag_fashion_ae_sa"
     item_attributes = {"brand": "Red Tag", "brand_wikidata": "Q132891092"}
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[Request]:
         countries = ["Saudi Arabia", "UAE"]

--- a/locations/spiders/redtag_fashion_ae_sa.py
+++ b/locations/spiders/redtag_fashion_ae_sa.py
@@ -24,6 +24,7 @@ class RedtagFashionAESASpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
             item = DictParser.parse(store)
+            item["email"] = None
             item["ref"] = f"{response.meta['country']}_{store['storecode']}"
             item["street_address"] = item.pop("addr_full")
 

--- a/locations/spiders/redtag_fashion_ae_sa.py
+++ b/locations/spiders/redtag_fashion_ae_sa.py
@@ -25,6 +25,7 @@ class RedtagFashionAESASpider(Spider):
         for store in response.json():
             item = DictParser.parse(store)
             item["email"] = None
+            item["branch"] = item.pop("name").removeprefix("REDTAG ").removeprefix("RT").strip(" -")
             item["ref"] = f"{response.meta['country']}_{store['storecode']}"
             item["street_address"] = item.pop("addr_full")
 


### PR DESCRIPTION
Fix:

- Point requests at `https://www.redtagfashion.com/locations/locations.php?country=...`.
- Add `requires_proxy = True` so requests route through the Zyte proxy and clear the WAF challenge.

Spider produces below stats:

```
{'atp/brand/Red Tag': 140,
 'atp/brand_wikidata/Q132891092': 140,
 'atp/category/shop/clothes': 140,
 'atp/clean_strings/street_address': 1,
 'atp/country/AE': 14,
 'atp/country/SA': 126,
 'atp/field/branch/missing': 140,
 'atp/field/country/from_reverse_geocoding': 14,
 'atp/field/housenumber/missing': 140,
 'atp/field/opening_hours/missing': 20,
 'atp/field/operator/missing': 140,
 'atp/field/operator_wikidata/missing': 140,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 56,
 'atp/field/postcode/missing': 140,
 'atp/field/state/missing': 126,
 'atp/field/street/missing': 140,
 'atp/field/twitter/missing': 140,
 'atp/field/unit/missing': 140,
 'atp/item_scraped_host_count/www.redtagfashion.com': 140,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 140,
 'atp/nsi/match_failed': 140,
 'downloader/request_bytes': 1078,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 14955,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 3,
 'elapsed_time_seconds': 3.688000000000102,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 6, 6, 20, 49, 860512, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 120596,
 'httpcompression/response_count': 3,
 'item_scraped_count': 140,
 'items_per_minute': 2800.0,
 'log_count/DEBUG': 143,
 'log_count/INFO': 3,
 'response_received_count': 3,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 7, 6, 6, 20, 46, 172959, tzinfo=datetime.timezone.utc)}
```