### PR TITLE
Repair truncated GeoJSON/NDGeoJSON output left by spiders killed mid-crawl

### DIFF
--- a/ci/repair_truncated_geojson.py
+++ b/ci/repair_truncated_geojson.py
@@ -1,0 +1,130 @@
+import json
+import logging
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Written by GeoJsonExporter.finish_exporting() once a spider closes cleanly.
+# Its absence means the spider process was killed (OOM, timeout, crash) before
+# Scrapy's spider_closed signal ever fired.
+GEOJSON_TRAILER = b"\n]}\n"
+
+
+def _looks_complete(geojson_path: Path) -> bool:
+    size = geojson_path.stat().st_size
+    if size == 0:
+        # A spider that scraped zero items never gets its header/trailer
+        # written either (see GeoJsonExporter.export_item's first_item
+        # check) - an empty file is the correct, valid output for that case.
+        return True
+    with geojson_path.open("rb") as f:
+        f.seek(max(0, size - len(GEOJSON_TRAILER)))
+        return f.read() == GEOJSON_TRAILER
+
+
+def _split_ndgeojson_lines(ndgeojson_path: Path) -> tuple[list[str], list[dict], int]:
+    """Read a newline-delimited GeoJSON file, separating lines that parse as
+    valid JSON objects from malformed ones. Each line is written
+    independently and carries its own "dataset_attributes", so a process
+    killed mid-crawl can only ever leave a trailing line half-written -
+    every earlier line is unaffected.
+    """
+    valid_lines = []
+    valid_features = []
+    dropped = 0
+    with ndgeojson_path.open("r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                feature = json.loads(line)
+            except json.JSONDecodeError:
+                dropped += 1
+                continue
+            valid_lines.append(line)
+            valid_features.append(feature)
+    return valid_lines, valid_features, dropped
+
+
+def _rebuild_geojson(geojson_path: Path, features: list[dict]) -> None:
+    dataset_attributes = features[0].get("dataset_attributes", {})
+    with geojson_path.open("w", encoding="utf-8") as out:
+        out.write('{"type":"FeatureCollection","dataset_attributes":')
+        json.dump(
+            dataset_attributes,
+            out,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        out.write(',"features":[\n')
+        for i, feature in enumerate(features):
+            if i:
+                out.write(",\n")
+            cleaned = {k: v for k, v in feature.items() if k != "dataset_attributes"}
+            json.dump(cleaned, out, ensure_ascii=False, separators=(",", ":"))
+        out.write("\n]}\n")
+
+
+def repair_spider_output(geojson_path: Path, ndgeojson_path: Path) -> None:
+    geojson_complete = geojson_path.exists() and _looks_complete(geojson_path)
+
+    valid_lines, valid_features, dropped = _split_ndgeojson_lines(ndgeojson_path)
+
+    if dropped:
+        with ndgeojson_path.open("w", encoding="utf-8") as f:
+            for line in valid_lines:
+                f.write(line + "\n")
+        logger.info(
+            "Dropped %d malformed trailing line(s) from %s",
+            dropped,
+            ndgeojson_path.name,
+        )
+
+    if geojson_complete:
+        return
+
+    if not valid_features:
+        logger.warning(
+            "%s is incomplete and %s has no usable features to rebuild from",
+            geojson_path.name,
+            ndgeojson_path.name,
+        )
+        return
+
+    _rebuild_geojson(geojson_path, valid_features)
+    logger.info(
+        "Rebuilt %s from %s (%d feature(s))",
+        geojson_path.name,
+        ndgeojson_path.name,
+        len(valid_features),
+    )
+
+
+def repair_directory(directory: Path) -> None:
+    for ndgeojson_path in sorted(directory.glob("*.ndgeojson")):
+        geojson_path = ndgeojson_path.with_suffix(".geojson")
+        repair_spider_output(geojson_path, ndgeojson_path)
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="Repair .geojson/.ndgeojson output left incomplete by a spider process killed mid-crawl"
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        required=True,
+        help="Directory containing .geojson/.ndgeojson output files",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
+    repair_directory(Path(args.directory))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/run_all_spiders.sh
+++ b/ci/run_all_spiders.sh
@@ -83,6 +83,14 @@ if [ ! $retval -eq 0 ]; then
 fi
 (>&2 echo "Done running spiders")
 
+# A spider process killed mid-crawl (OOM, timeout, crash) never gets to write
+# its GeoJSON trailer, leaving output/*.geojson invalid and output/*.ndgeojson
+# with a malformed trailing line - the latter breaks the parquet build for
+# every spider, not just the one that was killed, since it's read in one
+# batch below. Repair before anything downstream consumes these files.
+(>&2 echo "Repairing any GeoJSON output left incomplete by a killed spider")
+uv run python ci/repair_truncated_geojson.py --directory "${SPIDER_RUN_DIR}/output"
+
 OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson | wc -l | tr -d ' ')
 (>&2 echo "Generated ${OUTPUT_LINECOUNT} lines")
 

--- a/ci/run_group_spiders.sh
+++ b/ci/run_group_spiders.sh
@@ -89,6 +89,14 @@ if [ ! $retval -eq 0 ]; then
 fi
 (>&2 echo "Done running spiders")
 
+# A spider process killed mid-crawl (OOM, timeout, crash) never gets to write
+# its GeoJSON trailer, leaving output/*.geojson invalid and output/*.ndgeojson
+# with a malformed trailing line - the latter breaks the parquet build for
+# every spider, not just the one that was killed, since it's read in one
+# batch below. Repair before anything downstream consumes these files.
+(>&2 echo "Repairing any GeoJSON output left incomplete by a killed spider")
+uv run python ci/repair_truncated_geojson.py --directory "${SPIDER_RUN_DIR}/output"
+
 OUTPUT_LINECOUNT=$(cat "${SPIDER_RUN_DIR}"/output/*.geojson | wc -l | tr -d ' ')
 (>&2 echo "Generated ${OUTPUT_LINECOUNT} lines")
 

--- a/tests/test_repair_truncated_geojson.py
+++ b/tests/test_repair_truncated_geojson.py
@@ -1,0 +1,160 @@
+import json
+from pathlib import Path
+
+from ci.repair_truncated_geojson import repair_directory, repair_spider_output
+
+FEATURE_A = {
+    "type": "Feature",
+    "id": "a",
+    "dataset_attributes": {
+        "@spider": "example",
+        "spider:collection_time": "2026-01-01T00:00:00",
+    },
+    "properties": {"ref": "1"},
+    "geometry": {"type": "Point", "coordinates": [1, 2]},
+}
+FEATURE_B = {
+    "type": "Feature",
+    "id": "b",
+    "dataset_attributes": {
+        "@spider": "example",
+        "spider:collection_time": "2026-01-01T00:00:00",
+    },
+    "properties": {"ref": "2"},
+    "geometry": {"type": "Point", "coordinates": [3, 4]},
+}
+
+
+def _write_ndgeojson(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_complete_geojson(path: Path, features: list[dict]) -> None:
+    body = ",\n".join(
+        json.dumps(
+            {k: v for k, v in f.items() if k != "dataset_attributes"},
+            separators=(",", ":"),
+        )
+        for f in features
+    )
+    path.write_text(
+        '{"type":"FeatureCollection","dataset_attributes":{"@spider":"example"},"features":[\n'
+        + body
+        + "\n]}\n",
+        encoding="utf-8",
+    )
+
+
+def test_complete_files_are_left_untouched(tmp_path: Path):
+    geojson_path = tmp_path / "example.geojson"
+    ndgeojson_path = tmp_path / "example.ndgeojson"
+
+    _write_complete_geojson(geojson_path, [FEATURE_A, FEATURE_B])
+    _write_ndgeojson(ndgeojson_path, [json.dumps(FEATURE_A), json.dumps(FEATURE_B)])
+
+    geojson_before = geojson_path.read_bytes()
+    ndgeojson_before = ndgeojson_path.read_bytes()
+
+    repair_spider_output(geojson_path, ndgeojson_path)
+
+    assert geojson_path.read_bytes() == geojson_before
+    assert ndgeojson_path.read_bytes() == ndgeojson_before
+
+
+def test_empty_geojson_is_treated_as_valid_zero_item_output(tmp_path: Path):
+    geojson_path = tmp_path / "example.geojson"
+    ndgeojson_path = tmp_path / "example.ndgeojson"
+
+    geojson_path.write_text("", encoding="utf-8")
+    ndgeojson_path.write_text("", encoding="utf-8")
+
+    repair_spider_output(geojson_path, ndgeojson_path)
+
+    assert geojson_path.read_text() == ""
+
+
+def test_missing_trailer_is_rebuilt_from_ndgeojson(tmp_path: Path):
+    geojson_path = tmp_path / "example.geojson"
+    ndgeojson_path = tmp_path / "example.ndgeojson"
+
+    # Simulates a process killed right after the comma separator for the next
+    # (never-written) item was flushed but before the "]}\n" trailer.
+    geojson_path.write_text(
+        '{"type":"FeatureCollection","dataset_attributes":{"@spider":"example"},"features":[\n'
+        '{"type":"Feature","id":"a","properties":{"ref":"1"},"geometry":{"type":"Point","coordinates":[1,2]}},\n',
+        encoding="utf-8",
+    )
+    _write_ndgeojson(ndgeojson_path, [json.dumps(FEATURE_A), json.dumps(FEATURE_B)])
+
+    repair_spider_output(geojson_path, ndgeojson_path)
+
+    rebuilt = json.loads(geojson_path.read_text())
+    assert rebuilt["type"] == "FeatureCollection"
+    assert rebuilt["dataset_attributes"] == FEATURE_A["dataset_attributes"]
+    assert [f["id"] for f in rebuilt["features"]] == ["a", "b"]
+    assert "dataset_attributes" not in rebuilt["features"][0]
+
+
+def test_malformed_trailing_ndgeojson_line_is_dropped_and_geojson_rebuilt(
+    tmp_path: Path,
+):
+    geojson_path = tmp_path / "example.geojson"
+    ndgeojson_path = tmp_path / "example.ndgeojson"
+
+    geojson_path.write_text(
+        '{"type":"FeatureCollection","dataset_attributes":{},"features":[\n',
+        encoding="utf-8",
+    )
+    _write_ndgeojson(
+        ndgeojson_path,
+        [
+            json.dumps(FEATURE_A),
+            '{"type":"Feature","id":"b","properties":{"ref":"2"},"geometry":{"type":"Poin',
+        ],
+    )
+
+    repair_spider_output(geojson_path, ndgeojson_path)
+
+    remaining_ndgeojson_lines = ndgeojson_path.read_text().strip().splitlines()
+    assert len(remaining_ndgeojson_lines) == 1
+    assert json.loads(remaining_ndgeojson_lines[0])["id"] == "a"
+
+    rebuilt = json.loads(geojson_path.read_text())
+    assert [f["id"] for f in rebuilt["features"]] == ["a"]
+
+
+def test_no_usable_features_leaves_geojson_alone(tmp_path: Path, caplog):
+    geojson_path = tmp_path / "example.geojson"
+    ndgeojson_path = tmp_path / "example.ndgeojson"
+
+    geojson_path.write_text(
+        '{"type":"FeatureCollection","dataset_attributes":{},"features":[\n',
+        encoding="utf-8",
+    )
+    ndgeojson_path.write_text(
+        '{"type":"Feature","id":"a","properties":{}, "geom', encoding="utf-8"
+    )
+
+    original = geojson_path.read_bytes()
+    repair_spider_output(geojson_path, ndgeojson_path)
+
+    assert geojson_path.read_bytes() == original
+    assert ndgeojson_path.read_text() == ""
+
+
+def test_repair_directory_processes_every_spider(tmp_path: Path):
+    _write_ndgeojson(tmp_path / "good.ndgeojson", [json.dumps(FEATURE_A)])
+    _write_complete_geojson(tmp_path / "good.geojson", [FEATURE_A])
+
+    (tmp_path / "broken.geojson").write_text(
+        '{"type":"FeatureCollection","dataset_attributes":{},"features":[\n',
+        encoding="utf-8",
+    )
+    _write_ndgeojson(
+        tmp_path / "broken.ndgeojson", [json.dumps(FEATURE_A), json.dumps(FEATURE_B)]
+    )
+
+    repair_directory(tmp_path)
+
+    rebuilt = json.loads((tmp_path / "broken.geojson").read_text())
+    assert [f["id"] for f in rebuilt["features"]] == ["a", "b"]

--- a/tests/test_repair_truncated_geojson.py
+++ b/tests/test_repair_truncated_geojson.py
@@ -38,9 +38,7 @@ def _write_complete_geojson(path: Path, features: list[dict]) -> None:
         for f in features
     )
     path.write_text(
-        '{"type":"FeatureCollection","dataset_attributes":{"@spider":"example"},"features":[\n'
-        + body
-        + "\n]}\n",
+        '{"type":"FeatureCollection","dataset_attributes":{"@spider":"example"},"features":[\n' + body + "\n]}\n",
         encoding="utf-8",
     )
 
@@ -131,9 +129,7 @@ def test_no_usable_features_leaves_geojson_alone(tmp_path: Path, caplog):
         '{"type":"FeatureCollection","dataset_attributes":{},"features":[\n',
         encoding="utf-8",
     )
-    ndgeojson_path.write_text(
-        '{"type":"Feature","id":"a","properties":{}, "geom', encoding="utf-8"
-    )
+    ndgeojson_path.write_text('{"type":"Feature","id":"a","properties":{}, "geom', encoding="utf-8")
 
     original = geojson_path.read_bytes()
     repair_spider_output(geojson_path, ndgeojson_path)
@@ -150,9 +146,7 @@ def test_repair_directory_processes_every_spider(tmp_path: Path):
         '{"type":"FeatureCollection","dataset_attributes":{},"features":[\n',
         encoding="utf-8",
     )
-    _write_ndgeojson(
-        tmp_path / "broken.ndgeojson", [json.dumps(FEATURE_A), json.dumps(FEATURE_B)]
-    )
+    _write_ndgeojson(tmp_path / "broken.ndgeojson", [json.dumps(FEATURE_A), json.dumps(FEATURE_B)])
 
     repair_directory(tmp_path)
 


### PR DESCRIPTION
## Summary

Fixes #17553. When a spider process is killed mid-crawl (OOM, an external `timeout`, a hard crash) Scrapy's `spider_closed` signal never fires, so `GeoJsonExporter.finish_exporting()` never runs and the `.geojson` output is left without its closing `]}` - invalid JSON, as seen with `inditex.geojson` in the 2026-07-18 run.

The same crash also leaves the sibling `.ndgeojson` file with a malformed trailing line. `ci/ndgeojsons_to_parquet.py` globs every spider's `.ndgeojson` into a single DuckDB `read_ndjson()` call, and one malformed line makes that call hard-fail for the *entire* run - `output.parquet` for the 2026-07-18 run 404s as a result, confirming this happened.

Each `.ndgeojson` line is self-contained (it embeds its own `dataset_attributes`), so it's crash-safe up to the last, possibly-truncated line - only `.geojson` needs a trailer written at close. `ci/repair_truncated_geojson.py` uses this: for each spider, it drops any malformed trailing line(s) from `.ndgeojson`, and if `.geojson` wasn't closed properly, rebuilds it from the (now-clean) `.ndgeojson` lines. It's wired into `ci/run_group_spiders.sh` and `ci/run_all_spiders.sh` right after spiders finish, before tippecanoe/pmtiles and the parquet build consume this output.

Since SIGKILL can't be caught in-process, this can't be prevented at crawl time - it's a post-crawl repair, turning "one crashed spider breaks the whole run's parquet output and ships an unparseable geojson file" into "that spider loses its last few in-flight items but the run completes cleanly."

Verified end-to-end against the real truncated `inditex.geojson` from the affected run (3826 features) - repaired file parses as valid GeoJSON and a synthetic `.ndgeojson` with a malformed trailing line built from the same data now ingests successfully into `ci/ndgeojsons_to_parquet.py`'s DuckDB pipeline, where it previously raised `Invalid Input Error: Malformed JSON`.