### PR TITLE
[Westpac NZ] Fix spider

### DIFF
--- a/locations/spiders/westpac_nz.py
+++ b/locations/spiders/westpac_nz.py
@@ -21,8 +21,7 @@ class WestpacNZSpider(CamoufoxSpider):
             "branches"
         ]:
             item = DictParser.parse(location)
-            if "0800 400 600" in (item.get("phone") or ""):
-                item["phone"] = None
+            item["phone"] = None
             if location["siteName"].startswith("Community Banking - "):
                 item["branch"] = location["siteName"].removeprefix("Community Banking - ")
                 item["name"] = "Westpac Community Banking"

--- a/locations/spiders/westpac_nz.py
+++ b/locations/spiders/westpac_nz.py
@@ -1,21 +1,20 @@
 import json
 from typing import Any
 
-from scrapy import Spider
 from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
-from locations.user_agents import BROWSER_DEFAULT
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class WestpacNZSpider(Spider):
+class WestpacNZSpider(CamoufoxSpider):
     name = "westpac_nz"
     item_attributes = {"brand": "Westpac", "brand_wikidata": "Q2031726"}
     start_urls = ["https://www.westpac.co.nz/contact-us/branch-finder/"]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
-    requires_proxy = "NZ"
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in json.loads(response.xpath('//div[@class="js-branch-finder-map container"]/@data-props').get())[
@@ -52,7 +51,13 @@ class WestpacNZSpider(Spider):
                     pass
                 else:
                     open_time, closed_time = location[hours_key].split(" - ")
-                    item["opening_hours"].add_range(day, open_time, closed_time, "%H:%M%p")
+                    item["opening_hours"].add_range(day, open_time, closed_time, "%I:%M%p")
+
+            if isinstance(item["opening_hours"], OpeningHours) and not item["opening_hours"].day_hours:
+                # Community banking sites list every day as closed, then give
+                # their fortnightly visiting schedule as free text in "note".
+                # Emitting "Mo-Su closed" would wrongly state they never open.
+                item["opening_hours"] = None
 
             match location["locationType"]:
                 case "Branch":


### PR DESCRIPTION
```
{'atp/brand/Westpac': 378,
 'atp/brand_wikidata/Q2031726': 378,
 'atp/category/amenity/atm': 260,
 'atp/category/amenity/bank': 118,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 20,
 'atp/clean_strings/ref': 20,
 'atp/country/NZ': 378,
 'atp/field/city/missing': 378,
 'atp/field/country/from_spider_name': 378,
 'atp/field/email/missing': 378,
 'atp/field/housenumber/missing': 378,
 'atp/field/name/missing': 260,
 'atp/field/opening_hours/missing': 51,
 'atp/field/operator/missing': 118,
 'atp/field/operator_wikidata/missing': 118,
 'atp/field/phone/missing': 373,
 'atp/field/postcode/missing': 378,
 'atp/field/state/missing': 378,
 'atp/field/street/missing': 378,
 'atp/field/street_address/missing': 378,
 'atp/field/twitter/missing': 378,
 'atp/field/unit/missing': 378,
 'atp/item_scraped_host_count/www.westpac.co.nz': 378,
 'atp/lineage': 'S_?',
 'atp/located_in/New World': 10,
 'atp/located_in/Pak n Save': 6,
 'atp/located_in/Woolworths': 54,
 'atp/nsi/match_perfect': 378,
 'atp/operator/Westpac': 260,
 'atp/operator_wikidata/Q2031726': 260,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 25,
 'camoufox/request_count/aborted': 24,
 'camoufox/request_count/method/GET': 25,
 'camoufox/request_count/navigation': 1,
 'camoufox/request_count/resource_type/document': 1,
 'camoufox/request_count/resource_type/font': 2,
 'camoufox/request_count/resource_type/image': 11,
 'camoufox/request_count/resource_type/script': 9,
 'camoufox/request_count/resource_type/stylesheet': 2,
 'camoufox/response_count': 1,
 'camoufox/response_count/method/GET': 1,
 'camoufox/response_count/resource_type/document': 1,
 'downloader/request_bytes': 350,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1747253,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 71.84399999999914,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 21, 12, 44, 15, 923931, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 378,
 'items_per_minute': 319.4366197183098,
 'log_count/DEBUG': 431,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.8450704225352113,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 21, 12, 43, 4, 83695, tzinfo=datetime.timezone.utc)}
```