### PR TITLE
[Beev GB] Fix Spider

### DIFF
--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -11,6 +11,7 @@ class BeevGBSpider(Spider):
     name = "beev_gb"
     item_attributes = {"brand": "Be.EV", "brand_wikidata": "Q118263083"}
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(

--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -1,6 +1,5 @@
 from typing import AsyncIterator
 
-from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no

--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -1,3 +1,4 @@
+import json
 from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
@@ -19,7 +20,7 @@ class BeevGBSpider(PlaywrightSpider):
         )
 
     def parse(self, response, **kwargs):
-        for location in response.json():
+        for location in json.loads(response.xpath("//pre//text()").get()):
             if location["status"] == 4:
                 continue  # Upcoming
 

--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -5,13 +5,14 @@ from scrapy.http import JsonRequest
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
-class BeevGBSpider(Spider):
+class BeevGBSpider(PlaywrightSpider):
     name = "beev_gb"
     item_attributes = {"brand": "Be.EV", "brand_wikidata": "Q118263083"}
-    custom_settings = {"ROBOTSTXT_OBEY": False}
-    requires_proxy = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(


### PR DESCRIPTION
```python
{'atp/brand/Be.EV': 582,
 'atp/brand_wikidata/Q118263083': 582,
 'atp/category/amenity/charging_station': 582,
 'atp/clean_strings/name': 6,
 'atp/clean_strings/postcode': 3,
 'atp/country/GB': 582,
 'atp/field/branch/missing': 582,
 'atp/field/city/missing': 582,
 'atp/field/country/from_spider_name': 582,
 'atp/field/email/missing': 582,
 'atp/field/housenumber/missing': 582,
 'atp/field/opening_hours/missing': 582,
 'atp/field/phone/missing': 582,
 'atp/field/state/missing': 582,
 'atp/field/street/missing': 582,
 'atp/field/street_address/missing': 582,
 'atp/field/twitter/missing': 582,
 'atp/field/unit/missing': 582,
 'atp/item_scraped_host_count/be-ev.co.uk': 582,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 582,
 'atp/operator/Iduna': 582,
 'atp/operator_wikidata/Q118263083': 582,
 'downloader/request_bytes': 666,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 224712,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 7.889999999955762,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 6, 10, 30, 42, 685077, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 582,
 'items_per_minute': 4988.571428571428,
 'log_count/DEBUG': 583,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 8.571428571428571,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 6, 10, 30, 34, 793434, tzinfo=datetime.timezone.utc)}
```