### PR TITLE
[Nordstrom Rack] Fix spider

### DIFF
--- a/locations/spiders/nordstrom_rack.py
+++ b/locations/spiders/nordstrom_rack.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.linked_data_parser import LinkedDataParser
 from locations.microdata_parser import MicrodataParser
 
@@ -18,4 +19,6 @@ class NordstromRackSpider(SitemapSpider):
 
     def parse(self, response):
         MicrodataParser.convert_to_json_ld(response)
-        return LinkedDataParser.parse(response, "ClothingStore")
+        if item := LinkedDataParser.parse(response, "Organization"):
+            apply_category(Categories.SHOP_CLOTHES, item)
+            yield item

--- a/locations/spiders/nordstrom_rack.py
+++ b/locations/spiders/nordstrom_rack.py
@@ -1,11 +1,17 @@
+import re
+from typing import Iterable
+from urllib.parse import parse_qs, urlencode, urljoin, urlparse
+
+from scrapy import Selector, Spider
+from scrapy.http import Response, TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class NordstromRackSpider(SitemapSpider):
+class NordstromRackSpider(SitemapSpider, StructuredDataSpider):
     name = "nordstrom_rack"
     item_attributes = {"brand": "Nordstrom Rack", "brand_wikidata": "Q21463374"}
     sitemap_urls = ["https://stores.nordstromrack.com/sitemap.xml"]
@@ -16,9 +22,9 @@ class NordstromRackSpider(SitemapSpider):
         )
     ]
     drop_attributes = {"image"}
+    wanted_types = ["Organization"]
 
-    def parse(self, response):
-        MicrodataParser.convert_to_json_ld(response)
-        if item := LinkedDataParser.parse(response, "Organization"):
-            apply_category(Categories.SHOP_CLOTHES, item)
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Nordstrom Rack ").removeprefix("at ")
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item

--- a/locations/spiders/nordstrom_rack.py
+++ b/locations/spiders/nordstrom_rack.py
@@ -1,9 +1,6 @@
-import re
 from typing import Iterable
-from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
-from scrapy import Selector, Spider
-from scrapy.http import Response, TextResponse
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category


### PR DESCRIPTION
Store pages changed their microdata itemtype from ClothingStore to a combined LocalBusiness/Organization type (which parses as Organization), so the spider matched nothing and produced no items. Parse Organization, and set the clothes category explicitly.