### PR TITLE
[Bata IN] Add spider

### DIFF
--- a/locations/spiders/bata_in.py
+++ b/locations/spiders/bata_in.py
@@ -1,0 +1,58 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import DELIMITERS_EN, OpeningHours, day_range, sanitise_day
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BataINSpider(SitemapSpider, StructuredDataSpider):
+    name = "bata_in"
+    BATA = {"brand": "Bata", "brand_wikidata": "Q688082"}
+    HUSH_PUPPIES = {"brand": "Hush Puppies", "brand_wikidata": "Q1828588"}
+    allowed_domains = ["stores.bata.com"]
+    sitemap_urls = ["https://stores.bata.com/sitemap.xml"]
+    sitemap_rules = [(r"-store-in-", "parse")]
+    search_for_email = False
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["ref"] = response.xpath('//*[contains(text(), "Store Code:")]/text()').re_first(r"Store Code:\s*(\S+)")
+
+        # Coordinates are supplied on the business itself rather than in a "geo" object.
+        item["lat"] = ld_data.get("latitude")
+        item["lon"] = ld_data.get("longitude")
+        item["branch"] = item.pop("name", "").removeprefix("Bata in ")
+        item["addr_full"] = item.pop("street_address")
+
+        item["opening_hours"] = OpeningHours()
+        for row in response.xpath('(//ul[@ref="overflowList"])[1]/li/text()').getall():
+            day, _, hours = row.partition(":")
+            open_time, _, close_time = hours.strip().partition(" - ")
+
+            # Days appear either as a single day ("Monday") or a range ("Sunday - Saturday").
+            days = [day] if sanitise_day(day) else []
+            for delimiter in DELIMITERS_EN:
+                start, sep, end = day.partition(delimiter)
+                if sep and sanitise_day(start) and sanitise_day(end):
+                    days = day_range(start, end)
+                    break
+            try:
+                item["opening_hours"].add_days_range(
+                    days, open_time.strip(), close_time.strip(), time_format="%I:%M %p"
+                )
+            except ValueError:
+                # Some stores contain malformed hours (e.g. "24:00 AM"); skip those entries.
+                continue
+
+        if "hush-puppies" in response.url:
+            item.update(self.HUSH_PUPPIES)
+        else:
+            item.update(self.BATA)
+        apply_category(Categories.SHOP_SHOES, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Bata India, replacing the dead `en_IN` endpoint removed from the `bata`
spider in the [PR](https://github.com/alltheplaces/alltheplaces/pull/17418).

The locator serves two brands, which are attributed separately: Bata (Q688082) and Hush Puppies (Q1828588).

```
{'atp/brand/Bata': 1761,
 'atp/brand/Hush Puppies': 128,
 'atp/brand_wikidata/Q1828588': 128,
 'atp/brand_wikidata/Q688082': 1761,
 'atp/category/shop/shoes': 1889,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/city': 3,
 'atp/clean_strings/street_address': 144,
 'atp/country/IN': 1889,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 133,
 'atp/field/email/missing': 1889,
 'atp/field/housenumber/missing': 1889,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 1889,
 'atp/field/operator_wikidata/missing': 1889,
 'atp/field/phone/missing': 29,
 'atp/field/state/missing': 1889,
 'atp/field/street/missing': 1889,
 'atp/field/twitter/missing': 1889,
 'atp/field/unit/missing': 1889,
 'atp/item_scraped_host_count/stores.bata.com': 1890,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 1889,
 'downloader/request_bytes': 792573,
 'downloader/request_count': 1892,
 'downloader/request_method_count/GET': 1892,
 'downloader/response_bytes': 217747468,
 'downloader/response_count': 1892,
 'downloader/response_status_count/200': 1892,
 'elapsed_time_seconds': 2307.547,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 7, 53, 1, 172738, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 837536796,
 'httpcompression/response_count': 1891,
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 1889,
 'items_per_minute': 49.12873862158647,
 'log_count/DEBUG': 3782,
 'log_count/INFO': 41,
 'request_depth_max': 1,
 'response_received_count': 1892,
 'responses_per_minute': 49.20676202860858,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1891,
 'scheduler/dequeued/memory': 1891,
 'scheduler/enqueued': 1891,
 'scheduler/enqueued/memory': 1891,
 'start_time': datetime.datetime(2026, 7, 20, 7, 14, 33, 638979, tzinfo=datetime.timezone.utc)}
```