### PR TITLE
[Praxis NL] Add spider (173 locations)

### DIFF
--- a/locations/spiders/praxis_nl.py
+++ b/locations/spiders/praxis_nl.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_NL, OpeningHours
+
+
+class PraxisNLSpider(SitemapSpider):
+    name = "praxis_nl"
+    item_attributes = {"brand": "Praxis", "brand_wikidata": "Q2741995"}
+    sitemap_urls = ["https://www.praxis.nl/store/sitemap.xml"]
+
+    # Structured data is not present for all store URLs
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        try:
+            poi = chompjs.parse_js_object(
+                response.xpath('//script[contains(text(), "storeDetail")]/text()').re_first(
+                    r"storeDetail\s?=\s?(.*?});"
+                ),
+                json_params={"strict": False},
+            )
+        except Exception:
+            return
+        if not poi["showStoreDetail"]:
+            return
+        poi.update(poi.pop("address"))
+        poi["country"] = poi["country"].pop("isocode")
+        poi["name"] = poi.pop("displayName")
+        item = DictParser.parse(poi)
+        item["branch"] = item.pop("name")
+        item["addr_full"] = poi["formattedAddress"]
+        item["website"] = response.url
+        item["street_address"] = None
+
+        item["opening_hours"] = OpeningHours()
+        for day in poi["weekdays"]:
+            if day["closed"]:
+                item["opening_hours"].set_closed(DAYS_NL[day["weekDay"]])
+            else:
+                item["opening_hours"].add_range(
+                    DAYS_NL[day["weekDay"]], day["openingTime"]["formattedHour"], day["closingTime"]["formattedHour"]
+                )
+
+        apply_category(Categories.SHOP_DOITYOURSELF, item)
+        yield item


### PR DESCRIPTION
Add `praxis_nl`, scraping Praxis DIY stores in the Netherlands from the store sitemap; each store page embeds a `storeDetail` JS object parsed with `chompjs`. Category `shop=doityourself`; opening hours (including closed days), full + structured address, phone and website mapped per store; name/nsi_id filled by NSI.