### PR TITLE
[Axion AR] Add spider

### DIFF
--- a/locations/spiders/axion_ar.py
+++ b/locations/spiders/axion_ar.py
@@ -1,0 +1,94 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+# Per-day opening-hours fields ("<day>Horarios") mapped to OSM day abbreviations.
+HOURS_FIELDS = (
+    ("lunes", "Mo"),
+    ("martes", "Tu"),
+    ("miercoles", "We"),
+    ("jueves", "Th"),
+    ("viernes", "Fr"),
+    ("sabado", "Sa"),
+    ("domingo", "Su"),
+)
+
+
+class AxionARSpider(Spider):
+    name = "axion_ar"
+    item_attributes = {"brand": "Axion", "brand_wikidata": "Q62131749"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # top=1000 returns every station in one page; the filter keeps only service stations (EESS).
+        yield JsonRequest(
+            url="https://www.axionenergy.com/wp-json/axion/v1/estaciones?top=1000&filters=Title%20eq%20%27EESS%27"
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for poi in response.json()["items"]:
+            item = DictParser.parse(poi)  # maps Direccion (-> addr_full), Telefono (-> phone)
+            item.pop("name", None)  # DictParser sets this from "Title", which is just the type "EESS"
+            item.pop("email", None)  # the source email field is malformed (duplicated)
+            if (item.get("phone") or "").startswith("0800"):
+                item.pop("phone")  # shared national call-centre line, not the branch's own number
+            item["ref"] = poi["PBL"]
+            item["branch"] = poi.get("NombreEESSAgro") or poi.get("RazonSocial")
+            item["street_address"] = item.pop("addr_full", None)
+            item["city"] = poi.get("Localidad")
+            item["state"] = poi.get("Provincia")
+            item["lat"], item["lon"] = self.parse_coordinates(poi.get("Latitud"), poi.get("Longitud"))
+            item["opening_hours"] = self.parse_opening_hours(poi)
+            apply_category(Categories.FUEL_STATION, item)
+            apply_yes_no(Fuel.OCTANE_95, item, poi.get("AXIONSUPER") == "1")  # Axion Súper
+            apply_yes_no(Fuel.OCTANE_98, item, poi.get("QUANTIUM") == "1")  # Quantium premium petrol
+            apply_yes_no(Fuel.DIESEL, item, poi.get("AXIONDIESELX10") == "1" or poi.get("QUANTIUMDIESELX10") == "1")
+            apply_yes_no(Fuel.CNG, item, poi.get("GNC") == "1")
+            # NB: the on-site Spot!/AXION shop is deliberately NOT tagged shop=convenience.
+            # That is a top-level category tag, and NSI only matches a brand when the item's
+            # categories are a subset of the brand's; Axion's NSI entry is amenity=fuel only,
+            # so adding shop=convenience breaks the brand match (name/nsi_id lost).
+            apply_yes_no(
+                Extras.FAST_FOOD, item, poi.get("ParadaSanguchera") == "1"
+            )  # Parada Sanguchera sandwich counter
+            apply_yes_no(Extras.CAR_REPAIR, item, poi.get("BoschCarService") == "1")
+            apply_yes_no(Extras.OIL_CHANGE, item, poi.get("CastrolOilExpress") == "1")
+            yield item
+
+    @staticmethod
+    def parse_opening_hours(poi: dict) -> OpeningHours:
+        oh = OpeningHours()
+        for field, day in HOURS_FIELDS:
+            for time_range in (poi.get("{}Horarios".format(field)) or "").split(","):
+                time_range = time_range.strip().replace(" ", "")
+                if "-" not in time_range:
+                    continue
+                start, end = time_range.split("-", 1)
+                if end == "24:00":  # OpeningHours parses %H:%M, which has no hour 24
+                    end = "23:59"
+                try:
+                    oh.add_range(day, start, end)
+                except ValueError:
+                    pass
+        return oh
+
+    @staticmethod
+    def parse_coordinates(latitude: str, longitude: str) -> tuple[float | None, float | None]:
+        def to_float(value: str) -> float | None:
+            value = (value or "").replace(",", ".")
+            parts = value.split(".")
+            if len(parts) > 2:  # a few coordinates carry a stray separator, e.g. "-33.624.167"
+                value = "{}.{}".format(parts[0], "".join(parts[1:]))
+            try:
+                return float(value)
+            except ValueError:
+                return None
+
+        lat, lon = to_float(latitude), to_float(longitude)
+        if lat and lon and -56.0 < lat < -21.0 and -74.0 < lon < -53.0:
+            return lat, lon
+        return None, None


### PR DESCRIPTION
Data source: https://www.axionenergy.com/estaciones-de-servicio/
API (GET JSON): https://www.axionenergy.com/wp-json/axion/v1/estaciones?top=1000&filters=Title eq 'EESS' — WordPress REST endpoint; top=1000 returns all stations, Title eq 'EESS' limits to service stations (EESS = estación de servicio).

Category: all → Categories.FUEL_STATION (571 across Argentina; NSI also lists PY/UY, but this feed is AR-only, hence axion_ar). Stations with an on-site store additionally get shop=convenience.

Fuel types (from the 1/0 product flags):

AXIONSUPER → fuel:octane_95 (Axion Súper — grade-2 petrol, ≥95 RON)
QUANTIUM → fuel:octane_98 (Quantium — grade-3 premium petrol, ≥98 RON)
AXIONDIESELX10 / QUANTIUMDIESELX10 → fuel:diesel
GNC → fuel:cng
Services (per-station capability flags):

Tienda → shop=convenience (540 — the on-site Spot! / AXION shop store)
ParadaSanguchera → fast_food (84 — the "Parada Sanguchera" sandwich counter)
BoschCarService → service:vehicle:car_repair (8)
CastrolOilExpress → service:vehicle:oil_change (3)
Payment-app acceptance flags (Amex, MODO, Bna, Brubank, BbvaGo, AXIONcard) and register-cashback (ExtraCash) are intentionally omitted — they aren't physical on-site services.

Opening hours: parsed from the per-day lunesHorarios…domingoHorarios fields (format HH:MM-HH:MM) into OSM opening_hours (555/571; multi-range and per-day-varying schedules supported, 00:00-24:00 normalised to a 24/7 day). The remaining 16 are blank in the source.

Fields: DictParser maps Direccion→addr:street_address and Telefono→phone; ref=PBL, branch=NombreEESSAgro (fallback RazonSocial), addr:city=Localidad, addr:state=Provincia, lat/lon from Latitud/Longitud (comma decimals; a stray extra separator like -33.624.167 is repaired; coordinates outside Argentina are dropped). NSI supplies name=Axion.

Notes:

DictParser's auto-mapped name (the "EESS" Title) and the malformed email field (a duplicated string) are dropped.
ref=PBL yields 571 (6 records are exact duplicates, dropped by the pipeline).
Phone: location-specific numbers with area codes are kept (formatted to E.164, e.g. +54 11 4692-1353); the shared 0800-888-0282 national call-centre line (88 stations) is dropped as it isn't a branch's own number. 460 stations retain a phone.

Sample POI:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "150107", 
      "amenity": "fuel", 
      "branch": "ALVAREZ OSCAR NORBERTO Y RADAMES",
      "addr:street_address": "MENDOZA 205", 
      "addr:city": "MORON - GBA",
      "addr:state": "Buenos Aires", 
      "addr:country": "AR",
      "phone": "+54 11 4692-1353", 
      "opening_hours": "Mo-Su 06:00-23:00",
      "shop": "convenience",
      "fuel:octane_95": "yes", "fuel:octane_98": "yes", "fuel:diesel": "yes",
      "brand": "Axion", "brand:wikidata": "Q62131749"
    },
    "geometry": {"type": "Point", "coordinates": [-58.622471, -34.645959]}
  }
]
```
Json Stats:
```
{
  "item_scraped_count": 571,
  "atp/category/amenity/fuel": 571,
  "atp/nsi/match_perfect": 571,
  "atp/field/country/from_spider_name": 571,
  "finish_reason": "finished"
}
```