### PR TITLE
[Louisiana DOT] Reintroduce spider for traffic cameras

### DIFF
--- a/locations/spiders/infrastructure/louisiana_department_of_transportation_and_development_us.py
+++ b/locations/spiders/infrastructure/louisiana_department_of_transportation_and_development_us.py
@@ -1,0 +1,11 @@
+from locations.storefinders.traveliq_web_cameras import TravelIQWebCamerasSpider
+
+
+class LouisianaDepartmentOfTransportationAndDevelopmentUSSpider(TravelIQWebCamerasSpider):
+    name = "louisiana_department_of_transportation_and_development_us"
+    item_attributes = {
+        "operator": "Louisiana Department of Transportation & Development",
+        "operator_wikidata": "Q2400783",
+        "state": "LA",
+    }
+    allowed_domains = ["511la.org"]


### PR DESCRIPTION
The earlier spider was removed by #17468 as it was not working. It appears a backend TravelIQ/website change or upgrade has occurred and the data is still available with an alternative storefinder class for TravelIQ.