### PR TITLE
[Therapie Clinic] Fix spider

### DIFF
--- a/locations/spiders/therapie_clinic.py
+++ b/locations/spiders/therapie_clinic.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import scrapy
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.dict_parser import DictParser
@@ -8,10 +8,11 @@ from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class TherapieClinicSpider(scrapy.Spider):
+class TherapieClinicSpider(Spider):
     name = "therapie_clinic"
     item_attributes = {"brand": "Thérapie Clinic", "brand_wikidata": "Q123034602"}
     start_urls = ["https://therapieclinic.com/api/clinic/locations"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["locations"]:
@@ -30,7 +31,7 @@ class TherapieClinicSpider(scrapy.Spider):
             for rule in self.get_primary(place["businessHours"]).get("timePeriods") or []:
                 if rule["closed"] is True:
                     item["opening_hours"].set_closed(rule["openDay"])
-                elif rule["closed"] is True:
+                elif rule["open24Hours"] is True:
                     item["opening_hours"].add_range(rule["openDay"], "00:00", "24:00")
                 else:
                     item["opening_hours"].add_range(rule["openDay"], rule["openTime"], rule["closeTime"])

--- a/locations/spiders/therapie_clinic.py
+++ b/locations/spiders/therapie_clinic.py
@@ -3,6 +3,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -35,6 +36,8 @@ class TherapieClinicSpider(Spider):
                     item["opening_hours"].add_range(rule["openDay"], "00:00", "24:00")
                 else:
                     item["opening_hours"].add_range(rule["openDay"], rule["openTime"], rule["closeTime"])
+
+            apply_category(Categories.SHOP_BEAUTY, item)
 
             yield item
 


### PR DESCRIPTION
```
{'atp/brand/Thérapie Clinic': 101,
 'atp/brand_wikidata/Q123034602': 101,
 'atp/category/missing': 2,
 'atp/category/shop/beauty': 99,
 'atp/country/GB': 64,
 'atp/country/IE': 35,
 'atp/country/US': 2,
 'atp/field/email/missing': 101,
 'atp/field/housenumber/missing': 101,
 'atp/field/name/missing': 2,
 'atp/field/opening_hours/missing': 10,
 'atp/field/operator/missing': 101,
 'atp/field/operator_wikidata/missing': 101,
 'atp/field/phone/missing': 4,
 'atp/field/state/missing': 64,
 'atp/field/street/missing': 101,
 'atp/field/twitter/missing': 101,
 'atp/field/unit/missing': 101,
 'atp/item_scraped_host_count/therapieclinic.com': 101,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 101,
 'atp/nsi/location_unknown': 2,
 'atp/nsi/match_failed': 2,
 'atp/nsi/match_imperfect': 99,
 'downloader/request_bytes': 346,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 31058,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.75,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 17, 7, 4, 5, 768242, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 346789,
 'httpcompression/response_count': 1,
 'item_scraped_count': 101,
 'items_per_minute': 3030.0,
 'log_count/DEBUG': 102,
 'log_count/INFO': 3,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 17, 7, 4, 3, 19911, tzinfo=datetime.timezone.utc)}
```