### PR TITLE
[Dapsa AR] Add spider

### DIFF
--- a/locations/spiders/dapsa_ar.py
+++ b/locations/spiders/dapsa_ar.py
@@ -8,7 +8,7 @@ from locations.storefinders.storepoint import StorepointSpider
 
 class DapsaARSpider(StorepointSpider):
     name = "dapsa_ar"
-    item_attributes = {"brand": "Dapsa"}  # no Wikidata/NSI entry for this Argentine fuel brand
+    item_attributes = {"brand": "Dapsa", "brand_wikidata": "Q140480567"}
     key = "163ea721fda366"
 
     def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:

--- a/locations/spiders/dapsa_ar.py
+++ b/locations/spiders/dapsa_ar.py
@@ -1,0 +1,39 @@
+import re
+from typing import Iterable
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.storefinders.storepoint import StorepointSpider
+
+
+class DapsaARSpider(StorepointSpider):
+    name = "dapsa_ar"
+    item_attributes = {"brand": "Dapsa"}  # no Wikidata/NSI entry for this Argentine fuel brand
+    key = "163ea721fda366"
+
+    def parse_item(self, item: Feature, location: dict, **kwargs) -> Iterable[Feature]:
+        # The helper mapped "streetaddress" to addr_full, but that field is actually "<city>, <province>,
+        # ARGENTINA"; the real street line is in "description".
+        item.pop("addr_full", None)
+        item["street_address"] = location.get("description")
+        locality = [part.strip() for part in (location.get("streetaddress") or "").split(",")]
+        if locality:
+            item["city"] = locality[0]
+        if len(locality) >= 3:
+            item["state"] = locality[1]
+
+        if branch := item.pop("name", None):
+            item["branch"] = re.sub(r"^DAPSA\s+", "", branch).strip() or None
+
+        apply_category(Categories.FUEL_STATION, item)
+
+        tags = [tag.strip().lower() for tag in (location.get("tags") or "").split(",")]
+        apply_yes_no(Fuel.CNG, item, "gnc" in tags)  # GNC = gas natural comprimido
+        apply_yes_no(Extras.CAR_WASH, item, "lavado" in tags)
+        apply_yes_no(Extras.COMPRESSED_AIR, item, "aire" in tags)
+        apply_yes_no(Extras.WIFI, item, "wifi" in tags or "wiffi" in tags)
+        apply_yes_no(Extras.ATM, item, any("cajero" in tag for tag in tags))
+        if "24hs" in tags:
+            item["opening_hours"] = "24/7"
+
+        yield item


### PR DESCRIPTION
**Data source:** https://www.dapsa.com/estaciones-de-servicio/ (Storepoint locator).
**API (JSON):** `https://api.storepoint.co/v1/163ea721fda366/locations` — via the `StorepointSpider` storefinder helper.

**Category:** all → `Categories.FUEL_STATION` (`amenity=fuel`), 157 stations across Argentina.

**Attributes** (from Storepoint `tags`): `fuel:cng` (GNC), `car_wash` (lavado), `compressed_air` (aire), `internet_access=wlan` (wifi), `atm` (cajero), `opening_hours=24/7` (24hs). Other tags (food/shop/agro services) are not mapped to the fuel node.

**Fields:** `ref`=Storepoint `id`; `branch`=`name` (station/operator label, leading "DAPSA " stripped); `addr:street_address`=`description` (the real street; Storepoint's `streetaddress` field holds city/province, so it's split into `addr:city`/`addr:state`); lat/lon from `loc_lat`/`loc_long`.

**Notes:**
- **No Wikidata/NSI entry for Dapsa** → `brand` set without `brand_wikidata`; `nsi/match_failed` is expected. A Wikidata item would enable NSI matching (PR will be created).
- Day-level opening hours are all null in the source; only the `24hs` tag yields `24/7`.
- Phones kept where present (20, location-specific with area codes); no website in source.

**Sample POI:**
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "45501615", "amenity": "fuel", "branch": "2103 SRL",
      "addr:street_address": "Julián Martel 5483", "addr:city": "JOSE C. PAZ",
      "addr:state": "PROVINCIA DE BUENOS AIRES", "addr:country": "AR",
      "brand": "Dapsa"
    },
    "geometry": {"type": "Point", "coordinates": [-58.765667, -34.525605]}
  }
]
```
json
```
{
  "item_scraped_count": 157,
  "atp/category/amenity/fuel": 157,
  "atp/brand/Dapsa": 157,
  "atp/field/country/from_spider_name": 157,
  "atp/nsi/match_failed": 157,
  "finish_reason": "finished"
}
```
> Dapsa has no Wikidata/NSI entry, so `brand` is set without `brand_wikidata` (hence `nsi/match_failed`). See notes.