### PR TITLE
[Fishbowl AU] Fix Spider

### DIFF
--- a/locations/spiders/fishbowl_au.py
+++ b/locations/spiders/fishbowl_au.py
@@ -1,29 +1,26 @@
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from typing import Iterable
 
+from scrapy.http import TextResponse
+
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class FishbowlAUSpider(Spider):
+class FishbowlAUSpider(JSONBlobSpider):
     name = "fishbowl_au"
     item_attributes = {"brand": "Fishbowl", "brand_wikidata": "Q110785465"}
-    allowed_domains = ["fishbowl.com.au", "api.mapbox.com"]
-    start_urls = ["https://fishbowl.com.au/assets/js/main.js"]
+    start_urls = ["https://storemapper-herokuapp-com.global.ssl.fastly.net/api/users/38415-rW5LvC1Cy7c6N3Jf/stores.js"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    locations_key = "stores"
 
-    def parse(self, response):
-        features_url = response.text.split('const t="', 1)[1].split('"', 1)[0]
-        yield JsonRequest(url=features_url, callback=self.parse_locations)
-
-    def parse_locations(self, response):
-        for location in response.json()["features"]:
-            properties = {
-                "ref": location["id"],
-                "name": location["properties"]["title"],
-                "addr_full": location["properties"]["place_name"],
-                "lat": location["geometry"]["coordinates"][1],
-                "lon": location["geometry"]["coordinates"][0],
-                "state": location["properties"]["state"].upper(),
-                "image": location["properties"]["img"],
-            }
-            yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").replace("FISHBOWL - ", "")
+        oh = OpeningHours()
+        for day_time in feature.get("store_business_hours", []):
+            day = DAYS_FULL[int(day_time.get("week_day")) - 1]
+            open_time = day_time.get("open_time")
+            close_time = day_time.get("close_time")
+            oh.add_range(day=day, open_time=open_time, close_time=close_time)
+        item["opening_hours"] = oh
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Fishbowl': 59,
 'atp/brand_wikidata/Q110785465': 59,
 'atp/category/amenity/fast_food': 59,
 'atp/country/AU': 59,
 'atp/field/city/missing': 59,
 'atp/field/country/from_spider_name': 59,
 'atp/field/email/missing': 59,
 'atp/field/housenumber/missing': 59,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 59,
 'atp/field/operator_wikidata/missing': 59,
 'atp/field/phone/missing': 59,
 'atp/field/postcode/missing': 59,
 'atp/field/state/missing': 59,
 'atp/field/street/missing': 59,
 'atp/field/street_address/missing': 59,
 'atp/field/twitter/missing': 59,
 'atp/field/unit/missing': 59,
 'atp/item_scraped_host_count/storemapper-herokuapp-com.global.ssl.fastly.net': 59,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 59,
 'atp/nsi/match_imperfect': 59,
 'downloader/request_bytes': 397,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 10456,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 4.5310000000172295,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 8, 10, 8, 0, 397372, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 123586,
 'httpcompression/response_count': 1,
 'item_scraped_count': 59,
 'items_per_minute': 885.0,
 'log_count/DEBUG': 60,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 15.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 8, 10, 7, 55, 862207, tzinfo=datetime.timezone.utc)}
```