### PR TITLE
[Gulf AR] Add spider

### DIFF
--- a/locations/spiders/gulf_ar.py
+++ b/locations/spiders/gulf_ar.py
@@ -1,0 +1,132 @@
+import json
+import re
+import unicodedata
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours, sanitise_day
+from locations.pipelines.address_clean_up import merge_address_lines
+
+BASE = "https://master.d3cm5183c0na8t.amplifyapp.com"
+
+
+def gbp_time(value: dict | None) -> str:
+    # The brand's own payload carries times in Google-Business-Profile shape,
+    # {"hours": H, "minutes": M}; an absent component means zero, and hour 24 is
+    # the end-of-day midnight boundary.
+    value = value or {}
+    hours = value.get("hours", 0)
+    if hours >= 24:
+        return "23:59"
+    return "{:02d}:{:02d}".format(hours, value.get("minutes", 0))
+
+
+def slugify(value: str) -> str:
+    value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def service_present(value: Any) -> bool:
+    # The services sheet uses "SI"/"NO", except Gomería (tyre service) which
+    # repeats its own label instead of "SI"; treat anything but blank/"NO" as yes.
+    return bool(value) and str(value).strip().upper() != "NO"
+
+
+class GulfARSpider(Spider):
+    name = "gulf_ar"
+    item_attributes = {"brand": "Gulf", "brand_wikidata": "Q5617505"}
+    # Gulf has no worldwide store locator; the Argentine network (run under
+    # licence by DeltaPatagonia S.A.) is published on the brand's own site,
+    # gulfcombustibles.com, via a multi-tenant Next.js locator. We scrape that
+    # page: the station list is prerendered into the /gulf __NEXT_DATA__. The
+    # records use the Google-Business-Profile schema because the brand manages its
+    # listings there and its site republishes them (we never contact Google). The
+    # per-site services (GNC, car wash, ATM, tyres, store) live in a separate
+    # global table rendered only onto the city pages, keyed by PDV == storeCode.
+    start_urls = [BASE + "/gulf"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        locations = self.extract_next_data(response)["locations"]
+        # Fetch one city page to read the global services table, then join it to
+        # the full location list. The city is derived from a location so nothing
+        # is hardcoded; an errback still yields the stations if that page fails.
+        address = locations[0]["address"]
+        city_url = "{}/gulf/argentina/{}/{}".format(
+            BASE, slugify(address["administrativeArea"]), slugify(address["locality"])
+        )
+        yield response.follow(
+            city_url,
+            callback=self.parse_with_services,
+            cb_kwargs={"locations": locations},
+            errback=self.on_city_error,
+        )
+
+    def on_city_error(self, failure: Any) -> Any:
+        # City page unreachable: still emit every station, just without services.
+        self.logger.warning("services table fetch failed (%s); emitting stations without services", failure.value)
+        yield from self.build_items(failure.request.cb_kwargs["locations"], {})
+
+    def parse_with_services(self, response: Response, locations: list[dict]) -> Any:
+        table = self.extract_next_data(response).get("respAdditional", {}).get("gulfServices", [])
+        services = {}
+        for row in table:
+            row = {key.strip(): value for key, value in row.items()}
+            services[str(row.get("Nro PDV", "")).strip()] = row
+        yield from self.build_items(locations, services)
+
+    def build_items(self, locations: list[dict], services: dict[str, dict]) -> Any:
+        for location in locations:
+            item = DictParser.parse(location)  # maps locality -> city, postalCode -> postcode, primaryPhone -> phone
+            item.pop("name", None)  # DictParser sets this to the GBP resource path; NSI supplies name=Gulf
+            item.pop("website", None)  # only the generic brand homepage, never a venue-specific URL
+            item["ref"] = location["storeCode"]
+
+            if not (item.get("phone") or "").strip().startswith("0"):
+                item.pop("phone", None)  # drop bare local numbers with no Argentine area code (e.g. "491-3389")
+
+            address = location["address"]
+            item["street_address"] = merge_address_lines(address["addressLines"])
+            item["state"] = address.get("administrativeArea")
+            item["country"] = address.get("regionCode")
+            item["lat"] = location["latlng"]["latitude"]
+            item["lon"] = location["latlng"]["longitude"]
+            item["opening_hours"] = self.parse_hours(location.get("regularHours"))
+
+            apply_category(Categories.FUEL_STATION, item)
+            entry = services.get(item["ref"])
+            if entry:
+                apply_yes_no(Fuel.CNG, item, service_present(entry.get("GNC")))
+                apply_yes_no(Extras.CAR_WASH, item, service_present(entry.get("Lavadero")))
+                apply_yes_no(Extras.ATM, item, service_present(entry.get("Cajero Automático")))
+                apply_yes_no(Extras.TYRE_SERVICES, item, service_present(entry.get("Gomería")))
+                # NB: the on-site "Gulf Store" is deliberately NOT tagged shop=convenience.
+                # That is a top-level category tag, and NSI only matches a brand when the
+                # item's categories are a subset of the brand's; Gulf's NSI entry is
+                # amenity=fuel only, so adding shop=convenience breaks the brand match.
+            yield item
+
+    @staticmethod
+    def extract_next_data(response: Response) -> dict:
+        data = json.loads(response.xpath('//script[@id="__NEXT_DATA__"]/text()').get())
+        return data["props"]["pageProps"]
+
+    @staticmethod
+    def parse_hours(regular_hours: dict | None) -> OpeningHours | str | None:
+        periods = (regular_hours or {}).get("periods")
+        if not periods:
+            return None
+        # GBP encodes a 24-hour day as an empty openTime with a closeTime of hour
+        # 24; when every day is like that, the station is simply 24/7.
+        if len(periods) == 7 and all(
+            (p.get("closeTime") or {}).get("hours") == 24 and not (p.get("openTime") or {}) for p in periods
+        ):
+            return "24/7"
+        oh = OpeningHours()
+        for period in periods:
+            if day := sanitise_day(period["openDay"]):
+                oh.add_range(day, gbp_time(period.get("openTime")), gbp_time(period.get("closeTime")))
+        return oh


### PR DESCRIPTION
Data source: https://gulfcombustibles.com/donde-estamos/mapa-de-estaciones (the brand's own site)

How it's scraped: the locator is a multi-tenant Next.js app on AWS Amplify (master.d3cm5183c0na8t.amplifyapp.com, robots.txt Allow: /). The spider reads the brand's own pages — no third-party or Google endpoint is contacted:

GET /gulf — the full station list is prerendered into the page's __NEXT_DATA__ (props.pageProps.locations, 111 records). Parsing the embedded JSON avoids hardcoding the deploy-specific buildId.
GET /gulf/argentina/{province}/{city} — one city page (derived from the first station, nothing hardcoded) carries a global per-site services table (respAdditional.gulfServices), keyed by PDV number. The spider joins it to the station list by storeCode (covers 96/111). An errback still emits every station (without services) if that page is unreachable.
The records use the Google Business Profile schema (address, latlng, regularHours.periods, primaryPhone, storeCode) because Gulf/DeltaPatagonia manage their listings in GBP and their own site republishes them — the same pattern as several merged spiders (le_pain_quotidien, nandos_ae, nike, fnbc_ca, …).

Scope: Gulf has no worldwide locator; the Argentine network (operated under licence by DeltaPatagonia S.A.) is the only bulk-listed one — all 111 records are AR, hence gulf_ar.

Category: all → Categories.FUEL_STATION (111).

Fuel & services (joined from the gulfServices table):

GNC → fuel:cng (36)
Lavadero → car_wash (12)
Cajero Automático → atm (21, on-site)
Gomería → service:vehicle:tyres (9)
The on-site "Gulf Store" is intentionally not tagged shop=convenience: that top-level tag isn't part of Gulf's amenity=fuel NSI entry, so adding it makes NSI drop the brand match (category_unknown) and strips the name. Better to omit the store than lose the brand linkage.

Fields: DictParser maps locality→addr:city, postalCode→addr:postcode, primaryPhone→phone. Set manually: ref=storeCode (unique across all 111), addr:street_address=merge_address_lines(addressLines), addr:state=administrativeArea, addr:country=regionCode, lat/lon from latlng. name is supplied by NSI (Gulf).

Opening hours: parsed from GBP regularHours.periods; when all seven days are open-all-day (empty openTime + closeTime hour 24) the station is emitted as 24/7 (87 stations), otherwise per-day ranges. 108/111 have hours; 3 are blank in the source.

Notes:

DictParser's auto-mapped name (the GBP resource path accounts/.../locations/...) and the generic brand-homepage websiteUrl are dropped.
Phone: per-branch numbers with area codes are kept (formatted to E.164, e.g. +54 11 6063-4474); one bare local fragment with no area code (491-3389) is dropped per the format rule. 78 stations retain a phone.

Sample POIs:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1401", 
      "amenity": "fuel",
      "addr:street_address": "Sáenz Peña, y Sebastian Abalos", 
      "addr:city": "Santiago del Estero",
      "addr:state": "Santiago del Estero", 
      "addr:postcode": "4204", 
      "addr:country": "AR",
      "phone": "+54 385 421-1912", 
       "opening_hours": "24/7",
      "fuel:cng": "yes", "car_wash": "yes",
      "name": "Gulf", "brand": "Gulf", "brand:wikidata": "Q5617505"
    },
    "geometry": {"type": "Point", "coordinates": [-64.270666, -27.792686]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "22501", 
      "amenity": "fuel",
      "addr:street_address": "Córdoba 393", 
      "addr:city": "Morón",
      "addr:state": "Buenos Aires", 
      "addr:postcode": "1708", 
      "addr:country": "AR",
      "phone": "+54 11 3560-0860", 
      "opening_hours": "Mo-Fr 06:00-21:30; Sa-Su 09:00-21:00",
      "name": "Gulf", 
       "brand": "Gulf", 
       "brand:wikidata": "Q5617505"
    },
    "geometry": {"type": "Point", "coordinates": [-58.613452, -34.655628]}
  }
]
```
JSON :
```
{
  "item_scraped_count": 111,
  "atp/category/amenity/fuel": 111,
  "atp/country/AR": 111,
  "atp/nsi/match_perfect": 111,
  "finish_reason": "finished"
}
```