### PR TITLE
Add Government Data for fuel stations in Argentina

### DIFF
--- a/locations/spiders/government/gov_precios_surtidor_ar.py
+++ b/locations/spiders/government/gov_precios_surtidor_ar.py
@@ -1,0 +1,93 @@
+import csv
+from io import StringIO
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.licenses import Licenses
+from locations.settings import ITEM_PIPELINES
+
+
+class GovPreciosSurtidorARSpider(Spider):
+    name = "gov_precios_surtidor_ar"
+    dataset_attributes = Licenses.CCBY4.value | {
+        "attribution:name": "Secretaría de Energía de la Nación Argentina - Precios en Surtidor (Resolución 314/2016)",
+        "attribution:website": "http://datos.energia.gob.ar/dataset/precios-en-surtidor",
+        "use:commercial": "permit",
+    }
+    custom_settings = {
+        "DOWNLOAD_TIMEOUT": 300,
+        # Multi-operator open data: count operators rather than brands.
+        "ITEM_PIPELINES": ITEM_PIPELINES | {"locations.pipelines.count_operators.CountOperatorsPipeline": None},
+    }
+    # Argentina's Secretaría de Energía publishes every service station's current fuel
+    # prices (CC-BY-4.0, commercial use permitted with attribution). The CSV has one
+    # row per station x product x day/night schedule, so we group the rows of each
+    # station (idempresa) into one POI and derive the fuel types it sells.
+    start_urls = [
+        "https://datos.energia.gob.ar/dataset/1c181390-5045-475e-94dc-410429be4b17/resource/"
+        "80ac25de-a44a-4445-9215-090cf55cfda5/download/precios-en-surtidor-resolucin-3142016.csv"
+    ]
+
+    # idproducto -> OSM fuel tag. Argentine grades: "súper" (92-95 RON) is the common
+    # unleaded, "premium" (>95 RON) the high-octane one; both gas-oil grades are diesel.
+    FUELS = {
+        "2": Fuel.OCTANE_95,  # Nafta (súper) entre 92 y 95 Ron
+        "3": Fuel.OCTANE_98,  # Nafta (premium) de más de 95 Ron
+        "6": Fuel.CNG,  # GNC
+        "19": Fuel.DIESEL,  # Gas Oil Grado 2
+        "21": Fuel.DIESEL,  # Gas Oil Grado 3 (premium diesel)
+    }
+
+    # empresabandera -> brand. Wikidata codes are the NSI fuel-brand entries. Dapsa has
+    # no Wikidata item, so its name is set explicitly (NSI can't supply it); the others
+    # leave name unset so NSI fills it. Flags not listed here fall through to a raw
+    # brand=name mapping with an unmapped_brand stat so they can be added to NSI.
+    BRANDS = {
+        "YPF": {"brand": "YPF", "brand_wikidata": "Q2006989"},
+        "SHELL C.A.P.S.A.": {"brand": "Shell", "brand_wikidata": "Q110716465"},
+        "AXION": {"brand": "Axion", "brand_wikidata": "Q62131749"},
+        "PUMA": {"brand": "Puma", "brand_wikidata": "Q7259769"},
+        "GULF": {"brand": "Gulf", "brand_wikidata": "Q5617505"},
+        "REFINOR": {"brand": "Refinor", "brand_wikidata": "Q10358460"},
+        "DAPSA S.A.": {"brand": "Dapsa", "name": "Dapsa"},
+    }
+
+    # White-pump / unbranded independents: genuinely have no brand, so leave it unset.
+    UNBRANDED = {"BLANCA", "SIN EMPRESA BANDERA"}
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        stations: dict[str, dict] = {}
+        for row in csv.DictReader(StringIO(response.text)):
+            station = stations.setdefault(row["idempresa"], {"row": row, "products": set()})
+            station["products"].add(row["idproducto"])
+
+        for ref, station in stations.items():
+            row = station["row"]
+            item = DictParser.parse(row)  # maps latitud/longitud -> lat/lon and direccion -> addr_full
+            item["ref"] = ref
+            item["street_address"] = item.pop("addr_full", None)
+            item["city"] = row["localidad"]
+            item["state"] = row["provincia"]  # DictParser mismaps the macro-region ("region") to state
+            item["operator"] = row["empresa"]
+
+            bandera = row["empresabandera"].strip()
+            if bandera in self.BRANDS:
+                item["name"] = None  # use the NSI name for the brand
+                item.update(self.BRANDS[bandera])
+            elif bandera in self.UNBRANDED:
+                pass  # white-pump independents genuinely have no brand
+            else:
+                item["brand"] = item["name"] = bandera  # keep the raw flag until it is added to NSI
+                self.crawler.stats.inc_value("atp/{}/unmapped_brand/{}".format(self.name, bandera))
+
+            apply_category(Categories.FUEL_STATION, item)
+            for product in station["products"]:
+                if fuel := self.FUELS.get(product):
+                    apply_yes_no(fuel, item, True)
+                else:
+                    self.crawler.stats.inc_value("atp/{}/unmapped_product/{}".format(self.name, product))
+            yield item


