### PR TITLE
[Cornerstone Healthcare Group] Fix Spider

### DIFF
--- a/locations/spiders/cornerstone_healthcare_group_us.py
+++ b/locations/spiders/cornerstone_healthcare_group_us.py
@@ -1,26 +1,21 @@
+import json
 from typing import Any
 
 from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
-from locations.google_url import extract_google_position
-from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
-class CornerstoneHealthcareGroupUSSpider(CrawlSpider):
+class CornerstoneHealthcareGroupUSSpider(Spider):
     name = "cornerstone_healthcare_group_us"
     item_attributes = {"brand": "Cornerstone Healthcare Group"}
-    start_urls = ["https://cornerstonehospitals.com/locations"]
-    rules = [Rule(LinkExtractor(r"/locations/[^/]+/[^/]+$"), callback="parse")]
+    start_urls = ["https://www.cornerstonehospitals.com/locations"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
-        item["name"] = self.item_attributes["brand"]
-        item["branch"] = response.xpath("//h1//text()").get()
-        item["addr_full"] = response.xpath('//*[@class="cmp-text"]//p//text()').get().replace("|", "")
-        item["website"] = item["ref"] = response.url
-        extract_google_position(item, response)
-        apply_category(Categories.HOSPITAL, item)
-        yield item
+        for location in json.loads(response.xpath("//@data-markers-list").get()):
+            item = DictParser.parse(location)
+            item["website"] = item["ref"] = location["locationPagePath"]
+            apply_category(Categories.HOSPITAL, item)
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/Cornerstone Healthcare Group': 6,
 'atp/category/amenity/hospital': 6,
 'atp/category/multiple': 6,
 'atp/clean_strings/name': 1,
 'atp/country/US': 6,
 'atp/field/branch/missing': 6,
 'atp/field/brand_wikidata/missing': 6,
 'atp/field/country/from_spider_name': 6,
 'atp/field/email/missing': 6,
 'atp/field/housenumber/missing': 6,
 'atp/field/opening_hours/missing': 6,
 'atp/field/operator/missing': 6,
 'atp/field/operator_wikidata/missing': 6,
 'atp/field/state/from_reverse_geocoding': 6,
 'atp/field/street/missing': 6,
 'atp/field/twitter/missing': 6,
 'atp/field/unit/missing': 6,
 'atp/item_scraped_host_count/www.cornerstonehospitals.com': 6,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 6,
 'atp/nsi/match_failed': 6,
 'downloader/request_bytes': 691,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 9589,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.0,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 7, 6, 53, 879470, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 47207,
 'httpcompression/response_count': 1,
 'item_scraped_count': 6,
 'items_per_minute': 180.0,
 'log_count/DEBUG': 8,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 21, 7, 6, 51, 879056, tzinfo=datetime.timezone.utc)}
```