### PR TITLE
[Maserati] Fix Spider

### DIFF
--- a/locations/spiders/maserati.py
+++ b/locations/spiders/maserati.py
@@ -36,7 +36,7 @@ class MaseratiSpider(scrapy.Spider):
                 sales_item = item.deepcopy()
                 sales_item["ref"] = f"{item['ref']}-sales"
                 apply_category(Categories.SHOP_CAR, sales_item)
-                apply_yes_no(Extras.CAR_REPAIR, sales_item, is_service)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, is_service)
                 self.parse_hours(sales_item, row.get("opening_hours", []))
                 yield sales_item
 
@@ -44,7 +44,7 @@ class MaseratiSpider(scrapy.Spider):
                 service_item = item.deepcopy()
                 service_item["ref"] = f"{item['ref']}-service"
                 apply_category(Categories.SHOP_CAR_REPAIR, service_item)
-                apply_yes_no(Extras.BODY_REPAIR, service_item, row.get("autoBodyShop") == "true")
+                apply_yes_no(Extras.VEHICLE_BODY_REPAIR_SERVICES, service_item, row.get("autoBodyShop") == "true")
                 self.parse_hours(service_item, row.get("service_opening_hours", []))
                 yield service_item
 


### PR DESCRIPTION
```python
{'atp/brand/Maserati': 635,
 'atp/brand_wikidata/Q35962': 635,
 'atp/category/shop/car': 291,
 'atp/category/shop/car_repair': 344,
 'atp/clean_strings/phone': 2,
 'atp/country/AE': 7,
 'atp/country/AT': 4,
 'atp/country/AU': 13,
 'atp/country/AZ': 2,
 'atp/country/BE': 6,
 'atp/country/BG': 2,
 'atp/country/BH': 2,
 'atp/country/BR': 2,
 'atp/country/BY': 2,
 'atp/country/CA': 23,
 'atp/country/CH': 21,
 'atp/country/CL': 2,
 'atp/country/CN': 56,
 'atp/country/CR': 2,
 'atp/country/CY': 4,
 'atp/country/CZ': 3,
 'atp/country/DE': 38,
 'atp/country/DK': 3,
 'atp/country/DO': 2,
 'atp/country/EC': 2,
 'atp/country/EE': 2,
 'atp/country/EG': 2,
 'atp/country/ES': 15,
 'atp/country/FR': 21,
 'atp/country/GB': 18,
 'atp/country/GR': 2,
 'atp/country/GT': 2,
 'atp/country/HK': 2,
 'atp/country/HU': 1,
 'atp/country/ID': 1,
 'atp/country/IL': 2,
 'atp/country/IN': 4,
 'atp/country/IT': 57,
 'atp/country/JP': 35,
 'atp/country/KH': 1,
 'atp/country/KR': 15,
 'atp/country/KW': 2,
 'atp/country/KZ': 2,
 'atp/country/LB': 2,
 'atp/country/LT': 1,
 'atp/country/LU': 2,
 'atp/country/MA': 2,
 'atp/country/MT': 2,
 'atp/country/MX': 6,
 'atp/country/MY': 3,
 'atp/country/NL': 5,
 'atp/country/NO': 4,
 'atp/country/NZ': 4,
 'atp/country/OM': 2,
 'atp/country/PA': 2,
 'atp/country/PE': 2,
 'atp/country/PH': 2,
 'atp/country/PL': 4,
 'atp/country/PR': 2,
 'atp/country/PT': 4,
 'atp/country/PY': 2,
 'atp/country/QA': 3,
 'atp/country/RO': 2,
 'atp/country/RS': 2,
 'atp/country/SA': 4,
 'atp/country/SE': 3,
 'atp/country/SG': 2,
 'atp/country/TH': 3,
 'atp/country/TR': 8,
 'atp/country/TW': 6,
 'atp/country/UA': 4,
 'atp/country/US': 161,
 'atp/country/UY': 2,
 'atp/country/VN': 2,
 'atp/country/ZA': 2,
 'atp/field/branch/missing': 635,
 'atp/field/city/missing': 4,
 'atp/field/email/missing': 14,
 'atp/field/housenumber/missing': 635,
 'atp/field/opening_hours/missing': 202,
 'atp/field/operator/missing': 635,
 'atp/field/operator_wikidata/missing': 635,
 'atp/field/phone/invalid': 26,
 'atp/field/phone/missing': 30,
 'atp/field/postcode/missing': 19,
 'atp/field/state/from_reverse_geocoding': 23,
 'atp/field/state/missing': 109,
 'atp/field/street/missing': 635,
 'atp/field/twitter/missing': 635,
 'atp/field/unit/missing': 635,
 'atp/item_scraped_host_count/api.onthemap.io': 635,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 635,
 'downloader/exception_count': 1,
 'downloader/exception_type_count/scrapy.exceptions.IgnoreRequest': 1,
 'downloader/request_bytes': 439,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 724502,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 7.452326491000349,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 27, 10, 1, 3, 691306, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 635,
 'items_per_minute': 5442.857142857143,
 'log_count/DEBUG': 637,
 'log_count/INFO': 3,
 'memusage/max': 302059520,
 'memusage/startup': 302059520,
 'offsite/domains': 1,
 'offsite/filtered': 1,
 'response_received_count': 1,
 'responses_per_minute': 8.571428571428571,
 'robotstxt/request_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 27, 10, 0, 56, 238975, tzinfo=datetime.timezone.utc)}
```