### PR DESCRIPTION
Data source: Argentina,  Secretaría de Energía de la Nación (Subsecretaría de Eficiencia e Información Energética): 

https://datos.energia.gob.ar/dataset/precios-en-surtidor
License: CC-BY-4.0 (Licenses.CCBY4) — commercial use permitted with attribution; declared in dataset_attributes with attribution:name / attribution:website / use:commercial=permit.

Source data: the "Precios vigentes en surtidor - Resolución 314/2016" CSV resource, downloaded once (~9 MB, updated hourly by the agency).

Placement: locations/spiders/government/ — this is an open-government dataset spanning many operators, not a single brand.

Structure: the CSV holds one row per station × product × day/night schedule (~36.7k rows). The spider downloads it and groups the rows by idempresa into 4,626 unique service-station POIs, aggregating the products each station sells into fuel tags. (A plain Spider + csv is used rather than CSVFeedSpider because the data is many-rows-per-station and needs aggregation , CSVFeedSpider's one-item-per-row would lose all but one fuel type after ref-deduplication.

Category: all → Categories.FUEL_STATION.

Fuel types (from idproducto, aggregated per station):

Gas Oil Grado 2 / Gas Oil Grado 3 → fuel:diesel (4220) — both are diesel; OSM has no distinct "premium diesel" tag
Nafta (súper) 92-95 RON → fuel:octane_95 (4170)
Nafta (premium) >95 RON → fuel:octane_98 (4059)
GNC → fuel:cng (1861)
Brand (from empresabandera, via the standard mapped / white-pump / unmapped pattern):

Mapped flags use NSI-verified Wikidata (name left to NSI): YPF Q2006989 (1568), Shell Q110716465 (900), Axion Q62131749 (545), Puma Q7259769 (400), Gulf Q5617505 (95), Refinor Q10358460 (60). Dapsa (122) is a known brand with no Wikidata item, so its name is set explicitly.

White-pump independents BLANCA / SIN EMPRESA BANDERA (901) are genuinely unbranded → no brand.

Unrecognised flags keep their raw value as brand+name and are counted for future NSI mapping: VOY (34), OIL COMBUSTIBLES S.A. (1) under atp/gov_precios_surtidor_ar/unmapped_brand/*.
Fields: DictParser maps latitud/longitud→lat/lon and direccion→addr:street_address; then ref=idempresa, operator=empresa, addr:city=localidad, addr:state=provincia (overriding DictParser's mismap of the macro-region). CountOperatorsPipeline is attached since this is multi-operator data.

Notes:

No brand item_attributes (multi-operator). atp/nsi/match_failed (1058) is expected — the white-pump independents plus the no-Wikidata brands (Dapsa/Voy) , not a defect. : I will create a PR to add them in NSI.

4,623/4,626 stations have coordinates (3 have blank/invalid source coords).

The portal's robots.txt currently returns HTTP 500 (server-side). With ROBOTSTXT_OBEY left enabled, Scrapy fails open and the public open-data resource downloads normally — no robots directive is bypassed.

Prices are intentionally not emitted: the source splits them by Diurno/Nocturno (day/night), which doesn't map to OSM's self/full-service charge:* model, and pump prices are volatile hourly data.

Sample POIs:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "3728",
      "amenity": "fuel", 
      "operator": "ABDALA HNOS.S.R.L.",
      "addr:street_address": "LIBERTAD 2080", 
      "addr:city": "SANTIAGO DEL ESTERO", 
      "addr:state": "SANTIAGO DEL ESTERO",
      "brand": "Shell", 
      "brand:wikidata": "Q110716465", 
      "name": "Shell",
      "fuel:diesel": "yes", 
      "fuel:octane_95": "yes", 
      "fuel:octane_98": "yes", 
      "fuel:cng": "yes"
    },
    "geometry": {"type": "Point", "coordinates": [-64.27723, -27.79833]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "348", 
      "amenity": "fuel", 
      "operator": "ABELLA Y ALONSO S.R.L.",
      "addr:street_address": "MORENO 1701", 
      "addr:city": "VILLA BALLESTER", 
      "addr:state": "BUENOS AIRES",
      "fuel:diesel": "yes", 
      "fuel:octane_95": "yes", 
      "fuel:octane_98": "yes"
    },
    "geometry": {"type": "Point", "coordinates": [-58.55767, -34.53338]}
  }
]
```