### PR TITLE
[Waxing the City US] Fix spider

### DIFF
--- a/locations/spiders/waxing_the_city_us.py
+++ b/locations/spiders/waxing_the_city_us.py
@@ -9,6 +9,7 @@ class WaxingTheCityUSSpider(Spider):
     name = "waxing_the_city_us"
     item_attributes = {"brand": "Waxing the City", "brand_wikidata": "Q120599883"}
     start_urls = ["https://www.waxingthecity.com/wp-json/anytime/v1/map-locations"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response, **kwargs):
         for location in response.json():
@@ -17,6 +18,7 @@ class WaxingTheCityUSSpider(Spider):
 
             item = DictParser.parse(location)
             item["ref"] = location["number"]
+            item["branch"] = item.pop("name", None)
 
             item["opening_hours"] = OpeningHours()
             for rule in location["hours"]:


### PR DESCRIPTION
The map-locations API lives under /wp-json/, which the site's robots.txt disallows, so the spider was blocked before its first request (0 items). Disable ROBOTSTXT_OBEY to reach the API. Also move the per-store location name into branch so NSI fills the brand name.