### PR TITLE
[Ziko Apteka PL] Fix spider

### DIFF
--- a/locations/spiders/ziko_apteka_pl.py
+++ b/locations/spiders/ziko_apteka_pl.py
@@ -21,6 +21,12 @@ class ZikoAptekaPLSpider(JSONBlobSpider):
             # The endpoint returns 403 unless a same-site Referer is supplied.
             yield JsonRequest(url=url, headers={"Referer": "https://zikoapteka.pl/apteki"})
 
+    def pre_process_data(self, location: dict) -> None:
+        # Some records use a comma as the decimal separator in coordinates.
+        for key in ("lat", "lng"):
+            if isinstance(location.get(key), str):
+                location[key] = location[key].replace(",", ".")
+
     def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
         item["ref"] = location["mypostid"]
         item["city"] = location["city_name"][0]

--- a/locations/spiders/ziko_apteka_pl.py
+++ b/locations/spiders/ziko_apteka_pl.py
@@ -1,34 +1,44 @@
 import re
-from typing import AsyncIterator
+from typing import AsyncIterator, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, TextResponse
 
-from locations.dict_parser import DictParser
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_PL, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class ZikoAptekaPLSpider(Spider):
+class ZikoAptekaPLSpider(JSONBlobSpider):
     name = "ziko_apteka_pl"
     item_attributes = {"brand": "Ziko Apteka", "brand_wikidata": "Q63432892"}
     allowed_domains = ["zikoapteka.pl"]
     start_urls = ["https://zikoapteka.pl/wp-admin/admin-ajax.php?action=get_pharmacies"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
-            yield JsonRequest(url=url)
+            # The endpoint returns 403 unless a same-site Referer is supplied.
+            yield JsonRequest(url=url, headers={"Referer": "https://zikoapteka.pl/apteki"})
 
-    def parse(self, response):
-        for location in response.json().values():
-            item = DictParser.parse(location)
-            item["ref"] = location["mypostid"]
-            item["city"] = location["city_name"][0]
-            item.pop("state", None)
-            if location.get("link"):
-                item["website"] = "https://zikoapteka.pl/apteki" + location["link"] + "/"
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(
-                re.sub(r"\s+", " ", location["hours"].replace(".", "")), days=DAYS_PL
-            )
-            item["street_address"] = item.pop("addr_full", None)
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
+        item["ref"] = location["mypostid"]
+        item["city"] = location["city_name"][0]
+        item.pop("state", None)
+        if location.get("link"):
+            item["website"] = "https://zikoapteka.pl/apteki" + location["link"] + "/"
+        item["opening_hours"] = OpeningHours()
+        # drop the qualifier so "niedziela" is read as Sunday.
+        item["opening_hours"].add_ranges_from_string(
+            re.sub(
+                r"\s+",
+                " ",
+                re.sub(r"niehandlowa|handlowa", "", location["mp_pharmacy_hours"].replace("<br>", " ")).replace(
+                    ".", ""
+                ),
+            ),
+            days=DAYS_PL,
+        )
+        item["street_address"] = item.pop("addr_full", None)
+        apply_category(Categories.PHARMACY, item)
+        yield item


### PR DESCRIPTION
```
{'atp/brand/Ziko Apteka': 207,
 'atp/brand_wikidata/Q63432892': 207,
 'atp/category/amenity/pharmacy': 207,
 'atp/category/multiple': 207,
 'atp/clean_strings/lat': 1,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/street_address': 9,
 'atp/country/PL': 207,
 'atp/field/branch/missing': 207,
 'atp/field/country/from_spider_name': 207,
 'atp/field/email/missing': 207,
 'atp/field/housenumber/missing': 207,
 'atp/field/operator/missing': 207,
 'atp/field/operator_wikidata/missing': 207,
 'atp/field/phone/missing': 207,
 'atp/field/postcode/missing': 207,
 'atp/field/state/missing': 207,
 'atp/field/street/missing': 207,
 'atp/field/twitter/missing': 207,
 'atp/field/unit/missing': 207,
 'atp/item_scraped_host_count/zikoapteka.pl': 207,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 207,
 'downloader/request_bytes': 420,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 19042,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.828000000000088,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 9, 7, 20, 16, 96748, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 364205,
 'httpcompression/response_count': 1,
 'item_scraped_count': 207,
 'items_per_minute': 6210.0,
 'log_count/DEBUG': 208,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 9, 7, 20, 13, 274747, tzinfo=datetime.timezone.utc)}
```