### PR TITLE
[Walmart CA] Fix Spider

### DIFF
--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -21,6 +21,7 @@ class WalmartCASpider(Spider):
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
         "DOWNLOAD_DELAY": 5,
+        "DOWNLOAD_TIMEOUT": 60,
         "ROBOTSTXT_OBEY": False,
     }
     base_url = "https://www.walmart.ca/orchestra/graphql/storeFinderNearbyNodesQuery"

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -23,6 +23,7 @@ class WalmartCASpider(Spider):
         "DOWNLOAD_DELAY": 5,
         "DOWNLOAD_TIMEOUT": 50,
         "ROBOTSTXT_OBEY": False,
+        "COOKIES_ENABLED": False,
     }
     base_url = "https://www.walmart.ca/orchestra/graphql/storeFinderNearbyNodesQuery"
     hash = "d3236419dacf3a02137445459aeaeda81fd40630ddd2d3f218cf43f60e1ad16a"

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -21,7 +21,7 @@ class WalmartCASpider(Spider):
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,
         "DOWNLOAD_DELAY": 5,
-        "DOWNLOAD_TIMEOUT": 60,
+        "DOWNLOAD_TIMEOUT": 50,
         "ROBOTSTXT_OBEY": False,
     }
     base_url = "https://www.walmart.ca/orchestra/graphql/storeFinderNearbyNodesQuery"

--- a/locations/spiders/walmart_ca.py
+++ b/locations/spiders/walmart_ca.py
@@ -23,7 +23,6 @@ class WalmartCASpider(Spider):
         "DOWNLOAD_DELAY": 5,
         "DOWNLOAD_TIMEOUT": 50,
         "ROBOTSTXT_OBEY": False,
-        "COOKIES_ENABLED": False,
     }
     base_url = "https://www.walmart.ca/orchestra/graphql/storeFinderNearbyNodesQuery"
     hash = "d3236419dacf3a02137445459aeaeda81fd40630ddd2d3f218cf43f60e1ad16a"


### PR DESCRIPTION
```python
{'atp/brand/Walmart': 383,
 'atp/brand_wikidata/Q483551': 383,
 'atp/category/shop/department_store': 44,
 'atp/category/shop/supermarket': 339,
 'atp/country/CA': 383,
 'atp/duplicate_count': 10360,
 'atp/field/email/missing': 383,
 'atp/field/housenumber/missing': 383,
 'atp/field/operator/missing': 383,
 'atp/field/operator_wikidata/missing': 383,
 'atp/field/street/missing': 383,
 'atp/field/twitter/missing': 383,
 'atp/field/unit/missing': 383,
 'atp/item_scraped_host_count/www.walmart.ca': 10743,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 383,
 'downloader/request_bytes': 1048086,
 'downloader/request_count': 415,
 'downloader/request_method_count/GET': 415,
 'downloader/response_bytes': 5721660,
 'downloader/response_count': 415,
 'downloader/response_status_count/200': 301,
 'downloader/response_status_count/412': 114,
 'elapsed_time_seconds': 2564.1089999999967,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 7, 30, 3, 133436, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 38425543,
 'httpcompression/response_count': 301,
 'httperror/response_ignored_count': 114,
 'httperror/response_ignored_status_count/412': 114,
 'item_dropped_count': 10360,
 'item_dropped_reasons_count/DropItem': 10360,
 'item_scraped_count': 383,
 'items_per_minute': 8.962558502340093,
 'log_count/DEBUG': 11158,
 'log_count/INFO': 159,
 'response_received_count': 415,
 'responses_per_minute': 9.711388455538222,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'start_time': datetime.datetime(2026, 7, 20, 6, 47, 18, 994794, tzinfo=datetime.timezone.utc)}
```