### PR TITLE
[Mountain Warehouse] Fix spider

### DIFF
--- a/locations/react_server_components.py
+++ b/locations/react_server_components.py
@@ -41,6 +41,8 @@ def parse_rsc(data_raw: Iterable[int]) -> Iterator[tuple[int, Any]]:
         else:
             row_str = row_data.decode()
 
+            if not row_str:
+                continue
             if row_tag == "H":
                 yield row_id, (row_str[0], json.loads(row_str[1:]))
             elif row_tag == "T":

--- a/locations/spiders/mountain_warehouse.py
+++ b/locations/spiders/mountain_warehouse.py
@@ -16,7 +16,7 @@ class MountainWarehouseSpider(Spider):
     name = "mountain_warehouse"
     item_attributes = {"brand": "Mountain Warehouse", "brand_wikidata": "Q6925414"}
     allowed_domains = ["www.mountainwarehouse.com"]
-    start_urls = ["https://www.mountainwarehouse.com/stores/results/?search=all&lat=0&lng=0"]
+    start_urls = ["https://www.mountainwarehouse.com/stores/store-locator/?search=all&lat=0&lng=0"]
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()


### PR DESCRIPTION
The store locator moved from `/stores/results/` to `/stores/store-locator/`, and the site's React Flight stream now includes rows with empty payloads, which crashed the shared `parse_rsc` helper with a JSONDecodeError. Update the start URL and skip empty rows in `parse_rsc`.