### PR TITLE
[PrivatBank UA] Add spider

### DIFF
--- a/locations/spiders/privatbank_ua.py
+++ b/locations/spiders/privatbank_ua.py
@@ -1,0 +1,62 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_WEEKDAY, OpeningHours
+
+ENDPOINT = "https://map.privatbank.ua/google_geo_coding_api.php"
+# Map "objType" -> OSM category. NSI supplies name=ПриватБанк for banks/terminals; ATMs have no name.
+CATEGORIES = {
+    "branch": Categories.BANK,
+    "atm": Categories.ATM,
+    "terminal": {"amenity": "payment_terminal"},  # self-service payment terminals; no Categories enum
+}
+
+
+class PrivatbankUASpider(Spider):
+    name = "privatbank_ua"
+    item_attributes = {"brand": "ПриватБанк", "brand_wikidata": "Q1515015"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # The map search endpoint reads form-encoded POST params (a JSON body is ignored and returns a
+        # single fallback point), so JsonRequest is not used. A bounding box over all of Ukraine at a
+        # high zoom returns every point individually; machines sharing a coordinate stay grouped into
+        # one point and yield a single POI.
+        for obj_type in CATEGORIES:
+            yield Request(
+                ENDPOINT,
+                method="POST",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                body="lat1=53&lng1=40.5&lat2=44&lng2=22&zoom=20&type=" + obj_type,
+                cb_kwargs={"obj_type": obj_type},
+            )
+
+    def parse(self, response: Response, obj_type: str, **kwargs: Any) -> Any:
+        for point in response.json()["items"]:
+            if point.get("is_active") != 1:
+                continue  # closed or temporarily out of service
+            item = DictParser.parse(point)  # maps id -> ref, lat/lng -> lat/lon
+            item["opening_hours"] = self.parse_hours(point.get("work_time") or "")
+            apply_category(CATEGORIES[obj_type], item)
+            yield item
+
+    @staticmethod
+    def parse_hours(work_time: str) -> str | None:
+        # Only branches carry hours, as 4x HHMM (Mon-Fri open, close, lunch-break start, lunch-break
+        # end; "----" when absent). ATMs/terminals send an empty string. Weekends are not encoded.
+        if len(work_time) != 16:
+            return None
+        open_time, close_time, break_start, break_end = (work_time[i : i + 4] for i in range(0, 16, 4))
+        try:
+            hours = OpeningHours()
+            if break_start == "----":
+                hours.add_days_range(DAYS_WEEKDAY, open_time, close_time, time_format="%H%M")
+            else:
+                hours.add_days_range(DAYS_WEEKDAY, open_time, break_start, time_format="%H%M")
+                hours.add_days_range(DAYS_WEEKDAY, break_end, close_time, time_format="%H%M")
+            return hours.as_opening_hours()
+        except ValueError:
+            return None


### PR DESCRIPTION
Adds a spider for **PrivatBank** (ПриватБанк, [Q1515015](https://www.wikidata.org/wiki/Q1515015)) in Ukraine: ~13,000 POIs: branches, ATMs and self-service payment terminals.

### Source
`https://map.privatbank.ua/google_geo_coding_api.php` — the store-locator map's search endpoint. It takes a **form-encoded POST** (a JSON body is ignored and returns a single fallback point, so `JsonRequest` isn't used) with a bounding box (`lat1/lng1`=NE, `lat2/lng2`=SW, `zoom`, `type`). One request per `type` covering all of Ukraine at a high zoom returns every point individually.

### Modelling
- `type=branch` → `amenity=bank`, `type=atm` → `amenity=atm`, `type=terminal` → `amenity=payment_terminal` (all three have NSI entries; `name=ПриватБанк` supplied by NSI for banks/terminals, ATMs have no name).
- The endpoint **clusters machines that share a coordinate** into one point (`col`>1); those yield a single POI, which is the correct unit for a coordinates-based map. Inactive points (`is_active != 1`) are dropped.
- **Branch opening hours** are decoded from the feed's `work_time` field — 4×`HHMM` = Mon-Fri open, close, lunch-break start, lunch-break end (`----` when absent), verified against the detail endpoint. Weekends aren't encoded there. ATMs/terminals send no hours.

### Why no street addresses (deliberate)
The bulk search feed returns only `id + lat/lng + type` : no address. Addresses exist **only on a per-POI detail endpoint** (`item_details_api.php`, one request per point), which for ~13k points would be a ~3.5–4 hour serial crawl (`DOWNLOAD_DELAY=1`, single domain) and would time out in CI. This spider therefore emits coordinate POIs (brand/category from NSI). If preferred, branch addresses (`addr:street`/`housenumber`/`city`/`state`/`postcode`, all cleanly structured in the detail response) could be added at a modest ~971-request cost, leaving ATMs/terminals coords-only;
Happy to do that if reviewers want it.

### Sample
```json
[
  {"type":"Feature","properties":{
"ref":"CHBB",
"amenity":"bank",
"name":"ПриватБанк",
"opening_hours":"Mo-Fr 08:30-17:30",
"brand":"ПриватБанк",
"brand:wikidata":"Q1515015"},
"geometry":{"type":"Point","coordinates":[31.38446617,50.74100494]}},

  {"type":"Feature","properties":{
"ref":"CACH0160",
"amenity":"atm",
"brand":"ПриватБанк",
"brand:wikidata":"Q1515015"},
"geometry":{"type":"Point","coordinates":[31.30356979,51.49031830]}},

  {"type":"Feature","properties":{"ref":"TS200002",
"amenity":"payment_terminal",
"name":"ПриватБанк",
"brand":"ПриватБанк",
"brand:wikidata":"Q1515015"},
"geometry":{"type":"Point","coordinates":[35.00233459,48.41787720]}}
]
```
stats
```
{
  "item_scraped_count": 13092,
  "atp/category/amenity/bank": 971,
  "atp/category/amenity/atm": 5884,
  "atp/category/amenity/payment_terminal": 6237,
  "atp/nsi/match_perfect": 13092,
  "atp/field/country/from_spider_name": 13092,
  "finish_reason": "finished"
}