### PR TITLE
[Credicoop AR] Add spider

### DIFF
--- a/locations/spiders/credicoop_ar.py
+++ b/locations/spiders/credicoop_ar.py
@@ -1,0 +1,56 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+def valid_coordinates(latitude: str, longitude: str) -> tuple[float | None, float | None]:
+    # Some records carry empty, "0", or transposed coordinates; keep only points inside Argentina.
+    try:
+        lat, lon = float(latitude.replace(",", ".")), float(longitude.replace(",", "."))
+    except (AttributeError, ValueError):
+        return None, None
+    if -56.0 < lat < -21.0 and -74.0 < lon < -53.0:
+        return lat, lon
+    return None, None
+
+
+class CredicoopARSpider(Spider):
+    name = "credicoop_ar"
+    item_attributes = {"brand": "Credicoop", "brand_wikidata": "Q4854086"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # {items_per_page}/{page}: one oversized page returns every record.
+        yield JsonRequest(url="https://www.bancocredicoop.coop/api/filiales/Filiales/10000/1")
+        yield JsonRequest(
+            url="https://www.bancocredicoop.coop/api/cajeros/Cajeros/10000/1",
+            callback=self.parse_atm,
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for branch in response.json()["filiales"]:
+            item = DictParser.parse(branch)  # maps nombre (-> name), telefono (-> phone)
+            item["ref"] = branch["id_filial"]
+            item["branch"] = item.pop("name")
+            item["street_address"] = branch["domicilio"]
+            item["city"] = branch["localidad"]
+            item["state"] = branch["provincia"]
+            item["postcode"] = branch["codigo_postal"]
+            item["lat"], item["lon"] = valid_coordinates(branch["latitud"], branch["longitud"])
+            apply_yes_no(Extras.ATM, item, branch["cajero"] == "1")
+            apply_category(Categories.BANK, item)
+            yield item
+
+    def parse_atm(self, response: Response, **kwargs: Any) -> Any:
+        for atm in response.json()["cajeros"]:
+            item = DictParser.parse(atm)  # maps direccion (-> addr_full)
+            item["ref"] = atm["terminal"]
+            item["street_address"] = item.pop("addr_full", None)
+            item["city"] = atm["localidad"]
+            item["state"] = atm["provincia"]
+            item["lat"], item["lon"] = valid_coordinates(atm["latitud"], atm["longitud"])
+            apply_category(Categories.ATM, item)
+            yield item


### PR DESCRIPTION
Data source: https://www.bancocredicoop.coop/nuestrobanco/filiales and https://www.bancocredicoop.coop/nuestrobanco/cajeros (AngularJS locator).

API endpoints (GET JSON):

https://www.bancocredicoop.coop/api/filiales/Filiales/{itemsPerPage}/{page} → {"filiales": [...]} — 289 branches
https://www.bancocredicoop.coop/api/cajeros/Cajeros/{itemsPerPage}/{page} → {"cajeros": [...]} — 652 ATMs
A single oversized page (/10000/1) returns every record, so there's no pagination loop.

Category mapping:

filiales → Categories.BANK, tagged atm=yes where the branch's own on-site cajero flag is 1 (272 of 289 branches).
cajeros → Categories.ATM — standalone Credicoop ATM records, each with its own terminal id and coordinates.
ATM vs branch modelling (no duplication): branches and ATMs are two separate source feeds, so they're emitted as separate POIs , no deepcopy. 

Stats summary: 
941 items (289 bank + 652 atm), 
NSI match_perfect=941, 
country/AR=941 from spider name, 
0 errors. robots.txt allows all (User-Agent: *, no Disallow).

NSI notes: Q4854086 matches both the Credicoop amenity=bank and amenity=atm entries; ATMs receive operator=Credicoop from NSI. locationSet is AR-only , the site also has a Uruguay ATM feed, which is intentionally excluded (no NSI coverage for Credicoop outside AR).

Known limitations:

Opening hours skipped : the feed gives only a single daily open/close time (e.g. 10:00–15:00) with no weekday information, so a reliable OSM opening_hours can't be built; omitted rather than inventing Mo–Fr.
34 items have no geometry : 31 branches have empty coordinates, 1 branch has transposed lat/lon, 2 ATMs are at 0,0. These are validated out (0,0/out-of-Argentina never emitted); the items are still yielded with their full address.
No item-specific website :  the SPA has a /nuestrobanco/filiales/filial-{numero} route, but it isn't a verified stable deep link, so it's omitted rather than invented.
Phones kept : per-branch and all unique (286/286); ~128 are in local multi-line nnn/nnn format that the phone validator flags but are genuine branch numbers.

stats JSON
```
{
  "item_scraped_count": 941,
  "atp/category/amenity/bank": 289,
  "atp/category/amenity/atm": 652,
  "atp/nsi/match_perfect": 941,
  "atp/country/AR": 941,
  "atp/field/country/from_spider_name": 941,
  "atp/field/geometry/missing": 34,
  "atp/field/opening_hours/missing": 941,
  "finish_reason": "finished"
}
```

Sample POIs:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "143", "amenity": "bank", 
      "atm": "yes",
      "branch": "25 de Mayo",
      "addr:street_address": "Calle 29 Nro. 802", 
      "addr:city": "25 de Mayo",
      "addr:state": "Buenos Aires", 
      "addr:postcode": "6660", 
      "addr:country": "AR",
      "phone": "+54 2345 46-2713",
      "brand": "Credicoop", "brand:wikidata": "Q4854086"
    },
    "geometry": {"type": "Point", "coordinates": [-60.17011, -35.43302]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "127", "amenity": "bank", 
      "atm": "yes",
      "branch": "9 de Julio",
      "addr:street_address": "San Martín 1293", 
      "addr:city": "9 de Julio",
      "addr:state": "Buenos Aires", 
      "addr:postcode": "B6500EVV", 
      "addr:country": "AR",
      "phone": "+54 2317 43-0576",
      "brand": "Credicoop", "brand:wikidata": "Q4854086"
    },
    "geometry": {"type": "Point", "coordinates": [-60.88687, -35.44503]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "802431", 
      "amenity": "atm",
      "addr:street_address": "3 De Febrero 540", 
      "addr:city": "San Fernando",
      "addr:state": "Buenos Aires", 
      "addr:country": "AR",
      "brand": "Credicoop", 
      "brand:wikidata": "Q4854086",
      "operator": "Credicoop", 
      "operator:wikidata": "Q4854086"
    },
    "geometry": {"type": "Point", "coordinates": [-58.561507, -34.438392]}
  }
]
```