### PR TITLE
[Mazda CA] Fix Spider

### DIFF
--- a/locations/spiders/mazda_ca.py
+++ b/locations/spiders/mazda_ca.py
@@ -1,10 +1,13 @@
 import re
 from copy import deepcopy
+from typing import Any, AsyncIterator
 
 import scrapy
+from scrapy.http import JsonRequest
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.geo import city_locations
 from locations.hours import OpeningHours, sanitise_day
 from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.mazda_jp import MAZDA_SHARED_ATTRIBUTES
@@ -13,18 +16,22 @@ from locations.spiders.mazda_jp import MAZDA_SHARED_ATTRIBUTES
 class MazdaCASpider(scrapy.Spider):
     name = "mazda_ca"
     item_attributes = MAZDA_SHARED_ATTRIBUTES
-    start_urls = ["https://n8xgyscaa3.execute-api.ca-central-1.amazonaws.com/prod/api/Dealers"]
+
+    async def start(self) -> AsyncIterator[Any]:
+        for city in city_locations("CA", 0):
+            yield JsonRequest(
+                url=f'https://n8xgyscaa3.execute-api.ca-central-1.amazonaws.com/prod/api/Dealers?lang_code=en&limit=1000&keyword={city["name"]}'
+            )
 
     def parse(self, response, **kwargs):
         for dealer in response.json()["data"]:
             item = DictParser.parse(dealer)
-
             item["ref"] = dealer["dealer_code"]
             item["street_address"] = merge_address_lines([dealer["address_line_1"], dealer["address_line_2"]])
             item["email"] = dealer["oca_email"]
             item["state"] = dealer["province"]["province_code"]
 
-            if dealer["hours"]["sales"]:
+            if dealer.get("hours").get("sales"):
                 shop = deepcopy(item)
                 self.parse_hours(shop, dealer["hours"]["sales"])
                 apply_category(Categories.SHOP_CAR, shop)
@@ -32,14 +39,14 @@ class MazdaCASpider(scrapy.Spider):
                     apply_yes_no(Extras.CAR_REPAIR, shop, True)
                 yield shop
 
-            if dealer["hours"]["service"]:
+            if dealer.get("hours").get("service"):
                 service = deepcopy(item)
                 service["ref"] = f"{item['ref']}_service"
                 self.parse_hours(service, dealer["hours"]["service"])
                 apply_category(Categories.SHOP_CAR_REPAIR, service)
                 yield service
 
-            if dealer["hours"]["parts"]:
+            if dealer.get("hours").get("parts"):
                 parts = deepcopy(item)
                 parts["ref"] = f"{item['ref']}_parts"
                 self.parse_hours(parts, dealer["hours"]["parts"])


### PR DESCRIPTION
```python
{'atp/brand/Mazda': 378,
 'atp/brand_wikidata/Q35996': 378,
 'atp/category/shop/car': 126,
 'atp/category/shop/car_parts': 126,
 'atp/category/shop/car_repair': 126,
 'atp/country/CA': 378,
 'atp/duplicate_count': 18,
 'atp/field/branch/missing': 378,
 'atp/field/country/from_spider_name': 378,
 'atp/field/email/invalid': 6,
 'atp/field/email/missing': 27,
 'atp/field/housenumber/missing': 378,
 'atp/field/operator/missing': 378,
 'atp/field/operator_wikidata/missing': 378,
 'atp/field/street/missing': 378,
 'atp/field/twitter/missing': 378,
 'atp/field/unit/missing': 378,
 'atp/field/website/invalid': 9,
 'atp/item_scraped_host_count/n8xgyscaa3.execute-api.ca-central-1.amazonaws.com': 396,
 'atp/lineage': 'S_?',
 'atp/nsi/category_unknown': 126,
 'atp/nsi/match_failed': 126,
 'atp/nsi/match_perfect': 252,
 'downloader/request_bytes': 180398,
 'downloader/request_count': 416,
 'downloader/request_method_count/GET': 416,
 'downloader/response_bytes': 401118,
 'downloader/response_count': 416,
 'downloader/response_status_count/200': 415,
 'downloader/response_status_count/403': 1,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 515.5939999999828,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 11, 13, 9, 139226, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 18,
 'item_dropped_reasons_count/DropItem': 18,
 'item_scraped_count': 378,
 'items_per_minute': 44.03883495145631,
 'log_count/DEBUG': 814,
 'log_count/ERROR': 10,
 'log_count/INFO': 11,
 'log_count/WARNING': 3,
 'response_received_count': 416,
 'responses_per_minute': 48.46601941747573,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 415,
 'scheduler/dequeued/memory': 415,
 'scheduler/enqueued': 415,
 'scheduler/enqueued/memory': 415,
 'spider_exceptions/AttributeError': 1,
 'spider_exceptions/count': 1,
 'start_time': datetime.datetime(2026, 7, 20, 11, 4, 33, 531017, tzinfo=datetime.timezone.utc)}
```