### PR TITLE
[Xpo Logistics] Fix spider

### DIFF
--- a/locations/spiders/xpo_logistics.py
+++ b/locations/spiders/xpo_logistics.py
@@ -1,30 +1,24 @@
-import ast
+from typing import Iterable
 
-import scrapy
+from scrapy.http import TextResponse
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
 
 
-class XpoLogisticsSpider(scrapy.Spider):
+class XpoLogisticsSpider(ArcGISFeatureServerSpider):
     name = "xpo_logistics"
     item_attributes = {"brand": "XPO Logistics", "brand_wikidata": "Q8042415"}
-    allowed_domains = ["www.xpo.com"]
-    start_urls = ("https://www.xpo.com/global-locations/",)
+    host = "maps.xpo.com"
+    context_path = "ltlbisvc"
+    service_id = "ServiceMap/PRODUCTION_Service_Map_SIC"
+    server_type = "MapServer"
+    layer_id = "0"
 
-    def parse(self, response):
-        script = response.xpath('//script[@id="globalLocations"]/text()').extract_first()
-        data = ast.literal_eval(script)
-
-        for store in data:
-            yield Feature(
-                lat=float(store["latitude"]),
-                lon=float(store["longitude"].replace(",", "")),
-                phone=store["telephone"],
-                ref=f"{store['office_name']}-{store['postal_code']}",
-                addr_full=store["street"],
-                city=store["city"],
-                state=store["state"],
-                postcode=store["postal_code"],
-                country=store["country"],
-                name=store["office_name"],
-            )
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature.get("sic_cd")
+        item["name"] = feature.get("terminal_nm")
+        item["phone"] = feature.get("terminal_phone")
+        apply_category(Categories.OFFICE_COURIER, item)
+        yield item


### PR DESCRIPTION
```
{'atp/brand/XPO Logistics': 348,
 'atp/brand_wikidata/Q8042415': 348,
 'atp/category/office/courier': 348,
 'atp/country/CA': 17,
 'atp/country/MX': 2,
 'atp/country/PR': 1,
 'atp/country/US': 328,
 'atp/field/branch/missing': 348,
 'atp/field/city/missing': 348,
 'atp/field/country/from_reverse_geocoding': 348,
 'atp/field/email/missing': 348,
 'atp/field/housenumber/missing': 348,
 'atp/field/opening_hours/missing': 348,
 'atp/field/operator/missing': 348,
 'atp/field/operator_wikidata/missing': 348,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 10,
 'atp/field/postcode/missing': 348,
 'atp/field/street/missing': 348,
 'atp/field/street_address/missing': 348,
 'atp/field/twitter/missing': 348,
 'atp/field/unit/missing': 348,
 'atp/item_scraped_host_count/maps.xpo.com': 348,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 348,
 'atp/nsi/match_failed': 348,
 'downloader/request_bytes': 1641,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 23556,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.452999999979511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 10, 8, 27, 42, 988946, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 188710,
 'httpcompression/response_count': 2,
 'item_scraped_count': 348,
 'items_per_minute': 5220.0,
 'log_count/DEBUG': 350,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 7, 10, 8, 27, 38, 534189, tzinfo=datetime.timezone.utc)}
```