### PR TITLE
[Sofia Urban Mobility Center BG] Fix spider

### DIFF
--- a/locations/spiders/sofia_urban_mobility_center_bg.py
+++ b/locations/spiders/sofia_urban_mobility_center_bg.py
@@ -1,19 +1,17 @@
 import re
 from typing import Any, Iterable
 
+import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.items import Feature
 
 
 class SofiaUrbanMobilityCenterBGSpider(Spider):
-    """Spider for Sofia Urban Mobility Center (Център за градска мобилност) ticket offices.
-    Closes #5846
-    """
-
     name = "sofia_urban_mobility_center_bg"
     item_attributes = {
         "brand": "Център за градска мобилност",
@@ -22,62 +20,27 @@ class SofiaUrbanMobilityCenterBGSpider(Spider):
     start_urls = ["https://webportal.sofiatraffic.bg/bg/contacts"]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        # The page is a React SPA — the location data lives in a versioned JS bundle
-        bundle_path = response.xpath('//script[@type="module"]/@src').get()
-        if not bundle_path:
-            self.logger.error("Could not find JS bundle link")
-            return
-        yield response.follow(bundle_path, callback=self.parse_bundle)
+        if bundle_path := response.xpath('//script[@type="module"]/@src').get():
+            yield response.follow(bundle_path, callback=self.parse_bundle)
 
     def parse_bundle(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        js = response.text
-
-        # Find the Fv={...} object containing all office locations
-        idx = js.find("const Fv={")
-        if idx < 0:
-            self.logger.error("Could not find locations object in JS bundle")
+        if not (anchor := re.search(r"=\{1:\{name:\{bg:", response.text)):
             return
+        for office in chompjs.parse_js_object(response.text[anchor.start() + 1 :]).values():
+            office.update(office.pop("location"))
+            office["name"] = office["name"].get("en") or office["name"]["bg"]
+            item = DictParser.parse(office)
+            item["branch"] = item.pop("name")
 
-        start = idx + len("const Fv=")
-        depth = 0
-        end = start
-        for i, c in enumerate(js[start:], start):
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                depth -= 1
-                if depth == 0:
-                    end = i + 1
-                    break
-
-        raw = js[start:end]
-
-        # Parse each location entry with regex — the JS uses unquoted numeric keys
-        # and single-quoted strings which aren't valid JSON
-        for m in re.finditer(
-            r"\d+:\{name:\{bg:'(.*?)',en:'(.*?)'\},id:(\d+).*?"
-            r"workingHours:\{weekday:\"(.*?)\",saturday:\"(.*?)\",sunday:\"(.*?)\".*?"
-            r"location:\{lat:([\d.]+),lng:([\d.]+)\}",
-            raw,
-            re.DOTALL,
-        ):
-            name_bg, name_en, ref, weekday, saturday, sunday, lat, lng = m.groups()
-
-            item = Feature()
-            item["ref"] = ref
-            item["name"] = name_en or name_bg
-            item["lat"] = float(lat)
-            item["lon"] = float(lng)
-
-            oh = OpeningHours()
-            if weekday:
-                for day in ["Mo", "Tu", "We", "Th", "Fr"]:
-                    oh.add_range(day, *weekday.split("-"))
-            if saturday:
-                oh.add_range("Sa", *saturday.split("-"))
-            if sunday:
-                oh.add_range("Su", *sunday.split("-"))
-            item["opening_hours"] = oh
+            hours = office["workingHours"]
+            item["opening_hours"] = OpeningHours()
+            for day in ["Mo", "Tu", "We", "Th", "Fr"]:
+                if hours.get("weekday"):
+                    item["opening_hours"].add_range(day, *hours["weekday"].split("-"))
+            if hours.get("saturday"):
+                item["opening_hours"].add_range("Sa", *hours["saturday"].split("-"))
+            if hours.get("sunday"):
+                item["opening_hours"].add_range("Su", *hours["sunday"].split("-"))
 
             apply_category(Categories.SHOP_TICKET, item)
             yield item


### PR DESCRIPTION
The office data lives in a minified JS bundle, and a rebuild renamed the variable holding it, so the fixed-name lookup found nothing.

- Anchor on the object's distinctive first entry rather than the volatile variable name, so future rebuilds don't break it.
- Parse it with `chompjs`/`DictParser` instead of a brittle per-record regex, which also recovers three offices the old regex silently dropped (45 → 48).

Local crawl yields 48 offices with coordinates and opening hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)