### PR TITLE
[Kokoro GB] Fix Spider

### DIFF
--- a/locations/spiders/kokoro_gb.py
+++ b/locations/spiders/kokoro_gb.py
@@ -5,7 +5,6 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class KokoroGBSpider(Spider):
@@ -14,11 +13,13 @@ class KokoroGBSpider(Spider):
     start_urls = ["https://kokorouk.com/locations/"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//div[contains(@class, "wp-block-group-is-layout-flex")]'):
+        for location in response.xpath('//*[@class="location-collapse-list"]'):
             item = Feature()
-            item["ref"] = item["branch"] = location.xpath("h2/text()").get()
-            item["addr_full"] = merge_address_lines(location.xpath("p/text()").getall())
-
+            item["branch"] = item["ref"] = location.xpath('.//*[@class="body-1"]/text()').get()
+            item["addr_full"] = location.xpath('.//*[@class="body-3"]/text()').get()
+            item["lat"], item["lon"] = (
+                response.xpath('//*[@class="location"]/text()').get().replace("{", "").replace("}", "").split(",")
+            )
             apply_category(Categories.FAST_FOOD, item)
 
             yield item


### PR DESCRIPTION
```python
{'atp/brand/KOKORO': 84,
 'atp/brand_wikidata/Q117050264': 84,
 'atp/category/amenity/fast_food': 84,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/clean_strings/lon': 84,
 'atp/country/GB': 84,
 'atp/field/city/missing': 84,
 'atp/field/country/from_spider_name': 84,
 'atp/field/email/missing': 84,
 'atp/field/housenumber/missing': 84,
 'atp/field/opening_hours/missing': 84,
 'atp/field/operator/missing': 84,
 'atp/field/operator_wikidata/missing': 84,
 'atp/field/phone/missing': 84,
 'atp/field/state/missing': 84,
 'atp/field/street/missing': 84,
 'atp/field/street_address/missing': 84,
 'atp/field/twitter/missing': 84,
 'atp/field/unit/missing': 84,
 'atp/item_scraped_host_count/kokorouk.com': 84,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 84,
 'downloader/request_bytes': 1295,
 'downloader/request_count': 3,
 'downloader/request_method_count/GET': 3,
 'downloader/response_bytes': 56111,
 'downloader/response_count': 3,
 'downloader/response_status_count/200': 2,
 'downloader/response_status_count/301': 1,
 'elapsed_time_seconds': 4.84400000000096,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 13, 8, 38, 38, 441635, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 503369,
 'httpcompression/response_count': 2,
 'item_scraped_count': 84,
 'items_per_minute': 1260.0,
 'log_count/DEBUG': 87,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2,
 'scheduler/dequeued/memory': 2,
 'scheduler/enqueued': 2,
 'scheduler/enqueued/memory': 2,
 'start_time': datetime.datetime(2026, 7, 13, 8, 38, 33, 595882, tzinfo=datetime.timezone.utc)}
```