### PR TITLE
[Mango] Add spider (1866 locations)

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -797,6 +797,36 @@ DAYS_IS = {
     "Sunnudagur": "Su",
 }
 
+DAYS_AR = {
+    "الاثنين": "Mo",
+    "الإثنين": "Mo",
+    "الثلاثاء": "Tu",
+    "الأربعاء": "We",
+    "الاربعاء": "We",
+    "الخميس": "Th",
+    "الجمعة": "Fr",
+    "السبت": "Sa",
+    "الأحد": "Su",
+    "الاحد": "Su",
+}
+
+DAYS_UA = {
+    "понеділок": "Mo",
+    "Понеділок": "Mo",
+    "вівторок": "Tu",
+    "Вівторок": "Tu",
+    "середа": "We",
+    "Середа": "We",
+    "четвер": "Th",
+    "Четвер": "Th",
+    "п’ятниця": "Fr",
+    "П’ятниця": "Fr",
+    "субота": "Sa",
+    "Субота": "Sa",
+    "неділя": "Su",
+    "Неділя": "Su",
+}
+
 # See https://github.com/alltheplaces/alltheplaces/issues/7360
 # A list ordered by languages most frequently used for web content as of January 2024, by share of websites.
 # See WPStoreLocator for example usage.

--- a/locations/spiders/mango.py
+++ b/locations/spiders/mango.py
@@ -1,10 +1,10 @@
+import json
 from typing import Any, Iterable
 
 import chompjs
 from scrapy import Request
 from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
 from locations.hours import (
@@ -36,15 +36,17 @@ from locations.hours import (
     sanitise_day,
 )
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
 from locations.react_server_components import parse_rsc
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class MangoSpider(Spider):
+class MangoSpider(PlaywrightSpider):
     name = "mango"
     item_attributes = {"brand": "Mango", "brand_wikidata": "Q136503"}
     start_urls = ["https://api.shop.mango.com/cs/online-configuration/v1/country?channelId=shop"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     LANGUAGE_DAYS_MAP = {
         "AR": DAYS_AR,
@@ -73,7 +75,7 @@ class MangoSpider(Spider):
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for country in response.json()["countries"]:
+        for country in json.loads(response.xpath("//pre/text()").get())["countries"]:
             if not country.get("hasOnlineAccess"):  # Skip countries with no available stores
                 continue
             country_code = country.get("mangoIso")

--- a/locations/spiders/mango.py
+++ b/locations/spiders/mango.py
@@ -1,0 +1,123 @@
+from typing import Any, Iterable
+
+import chompjs
+from scrapy import Request
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import Spider
+
+from locations.dict_parser import DictParser
+from locations.hours import (
+    DAYS_BG,
+    DAYS_CN,
+    DAYS_CZ,
+    DAYS_DE,
+    DAYS_EN,
+    DAYS_ES,
+    DAYS_FR,
+    DAYS_GR,
+    DAYS_HR,
+    DAYS_HU,
+    DAYS_ID,
+    DAYS_IT,
+    DAYS_KR,
+    DAYS_NL,
+    DAYS_NO,
+    DAYS_PL,
+    DAYS_PT,
+    DAYS_RO,
+    DAYS_RU,
+    DAYS_SE,
+    DAYS_TH,
+    DAYS_TR,
+    OpeningHours,
+    sanitise_day,
+)
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
+from locations.user_agents import BROWSER_DEFAULT
+
+
+class MangoSpider(Spider):
+    name = "mango"
+    item_attributes = {"brand": "Mango", "brand_wikidata": "Q136503"}
+    start_urls = ["https://api.shop.mango.com/cs/online-configuration/v1/country?channelId=shop"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+
+    LANGUAGE_DAYS_MAP = {
+        "BG": DAYS_BG,
+        "CS": DAYS_CZ,
+        "DE": DAYS_DE,
+        "EL": DAYS_GR,
+        "ES": DAYS_ES,
+        "FR": DAYS_FR,
+        "HR": DAYS_HR,
+        "HU": DAYS_HU,
+        "ID": DAYS_ID,
+        "IT": DAYS_IT,
+        "KO": DAYS_KR,
+        "NO": DAYS_NO,
+        "NL": DAYS_NL,
+        "PT": DAYS_PT,
+        "PL": DAYS_PL,
+        "RO": DAYS_RO,
+        "RU": DAYS_RU,
+        "SV": DAYS_SE,
+        "TH": DAYS_TH,
+        "TR": DAYS_TR,
+        "ZH": DAYS_CN,
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for country in response.json()["countries"]:
+            if not country.get("hasOnlineAccess"):  # Skip countries with no available stores
+                continue
+            country_code = country.get("mangoIso")
+            default_language = ""
+            for language in country.get("languages", []):
+                if language.get("defaultLanguage"):
+                    default_language = language.get("iso")
+                    break
+            if default_language:
+                yield Request(
+                    url=f"https://shop.mango.com/{country_code}/{default_language}/stores".lower(),
+                    callback=self.parse_store_urls,
+                    cb_kwargs={"country": country_code, "language": default_language.upper()},
+                )
+
+    def parse_store_urls(self, response: Response, country: str, language: str) -> Any:
+        for link in LinkExtractor(allow=r"/[a-z]{2}/[a-z]{2}/stores/[^/]+/[^/]+/\d+$").extract_links(response):
+            yield response.follow(
+                url=link.url, callback=self.parse_store_details, cb_kwargs={"country": country, "language": language}
+            )
+
+    def parse_store_details(self, response: Response, country: str, language: str) -> Iterable[Feature]:
+        scripts = response.xpath('//script[contains(text(), "timeSchedule")]/text()').getall()
+        objs = [chompjs.parse_js_object(s) for s in scripts]
+        rsc = "".join([s for n, s in objs]).encode()
+        if store_data := DictParser.get_nested_key(dict(parse_rsc(rsc)), "stores"):
+            store = store_data[0]
+            store.update(store.pop("details", {}))
+            store.update(store.pop("addresses", {}))
+            item = DictParser.parse(store)
+            item["street_address"] = item.pop("addr_full", None)
+            item["branch"] = store.get("shoppingCenter")
+            item["website"] = response.url
+            item["country"] = country
+            try:
+                item["opening_hours"] = self.parse_opening_hours(store.get("timeSchedule", []), language)
+            except Exception as e:
+                self.logger.error(f'Failed to parse opening hours:{store.get("timeSchedule")} {e}')
+            yield item
+
+    def parse_opening_hours(self, rules: list[dict], language: str) -> OpeningHours:
+        opening_hours = OpeningHours()
+        days = self.LANGUAGE_DAYS_MAP.get(language) or DAYS_EN
+        for day_time in rules:
+            if day := sanitise_day(day_time.get("dayOfWeek"), days):
+                for open_close_time in day_time.get("timeList") or []:
+                    open_time = open_close_time.get("openHour")
+                    close_time = open_close_time.get("closeHour")
+                    if open_time != "-":
+                        opening_hours.add_range(day=day, open_time=open_time, close_time=close_time)
+        return opening_hours

--- a/locations/spiders/mango.py
+++ b/locations/spiders/mango.py
@@ -8,6 +8,7 @@ from scrapy.spiders import Spider
 
 from locations.dict_parser import DictParser
 from locations.hours import (
+    DAYS_AR,
     DAYS_BG,
     DAYS_CN,
     DAYS_CZ,
@@ -30,6 +31,7 @@ from locations.hours import (
     DAYS_SE,
     DAYS_TH,
     DAYS_TR,
+    DAYS_UA,
     OpeningHours,
     sanitise_day,
 )
@@ -45,6 +47,7 @@ class MangoSpider(Spider):
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     LANGUAGE_DAYS_MAP = {
+        "AR": DAYS_AR,
         "BG": DAYS_BG,
         "CS": DAYS_CZ,
         "DE": DAYS_DE,
@@ -65,6 +68,7 @@ class MangoSpider(Spider):
         "SV": DAYS_SE,
         "TH": DAYS_TH,
         "TR": DAYS_TR,
+        "UK": DAYS_UA,
         "ZH": DAYS_CN,
     }
 


### PR DESCRIPTION
```python
{'atp/brand/Mango': 1866,
 'atp/brand_wikidata/Q136503': 1866,
 'atp/category/shop/clothes': 1866,
 'atp/clean_strings/branch': 71,
 'atp/clean_strings/phone': 2,
 'atp/clean_strings/postcode': 6,
 'atp/clean_strings/street_address': 137,
 'atp/country/AD': 7,
 'atp/country/AE': 11,
 'atp/country/AL': 2,
 'atp/country/AM': 3,
 'atp/country/AO': 2,
 'atp/country/AT': 13,
 'atp/country/AW': 1,
 'atp/country/AZ': 3,
 'atp/country/BA': 1,
 'atp/country/BE': 39,
 'atp/country/BG': 6,
 'atp/country/BH': 2,
 'atp/country/BM': 1,
 'atp/country/BO': 1,
 'atp/country/BY': 3,
 'atp/country/CA': 14,
 'atp/country/CH': 10,
 'atp/country/CI': 2,
 'atp/country/CL': 36,
 'atp/country/CM': 2,
 'atp/country/CN': 2,
 'atp/country/CO': 30,
 'atp/country/CR': 4,
 'atp/country/CW': 1,
 'atp/country/CY': 5,
 'atp/country/CZ': 7,
 'atp/country/DE': 190,
 'atp/country/DK': 6,
 'atp/country/DO': 2,
 'atp/country/EC': 5,
 'atp/country/EE': 3,
 'atp/country/ES': 386,
 'atp/country/FI': 2,
 'atp/country/FR': 200,
 'atp/country/GB': 65,
 'atp/country/GE': 5,
 'atp/country/GF': 1,
 'atp/country/GI': 1,
 'atp/country/GP': 1,
 'atp/country/GR': 17,
 'atp/country/GT': 1,
 'atp/country/HK': 3,
 'atp/country/HR': 13,
 'atp/country/HU': 6,
 'atp/country/ID': 6,
 'atp/country/IE': 9,
 'atp/country/IL': 1,
 'atp/country/IN': 9,
 'atp/country/IQ': 2,
 'atp/country/IS': 2,
 'atp/country/IT': 127,
 'atp/country/JO': 4,
 'atp/country/KE': 1,
 'atp/country/KG': 2,
 'atp/country/KH': 1,
 'atp/country/KR': 4,
 'atp/country/KW': 6,
 'atp/country/KZ': 17,
 'atp/country/LA': 1,
 'atp/country/LB': 3,
 'atp/country/LK': 3,
 'atp/country/LT': 5,
 'atp/country/LU': 5,
 'atp/country/LV': 4,
 'atp/country/LY': 1,
 'atp/country/MA': 4,
 'atp/country/MD': 1,
 'atp/country/ME': 1,
 'atp/country/MK': 1,
 'atp/country/MM': 1,
 'atp/country/MN': 3,
 'atp/country/MQ': 1,
 'atp/country/MT': 2,
 'atp/country/MU': 2,
 'atp/country/MX': 49,
 'atp/country/MY': 8,
 'atp/country/NG': 2,
 'atp/country/NL': 36,
 'atp/country/NO': 5,
 'atp/country/PA': 2,
 'atp/country/PE': 36,
 'atp/country/PH': 7,
 'atp/country/PL': 33,
 'atp/country/PT': 48,
 'atp/country/PY': 2,
 'atp/country/QA': 7,
 'atp/country/RE': 2,
 'atp/country/RO': 17,
 'atp/country/RS': 2,
 'atp/country/RU': 41,
 'atp/country/SA': 23,
 'atp/country/SE': 5,
 'atp/country/SG': 9,
 'atp/country/SI': 2,
 'atp/country/SK': 3,
 'atp/country/SN': 1,
 'atp/country/SR': 1,
 'atp/country/SV': 1,
 'atp/country/TH': 9,
 'atp/country/TN': 2,
 'atp/country/TR': 73,
 'atp/country/TW': 8,
 'atp/country/UA': 14,
 'atp/country/US': 62,
 'atp/country/UY': 1,
 'atp/country/UZ': 2,
 'atp/country/VE': 3,
 'atp/country/VN': 3,
 'atp/country/ZA': 3,
 'atp/field/branch/missing': 739,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 1866,
 'atp/field/geometry/invalid': 9,
 'atp/field/geometry/missing': 1,
 'atp/field/housenumber/missing': 1866,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1866,
 'atp/field/operator_wikidata/missing': 1866,
 'atp/field/phone/invalid': 144,
 'atp/field/phone/missing': 23,
 'atp/field/postcode/missing': 47,
 'atp/field/state/from_reverse_geocoding': 76,
 'atp/field/state/missing': 1793,
 'atp/field/street/missing': 1866,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 1866,
 'atp/field/unit/missing': 1866,
 'atp/item_scraped_host_count/shop.mango.com': 1866,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 1866,
 'atp/nsi/match_imperfect': 1866,
 'downloader/exception_count': 4,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 4,
 'downloader/request_bytes': 3045640,
 'downloader/request_count': 2022,
 'downloader/request_method_count/GET': 2022,
 'downloader/response_bytes': 53583353,
 'downloader/response_count': 2022,
 'downloader/response_status_count/200': 2019,
 'downloader/response_status_count/404': 3,
 'elapsed_time_seconds': 32.06199999999808,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 9, 12, 44, 29, 989417, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2022,
 'httpcompression/response_bytes': 317611775,
 'httpcompression/response_count': 2019,
 'httperror/response_ignored_count': 2,
 'httperror/response_ignored_status_count/404': 2,
 'item_scraped_count': 1866,
 'items_per_minute': 3498.75,
 'log_count/DEBUG': 3893,
 'log_count/INFO': 5,
 'request_depth_max': 2,
 'response_received_count': 2022,
 'responses_per_minute': 3791.25,
 'robotstxt/forbidden': 4,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2024,
 'scheduler/dequeued/memory': 2024,
 'scheduler/enqueued': 2024,
 'scheduler/enqueued/memory': 2024,
 'start_time': datetime.datetime(2026, 7, 9, 12, 43, 57, 938266, tzinfo=datetime.timezone.utc)}
```