### PR TITLE
[Dollar Tree US] Add download timeout to fix spider

### DIFF
--- a/locations/spiders/dollar_tree_us.py
+++ b/locations/spiders/dollar_tree_us.py
@@ -12,6 +12,7 @@ class DollarTreeUSSpider(YextAnswersSpider):
     experience_key = "pages-locator-usa-only"
     feature_type = "dollar-tree-usa"
     custom_settings = {"DOWNLOAD_TIMEOUT": 120}
+    requires_proxy = True
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         item.pop("facebook", None)

--- a/locations/spiders/dollar_tree_us.py
+++ b/locations/spiders/dollar_tree_us.py
@@ -11,6 +11,7 @@ class DollarTreeUSSpider(YextAnswersSpider):
     api_key = "7a860787290ef5396ebe3ffe229d96c3"
     experience_key = "pages-locator-usa-only"
     feature_type = "dollar-tree-usa"
+    custom_settings = {"DOWNLOAD_TIMEOUT": 120}
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         item.pop("facebook", None)


### PR DESCRIPTION
Spider is working fine when checked on US network.

```
{'atp/brand/Dollar Tree': 9140,
 'atp/brand_wikidata/Q5289230': 9140,
 'atp/category/shop/variety_store': 9140,
 'atp/cdn/cloudflare/response_count': 184,
 'atp/cdn/cloudflare/response_status_count/200': 183,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/street_address': 1,
 'atp/country/US': 9140,
 'atp/field/email/missing': 9140,
 'atp/field/housenumber/missing': 9140,
 'atp/field/operator/missing': 9140,
 'atp/field/operator_wikidata/missing': 9140,
 'atp/field/street/missing': 9140,
 'atp/field/twitter/missing': 9140,
 'atp/field/unit/missing': 9140,
 'atp/item_scraped_host_count/liveapi.yext.com': 9140,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 9140,
 'downloader/request_bytes': 182713,
 'downloader/request_count': 184,
 'downloader/request_method_count/GET': 184,
 'downloader/response_bytes': 67283625,
 'downloader/response_count': 184,
 'downloader/response_status_count/200': 183,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 290.9850000000006,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 22, 13, 23, 2, 793997, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 326093247,
 'httpcompression/response_count': 183,
 'item_scraped_count': 9140,
 'items_per_minute': 1891.0344827586207,
 'log_count/DEBUG': 9324,
 'log_count/INFO': 7,
 'request_depth_max': 182,
 'response_received_count': 184,
 'responses_per_minute': 38.06896551724138,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 183,
 'scheduler/dequeued/memory': 183,
 'scheduler/enqueued': 183,
 'scheduler/enqueued/memory': 183,
 'start_time': datetime.datetime(2026, 7, 22, 13, 18, 11, 814123, tzinfo=datetime.timezone.utc)}
```