### PR TITLE
Fix DuckDB memory limit sizing to respect container's cgroup limit

### DIFF
--- a/ci/ndgeojsons_to_parquet.py
+++ b/ci/ndgeojsons_to_parquet.py
@@ -24,8 +24,35 @@ logging.basicConfig(
 )
 
 
+def cgroup_memory_limit_bytes() -> int | None:
+    # psutil.virtual_memory().total reads the host/VM's physical memory, which on
+    # Fargate can be larger than the memory actually allocated to the task - the
+    # container is still capped by the cgroup limit below. Without this, DuckDB
+    # gets configured with a limit bigger than what the container can actually
+    # use and is silently OOM-killed by the container runtime.
+    for path in (
+        Path("/sys/fs/cgroup/memory.max"),  # cgroup v2
+        Path("/sys/fs/cgroup/memory/memory.limit_in_bytes"),  # cgroup v1
+    ):
+        try:
+            raw = path.read_text().strip()
+        except OSError:
+            continue
+        if raw == "max":
+            continue
+        try:
+            limit = int(raw)
+        except ValueError:
+            continue
+        # An unset cgroup v1 limit reads as a very large sentinel value rather than "max".
+        if limit >= psutil.virtual_memory().total:
+            continue
+        return limit
+    return None
+
+
 def duckdb_memory_limit() -> str:
-    total_bytes = psutil.virtual_memory().total
+    total_bytes = cgroup_memory_limit_bytes() or psutil.virtual_memory().total
     # Reserve 2 GB for Python, pyarrow, and OS overhead
     reserved_bytes = 2 * 1024**3
     duckdb_bytes = max(total_bytes - reserved_bytes, reserved_bytes)
@@ -66,10 +93,11 @@ def to_parquet(input_dir_path: Path, output_file_path: Path) -> None:
             logger.info("Spatial extension loaded successfully")
 
             logger.info("Configuring DuckDB settings...")
+            cgroup_limit = cgroup_memory_limit_bytes()
             memory_limit = duckdb_memory_limit()
-            logger.info(
-                f"Setting DuckDB memory limit to {memory_limit} (total system RAM: {psutil.virtual_memory().total / 1024**3:.1f} GB)"
-            )
+            source = "cgroup limit" if cgroup_limit is not None else "total system RAM"
+            detected_bytes = cgroup_limit if cgroup_limit is not None else psutil.virtual_memory().total
+            logger.info(f"Setting DuckDB memory limit to {memory_limit} ({source}: {detected_bytes / 1024**3:.1f} GB)")
             con.execute(f"SET temp_directory='{temp_dir}'")
             con.execute(f"SET memory_limit='{memory_limit}'")
             con.execute("SET threads=2")

--- a/tests/test_ndgeojson_to_parquet.py
+++ b/tests/test_ndgeojson_to_parquet.py
@@ -1,9 +1,61 @@
 import shutil
 from pathlib import Path
 
+import psutil
 from pandas import read_parquet
 
-from ci.ndgeojsons_to_parquet import to_parquet
+from ci.ndgeojsons_to_parquet import cgroup_memory_limit_bytes, duckdb_memory_limit, to_parquet
+
+
+def _patch_cgroup_v2_path(monkeypatch, cgroup_v2_file: Path):
+    monkeypatch.setattr(
+        "ci.ndgeojsons_to_parquet.Path",
+        lambda p: cgroup_v2_file if p == "/sys/fs/cgroup/memory.max" else Path(p),
+    )
+
+
+def test_cgroup_memory_limit_bytes_prefers_cgroup_v2(monkeypatch, tmp_path: Path):
+    # Well below actual host RAM so it isn't mistaken for an unset/sentinel limit.
+    limit_bytes = 1024**3  # 1 GiB
+    cgroup_v2 = tmp_path / "memory.max"
+    cgroup_v2.write_text(str(limit_bytes))
+    _patch_cgroup_v2_path(monkeypatch, cgroup_v2)
+
+    assert cgroup_memory_limit_bytes() == limit_bytes
+
+
+def test_cgroup_memory_limit_bytes_ignores_unset_v2_limit(monkeypatch, tmp_path: Path):
+    cgroup_v2 = tmp_path / "memory.max"
+    cgroup_v2.write_text("max")
+    _patch_cgroup_v2_path(monkeypatch, cgroup_v2)
+
+    assert cgroup_memory_limit_bytes() is None
+
+
+def test_cgroup_memory_limit_bytes_none_when_no_cgroup_files(monkeypatch, tmp_path: Path):
+    missing = tmp_path / "does-not-exist"
+    monkeypatch.setattr("ci.ndgeojsons_to_parquet.Path", lambda p: missing)
+
+    assert cgroup_memory_limit_bytes() is None
+
+
+def test_duckdb_memory_limit_uses_cgroup_limit_over_host_ram(monkeypatch, tmp_path: Path):
+    limit_bytes = 1024**3  # 1 GiB, well below actual host RAM
+    cgroup_v2 = tmp_path / "memory.max"
+    cgroup_v2.write_text(str(limit_bytes))
+    _patch_cgroup_v2_path(monkeypatch, cgroup_v2)
+
+    # duckdb_memory_limit reserves 2GB and floors to whole GB, so a 1GB cgroup
+    # limit (less than the 2GB reservation) clamps to the reservation itself.
+    assert duckdb_memory_limit() == "2GB"
+
+
+def test_duckdb_memory_limit_falls_back_to_host_ram_without_cgroup(monkeypatch, tmp_path: Path):
+    missing = tmp_path / "does-not-exist"
+    monkeypatch.setattr("ci.ndgeojsons_to_parquet.Path", lambda p: missing)
+
+    expected_gb = max(psutil.virtual_memory().total - 2 * 1024**3, 2 * 1024**3) // 1024**3
+    assert duckdb_memory_limit() == f"{expected_gb}GB"
 
 
 def test_to_parquet(tmp_path: Path):


### PR DESCRIPTION
## Summary
- `duckdb_memory_limit()` sized DuckDB's memory limit off `psutil.virtual_memory().total`, which on Fargate reports the underlying microVM's physical RAM, not the memory the ECS task definition actually allocates to the container.
- On the current `atp-runallspiders` task (2 vCPU / 8GB), this logged `Setting DuckDB memory limit to 13GB (total system RAM: 15.4 GB)` — DuckDB was configured to use ~5GB more than the container's cgroup enforces, risking a silent OOM-kill mid-run during the parquet sort/write step.
- Now reads the cgroup memory limit (`/sys/fs/cgroup/memory.max` for cgroup v2, falling back to `memory.limit_in_bytes` for cgroup v1) when present, and only falls back to `psutil`'s host RAM reading outside a container.