### PR TITLE
[Pep] Fix spider

### DIFF
--- a/locations/spiders/pep.py
+++ b/locations/spiders/pep.py
@@ -5,6 +5,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, sanitise_day
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -14,16 +15,16 @@ class PepSpider(Spider):
     name = "pep"
     start_urls = ["https://www.pepstores.com/cdn/shop/t/6/assets/env.js"]
     brands = {
-        "PEP": ("PEP", "Q7166182"),
-        "PEP Cell": ("PEP Cell", "Q128802743"),
-        "PEP Home": ("PEP Home", "Q128802022"),
+        "PEP Cell": ("PEP Cell", "Q128802743", Categories.SHOP_MOBILE_PHONE),
+        "PEP Home": ("PEP Home", "Q128802022", Categories.SHOP_HOUSEWARE),
+        "PEP": ("PEP", "Q7166182", Categories.SHOP_CLOTHES),
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         if api_key := re.search(r"middleware_api_key=\"(.+?)\"", response.text):
             token = api_key.group(1)
             yield JsonRequest(
-                url="https://pep.commercebridge.tech/rest/v1/store/locator?limit=10000",
+                url="https://ecom.pep.commercebridge.tech/rest/v1/store/locator?limit=10000",
                 headers={
                     "Authorization": f"Bearer {token}",
                 },
@@ -35,15 +36,18 @@ class PepSpider(Spider):
             item = DictParser.parse(location)
             item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
 
-            if not location.get("latitude") and not item["street_address"]:  # Not enough address info
+            if not location.get("latitude") and not item["street_address"]:
                 continue
 
-            # Not unique to the POI
             item.pop("image", None)
             item.pop("email", None)
 
-            item["brand"], item["brand_wikidata"] = self.brands.get(location["brand"].strip()) or self.brands["PEP"]
+            raw_brand = location["brand"].strip()
+            item["brand"], item["brand_wikidata"], category = next(
+                (v for prefix, v in self.brands.items() if raw_brand.startswith(prefix)), self.brands["PEP"]
+            )
             item["branch"] = item.pop("name").replace(item["brand"], "").strip()
+            apply_category(category, item)
 
             item["opening_hours"] = OpeningHours()
             if hours_text := location.get("openingHours") or location.get("opening_hours"):


### PR DESCRIPTION
The store locator API moved host, so the spider stopped yielding, and the
source brand values had gained a country suffix ("PEP Cell South Africa"),
which collapsed every sub-brand to the default PEP.

- Re-point to the ecom.pep.commercebridge.tech host.
- Match the brand by prefix so PEP Cell and PEP Home are recognised again
  across all five countries.

2789 stores across ZA, NA, BW, LS and SZ.