### PR TITLE
[Burgermeister] Fix spider

### DIFF
--- a/locations/spiders/burgermeister.py
+++ b/locations/spiders/burgermeister.py
@@ -11,7 +11,7 @@ class BurgermeisterSpider(JSONBlobSpider):
     name = "burgermeister"
     item_attributes = {"brand": "Burgermeister", "brand_wikidata": "Q116382535"}
     start_urls = [
-        "https://burgermeister.com/wp-admin/admin-ajax.php?filter=%7B%22map_id%22%3A%226%22%2C%22mashupIDs%22%3A%5B%5D%2C%22customFields%22%3A%5B%5D%7D&route=%2Ffeatures%2F&action=wpgmza_rest_api_request"
+        "https://burgermeister.com/api-json.php?filter=%7B%22map_id%22%3A%226%22%2C%22mashupIDs%22%3A%5B%5D%2C%22customFields%22%3A%5B%5D%7D&route=%2Ffeatures%2F&action=wpgmza_rest_api_request"
     ]
     locations_key = "markers"
 


### PR DESCRIPTION
The WP Google Maps AJAX endpoint moved from /wp-admin/admin-ajax.php to /api-json.php (security-plugin rename). Update the start URL.

31 locations, previously 0.