### PR TITLE
[Cenex] Fix spider

### DIFF
--- a/locations/spiders/cenex.py
+++ b/locations/spiders/cenex.py
@@ -1,64 +1,62 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class CenexSpider(Spider):
+class CenexSpider(JSONBlobSpider):
     name = "cenex"
     item_attributes = {"brand": "Cenex", "brand_wikidata": "Q62127191"}
+    locations_key = "Locations"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
             "https://www.cenex.com/chs-sitecore/api/locationsearch/search",
             method="POST",
             data={
-                "SearchLat": 0,
-                "SearchLong": 0,
-                "LocationTypes": [1, 16, 15],
+                "Bounds": {
+                    "NorthEast": {"Latitude": 90, "Longitude": 180},
+                    "SouthWest": {"Latitude": -90, "Longitude": -180},
+                },
+                "LocationTypes": [1, 2, 4, 8],
                 "Amenities": [],
-                "Organizations": ["28e93e82-edfa-418e-90aa-7ded057a0c68"],
-                "NELat": 90,
-                "NELong": 180,
-                "SWLat": -90,
-                "SWLong": -180,
             },
         )
 
-    def parse(self, response):
-        for store in response.json()["Locations"]:
-            amenities = [a["Name"] for a in store["Amenities"]]
-            item = Feature(
-                lon=store["Long"],
-                lat=store["Lat"],
-                ref=store["Id"],
-                name=store["Name"],
-                addr_full=store["Address"],
-                country="US",
-                phone=store["Phone"],
-                opening_hours="24/7" if "24-hour fueling" in amenities else None,
-            )
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Iterable[Feature]:
+        types = feature["Types"].split("|")
+        if "GasStation" not in types and "PremiumDiesel" not in types:
+            return  # Bulk lubricant/propane co-op dealers, not fuel stations
 
-            apply_category(Categories.FUEL_STATION, item)
-            apply_yes_no(Extras.ATM, item, "ATM" in amenities)
-            apply_yes_no(Extras.COMPRESSED_AIR, item, "Air" in amenities)
-            apply_yes_no(Fuel.BIODIESEL, item, "Biodiesel" in amenities)
-            apply_yes_no(Extras.CAR_WASH, item, "Car wash" in amenities)
-            # "Cenex® Lubricants"
-            apply_yes_no(Fuel.DIESEL, item, "Cenex® premium diesel fuel" in amenities)
-            apply_yes_no("shop=yes", item, "Convenience store" in amenities)
-            # "DEF Available"
-            apply_yes_no(Fuel.DIESEL, item, "Diesel fuel" in amenities)
-            apply_yes_no(Fuel.E85, item, "Flex fuels" in amenities)
-            # "Made Fresh Foods"
-            # "No Inside Services"
-            apply_yes_no(Fuel.PROPANE, item, "Propane cylinder filling or exchange" in amenities)
-            apply_yes_no("food=yes", item, "Restaurant" in amenities)
-            apply_yes_no("hgv", item, "Truck stop" in amenities)
-            apply_yes_no(Fuel.HGV_DIESEL, item, "Truck stop" in amenities)
-            apply_yes_no(Extras.WIFI, item, "Wi-Fi" in amenities)
+        item["country"] = "US"
+        amenities = [a["Name"] for a in feature["Amenities"]]
 
-            yield item
+        apply_category(Categories.FUEL_STATION, item)
+        apply_yes_no(Extras.ATM, item, "ATM" in amenities)
+        apply_yes_no(Extras.COMPRESSED_AIR, item, "Free Air" in amenities)
+        apply_yes_no(Extras.CAR_WASH, item, "Car Wash" in amenities)
+        apply_yes_no(Fuel.DIESEL, item, "Diesel Fuel" in amenities or "PremiumDiesel" in types)
+        apply_yes_no(Fuel.HGV_DIESEL, item, "PremiumDiesel" in types)
+        apply_yes_no(Fuel.ETHANOL_FREE, item, "Ethanol-free Gas" in amenities)
+        apply_yes_no(Fuel.PROPANE, item, "Propane" in amenities)
+        apply_yes_no(
+            "food=yes",
+            item,
+            any(
+                a in amenities
+                for a in [
+                    "Beer",
+                    "Chicken Restaurant",
+                    "Coffee Shop",
+                    "Donuts",
+                    "Fast Food Restaurant",
+                    "Pizza Takeaway",
+                    "Sandwich Shop",
+                ]
+            ),
+        )
+
+        yield item


### PR DESCRIPTION
The store-locator API changed its request/response schema, so the spider
stopped yielding: the search now takes a nested Bounds object and
LocationTypes bitmask values, and returns coordinates under a nested
Coordinates object.

- Remap the request payload and coordinate/amenity parsing to the current API.
- Rework onto JSONBlobSpider so DictParser handles the core fields.
- Restrict output to fuel stations (Types GasStation/PremiumDiesel), dropping
  bulk lubricant/propane co-op dealers.
- Tag Cenex premium diesel as diesel + HGV diesel.

1479 fuel stations, all with coordinates.