### PR TITLE
[Bags To Go AU] Fix spider

### DIFF
--- a/locations/spiders/bags_to_go_au.py
+++ b/locations/spiders/bags_to_go_au.py
@@ -1,11 +1,11 @@
 from typing import Any
 from urllib.parse import urljoin
 
-from scrapy.http import Response, TextResponse
+from scrapy.http import Response
+from scrapy.selector import Selector
 from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
-from locations.google_url import extract_google_position
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -16,21 +16,29 @@ class BagsToGoAUSpider(Spider):
     start_urls = ["https://bagstogo.com.au/pages/store-locator"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath("//details[@id]"):
+        for location in response.xpath('//li[contains(@class, "accordion-item")]'):
+            toggle = location.xpath('.//div[contains(@class, "accordion-toggle")]')
             item = Feature()
-            item["city"] = location.xpath("./@id").get("").title()
-            item["ref"] = location.xpath('.//a[contains(text(),"View")]/@href').get()
-            item["branch"] = item["ref"].title().replace("-", " ")
-            item["addr_full"] = response.xpath(f'//*[@data-title="{item["branch"]}"]/@data-address').get()
+            item["branch"] = toggle.attrib.get("data-title")
+            item["addr_full"] = toggle.attrib.get("data-address")
+            try:
+                # One store has a corrupt junk string in data-lat.
+                item["lat"] = float(toggle.attrib.get("data-lat", ""))
+                item["lon"] = float(toggle.attrib.get("data-lng", ""))
+            except ValueError:
+                pass
+            item["state"] = location.attrib.get("data-area", "").upper()
+            if image := toggle.attrib.get("data-img"):
+                item["image"] = response.urljoin(image)
+            item["ref"] = location.xpath('.//a[contains(text(), "View")]/@href').get()
             item["website"] = urljoin("https://bagstogo.com.au/pages/", item["ref"])
             item["opening_hours"] = self.parse_opening_hours(location)
-            extract_google_position(item, location)
             apply_category(Categories.SHOP_BAG, item)
             yield item
 
-    def parse_opening_hours(self, location: TextResponse) -> OpeningHours:
+    def parse_opening_hours(self, location: Selector) -> OpeningHours:
         opening_hours = OpeningHours()
-        for rule in location.xpath('.//*[contains(text(),"Opening hours")]/following-sibling::table/tr'):
+        for rule in location.xpath(".//table/tr"):
             opening_hours.add_ranges_from_string(
                 f"{rule.xpath('./td[1]/text()').get()}: {rule.xpath('./td[2]/text()').get()}"
             )


### PR DESCRIPTION
- The store locator page was redesigned, replacing the `<details>` blocks the spider parsed with an accordion list, so the spider returned zero features.
- Read each store from the accordion items' data attributes, which also now carry coordinates and a store photo directly.