### PR TITLE
[Bata] Remove dead Indian store finder url

### DIFF
--- a/locations/spiders/bata.py
+++ b/locations/spiders/bata.py
@@ -15,7 +15,6 @@ class BataSpider(JSONBlobSpider):
         "https://www.bata.com/on/demandware.store/Sites-bata-cl-Site/es_CL/Stores-FindStores",
         "https://www.bata.com/on/demandware.store/Sites-bata-cz-sfra-Site/cs_CZ/Stores-FindStores",
         "https://www.bata.com/on/demandware.store/Sites-bata-id-Site/en_ID/Stores-FindStores",
-        "https://www.bata.com/on/demandware.store/Sites-bata-in-Site/en_IN/Stores-FindStores",
         "https://www.bata.com/on/demandware.store/Sites-bata-it-sfra-Site/it_IT/Stores-FindStores",
         "https://www.bata.com/on/demandware.store/Sites-bata-my-Site/en_MY/Stores-FindStores",
         "https://www.bata.com/on/demandware.store/Sites-bata-sk-sfra-Site/sk_SK/Stores-FindStores",


### PR DESCRIPTION
The `bata` spider queries eight country store finder endpoints. The India one: https://www.bata.com/on/demandware.store/Sites-bata-in-Site/en_IN/Stores-FindStores no longer returns any store data (the other seven still work).

India accounted for roughly 1080 of the ~2200 items this spider used to produce, which matches
the drop seen in recent pipeline runs: output fell to ~1105 items (the seven surviving countries).

This PR removes the dead endpoint. India is covered separately by a new `bata_in` spider,
which uses the dedicated store locator at `stores.bata.com`. [PR ](https://github.com/alltheplaces/alltheplaces/pull/17419) created to add bata_in spider.