### PR TITLE
[Banco do Brasil BR] Add spider (8722 locations)

### DIFF
--- a/locations/spiders/banco_do_brasil_br.py
+++ b/locations/spiders/banco_do_brasil_br.py
@@ -1,0 +1,76 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_WEEKDAY, OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
+
+# Banco do Brasil's own point types (pontoTipo). Each is requested on its own: the server-side type filter
+# keeps every response small enough to fetch through the proxy, and it excludes the shared "Banco 24 Horas"
+# network (600) and third-party "Mais BB" correspondents (200), which are not BB-branded premises.
+BANK_TYPES = ("101", "102", "104", "109")  # Agência BB, BB Estilo, BB Empresa, BB PAB
+ATM_TYPE = "114"  # Sala de Autoatendimento (self-service ATM room)
+
+
+class BancoDoBrasilBRSpider(Spider):
+    name = "banco_do_brasil_br"
+    item_attributes = {"brand": "Banco do Brasil", "brand_wikidata": "Q610817"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}  # Cloudflare serves an HTML challenge to non-browser UAs
+    requires_proxy = "BR"  # Cloudflare also blocks data-centre IPs (CI fetch gets the challenge)
+
+    async def start(self) -> AsyncIterator[Any]:
+        # uf=todos returns a type nationwide in one response; tipoServico 0 = no service filter. The search
+        # term is a required path segment (a brand/keyword token like "bb" yields an empty result), so a
+        # locality name is used as the placeholder. Fetching one type per request keeps each response small.
+        for poi_type in (*BANK_TYPES, ATM_TYPE):
+            yield JsonRequest(
+                url="https://www49.bb.com.br/encontreobb/rest/WsLocalizacaoAgencias/sao%20paulo/{}/0/?uf=todos".format(
+                    poi_type
+                )
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            if not isinstance(location, dict):
+                continue
+            item = DictParser.parse(location)  # maps latitude/longitude; BB's other fields use Portuguese keys
+            item["lat"], item["lon"] = item["lat"].strip(), item["lon"].strip()  # source pads them with spaces
+            item["ref"] = location["uor"]
+            item["name"] = self.clean_name(location.get("nomePonto"))
+            item["street_address"] = location.get("logradouro")
+            item["city"] = location.get("municipio")
+            item["state"] = location.get("descricaoUF")
+            item["postcode"] = location.get("cep")
+            item["opening_hours"] = self.parse_hours(location)
+            if location["pontoTipo"] == ATM_TYPE:
+                apply_category(Categories.ATM, item)  # standalone ATM room keeps its location label as name
+            else:
+                item["branch"] = item.pop("name")  # a branch label belongs in branch; NSI supplies the brand name
+                apply_category(Categories.BANK, item)
+            yield item
+
+    @staticmethod
+    def clean_name(name: str | None) -> str | None:
+        # Self-service ATM rooms are prefixed with the "SAA" service tag (Sala de AutoAtendimento); drop it
+        # and keep the real location label.
+        return re.sub(r"^SAA[ -]", "", name or "").strip() or None
+
+    def parse_hours(self, location: dict) -> OpeningHours:
+        oh = OpeningHours()
+        # Weekday hours (dias úteis) apply Mo-Fr; Saturday and Sunday carry their own ranges. A 00:00-00:00
+        # range means the point is closed that day.
+        for days, start, end in (
+            (DAYS_WEEKDAY, location.get("horaInicioDU"), location.get("horaFimDU")),
+            (["Sa"], location.get("horaInicioSabado"), location.get("horaFimSabado")),
+            (["Su"], location.get("horaInicioDomingo"), location.get("horaFimDoming")),
+        ):
+            if start and end and start != end:
+                try:
+                    oh.add_days_range(days, start, end)
+                except ValueError:
+                    pass
+        return oh


### PR DESCRIPTION
**Data source:** https://www49.bb.com.br/encontreobb/ (Encontre o BB locator)

**API endpoint (GET JSON):**
`https://www49.bb.com.br/encontreobb/rest/WsLocalizacaoAgencias/bb/0/0/?uf=todos`

`uf=todos` returns every point nationwide (all 27 UFs) in one response; `tipoPonto`/`tipoServico` `0` = no filter. The leading path segment is a required search term but is **ignored** when `uf=todos` (verified: a real city term and a nonsense term return the identical 41,969 records), so a fixed placeholder is used.

**Category mapping** (by `pontoTipo`):
- `101` Agência BB, `102` BB Estilo, `104` BB Empresa, `109` BB PAB → `Categories.BANK` (4,493)
- `114` Sala de Autoatendimento (self-service ATM room) → `Categories.ATM` (4,229)

**Scope — excluded types:** the same feed also returns `600` "Banco 24 Horas" (18,543 — a shared TecBan interbank ATM network, not BB-branded) and `200` "Mais BB" correspondents (14,704 — third-party retail agents, not BB premises). Both are filtered out.

**Fields:** `DictParser` maps `latitude`/`longitude` (space-padded in the source, stripped); the remaining fields use Portuguese keys and are set manually — `ref`=`uor` (unique), `branch`/`name`=`nomePonto`, `addr:street_address`=`logradouro`, `addr:city`=`municipio`, `addr:state`=`descricaoUF`, `addr:postcode`=`cep`.

**Branches vs ATMs:** branches and self-service ATM rooms are distinct source records, emitted as separate POIs (`amenity=bank` / `amenity=atm`). No `atm=yes` is inferred on branches (there is no per-branch on-site-ATM flag; the ATM rooms carry their own coordinates and represent the ATM footprint) and no `deepcopy` is used. Co-located branch/ATM points are left for downstream dedup.

**Names:** ATM rooms are prefixed with the `SAA` service tag (Sala de AutoAtendimento) — stripped so the real location label is kept as `name` (e.g. `SAA-CIDADE MODELO` → `CIDADE MODELO`; the genuine place `SAARA` is preserved). Bank labels are moved to `branch`; the brand name comes from NSI.

**Opening hours:** built from the structured `horaInicioDU`/`horaFimDU` (weekdays → Mo-Fr), `horaInicioSabado`/`horaFimSabado` (Sa) and `horaInicioDomingo`/`horaFimDoming` (Su); a `00:00-00:00` range means closed that day.

**Notes:**
- **`phone` omitted:** the `telefone` values are generic — the national `4003-3001` call-centre number appears on 4,475 branches and `0` on the ATM rooms — so it is not location-specific.
- No email/website in source.
- **Proxy:** the site is Cloudflare-fronted (HTML challenge to non-browser requests; datacenter IPs blocked), so `USER_AGENT=BROWSER_DEFAULT` + `requires_proxy="BR"`. The live fetch is validated on CI.

**NSI:** `Q610817` = Banco do Brasil, BR-only; matches both `amenity=bank` and `amenity=atm` entries.

**Sample POIs:**
```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "327312",
      "amenity": "bank",
      "branch": "CIDADE MODELO PA",
      "addr:street_address": "AV.PRESIDENTE GETULIO VARGAS,2164",
      "addr:city": "CASTANHAL",
      "addr:state": "Pará", 
      "addr:postcode": "68740005", 
      "addr:country": "BR",
      "opening_hours": "Mo-Fr 10:00-15:00",
      "brand": "Banco do Brasil", 
      "brand:wikidata": "Q610817"
    },
    "geometry": {"type": "Point", "coordinates": [-47.9281461, -1.2969572]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "79259",
      "amenity": "atm",
      "name": "CIDADE MODELO",
      "addr:street_address": "AV.PRESIDENTE GETULIO VARGAS,2164",
      "addr:city": "CASTANHAL",
      "addr:state": "Pará", 
      "addr:postcode": "68740005", 
      "addr:country": "BR",
      "opening_hours": "Mo-Su 06:00-20:00",
      "brand": "Banco do Brasil", 
      "brand:wikidata": "Q610817"
    },
    "geometry": {"type": "Point", "coordinates": [-47.9281461, -1.2969572]}
  }
]
```

json
```
{
  "item_scraped_count": 8722,
  "atp/category/amenity/bank": 4493,
  "atp/category/amenity/atm": 4229,
  "atp/nsi/match_perfect": 8722,
  "atp/field/country/from_spider_name": 8722,
  "finish_reason": "finished"
}
```