### PR TITLE
[KPMG] Fix spider

### DIFF
--- a/locations/spiders/kpmg.py
+++ b/locations/spiders/kpmg.py
@@ -1,38 +1,22 @@
-import json
+from typing import Any, Iterable
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class KpmgSpider(SitemapSpider):
+class KpmgSpider(SitemapSpider, StructuredDataSpider):
     name = "kpmg"
     item_attributes = {"brand": "KPMG", "brand_wikidata": "Q493751"}
-    allowed_domains = ["kpmg.com", ""]
     sitemap_urls = ["https://kpmg.com/sitemap-index.xml"]
-    sitemap_rules = [("/offices/", "parse")]
+    sitemap_rules = [(r"/offices/", "parse_sd")]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def find_between(self, text, first, last):
-        start = text.index(first) + len(first)
-        end = text.index(last, start)
-        return text[start:end]
-
-    def parse(self, response):
-        data = response.xpath('//script[contains(text(),"var kpmgMetaData")]/text()').get()
-        data = json.loads(self.find_between(data, "var kpmgMetaData=", ";var"))
-
-        properties = {
-            "ref": response.url,
-            "name": data.get("KPMG_Location_Company_Name"),
-            "street_address": data.get("KPMG_Location_Address_Line_1"),
-            "postcode": data.get("KPMG_Location_Address_Postal_Code"),
-            "city": data.get("KPMG_Location_Address_City"),
-            "country": data.get("KPMG_Location_Country_ISO"),
-            "lat": data.get("KPMG_Location_Latitude"),
-            "lon": data.get("KPMG_Location_Longitude"),
-            "phone": data.get("KPMG_Location_Telephone_Number"),
-            "website": response.url,
-        }
-
-        yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        if name := item.pop("name", None):
+            item["branch"] = name.removesuffix(" office").strip()
+        apply_category(Categories.OFFICE_CONSULTING, item)
+        yield item


### PR DESCRIPTION
The `var kpmgMetaData` blob the spider read was removed from the office pages, so `find_between` raised for every page (the spider yielded only 3 items).

Extract offices from the `LocalBusiness` ld+json (nested in `@graph`) via `StructuredDataSpider`, and apply `office=consulting` explicitly. This recovers ~290 offices with coordinates and phone.

Offices in markets whose pages render address/coordinates client-side (e.g. US, DE, FI) have no static LocalBusiness data and are not covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)