### PR TITLE
[Castorama FR] Fix Spider

### DIFF
--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -15,6 +15,7 @@ class CastoramaFRSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(restrict_xpaths='//*[@data-testid="html"]//li', allow=r"/store/\d+"), callback="parse_sd")
     ]
     time_format = "%H:%M:%S Europe/Paris"
+    wanted_types = ["HardwareStore"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None

--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -1,18 +1,21 @@
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CastoramaFRSpider(SitemapSpider, StructuredDataSpider):
+class CastoramaFRSpider(CrawlSpider, StructuredDataSpider):
     name = "castorama_fr"
     item_attributes = {"brand": "Castorama", "brand_wikidata": "Q966971"}
-    sitemap_urls = ["https://www.castorama.fr/robots.txt"]
-    sitemap_follow = ["sitemap-magasins.xml"]
-    sitemap_rules = [(r"/store/\d+", "parse_sd")]
+    start_urls = ["https://www.castorama.fr/magasin"]
+    rules = [
+        Rule(LinkExtractor(restrict_xpaths='//*[@data-testid="html"]//li', allow=r"/store/\d+"), callback="parse_sd")
+    ]
     time_format = "%H:%M:%S Europe/Paris"
+    # wanted_types = ["HardwareStore"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None

--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -16,6 +16,8 @@ class CastoramaFRSpider(CrawlSpider, StructuredDataSpider):
     ]
     time_format = "%H:%M:%S Europe/Paris"
     wanted_types = ["HardwareStore"]
+    search_for_facebook = False
+    search_for_twitter = False
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None

--- a/locations/spiders/castorama_fr.py
+++ b/locations/spiders/castorama_fr.py
@@ -15,7 +15,6 @@ class CastoramaFRSpider(CrawlSpider, StructuredDataSpider):
         Rule(LinkExtractor(restrict_xpaths='//*[@data-testid="html"]//li', allow=r"/store/\d+"), callback="parse_sd")
     ]
     time_format = "%H:%M:%S Europe/Paris"
-    # wanted_types = ["HardwareStore"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None


### PR DESCRIPTION
```python
{'atp/brand/Castorama': 85,
 'atp/brand_wikidata/Q966971': 85,
 'atp/category/shop/doityourself': 85,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/street_address': 2,
 'atp/country/FR': 85,
 'atp/field/email/missing': 85,
 'atp/field/housenumber/missing': 85,
 'atp/field/operator/missing': 85,
 'atp/field/operator_wikidata/missing': 85,
 'atp/field/state/missing': 85,
 'atp/field/street/missing': 85,
 'atp/field/unit/missing': 85,
 'atp/item_scraped_host_count/www.castorama.fr': 85,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 85,
 'atp/nsi/match_failed': 85,
 'downloader/exception_count': 2,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 2,
 'downloader/request_bytes': 38300,
 'downloader/request_count': 97,
 'downloader/request_method_count/GET': 97,
 'downloader/response_bytes': 17052007,
 'downloader/response_count': 97,
 'downloader/response_status_count/200': 89,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/503': 6,
 'dupefilter/filtered': 5,
 'elapsed_time_seconds': 116.70300000003772,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 7, 8, 42, 7, 562974, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 69787501,
 'httpcompression/response_count': 93,
 'item_scraped_count': 85,
 'items_per_minute': 43.96551724137931,
 'log_count/DEBUG': 185,
 'log_count/INFO': 4,
 'request_depth_max': 1,
 'response_received_count': 89,
 'responses_per_minute': 46.03448275862069,
 'robotstxt/forbidden': 2,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 96,
 'scheduler/dequeued/memory': 96,
 'scheduler/enqueued': 96,
 'scheduler/enqueued/memory': 96,
 'start_time': datetime.datetime(2026, 7, 7, 8, 40, 10, 854373, tzinfo=datetime.timezone.utc)}
```