### PR TITLE
[Aldi Sud HU] Fix Spider

### DIFF
--- a/locations/spiders/aldi_sud_hu.py
+++ b/locations/spiders/aldi_sud_hu.py
@@ -13,5 +13,6 @@ class AldiSudHUSpider(UberallSpider):
     key = "rDCKKjdtbi2w0Qx3Cq1axERNtccFqZ"
 
     def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
+        item["name"] = None
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item

--- a/locations/spiders/aldi_sud_hu.py
+++ b/locations/spiders/aldi_sud_hu.py
@@ -13,6 +13,6 @@ class AldiSudHUSpider(UberallSpider):
     key = "rDCKKjdtbi2w0Qx3Cq1axERNtccFqZ"
 
     def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
-        item["name"] = None
+        item["name"] = item["phone"] = None
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item

--- a/locations/spiders/aldi_sud_hu.py
+++ b/locations/spiders/aldi_sud_hu.py
@@ -1,35 +1,17 @@
-from scrapy import Spider
+from typing import Iterable
+
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_HU, OpeningHours, sanitise_day
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
 
 
-class AldiSudHUSpider(Spider):
+class AldiSudHUSpider(UberallSpider):
     name = "aldi_sud_hu"
     item_attributes = {"brand_wikidata": "Q41171672"}
-    start_urls = [
-        "https://www.aldi.hu/hu/hu/.get-stores-in-radius.json?latitude=47.162494&longitude=19.503304&radius=2500000"
-    ]
+    key = "rDCKKjdtbi2w0Qx3Cq1axERNtccFqZ"
 
-    def parse(self, response):
-        for store in response.json()["stores"]:
-            item = DictParser.parse(store)
-            if store["storeType"] == "N":
-                continue
-            if item["country"] != "HU":
-                continue
-            item["name"] = None  # ref
-
-            item["website"] = store.get("url")
-
-            oh = OpeningHours()
-            for rule in store["openUntilSorted"]["openingHours"]:
-                day = sanitise_day(rule["day"], DAYS_HU)
-                if not rule.get("closed", False):
-                    oh.add_range(day, rule["openFormatted"], rule["closeFormatted"])
-            item["opening_hours"] = oh
-
-            apply_category(Categories.SHOP_SUPERMARKET, item)
-
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Aldi': 188,
 'atp/brand_wikidata/Q41171672': 188,
 'atp/category/shop/supermarket': 188,
 'atp/country/HU': 188,
 'atp/field/branch/missing': 188,
 'atp/field/email/missing': 188,
 'atp/field/housenumber/missing': 188,
 'atp/field/operator/missing': 188,
 'atp/field/operator_wikidata/missing': 188,
 'atp/field/state/missing': 1,
 'atp/field/street/missing': 188,
 'atp/field/twitter/missing': 188,
 'atp/field/unit/missing': 188,
 'atp/item_scraped_host_count/uberall.com': 188,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 188,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16468,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.577999999979511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 6, 7, 53, 29, 749832, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 149635,
 'httpcompression/response_count': 2,
 'item_scraped_count': 188,
 'items_per_minute': 2820.0,
 'log_count/DEBUG': 190,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 6, 7, 53, 25, 171800, tzinfo=datetime.timezone.utc)}
```