### PR TITLE
[Hobby Lobby US] Fix spider

### DIFF
--- a/locations/spiders/hobby_lobby_us.py
+++ b/locations/spiders/hobby_lobby_us.py
@@ -1,12 +1,18 @@
-from urllib.parse import urlparse
+from typing import Iterable
 
+from chompjs import chompjs
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.react_server_components import parse_rsc
 
 
-class HobbyLobbyUSSpider(SitemapSpider, StructuredDataSpider):
+class HobbyLobbyUSSpider(SitemapSpider, JSONBlobSpider):
     name = "hobby_lobby_us"
     allowed_domains = ["www.hobbylobby.com"]
     item_attributes = {
@@ -15,26 +21,29 @@ class HobbyLobbyUSSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://www.hobbylobby.com/sitemap-Store.xml"]
     sitemap_rules = [
-        (r"/stores/search/(\d+)$", "parse_sd"),
+        (r"/stores/search/(\d+)$", "parse"),
     ]
-    time_format = "%I:%M %p"
-    # There are only social links for branch, not location
-    search_for_twitter = False
-    search_for_facebook = False
 
-    def pre_process_data(self, ld_data, **kwargs):
-        ld_data.pop("name", None)
-        # Broken image link
-        ld_data.pop("image", None)
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        objs = [
+            chompjs.parse_js_object(s)
+            for s in response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        ]
+        rsc = "".join([s for n, s in objs]).encode()
+        return [DictParser.get_nested_key(dict(parse_rsc(rsc)), "storeDetails")["data"]]
 
-        # ID/ref should be store number, not main website URL
-        url = urlparse(ld_data["url"])
-        ref = url.path.split("/")[-1]
-        ld_data["@id"] = ref
-        # Store URLs have the wrong domain
-        url = url._replace(scheme="https", netloc="www.hobbylobby.com")
-        ld_data["url"] = url.geturl()
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = feature["commonName"].split("-")[0].strip()
+        item["website"] = response.url
+        item["opening_hours"] = self.parse_opening_hours(feature.get("thisWeek", {}).get("hours", []))
         apply_category(Categories.SHOP_CRAFT, item)
         yield item
+
+    def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for rule in rules:
+            if rule["startTime"].lower() == "closed":
+                opening_hours.set_closed(rule["day"])
+                continue
+            opening_hours.add_range(rule["day"], rule["startTime"], rule["endTime"], "%I:%M %p")
+        return opening_hours


### PR DESCRIPTION
```python
{'atp/brand/Hobby Lobby': 1090,
 'atp/brand_wikidata/Q5874938': 1090,
 'atp/category/shop/craft': 1090,
 'atp/clean_strings/city': 6,
 'atp/clean_strings/street_address': 24,
 'atp/country/US': 1090,
 'atp/field/branch/missing': 52,
 'atp/field/country/from_spider_name': 1090,
 'atp/field/email/missing': 1090,
 'atp/field/housenumber/missing': 1090,
 'atp/field/operator/missing': 1090,
 'atp/field/operator_wikidata/missing': 1090,
 'atp/field/street/missing': 1090,
 'atp/field/twitter/missing': 1090,
 'atp/field/unit/missing': 1090,
 'atp/item_scraped_host_count/www.hobbylobby.com': 1090,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 1090,
 'downloader/request_bytes': 1061313,
 'downloader/request_count': 1095,
 'downloader/request_method_count/GET': 1095,
 'downloader/response_bytes': 34406940,
 'downloader/response_count': 1095,
 'downloader/response_status_count/200': 1092,
 'downloader/response_status_count/503': 3,
 'elapsed_time_seconds': 25.343999999997322,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 20, 15, 31, 7, 733189, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 1095,
 'httpcompression/response_bytes': 202976382,
 'httpcompression/response_count': 1095,
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/503': 1,
 'item_scraped_count': 1090,
 'items_per_minute': 2616.0,
 'log_count/DEBUG': 2187,
 'log_count/ERROR': 1,
 'log_count/INFO': 4,
 'request_depth_max': 1,
 'response_received_count': 1093,
 'responses_per_minute': 2623.2,
 'retry/count': 2,
 'retry/max_reached': 1,
 'retry/reason_count/503 Service Unavailable': 2,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1094,
 'scheduler/dequeued/memory': 1094,
 'scheduler/enqueued': 1094,
 'scheduler/enqueued/memory': 1094,
 'start_time': datetime.datetime(2026, 7, 20, 15, 30, 42, 379103, tzinfo=datetime.timezone.utc)}
```