### PR TITLE
[YPF AR] Add spider (1702 locations)

### DIFF
--- a/locations/spiders/ypf_ar.py
+++ b/locations/spiders/ypf_ar.py
@@ -10,10 +10,9 @@ from locations.dict_parser import DictParser
 class YpfARSpider(Spider):
     name = "ypf_ar"
     item_attributes = {"brand": "YPF", "brand_wikidata": "Q2006989"}
-    # mapa.ypf.com loads every service station from this endpoint. EV chargers
-    # (CARGADOR_ELECTRICO, 32 stations) are left for a dedicated charging-station spider,
-    # and the YPF Full shop (TIPO_FULL) is intentionally not tagged shop=convenience --
-    # that top-level tag isn't in YPF's amenity=fuel NSI entry and would break the match.
+    # mapa.ypf.com loads every service station from this endpoint. The YPF Full shop
+    # (TIPO_FULL) is intentionally not tagged shop=convenience -- that top-level tag isn't
+    # in YPF's amenity=fuel NSI entry and would break the match.
 
     async def start(self) -> AsyncIterator[Request]:
         # The endpoint returns "Acceso Denegado" unless the mapa.ypf.com referer is sent.
@@ -42,5 +41,6 @@ class YpfARSpider(Spider):
             apply_category(Categories.FUEL_STATION, item)
             apply_yes_no(Fuel.CNG, item, location.get("TIPO_DESPACHO") in ("DUAL", "GNC"))
             apply_yes_no(Fuel.ADBLUE, item, location.get("AZUL32") is True)  # "Azul 32" = AdBlue (AUS 32)
+            apply_yes_no(Fuel.ELECTRIC, item, location.get("CARGADOR_ELECTRICO") == "SI")
 
             yield item

--- a/locations/spiders/ypf_ar.py
+++ b/locations/spiders/ypf_ar.py
@@ -1,0 +1,46 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class YpfARSpider(Spider):
+    name = "ypf_ar"
+    item_attributes = {"brand": "YPF", "brand_wikidata": "Q2006989"}
+    # mapa.ypf.com loads every service station from this endpoint. EV chargers
+    # (CARGADOR_ELECTRICO, 32 stations) are left for a dedicated charging-station spider,
+    # and the YPF Full shop (TIPO_FULL) is intentionally not tagged shop=convenience --
+    # that top-level tag isn't in YPF's amenity=fuel NSI entry and would break the match.
+
+    async def start(self) -> AsyncIterator[Request]:
+        # The endpoint returns "Acceso Denegado" unless the mapa.ypf.com referer is sent.
+        yield Request(
+            url="https://magui.ypf.com/boxes/eess/get/",
+            headers={"Origin": "https://mapa.ypf.com", "Referer": "https://mapa.ypf.com/"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            if location.get("ESTADO_DE_LA_BOCA") != "ACTIVA":
+                continue  # inactive / closed station
+            if location.get("TIPO_ESTABLECIMIENTO") == "PUNTO ELECTRICO":
+                continue  # EV-only point, not a fuel station
+
+            item = DictParser.parse(location)  # maps DIRECCION -> addr_full
+            item["ref"] = str(location["APIES"])
+            item["street_address"] = item.pop("addr_full", None)
+            item["city"] = location.get("LOCALIDAD_GEOGRAFICA")
+            item["state"] = location.get("PROVINCIA_GEOGRAFICA")
+            item["postcode"] = location.get("CODIGO_POSTAL")
+            item["lat"] = location.get("POINT_Y")
+            item["lon"] = location.get("POINT_X")
+            item["operator"] = location.get("RAZON_SOCIAL")
+
+            apply_category(Categories.FUEL_STATION, item)
+            apply_yes_no(Fuel.CNG, item, location.get("TIPO_DESPACHO") in ("DUAL", "GNC"))
+            apply_yes_no(Fuel.ADBLUE, item, location.get("AZUL32") is True)  # "Azul 32" = AdBlue (AUS 32)
+
+            yield item

--- a/locations/spiders/ypf_ar.py
+++ b/locations/spiders/ypf_ar.py
@@ -25,8 +25,8 @@ class YpfARSpider(Spider):
         for location in response.json():
             if location.get("ESTADO_DE_LA_BOCA") != "ACTIVA":
                 continue  # inactive / closed station
-            if location.get("TIPO_ESTABLECIMIENTO") == "PUNTO ELECTRICO":
-                continue  # EV-only point, not a fuel station
+            if not location.get("ES_ESTACION"):
+                continue  # not a fuel station (EV-only point or standalone Full shop)
 
             item = DictParser.parse(location)  # maps DIRECCION -> addr_full
             item["ref"] = str(location["APIES"])


### PR DESCRIPTION
**Brand:** YPF : `brand:wikidata=Q2006989`.

**Data source:** the store locator https://mapa.ypf.com/?filter=combustibles loads all stations from `GET https://magui.ypf.com/boxes/eess/get/`. The endpoint returns "Acceso Denegado" unless the `mapa.ypf.com` `Referer`/`Origin` headers are sent (basic hotlink protection).

**Scope:** 1750 records → 1702 emitted. Skipped: 47 `ESTADO_DE_LA_BOCA != "ACTIVA"` (inactive/closed) and 1 `TIPO_ESTABLECIMIENTO == "PUNTO ELECTRICO"` (EV-only point).

**Category:** all → `amenity=fuel`.

**Fuel types:**
- `fuel:cng` (550) — from `TIPO_DESPACHO` in (`DUAL`, `GNC`)
- `fuel:adblue` (92) — from `AZUL32` (YPF's "Azul 32" = AdBlue / AUS 32)
- Specific petrol/diesel grades aren't in the feed, so only the flags the API provides are tagged.

**Fields:** `DictParser` maps `DIRECCION → addr:street_address`; `ref=APIES`, `operator=RAZON_SOCIAL`, `addr:city=LOCALIDAD_GEOGRAFICA`, `addr:state=PROVINCIA_GEOGRAFICA`, `addr:postcode=CODIGO_POSTAL`, lat/lon from `POINT_Y`/`POINT_X`. `name` left to NSI (YPF).

**Deliberately out of scope (flagged for follow-up):**
- **EV charging** — 32 stations have `CARGADOR_ELECTRICO="SI"` with connector counts (`CANT_CONTECTORES_ELECTRICOS`). Per convention these belong in a dedicated `charging_station` spider, not the fuel spider.
- **YPF Full shop** (`TIPO_FULL`) — not tagged `shop=convenience`: that top-level tag isn't in YPF's `amenity=fuel` NSI entry and would break the brand match.

**Sample POI:**
```json
{"type":"Feature",
"properties":{
"ref":"3263",
"amenity":"fuel",
"operator":"OPESSA CORDOBA LA FRANCE",
"addr:street_address":"MONSEÑOR PABLO CABRERA Y CARDEÑOZA",
"addr:city":"Cordoba",
"addr:state":"Cordoba",
"addr:postcode":"5000",
"brand":"YPF",
"brand:wikidata":"Q2006989",
"fuel:cng":"yes"},
"geometry":{"type":"Point","coordinates":[-64.20617,-31.371]}}
```
json
```
{
  "item_scraped_count": 1702,
  "atp/category/amenity/fuel": 1702,
  "atp/nsi/match_perfect": 1702,
  "atp/field/country/from_spider_name": 1702,
  "finish_reason": "finished"
}
```