### PR TITLE
[Circle K NO] Fix spider

### DIFF
--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -23,17 +23,17 @@ class CircleKNOSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if item["name"].startswith("CIRCLE K AUTOMAT "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K AUTOMAT ")
+        elif item["name"].startswith("CIRCLE K BILVASK "):
+            item["branch"] = item.pop("name").removeprefix("CIRCLE K BILVASK ")
+            apply_category(Categories.CAR_WASH, item)
         elif item["name"].startswith("CIRCLE K TRUCK "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K TRUCK ")
             item["name"] = "Circle K Truck"
         elif item["name"].startswith("CIRCLE K LADER "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K LADER ")
-            item["name"] = "Circle K"
+            item["name"] = "Circle K Lader"
         elif item["name"].startswith("CIRCLE K "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K ")
-        else:
-            item["branch"] = item.pop("name")
-            item["name"] = "Circle K"
 
         extract_google_position(item, response)
 
@@ -44,7 +44,7 @@ class CircleKNOSpider(SitemapSpider, StructuredDataSpider):
         charging_station = response.xpath('//img[contains(@src, "FeatureEVCharger")]/@src').get()
         if not fuels and charging_station:
             apply_category(Categories.CHARGING_STATION, item)
-        else:
+        elif fuels:
             apply_category(Categories.FUEL_STATION, item)
             apply_yes_no(Fuel.ELECTRIC, item, bool(charging_station))
 

--- a/locations/spiders/circle_k_no.py
+++ b/locations/spiders/circle_k_no.py
@@ -1,18 +1,24 @@
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import Rule
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.spiders.circle_k_dk import CircleKDKSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class CircleKNOSpider(CircleKDKSpider):
+class CircleKNOSpider(SitemapSpider, StructuredDataSpider):
     name = "circle_k_no"
     item_attributes = {"brand": "Circle K", "brand_wikidata": "Q3268010"}
-    start_urls = ["https://www.circlek.no/stations"]
-    rules = [Rule(LinkExtractor(allow="/station/circle"), callback="parse")]
+    sitemap_urls = ["https://www.circlek.no/sitemaps/stations/sitemap.xml"]
+    sitemap_rules = [(r"/station/[-\w]+", "parse_sd")]
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        rules = ld_data.get("openingHours") or []
+        for idx, rule in enumerate(rules):
+            if len(rule) == 2:
+                rules[idx] = "{} 00:00-24:00".format(rule)
+        ld_data["openingHours"] = rules
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if item["name"].startswith("CIRCLE K AUTOMAT "):
@@ -22,8 +28,12 @@ class CircleKNOSpider(CircleKDKSpider):
             item["name"] = "Circle K Truck"
         elif item["name"].startswith("CIRCLE K LADER "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K LADER ")
+            item["name"] = "Circle K"
         elif item["name"].startswith("CIRCLE K "):
             item["branch"] = item.pop("name").removeprefix("CIRCLE K ")
+        else:
+            item["branch"] = item.pop("name")
+            item["name"] = "Circle K"
 
         extract_google_position(item, response)
 


### PR DESCRIPTION
https://www.circlek.no/stations page is no longer providing station urls at the time of writing. Hence, switched to `Sitemap`.

```python
{'atp/brand/Circle K': 460,
 'atp/brand_wikidata/Q3268010': 460,
 'atp/category/amenity/charging_station': 9,
 'atp/category/amenity/fuel': 451,
 'atp/clean_strings/branch': 2,
 'atp/country/NO': 460,
 'atp/field/city/missing': 2,
 'atp/field/email/missing': 460,
 'atp/field/housenumber/missing': 460,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 451,
 'atp/field/operator_wikidata/missing': 451,
 'atp/field/phone/missing': 3,
 'atp/field/state/missing': 460,
 'atp/field/street/missing': 460,
 'atp/field/twitter/missing': 460,
 'atp/field/unit/missing': 460,
 'atp/item_scraped_host_count/www.circlek.no': 460,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 460,
 'atp/operator/Circle K': 9,
 'atp/operator_wikidata/Q3268010': 9,
 'downloader/request_bytes': 190845,
 'downloader/request_count': 462,
 'downloader/request_method_count/GET': 462,
 'downloader/response_bytes': 6903744,
 'downloader/response_count': 462,
 'downloader/response_status_count/200': 462,
 'elapsed_time_seconds': 8.485000000000582,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 9, 52, 20, 846348, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 462,
 'httpcompression/response_bytes': 37897317,
 'httpcompression/response_count': 462,
 'item_scraped_count': 460,
 'items_per_minute': 3450.0,
 'log_count/DEBUG': 923,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 462,
 'responses_per_minute': 3465.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 461,
 'scheduler/dequeued/memory': 461,
 'scheduler/enqueued': 461,
 'scheduler/enqueued/memory': 461,
 'start_time': datetime.datetime(2026, 7, 20, 9, 52, 12, 370635, tzinfo=datetime.timezone.utc)}
```