### PR TITLE
[Cenex] Code to fetch operator

### DIFF
--- a/locations/spiders/cenex.py
+++ b/locations/spiders/cenex.py
@@ -31,7 +31,9 @@ class CenexSpider(JSONBlobSpider):
         if "GasStation" not in types and "PremiumDiesel" not in types:
             return  # Bulk lubricant/propane co-op dealers, not fuel stations
 
+        item["operator"] = item.pop("name")
         item["country"] = "US"
+
         amenities = [a["Name"] for a in feature["Amenities"]]
 
         apply_category(Categories.FUEL_STATION, item)


### PR DESCRIPTION
```
{'atp/brand/Cenex': 1479,
 'atp/brand_wikidata/Q62127191': 1479,
 'atp/category/amenity/fuel': 1479,
 'atp/country/US': 1479,
 'atp/field/email/missing': 1479,
 'atp/field/housenumber/missing': 1479,
 'atp/field/opening_hours/missing': 1479,
 'atp/field/operator/missing': 1479,
 'atp/field/operator_wikidata/missing': 1479,
 'atp/field/phone/missing': 87,
 'atp/field/street/missing': 1479,
 'atp/field/twitter/missing': 1479,
 'atp/field/unit/missing': 1479,
 'atp/item_scraped_host_count/www.cenex.com': 1479,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 1479,
 'downloader/request_bytes': 866,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 159151,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.578000000000031,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 15, 12, 5, 5, 888292, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 847110,
 'httpcompression/response_count': 2,
 'item_scraped_count': 1479,
 'items_per_minute': 11092.5,
 'log_count/DEBUG': 1481,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 15, 12, 4, 57, 318289, tzinfo=datetime.timezone.utc)}
```