### PR TITLE
[Jockey IN] Add spider

### DIFF
--- a/locations/spiders/jockey_in.py
+++ b/locations/spiders/jockey_in.py
@@ -1,0 +1,21 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class JockeyINSpider(SitemapSpider, StructuredDataSpider):
+    name = "jockey_in"
+    item_attributes = {"brand": "Jockey", "brand_wikidata": "Q534235"}
+    sitemap_urls = ["https://stores.jockey.in/sitemaps/v1/google/index-10001.xml"]
+    sitemap_rules = [(r"jockey-exclusive-store-[\w\-/]+/home", "parse_sd")]
+    time_format = "%I:%M %p"
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["name"] = None
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item

--- a/locations/spiders/jockey_in.py
+++ b/locations/spiders/jockey_in.py
@@ -10,7 +10,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class JockeyINSpider(SitemapSpider, StructuredDataSpider):
     name = "jockey_in"
-    item_attributes = {"brand": "Jockey", "brand_wikidata": "Q534235"}
+    item_attributes = {"name": "Jockey", "brand": "Jockey"}
     sitemap_urls = ["https://stores.jockey.in/sitemaps/v1/google/index-10001.xml"]
     sitemap_rules = [(r"jockey-exclusive-store-[\w\-/]+/home", "parse_sd")]
     time_format = "%I:%M %p"

--- a/locations/spiders/jockey_in.py
+++ b/locations/spiders/jockey_in.py
@@ -17,5 +17,7 @@ class JockeyINSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
         item["name"] = None
+        if "stores.jockey.in" in item["facebook"] or "com/jockeyindia" in item["facebook"]:
+            item["facebook"] = None
         apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
Add `jockey_in` — Jockey Exclusive Store locations in India from the `stores.jockey.in` Yext sitemap (JSON-LD `ClothingStore`).

- ~194 stores, `shop=clothes`, 100% valid coordinates.
- `name` cleared: the India licensee is not in NSI (`Q534235` is US-scoped) so the SEO-style JSON-LD title is not a useful POI name; `brand=Jockey` identifies the store.