### PR TITLE
[Exxon Mobil] Fix spider

### DIFF
--- a/locations/spiders/exxon_mobil.py
+++ b/locations/spiders/exxon_mobil.py
@@ -5,6 +5,7 @@ from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMet
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.pipelines.address_clean_up import clean_address
+from locations.user_agents import BROWSER_DEFAULT
 
 # We can get the first 250 from the API, but can't find a way to get the next 250 :(
 # So instead get the ids from the sitemap and call the individual api endpoint
@@ -39,7 +40,12 @@ class ExxonMobilSpider(SitemapSpider):
         "https://www.esso.nl/robots.txt",
     ]
     sitemap_rules = [(r"/find-station/.+-\d+$", "parse")]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": BROWSER_DEFAULT,
+        "RETRY_HTTP_CODES": [403],  # Sometimes server blocks and sometimes allows
+        "RETRY_TIMES": 5,
+    }
 
     brands = {
         "Exxon": {"brand": "Exxon", "brand_wikidata": "Q109675651"},


### PR DESCRIPTION
Stats produced for few items on US network:

```
{'atp/brand/Esso': 1672,
 'atp/brand/Mobil': 330,
 'atp/brand_wikidata/Q109676002': 330,
 'atp/brand_wikidata/Q867662': 1672,
 'atp/category/amenity/fuel': 2010,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/closed_check': 2,
 'atp/country/BE': 426,
 'atp/country/CA': 536,
 'atp/country/DE': 549,
 'atp/country/GU': 20,
 'atp/country/LU': 35,
 'atp/country/MP': 5,
 'atp/country/NO': 234,
 'atp/country/NZ': 147,
 'atp/country/SG': 58,
 'atp/exxonmobil/unknown_brand/': 8,
 'atp/field/branch/missing': 2010,
 'atp/field/brand/missing': 8,
 'atp/field/brand_wikidata/missing': 8,
 'atp/field/city/missing': 4,
 'atp/field/email/missing': 2010,
 'atp/field/housenumber/missing': 2010,
 'atp/field/opening_hours/missing': 63,
 'atp/field/operator/missing': 2010,
 'atp/field/operator_wikidata/missing': 2010,
 'atp/field/phone/invalid': 165,
 'atp/field/phone/missing': 142,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 1327,
 'atp/field/street/missing': 2010,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 2010,
 'atp/field/unit/missing': 2010,
 'atp/item_scraped_host_count/guam.mobil.com': 20,
 'atp/item_scraped_host_count/www.esso.be': 426,
 'atp/item_scraped_host_count/www.esso.com.sg': 58,
 'atp/item_scraped_host_count/www.esso.de': 549,
 'atp/item_scraped_host_count/www.esso.lu': 35,
 'atp/item_scraped_host_count/www.esso.no': 234,
 'atp/item_scraped_host_count/www.exxon.com': 541,
 'atp/item_scraped_host_count/www.mobil.co.nz': 147,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 8,
 'atp/nsi/match_failed': 8,
 'atp/nsi/match_perfect': 2002,
 'downloader/request_bytes': 3119086,
 'downloader/request_count': 4512,
 'downloader/request_method_count/GET': 4512,
 'downloader/response_bytes': 7727885,
 'downloader/response_count': 4512,
 'downloader/response_status_count/200': 2286,
 'downloader/response_status_count/301': 5,
 'downloader/response_status_count/403': 2220,
 'downloader/response_status_count/404': 1,
 'dupefilter/filtered': 3876,
 'elapsed_time_seconds': 1324.562,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2026, 7, 15, 7, 10, 47, 532083, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 14207255,
 'httpcompression/response_count': 2252,
 'httperror/response_ignored_count': 17,
 'httperror/response_ignored_status_count/403': 16,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 2010,
 'items_per_minute': 91.08761329305136,
 'log_count/DEBUG': 6523,
 'log_count/ERROR': 16,
 'log_count/INFO': 103,
 'log_count/WARNING': 5,
 'request_depth_max': 3,
 'response_received_count': 2303,
 'responses_per_minute': 104.3655589123867,
 'retry/count': 2204,
 'retry/max_reached': 16,
 'retry/reason_count/403 Forbidden': 2204,
 'scheduler/dequeued': 4512,
 'scheduler/dequeued/memory': 4512,
 'scheduler/enqueued': 8522,
 'scheduler/enqueued/memory': 8522,
 'start_time': datetime.datetime(2026, 7, 15, 6, 48, 42, 967387, tzinfo=datetime.timezone.utc)}
```