### PR TITLE
[Wolt Market NO] Fix spider

### DIFF
--- a/locations/spiders/wolt_market_no.py
+++ b/locations/spiders/wolt_market_no.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from scrapy.http import TextResponse
+
 from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.sylinder import SylinderSpider
@@ -8,8 +10,15 @@ from locations.storefinders.sylinder import SylinderSpider
 class WoltMarketNOSpider(SylinderSpider):
     name = "wolt_market_no"
     item_attributes = {"name": "Wolt Market", "brand": "Wolt Market", "brand_wikidata": "Q30024526"}
-    app_keys = ["4220"]
+    # Wolt Market stores are no longer assigned a chain id, so the
+    # full store list is requested and matched on store slug instead.
+    app_keys = []
     warn_if_no_base_url = False
+
+    def parse(self, response: TextResponse) -> Iterable[Feature]:
+        for location in response.json():
+            if location["storeDetails"]["slug"].startswith("wolt-market-"):
+                yield from self.parse_location(location)
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("Wolt Market ").removesuffix(" DV")


### PR DESCRIPTION
```
{'atp/brand/Wolt Market': 5,
 'atp/brand_wikidata/Q30024526': 5,
 'atp/category/dark_store/grocery': 5,
 'atp/country/NO': 5,
 'atp/field/country/from_spider_name': 5,
 'atp/field/housenumber/missing': 5,
 'atp/field/opening_hours/missing': 5,
 'atp/field/operator/missing': 5,
 'atp/field/operator_wikidata/missing': 5,
 'atp/field/street/missing': 5,
 'atp/field/street_address/missing': 5,
 'atp/field/twitter/missing': 5,
 'atp/field/unit/missing': 5,
 'atp/item_scraped_host_count/api.ngdata.no': 5,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 5,
 'atp/nsi/match_failed': 5,
 'downloader/request_bytes': 699,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5630374,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 4.171999999999997,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 9, 48, 2, 697551, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 5,
 'items_per_minute': 75.0,
 'log_count/DEBUG': 8,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 21, 9, 47, 58, 524549, tzinfo=datetime.timezone.utc)}
```