### PR TITLE
[Hofer AT] Fix Spider

### DIFF
--- a/locations/spiders/hofer_at.py
+++ b/locations/spiders/hofer_at.py
@@ -1,31 +1,7 @@
-from scrapy import Spider
-
-from locations.dict_parser import DictParser
-from locations.hours import DAYS_DE, OpeningHours, sanitise_day
+from locations.storefinders.uberall import UberallSpider
 
 
-class HoferATSpider(Spider):  # Aldi Sud
+class HoferATSpider(UberallSpider):
     name = "hofer_at"
     item_attributes = {"brand": "Hofer", "brand_wikidata": "Q15815751"}
-    start_urls = [
-        "https://www.hofer.at/at/de/.get-stores-in-radius.json?latitude=47.516231&longitude=14.550072&radius=2500000"
-    ]
-
-    def parse(self, response):
-        for store in response.json()["stores"]:
-            item = DictParser.parse(store)
-            if store["storeType"] == "N":
-                continue
-            if item["country"] != "AT":
-                continue
-
-            item["website"] = store.get("url")
-
-            oh = OpeningHours()
-            for rule in store["openUntilSorted"]["openingHours"]:
-                day = sanitise_day(rule["day"], DAYS_DE)
-                if not rule.get("closed", False):
-                    oh.add_range(day, rule["openFormatted"], rule["closeFormatted"])
-            item["opening_hours"] = oh
-
-            yield item
+    key = "a7cWdBAwU03AxF6RRxwgY9Phxzh3sf"


### PR DESCRIPTION
```python
{'atp/brand/Hofer': 549,
 'atp/brand_wikidata/Q15815751': 549,
 'atp/category/shop/supermarket': 549,
 'atp/country/AT': 549,
 'atp/field/branch/missing': 549,
 'atp/field/email/missing': 549,
 'atp/field/housenumber/missing': 549,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 549,
 'atp/field/operator_wikidata/missing': 549,
 'atp/field/phone/missing': 1,
 'atp/field/street/missing': 549,
 'atp/field/twitter/missing': 549,
 'atp/field/unit/missing': 549,
 'atp/item_scraped_host_count/uberall.com': 549,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 549,
 'atp/nsi/match_imperfect': 549,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 43323,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 5.235000000000582,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 5, 10, 22, 353737, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 470547,
 'httpcompression/response_count': 2,
 'item_scraped_count': 549,
 'items_per_minute': 6588.0,
 'log_count/DEBUG': 551,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 24.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 21, 5, 10, 17, 128224, tzinfo=datetime.timezone.utc)}
```