### PR TITLE
[Tatra Banka SK] Fix Spider

### DIFF
--- a/locations/spiders/tatra_banka_sk.py
+++ b/locations/spiders/tatra_banka_sk.py
@@ -1,19 +1,22 @@
+import json
 from typing import Any, AsyncIterator
 
-from scrapy import FormRequest, Spider
+from scrapy import FormRequest
 from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 
 
-class TatraBankaSKSpider(Spider):
+class TatraBankaSKSpider(PlaywrightSpider):
     name = "tatra_banka_sk"
     item_attributes = {"brand": "Tatra banka", "brand_wikidata": "Q1718069"}
     requires_proxy = True
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[Any]:
         yield FormRequest(
@@ -46,7 +49,7 @@ class TatraBankaSKSpider(Spider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json().get("places", []):
+        for location in json.loads(response.xpath("//pre//text()").get()).get("places", []):
             if not location.get("active", True) or location.get("temporarilyClosed"):
                 continue
 


### PR DESCRIPTION
```python
{'atp/brand/Tatra banka': 388,
 'atp/brand_wikidata/Q1718069': 388,
 'atp/category/amenity/atm': 303,
 'atp/category/amenity/bank': 85,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/lat': 1,
 'atp/clean_strings/lon': 1,
 'atp/clean_strings/postcode': 5,
 'atp/clean_strings/street': 3,
 'atp/country/SK': 388,
 'atp/field/country/from_spider_name': 388,
 'atp/field/email/missing': 372,
 'atp/field/housenumber/missing': 2,
 'atp/field/name/missing': 303,
 'atp/field/opening_hours/missing': 118,
 'atp/field/operator/missing': 85,
 'atp/field/operator_wikidata/missing': 85,
 'atp/field/state/missing': 388,
 'atp/field/street_address/missing': 388,
 'atp/field/twitter/missing': 388,
 'atp/field/unit/missing': 388,
 'atp/item_scraped_host_count/www.tatrabanka.sk': 388,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 388,
 'atp/operator/Tatra banka': 303,
 'atp/operator_wikidata/Q1718069': 303,
 'downloader/request_bytes': 748,
 'downloader/request_count': 1,
 'downloader/request_method_count/POST': 1,
 'downloader/response_bytes': 1966087,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 25.015999999988708,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 12, 17, 8, 431999, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 388,
 'items_per_minute': 931.1999999999999,
 'log_count/DEBUG': 394,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/POST': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 2.4,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 21, 12, 16, 43, 416381, tzinfo=datetime.timezone.utc)}
```