### PR TITLE
[One NZ] Fix spider

### DIFF
--- a/locations/spiders/one_nz.py
+++ b/locations/spiders/one_nz.py
@@ -21,7 +21,8 @@ class OneNZSpider(JSONBlobSpider):
         )
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["lat"], item["lon"] = feature["latlng"]["latitude"], feature["latlng"]["longitude"]
+        if latlng := feature.get("latlng"):
+            item["lat"], item["lon"] = latlng["latitude"], latlng["longitude"]
         item["branch"] = item.pop("name").removeprefix("One NZ ")
         item["street_address"] = feature["address"]["addressLines"][0]
         item["ref"] = feature["storeCode"]

--- a/locations/spiders/one_nz.py
+++ b/locations/spiders/one_nz.py
@@ -26,8 +26,7 @@ class OneNZSpider(JSONBlobSpider):
         item["branch"] = item.pop("name").removeprefix("One NZ ")
         item["street_address"] = feature["address"]["addressLines"][0]
         item["ref"] = feature["storeCode"]
-        if feature["phoneNumber"] == "0800 800 021":
-            item["phone"] = ""
+        item.pop("phone", None)
         try:
             item["opening_hours"] = self.parse_opening_hours(feature["regularHours"])
         except ValueError:


### PR DESCRIPTION
One store has no latlng key, so the unconditional feature["latlng"]["latitude"] raised KeyError and aborted the whole crawl (only 19 of 57 stores reached output). Guard the coordinate access with .get() so that store still yields with its address.