### PR TITLE
[Boels] Collect opening hours

### DIFF
--- a/locations/spiders/boels.py
+++ b/locations/spiders/boels.py
@@ -1,5 +1,11 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -8,3 +14,33 @@ class BoelsSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Boels", "brand_wikidata": "Q19901961"}
     sitemap_urls = ["https://www.boels.com/robots.txt"]
     sitemap_rules = [(r"https://www.boels.com/en-\w\w/branches/[\w+]", "parse")]
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Boels ").replace("; ", " - ")
+        item["state"] = None
+
+        try:
+            if ld_data.get("openingHoursSpecification"):
+                item["opening_hours"] = self.parse_opening_hours(ld_data["openingHoursSpecification"])
+        except Exception:
+            pass
+
+        apply_category(Categories.SHOP_TOOL_HIRE, item)
+        yield item
+
+    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in rules:
+            rule["dayOfWeek"] = rule["dayOfWeek"].removeprefix("https://www.schema.org/")
+            if rule["opens"] == rule["closes"] == "00:00":
+                oh.set_closed(rule["dayOfWeek"])
+            else:
+                if " &amp; " in rule["opens"]:
+                    start_1, start_2 = rule["opens"].split(" &amp; ")
+                    end_1, end_2 = rule["closes"].split(" &amp; ")
+                    oh.add_range(rule["dayOfWeek"], start_1, end_1)
+                    oh.add_range(rule["dayOfWeek"], start_2, end_2)
+                else:
+                    oh.add_range(rule["dayOfWeek"], rule["opens"], rule["closes"])
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Boels': 459,
 'atp/brand_wikidata/Q19901961': 459,
 'atp/category/shop/tool_hire': 459,
 'atp/clean_strings/branch': 86,
 'atp/clean_strings/city': 58,
 'atp/clean_strings/phone': 8,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/street_address': 79,
 'atp/country/AT': 20,
 'atp/country/BE': 47,
 'atp/country/CH': 3,
 'atp/country/CZ': 23,
 'atp/country/DE': 203,
 'atp/country/FR': 7,
 'atp/country/GB': 25,
 'atp/country/HR': 3,
 'atp/country/HU': 1,
 'atp/country/IT': 2,
 'atp/country/LU': 1,
 'atp/country/NL': 108,
 'atp/country/PL': 11,
 'atp/country/SI': 1,
 'atp/country/SK': 4,
 'atp/field/email/missing': 459,
 'atp/field/housenumber/missing': 459,
 'atp/field/name/missing': 12,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 459,
 'atp/field/operator_wikidata/missing': 459,
 'atp/field/street/missing': 459,
 'atp/field/street_address/missing': 25,
 'atp/field/twitter/missing': 459,
 'atp/field/unit/missing': 459,
 'atp/item_scraped_host_count/www.boels.com': 459,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/location_unknown': 12,
 'atp/nsi/match_failed': 12,
 'atp/nsi/match_perfect': 447,
 'downloader/request_bytes': 429159,
 'downloader/request_count': 772,
 'downloader/request_method_count/GET': 772,
 'downloader/response_bytes': 87689452,
 'downloader/response_count': 772,
 'downloader/response_status_count/200': 707,
 'downloader/response_status_count/301': 65,
 'dupefilter/filtered': 93,
 'elapsed_time_seconds': 5.972072698001284,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 6, 11, 32, 15, 17649, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 772,
 'httpcompression/response_bytes': 8079778,
 'httpcompression/response_count': 144,
 'item_scraped_count': 459,
 'items_per_minute': 5508.0,
 'log_count/ERROR': 104,
 'log_count/INFO': 3,
 'log_count/WARNING': 450,
 'memusage/max': 302563328,
 'memusage/startup': 302563328,
 'request_depth_max': 3,
 'response_received_count': 707,
 'responses_per_minute': 8484.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 771,
 'scheduler/dequeued/memory': 771,
 'scheduler/enqueued': 771,
 'scheduler/enqueued/memory': 771,
 'start_time': datetime.datetime(2026, 7, 6, 11, 32, 9, 45575, tzinfo=datetime.timezone.utc)}
```