### PR TITLE
[Circle  K DK] Fix spider

### DIFF
--- a/locations/spiders/circle_k_dk.py
+++ b/locations/spiders/circle_k_dk.py
@@ -21,16 +21,23 @@ class CircleKDKSpider(SitemapSpider, StructuredDataSpider):
         ld_data["openingHours"] = rules
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        if item["name"].startswith("CIRCLE K TRUCK "):
-            item["branch"] = item.pop("name").removeprefix("CIRCLE K TRUCK ")
+        category = Categories.FUEL_STATION
+        if item["name"].startswith("CIRCLE K TRUCK ") or item["name"].startswith("TRUCKANLÆG "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K TRUCK ").removeprefix("TRUCKANLÆG ")
+            item["name"] = "Circle K Truck"
+        elif "TRUCK HOME" in item["name"].replace(",", ""):
             item["name"] = "Circle K Truck"
         elif item["name"].startswith("CIRCLE K MOTORVEJSCENTER "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K MOTORVEJSCENTER ")
             item["name"] = "Circle K Motorvejscenter"
+        elif item["name"].startswith("CIRCLE K EV"):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K EV")
+            item["name"] = "Circle K"
+            category = Categories.CHARGING_STATION
         elif item["name"].startswith("CIRCLE K "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K ")
 
         extract_google_position(item, response)
 
-        apply_category(Categories.FUEL_STATION, item)
+        apply_category(category, item)
         yield item

--- a/locations/spiders/circle_k_dk.py
+++ b/locations/spiders/circle_k_dk.py
@@ -1,7 +1,7 @@
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.google_url import extract_google_position
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
@@ -30,8 +30,8 @@ class CircleKDKSpider(SitemapSpider, StructuredDataSpider):
         elif item["name"].startswith("CIRCLE K MOTORVEJSCENTER "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K MOTORVEJSCENTER ")
             item["name"] = "Circle K Motorvejscenter"
-        elif item["name"].startswith("CIRCLE K EV"):
-            item["branch"] = item.pop("name").removeprefix("CIRCLE K EV")
+        elif item["name"].startswith("CIRCLE K EV "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K EV ")
             item["name"] = "Circle K"
             category = Categories.CHARGING_STATION
         elif item["name"].startswith("CIRCLE K "):
@@ -40,4 +40,29 @@ class CircleKDKSpider(SitemapSpider, StructuredDataSpider):
         extract_google_position(item, response)
 
         apply_category(category, item)
+
+        fuels = [
+            fuel.strip("/").rsplit("/", 1)[-1].removeprefix("Feature").removeprefix("Fuel")
+            for fuel in response.xpath('//*[@class="field-fuel-list"][1]//img/@src').getall()
+        ]
+
+        apply_yes_no(Fuel.ADBLUE, item, "AdBlue" in fuels)
+        apply_yes_no(Fuel.OCTANE_95, item, "Miles95" in fuels)
+        apply_yes_no(Fuel.OCTANE_95, item, "MilesPlus95" in fuels)
+        apply_yes_no(Fuel.DIESEL, item, "MilesDiesel" in fuels)
+        apply_yes_no(Fuel.DIESEL, item, "MilesPlusDiesel" in fuels)
+        apply_yes_no(Fuel.BIODIESEL, item, "HVO100" in fuels)
+        apply_yes_no(Fuel.ELECTRIC, item, "EVCharger" in fuels and category != Categories.CHARGING_STATION)
+
+        services = [
+            service.split("?")[0].rsplit("/", 1)[-1].removeprefix("Feature")
+            for service in response.xpath('//*[@itemprop="makesOffer"]//img/@src').getall()
+        ]
+
+        apply_yes_no(Extras.WIFI, item, "Wifi" in services)
+        apply_yes_no(Extras.CAR_WASH, item, "CarWash" in services or "CarWashJetWash" in services)
+        apply_yes_no(Extras.VACUUM_CLEANER, item, "VacuumCleaner" in services)
+        apply_yes_no(Extras.SHOWERS, item, "Shower" in services)
+        apply_yes_no(Extras.TOILETS, item, "ToiletsBoth" in services)
+
         yield item

--- a/locations/spiders/circle_k_dk.py
+++ b/locations/spiders/circle_k_dk.py
@@ -1,6 +1,5 @@
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
@@ -8,11 +7,11 @@ from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKDKSpider(CrawlSpider, StructuredDataSpider):
+class CircleKDKSpider(SitemapSpider, StructuredDataSpider):
     name = "circle_k_dk"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
-    start_urls = ["https://www.circlek.dk/stations"]
-    rules = [Rule(LinkExtractor(allow="/station/circle"), callback="parse_sd")]
+    sitemap_urls = ["https://www.circlek.dk/sitemaps/stations/sitemap.xml"]
+    sitemap_rules = [(r"/station/(?!ingo-)[-\w]+", "parse_sd")]
 
     def pre_process_data(self, ld_data: dict, **kwargs):
         rules = ld_data.get("openingHours") or []


### PR DESCRIPTION
The https://www.circlek.dk/stations page behaves inconsistently. At times it loads the station URLs correctly, while at other times it fails to do so. Hence, `Sitemap` is now used.

```python
{'atp/brand/Circle K': 247,
 'atp/brand_wikidata/Q3268010': 247,
 'atp/category/amenity/charging_station': 9,
 'atp/category/amenity/fuel': 238,
 'atp/country/DK': 247,
 'atp/field/branch/missing': 2,
 'atp/field/email/missing': 247,
 'atp/field/housenumber/missing': 247,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 238,
 'atp/field/operator_wikidata/missing': 238,
 'atp/field/phone/missing': 17,
 'atp/field/state/missing': 247,
 'atp/field/street/missing': 247,
 'atp/field/twitter/missing': 247,
 'atp/field/unit/missing': 247,
 'atp/item_scraped_host_count/www.circlek.dk': 247,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 247,
 'atp/operator/Circle K': 9,
 'atp/operator_wikidata/Q3268010': 9,
 'downloader/request_bytes': 104030,
 'downloader/request_count': 251,
 'downloader/request_method_count/GET': 251,
 'downloader/response_bytes': 3957494,
 'downloader/response_count': 251,
 'downloader/response_status_count/200': 249,
 'downloader/response_status_count/301': 2,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 4.17200000000048,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 8, 39, 29, 913621, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 251,
 'httpcompression/response_bytes': 21434317,
 'httpcompression/response_count': 249,
 'item_scraped_count': 247,
 'items_per_minute': 3705.0,
 'log_count/DEBUG': 500,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 249,
 'responses_per_minute': 3735.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 250,
 'scheduler/dequeued/memory': 250,
 'scheduler/enqueued': 250,
 'scheduler/enqueued/memory': 250,
 'start_time': datetime.datetime(2026, 7, 20, 8, 39, 25, 749437, tzinfo=datetime.timezone.utc)}
```