### PR TITLE
[Banco do Nordeste BR] Fix spider

### DIFF
--- a/locations/spiders/banco_do_nordeste_br.py
+++ b/locations/spiders/banco_do_nordeste_br.py
@@ -1,9 +1,10 @@
-from typing import Any
+from typing import Any, Iterable
 
 import scrapy
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.hours import DAYS_WEEKDAY, OpeningHours
 from locations.items import Feature
 
 
@@ -12,15 +13,25 @@ class BancoDoNordesteBRSpider(scrapy.Spider):
     item_attributes = {"brand": "Banco do Nordeste", "brand_wikidata": "Q4854137"}
     start_urls = ["https://api.bnb.gov.br/corporativo/api/agencia/endereco?codigoMunicipio=&siglaUf=&tamanho=10000"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         for location in response.json():
             item = Feature()
             item["branch"] = location["descricao"]
             item["street"] = location["logradouro"]
-            item["housenumber"] = location["numero"]
+            item["housenumber"] = str(location["numero"]) if location.get("numero") else None
             item["state"] = location["siglaUf"]
             item["city"] = location["nomeMunicipio"]
             item["postcode"] = str(location["cep"])
             item["ref"] = location["codigo"]
+
+            if (ddd := location.get("numeroDDD")) and (number := location.get("numeroTelefone")):
+                item["phone"] = f"+55 {ddd.lstrip('0')} {number}"
+
+            opening = location.get("horarioAbertura")
+            closing = location.get("horarioFechamento")
+            if opening and closing and opening != "00:00" and closing != "00:00":
+                item["opening_hours"] = OpeningHours()
+                item["opening_hours"].add_days_range(DAYS_WEEKDAY, opening, closing)
+
             apply_category(Categories.BANK, item)
             yield item


### PR DESCRIPTION
`housenumber` was assigned the raw integer from the API, which the address pipeline rejected — logging an error for every branch. Cast it to a string (guarding null values).

Also collect the phone and weekday opening hours the API already exposes.

Local crawl yields 300 branches with no item errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)