### PR TITLE
[Yes BR] Fix spider

### DIFF
--- a/locations/spiders/yes_br.py
+++ b/locations/spiders/yes_br.py
@@ -1,32 +1,22 @@
-import re
 from typing import Iterable
 
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class YesBRSpider(JSONBlobSpider):
+class YesBRSpider(SitemapSpider, StructuredDataSpider):
     name = "yes_br"
     item_attributes = {"brand": "Yes! Idiomas", "brand_wikidata": "Q121365811"}
-    start_urls = [
-        "https://yes.com.br/site_novo/index.php?hcs=locatoraid&hca=search%3Asearch%2F%2Fproduct%2F",
-    ]
-    locations_key = "results"
+    sitemap_urls = ["https://www.yes.com.br/sitemap.xml"]
+    sitemap_rules = [(r"/escolas/[^/]+$", "parse")]
+    wanted_types = ["LanguageSchool"]
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["addr_full"] = feature.get("address").replace("<br>\n", ",")
-        if phone := feature.get("phone"):
-            all_numbers = re.search(r">(.*)<", phone).group(1)
-            if "/" in all_numbers:
-                item["phone"] = all_numbers.split("/")[0].lstrip()
-            else:
-                item["phone"] = all_numbers.replace("Telefone ", "")
-        item["website"] = feature.get("website_url")
-        item["street_address"] = feature.get("street1")
-        item["street"] = feature.get("street2")
-        item["branch"] = item.pop("name").replace("YES! ", "")
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").replace("YES! ", "").title()
+        item["website"] = response.url
         apply_category(Categories.LANGUAGE_SCHOOL, item)
         yield item


### PR DESCRIPTION
```
{'atp/brand/Yes! Idiomas': 123,
 'atp/brand_wikidata/Q121365811': 123,
 'atp/category/amenity/language_school': 123,
 'atp/clean_strings/phone': 2,
 'atp/country/BR': 123,
 'atp/field/email/missing': 123,
 'atp/field/housenumber/missing': 123,
 'atp/field/opening_hours/missing': 123,
 'atp/field/operator/missing': 123,
 'atp/field/operator_wikidata/missing': 123,
 'atp/field/street/missing': 123,
 'atp/field/twitter/missing': 123,
 'atp/field/unit/missing': 123,
 'atp/item_scraped_host_count/www.yes.com.br': 123,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 123,
 'downloader/request_bytes': 48563,
 'downloader/request_count': 125,
 'downloader/request_method_count/GET': 125,
 'downloader/response_bytes': 1786475,
 'downloader/response_count': 125,
 'downloader/response_status_count/200': 125,
 'elapsed_time_seconds': 150.25,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 9, 13, 5, 35, 531083, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9951094,
 'httpcompression/response_count': 124,
 'item_scraped_count': 123,
 'items_per_minute': 49.2,
 'log_count/DEBUG': 248,
 'log_count/INFO': 5,
 'request_depth_max': 1,
 'response_received_count': 125,
 'responses_per_minute': 50.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 124,
 'scheduler/dequeued/memory': 124,
 'scheduler/enqueued': 124,
 'scheduler/enqueued/memory': 124,
 'start_time': datetime.datetime(2026, 7, 9, 13, 3, 5, 291753, tzinfo=datetime.timezone.utc)}
```