### PR TITLE
Gscaltex kr patch

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -746,6 +746,7 @@ class PaymentMethods(Enum):
     HUAWEI_PAY = "payment:huawei_pay"
     ID = "payment:id"
     JCB = "payment:jcb"
+    KAKAO_PAY = "payment:kakaopay"
     KUSTERS = "payment:kusters"
     LINE_PAY = "payment:line_pay"
     MAES = "payment:maes"
@@ -763,8 +764,10 @@ class PaymentMethods(Enum):
     MIR = "payment:mir"
     MPESA = "payment:mpesa"
     NANACO = "payment:nanaco"
+    NAVER_PAY = "payment:naver_pay"
     NOTES = "payment:notes"
     OCTA_PLUS = "payment:octa_plus"
+    PAYCO = "payment:payco"
     PAYPAL = "payment:paypal"
     PAYPAY = "payment:paypay"
     POWERCARD = "payment:powercard"
@@ -792,6 +795,7 @@ class PaymentMethods(Enum):
     WAON = "payment:waon"
     WECHAT = "payment:wechat"
     XXIMO = "payment:xximo"
+    ZERO_PAY = "payment:zero_pay"
 
 
 payment_method_aliases = {

--- a/locations/spiders/gscaltex_kr.py
+++ b/locations/spiders/gscaltex_kr.py
@@ -31,7 +31,7 @@ class GscaltexKRSpider(Spider):
             apply_yes_no(PaymentMethods.NAVER_PAY, item, location["naverPayYn"] == "Y")
             apply_yes_no(PaymentMethods.PAYCO, item, location["paycoYn"] == "Y")
             apply_yes_no(PaymentMethods.ZERO_PAY, item, location["zeroPayYn"] == "Y")
-            
+
             apply_category(Categories.FUEL_STATION, item)
 
             # TODO: location["siteSxnCd"]

--- a/locations/spiders/gscaltex_kr.py
+++ b/locations/spiders/gscaltex_kr.py
@@ -3,7 +3,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, Extras, Fuel, PaymentMethods, apply_category, apply_yes_no
 from locations.items import Feature
 
 
@@ -16,6 +16,7 @@ class GscaltexKRSpider(Spider):
         for location in response.json()["siteList"]:
             item = Feature()
             item["ref"] = location["siteCd"]
+            item["branch"] = location["siteNm"]
             item["phone"] = location["telNo"]
             item["postcode"] = location["zipNo"]
             item["street_address"] = location["detAddr"]
@@ -23,6 +24,14 @@ class GscaltexKRSpider(Spider):
             item["lon"] = location["longi"]
 
             apply_yes_no(Extras.CAR_WASH, item, location["carWashYn"] == "Y")
+            apply_yes_no("self_service", item, location["selfYn"] == "Y")
+            apply_yes_no(Fuel.LPG, item, location["lpgYn"] == "Y")
+
+            apply_yes_no(PaymentMethods.KAKAO_PAY, item, location["kakaoPayYn"] == "Y")
+            apply_yes_no(PaymentMethods.NAVER_PAY, item, location["naverPayYn"] == "Y")
+            apply_yes_no(PaymentMethods.PAYCO, item, location["paycoYn"] == "Y")
+            apply_yes_no(PaymentMethods.ZERO_PAY, item, location["zeroPayYn"] == "Y")
+            
             apply_category(Categories.FUEL_STATION, item)
 
             # TODO: location["siteSxnCd"]


### PR DESCRIPTION
- Set `branch` from `siteNm` (previously unused).
- Tag `self_service` from `selfYn`.
- Tag `fuel:lpg` from `lpgYn` using the existing `Fuel.LPG` enum.
- Tag Korean mobile payment methods (`kakaoPayYn`, `naverPayYn`, `paycoYn`, `zeroPayYn`) using new `PaymentMethods` enum values, since these payment methods are common across Korean fuel stations and other Korean POIs.

The upstream site exposes these fields but the spider was dropping them. Adding a `branch` value also lets multiple stations under the same brand be distinguished.

New `PaymentMethods` entries (`KAKAO_PAY`, `NAVER_PAY`, `PAYCO`, `ZERO_PAY`) were added rather than writing raw tags into `extras`, since these are likely to recur in other Korean spiders.