### PR TITLE
[Lululemon ]Fix Spider

### DIFF
--- a/locations/spiders/lululemon_ca_us.py
+++ b/locations/spiders/lululemon_ca_us.py
@@ -4,15 +4,19 @@ from scrapy.spiders import SitemapSpider
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class LululemonCAUSSpider(SitemapSpider):
+class LululemonCAUSSpider(SitemapSpider, PlaywrightSpider):
     name = "lululemon_ca_us"
     item_attributes = {"brand": "Lululemon", "brand_wikidata": "Q6702957"}
-    sitemap_urls = ("https://shop.lululemon.com/sitemap.xml",)
+    sitemap_urls = ["https://shop.lululemon.com/sitemap/Store_Sitemap_en_US.xml"]
     sitemap_rules = [
         (r"^https://shop.lululemon.com/stores/[^/]+/[^/]+/[^/]+$", "parse_store"),
     ]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse_store(self, response):
         data = json.loads(response.xpath('//script[@type="application/json"]/text()').extract_first())


### PR DESCRIPTION
```python
{'atp/brand/Lululemon': 555,
 'atp/brand_wikidata/Q6702957': 555,
 'atp/category/shop/clothes': 555,
 'atp/clean_strings/city': 4,
 'atp/clean_strings/state': 3,
 'atp/clean_strings/street_address': 6,
 'atp/country/CA': 83,
 'atp/country/US': 472,
 'atp/field/housenumber/missing': 555,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 555,
 'atp/field/operator_wikidata/missing': 555,
 'atp/field/postcode/missing': 555,
 'atp/field/street/missing': 555,
 'atp/field/unit/missing': 555,
 'atp/item_scraped_host_count/shop.lululemon.com': 555,
 'atp/nsi/category_missing': 555,
 'atp/nsi/match_imperfect': 555,
 'downloader/request_bytes': 235906,
 'downloader/request_count': 566,
 'downloader/request_method_count/GET': 566,
 'downloader/response_bytes': 117800096,
 'downloader/response_count': 566,
 'downloader/response_status_count/200': 566,
 'elapsed_time_seconds': 717.3600000000006,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 15, 7, 47, 29, 976107, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 555,
 'items_per_minute': 46.44351464435147,
 'log_count/DEBUG': 48027,
 'log_count/ERROR': 1,
 'log_count/INFO': 18,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 566,
 'playwright/page_count/closed': 566,
 'playwright/page_count/max_concurrent': 8,
 'playwright/request_count': 23173,
 'playwright/request_count/aborted': 22581,
 'playwright/request_count/method/GET': 23173,
 'playwright/request_count/navigation': 566,
 'playwright/request_count/resource_type/document': 566,
 'playwright/request_count/resource_type/font': 1695,
 'playwright/request_count/resource_type/image': 1043,
 'playwright/request_count/resource_type/script': 11959,
 'playwright/request_count/resource_type/stylesheet': 7910,
 'playwright/response_count': 566,
 'playwright/response_count/method/GET': 566,
 'playwright/response_count/resource_type/document': 566,
 'request_depth_max': 1,
 'response_received_count': 566,
 'responses_per_minute': 47.36401673640167,
 'scheduler/dequeued': 566,
 'scheduler/dequeued/memory': 566,
 'scheduler/enqueued': 566,
 'scheduler/enqueued/memory': 566,
 'start_time': datetime.datetime(2026, 7, 15, 7, 35, 32, 610094, tzinfo=datetime.timezone.utc)}
```