### PR TITLE
[Rewe DE] Fix spider

### DIFF
--- a/locations/spiders/rewe_de.py
+++ b/locations/spiders/rewe_de.py
@@ -1,6 +1,10 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
@@ -12,13 +16,16 @@ class ReweDESpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     allowed_domains = ["www.rewe.de"]
     sitemap_urls = ["https://www.rewe.de/sitemaps/sitemap-maerkte.xml"]
     sitemap_rules = [(r"/marktseite/[^/]+/(\d+)/[^/]+/$", "parse_sd")]
-    # Playwright needed to avoid blocking from certain IP address ranges.
-    # Probably use of data centre IPs is the main reason.
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60 * 1000}
 
-    def post_process_item(self, item, response, ld_data):
+    def pre_process_data(self, ld_data: dict, **kwargs: Any) -> None:
+        if opening_hours := ld_data.get("openingHours"):
+            ld_data["openingHours"] = [rule.replace(" Uhr", "") for rule in opening_hours]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
         item["name"] = None
-        item["street_address"] = item["street_address"].removesuffix(" null")
+        if item.get("street_address"):
+            item["street_address"] = item["street_address"].removesuffix(" null")
         item.pop("image", None)
 
         apply_category(Categories.SHOP_SUPERMARKET, item)


### PR DESCRIPTION
`street_address.removesuffix(" null")` raised an `AttributeError` for every store whose ld+json omitted a street address, logging an error each time. Guard the None case.

Also strip the " Uhr" suffix from the German opening hours so they parse instead of being dropped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)