### PR TITLE
[Bottega Veneta] Fix Spider

### DIFF
--- a/locations/spiders/bottega_veneta.py
+++ b/locations/spiders/bottega_veneta.py
@@ -1,15 +1,20 @@
+import json
+
 import scrapy
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class BottegaVenetaSpider(scrapy.Spider):
+class BottegaVenetaSpider(PlaywrightSpider):
     name = "bottega_veneta"
     item_attributes = {"brand": "Bottega Veneta", "brand_wikidata": "Q894874"}
     allowed_domains = ["bottegaveneta.com"]
     start_urls = ["https://www.bottegaveneta.com/de-de/storelocator"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response):
         countries = response.xpath('//select[@id="country"]/option/@value').extract()
@@ -18,7 +23,7 @@ class BottegaVenetaSpider(scrapy.Spider):
             yield scrapy.Request(url=url, callback=self.store_parse)
 
     def store_parse(self, response):
-        for store in response.json()["storesData"]["stores"]:
+        for store in json.loads(response.xpath("//pre//text()").get())["storesData"]["stores"]:
             item = DictParser.parse(store)
             item["website"] = store.get("detailsUrl")
             item["branch"] = item.pop("name")


### PR DESCRIPTION
```python
{'atp/brand/Bottega Veneta': 331,
 'atp/brand_wikidata/Q894874': 331,
 'atp/category/shop/fashion_accessories': 331,
 'atp/clean_strings/postcode': 1,
 'atp/clean_strings/state': 13,
 'atp/clean_strings/street_address': 3,
 'atp/country/AE': 7,
 'atp/country/AT': 1,
 'atp/country/AU': 5,
 'atp/country/AZ': 1,
 'atp/country/BH': 1,
 'atp/country/BR': 3,
 'atp/country/CA': 4,
 'atp/country/CH': 3,
 'atp/country/CN': 41,
 'atp/country/CY': 1,
 'atp/country/CZ': 1,
 'atp/country/DE': 8,
 'atp/country/ES': 7,
 'atp/country/FR': 16,
 'atp/country/GB': 13,
 'atp/country/GR': 4,
 'atp/country/HK': 6,
 'atp/country/ID': 2,
 'atp/country/IE': 1,
 'atp/country/IN': 3,
 'atp/country/IT': 18,
 'atp/country/JP': 43,
 'atp/country/KH': 1,
 'atp/country/KR': 28,
 'atp/country/KW': 3,
 'atp/country/MA': 1,
 'atp/country/MC': 1,
 'atp/country/MO': 3,
 'atp/country/MX': 6,
 'atp/country/MY': 2,
 'atp/country/NL': 2,
 'atp/country/PH': 3,
 'atp/country/PL': 1,
 'atp/country/PT': 1,
 'atp/country/QA': 4,
 'atp/country/SA': 5,
 'atp/country/SE': 1,
 'atp/country/SG': 5,
 'atp/country/TH': 7,
 'atp/country/TR': 4,
 'atp/country/TW': 16,
 'atp/country/US': 47,
 'atp/country/VN': 1,
 'atp/duplicate_count': 8,
 'atp/field/country/from_reverse_geocoding': 1,
 'atp/field/email/missing': 331,
 'atp/field/housenumber/missing': 331,
 'atp/field/opening_hours/missing': 23,
 'atp/field/operator/missing': 331,
 'atp/field/operator_wikidata/missing': 331,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 26,
 'atp/field/postcode/missing': 14,
 'atp/field/state/from_reverse_geocoding': 1,
 'atp/field/street/missing': 331,
 'atp/field/twitter/missing': 331,
 'atp/field/unit/missing': 331,
 'atp/item_scraped_host_count/www.bottegaveneta.com': 339,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 331,
 'atp/nsi/match_imperfect': 331,
 'downloader/request_bytes': 19838,
 'downloader/request_count': 48,
 'downloader/request_method_count/GET': 48,
 'downloader/response_bytes': 1674714,
 'downloader/response_count': 48,
 'downloader/response_status_count/200': 48,
 'elapsed_time_seconds': 148.96899999998277,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 16, 10, 0, 53, 639301, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 8,
 'item_dropped_reasons_count/DropItem': 8,
 'item_scraped_count': 331,
 'items_per_minute': 134.1891891891892,
 'log_count/DEBUG': 612,
 'log_count/INFO': 9,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 48,
 'playwright/page_count/closed': 48,
 'playwright/page_count/max_concurrent': 6,
 'playwright/request_count': 88,
 'playwright/request_count/aborted': 40,
 'playwright/request_count/method/GET': 88,
 'playwright/request_count/navigation': 48,
 'playwright/request_count/resource_type/document': 48,
 'playwright/request_count/resource_type/font': 1,
 'playwright/request_count/resource_type/image': 19,
 'playwright/request_count/resource_type/script': 18,
 'playwright/request_count/resource_type/stylesheet': 2,
 'playwright/response_count': 48,
 'playwright/response_count/method/GET': 48,
 'playwright/response_count/resource_type/document': 48,
 'request_depth_max': 1,
 'response_received_count': 48,
 'responses_per_minute': 19.45945945945946,
 'scheduler/dequeued': 48,
 'scheduler/dequeued/memory': 48,
 'scheduler/enqueued': 48,
 'scheduler/enqueued/memory': 48,
 'start_time': datetime.datetime(2026, 7, 16, 9, 58, 24, 659538, tzinfo=datetime.timezone.utc)}
```