### PR TITLE
[Cuisinella FR] Fix spider

### DIFF
--- a/locations/spiders/cuisinella_fr.py
+++ b/locations/spiders/cuisinella_fr.py
@@ -3,6 +3,7 @@ import html
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -14,21 +15,16 @@ class CuisinellaFRSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"/fr-fr/magasins/[\w-]+/[\w-]+", "parse")]
 
     def pre_process_data(self, ld_data: dict, **kwargs):
-        # Currently 100% malformed eg
-        # {
-        #     "@type": "GeoCoordinates",
-        #     "latitude": "16.242304, -61.562389?.Latitude",
-        #     "longitude": "16.242304, -61.562389?.Longitude",
-        # }
-
-        if (ld_data.get("geo") or {}).get("latitude").endswith("?.Latitude"):
-            lat_lon = ld_data["geo"]["latitude"].split("?", 1)
+        latitude = (ld_data.get("geo") or {}).get("latitude")
+        if isinstance(latitude, str) and latitude.endswith("?.Latitude"):
+            lat_lon = latitude.split("?", 1)
             if lat_lon[0]:
                 ld_data["geo"]["latitude"], ld_data["geo"]["longitude"] = lat_lon[0].split(", ", 1)
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["image"] = None
+        item["facebook"] = None
         if item.get("name"):
             item["branch"] = html.unescape(item.pop("name"))
-            # no name indicates a template page, perhaps coming soon.
+            apply_category(Categories.SHOP_KITCHEN, item)
             yield item


### PR DESCRIPTION
The site corrected the malformed coordinates it used to emit — latitude was a double-encoded string ("lat, lon?.Latitude") and is now a plain float, so the old .endswith() workaround crashed on every store. Guard the unpack so it only runs on the old string format. Also set the kitchen category explicitly and drop the non-unique brand Facebook link.

Note: one store (Fagnières) has no coordinates in the source — it's a real store, not a placeholder.