### PR TITLE
[Suzuki DE] Fix spider

### DIFF
--- a/locations/spiders/suzuki_de.py
+++ b/locations/spiders/suzuki_de.py
@@ -1,7 +1,8 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
+from urllib.parse import urlencode
 
 from scrapy import Spider
-from scrapy.http import FormRequest
+from scrapy.http import Request, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -12,9 +13,9 @@ class SuzukiDESpider(Spider):
     name = "suzuki_de"
     item_attributes = {"brand": "Suzuki", "brand_wikidata": "Q181642"}
 
-    async def start(self) -> AsyncIterator[FormRequest]:
+    async def start(self) -> AsyncIterator[Request]:
         for city in city_locations("DE", 50000):
-            form_data = {
+            params = {
                 "dealertype": ["V", "S"],
                 "searchtype": "2",
                 "count": "20",
@@ -22,12 +23,9 @@ class SuzukiDESpider(Spider):
                 "lat": str(city["latitude"]),
                 "lng": str(city["longitude"]),
             }
-            yield FormRequest(
-                url="https://auto.suzuki.de/dealersearch/search",
-                formdata=form_data,
-            )
+            yield Request(url="https://auto.suzuki.de/dealersearch/search?" + urlencode(params, doseq=True))
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():
             store["location"]["name"] = store["dealer"].get("dealername")
             store["location"]["website"] = store["dealer"].get("homepage")


### PR DESCRIPTION
The dealer-search endpoint is behind CloudFront, which rejects the POST request the spider sent (403 error page, no dealers returned). Send the search as a GET with the parameters in the query string, which returns the dealer JSON. Add type hints.