### PR TITLE
[Morrisons GB] Improve opening hours

### DIFF
--- a/locations/spiders/morrisons_gb.py
+++ b/locations/spiders/morrisons_gb.py
@@ -51,7 +51,12 @@ class MorrisonsGBSpider(Spider):
 
             item["opening_hours"] = OpeningHours()
             for day_abbrev, day_hours in location["openingTimes"].items():
-                item["opening_hours"].add_range(day_abbrev, day_hours["open"], day_hours["close"], "%H:%M:%S")
+                if day_hours["open"] == day_hours["close"] == "00:00:00":
+                    item["opening_hours"].set_closed(day_abbrev)
+                elif day_hours["open"] == day_hours["close"] == "00:00:01":
+                    item["opening_hours"].add_range(day_abbrev, "00:00", "24:00")
+                else:
+                    item["opening_hours"].add_range(day_abbrev, day_hours["open"], day_hours["close"], "%H:%M:%S")
 
             if location["storeFormat"] == "supermarket" and location["category"] == "Supermarket":
                 item.update(self.MORRISONS)


### PR DESCRIPTION
```python
{"atp/brand/Martin's": 1,
 'atp/brand/Morrisons': 1304,
 'atp/brand/Morrisons Daily': 1314,
 'atp/brand/Morrisons Select': 5,
 'atp/brand_wikidata/Q105221633': 5,
 'atp/brand_wikidata/Q116779207': 1,
 'atp/brand_wikidata/Q922344': 1304,
 'atp/brand_wikidata/Q99752411': 1314,
 'atp/category/amenity/cafe': 344,
 'atp/category/amenity/fuel': 341,
 'atp/category/amenity/pharmacy': 114,
 'atp/category/multiple': 113,
 'atp/category/shop/convenience': 1320,
 'atp/category/shop/supermarket': 505,
 'atp/cdn/cloudflare/response_count': 1,
 'atp/cdn/cloudflare/response_status_count/200': 1,
 'atp/country/GB': 2602,
 'atp/country/GG': 3,
 'atp/country/GI': 4,
 'atp/country/JE': 15,
 'atp/field/city/missing': 22,
 'atp/field/email/missing': 2624,
 'atp/field/housenumber/missing': 2624,
 'atp/field/name/missing': 7,
 'atp/field/operator/missing': 1513,
 'atp/field/operator_wikidata/missing': 1531,
 'atp/field/phone/invalid': 4,
 'atp/field/phone/missing': 38,
 'atp/field/state/missing': 8,
 'atp/field/street/missing': 2624,
 'atp/field/twitter/missing': 2624,
 'atp/field/unit/missing': 2624,
 'atp/item_scraped_host_count/my.morrisons.com': 2624,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 6,
 'atp/nsi/location_unknown': 4,
 'atp/nsi/match_failed': 10,
 'atp/nsi/match_perfect': 2614,
 "atp/operator/McColl's": 1093,
 'atp/operator/SandpiperCI': 18,
 'atp/operator_wikidata/Q16997477': 1093,
 'downloader/request_bytes': 1255611,
 'downloader/request_count': 2507,
 'downloader/request_method_count/GET': 2507,
 'downloader/response_bytes': 9757868,
 'downloader/response_count': 2507,
 'downloader/response_status_count/200': 1827,
 'downloader/response_status_count/404': 680,
 'elapsed_time_seconds': 11.019702578996657,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 23, 12, 50, 24, 59624, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 2507,
 'httpcompression/response_bytes': 29480666,
 'httpcompression/response_count': 2505,
 'httperror/response_ignored_count': 679,
 'httperror/response_ignored_status_count/404': 679,
 'item_scraped_count': 2624,
 'items_per_minute': 14312.727272727274,
 'log_count/INFO': 682,
 'log_count/WARNING': 1,
 'memusage/max': 344334336,
 'memusage/startup': 344334336,
 'request_depth_max': 1,
 'response_received_count': 2507,
 'responses_per_minute': 13674.545454545456,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 2505,
 'scheduler/dequeued/memory': 2505,
 'scheduler/enqueued': 2505,
 'scheduler/enqueued/memory': 2505,
 'start_time': datetime.datetime(2026, 7, 23, 12, 50, 13, 39917, tzinfo=datetime.timezone.utc)}
```