### PR TITLE
[sweetFrog US] Fix spider

### DIFF
--- a/locations/spiders/sweetfrog_us.py
+++ b/locations/spiders/sweetfrog_us.py
@@ -1,29 +1,33 @@
+from typing import Any, Iterable
+
 from chompjs import parse_js_object
-from scrapy import Request
+from scrapy.http import Response
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class SweetfrogUSSpider(StructuredDataSpider):
+class SweetfrogUSSpider(JSONBlobSpider):
     name = "sweetfrog_us"
     item_attributes = {"brand": "sweetFrog", "brand_wikidata": "Q16952110"}
-    allowed_domains = ["locator.kahalamgmt.com", "www.sweetfrog.com"]
     start_urls = ["https://locator.kahalamgmt.com/locator/index.php?mode=desktop&brand=38"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response):
-        locator_js_blob = response.xpath('//script[contains(text(), "Locator.stores[0] = ")]/text()').get()
-        location_js_blobs = list(filter(lambda x: "Locator.stores" in x, locator_js_blob.splitlines()))
-        locations = [parse_js_object(x.split(" = ", 1)[1]) for x in location_js_blobs]
-        for location in locations:
-            url = (
-                "https://www.sweetfrog.com/stores/frozen-yogurt-"
-                + location["cleanCity"]
-                + "/"
-                + str(location["StoreId"])
-            )
-            yield Request(url=url, callback=self.parse_sd)
+    def extract_json(self, response: Response) -> list[dict]:
+        return [
+            parse_js_object(line.split(" = ", 1)[1])
+            for line in response.text.splitlines()
+            if "Locator.stores[" in line and " = {" in line
+        ]
 
-    def post_process_item(self, item, response, ld_data):
-        item.pop("image", None)
+    def pre_process_data(self, location: dict) -> None:
+        location["street_address"] = location.pop("Address")
+
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
+        item.pop("name", None)
+        item["website"] = "https://www.sweetfrog.com/stores/frozen-yogurt-{}/{}".format(
+            location["cleanCity"], location["StoreId"]
+        )
+        apply_category(Categories.ICE_CREAM, item)
         yield item


### PR DESCRIPTION
The sweetfrog.com store pages went client-rendered and no longer expose a LocalBusiness ld+json node, so the spider returned zero features. Parse the Kahala locator data it already fetched directly instead of visiting each store page.