### PR TITLE
[Total Wine US] Fix spider

### DIFF
--- a/locations/spiders/total_wine_and_more_us.py
+++ b/locations/spiders/total_wine_and_more_us.py
@@ -1,12 +1,14 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Iterable
 
 import pycountry
 from scrapy import Spider
-from scrapy.http import FormRequest
+from scrapy.http import JsonRequest, Response
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.geo import city_locations
 from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 
@@ -14,29 +16,33 @@ class TotalWineAndMoreUSSpider(Spider):
     name = "total_wine_and_more_us"
     item_attributes = {"brand": "Total Wine", "brand_wikidata": "Q7828084"}
     allowed_domains = ["www.totalwine.com"]
-    start_urls = ["https://www.totalwine.com/registry/"]
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        for url in self.start_urls:
-            for state in pycountry.subdivisions.get(country_code="US"):
-                formdata = {
-                    "components[0][name]": "location-slideout-component",
-                    "components[0][version]": "2.0.7",
-                    "components[0][parameters][type]": "GET_STORES",
-                    "components[0][parameters][query]": state.name,
-                }
-                yield FormRequest(
-                    url=url, method="POST", headers={"Accept": "application/vnd.oc.unrendered+json"}, formdata=formdata
-                )
+    def make_request(self, query: str, state: str | None = None) -> JsonRequest:
+        return JsonRequest(
+            url="https://www.totalwine.com/registry/~actions/GET_STORES/location-slideout-component/",
+            data={"query": query},
+            meta={"query": query, "state": state},
+        )
 
-    def parse(self, response):
-        pagination = response.json()[0]["response"]["data"]["reactComponent"]["props"]["data"]["pagination"]
-        if pagination["totalResults"] == 0:
-            return
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for subdivision in pycountry.subdivisions.get(country_code="US"):
+            yield self.make_request(subdivision.name, subdivision.code.removeprefix("US-"))
 
-        for location in response.json()[0]["response"]["data"]["reactComponent"]["props"]["data"]["stores"]:
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature | JsonRequest]:
+        stores = DictParser.get_nested_key(response.json(), "stores") or []
+
+        pagination = DictParser.get_nested_key(response.json(), "pagination") or {}
+        if state := response.meta["state"]:
+            if pagination.get("totalResults", 0) > len(stores):
+                # The API returns at most 40 stores per query, so refine by city.
+                for city in city_locations("US", 100000):
+                    if city["admin1code"] == state:
+                        yield self.make_request("{}, {}".format(city["name"], response.meta["query"]))
+
+        for location in stores:
             item = DictParser.parse(location)
             item["ref"] = location["storeNumber"]
+            item["branch"] = item.pop("name")
             item["street_address"] = clean_address([location.get("address1"), location.get("address2")])
             item["website"] = "https://www.totalwine.com/store-info/" + item["ref"]
 
@@ -46,9 +52,14 @@ class TotalWineAndMoreUSSpider(Spider):
                 item["opening_hours"] = OpeningHours()
                 for day_hours in location["storeHours"]["days"]:
                     if day_hours["closedStatus"]:
-                        continue
-                    item["opening_hours"].add_range(
-                        day_hours["dayOfWeek"].title(), day_hours["openingTime"], day_hours["closingTime"], "%I:%M %p"
-                    )
+                        item["opening_hours"].set_closed(day_hours["dayOfWeek"].title())
+                    else:
+                        item["opening_hours"].add_range(
+                            day_hours["dayOfWeek"].title(),
+                            day_hours["openingTime"],
+                            day_hours["closingTime"],
+                            "%I:%M %p",
+                        )
 
+            apply_category(Categories.SHOP_ALCOHOL, item)
             yield item


### PR DESCRIPTION
- The store lookup is an OpenComponents server action and the pinned component version 2.0.7 no longer exists on the registry, so every request 404'd and the spider returned zero features.
- Call the `GET_STORES` action through the versionless `~actions` route, and refine any state reporting more than the 40-store response cap with per-city queries so large states are no longer truncated.