### PR TITLE
[Kipling US] Fix Spider

### DIFF
--- a/locations/spiders/kipling_us.py
+++ b/locations/spiders/kipling_us.py
@@ -1,37 +1,27 @@
-import re
-from typing import AsyncIterator
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
-
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
-from locations.pipelines.address_clean_up import clean_address
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 
 
-class KiplingUSSpider(Spider):
+class KiplingUSSpider(SitemapSpider):
     name = "kipling_us"
     item_attributes = {"brand": "Kipling", "brand_wikidata": "Q6414641"}
-    allowed_domains = ["www.kipling-usa.com"]
-    start_urls = [
-        "https://www.kipling-usa.com/on/demandware.store/Sites-kip-Site/default/Stores-GetNearestStores?&countryCode=US&onlyCountry=true&retailstores=true&outletstores=true"
-    ]
+    sitemap_urls = ["https://locations.kipling.com/sitemap.xml"]
+    sitemap_rules = [(r"https://locations.kipling.com/us/[^/]+/[^/]+/[^/]+$", "parse")]
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
-
-    def parse(self, response):
-        for location in response.json().values():
-            if (
-                "STORE CLOSED" in location.get("storeHours", "").upper()
-                or "STORE IS CLOSED" in location.get("storeHours", "").upper()
-            ):
-                continue
-            item = DictParser.parse(location)
-            item["ref"] = location["storeID"]
-            item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
-            hours_string = re.sub(r"\s+", " ", location.get("storeHours")).strip()
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(hours_string)
-            yield item
+    def parse(self, response: TextResponse, **kwargs):
+        item = Feature()
+        item["name"] = self.item_attributes["brand"]
+        item["branch"] = response.xpath("//h1/text()").get()
+        item["street_address"] = response.xpath('//*[@property="business:contact_data:street_address"]/@content').get()
+        item["city"] = response.xpath('//*[@property="business:contact_data:locality"]/@content').get()
+        item["state"] = response.xpath('//*[@property="business:contact_data:region"]/@content').get()
+        item["postcode"] = response.xpath('//*[@property="business:contact_data:postal_code"]/@content').get()
+        item["phone"] = response.xpath('//*[@property="business:contact_data:phone_number"]/@content').get()
+        item["lat"] = response.xpath('//*[@property="place:location:latitude"]/@content').get()
+        item["lon"] = response.xpath('//*[@property="place:location:longitude"]/@content').get()
+        item["ref"] = item["website"] = response.url
+        apply_category(Categories.SHOP_BAG, item)
+        yield item

--- a/locations/spiders/kipling_us.py
+++ b/locations/spiders/kipling_us.py
@@ -13,7 +13,6 @@ class KiplingUSSpider(SitemapSpider):
 
     def parse(self, response: TextResponse, **kwargs):
         item = Feature()
-        item["name"] = self.item_attributes["brand"]
         item["branch"] = response.xpath("//h1/text()").get()
         item["street_address"] = response.xpath('//*[@property="business:contact_data:street_address"]/@content').get()
         item["city"] = response.xpath('//*[@property="business:contact_data:locality"]/@content').get()
@@ -23,5 +22,7 @@ class KiplingUSSpider(SitemapSpider):
         item["lat"] = response.xpath('//*[@property="place:location:latitude"]/@content').get()
         item["lon"] = response.xpath('//*[@property="place:location:longitude"]/@content').get()
         item["ref"] = item["website"] = response.url
+
         apply_category(Categories.SHOP_BAG, item)
+
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Kipling': 31,
 'atp/brand_wikidata/Q6414641': 31,
 'atp/category/shop/bag': 31,
 'atp/cdn/cloudflare/response_count': 33,
 'atp/cdn/cloudflare/response_status_count/200': 33,
 'atp/country/US': 31,
 'atp/field/country/from_spider_name': 31,
 'atp/field/email/missing': 31,
 'atp/field/housenumber/missing': 31,
 'atp/field/opening_hours/missing': 31,
 'atp/field/operator/missing': 31,
 'atp/field/operator_wikidata/missing': 31,
 'atp/field/phone/missing': 9,
 'atp/field/street/missing': 31,
 'atp/field/twitter/missing': 31,
 'atp/field/unit/missing': 31,
 'atp/item_scraped_host_count/locations.kipling.com': 31,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 31,
 'atp/nsi/match_failed': 31,
 'downloader/request_bytes': 13081,
 'downloader/request_count': 33,
 'downloader/request_method_count/GET': 33,
 'downloader/response_bytes': 985714,
 'downloader/response_count': 33,
 'downloader/response_status_count/200': 33,
 'elapsed_time_seconds': 39.0630000000001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 13, 7, 54, 1, 550739, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6790592,
 'httpcompression/response_count': 33,
 'item_scraped_count': 31,
 'items_per_minute': 47.69230769230769,
 'log_count/DEBUG': 64,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 33,
 'responses_per_minute': 50.76923076923077,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 32,
 'scheduler/dequeued/memory': 32,
 'scheduler/enqueued': 32,
 'scheduler/enqueued/memory': 32,
 'start_time': datetime.datetime(2026, 7, 13, 7, 53, 22, 486755, tzinfo=datetime.timezone.utc)}
```