### PR TITLE
[OSM Exporter] Update for scrapy 2.17

### DIFF
--- a/locations/exporters/osm.py
+++ b/locations/exporters/osm.py
@@ -1,4 +1,6 @@
 import logging
+from io import BytesIO, TextIOWrapper
+from typing import Any
 from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 
@@ -18,11 +20,18 @@ class OSMExporter(XmlItemExporter):
     fields_to_export: dict[str, str] = {k: v for k, v in mapping}
     encoding = "UTF-8"
 
-    def __init__(self, file, **kwargs):
+    def __init__(self, file: BytesIO, **kwargs: Any):
         logging.warning("Deprecated, no not use!")
         if not self.encoding:
             raise RuntimeError("Encoding must be specified for this exporter. Default is 'UTF-8'.")
-        self.xg = XMLGenerator(file, encoding=self.encoding, short_empty_elements=True)
+        self.stream = TextIOWrapper(
+            file,
+            encoding=self.encoding,
+            errors="xmlcharrefreplace",
+            newline="\n",
+            write_through=True,
+        )
+        self.xg = XMLGenerator(self.stream, encoding=self.encoding, short_empty_elements=True)
 
     def start_exporting(self):
         self.xg.startDocument()


### PR DESCRIPTION
https://github.com/scrapy/scrapy/pull/7644 made `stream` a required attribute.