### PR TITLE
[Williams Sonoma US] Fix spider

### DIFF
--- a/locations/spiders/williams_sonoma_us.py
+++ b/locations/spiders/williams_sonoma_us.py
@@ -2,14 +2,15 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
-from locations.user_agents import BROWSER_DEFAULT
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class WilliamsSonomaUSSpider(JSONBlobSpider):
+class WilliamsSonomaUSSpider(JSONBlobSpider, CamoufoxSpider):
     name = "williams_sonoma_us"
     allowed_domains = ["www.williams-sonoma.com"]
     start_urls = [
@@ -19,8 +20,11 @@ class WilliamsSonomaUSSpider(JSONBlobSpider):
         "WS": {"brand": "Williams-Sonoma", "brand_wikidata": "Q2581220"},
         "PB": {"brand": "Pottery Barn", "brand_wikidata": "Q3400126"},
     }
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
     locations_key = ["storeListResponse", "stores"]
+
+    def extract_json(self, response: Response) -> dict | list[dict]:
+        return super().extract_json(response.replace(body=response.xpath("string(//body)").get()))
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("properties"))


### PR DESCRIPTION
```
{'atp/brand/Pottery Barn': 157,
 'atp/brand/Williams-Sonoma': 145,
 'atp/brand_wikidata/Q2581220': 145,
 'atp/brand_wikidata/Q3400126': 157,
 'atp/category/shop/furniture': 157,
 'atp/category/shop/houseware': 145,
 'atp/country/US': 302,
 'atp/field/branch/missing': 302,
 'atp/field/email/missing': 302,
 'atp/field/housenumber/missing': 302,
 'atp/field/operator/missing': 302,
 'atp/field/operator_wikidata/missing': 302,
 'atp/field/phone/missing': 2,
 'atp/field/street/missing': 302,
 'atp/field/twitter/missing': 302,
 'atp/field/unit/missing': 302,
 'atp/item_scraped_host_count/www.williams-sonoma.com': 302,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 157,
 'atp/nsi/match_perfect': 145,
 'atp/nsi/multiple_matches': 157,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 1,
 'camoufox/request_count/method/GET': 1,
 'camoufox/request_count/navigation': 1,
 'camoufox/request_count/resource_type/document': 1,
 'camoufox/response_count': 1,
 'camoufox/response_count/method/GET': 1,
 'camoufox/response_count/resource_type/document': 1,
 'downloader/request_bytes': 430,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 250127,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 89.34400000001187,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 13, 11, 45, 31, 639788, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 302,
 'items_per_minute': 203.59550561797752,
 'log_count/DEBUG': 307,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.6741573033707865,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 13, 11, 44, 2, 286751, tzinfo=datetime.timezone.utc)}
```