### PR TITLE
[Ici Paris XL] Fix Spider 

### DIFF
--- a/locations/spiders/ici_paris_xl.py
+++ b/locations/spiders/ici_paris_xl.py
@@ -51,7 +51,7 @@ class IciParisXlSpider(JSONBlobSpider, PlaywrightSpider):
                             rule.get("closingTime", {}).get("formattedHour"),
                             "%I:%M %p",
                         )
-        except:
+        except Exception:
             pass
         apply_category(Categories.SHOP_PERFUMERY, item)
         yield item

--- a/locations/spiders/ici_paris_xl.py
+++ b/locations/spiders/ici_paris_xl.py
@@ -18,7 +18,6 @@ class IciParisXlSpider(JSONBlobSpider, PlaywrightSpider):
     name = "ici_paris_xl"
     item_attributes = {"brand": "ICI PARIS XL", "brand_wikidata": "Q769749"}
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": FIREFOX_LATEST}
-    locations_key = "stores"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for country in ["be", "nl", "lu"]:
@@ -27,7 +26,6 @@ class IciParisXlSpider(JSONBlobSpider, PlaywrightSpider):
             )
 
     def extract_json(self, response: TextResponse) -> dict | list[dict]:
-        print(response.text)
         json_data = json.loads(response.xpath("//pre//text()").get())["stores"]
         return json_data
 

--- a/locations/spiders/ici_paris_xl.py
+++ b/locations/spiders/ici_paris_xl.py
@@ -1,20 +1,23 @@
+import json
 from typing import AsyncIterator, Iterable
 from urllib.parse import urljoin
 
-from scrapy.http import JsonRequest, Response
+from scrapy.http import JsonRequest, Response, TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours, sanitise_day
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import FIREFOX_LATEST
 
 
-class IciParisXlSpider(JSONBlobSpider):
+class IciParisXlSpider(JSONBlobSpider, PlaywrightSpider):
     name = "ici_paris_xl"
     item_attributes = {"brand": "ICI PARIS XL", "brand_wikidata": "Q769749"}
-    custom_settings = {"USER_AGENT": FIREFOX_LATEST}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": FIREFOX_LATEST}
     locations_key = "stores"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
@@ -22,6 +25,11 @@ class IciParisXlSpider(JSONBlobSpider):
             yield JsonRequest(
                 f"https://api.iciparisxl.{country}/api/v2/ici{country}2/stores?pageSize=10000&currentPage=0"
             )
+
+    def extract_json(self, response: TextResponse) -> dict | list[dict]:
+        print(response.text)
+        json_data = json.loads(response.xpath("//pre//text()").get())["stores"]
+        return json_data
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))
@@ -31,17 +39,21 @@ class IciParisXlSpider(JSONBlobSpider):
         item["branch"] = feature.get("displayName")
         item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2")])
         item["addr_full"] = feature.get("formattedAddress")
-        item["website"] = urljoin(f'https://www.iciparisxl.{item["country"].lower()}', feature.get("url"))
-        item["opening_hours"] = OpeningHours()
-        for rule in feature.get("openingHours", {}).get("weekDayOpeningList", []):
-            if day := sanitise_day(rule.get("shortenedWeekDay")):
-                if rule.get("closed"):
-                    item["opening_hours"].set_closed(day)
-                else:
-                    item["opening_hours"].add_range(
-                        day,
-                        rule.get("openingTime", {}).get("formattedHour"),
-                        rule.get("closingTime", {}).get("formattedHour"),
-                    )
+        item["website"] = item["ref"] = urljoin(f'https://www.iciparisxl.{item["country"].lower()}', feature.get("url"))
+        try:
+            item["opening_hours"] = OpeningHours()
+            for rule in feature.get("openingHours", {}).get("weekDayOpeningList", []):
+                if day := sanitise_day(rule.get("shortenedWeekDay")):
+                    if rule.get("closed"):
+                        item["opening_hours"].set_closed(day)
+                    else:
+                        item["opening_hours"].add_range(
+                            day,
+                            rule.get("openingTime", {}).get("formattedHour"),
+                            rule.get("closingTime", {}).get("formattedHour"),
+                            "%I:%M %p",
+                        )
+        except:
+            pass
         apply_category(Categories.SHOP_PERFUMERY, item)
         yield item


### PR DESCRIPTION
```python
{'atp/brand/ICI PARIS XL': 263,
 'atp/brand_wikidata/Q769749': 263,
 'atp/category/shop/perfumery': 263,
 'atp/country/BE': 119,
 'atp/country/LU': 2,
 'atp/country/NL': 142,
 'atp/field/email/missing': 263,
 'atp/field/housenumber/missing': 263,
 'atp/field/operator/missing': 263,
 'atp/field/operator_wikidata/missing': 263,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 9,
 'atp/field/state/missing': 3,
 'atp/field/state/wrong_type': 1,
 'atp/field/street/missing': 263,
 'atp/field/twitter/missing': 263,
 'atp/field/unit/missing': 263,
 'atp/item_scraped_host_count/api.iciparisxl.be': 119,
 'atp/item_scraped_host_count/api.iciparisxl.lu': 2,
 'atp/item_scraped_host_count/api.iciparisxl.nl': 142,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 263,
 'downloader/request_bytes': 1764,
 'downloader/request_count': 6,
 'downloader/request_method_count/GET': 6,
 'downloader/response_bytes': 689591,
 'downloader/response_count': 6,
 'downloader/response_status_count/200': 6,
 'elapsed_time_seconds': 11.218999999924563,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 9, 11, 17, 15, 27644, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 263,
 'items_per_minute': 1434.5454545454547,
 'log_count/DEBUG': 294,
 'log_count/ERROR': 1,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 6,
 'playwright/page_count/closed': 6,
 'playwright/page_count/max_concurrent': 3,
 'playwright/request_count': 6,
 'playwright/request_count/method/GET': 6,
 'playwright/request_count/navigation': 6,
 'playwright/request_count/resource_type/document': 6,
 'playwright/response_count': 6,
 'playwright/response_count/method/GET': 6,
 'playwright/response_count/resource_type/document': 6,
 'response_received_count': 6,
 'responses_per_minute': 32.72727272727273,
 'robotstxt/request_count': 3,
 'robotstxt/response_count': 3,
 'robotstxt/response_status_count/200': 3,
 'scheduler/dequeued': 3,
 'scheduler/dequeued/memory': 3,
 'scheduler/enqueued': 3,
 'scheduler/enqueued/memory': 3,
 'start_time': datetime.datetime(2026, 7, 9, 11, 17, 3, 808557, tzinfo=datetime.timezone.utc)}
```