### PR TITLE
Fix empty parquet output: bound sort memory with spatial batching, fix invalid GeoParquet CRS

### DIFF
--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -33,6 +33,20 @@ def duckdb_memory_limit() -> str:
     return f"{duckdb_gb}GB"
 
 
+# ST_Hilbert() returns a UINTEGER (32-bit) curve position. Used to split the
+# table into spatially-contiguous batches so no single ORDER BY has to sort/
+# materialize the whole dataset at once.
+HILBERT_RANGE = 2**32
+
+# Sorting and writing the whole table in one COPY holds the full row set
+# (geometry + properties + dataset_attributes) in memory during the sort. On
+# a ~43M row dataset that has been observed to exceed the container's memory
+# limit and get silently OOM-killed (see #14341/#16158). Splitting into
+# batches of roughly this many rows keeps each sort's peak memory bounded
+# regardless of total dataset size.
+TARGET_ROWS_PER_BATCH = 2_000_000
+
+
 def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
     if output_file_path.exists():
@@ -95,34 +109,61 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             geom_types = [t[0] for t in geom_types_raw if t and t[0] is not None]
             logger.info(f"Found geometry types: {geom_types}")
 
+            row_count = con.execute("SELECT count(*) FROM geojson_data").fetchone()[0]
+            num_batches = max(1, math.ceil(row_count / TARGET_ROWS_PER_BATCH))
+            logger.info(f"Table has {row_count:,} rows; writing in {num_batches} spatial batch(es)")
+
+            if num_batches > 1:
+                # Bucket rows into spatially-contiguous ranges of the Hilbert curve so each
+                # batch can be sorted and written independently, without needing the whole
+                # table's rows in memory at once. Buckets won't be perfectly balanced (data
+                # is denser in some regions than others), but this bounds the *typical* peak
+                # memory of any single sort to a small fraction of the full dataset.
+                con.execute("ALTER TABLE geojson_data ADD COLUMN batch_id INTEGER")
+                con.execute(f"""
+                    UPDATE geojson_data
+                    SET batch_id = LEAST(
+                        CAST(FLOOR(ST_Hilbert(geom) / ({HILBERT_RANGE} / {num_batches})) AS INTEGER),
+                        {num_batches - 1}
+                    )
+                """)
+
             # write parquet with a larger row group size (target 64-256 MB). 128MB chosen here.
             row_group_size = 134217728
 
-            logger.info(f"Writing parquet file with row group size {row_group_size}...")
-            con.execute(f"""
-            COPY (
-                SELECT
-                    id,
-                    type,
-                    dataset_attributes,
-                    properties,
-                    geom,
-                    {{
-                        'xmin': ST_XMin(geom),
-                        'ymin': ST_YMin(geom),
-                        'xmax': ST_XMax(geom),
-                        'ymax': ST_YMax(geom)
-                    }} as bbox
-                FROM geojson_data
-                ORDER BY ST_Hilbert(geom)
-            ) TO '{str(output_file_path)}'
-            (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE {row_group_size});
-            """)
-            logger.info("Parquet file written successfully")
+            batch_paths = []
+            for batch_num in range(num_batches):
+                batch_path = Path(temp_dir) / f"batch_{batch_num}.parquet"
+                where_clause = f"WHERE batch_id = {batch_num}" if num_batches > 1 else ""
+                logger.info(f"Writing batch {batch_num + 1}/{num_batches} to {batch_path}...")
+                con.execute(f"""
+                COPY (
+                    SELECT
+                        id,
+                        type,
+                        dataset_attributes,
+                        properties,
+                        geom,
+                        {{
+                            'xmin': ST_XMin(geom),
+                            'ymin': ST_YMin(geom),
+                            'xmax': ST_XMax(geom),
+                            'ymax': ST_YMax(geom)
+                        }} as bbox
+                    FROM geojson_data
+                    {where_clause}
+                    ORDER BY ST_Hilbert(geom)
+                ) TO '{str(batch_path)}'
+                (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE {row_group_size});
+                """)
+                batch_paths.append(batch_path)
+            logger.info("All batches written successfully")
 
-        # DuckDB connection is now closed; release its memory before loading with pyarrow
-        logger.info("Adding GeoParquet metadata...")
-        table = pq.read_table(str(output_file_path))
+        # DuckDB connection is now closed, releasing its memory before pyarrow runs.
+        # Merge the batch files into the final output one row group at a time so we
+        # never need to hold the full dataset in memory (unlike a read_table/write_table
+        # round trip over the whole file, which was itself a prior OOM risk).
+        logger.info("Merging batches into final parquet file with GeoParquet metadata...")
 
         if bbox_res is None:
             xmin, ymin, xmax, ymax = None, None, None, None
