### PR TITLE
[Chris Willemse Cycles ZA] Fix spider

### DIFF
--- a/locations/spiders/chris_willemse_cycles_za.py
+++ b/locations/spiders/chris_willemse_cycles_za.py
@@ -18,29 +18,24 @@ class ChrisWillemseCyclesZASpider(Spider):
     no_refs = True
 
     def parse(self, response: Response) -> Iterable[Feature]:
-        locations = parse_js_object(
+        markers = parse_js_object(
             response.xpath('//script[contains(text(), "var markers = ")]/text()').get().split("var markers =")[1]
         )
-        # Coordinates are completely invalid however Google Maps street view
-        # confirms the address was correct in 2022. Google Maps location
-        # reviews indicate the shop is still trading in early 2025.
-        if len(locations) != 1:
-            raise RuntimeError(
-                "This chain used to have more than one location and shared the same spider as parent brand with spider cycle_lab_za. Then it reduced to one location and the store locator page is no longer the same as cycle_lab_za. This new store locator page and this spider only supports a single location being returned. It appears though that this chain has expanded again to have more than one store. This spider thus needs to be rewritten."
+        cards = response.xpath('//*[@class="Store-Location"]')
+        for marker, card in zip(markers, cards):
+            if not marker[0].startswith("CWC"):
+                # The page also lists stores of the parent brand, captured by cycle_lab_za.
+                continue
+            item = Feature()
+            item["branch"] = marker[0].removeprefix("CWC ")
+            item["lat"], item["lon"] = marker[1], marker[2]
+            item["addr_full"] = merge_address_lines(
+                card.xpath('.//*[@class="Store-Location-Address"]//p/text()').getall()
             )
-        properties = {
-            "branch": locations[0][0],
-            "addr_full": merge_address_lines(
-                response.xpath('//div[@class="Store-Location-Address"]/div[1]/div[1]/p//text()').getall()
-            ),
-            "phone": response.xpath(
-                '//div[@class="Store-Location-Address"]/div[1]/div[1]/div[@class="number"]/h3/text()'
-            ).get(),
-            "opening_hours": OpeningHours(),
-        }
-        hours_text = " ".join(response.xpath('//div[@class="hours-location"]//text()').getall()).replace(
-            "Saturdays", "Saturday"
-        )
-        properties["opening_hours"].add_ranges_from_string(hours_text)
-        apply_category(Categories.SHOP_BICYCLE, properties)
-        yield Feature(**properties)
+            item["phone"] = card.xpath('.//i[@class="fa fa-phone"]/../text()').get("").strip()
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(
+                card.xpath('string(.//*[@class="hours-location"])').get("").replace("Saturdays", "Saturday")
+            )
+            apply_category(Categories.SHOP_BICYCLE, item)
+            yield item


### PR DESCRIPTION
The store page now lists all stores of the parent Cycle Lab group, so the spider's single-location guard raised a RuntimeError and it returned zero features. Pair the map markers with the store cards and emit only the CWC-branded location, which also gains coordinates from the now-valid markers. The parent brand's stores are left to `cycle_lab_za`.