### PR TITLE
[Up & Running GB] Fix spider

### DIFF
--- a/locations/spiders/up_and_running_gb.py
+++ b/locations/spiders/up_and_running_gb.py
@@ -1,9 +1,9 @@
-from typing import Iterable
+from typing import Any, Iterable
 
 from scrapy import Request
 from scrapy.http import Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.storefinders.stockist import StockistSpider
@@ -11,19 +11,32 @@ from locations.storefinders.stockist import StockistSpider
 
 class UpAndRunningGBSpider(StockistSpider):
     name = "up_and_running_gb"
-    item_attributes = {"brand_wikidata": "Q42847650", "brand": "Up & Running", "extras": Categories.SHOP_SPORTS.value}
+    item_attributes = {"brand_wikidata": "Q42847650", "brand": "Up & Running"}
     key = "u7820"
 
     def parse_item(self, item: Feature, feature: dict) -> Iterable[Request]:
+        item["branch"] = item.pop("name").removeprefix("Up & Running").strip()
+        item["website"] = None
+        apply_category(Categories.SHOP_SPORTS, item)
         for custom_field in feature["custom_fields"]:
             if custom_field["id"] == 1819:
                 yield Request(url=custom_field["value"], meta={"item": item}, callback=self.parse_opening_hours)
                 return
+        yield item
 
-    def parse_opening_hours(self, response: Response) -> Iterable[Feature]:
+    def parse_opening_hours(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         item = response.meta["item"]
         hours_text = " ".join(
-            filter(None, map(str.strip, response.xpath('//div[@class="map-section-content"]//p/text()').getall()))
+            filter(
+                None,
+                map(
+                    str.strip,
+                    response.xpath(
+                        '//h2[contains(., "Opening times")]'
+                        '/following-sibling::div[contains(@class, "image-with-text__text")]//text()'
+                    ).getall(),
+                ),
+            )
         )
         hours_text = hours_text.replace(":0am", ":00am")
         item["opening_hours"] = OpeningHours()


### PR DESCRIPTION
The Stockist store API is healthy, but the per-store opening-hours page moved to a new Shopify theme, so the `map-section-content` selector matched nothing and hours were lost.

- Read hours from the new "Opening times" block.
- Take `branch` from the store name; drop the generic homepage website (present on one record only).
- Apply `shop=sports` explicitly (was an item_attributes extra).

Local crawl yields 29 stores with coordinates and opening hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)