### PR TITLE
[Tavuk Dünyası TR] Add spider (342 locations)

### DIFF
--- a/locations/spiders/tavuk_dunyasi_tr.py
+++ b/locations/spiders/tavuk_dunyasi_tr.py
@@ -1,0 +1,37 @@
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class TavukDunyasiTRSpider(Spider):
+    name = "tavuk_dunyasi_tr"
+    item_attributes = {"brand": "Tavuk Dünyası", "brand_wikidata": "Q126924105"}
+    start_urls = ["https://www.tavukdunyasi.com/umbraco/surface/Common/GetAllRestaurants?culture=tr-TR&searchText="]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)
+            if name := item.pop("name", None):
+                item["branch"] = name.strip()
+            item["ref"] = location["code"]
+            item["street_address"] = item.pop("addr_full")
+            item["lat"] = location["latitude"].replace(",", ".")
+            item["lon"] = location["longitude"].replace(",", ".")
+            item["extras"]["addr:district"] = location["district"]
+
+            if times := re.findall(r"\d{1,2}:\d{2}", location.get("workingHour") or ""):
+                if len(times) == 2:
+                    open_time, close_time = times
+                    if close_time == "00:00":
+                        close_time = "24:00"
+                    item["opening_hours"] = OpeningHours()
+                    item["opening_hours"].add_days_range(DAYS, open_time, close_time)
+
+            apply_category(Categories.FAST_FOOD, item)
+            yield item

--- a/locations/spiders/tavuk_dunyasi_tr.py
+++ b/locations/spiders/tavuk_dunyasi_tr.py
@@ -21,8 +21,10 @@ class TavukDunyasiTRSpider(Spider):
                 item["branch"] = name.strip()
             item["ref"] = location["code"]
             item["street_address"] = item.pop("addr_full")
-            item["lat"] = location["latitude"].replace(",", ".")
-            item["lon"] = location["longitude"].replace(",", ".")
+            if latitude := (location["latitude"] or "").strip(", "):
+                item["lat"] = latitude.replace(",", ".")
+            if longitude := (location["longitude"] or "").strip(", "):
+                item["lon"] = longitude.replace(",", ".")
             item["extras"]["addr:district"] = location["district"]
 
             if times := re.findall(r"\d{1,2}:\d{2}", location.get("workingHour") or ""):


### PR DESCRIPTION
Add `tavuk_dunyasi_tr`, scraping Tavuk Dünyası fast-food chicken restaurants in Turkey from the site's `GetAllRestaurants` JSON endpoint (single request, 344 records). Category `amenity=fast_food`; branch, ref, address and district mapped per store; opening hours parsed from the source `workingHour` field; name/nsi_id/cuisine filled by NSI.