### PR TITLE
[Jll] Fix Spider

### DIFF
--- a/locations/spiders/jll.py
+++ b/locations/spiders/jll.py
@@ -1,43 +1,34 @@
-from typing import AsyncIterator
+import re
+from typing import Any
 
-from scrapy import Request, Spider
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class JllSpider(Spider):
     name = "jll"
     item_attributes = {"brand": "JLL", "brand_wikidata": "Q1703389"}
-    allowed_domains = ["jll.com"]
+    start_urls = ["https://www.jll.com/en-in/locations?sort_by_relevance=relevance&location_page=1"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    async def start(self) -> AsyncIterator[Request]:
-        base_url = "https://www.us.jll.com/bin/jll/search?q=locations&currentPage=/content/jll-dot-com/countries/amer/us/en/locations&top=100&p={page}&contentTypes=Location"
-        pages = ["1", "2", "3", "4"]
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        key = re.search(r"subscriptionIdentifier:\s*\"(.*)\",", response.text).group(1)
+        yield JsonRequest(
+            url="https://www.jll.com/api/search/template",
+            headers={"subscription-key": key.strip()},
+            data={
+                "id": "jll_location_search_template_v3",
+                "params": {"size": 500, "from": 0, "countries": ["United States"], "language": "en-US"},
+            },
+            method="POST",
+            callback=self.parse_location,
+        )
 
-        for page in pages:
-            url = base_url.format(page=page)
-            yield Request(url=url, callback=self.parse)
-
-    def parse(self, response):
-        data = response.json()
-
-        for place in data["azureSearch"]["value"]:
-            properties = {
-                "ref": place["id"],
-                "name": place["title"],
-                "street_address": place["streetAddress"],
-                "city": place["city"],
-                "state": place["stateProvince"],
-                "postcode": place["postalCode"],
-                "lat": place["latitude"],
-                "lon": place["longitude"],
-                "phone": place["telephoneNumber"],
-                "website": place["cityPageLink"],
-            }
-
-            if properties["website"].startswith("https://www.google.com"):
-                properties.pop("website")
-            elif properties["website"].startswith("https://www.us.jll.com/en/locations"):
-                properties["country"] = "US"
-
-            yield Feature(**properties)
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["hits"]["hits"]:
+            location.update(location.pop("_source"))
+            item = DictParser.parse(location)
+            item["ref"] = location["_id"]
+            yield item

--- a/locations/spiders/jll.py
+++ b/locations/spiders/jll.py
@@ -14,7 +14,11 @@ class JllSpider(Spider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        key = re.search(r"subscriptionIdentifier:\s*\"(.*)\",", response.text).group(1)
+        key_match = re.search(r"subscriptionIdentifier:\s*\"(.*)\",", response.text)
+        if not key_match:
+            self.logger.error("Could not find subscription key in response")
+            return
+        key = key_match.group(1)
         yield JsonRequest(
             url="https://www.jll.com/api/search/template",
             headers={"subscription-key": key.strip()},


### PR DESCRIPTION
```python
{'atp/brand/JLL': 276,
 'atp/brand_wikidata/Q1703389': 276,
 'atp/category/office/estate_agent': 276,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/phone': 18,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/street_address': 37,
 'atp/country/AE': 2,
 'atp/country/AR': 1,
 'atp/country/AU': 10,
 'atp/country/BE': 2,
 'atp/country/BR': 2,
 'atp/country/CA': 10,
 'atp/country/CH': 2,
 'atp/country/CL': 1,
 'atp/country/CN': 7,
 'atp/country/CO': 1,
 'atp/country/CR': 1,
 'atp/country/DE': 11,
 'atp/country/EG': 1,
 'atp/country/ES': 2,
 'atp/country/FI': 1,
 'atp/country/FR': 11,
 'atp/country/GB': 28,
 'atp/country/HK': 5,
 'atp/country/ID': 1,
 'atp/country/IE': 1,
 'atp/country/IL': 1,
 'atp/country/IN': 12,
 'atp/country/IT': 2,
 'atp/country/JP': 8,
 'atp/country/KE': 1,
 'atp/country/KR': 1,
 'atp/country/LK': 1,
 'atp/country/LU': 2,
 'atp/country/MA': 1,
 'atp/country/MX': 9,
 'atp/country/MY': 1,
 'atp/country/NL': 6,
 'atp/country/NZ': 1,
 'atp/country/PE': 1,
 'atp/country/PH': 2,
 'atp/country/PL': 6,
 'atp/country/PT': 6,
 'atp/country/SA': 3,
 'atp/country/SE': 2,
 'atp/country/SG': 2,
 'atp/country/TH': 2,
 'atp/country/TW': 1,
 'atp/country/US': 101,
 'atp/country/VN': 2,
 'atp/country/ZA': 2,
 'atp/field/branch/missing': 276,
 'atp/field/country/from_reverse_geocoding': 8,
 'atp/field/email/missing': 276,
 'atp/field/housenumber/missing': 276,
 'atp/field/opening_hours/missing': 276,
 'atp/field/operator/missing': 276,
 'atp/field/operator_wikidata/missing': 276,
 'atp/field/phone/invalid': 6,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 22,
 'atp/field/state/from_reverse_geocoding': 111,
 'atp/field/state/missing': 158,
 'atp/field/street/missing': 276,
 'atp/field/twitter/missing': 276,
 'atp/field/unit/missing': 276,
 'atp/item_scraped_host_count/www.jll.com': 276,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 276,
 'atp/nsi/match_imperfect': 276,
 'downloader/request_bytes': 1004,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 88372,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 18.84299999999348,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 10, 8, 49, 32, 341053, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 466964,
 'httpcompression/response_count': 2,
 'item_scraped_count': 276,
 'items_per_minute': 920.0,
 'log_count/DEBUG': 278,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 2,
 'responses_per_minute': 6.666666666666667,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 7, 10, 8, 49, 13, 511541, tzinfo=datetime.timezone.utc)}
```