### PR TITLE
[The Entertainer GB] Fix spider

### DIFF
--- a/locations/spiders/the_entertainer_gb.py
+++ b/locations/spiders/the_entertainer_gb.py
@@ -1,41 +1,54 @@
 from typing import Iterable
 
+import xmltodict
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class TheEntertainerGBSpider(JSONBlobSpider):
+class TheEntertainerGBSpider(PlaywrightSpider):
     name = "the_entertainer_gb"
     item_attributes = {"brand": "The Entertainer", "brand_wikidata": "Q7732289"}
     start_urls = [
         "https://www.thetoyshop.com/api/occ/v2/thetoyshop/stores?accuracy=0&currentPage=0&fields=FULL&pageSize=1200&query=doncaster&storeType=ALL&radius=10000000&sort=asc"
     ]
-    locations_key = ["stores"]
-    custom_settings = {
-        "ROBOTSTXT_OBEY": False,  # No robots.txt
-        "DEFAULT_REQUEST_HEADERS": {
-            "Content-Type": "application/json",
-            "Host": "www.thetoyshop.com",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0",
-            "Accept": "*/*",
-            "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
-            "Accept-Encoding": "gzip, deflate, br, zstd",
-            "Referer": "https://www.thetoyshop.com/store-finder?",
-            "X-Requested-With": "XMLHttpRequest",
-            "Connection": "keep-alive",
-        },
-    }
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["ref"] = feature["address"]["id"]
-        item["website"] = "https://www.thetoyshop.com/store/" + feature["name"].lower().replace(" ", "-")
-        item["street_address"] = merge_address_lines([feature["address"].get("line1"), feature["address"].get("line2")])
-        item["branch"] = item.pop("name")
-        if "tesco" in item["website"]:
-            return
-            # item["located_in"] = "Tesco"
-            # item["located_in_wikidata"] = "Q487494"
-        yield item
+    def parse(self, response: Response) -> Iterable[Feature]:
+        for feature in xmltodict.parse(response.body)["storeFinderSearchPage"].get("stores", []):
+            item = DictParser.parse(feature)
+            item["ref"] = feature["address"]["id"]
+            item["website"] = "https://www.thetoyshop.com/store/" + feature["name"].lower().replace(" ", "-")
+            item["street_address"] = merge_address_lines(
+                [feature["address"].get("line1"), feature["address"].get("line2")]
+            )
+            item["phone"] = feature["address"].get("phone")
+            item["branch"] = item.pop("name")
+            item["opening_hours"] = self.parse_opening_hours(feature.get("openingHours", {}))
+            if "tesco" in item["website"]:
+                continue
+                # item["located_in"] = "Tesco"
+                # item["located_in_wikidata"] = "Q487494"
+
+            apply_category(Categories.SHOP_TOYS, item)
+            yield item
+
+    def parse_opening_hours(self, opening_hours: dict) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in opening_hours.get("weekDayOpeningList", []):
+            if rule.get("closed") != "false":
+                oh.set_closed(rule["weekDay"])
+            else:
+                oh.add_range(
+                    rule["weekDay"],
+                    rule["openingTime"]["formattedHour"],
+                    rule["closingTime"]["formattedHour"],
+                )
+        return oh


### PR DESCRIPTION
```
{'atp/brand/The Entertainer': 153,
 'atp/brand_wikidata/Q7732289': 153,
 'atp/category/shop/toys': 153,
 'atp/country/GB': 153,
 'atp/field/email/missing': 153,
 'atp/field/housenumber/missing': 153,
 'atp/field/operator/missing': 153,
 'atp/field/operator_wikidata/missing': 153,
 'atp/field/state/missing': 153,
 'atp/field/street/missing': 153,
 'atp/field/twitter/missing': 153,
 'atp/field/unit/missing': 153,
 'atp/item_scraped_host_count/www.thetoyshop.com': 153,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 153,
 'downloader/request_bytes': 392,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 6218708,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 12.187000000005355,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 24, 5, 4, 16, 614842, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 153,
 'items_per_minute': 765.0,
 'log_count/DEBUG': 158,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 5.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 24, 5, 4, 4, 422331, tzinfo=datetime.timezone.utc)}
```