### PR TITLE
[Talbots CA US] Fix spider

### DIFF
--- a/locations/spiders/talbots_ca_us.py
+++ b/locations/spiders/talbots_ca_us.py
@@ -2,16 +2,17 @@ import re
 
 from scrapy import Spider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import clean_address
 
 
-class TalbotsUSSpider(Spider):
-    name = "talbots_us"
-    item_attributes = {"brand": "Talbots", "brand_wikidata": "Q7679064", "extras": Categories.SHOP_CLOTHES.value}
+class TalbotsCAUSSpider(Spider):
+    name = "talbots_ca_us"
+    item_attributes = {"brand": "Talbots", "brand_wikidata": "Q7679064"}
     allowed_domains = ["www.talbots.com"]
+    custom_settings = {"USER_AGENT": "Mozilla/5.0"}
     start_urls = [
         "https://www.talbots.com/on/demandware.store/Sites-talbotsus-Site/default/Stores-GetNearestStores?latitude=-37.8159&longitude=144.9669&countryCode=US&distanceUnit=mi&maxdistance=15000&filterType=PRODUCT-LINE&filterValue=ALL"
     ]
@@ -20,6 +21,7 @@ class TalbotsUSSpider(Spider):
         for store_id, store_details in response.json()["stores"].items():
             item = DictParser.parse(store_details)
             item["ref"] = store_id
+            item["branch"] = item.pop("name").title()
             item["street_address"] = clean_address([store_details.get("address1"), store_details.get("address2")])
             item["website"] = "https://www.talbots.com/stores/{}/{}/{}/{}.html".format(
                 store_details["stateCode"].lower(),
@@ -30,4 +32,5 @@ class TalbotsUSSpider(Spider):
             hours_text = store_details.get("storeHours", "").replace("<br>", " ")
             item["opening_hours"] = OpeningHours()
             item["opening_hours"].add_ranges_from_string(hours_text)
+            apply_category(Categories.SHOP_CLOTHES, item)
             yield item

--- a/locations/spiders/talbots_ca_us.py
+++ b/locations/spiders/talbots_ca_us.py
@@ -1,23 +1,26 @@
 import re
+from typing import Any
 
 from scrapy import Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import clean_address
+from locations.settings import USER_AGENT
 
 
 class TalbotsCAUSSpider(Spider):
     name = "talbots_ca_us"
     item_attributes = {"brand": "Talbots", "brand_wikidata": "Q7679064"}
     allowed_domains = ["www.talbots.com"]
-    custom_settings = {"USER_AGENT": "Mozilla/5.0"}
     start_urls = [
         "https://www.talbots.com/on/demandware.store/Sites-talbotsus-Site/default/Stores-GetNearestStores?latitude=-37.8159&longitude=144.9669&countryCode=US&distanceUnit=mi&maxdistance=15000&filterType=PRODUCT-LINE&filterValue=ALL"
     ]
+    custom_settings = {"USER_AGENT": USER_AGENT.removeprefix("Mozilla/5.0 (X11; Linux x86_64) ")}
 
-    def parse(self, response):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for store_id, store_details in response.json()["stores"].items():
             item = DictParser.parse(store_details)
             item["ref"] = store_id


### PR DESCRIPTION
The store search endpoint serves a PerimeterX challenge to the default user agent, so the spider returned zero features. A generic `Mozilla/5.0` user agent receives the JSON normally (full browser user-agent strings get fingerprint-checked and challenged). Also pop the per-store name to branch, set the category explicitly, and rename to `talbots_ca_us` since the chain also has Canadian stores.