### PR TITLE
[Voyage Care GB] Fix Spider

### DIFF
--- a/locations/spiders/voyage_care_gb.py
+++ b/locations/spiders/voyage_care_gb.py
@@ -1,35 +1,37 @@
-from typing import Iterable
+import json
 
+import scrapy
+from scrapy import Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address, merge_address_lines
 
 
-class VoyageCareGBSpider(JSONBlobSpider):
+class VoyageCareGBSpider(Spider):
     name = "voyage_care_gb"
     item_attributes = {"brand": "Voyage Care", "brand_wikidata": "Q134484515"}
-    allowed_domains = ["www.voyagecare.com"]
-    start_urls = ["https://www.voyagecare.com/wp-json/voyagecare/v1/services/null/null/null/null/0/0/500"]
-    locations_key = "body"
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.voyagecare.com/your-support/"]
 
-    def pre_process_data(self, feature: dict) -> None:
-        feature.update(feature.pop("properties"))
+    def parse(self, response: Response, **kwargs):
+        for location in json.loads(response.xpath("//@data-map-locations").get()):
+            if "/?post_type=" not in location.get("guid"):
+                yield scrapy.Request(
+                    url=location.get("guid"),
+                    callback=self.parse_details,
+                    cb_kwargs={
+                        "lat": location.get("meta").get("latitude"),
+                        "lon": location.get("meta").get("longitude"),
+                    },
+                )
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["ref"] = str(feature["id"])
-        item["branch"] = feature["post_title"]
-        item["addr_full"] = clean_address([feature["address1_composite"]])
-        item["street_address"] = merge_address_lines(
-            [feature.get("address1_line1"), feature.get("address1_line2"), feature.get("address1_line3")]
-        )
-        item["city"] = feature["address1_city"]
-        item["postcode"] = feature["address1_postalcode"]
-        item["state"] = feature["address1_stateorprovince"]
-        item["website"] = "https://www.voyagecare.com/" + feature["route"]
+    def parse_details(self, response, **kwargs):
+        item = Feature()
+        item["name"] = self.item_attributes["brand"]
+        item["branch"] = response.xpath('//*[@class="text-content"]//h1//text()').get()
+        item["addr_full"] = response.xpath('//*[@class="text-content"]//p//text()').get()
+        item["lat"] = kwargs["lat"]
+        item["lon"] = kwargs["lon"]
+        item["website"] = item["ref"] = response.url
         apply_category(Categories.SOCIAL_FACILITY, item)
-        item["extras"]["social_facility:for"] = "disabled"
         yield item


### PR DESCRIPTION
```python
{'atp/brand/Voyage Care': 278,
 'atp/brand_wikidata/Q134484515': 278,
 'atp/category/amenity/social_facility': 278,
 'atp/clean_strings/addr_full': 277,
 'atp/country/GB': 278,
 'atp/field/city/missing': 278,
 'atp/field/country/from_spider_name': 278,
 'atp/field/email/missing': 278,
 'atp/field/housenumber/missing': 278,
 'atp/field/opening_hours/missing': 278,
 'atp/field/operator/missing': 278,
 'atp/field/operator_wikidata/missing': 278,
 'atp/field/phone/missing': 278,
 'atp/field/postcode/missing': 276,
 'atp/field/state/missing': 278,
 'atp/field/street/missing': 278,
 'atp/field/street_address/missing': 278,
 'atp/field/twitter/missing': 278,
 'atp/field/unit/missing': 278,
 'atp/item_scraped_host_count/www.voyagecare.com': 278,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 278,
 'atp/nsi/match_failed': 278,
 'downloader/request_bytes': 122040,
 'downloader/request_count': 304,
 'downloader/request_method_count/GET': 304,
 'downloader/response_bytes': 16687325,
 'downloader/response_count': 304,
 'downloader/response_status_count/200': 280,
 'downloader/response_status_count/301': 4,
 'downloader/response_status_count/404': 20,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 369.23968838400015,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 24, 10, 13, 37, 307788, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 62715177,
 'httpcompression/response_count': 300,
 'httperror/response_ignored_count': 20,
 'httperror/response_ignored_status_count/404': 20,
 'item_scraped_count': 278,
 'items_per_minute': 45.203252032520325,
 'log_count/DEBUG': 583,
 'log_count/INFO': 29,
 'memusage/max': 467345408,
 'memusage/startup': 294375424,
 'request_depth_max': 1,
 'response_received_count': 300,
 'responses_per_minute': 48.78048780487805,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 303,
 'scheduler/dequeued/memory': 303,
 'scheduler/enqueued': 303,
 'scheduler/enqueued/memory': 303,
 'start_time': datetime.datetime(2026, 7, 24, 10, 7, 28, 68097, tzinfo=datetime.timezone.utc)}
```