### PR TITLE
[Pathé NL] Add spider

### DIFF
--- a/locations/spiders/pathe_nl.py
+++ b/locations/spiders/pathe_nl.py
@@ -13,6 +13,7 @@ class PatheNLSpider(Spider):
     item_attributes = {"brand": "Pathé", "brand_wikidata": "Q3060526"}
     start_urls = ["https://www.pathe.nl/api/cinemas"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}  # the API returns HTTP 403 to non-browser user agents
+    requires_proxy = "NL"  # Akamai also blocks data-centre IPs (CI fetch gets HTTP 403); needs a NL proxy
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for cinema in response.json():

--- a/locations/spiders/pathe_nl.py
+++ b/locations/spiders/pathe_nl.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class PatheNLSpider(Spider):
+    name = "pathe_nl"
+    item_attributes = {"brand": "Pathé", "brand_wikidata": "Q3060526"}
+    start_urls = ["https://www.pathe.nl/api/cinemas"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}  # the API returns HTTP 403 to non-browser user agents
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for cinema in response.json():
+            if not cinema["status"]:
+                continue
+            for theater in cinema["theaters"]:
+                item = DictParser.parse(theater)  # maps name, addressLine1 (-> street_address), city, postcode
+                item["ref"] = cinema["slug"]
+                item["lat"] = theater["gpsPosition"]["x"]
+                item["lon"] = theater["gpsPosition"]["y"]
+                item["website"] = "https://www.pathe.nl/nl/bioscopen/{}".format(cinema["slug"])
+                apply_category(Categories.CINEMA, item)
+                yield item


### PR DESCRIPTION
Data source: https://www.pathe.nl/nl/bioscopen
API endpoint: https://www.pathe.nl/api/cinemas

Category mapping:
cinema -> Categories.CINEMA

Notes: Netherlands cinemas from Pathé's `/api/cinemas` endpoint — the same platform as the existing `pathe_fr` spider, so this mirrors its approach. 
The API returns HTTP 403 to non-browser user agents, so `USER_AGENT: BROWSER_DEFAULT` is set (no proxy required). `DictParser` maps the theater name, `addressLine1` → `addr:street_address`, `addressCity` → `addr:city`, and `addressZip` → `addr:postcode`; latitude/longitude come from `gpsPosition` (x/y), and `ref` is the cinema `slug`. 
Each cinema's `website` (`/nl/bioscopen/{slug}`) was verified to resolve to the specific cinema page. 
All 31 cinemas are active (`status: true`) and carry coordinates.

Stats summary:
31 total items — 31 cinemas. 
NSI: 31 match_perfect. 
Country derived from spider name: 31.

Sample POIs:

```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "pathe-amsterdam-noord",
      "amenity": "cinema",
      "@source_uri": "https://www.pathe.nl/api/cinemas",
      "@spider": "pathe_nl",
      "addr:street_address": "Buikslotermeerplein 2003",
      "addr:city": "Amsterdam",
      "addr:postcode": "1025 XL",
      "addr:country": "NL",
      "name": "Pathé Amsterdam-Noord",
      "website": "https://www.pathe.nl/nl/bioscopen/pathe-amsterdam-noord",
      "brand": "Pathé",
      "brand:wikidata": "Q3060526",
      "nsi_id": "pathe-dedd66"
    },
    "geometry": { "type": "Point", "coordinates": [4.934719512632164, 52.400857376795486] }
  }
]
```

```
{
  "atp/brand/Pathé": 31,
  "atp/brand_wikidata/Q3060526": 31,
  "atp/category/amenity/cinema": 31,
  "atp/country/NL": 31,
  "atp/field/country/from_spider_name": 31,
  "atp/nsi/match_perfect": 31,
  "downloader/request_count": 2,
  "downloader/response_status_count/200": 2,
  "finish_reason": "finished",
  "item_scraped_count": 31
}
```