### PR TITLE
[Wolle Rödel DE] Fix spider

### DIFF
--- a/locations/spiders/wolle_rodel_de.py
+++ b/locations/spiders/wolle_rodel_de.py
@@ -1,22 +1,33 @@
-import scrapy
+import re
+from typing import Any, Iterable
 
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import apply_category
 from locations.dict_parser import DictParser
+from locations.items import Feature
 
 
-class WolleRodelDESpider(scrapy.Spider):
+class WolleRodelDESpider(Spider):
+    name = "wolle_rodel_de"
     item_attributes = {
         "brand_wikidata": "Q107357091",
         "brand": "Wolle Rödel",
     }
-    name = "wolle_rodel_de"
     allowed_domains = ["www.wolle-roedel.com"]
     start_urls = ["https://www.wolle-roedel.com/StoreLocator/getStores"]
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         for location in response.json()["data"]:
+            location.pop("email", None)
             item = DictParser.parse(location)
-            item["ref"] = location["_uniqueIdentifier"]
-            item["name"] = location["label"]
-            item["website"] = "https://www.wolle-roedel.com/" + location["translated"]["seoUrl"]
-            # TODO: location["extensions"] contains business hours, but the days of the week are keys like '1dd4f7f0b2094a909f0d3cda1acd9be4'
+
+            branch = location["label"].removeprefix("Wolle Rödel").strip()
+            if host := re.search(r"\s*\(([^)]+)\)\s*$", branch):
+                item["located_in"] = host.group(1).removeprefix("im ").strip()
+                branch = branch[: host.start()].strip()
+            item["branch"] = branch
+
+            apply_category({"shop": "fabric"}, item)
             yield item


### PR DESCRIPTION
The StoreLocator API changed shape: `translated.seoUrl` was removed (raising a `KeyError`) and `_uniqueIdentifier` now returns null, so the spider yielded nothing.

- Let `DictParser` derive the ref (from `id`) and address fields.
- Take `branch` from the label, splitting the trailing host store into `located_in`.
- Drop the shared parent-company email and the now-absent website.
- Apply `shop=fabric` explicitly.

Local crawl now yields 69 stores with coordinates and phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)