### PR TITLE
[Riyad Bank SA] Add spider

### DIFF
--- a/locations/spiders/riyad_bank_sa.py
+++ b/locations/spiders/riyad_bank_sa.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, AsyncIterator
 from urllib.parse import urlencode
 
@@ -39,7 +40,8 @@ class RiyadBankSASpider(Spider):
         for location in response.json()["locations"]:
             item = DictParser.parse(location)  # maps Latitude/Longitude -> lat/lon, Phone -> phone
             item["ref"] = location["_id"]
-            item["branch"] = location["Title_Name_AR"]  # Arabic branch name; NSI supplies name=بنك الرياض
+            # Arabic branch name (strip the occasional leading branch-code prefix); NSI supplies name=بنك الرياض
+            item["branch"] = re.sub(r"^[\d٠-٩]+\.?\s+", "", location["Title_Name_AR"])
             item["addr_full"] = location["Address_AR"]  # free-form "street, city, region"
             item["city"] = (location.get("BranchLocationCity") or {}).get("ar")
             item.pop("state", None)  # "Region" is a coarse bank grouping (e.g. Hail -> Eastern); leave state to coords

--- a/locations/spiders/riyad_bank_sa.py
+++ b/locations/spiders/riyad_bank_sa.py
@@ -39,15 +39,17 @@ class RiyadBankSASpider(Spider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["locations"]:
-            item = DictParser.parse(location)  # maps Latitude/Longitude -> lat/lon, Phone -> phone
+            item = DictParser.parse(location)  # maps Latitude/Longitude -> lat/lon
             item["ref"] = location["_id"]
             # Arabic branch name (strip the occasional leading branch-code prefix); NSI supplies name=بنك الرياض
             item["branch"] = re.sub(r"^[\d٠-٩]+\.?\s+", "", location["Title_Name_AR"])
             item["addr_full"] = location["Address_AR"]  # free-form "street, city, region"
             item["city"] = (location.get("BranchLocationCity") or {}).get("ar")
             item.pop("state", None)  # "Region" is a coarse bank grouping (e.g. Hail -> Eastern); leave state to coords
-            if (item.get("phone") or "").replace("-", "").startswith("800"):
-                item.pop("phone")  # shared call-centre number, not the branch's own line
+            # Phone may hold several <br/>-separated numbers; drop "NA" and the shared 800 call-centre line.
+            phones = [p.strip() for p in re.split(r"<br\s*/?>", location.get("Phone") or "")]
+            phones = [p for p in phones if p and p.upper() != "NA" and not p.replace("-", "").startswith("800")]
+            item["phone"] = "; ".join(phones) or None
             item["opening_hours"] = self.parse_hours(location.get("OpeningHours"))
 
             apply_category(Categories.BANK, item)

--- a/locations/spiders/riyad_bank_sa.py
+++ b/locations/spiders/riyad_bank_sa.py
@@ -1,0 +1,50 @@
+from typing import Any, AsyncIterator
+from urllib.parse import urlencode
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+# Liferay portlet parameter prefix for the "Locate Us" portlet on /branches-atms.
+PARAM = "_com_rb_locate_us_RbLocateUsPortlet_INSTANCE_ytfr_"
+
+
+class RiyadBankSASpider(Spider):
+    name = "riyad_bank_sa"
+    item_attributes = {"brand": "بنك الرياض", "brand_wikidata": "Q3433985"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        # The portlet resource is a form-encoded POST that returns JSON; "all-regions" gives
+        # every branch. Only branches are scraped: the ATM service types (atm, kiosk) return
+        # a server error, and atme exposes a separate English-only schema.
+        yield Request(
+            "https://www.riyadbank.com/branches-atms?p_p_id=com_rb_locate_us_RbLocateUsPortlet_INSTANCE_ytfr"
+            "&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_cacheability=cacheLevelPage",
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=urlencode(
+                {
+                    PARAM + "region": "all-regions",
+                    PARAM + "city": "",
+                    PARAM + "services": "",
+                    PARAM + "t": "branches",
+                    PARAM + "q": "",
+                }
+            ),
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["locations"]:
+            item = DictParser.parse(location)  # maps Latitude/Longitude -> lat/lon, Phone -> phone
+            item["ref"] = location["_id"]
+            item["branch"] = location["Title_Name_AR"]  # Arabic branch name; NSI supplies name=بنك الرياض
+            item["addr_full"] = location["Address_AR"]  # free-form "street, city, region"
+            item["city"] = (location.get("BranchLocationCity") or {}).get("ar")
+            item.pop("state", None)  # "Region" is a coarse bank grouping (e.g. Hail -> Eastern); leave state to coords
+            if (item.get("phone") or "").replace("-", "").startswith("800"):
+                item.pop("phone")  # shared call-centre number, not the branch's own line
+
+            apply_category(Categories.BANK, item)
+            yield item

--- a/locations/spiders/riyad_bank_sa.py
+++ b/locations/spiders/riyad_bank_sa.py
@@ -7,6 +7,7 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
 
 # Liferay portlet parameter prefix for the "Locate Us" portlet on /branches-atms.
 PARAM = "_com_rb_locate_us_RbLocateUsPortlet_INSTANCE_ytfr_"
@@ -47,6 +48,26 @@ class RiyadBankSASpider(Spider):
             item.pop("state", None)  # "Region" is a coarse bank grouping (e.g. Hail -> Eastern); leave state to coords
             if (item.get("phone") or "").replace("-", "").startswith("800"):
                 item.pop("phone")  # shared call-centre number, not the branch's own line
+            item["opening_hours"] = self.parse_hours(location.get("OpeningHours"))
 
             apply_category(Categories.BANK, item)
             yield item
+
+    @staticmethod
+    def parse_hours(raw: str | None) -> OpeningHours | None:
+        # e.g. "9:30 - 4:30" -> Su-Th 09:30-16:30: Saudi banks run Sunday-Thursday and close in
+        # the afternoon (a close hour below the open hour is PM). Any trailing note is ignored.
+        match = re.match(r"(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})", raw or "")
+        if not match:
+            return None
+        try:
+            open_h, open_m, close_h, close_m = map(int, match.groups())
+            if close_h < open_h:
+                close_h += 12
+            hours = OpeningHours()
+            hours.add_days_range(
+                DAYS_FROM_SUNDAY[:5], "{:02d}:{:02d}".format(open_h, open_m), "{:02d}:{:02d}".format(close_h, close_m)
+            )
+            return hours
+        except ValueError:
+            return None


### PR DESCRIPTION
Source
The "Locate Us" Liferay portlet on riyadbank.com/branches-atms — a form-encoded POST resource that returns JSON. Passing region=all-regions and t=branches returns every branch in a single request; no session/CSRF handshake is needed.

Field notes
Arabic-first, matching NSI. branch is the Arabic branch label (Title_Name_AR, with the occasional leading branch-code prefix stripped). name and brand are supplied by NSI (riyadbank-8f3bad), which also fills brand:ar, brand:en, name:ar, name:en, and bic.
Address. addr:full from Address_AR; addr:city from BranchLocationCity.ar.
addr:state omitted on purpose. The API's Region is a coarse bank grouping with real errors (e.g. a Hā'il branch tagged "Eastern"), so state is left to the coordinates rather than emitting bad data.
Phone. The Phone field can carry several <br/>-separated numbers plus "NA" placeholders. These are split; "NA" and the shared 800… call-centre line are dropped; remaining real numbers are joined with ;.
Opening hours. Saudi banks run Sunday–Thursday and close in the afternoon, so "9:30 - 4:30" → Su-Th 09:30-16:30 (a close hour lower than the open hour is read as PM). Trailing notes (e.g. a Founding-Day remark) are ignored.
ATMs not included. The atm/kiosk service endpoints are server-broken everywhere tested, and the only working ATM feed (atme) returns just 14 English-only records — a non-representative sliver — so this spider is branches-only.

**Sample POI:**
```json
{
  "ref": "8760",
  "amenity": "bank",
  "name": "بنك الرياض",
  "branch": "فرع العريسة",
  "addr:full": "حي العريسة - طريق الملك عبدالعزيز, نجران, نجران",
  "addr:city": "نجران",
  "phone": "+966 17 542 3848;+966 17 542 3817",
  "opening_hours": "Mo-Th 09:30-16:30; Su 09:30-16:30",
  "brand": "بنك الرياض",
  "brand:wikidata": "Q3433985"
}
```
json
```{
  "item_scraped_count": 256,
  "atp/category/amenity/bank": 256,
  "atp/nsi/match_perfect": 256,
  "atp/field/country/from_spider_name": 256,
  "finish_reason": "finished"
}
```