### PR TITLE
[Banco Nación AR] Add spider

### DIFF
--- a/locations/spiders/banco_nacion_ar.py
+++ b/locations/spiders/banco_nacion_ar.py
@@ -1,0 +1,66 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class BancoNacionARSpider(Spider):
+    name = "banco_nacion_ar"
+    item_attributes = {"brand": "Banco Nación", "brand_wikidata": "Q2883376"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # The locator returns results only for a selected province (province 0 = "none" -> empty), so
+        # query each Argentine province id from the locator's dropdown (there is no 1 or 3). All five
+        # boolean filter flags are required or the endpoint returns HTTP 500. The SUCURSALES view lists
+        # every branch; the CAJEROS view additionally returns the standalone "extrabancario" ATMs
+        # (airports, hospitals, universities, ...) that are located away from a branch.
+        for location_type, criterion in (("branch", "SUCURSALES"), ("atm", "CAJEROS")):
+            for province in (2, *range(4, 27)):
+                yield JsonRequest(
+                    url="https://www.bna.com.ar/SucursalesCajeros/_BuscarSucursalesyCajeros"
+                    "?criterioDeBusqueda={}&provincia={}&localidad=0&novidentes=false&puntoEfectivo=false"
+                    "&exclusivoClientes=false&centroAtencionEmpresas=false&tas=false".format(criterion, province),
+                    cb_kwargs={"location_type": location_type},
+                )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for location in response.json():
+            # The CAJEROS view also repeats every branch (those rows have no "nombre"); the branches are
+            # already yielded from the SUCURSALES view, so keep only the standalone ATM records here.
+            if location_type == "atm" and not location.get("nombre"):
+                continue
+
+            item = DictParser.parse(location)  # maps latitud/longitud and "direccion" (-> addr_full)
+            item["street_address"] = item.pop("addr_full", None)  # "direccion" is the street line only
+            item["city"] = location.get("LOC_Nombre")
+            item["state"] = location.get("PRO_Nombre")  # Argentine province
+
+            if location_type == "branch":
+                item["ref"] = str(location["suc_codcasa"])
+                item["branch"] = location["sucursal"]
+                item["postcode"] = location.get("SUC_codigopostal")
+                if (area_code := location.get("SUC_prefijo")) and (telephone := location.get("SUC_telefono")):
+                    item["phone"] = "{} {}".format(area_code, telephone)
+                # ATMs are reported only as a per-branch count in the "textoCajeros" summary
+                # ("Total cajeros: N", shown for every branch incl. 0), so the branch carries atm=yes/no.
+                if atm_count := re.search(r"Total cajeros:\s*(\d+)", location.get("textoCajeros") or ""):
+                    apply_yes_no(Extras.ATM, item, int(atm_count.group(1)) > 0, apply_positive_only=False)
+                apply_category(Categories.BANK, item)
+            else:
+                item["ref"] = str(location["id_entidad"])
+                # Keep the venue label but drop trailing "ATM"/"EXTRABANCARIO" service words
+                # (some records are only those words, leaving no real name).
+                item["name"] = (
+                    re.sub(r"(\s*\b(?:ATM|EXTRABANCARIO)\b)+$", "", location["nombre"], flags=re.IGNORECASE).strip()
+                    or None
+                )
+                # "horarioAtencion" is a uniform "24hs" on every ATM, including ones inside venues that
+                # clearly close (universities, hospitals, public offices), so it is an unreliable default
+                # and no opening_hours is emitted.
+                apply_category(Categories.ATM, item)
+
+            yield item


### PR DESCRIPTION
Data source: https://www.bna.com.ar/institucional/sucursales

The spider uses the Banco Nación branch/ATM locator API: https://www.bna.com.ar/SucursalesCajeros/_BuscarSucursalesyCajeros

Category mapping:
SUCURSAL (branch) -> Categories.BANK ; standalone "extrabancario" ATM -> Categories.ATM

Notes: The locator returns results only for a selected province (province 0 = "none selected" -> empty), so the spider queries each Argentine province id from the locator's dropdown; all five boolean filter flags are required or the endpoint returns HTTP 500. 
Two views are fetched per province: `SUCURSALES` lists every branch, and `CAJEROS` additionally returns the standalone "extrabancario" ATMs (airports, hospitals, universities, courthouses, …) located away from a branch , those rows have a populated `nombre` and their own coordinates and are emitted as `amenity=atm` (the branch rows repeated in that view are skipped). 
Branches expose on-site ATMs only as a count in the `textoCajeros` summary ("Total cajeros: N", shown for every branch incl. 0), so each branch carries `atm=yes` (705) / `atm=no` (15); there are no per-ATM coordinates for on-branch machines. `DictParser` maps latitude/longitude and `direccion`; city/province/postcode/phone come from the Spanish source keys. 
Opening hours are not emitted: branches have no `horarioAtencion`, and every extrabancario ATM carries a uniform "24hs" default (including ATMs inside venues that clearly close), so it is unreliable. 
Phone is kept only when both area code and number are present. ATM display names have their trailing "ATM"/"EXTRABANCARIO" service words stripped.

Stats summary:
1027 total items 
720 banks (705 with atm=yes)
307 standalone ATMs 
NSI: 1027 match_perfect Country derived from spider name: 1027

Sample POIs:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1015",
      "atm": "yes",
      "amenity": "bank",
      "@source_uri": "https://www.bna.com.ar/SucursalesCajeros/_BuscarSucursalesyCajeros?criterioDeBusqueda=SUCURSALES&provincia=2&localidad=0&novidentes=false&puntoEfectivo=false&exclusivoClientes=false&centroAtencionEmpresas=false&tas=false",
      "@spider": "banco_nacion_ar",
      "official_name": "Banco de la Nación Argentina",
      "addr:street_address": "Bmé. Mitre esq. Elicagaray",
      "addr:city": "Adolfo Gonzales Chaves",
      "addr:state": "Buenos Aires",
      "addr:postcode": "7513",
      "addr:country": "AR",
      "name": "Banco Nación",
      "branch": "ADOLFO GONZALES CHAVES",
      "phone": "+54 2983 48-1542",
      "brand": "Banco Nación",
      "brand:wikidata": "Q2883376",
      "nsi_id": "banconacion-841353"
    },
    "geometry": { "type": "Point", "coordinates": [-60.0982, -38.0324] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "285",
      "amenity": "atm",
      "@source_uri": "https://www.bna.com.ar/SucursalesCajeros/_BuscarSucursalesyCajeros?criterioDeBusqueda=CAJEROS&provincia=2&localidad=0&novidentes=false&puntoEfectivo=false&exclusivoClientes=false&centroAtencionEmpresas=false&tas=false",
      "@spider": "banco_nacion_ar",
      "addr:street_address": "CALLE 8 925",
      "addr:city": "La Plata",
      "addr:state": "Buenos Aires",
      "addr:country": "AR",
      "name": "TRIBUNALES FEDERALES DE LA PLATA",
      "brand": "Banco Nación",
      "brand:wikidata": "Q2883376",
      "operator": "Banco Nación",
      "operator:wikidata": "Q2883376",
      "nsi_id": "banconacion-b67a7c"
    },
    "geometry": { "type": "Point", "coordinates": [-57.950488, -34.91604] }
  }
]
```
```
{
  "atp/category/amenity/atm": 307,
  "atp/category/amenity/bank": 720,
  "atp/country/AR": 1027,
  "atp/field/country/from_spider_name": 1027,
  "atp/field/opening_hours/missing": 1027,
  "atp/nsi/match_perfect": 1027,
  "atp/operator/Banco Nación": 307,
  "downloader/request_count": 49,
  "downloader/response_status_count/200": 49,
  "finish_reason": "finished",
  "item_scraped_count": 1027
}
```