### PR TITLE
[Espaçolaser BR] Fix Spider

### DIFF
--- a/locations/spiders/espacolaser_br.py
+++ b/locations/spiders/espacolaser_br.py
@@ -1,36 +1,26 @@
-from locations.hours import DAYS, OpeningHours
-from locations.json_blob_spider import JSONBlobSpider
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
 
 
-class EspacolaserBRSpider(JSONBlobSpider):
+class EspacolaserBRSpider(SitemapSpider):
     name = "espacolaser_br"
     item_attributes = {
         "brand": "Espaçolaser",
         "brand_wikidata": "Q112326409",
     }
-    start_urls = [
-        "https://func-prd-ecom-svc-ecm-el.azurewebsites.net/api/espacolaser/pt-BR/GetEstablishments?lat=-34&lng=138&appChannel=ECM_SL_BRA&skip=0&code=0FRo43/d4a16aXUWaJIc0sTUK58L2jyZCat2VWG8P9IUEwguAmpzNw=="
-    ]
+    sitemap_urls = ["https://espacolaser.com.br/sitemap.xml"]
+    sitemap_rules = [("/unidade", "parse")]
 
-    def extract_json(self, response):
-        return response.json()["list"]
-
-    def post_process_item(self, item, response, location):
-        # {'Id': 488, 'FatherId': 379, 'Description': 'RS - PORTO ALEGRE - SARANDI ESPACOLASER', 'AddressLat': -29.9993391, 'AddressLng': -51.1312627,
-        # 'AppChannels': [{'channel': 'ECM_BRA'}, {'channel': 'LP_BRA'}, {'channel': 'APP_AGE'}, {'channel': 'ECM_SL_BRA'}, {'channel': 'ECM_AGE'}, {'channel': 'WPP_BRA'}],
-        # 'Address': {'PostalCode': '91130-720', 'Type': 'git digit ', 'Description': 'SERTÓRIO', 'StateAbrev': 'RS', 'City': 'PORTO ALEGRE',
-        # 'Neighborhood': 'SARANDI', 'Number': '8000', 'Complement': None}, 'SchedulerCalendarTime': [{'StartTime': '14:00', 'EndTime': '20:00', 'DaysOfWeek': [0]}, {'StartTime': '9:00', 'EndTime': '22:00', 'DaysOfWeek': [1, 2, 3, 4, 5, 6]}],
-        # 'Phones': [{'Number': '+55 (51) 30181484', 'Type': 'Commercial'}, {'Number': '+55 (51) 996440964', 'Type': 'WhatsappPhone'}],
-        # 'Resources': [{'Id': 3, 'Description': 'ALEXANDRITE', 'Inactive': False, 'IsEquipment': True, 'IsScheduler': False, 'Quantity': 1}],
-        # 'Emails': ['poa-centerlar@espacolaser.com.br'], 'SchedulerResourceClassifier': 2, 'MaximumNumberOfDaysForScheduling': 90}
-        item["email"] = location["Emails"][0]
-        item["lat"] = location["AddressLat"]
-        item["lon"] = location["AddressLng"]
-        item["phone"] = location["Phones"][0]["Number"]  # TODO: Make more robust to select type=Commercial
-
-        oh = OpeningHours()
-        for rule in location["SchedulerCalendarTime"]:
-            for day in rule["DaysOfWeek"]:
-                oh.add_range(DAYS[day], rule["StartTime"], rule["EndTime"])
-        item["opening_hours"] = oh
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["branch"] = response.xpath("//h1/text()").get()
+        item["street_address"] = response.xpath('//*[@class="col enderecos"]//p//text()').get()
+        item["ref"] = item["website"] = response.url
+        item["phone"] = response.xpath('//*[@class="col contatos"]//p//text()').get()
+        extract_google_position(item, response)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Espaçolaser': 805,
 'atp/brand_wikidata/Q112326409': 805,
 'atp/category/shop/beauty': 805,
 'atp/clean_strings/phone': 684,
 'atp/clean_strings/street_address': 704,
 'atp/country/BR': 805,
 'atp/field/branch/missing': 50,
 'atp/field/city/missing': 805,
 'atp/field/country/from_spider_name': 805,
 'atp/field/email/missing': 805,
 'atp/field/geometry/missing': 103,
 'atp/field/housenumber/missing': 805,
 'atp/field/opening_hours/missing': 805,
 'atp/field/operator/missing': 805,
 'atp/field/operator_wikidata/missing': 805,
 'atp/field/phone/invalid': 16,
 'atp/field/phone/missing': 129,
 'atp/field/postcode/missing': 805,
 'atp/field/state/missing': 805,
 'atp/field/street/missing': 805,
 'atp/field/street_address/missing': 101,
 'atp/field/twitter/missing': 805,
 'atp/field/unit/missing': 805,
 'atp/item_scraped_host_count/espacolaser.com.br': 805,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 805,
 'atp/nsi/match_imperfect': 805,
 'downloader/request_bytes': 383338,
 'downloader/request_count': 815,
 'downloader/request_method_count/GET': 815,
 'downloader/response_bytes': 41006789,
 'downloader/response_count': 815,
 'downloader/response_status_count/200': 807,
 'downloader/response_status_count/404': 8,
 'elapsed_time_seconds': 1078.579000000027,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 8, 6, 23, 10, 258379, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 558156297,
 'httpcompression/response_count': 814,
 'httperror/response_ignored_count': 8,
 'httperror/response_ignored_status_count/404': 8,
 'item_scraped_count': 805,
 'items_per_minute': 44.80519480519481,
 'log_count/DEBUG': 1620,
 'log_count/INFO': 29,
 'request_depth_max': 1,
 'response_received_count': 815,
 'responses_per_minute': 45.3617810760668,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 814,
 'scheduler/dequeued/memory': 814,
 'scheduler/enqueued': 814,
 'scheduler/enqueued/memory': 814,
 'start_time': datetime.datetime(2026, 7, 8, 6, 5, 11, 666154, tzinfo=datetime.timezone.utc)}
```