### PR TITLE
[AED defibrillators JP] fix to only request current locations

### DIFF
--- a/locations/spiders/aed_jp.py
+++ b/locations/spiders/aed_jp.py
@@ -1,7 +1,7 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -9,25 +9,20 @@ from locations.dict_parser import DictParser
 
 class AedJPSpider(Spider):
     name = "aed_jp"
-
     custom_settings = {"DOWNLOAD_TIMEOUT": 60}
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield self.get_page(1)
-
-    def get_page(self, n):
-        return Request(
-            f"https://www.qqzaidanmap.jp/api/aed/list?limit=200&page={n}",
-            meta={"page": n},
+    def make_request(self, rank: str, page: int, limit: int = 200) -> JsonRequest:
+        return JsonRequest(
+            url=f"https://www.qqzaidanmap.jp/api/aed/list?aed[install_prefecture_id]=&aed[install_address]=&aed[install_location_name]=&aed[rank]={rank}&limit={limit}&aed[install_type_id][]=&page={page}",
+            cb_kwargs=dict(rank=rank, page=page),
         )
 
-    def parse(self, response):
-        data = response.json()
-        aeds = data["aeds"]
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for rank in ["A", "B", "C", "D"]:
+            yield self.make_request(rank, 1)
 
-        for aed in aeds:
-            if aed["rank"] == "E":  # removes AEDs older than 8 years.
-                continue
+    def parse(self, response: Response, rank: str, page: int) -> Any:
+        for aed in response.json()["aeds"]:
             item = DictParser.parse(aed)
             item["ref"] = aed["id"]
             item["lat"] = aed["location"]["latitude"]
@@ -43,5 +38,5 @@ class AedJPSpider(Spider):
 
             yield item
 
-        if data["pages"]["current_page"] < data["pages"]["total_pages"]:
-            yield self.get_page(1 + response.meta["page"])
+        if page < response.json()["pages"]["total_pages"]:
+            yield self.make_request(rank, page + 1)


### PR DESCRIPTION
This was done earlier by throwing away rank E (older than 8 years) values but I figured out how to specifically request only rank A-D ones. Should run much faster now. Below is a test with 3 pages for each type.

{'atp/category/emergency/defibrillator': 2400,
 'atp/clean_strings/name': 62,
 'atp/clean_strings/street_address': 2,
 'atp/country/JP': 2400,
 'atp/field/branch/missing': 2400,
 'atp/field/brand/missing': 2400,
 'atp/field/brand_wikidata/missing': 2400,
 'atp/field/city/missing': 2400,
 'atp/field/country/from_spider_name': 2400,
 'atp/field/email/missing': 2400,
 'atp/field/housenumber/missing': 2400,
 'atp/field/opening_hours/missing': 2400,
 'atp/field/operator/missing': 2400,
 'atp/field/operator_wikidata/missing': 2400,
 'atp/field/phone/missing': 2400,
 'atp/field/postcode/missing': 2400,
 'atp/field/state/missing': 2400,
 'atp/field/street/missing': 2400,
 'atp/field/twitter/missing': 2400,
 'atp/field/unit/missing': 2400,
 'atp/item_scraped_host_count/www.qqzaidanmap.jp': 2400,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 2400,
 'atp/nsi/match_failed': 2400,
 'downloader/request_bytes': 9224,
 'downloader/request_count': 13,
 'downloader/request_method_count/GET': 13,
 'downloader/response_bytes': 2821736,
 'downloader/response_count': 13,
 'downloader/response_status_count/200': 13,
 'elapsed_time_seconds': 84.70299999997951,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 9, 2, 2, 41, 338957, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 2400,
 'items_per_minute': 1714.2857142857144,
 'log_count/DEBUG': 2413,
 'log_count/INFO': 4,
 'request_depth_max': 2,
 'response_received_count': 13,
 'responses_per_minute': 9.285714285714286,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 12,
 'scheduler/dequeued/memory': 12,
 'scheduler/enqueued': 12,
 'scheduler/enqueued/memory': 12,
 'start_time': datetime.datetime(2026, 7, 9, 2, 1, 16, 644142, tzinfo=datetime.timezone.utc)}