### PR TITLE
[NO Kartverket Addresses] Disable AddressCleanUpPipeline, fix addr:type

### DIFF
--- a/locations/address_spider.py
+++ b/locations/address_spider.py
@@ -19,7 +19,7 @@ class AddressSpider(Spider):
                 "locations.pipelines.clean_strings.CleanStringsPipeline": 354,
                 "locations.pipelines.country_code_clean_up.CountryCodeCleanUpPipeline": None,
                 "locations.pipelines.state_clean_up.StateCodeCleanUpPipeline": None,
-                "locations.pipelines.address_clean_up.AddressCleanUpPipeline": 357,
+                "locations.pipelines.address_clean_up.AddressCleanUpPipeline": None,
                 "locations.pipelines.phone_clean_up.PhoneCleanUpPipeline": None,
                 "locations.pipelines.email_clean_up.EmailCleanUpPipeline": None,
                 "locations.pipelines.geojson_geometry_reprojection.GeoJSONGeometryReprojectionPipeline": None,

--- a/locations/spiders/addresses/no/no_kartverket_addresses.py
+++ b/locations/spiders/addresses/no/no_kartverket_addresses.py
@@ -80,9 +80,9 @@ class NoKartverketAddressesSpider(AddressSpider):
         if tilleggsnavn := self._strip_value(row.get("adressetilleggsnavn")):
             item["extras"]["addr:place"] = tilleggsnavn
 
-        # Address type (Vegadresse or Matrikkeladresse)
-        if objtype := self._strip_value(row.get("objtype")):
-            item["extras"]["addr:type"] = objtype
+        # Address type (vegadresse or matrikkeladresse)
+        if address_type := self._strip_value(row.get("adressetype")):
+            item["extras"]["addr:type"] = address_type
 
         # Matrikkel references for cadastral addresses
         if gardsnummer := self._strip_value(row.get("gardsnummer")):
@@ -93,10 +93,6 @@ class NoKartverketAddressesSpider(AddressSpider):
             item["extras"]["ref:NO:festenummer"] = festenummer
         if undernummer := self._strip_value(row.get("undernummer")):
             item["extras"]["ref:NO:undernummer"] = undernummer
-
-        # Unit numbers (apartments)
-        if bruksenhetsnummer := self._strip_value(row.get("bruksenhetsnummer")):
-            item["extras"]["unit"] = bruksenhetsnummer
 
         return item
 


### PR DESCRIPTION
Disable AddressCleanUpPipeline for AddressSpider. Addreess sources should be cleaner than POI sources - it's the nature of the supplier pool. Norway highlighted this, there are quite a few valid 2 letter street names!

Also, read the address type from the correct "adressetype" column (was "objtype", which is absent) and drop the apartment unit number, which is not part of the address point.
