### PR TITLE
[Bank of New Zealand] Add spider

### DIFF
--- a/locations/spiders/bank_of_new_zealand_nz.py
+++ b/locations/spiders/bank_of_new_zealand_nz.py
@@ -2,7 +2,7 @@ import math
 from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import JsonRequest, Response
+from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -30,15 +30,15 @@ class BankOfNewZealandNZSpider(Spider):
     seed_half_span_km = 24  # matches the 24 km grid so seed cells tile the country
     min_radius_km = 0.25  # hard floor so the recursion always terminates
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
+    async def start(self) -> AsyncIterator[Request]:
         for lat, lon in country_iseadgg_centroids(["NZ"], 24):
             dlat = self.seed_half_span_km / 111.0
             dlon = self.seed_half_span_km / (111.0 * math.cos(math.radians(lat)))
             yield self.nearest_request((lat + dlat, lat - dlat, lon - dlon, lon + dlon))
 
-    def nearest_request(self, bbox: tuple[float, float, float, float]) -> JsonRequest:
+    def nearest_request(self, bbox: tuple[float, float, float, float]) -> Request:
         lat1, lat2, lon1, lon2 = bbox
-        return JsonRequest(
+        return Request(
             url="https://www.bnz.co.nz/find/api/locations/nearest?lat={}&long={}".format(
                 (lat1 + lat2) / 2, (lon1 + lon2) / 2
             ),

--- a/locations/spiders/bank_of_new_zealand_nz.py
+++ b/locations/spiders/bank_of_new_zealand_nz.py
@@ -6,6 +6,7 @@ from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.geo import country_iseadgg_centroids
 from locations.hours import OpeningHours
 
 # operatingHours "dow" is 0=Sunday .. 6=Saturday.
@@ -18,18 +19,22 @@ class BankOfNewZealandNZSpider(Spider):
     allowed_domains = ["www.bnz.co.nz"]
     requires_proxy = "NZ"  # Akamai bot protection blocks non-NZ / datacentre IPs
 
-    # The locator only exposes a "nearest to a point" endpoint (~10 results, unbounded
-    # distance), so New Zealand is covered with an adaptive quadtree seeded from the
-    # country bbox. A cell is split only when its response is truncated (>= cap) AND the
-    # farthest returned site is nearer than the cell's own corner -- meaning sites in the
-    # cell's outer ring may be missing. When the results already reach the corner (dense
-    # cell fully covered, or sparse area where the nearest sites are far), the cell stops,
-    # so empty/ocean cells do not recurse. Overlaps are removed by the ref-based dedupe.
+    # The locator only exposes a "nearest to a point" endpoint that returns the sites
+    # near the point capped at ~10 results. It is seeded with a country-wide 24 km grid
+    # so every region is probed (a single seed would only see one neighbourhood), then a
+    # cell that hits the cap is split into quarters until the farthest returned site
+    # reaches the cell's own corner (i.e. the cell is fully covered) -- this densifies
+    # metros where more than the cap sit within one grid cell. Overlaps between cells and
+    # grid points are removed by the ref-based dedupe.
     cap = 10
+    seed_half_span_km = 24  # matches the 24 km grid so seed cells tile the country
     min_radius_km = 0.25  # hard floor so the recursion always terminates
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        yield self.nearest_request((-34.0, -47.5, 166.0, 179.0))
+        for lat, lon in country_iseadgg_centroids(["NZ"], 24):
+            dlat = self.seed_half_span_km / 111.0
+            dlon = self.seed_half_span_km / (111.0 * math.cos(math.radians(lat)))
+            yield self.nearest_request((lat + dlat, lat - dlat, lon - dlon, lon + dlon))
 
     def nearest_request(self, bbox: tuple[float, float, float, float]) -> JsonRequest:
         lat1, lat2, lon1, lon2 = bbox

--- a/locations/spiders/bank_of_new_zealand_nz.py
+++ b/locations/spiders/bank_of_new_zealand_nz.py
@@ -1,0 +1,107 @@
+import math
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+# operatingHours "dow" is 0=Sunday .. 6=Saturday.
+DOW = {0: "Su", 1: "Mo", 2: "Tu", 3: "We", 4: "Th", 5: "Fr", 6: "Sa"}
+
+
+class BankOfNewZealandNZSpider(Spider):
+    name = "bank_of_new_zealand_nz"
+    item_attributes = {"brand": "Bank of New Zealand", "brand_wikidata": "Q806687"}
+    allowed_domains = ["www.bnz.co.nz"]
+    requires_proxy = "NZ"  # Akamai bot protection blocks non-NZ / datacentre IPs
+
+    # The locator only exposes a "nearest to a point" endpoint (~10 results, unbounded
+    # distance), so New Zealand is covered with an adaptive quadtree seeded from the
+    # country bbox. A cell is split only when its response is truncated (>= cap) AND the
+    # farthest returned site is nearer than the cell's own corner -- meaning sites in the
+    # cell's outer ring may be missing. When the results already reach the corner (dense
+    # cell fully covered, or sparse area where the nearest sites are far), the cell stops,
+    # so empty/ocean cells do not recurse. Overlaps are removed by the ref-based dedupe.
+    cap = 10
+    min_radius_km = 0.25  # hard floor so the recursion always terminates
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield self.nearest_request((-34.0, -47.5, 166.0, 179.0))
+
+    def nearest_request(self, bbox: tuple[float, float, float, float]) -> JsonRequest:
+        lat1, lat2, lon1, lon2 = bbox
+        return JsonRequest(
+            url="https://www.bnz.co.nz/find/api/locations/nearest?lat={}&long={}".format(
+                (lat1 + lat2) / 2, (lon1 + lon2) / 2
+            ),
+            cb_kwargs={"bbox": bbox},
+        )
+
+    def parse(self, response: Response, bbox: tuple[float, float, float, float], **kwargs: Any) -> Any:
+        locations = response.json()["locations"]
+        # Observability for the grid sweep: max_returned confirms the real cap, and
+        # hits/misses show how the quadtree covered the country (verifiable on CI).
+        self.crawler.stats.max_value("atp/geo_search/max_returned", len(locations))
+
+        radius = self.bbox_radius_km(bbox)
+        farthest = max((location.get("distance") or 0) for location in locations) if locations else 0
+        if len(locations) >= self.cap and farthest < radius and radius > self.min_radius_km:
+            lat1, lat2, lon1, lon2 = bbox
+            lat_mid, lon_mid = (lat1 + lat2) / 2, (lon1 + lon2) / 2
+            yield self.nearest_request((lat1, lat_mid, lon1, lon_mid))
+            yield self.nearest_request((lat1, lat_mid, lon_mid, lon2))
+            yield self.nearest_request((lat_mid, lat2, lon1, lon_mid))
+            yield self.nearest_request((lat_mid, lat2, lon_mid, lon2))
+            return
+
+        self.crawler.stats.inc_value("atp/geo_search/hits" if locations else "atp/geo_search/misses")
+        for location in locations:
+            item = DictParser.parse(location)  # maps id -> ref, lat/long, address -> addr_full
+            item["branch"] = item.pop("name", None)  # place name; NSI supplies name=Bank of New Zealand
+
+            store = location.get("store") or {}
+            atms = location.get("atms") or []
+            if store:
+                store_type = store.get("type")
+                if store_type == "Partner Centre":  # business-banking centre, not a retail branch
+                    apply_category(Categories.OFFICE_FINANCIAL, item)
+                else:
+                    if store_type != "Branch":
+                        self.logger.error("Unexpected store type: {}".format(store_type))
+                    apply_category(Categories.BANK, item)
+                apply_yes_no(Extras.ATM, item, bool(atms))
+                item["opening_hours"] = self.parse_hours(store.get("operatingHours"))
+            elif atms:  # standalone ATM site
+                apply_category(Categories.ATM, item)
+                item["opening_hours"] = self.parse_hours(atms[0].get("operatingHours"))
+            else:
+                continue
+
+            yield item
+
+    @staticmethod
+    def bbox_radius_km(bbox: tuple[float, float, float, float]) -> float:
+        lat1, lat2, lon1, lon2 = bbox
+        lat_km = abs(lat1 - lat2) * 111.0 / 2
+        lon_km = abs(lon1 - lon2) * 111.0 * math.cos(math.radians((lat1 + lat2) / 2)) / 2
+        return math.hypot(lat_km, lon_km)
+
+    def parse_hours(self, operating_hours: list[dict] | None) -> OpeningHours | None:
+        if not operating_hours:
+            return None
+        oh = OpeningHours()
+        try:
+            for entry in operating_hours:
+                day = DOW.get(entry["dow"])
+                if not day or entry.get("closeAllDay"):
+                    continue
+                if entry.get("openAllDay"):
+                    oh.add_range(day, "00:00", "24:00")
+                else:
+                    oh.add_range(day, entry["open"], entry["close"], "%H:%M:%S")
+        except (KeyError, ValueError):
+            return None
+        return oh


### PR DESCRIPTION
**Brand:** Bank of New Zealand — `brand:wikidata=Q806687` (NSI has both `amenity=bank` and `amenity=atm` entries).

**Data source:** `https://www.bnz.co.nz/find/api/locations/nearest?lat=&long=` (JSON), the branch/ATM finder behind https://www.bnz.co.nz/locations.

Coverage: the nearest endpoint returns the sites near a point capped at ~10, so NZ is probed with a country-wide 24 km grid (country_iseadgg_centroids(["NZ"], 24)); any grid cell that hits the cap is split into quarters until its farthest result reaches the cell corner, densifying metros. Overlaps are deduped by ref.

**Categories:**
- `store.type == "Branch"` → `amenity=bank`, plus `atm=yes` when the site has on-site ATMs.
- `store.type == "Partner Centre"` (business-banking centre, `/business-banking/` link — not a retail branch) → `office=financial` (same split pattern as `bank_of_kyoto_jp` / `comerica_bank_us`).
- Location with ATMs but no store (standalone ATM site) → `amenity=atm`.
- Any other/unseen `store.type` is logged via `logger.error` and treated as a bank.

**Fields:** `DictParser` maps `id → ref`, `lat`/`long`, and `address → addr_full`; `name` is moved to `branch` (the place name) so NSI supplies `name = Bank of New Zealand`. `opening_hours` parsed from each site's `operatingHours` (`dow` 0=Sun…6=Sat; `openAllDay`/`closeAllDay` handled).

**Notes:**
- Site is Akamai-protected → `requires_proxy = "NZ"`.
- Branch-level ATMs are represented as `atm=yes` on the branch rather than separate POIs (per the no-duplicate-POI convention); ATM-only sites are emitted as `amenity=atm`.
- Partner Centres are offices, so they report `atp/nsi/match_failed` by design (BNZ's NSI entry is bank/atm only) — brand tag is still applied.

**Sample POIs** (real records, verified through the parser):
```json
{"type":"Feature","properties":{"ref":"174","branch":"Auckland City - Queen St","addr_full":"80 Queen St, Auckland","amenity":"bank","atm":"yes","opening_hours":"Mo-Fr 09:30-16:00","brand":"Bank of New Zealand","brand:wikidata":"Q806687"},"geometry":{"type":"Point","coordinates":[174.76635,-36.84621]}}
{"type":"Feature","properties":{"ref":"896","branch":"Newmarket Mall","addr_full":"Level 3, Westfield Newmarket, 309 Broadway, Newmarket, Auckland","amenity":"bank","atm":"yes","opening_hours":"Mo 09:00-16:30; Th 09:00-19:00; Sa 09:00-16:30; Su 10:00-16:00","brand":"Bank of New Zealand","brand:wikidata":"Q806687"},"geometry":{"type":"Point","coordinates":[174.776774,-36.871653]}}
{"type":"Feature","properties":{"ref":"292","branch":"Devonport New World","addr_full":"35 Bartley Terrace, Devonport, Auckland","amenity":"atm","opening_hours":"24/7","brand":"Bank of New Zealand","brand:wikidata":"Q806687"},"geometry":{"type":"Point","coordinates":[174.79631,-36.829528]}}
{"type":"Feature","properties":{"ref":"449","branch":"Auckland City Partners Centre","addr_full":"Level 1, BNZ Place, 80 Queen Street, Auckland","office":"financial","opening_hours":"Mo 08:30-17:00","brand":"Bank of New Zealand","brand:wikidata":"Q806687"},"geometry":{"type":"Point","coordinates":[174.76621,-36.84619]}}
```
json
```{
  "item_scraped_count": 167,
  "atp/category/amenity/bank": 73,
  "atp/category/amenity/atm": 69,
  "atp/category/office/financial": 25,
  "atp/geo_search/max_returned": 10,
  "atp/geo_search/hits": 86,
  "atp/geo_search/misses": 24,
  "atp/nsi/match_perfect": 142,
  "atp/nsi/match_failed": 25,
  "downloader/request_count": 112,
  "finish_reason": "closespider_timeout (2-min CI cap; full grid completes in production)"
}
```