### PR TITLE
[República UY] Add spider

### DIFF
--- a/locations/spiders/republica_uy.py
+++ b/locations/spiders/republica_uy.py
@@ -25,7 +25,7 @@ class RepublicaUYSpider(ArcGISFeatureServerSpider):
         item["state"] = feature.get("DEPARTAMENTO")
         # LOCAL is prefixed with an internal point number (e.g. "001-AIGUA", "179 - AG..."); keep the label.
         item["name"] = re.sub(r"^\d+\s*-\s*", "", feature.get("LOCAL") or "").strip() or None
-        if "SUC" in feature["TIPO"]:
+        if "SUC" in feature.get("TIPO", ""):
             item["branch"] = item.pop("name")  # branch label belongs in branch; NSI supplies the brand name
             apply_category(Categories.BANK, item)
         else:  # self-service ATM island keeps its location label as name

--- a/locations/spiders/republica_uy.py
+++ b/locations/spiders/republica_uy.py
@@ -1,0 +1,33 @@
+import re
+from typing import Iterable
+
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
+
+
+class RepublicaUYSpider(ArcGISFeatureServerSpider):
+    name = "republica_uy"
+    item_attributes = {"brand": "República", "brand_wikidata": "Q4077337"}
+    host = "services8.arcgis.com"
+    context_path = "L7tmljogVEu5CMWs/arcgis"
+    service_id = "Servicios_RedBROU"
+    layer_id = "0"
+    # The layer also lists third-party correspondent networks (REDPAGOS, ABITAB, SCANNTECH, URUPAGO); keep
+    # only BROU's own branches (TIPO ends "SUC") and self-service ATM islands (TIPO ends "ISLA").
+    where_query = "TIPO LIKE '%SUC' OR TIPO LIKE '%ISLA'"
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full", None)  # DIRECCION is the street line only
+        item["city"] = feature.get("LOCALIDAD")
+        item["state"] = feature.get("DEPARTAMENTO")
+        # LOCAL is prefixed with an internal point number (e.g. "001-AIGUA", "179 - AG..."); keep the label.
+        item["name"] = re.sub(r"^\d+\s*-\s*", "", feature.get("LOCAL") or "").strip() or None
+        if "SUC" in feature["TIPO"]:
+            item["branch"] = item.pop("name")  # branch label belongs in branch; NSI supplies the brand name
+            apply_category(Categories.BANK, item)
+        else:  # self-service ATM island keeps its location label as name
+            apply_category(Categories.ATM, item)
+        yield item


### PR DESCRIPTION
Banco República (BROU), Uruguay — brand `República` (`Q4077337`, UY-only in NSI; both `amenity=bank` and `amenity=atm`).

**Data source:** https://www.brou.com.uy/institucional/red-fisica/mapa (BROU "Red Física" ArcGIS web app).

**API (ArcGIS Feature Server):**
`https://services8.arcgis.com/L7tmljogVEu5CMWs/arcgis/rest/services/Servicios_RedBROU/FeatureServer/0`
Scraped via the repo's `ArcGISFeatureServerSpider` storefinder helper (which runs `DictParser.parse` on each feature and auto-paginates). The layer holds 1,921 features total.

**Category mapping** (by the `TIPO` field):
- `TIPO` ending `SUC` (sucursal) → `Categories.BANK` — 181
- `TIPO` ending `ISLA` (self-service island) → `Categories.ATM` — 117

**Scope — third-party networks excluded:** the same layer also lists correspondent/payment networks that are **not** BROU-branded premises — `ABITAB` (523), `REDPAGOS` (480), `SCANNTECH` (447), `URUPAGO` (173). A server-side `where_query` (`TIPO LIKE '%SUC' OR TIPO LIKE '%ISLA'`) keeps only BROU's own 298 points.

**ATMs vs branches:** `SUC` are full-service branches (service flags show deposits + withdrawals) → `amenity=bank`; `ISLA` are self-service points (all do cash withdrawal, ~none do deposits) → standalone `amenity=atm`. ISLA are separate source records with their own coordinates and are almost never co-located with a branch (3/117 shared coords), so they're emitted as standalone ATMs. The source has **no explicit on-site-ATM flag** on branch records, so `atm=yes` is not inferred (avoids over-tagging from the non-specific `RETIRO_PESOS` capability flag). No `deepcopy`; nothing dropped.

**Fields:** `DictParser` (via the helper) maps `ref`=`ObjectId`, `addr:street_address`=`DIRECCION`, and the WGS84 geometry (`outSR=4326`); the Spanish-keyed fields it can't map are set manually — `addr:city`=`LOCALIDAD`, `addr:state`=`DEPARTAMENTO`. `LOCAL` is parsed into `name` (leading point-number prefix stripped, e.g. `001-AIGUA` → `AIGUA`, `179 - AG…` → `AG…`) then moved to `branch` for `SUC`; standalone `ISLA` keep it as `name`. NSI supplies the brand name on branches.

**Notes:**
- `opening_hours` omitted — `HORARIO` is null on every feature and `TIPO`'s schedule hints (`24 HRS`/`DIURNO`/`LUN A VIE`) carry no explicit times.
- No phone/email/website in the source.
- No proxy needed — ArcGIS Online is a public CloudFront endpoint.

**Sample POIs:**
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1", "amenity": "bank", 
      "branch": "DTA CIUDAD VIEJA",
      "addr:street_address": "PIEDRAS 369",
      "addr:city": "CIUDAD VIEJA",
      "addr:state": "MONTEVIDEO", 
      "addr:country": "UY",
      "brand": "República", 
      "brand:wikidata": "Q4077337"
    },
    "geometry": {"type": "Point", "coordinates": [-56.2088237, -34.9051485]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "2", "amenity": "atm",
      "name": "BANCO CENTRAL (BCU)",
      "addr:street_address": "DIAGONAL FABINI S/N ESQ. FLORIDA", 
      "addr:city": "CIUDAD VIEJA",
      "addr:state": "MONTEVIDEO", 
       "addr:country": "UY",
      "brand": "República", 
      "brand:wikidata": "Q4077337"
    },
    "geometry": {"type": "Point", "coordinates": [-56.200232, -34.903335]}
  }
]
```
json
```
{
  "item_scraped_count": 298,
  "atp/category/amenity/bank": 181,
  "atp/category/amenity/atm": 117,
  "atp/nsi/match_perfect": 298,
  "atp/field/country/from_spider_name": 298,
  "finish_reason": "finished"
}
```