### PR TITLE
[PacSun US] Fix spider

### DIFF
--- a/locations/spiders/pacsun_us.py
+++ b/locations/spiders/pacsun_us.py
@@ -1,40 +1,49 @@
-import re
-from typing import Iterable
+import json
+from typing import Any, Iterable
 
+from scrapy import Selector, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours, day_range, sanitise_day
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class PacsunUSSpider(JSONBlobSpider):
+class PacsunUSSpider(Spider):
     name = "pacsun_us"
     item_attributes = {"brand": "PacSun", "brand_wikidata": "Q7121857"}
-    requires_proxy = True
+    custom_settings = {"USER_AGENT": "Mozilla/5.0"}
     start_urls = ["https://www.pacsun.com/on/demandware.store/Sites-pacsun-Site/default/Stores-FindStores?radius=30000"]
-    locations_key = "stores"
 
-    def pre_process_data(self, feature: dict) -> None:
-        feature["street-address"] = merge_address_lines([feature["address1"], feature["address2"]])
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        data = response.json()
+        cards = {
+            card.xpath("./@id").get(): card
+            for card in Selector(text=data["storesResultsHtml"]).xpath('//div[contains(@class, "store-result")]')
+        }
+        for location in json.loads(data["locations"]):
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["branch"] = item.pop("name")
-        item["website"] = feature["seoURL"]
-        item["opening_hours"] = OpeningHours()
-        for start_day, end_day, start_time, end_time in re.findall(
-            r"(\w+)(?: - (\w+))? (\d+:\d+ (?:AM|PM)) +- (\d+:\d+ (?:AM|PM))",
-            feature["storeHours"],
-        ):
-            start_day = sanitise_day(start_day)
-            end_day = sanitise_day(end_day)
+            if card := cards.get(location["storeID"]):
+                item["street_address"] = merge_address_lines(
+                    card.xpath('.//span[contains(@class, "store-locator-address")]/text()').getall()
+                )
+                city, state, postcode = (
+                    card.xpath('.//address/a/div/span[@class="store-locator-details"]/text()').getall() + [None] * 3
+                )[:3]
+                item["city"] = city.strip().rstrip(",") if city else None
+                item["state"] = state.strip() if state else None
+                item["postcode"] = postcode.strip() if postcode else None
+                item["phone"] = card.xpath('.//a[contains(@class, "storelocator-phone")]/text()').get("").strip()
+                item["website"] = card.xpath('.//a[contains(@class, "store-map")]/@href').get()
 
-            if start_day and end_day:
-                for day in day_range(start_day, end_day):
-                    item["opening_hours"].add_range(day, start_time, end_time, time_format="%I:%M %p")
-            elif start_day:
-                item["opening_hours"].add_range(start_day, start_time, end_time, time_format="%I:%M %p")
-        apply_category(Categories.SHOP_CLOTHES, item)
-        yield item
+                item["opening_hours"] = OpeningHours()
+                item["opening_hours"].add_ranges_from_string(
+                    "; ".join(card.xpath('.//div[@class="hours"]/text()').getall())
+                )
+
+            apply_category(Categories.SHOP_CLOTHES, item)
+            yield item


### PR DESCRIPTION
- The Demandware `Stores-FindStores` response was restructured: the `stores` array is now skeletal, with details moved into a rendered HTML fragment and coordinates into a separate `locations` JSON string, so the spider crashed with a KeyError and returned zero features.
- Merge the `locations` entries with each store's card in `storesResultsHtml`, and use a generic `Mozilla/5.0` user agent, which the store search endpoint serves without the PerimeterX challenge, removing the need for a proxy.