### PR TITLE
[Banco Macro AR] Add spider

### DIFF
--- a/locations/spiders/banco_macro_ar.py
+++ b/locations/spiders/banco_macro_ar.py
@@ -1,0 +1,74 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class BancoMacroARSpider(Spider):
+    name = "banco_macro_ar"
+    item_attributes = {"brand": "Macro", "brand_wikidata": "Q2335199"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        # Bulk endpoints behind the branch/ATM finder (banco=BM = Banco Macro). The API needs an
+        # "Accept: application/json" header (a request without it gets HTTP 400), but JsonRequest can't
+        # be used: its "Content-Type: application/json" header makes the endpoint return an empty body.
+        # The "UNegocio_BusquedaComercios" endpoint is skipped: it lists third-party merchants
+        # (Carrefour, etc.) offering cash withdrawal, not Macro locations.
+        yield Request(
+            url="https://www.macro.com.ar/interfaces/UNegocio_BusquedaSucursales/V1/R0/?banco=BM&datosCompletos=true",
+            headers={"Accept": "application/json"},
+            cb_kwargs={"location_type": "branch"},
+        )
+        yield Request(
+            url="https://www.macro.com.ar/interfaces/UNegocio_BusquedaCajeros/V1/R0/?banco=BM",
+            headers={"Accept": "application/json"},
+            cb_kwargs={"location_type": "atm"},
+        )
+
+    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
+        elements = response.json()["elements"]
+        # A coordinate shared across more than one province is a geocoding-failure placeholder
+        # (one point is pinned to ATMs in 8 different provinces), not a real location.
+        provinces_per_coordinate: dict[tuple, set] = {}
+        for location in elements:
+            key = (location.get("latitud"), location.get("longitud"))
+            provinces_per_coordinate.setdefault(key, set()).add(location.get("provincia"))
+
+        for location in elements:
+            coordinate = (location.get("latitud"), location.get("longitud"))
+            if not self._valid_coordinates(location) or len(provinces_per_coordinate[coordinate]) > 1:
+                continue  # drop corrupt or placeholder coordinates
+
+            item = DictParser.parse(location)
+            item["state"] = location.get("provincia")  # DictParser otherwise maps a region/division here
+            item["city"] = location.get("localidad")
+            item["postcode"] = location.get("codpostal")
+            item["street_address"] = location.get("domicilio")
+
+            if location_type == "branch":
+                if location.get("habilitada") != "SI":  # skip disabled / non-operational branches
+                    continue
+                # "codigo" is a shared zone code, not a branch id; the address identifies each branch
+                # and collapses the feed's duplicate metadata rows.
+                item["ref"] = "{}, {}".format(location["domicilio"], location["localidad"])
+                item["branch"] = item.pop("name", None)  # DictParser maps "nombre"
+                item.pop("phone", None)  # "telefono" is a multi-number "/"-joined string, not a clean phone
+                # "horario" is only a time range with no weekdays ("08:00 a 13:00"), so no opening_hours.
+                apply_yes_no(Extras.WIFI, item, location.get("wifi") == "SI")
+                apply_category(Categories.BANK, item)
+            else:
+                item["ref"] = location["codigo"]  # unique ATM code, e.g. "S1CBM533"
+                apply_category(Categories.ATM, item)
+
+            yield item
+
+    def _valid_coordinates(self, location: dict) -> bool:
+        try:
+            lat, lon = float(location["latitud"]), float(location["longitud"])
+        except (TypeError, ValueError, KeyError):
+            return False
+        # Reject corrupt values (lat == lon, projected UTM, points outside Argentina).
+        return lat != lon and -56 < lat < -21 and -74 < lon < -53


### PR DESCRIPTION
Data source: https://www.macro.com.ar/buscador-cajeros-sucursales
API endpoints (banco=BM = Banco Macro):
- https://www.macro.com.ar/interfaces/UNegocio_BusquedaSucursales/V1/R0/?banco=BM&datosCompletos=true
- https://www.macro.com.ar/interfaces/UNegocio_BusquedaCajeros/V1/R0/?banco=BM

Category mapping:
SUCURSAL (branch) -> Categories.BANK ; CAJERO (ATM) -> Categories.ATM

### No duplicated POIs
Branches (`amenity=bank`) and ATMs (`amenity=atm`) come from two separate feeds and are emitted 1:1. Branches are **not** tagged `atm=yes`: the `cajeros` feed already lists every ATM as its own POI (with a unique `codigo`), so tagging branches would duplicate them. Nothing is deep-copied.

### No unreliable opening_hours
`opening_hours` is not emitted. `horario` is only a time range (e.g. `"08:00 a 13:00"`, largely boilerplate) with no weekday information; emitting it would require inventing Mon–Fri.

### Data-quality handling
- **Request**: the API returns HTTP 400 without `Accept: application/json`, but `JsonRequest` can't be used — its `Content-Type: application/json` header makes the endpoint return an empty body , so a plain `Request` with the `Accept` header is used.
- **Coordinates**: dropped corrupt values (lat==lon, projected UTM, points outside Argentina) and geocoding-failure placeholders (a coordinate pinned to different-address ATMs across up to 8 provinces). Remaining coordinates are the source's; a small number (~0.3%) may be imprecise, consistent with source data.
- **Branch ref**: `codigo` is a shared zone code (not a branch id), so the address (`domicilio, localidad`) identifies each branch and collapses the feed's duplicate metadata rows (69 dropped). ATMs use their unique `codigo`.
- **Excluded**: the `UNegocio_BusquedaComercios` endpoint (third-party merchants offering cash withdrawal — Carrefour, etc., `banco=""`), disabled branches (`habilitada != "SI"`), and `telefono` (a multi-number `/`-joined string, not a clean phone). `DictParser`'s region→`addr:state` mis-map is overridden with `provincia`. `wifi=SI` → `internet_access=wlan`.

Stats summary:
2298 total items 
429 banks 
1869 ATMs 
NSI: 2298 match_perfect 
Country derived from spider name: 2298

Sample POIs:

```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "SARMIENTO 878, OBERÁ",
      "amenity": "bank",
      "@spider": "banco_macro_ar",
      "addr:street_address": "SARMIENTO 878",
      "addr:city": "OBERÁ",
      "addr:state": "MISIONES",
      "addr:postcode": "3360",
      "addr:country": "AR",
      "name": "Macro",
      "branch": "OBERA",
      "brand": "Macro",
      "brand:wikidata": "Q2335199",
      "nsi_id": "macro-841353"
    },
    "geometry": { "type": "Point", "coordinates": [-55.121231, -27.48517] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "S1CBM908",
      "amenity": "atm",
      "@spider": "banco_macro_ar",
      "addr:street_address": "25 DE MAYO 160",
      "addr:city": "CORDOBA",
      "addr:state": "CÓRDOBA",
      "addr:postcode": "5000",
      "addr:country": "AR",
      "brand": "Macro",
      "brand:wikidata": "Q2335199",
      "operator": "Macro",
      "operator:wikidata": "Q2335199",
      "nsi_id": "macro-b67a7c"
    },
    "geometry": { "type": "Point", "coordinates": [-64.1815567, -31.4154739] }
  }
]
```

```
{
  "atp/brand/Macro": 2298,
  "atp/category/amenity/atm": 1869,
  "atp/category/amenity/bank": 429,
  "atp/country/AR": 2298,
  "atp/duplicate_count": 69,
  "atp/field/country/from_spider_name": 2298,
  "atp/field/opening_hours/missing": 2298,
  "atp/field/phone/missing": 2298,
  "atp/nsi/match_perfect": 2298,
  "downloader/request_count": 3,
  "downloader/response_status_count/200": 3,
  "finish_reason": "finished",
  "item_scraped_count": 2298
}
```