### PR TITLE
[toom Baumarkt DE] Fix spider

### DIFF
--- a/locations/spiders/toom_baumarkt_de.py
+++ b/locations/spiders/toom_baumarkt_de.py
@@ -1,16 +1,33 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any, Iterable
 
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class ToomBaumarktDESpider(SitemapSpider, StructuredDataSpider):
+class ToomBaumarktDESpider(JSONBlobSpider):
     name = "toom_baumarkt_de"
     item_attributes = {"brand": "toom Baumarkt", "brand_wikidata": "Q2442970"}
-    sitemap_urls = ["https://static.toom.de/sitemap/cms.xml"]
-    sitemap_follow = ["newmarkets"]
-    json_parser = "chompjs"
+    start_urls = ["https://api.toom.de/public/api/markets"]
+    locations_key = "markets"
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name").split(" in ", 1)[1]
+    def pre_process_data(self, location: dict) -> None:
+        location.update(location.pop("address"))
+        location.pop("country", None)
 
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        item["street_address"] = location["street"]
+        item["website"] = "https://toom.de/" + location["link"]
+
+        item["opening_hours"] = OpeningHours()
+        for rule in location["openingTimes"]:
+            value = rule["value"]
+            if value.get("opening") and value.get("closing"):
+                item["opening_hours"].add_range(DAYS[value["dayofweek"]], value["opening"], value["closing"])
+
+        apply_category(Categories.SHOP_DOITYOURSELF, item)
         yield item

--- a/locations/spiders/toom_baumarkt_de.py
+++ b/locations/spiders/toom_baumarkt_de.py
@@ -20,7 +20,7 @@ class ToomBaumarktDESpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
-        item["street_address"] = location["street"]
+        item["street_address"] = item.pop("street")
         item["website"] = "https://toom.de/" + location["link"]
 
         item["opening_hours"] = OpeningHours()


### PR DESCRIPTION
Store pages no longer expose a LocalBusiness ld+json node, so the spider returned zero features. Switch to the `api.toom.de/public/api/markets` API that backs the market overview map, which returns all markets with coordinates, address, contact details and opening hours.