### PR TITLE
Fix Alice Pizza IT brand tag to match NSI

### DIFF
--- a/locations/spiders/alice_pizza.py
+++ b/locations/spiders/alice_pizza.py
@@ -11,7 +11,7 @@ from locations.items import Feature
 
 class AlicePizzaSpider(scrapy.Spider):
     name = "alice_pizza"
-    item_attributes = {"brand": "Alice Pizza", "brand_wikidata": "Q113973272"}
+    item_attributes = {"brand": "Alice", "brand_wikidata": "Q113973272"}
     start_urls = ["https://www.alicepizza.it/pizzerie/"]
     skip_auto_cc_domain = True
 


### PR DESCRIPTION
alice_pizza.py sets brand to "Alice Pizza" but NSI (Q113973272) expects "Alice", which breaks test_item_attributes_brand_strings_match_nsi on master and cascades that failure to every other open PR's CI.