### PR TITLE
[Banco Provincia AR] Add spider

### DIFF
--- a/locations/spiders/banco_provincia_ar.py
+++ b/locations/spiders/banco_provincia_ar.py
@@ -1,0 +1,44 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class BancoProvinciaARSpider(Spider):
+    name = "banco_provincia_ar"
+    item_attributes = {"brand": "Banco Provincia", "brand_wikidata": "Q4856209"}
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        # Bulk endpoints published by the branch finder's appsettings.json. "filiales" is intentionally
+        # skipped: its entries are correspondent banks in other countries and two coordinate-less foreign
+        # offices (Montevideo, São Paulo) — none of them Argentine Banco Provincia locations.
+        for location_type, endpoint in (("branch", "sucursales"), ("atm", "cajeros")):
+            yield JsonRequest(
+                url="https://www.bancoprovincia.com.ar/gateway/webback/buscador/{}".format(endpoint),
+                cb_kwargs={"location_type": location_type},
+            )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            item["city"] = location.get("localidad")
+            item["state"] = location.get("provincia")  # CABA or Buenos Aires province
+            item["postcode"] = location.get("codigoPostal")
+
+            if location_type == "branch":
+                item["ref"] = str(location["numero"])
+                item["branch"] = item.pop("name", None)  # DictParser maps "nombre" -> name
+                item["street_address"] = location["domicilio"]
+                item.pop("phone", None)  # "telefono" is a doubled, multi-number string, not a clean phone
+                # "horario" carries only a time range with no weekdays ("10 a 15 hs"), so no opening_hours.
+                apply_category(Categories.BANK, item)
+            else:
+                # ATMs have no id of their own; idSucursal + street uniquely identifies each machine.
+                item["ref"] = "{}-{}".format(location["idSucursal"], location["direccion"])
+                item["street_address"] = item.pop("addr_full", None)  # DictParser maps "direccion"
+                apply_category(Categories.ATM, item)
+
+            yield item


### PR DESCRIPTION
Data source: https://www.bancoprovincia.com.ar/buscadorsucursales

The spider uses the branch finder's bulk endpoints (from the Blazor app's `appsettings.json`):
- https://www.bancoprovincia.com.ar/gateway/webback/buscador/sucursales
- https://www.bancoprovincia.com.ar/gateway/webback/buscador/cajeros

Category mapping:
SUCURSAL (branch) -> Categories.BANK ; 
CAJERO (ATM) -> Categories.ATM

### No duplicated POIs
Branches (`amenity=bank`) and ATMs (`amenity=atm`) come from two separate source feeds, each with its own coordinates, and are emitted 1:1 , nothing is duplicated or deep-copied. 
Branches are **not** tagged `atm=yes`: the branch feed has no ATM field, and the ATM feed's `idSucursal` is only an administrative "responsible branch" (the ATM sits a median 119 m and up to ~366 km away — only 142/338 are within 50 m, and just 1 shares a branch's exact coordinates). 
Inferring on-site ATMs from that link would be unreliable, so it is not done. The ATMs are fully represented as their own POIs.

### No unreliable opening_hours
`opening_hours` is intentionally not emitted. The branch `horario` field is a boilerplate time range (`"10 a 15 hs"` on 345/350 records) with **no weekday information**; emitting it would require inventing Mon–Fri. The ATM feed has no hours at all.

### Scope: Argentina only
The `filiales` endpoint is skipped: its `tipo 2` entries are **correspondent banks in other countries** (e.g. Deutsche Bank, Commerzbank, Raiffeisen), not Banco Provincia locations, and its two `tipo 1` foreign offices (Montevideo, São Paulo) have **no coordinates** and fall outside this brand's NSI coverage (`Q4856209` `locationSet` = `ar`). All 695 emitted records are in Argentina (CABA + Buenos Aires province).

### Other decisions
- `DictParser` maps coordinates, the branch `nombre`, and the ATM `direccion`; `localidad`/`provincia`/`codigoPostal` → `addr:city`/`addr:state`/`addr:postcode`, and the clean `domicilio`/`direccion` → `addr:street_address`.
- `ref`: branches use `numero`; ATMs have no native id, so `idSucursal-direccion` (verified unique) is used.
- `telefono` is dropped — it is a duplicated, multi-number free-form string, not a reliable single phone.

Stats summary:
695 total items 
350 banks 
345 ATMs 
NSI: 695 match_perfect 
Country derived from spider name: 695

Sample POIs:

```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1000",
      "amenity": "bank",
      "@spider": "banco_provincia_ar",
      "official_name": "Banco de la Provincia de Buenos Aires",
      "addr:street_address": "San Martín 137",
      "addr:city": "SAN NICOLÁS",
      "addr:state": "CIUDAD DE BUENOS AIRES",
      "addr:postcode": "C1004AAC",
      "addr:country": "AR",
      "name": "Banco Provincia",
      "branch": "CASA BUENOS AIRES",
      "brand": "Banco Provincia",
      "brand:wikidata": "Q4856209",
      "nsi_id": "bancoprovincia-841353"
    },
    "geometry": { "type": "Point", "coordinates": [-58.373469, -34.606641] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "1208-DR. ANGEL C. ROTTA 2700",
      "amenity": "atm",
      "@spider": "banco_provincia_ar",
      "addr:street_address": "DR. ANGEL C. ROTTA 2700",
      "addr:city": "SAN BERNARDO",
      "addr:state": "BUENOS AIRES",
      "addr:postcode": "B7108BKB",
      "addr:country": "AR",
      "brand": "Banco Provincia",
      "brand:wikidata": "Q4856209",
      "operator": "Banco Provincia",
      "operator:wikidata": "Q4856209",
      "nsi_id": "bancoprovincia-b67a7c"
    },
    "geometry": { "type": "Point", "coordinates": [-58.4937539, -36.6901181] }
  }
]
```

```
{
  "atp/brand/Banco Provincia": 695,
  "atp/category/amenity/atm": 345,
  "atp/category/amenity/bank": 350,
  "atp/country/AR": 695,
  "atp/field/country/from_spider_name": 695,
  "atp/field/opening_hours/missing": 695,
  "atp/field/phone/missing": 695,
  "atp/field/postcode/missing": 7,
  "atp/nsi/match_perfect": 695,
  "downloader/request_count": 3,
  "downloader/response_status_count/200": 3,
  "finish_reason": "finished",
  "item_scraped_count": 695
}
```