### PR TITLE
[Puma Energy AR] Add spider (413 locations)

### DIFF
--- a/locations/spiders/puma_energy_ar.py
+++ b/locations/spiders/puma_energy_ar.py
@@ -1,0 +1,57 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+# Products listed in the "text" field -> OSM fuel tag.
+FUELS = {
+    "Puma Super": Fuel.OCTANE_95,
+    "Max Premium": Fuel.OCTANE_98,
+    "Puma Diesel": Fuel.DIESEL,
+    "ION Puma Diesel": Fuel.DIESEL,
+}
+
+
+class PumaEnergyARSpider(Spider):
+    name = "puma_energy_ar"
+    item_attributes = {"brand": "Puma", "brand_wikidata": "Q7259769"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        # get_stations is a Laravel endpoint that needs a CSRF token from the locator page.
+        yield Request("https://pumaenergyarg.com.ar/encontra_tu_estacion", callback=self.parse_token)
+
+    def parse_token(self, response: Response, **kwargs: Any) -> Any:
+        # Empty filter arrays return the whole network; the arrays must be sent as JSON
+        # (form encoding drops empty arrays and the endpoint then 500s).
+        yield JsonRequest(
+            url="https://pumaenergyarg.com.ar/get_stations",
+            data={
+                "_token": response.xpath('//meta[@name="csrf-token"]/@content').get(),
+                "fuel_type": [],
+                "shop_type": [],
+                "franchise": [],
+                "puma_pris": 0,
+                "chargebox": 0,
+            },
+            callback=self.parse,
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)  # maps id -> ref, name, lat/lon, address -> addr_full
+            item["branch"] = item.pop("name", None)  # station location label; NSI supplies name=Puma
+
+            apply_category(Categories.FUEL_STATION, item)
+            if "24hs" in (location.get("schedule") or ""):
+                item["opening_hours"] = "24/7"
+            apply_yes_no(Fuel.CNG, item, location.get("fuel_type") in ("Dual", "GNC"))
+            apply_yes_no(Fuel.ELECTRIC, item, location.get("chargebox") == "1")
+            for product in re.split(r"<br\s*/?>", location.get("text") or ""):
+                if fuel := FUELS.get(product.strip(" -").strip()):
+                    apply_yes_no(fuel, item, True)
+
+            yield item

--- a/locations/spiders/puma_energy_ar.py
+++ b/locations/spiders/puma_energy_ar.py
@@ -42,8 +42,8 @@ class PumaEnergyARSpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json():
-            item = DictParser.parse(location)  # maps id -> ref, name, lat/lon, address -> addr_full
-            item["branch"] = item.pop("name", None)  # station location label; NSI supplies name=Puma
+            item = DictParser.parse(location)  # maps id -> ref, lat/lon, address -> addr_full
+            item.pop("name", None)  # API "name" is the street address (kept in addr_full); NSI supplies name=Puma
 
             apply_category(Categories.FUEL_STATION, item)
             if "24hs" in (location.get("schedule") or ""):

--- a/locations/spiders/puma_energy_ar.py
+++ b/locations/spiders/puma_energy_ar.py
@@ -37,7 +37,6 @@ class PumaEnergyARSpider(Spider):
                 "puma_pris": 0,
                 "chargebox": 0,
             },
-            callback=self.parse,
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:


### PR DESCRIPTION
**Brand:** Puma (Puma Energy) — `brand:wikidata=Q7259769`.

**Data source:** 
https://pumaenergyarg.com.ar/encontra_tu_estacion. 
The map loads stations from `POST https://pumaenergyarg.com.ar/get_stations` (Laravel). 
The spider first GETs the locator page for the CSRF token, then POSTs a JSON body with 
**empty filter arrays** 
(`fuel_type`/`shop_type`/`franchise`=`[]`, `puma_pris`/`chargebox`=`0`), which returns the full network (413 stations). 
The arrays must be sent as JSON — form encoding drops empty arrays and the endpoint then returns HTTP 500.

**Category:** all → `amenity=fuel`.

**Fuel types** (from the per-station product list in the `text` field, plus `fuel_type` and `chargebox`):
- `Puma Super` → `fuel:octane_95` (408)
- `Max Premium` → `fuel:octane_98` (408) — premium petrol, mapped to 98 per the AR >95 RON convention (best-effort)
- `Puma Diesel` / `ION Puma Diesel` → `fuel:diesel` (200)
- `fuel_type` in (`Dual`, `GNC`) → `fuel:cng` (200)
- `chargebox == "1"` → `fuel:electricity` (6)

**Fields:** 
`DictParser` maps `id → ref`, lat/lon, and `address → addr:full`. The API `name` is just the street address (already in `addr:full`), so it's dropped — **NSI supplies `name=Puma`**. `opening_hours=24/7` (every record's `schedule` is "Abierto las 24hs."). No `operator` field exists in the feed.

**Notes / out of scope:**
- The on-site shop (`shop_type`) is **not** tagged `shop=convenience` — that top-level tag isn't in Puma's `amenity=fuel` NSI entry and would break the brand match.
- Food co-brand (`franchise`: Dean&Dennys / Havanna / Subway) and the `puma_pris` loyalty flag are ancillary and left out.
- CSRF: the `get_stations` POST requires the `_token` from the locator page's `csrf-token` meta (carried with the session cookies) — a standard Laravel anti-forgery token, no custom/browser headers.

**Sample POIs:**
```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1", 
      "amenity": "fuel", 
      "name": "Puma",
      "addr:full": "RUTA 2 KM. 116, 300, CHASCOMUS, BUENOS AIRES", 
      "opening_hours": "24/7",
      "fuel:octane_95": "yes", 
       "fuel:octane_98": "yes", 
       "fuel:diesel": "yes", 
      "fuel:cng": "yes", 
      "fuel:electricity": "yes",
      "brand": "Puma", 
      "brand:wikidata": "Q7259769"
    },
    "geometry": {"type": "Point", "coordinates": [-58.008532, -35.531806]}
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "8", 
      "amenity": "fuel", 
      "name": "Puma",
      "addr:full": "CASEY Y SAN MARTIN, PIGUE, BUENOS AIRES", 
      "opening_hours": "24/7",
      "fuel:octane_95": "yes", 
      "fuel:octane_98": "yes",
      "brand": "Puma", 
      "brand:wikidata": "Q7259769"
    },
    "geometry": {"type": "Point", "coordinates": [-62.40739, -37.60218]}
  }
]
```
json
```{
  "item_scraped_count": 413,
  "atp/category/amenity/fuel": 413,
  "atp/nsi/match_perfect": 413,
  "atp/field/country/from_spider_name": 413,
  "finish_reason": "finished"
}
```