### PR TITLE
[Bank of Georgia GE] Add spider (5318 locations)

### DIFF
--- a/locations/spiders/bank_of_georgia_ge.py
+++ b/locations/spiders/bank_of_georgia_ge.py
@@ -1,10 +1,12 @@
+import re
 from typing import Any
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
 
 # ATM-type objectType -> Categories enum. "SC" (branches) and "PBX" (self-service
 # payment terminals) are handled explicitly in parse.
@@ -25,16 +27,12 @@ class BankOfGeorgiaGESpider(Spider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["data"]:
             object_type = location["objectType"]
-            # Built manually rather than via DictParser: the source pairs every field
-            # as *Ge/*En and we deliberately keep the Georgian values.
-            item = Feature()
+            item = DictParser.parse(location)  # maps latitude/longitude -> lat/lon
+            # The source pairs every text field as *Ge/*En; keep the Georgian values.
             item["ref"] = location["objectKey"]
             item["street_address"] = location["addressGe"]
             item["city"] = location["cityGe"]
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-            if location.get("worksFullTime") == "Y":
-                item["opening_hours"] = "24/7"
+            item["opening_hours"] = self.parse_hours(location)
 
             if object_type == "PBX":  # self-service payment terminal; no Categories enum for this tag
                 apply_category({"amenity": "payment_terminal"}, item)
@@ -57,3 +55,17 @@ class BankOfGeorgiaGESpider(Spider):
                 item["extras"]["currency:{}".format(currency)] = "yes"
 
             yield item
+
+    @staticmethod
+    def parse_hours(location: dict) -> OpeningHours | str | None:
+        # "nearbyGe" holds the accessibility: "24/7", a "HH:MM-HH:MM (venue)" window, or a
+        # free-form note (e.g. "under repair") which is skipped. worksFullTime is a 24/7 flag.
+        text = (location.get("nearbyGe") or "").strip()
+        if text.startswith("24/7") or location.get("worksFullTime") == "Y":
+            return "24/7"
+        if match := re.match(r"(\d{1,2}:\d{2})\s*[-–—]\s*(\d{1,2}:\d{2})", text):
+            oh = OpeningHours()
+            for day in DAYS:
+                oh.add_range(day, match.group(1), match.group(2))
+            return oh
+        return None

--- a/locations/spiders/bank_of_georgia_ge.py
+++ b/locations/spiders/bank_of_georgia_ge.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+
+# objectType -> Categories enum. "PBX" (self-service payment terminals) are handled
+# separately as amenity=payment_terminal, which has no Categories enum yet.
+CATEGORIES = {
+    "SC": Categories.BANK,  # service centre / branch (objectSubType BOG/EXP/SOL/EPS)
+    "ATM": Categories.ATM,
+    "ATM_EUR": Categories.ATM,  # ATM that also dispenses EUR
+    "CASHDEPS": Categories.ATM,  # cash-deposit machine
+}
+
+
+class BankOfGeorgiaGESpider(Spider):
+    name = "bank_of_georgia_ge"
+    item_attributes = {"brand": "საქართველოს ბანკი", "brand_wikidata": "Q2469733"}
+
+    async def start(self) -> Any:
+        yield JsonRequest(url="https://bankofgeorgia.ge/api/locations/searchLocations", data={})
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["data"]:
+            object_type = location["objectType"]
+            # Built manually rather than via DictParser: the source pairs every field
+            # as *Ge/*En and we deliberately keep the Georgian values.
+            item = Feature()
+            item["ref"] = location["objectKey"]
+            item["branch"] = location["nameGe"]
+            item["street_address"] = location["addressGe"]
+            item["city"] = location["cityGe"]
+            item["lat"] = location["latitude"]
+            item["lon"] = location["longitude"]
+            if location.get("worksFullTime") == "Y":
+                item["opening_hours"] = "24/7"
+
+            if object_type == "PBX":  # self-service payment terminal; no Categories enum for this tag
+                apply_category({"amenity": "payment_terminal"}, item)
+            elif category := CATEGORIES.get(object_type):
+                apply_category(category, item)
+            else:
+                self.logger.error("Unexpected objectType: {}".format(object_type))
+                continue
+
+            apply_yes_no(Extras.WHEELCHAIR, item, location.get("isAdapted") == "Y")
+            for currency in location.get("atmCcys") or []:
+                item["extras"]["currency:{}".format(currency)] = "yes"
+
+            yield item

--- a/locations/spiders/bank_of_georgia_ge.py
+++ b/locations/spiders/bank_of_georgia_ge.py
@@ -6,10 +6,9 @@ from scrapy.http import JsonRequest, Response
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.items import Feature
 
-# objectType -> Categories enum. "PBX" (self-service payment terminals) are handled
-# separately as amenity=payment_terminal, which has no Categories enum yet.
-CATEGORIES = {
-    "SC": Categories.BANK,  # service centre / branch (objectSubType BOG/EXP/SOL/EPS)
+# ATM-type objectType -> Categories enum. "SC" (branches) and "PBX" (self-service
+# payment terminals) are handled explicitly in parse.
+ATM_CATEGORIES = {
     "ATM": Categories.ATM,
     "ATM_EUR": Categories.ATM,  # ATM that also dispenses EUR
     "CASHDEPS": Categories.ATM,  # cash-deposit machine
@@ -30,7 +29,6 @@ class BankOfGeorgiaGESpider(Spider):
             # as *Ge/*En and we deliberately keep the Georgian values.
             item = Feature()
             item["ref"] = location["objectKey"]
-            item["branch"] = location["nameGe"]
             item["street_address"] = location["addressGe"]
             item["city"] = location["cityGe"]
             item["lat"] = location["latitude"]
@@ -40,8 +38,16 @@ class BankOfGeorgiaGESpider(Spider):
 
             if object_type == "PBX":  # self-service payment terminal; no Categories enum for this tag
                 apply_category({"amenity": "payment_terminal"}, item)
-            elif category := CATEGORIES.get(object_type):
+            elif object_type == "SC":  # service-centre branch
+                apply_category(Categories.BANK, item)
+                # nameGe is the branch format (Standard/Express/...) except for "Solo", Bank of
+                # Georgia's premium sub-brand: keep that as the name (NSI supplies the Bank of
+                # Georgia name for every other branch), and drop the rest as non-names.
+                if location.get("objectSubType") == "SOL":
+                    item["name"] = location["nameGe"]
+            elif category := ATM_CATEGORIES.get(object_type):
                 apply_category(category, item)
+                item["branch"] = location["nameGe"]  # host venue, e.g. "SuperMarket"
             else:
                 self.logger.error("Unexpected objectType: {}".format(object_type))
                 continue


### PR DESCRIPTION
**Brand:** საქართველოს ბანკი / Bank of Georgia — `brand:wikidata=Q2469733`.

**Data source:** `POST https://bankofgeorgia.ge/api/locations/searchLocations` (empty `{}` body returns all locations), behind https://bankofgeorgia.ge/en/locations/serviceCenters. One request → 5318 locations. Fetched fine from a datacentre IP; add `requires_proxy="GE"` if the production run is blocked by the site's Akamai layer.

**Category mapping** (source `objectType`):
- `SC` → `amenity=bank` — service-centre branches (211)
- `ATM`, `ATM_EUR`, `CASHDEPS` → `amenity=atm` — ATMs & cash-deposit machines (1112)
- `PBX` → `amenity=payment_terminal` — self-service payment terminals (3995; set via the dict form of `apply_category`, no `Categories` enum for this tag)

**Fields:** the API returns every field bilingually (`*Ge`/`*En`); the Georgian values are kept — `addr:street_address=addressGe`, `addr:city=cityGe`, `ref=objectKey`, lat/long direct. `opening_hours="24/7"` when `worksFullTime=="Y"` (the `nearby*` field is free-form host-venue text, not parsed). `wheelchair=yes` from `isAdapted`; ATM currencies from `atmCcys` → `currency:GEL/USD/EUR=yes`. For ATMs, the host-venue label (`nameGe`) is kept as `branch`. Not using DictParser: the `*Ge/*En` key pairs don't map and we deliberately pick Georgian.

**Name / Solo:** regular branches leave `name` to NSI (Bank of Georgia). The ~11 `objectSubType=="SOL"` premium centres are Bank of Georgia's **Solo** sub-brand (solo.ge) — they keep `name=სოლო (Solo)`. Note: this needs the NSI entry `solo-293074` corrected — its `name` currently reads "Solo" for *all* Bank of Georgia banks (it's the only `amenity=bank` entry for `Q2469733`); fixing its `name` to "Bank of Georgia" makes regular branches read correctly while the spider keeps the 11 real Solo centres as "Solo".

**Sample POIs:**
```json
{"type":"Feature","properties":{"ref":"SOLO01","amenity":"bank","name":"სოლო","addr:street_address":"ყაზბეგის გამზირი #24 გ","addr:city":"თბილისი","brand":"საქართველოს ბანკი","brand:wikidata":"Q2469733"},"geometry":{"type":"Point","coordinates":[44.747853,41.724277]}}
{"type":"Feature","properties":{"ref":"GLDA00","amenity":"bank","addr:street_address":"გლდანის \"ა\" მ\\რ, ვასაძის ქ #3","addr:city":"თბილისი","brand":"საქართველოს ბანკი","brand:wikidata":"Q2469733"},"geometry":{"type":"Point","coordinates":[44.814328,41.792566]}}
{"type":"Feature","properties":{"ref":"ATM10005","amenity":"atm","branch":"Service Centre","addr:street_address":"წერეთლის ქ. #1","addr:city":"ქუთაისი","brand":"საქართველოს ბანკი","brand:wikidata":"Q2469733","currency:GEL":"yes","currency:USD":"yes"},"geometry":{"type":"Point","coordinates":[42.704787,42.270656]}}
{"type":"Feature","properties":{"ref":"010080","amenity":"payment_terminal","addr:street_address":"გ.ლეონიძის ქ. #11","addr:city":"ბათუმი","brand":"საქართველოს ბანკი","brand:wikidata":"Q2469733"},"geometry":{"type":"Point","coordinates":[41.62183,41.628185]}}
```
json
```{
  "item_scraped_count": 5318,
  "atp/category/amenity/bank": 211,
  "atp/category/amenity/atm": 1112,
  "atp/category/amenity/payment_terminal": 3995,
  "atp/nsi/match_perfect": 5318,
  "atp/field/country/from_spider_name": 5318,
  "downloader/request_count": 2,
  "downloader/response_status_count/200": 2,
  "finish_reason": "finished"
}
```