### PR TITLE
[Top Garage FR] Add spider (920 locations)

### DIFF
--- a/locations/spiders/top_garage_fr.py
+++ b/locations/spiders/top_garage_fr.py
@@ -1,0 +1,19 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TopGarageFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "top_garage_fr"
+    item_attributes = {"brand": "Top Garage", "brand_wikidata": "Q117602800"}
+    sitemap_urls = ["https://garage.top-garage.fr/sitemap_pois.xml"]
+    sitemap_rules = [(r"/details$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
+        yield item


### PR DESCRIPTION
Add `top_garage_fr` — Top Garage franchised garages from the `garage.top-garage.fr` POI sitemap (JSON-LD `AutomotiveBusiness`).

- ~900 garages across metropolitan France and the overseas departments (GP/GF/RE), `shop=car_repair`, 100% valid coordinates.
- `apply_category` set explicitly so the overseas-territory stores (outside the brand's NSI `fx` location set) are still categorised.
- Per-garage trading names retained as `name` — each is an independently-named business operating under the Top Garage banner.