### PR TITLE
[Billy Tacos] Add spider

### DIFF
--- a/locations/spiders/billy_tacos.py
+++ b/locations/spiders/billy_tacos.py
@@ -6,7 +6,7 @@ class BillyTacosSpider(StoreRocketSpider):
     name = "billy_tacos"
     item_attributes = {"brand": "Billy Tacos", "brand_wikidata": "Q122167398"}
     storerocket_id = "2rpXRR0JB5"
-    
+
     def parse_item(self, item, location):
         apply_category(Categories.FAST_FOOD, item)
         item["extras"]["cuisine"] = "mexican;taco"

--- a/locations/spiders/billy_tacos.py
+++ b/locations/spiders/billy_tacos.py
@@ -1,0 +1,13 @@
+from locations.categories import Categories, apply_category
+from locations.storefinders.storerocket import StoreRocketSpider
+
+
+class BillyTacosSpider(StoreRocketSpider):
+    name = "billy_tacos"
+    item_attributes = {"brand": "Billy Tacos", "brand_wikidata": "Q122167398"}
+    storerocket_id = "2rpXRR0JB5"
+    
+    def parse_item(self, item, location):
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "mexican;taco"
+        yield item


### PR DESCRIPTION
Added a new spider for Billy Tacos (Italy).

Brand: Billy Tacos
Locations extracted: 69
Store locator used: https://billytacos.it/trova-uno-store (using StoreRocket API)
Includes Wikidata ID (Q122167398)
Phone numbers and most opening hours successfully parsed.
Ran locally via `scrapy crawl billy_tacos` without errors.

Checklist:

- [x] Tested the spider locally and it's working
- [x] Included Wikidata ID for the brand
- [x] Set standard tags (amenity, cuisine)
