### PR TITLE
[Boston Market US] Fix spider

### DIFF
--- a/locations/spiders/boston_market_us.py
+++ b/locations/spiders/boston_market_us.py
@@ -1,45 +1,22 @@
-import re
 from typing import Iterable
 
-from chompjs import parse_js_object
-from scrapy import Spider
-from scrapy.http import Request, Response
+from scrapy.http import TextResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class BostonMarketUSSpider(Spider):
+class BostonMarketUSSpider(CrawlSpider, StructuredDataSpider):
     name = "boston_market_us"
     item_attributes = {"brand": "Boston Market", "brand_wikidata": "Q603617"}
-    allowed_domains = ["www.bostonmarket.com"]
-    start_urls = ["https://www.bostonmarket.com/store-location.txt"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}  # HTML 404 page causes robots.txt parse warnings
+    start_urls = ["https://www.bostonmarket.com/order"]
+    rules = [Rule(LinkExtractor(r"/bm(\d+)$"), "parse_sd")]
+    drop_attributes = {"image"}
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        if matches := re.findall(r"static\/chunks\/\d+-[0-9a-f]+\.js", response.text):
-            js_files = list(set(matches))
-            for js_file in js_files:
-                yield Request(url=f"https://www.bostonmarket.com/_next/{js_file}", callback=self.parse_js_file)
-
-    def parse_js_file(self, response: Response) -> Iterable[Feature]:
-        if '{name:"Boston Market Corporation",position:{lat:' not in response.text:
-            # Not the JavaScript file we want that contains restaurant
-            # location information.
-            return
-
-        js_blob = (
-            '[{name:"Boston Market Corporation",'
-            + response.text.split('=[{name:"Boston Market Corporation",', 1)[1].split("}]", 1)[0]
-            + "}]"
-        )
-        features = parse_js_object(js_blob)
-        for feature in features:
-            if feature["status"] != "Open":
-                continue
-            item = DictParser.parse(feature)
-            item["ref"] = str(feature["storeNumber"])
-            item.pop("name", None)
-            apply_category(Categories.FAST_FOOD, item)
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item.pop("name", None)
+        apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
Boston Market now operates only six stores in the `US`, down from more than 50.

```python
{'atp/brand/Boston Market': 6,
 'atp/brand_wikidata/Q603617': 6,
 'atp/category/amenity/fast_food': 6,
 'atp/cdn/cloudflare/response_count': 7,
 'atp/cdn/cloudflare/response_status_count/200': 7,
 'atp/country/US': 6,
 'atp/field/branch/missing': 6,
 'atp/field/email/missing': 6,
 'atp/field/housenumber/missing': 6,
 'atp/field/operator/missing': 6,
 'atp/field/operator_wikidata/missing': 6,
 'atp/field/street/missing': 6,
 'atp/field/twitter/missing': 6,
 'atp/field/unit/missing': 6,
 'atp/item_scraped_host_count/bostonmarket.orders.co': 6,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 6,
 'downloader/request_bytes': 3297,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 343900,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 9,
 'elapsed_time_seconds': 11.922000000005937,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 7, 24, 5, 890022, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7291492,
 'httpcompression/response_count': 9,
 'item_scraped_count': 6,
 'items_per_minute': 32.72727272727273,
 'log_count/DEBUG': 15,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 9,
 'responses_per_minute': 49.09090909090909,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 2,
 'scheduler/dequeued': 7,
 'scheduler/dequeued/memory': 7,
 'scheduler/enqueued': 7,
 'scheduler/enqueued/memory': 7,
 'start_time': datetime.datetime(2026, 7, 21, 7, 23, 53, 972960, tzinfo=datetime.timezone.utc)}
```
