### PR TITLE
[Mercator SI] Fix spider

### DIFF
--- a/locations/spiders/mercator_si.py
+++ b/locations/spiders/mercator_si.py
@@ -14,7 +14,7 @@ class MercatorSISpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.mercator.si/sitemap.xml"]
     sitemap_follow = ["/Store/"]
     sitemap_rules = [(r"^https:\/\/www\.mercator\.si\/prodajna-.*/.*/$", "parse_sd")]
-    wanted_types = ["LocalBusiness"]
+    wanted_types = ["LocalBusiness", "Store"]
     search_for_facebook = False
     search_for_twitter = False
     search_for_email = False
@@ -22,6 +22,8 @@ class MercatorSISpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response: Response, ld_data, **kwargs):
         if item["website"] == "https://www.mercator.si/prodajna-mesta/page-6/":
             return
+
+        item.pop("facebook", None)
 
         if name := item.get("name"):
             label = html.unescape(name).upper()


### PR DESCRIPTION
Store pages changed their structured-data @type from LocalBusiness to Store, so the spider's wanted_types matched nothing and it produced no items. Add Store to wanted_types. Also drop the shared brand Facebook link that leaks in via ld+json sameAs (the spider already sets search_for_facebook=False).