### PR TITLE
[Euromobil NL] Fix Spider

### DIFF
--- a/locations/spiders/euromobil_nl.py
+++ b/locations/spiders/euromobil_nl.py
@@ -4,4 +4,4 @@ from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 class EuromobilNLSpider(WPStoreLocatorSpider):
     name = "euromobil_nl"
     item_attributes = {"brand": "Euromobil", "brand_wikidata": "Q1375118"}
-    allowed_domains = ["euromobil.nl"]
+    allowed_domains = ["europcar.nl"]


### PR DESCRIPTION
```python
{'atp/brand/Euromobil': 54,
 'atp/brand_wikidata/Q1375118': 54,
 'atp/category/amenity/car_rental': 54,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/NL': 54,
 'atp/field/branch/missing': 54,
 'atp/field/country/from_spider_name': 54,
 'atp/field/email/missing': 1,
 'atp/field/housenumber/missing': 54,
 'atp/field/opening_hours/missing': 54,
 'atp/field/operator/missing': 54,
 'atp/field/operator_wikidata/missing': 54,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 54,
 'atp/field/street/missing': 54,
 'atp/field/twitter/missing': 54,
 'atp/field/unit/missing': 54,
 'atp/item_scraped_host_count/europcar.nl': 54,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 54,
 'atp/nsi/match_imperfect': 54,
 'downloader/request_bytes': 934,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 5710,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 8.21799999999348,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 22, 10, 26, 22, 194308, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17957,
 'httpcompression/response_count': 2,
 'item_scraped_count': 54,
 'items_per_minute': 405.0,
 'log_count/DEBUG': 56,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 15.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 22, 10, 26, 13, 979116, tzinfo=datetime.timezone.utc)}
```