### PR TITLE
[BBVA Argentina AR] Add spider

### DIFF
--- a/locations/spiders/bbva_ar.py
+++ b/locations/spiders/bbva_ar.py
@@ -1,0 +1,47 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class BbvaARSpider(Spider):
+    name = "bbva_ar"
+    item_attributes = {"brand": "BBVA Argentina", "brand_wikidata": "Q2876788"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}  # the API returns HTTP 403 to non-browser user agents
+    requires_proxy = "AR"  # Akamai also blocks data-centre IPs (CI fetch gets HTTP 403); needs an AR proxy
+
+    async def start(self) -> AsyncIterator[Any]:
+        # Country-wide radius from Buenos Aires returns all branches at once; branchType filters to public
+        # retail branches (COMPANIES/CORPORATE are administrative units co-located at head office). The API
+        # exposes no ATMs (branchType=ATM and /pois/v0/atms are both empty).
+        yield JsonRequest(
+            url="https://servicios.bbva.com.ar/openmarket/servicios/pois/v0/branches"
+            "?latitude=-34.6037345&longitude=-58.3837591&radius=5000000&branchType=INDIVIDUALS,INTEGRAL"
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for branch in response.json()["data"]:
+            item = DictParser.parse(branch)  # maps id (-> ref), city, zipCode (-> postcode)
+            item.pop("state", None)  # address.state duplicates city (locality name, not a province)
+            item.pop("phone", None)  # telephone has no area code (6-8 local digits), not a dialable number
+            item["branch"] = branch["description"]
+            item["street_address"] = branch["address"]["addressName"]
+            item["lat"] = branch["address"]["geolocation"]["latitude"]
+            item["lon"] = branch["address"]["geolocation"]["longitude"]
+            item["opening_hours"] = self.parse_opening_hours(branch["openingHours"])
+            apply_category(Categories.BANK, item)
+            yield item
+
+    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours | None:
+        try:
+            oh = OpeningHours()
+            for rule in rules:
+                oh.add_range(rule["dayOfWeek"], rule["from"], rule["to"], time_format="%H:%M:%S")
+            return oh
+        except (KeyError, ValueError):
+            return None


### PR DESCRIPTION
Data source: https://buscador.bbva.com.ar/buscadordecajerosysucursales/

API endpoint (GET JSON):

https://servicios.bbva.com.ar/openmarket/servicios/pois/v0/branches?latitude=-34.6037345&longitude=-58.3837591&radius=5000000&branchType=INDIVIDUALS,INTEGRAL
A single proximity query centred on Buenos Aires with a country-wide radius returns all 225 branches (no pagination). Coverage is nationwide (verified Tierra del Fuego → Jujuy), so this is the complete branch set.

Category mapping: all records → Categories.BANK (225: 223 INTEGRAL + 2 INDIVIDUALS).

Fields: ref=id, branch=description, addr:street_address=address.addressName, addr:city=address.city, addr:postcode=address.zipCode, lat/lon=address.geolocation, opening_hours from the structured openingHours (weekday + from/to; e.g. Mo-Fr 10:00-15:00, 9 distinct patterns).

Notes / decisions:

DictParser used, then corrected: address.state is dropped — it duplicates city (both hold the locality; 134 identical values, state.id always 0) and is not a real province.
phone omitted: the telephone values are area-code-less local fragments (6–8 digits) reusing head-office switchboard prefixes across cities — not dialable per-branch numbers — so they're dropped rather than emitted as invalid contact data.
ATMs: none exposed. /pois/v0/atms → 404, branchType=ATM → empty, atmsInBranch empty on every branch, and the unfiltered feed contains only branch types. Branch-only by necessity — no atm=yes inferred, no ATM POIs fabricated.
branchType=INDIVIDUALS,INTEGRAL: limits to the 225 public retail branches. The 6 COMPANIES/CORPORATE records are internal head-office units (4 share identical coordinates + phone), so including them would create co-located duplicate POIs — excluded intentionally.
Proxy / UA: the API 403s non-browser UAs and its Akamai WAF blocks datacenter IPs → USER_AGENT=BROWSER_DEFAULT + requires_proxy="AR" (same pattern as Pathé NL). Fetch validated on CI.
NSI: Q2876788 = BBVA Argentina, AR-only; the branch entry provides name.

Sample POI:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1", 
      "amenity": "bank", 
       "branch": "ASAMBLEA",
      "addr:street_address": "AV. ASAMBLEA 695", 
       "addr:city": "CAPITAL FEDERAL",
      "addr:postcode": "1424", 
      "addr:country": "AR",
      "opening_hours": "Mo-Fr 10:00-15:00",
      "brand": "BBVA Argentina", 
      "brand:wikidata": "Q2876788"
    },
    "geometry": {"type": "Point", "coordinates": [-58.434905, -34.634342]}
  }
]
```

Stats (expected, from offline parse of the captured response — authoritative stats will come from the CI fetch, since the live fetch is Akamai-blocked locally):
```
{
  "item_scraped_count": 225,
  "atp/category/amenity/bank": 225,
  "atp/field/opening_hours/missing": 0,
  "atp/field/geometry/missing": 0,
  "atp/field/country/from_spider_name": 225,
  "atp/nsi/match_perfect": 225
}
```
