### PR TITLE
[Woolovers GB] Fix spider

### DIFF
--- a/locations/spiders/woolovers_gb.py
+++ b/locations/spiders/woolovers_gb.py
@@ -17,7 +17,8 @@ class WooloversGBSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["addr_full"] = item.pop("street_address")
-        item["website"] = "https://" + item["website"]
+        if website := item.get("website"):
+            item["website"] = website if website.startswith("http") else "https://" + website
         item["lat"], item["lon"] = feature["loc_lat"], feature["loc_long"]
         item["branch"] = item.pop("name")
         oh = OpeningHours()


### PR DESCRIPTION
```
{'atp/brand/WoolOvers': 11,
 'atp/brand_wikidata/Q139586777': 11,
 'atp/category/shop/clothes': 11,
 'atp/country/GB': 11,
 'atp/field/city/missing': 11,
 'atp/field/country/from_spider_name': 11,
 'atp/field/email/missing': 11,
 'atp/field/housenumber/missing': 11,
 'atp/field/operator/missing': 11,
 'atp/field/operator_wikidata/missing': 11,
 'atp/field/state/missing': 11,
 'atp/field/street/missing': 11,
 'atp/field/street_address/missing': 11,
 'atp/field/twitter/missing': 11,
 'atp/field/unit/missing': 11,
 'atp/item_scraped_host_count/api.storepoint.co': 11,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 11,
 'atp/nsi/match_failed': 11,
 'downloader/request_bytes': 355,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 2212,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 1.327999999979511,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 16, 6, 35, 18, 446072, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7245,
 'httpcompression/response_count': 1,
 'item_scraped_count': 11,
 'items_per_minute': 660.0,
 'log_count/DEBUG': 12,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 60.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 16, 6, 35, 17, 119123, tzinfo=datetime.timezone.utc)}
```