### PR TITLE
[Uniform Destination US] Fix spider

### DIFF
--- a/locations/spiders/uniform_destination_us.py
+++ b/locations/spiders/uniform_destination_us.py
@@ -15,5 +15,6 @@ class UniformDestinationUSSpider(StorepointSpider):
 
         item["branch"] = location.get("description")
         item["addr_full"] = location.get("streetaddress")
+        item["website"] = None
 
         yield item


### PR DESCRIPTION
The Storepoint record's `website` is a scheme-less bare domain (`uniformdestination.com`) that's identical across all stores, so it failed URL-scheme validation and logged an error for every location. It's not a per-store URL — drop it.

Crawl yields 43 stores with coordinates and per-store phone, and no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)