### PR TITLE
[H-E-B US] Fix spider

### DIFF
--- a/locations/spiders/h_e_b_us.py
+++ b/locations/spiders/h_e_b_us.py
@@ -12,7 +12,6 @@ from locations.hours import OpeningHours, sanitise_day
 class HEBUSSpider(Spider):
     name = "h_e_b_us"
     item_attributes = {"brand": "H-E-B", "brand_wikidata": "Q830621"}
-    proxy_required = True
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
Drop the stale proxy_required flag: the /graphql store API works over direct HTTP (660 locations incl. adjacent pharmacies), while the proxy it was routed through is now blocked by H-E-B, yielding zero in production.