@@ -131,18 +172,41 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
         geo_meta = {
             "version": "1.1.0",
             "primary_column": "geom",
-            "columns": {"geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"], "crs": "EPSG:4326"}},
+            # No "crs" key: per the GeoParquet spec, omitting it means the default of
+            # OGC:CRS84 (WGS84, lon/lat axis order), which matches our WKB geometries.
+            # "EPSG:4326" would be wrong here - that CRS formally specifies lat/lon axis
+            # order, the opposite of what's actually stored, which readers (e.g. DuckDB)
+            # correctly reject.
+            "columns": {"geom": {"encoding": "WKB", "geometry_types": geom_types or ["Unknown"]}},
             "bbox": [xmin, ymin, xmax, ymax],
         }
 
-        existing_md = table.schema.metadata or {}
-        new_md = dict(existing_md)
-        new_md[b"geo"] = json.dumps(geo_meta, ensure_ascii=False).encode("utf-8")
+        writer = None
+        try:
+            for batch_path in batch_paths:
+                parquet_file = pq.ParquetFile(str(batch_path))
+                for row_group_idx in range(parquet_file.num_row_groups):
+                    row_group_table = parquet_file.read_row_group(row_group_idx)
+                    if writer is None:
+                        schema = row_group_table.schema.with_metadata(
+                            {
+                                **(row_group_table.schema.metadata or {}),
+                                b"geo": json.dumps(geo_meta, ensure_ascii=False).encode("utf-8"),
+                            }
+                        )
+                        writer = pq.ParquetWriter(str(output_file_path), schema, compression="ZSTD")
+                    writer.write_table(row_group_table)
 
-        table = table.replace_schema_metadata(new_md)
-
-        logger.info("Writing final parquet file with metadata...")
-        pq.write_table(table, str(output_file_path), compression="ZSTD")
+            if writer is None:
+                # No rows in any batch (empty dataset) - still emit a valid, empty parquet
+                # file with the right schema and GeoParquet metadata rather than nothing.
+                schema = pq.ParquetFile(str(batch_paths[0])).schema_arrow.with_metadata(
+                    {b"geo": json.dumps(geo_meta, ensure_ascii=False).encode("utf-8")}
+                )
+                writer = pq.ParquetWriter(str(output_file_path), schema, compression="ZSTD")
+        finally:
+            if writer is not None:
+                writer.close()
 
     file_size = output_file_path.stat().st_size
     logger.info(f"✓ Created {output_file_path} ({file_size:,} bytes)")


### PR DESCRIPTION
## Problem

`output.parquet` has been empty (0 bytes) on every weekly run since 2026-02-17 (#14341, #16158). PR #16659 diagnosed and fixed the originally reported cause (DuckDB `memory_limit` too high, no headroom on the 8GB ECS Fargate task) but the failure has persisted on every run since that fix merged.

Confirmed via CloudWatch logs (`/ecs/atp-runallspiders`) that the process is still dying during the `COPY ... ORDER BY ST_Hilbert(geom)` step, ~3-4 seconds after it starts, with no Python traceback logged - consistent with an OS-level OOM kill, not a caught DuckDB exception. The dataset has grown to ~43M rows / 4818 spiders since the prior fix was sized, and a full-table `ORDER BY` has to materialize sort keys plus full row payloads (including variable-size `properties`/`dataset_attributes` maps) for the entire table at once.

Investigated whether a corrupt/pathological geometry was responsible (the run's bounding box was suspiciously exactly `(-180,-90,180,90)`), but scanning all 4818 per-spider GeoJSON files in a recent run's `output.zip` found no invalid coordinates - the global bbox is legitimate (McDonald's, Hertz, airports, etc. are genuinely worldwide datasets).

## Fix

**Bound sort memory with spatial batching:** instead of one `COPY ... ORDER BY ST_Hilbert(geom)` over the whole table, split it into ~2M row batches bucketed by contiguous ranges of the Hilbert curve value, sort/write each batch independently, then stream the batches into the final output one row group at a time via `pyarrow.parquet.ParquetWriter`. This also removes the previous `pq.read_table()`/`pq.write_table()` round trip (which itself required holding the whole ~2.8GB file in memory a second time just to attach GeoParquet metadata) in favor of streaming writes with metadata attached upfront.

Verified locally that this preserves data integrity (row counts, no duplicates) and spatial clustering quality (mean/median consecutive-point distance is effectively unchanged vs. the monolithic sort) on a synthetic 50k-row dataset forced into 5 batches.

**Fix invalid GeoParquet CRS metadata:** while testing, found that reading our own output back with DuckDB fails with `Invalid Input Error: Geoparquet column 'geom' has invalid CRS`. The script was writing `"crs": "EPSG:4326"`, but EPSG:4326 formally specifies **lat/lon** axis order, while our WKB geometries are stored **lon/lat** (standard GeoJSON/WKB convention) - a real mismatch that DuckDB correctly rejects. Per the GeoParquet spec, omitting the `crs` field defaults to `OGC:CRS84`, which is WGS84 with lon/lat axis order and matches our data. This bug predates this PR and is unrelated to the OOM issue, but was easy to fix alongside it.

Also handles the empty-dataset edge case (no rows) by emitting a valid empty parquet file with correct schema/metadata instead of erroring.