### PR TITLE
[Luminor Bank LV] Add spider

### DIFF
--- a/locations/spiders/luminor_lv.py
+++ b/locations/spiders/luminor_lv.py
@@ -1,0 +1,84 @@
+import json
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class LuminorLVSpider(Spider):
+    name = "luminor_lv"
+    item_attributes = {"brand": "Luminor Bank", "brand_wikidata": "Q28966957"}
+    # Cloudflare serves a JS challenge to datacenter IPs (including for robots.txt), so a proxy is
+    # required and robots.txt cannot be fetched/obeyed.
+    requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.luminor.lv/lv/musu-tikls"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if not (contacts := self.extract_page_contacts(response)):
+            self.logger.error("Unable to find Luminor contacts data")
+            return
+
+        for ref, location in contacts.get("map_objects", {}).items():
+            object_types = {str(object_type) for object_type in location.get("object_types", [])}
+            has_branch = "74" in object_types
+            has_atm = location.get("pin_icon") in ["cash-out", "cash-in-out", "partner"] or bool(
+                {"70", "71", "75"} & object_types
+            )
+            if not (has_branch or has_atm):
+                continue
+
+            item = DictParser.parse(location)  # maps title -> name, nested geolocation -> lat/lon, address -> addr_full
+            item["ref"] = ref  # ref is the map_objects key, not a field on the record
+            item["name"] = self.clean_branch(item.get("name"))
+            item["street_address"] = item.pop("addr_full", None)  # "address" is a street + house-number line
+            item["city"] = self.get_city(location, contacts)  # DictParser maps "town" as an id pair, not a name
+
+            if has_branch:
+                item["branch"] = item.pop("name")  # branch: move label to branch, NSI supplies name
+                apply_yes_no(Extras.ATM, item, has_atm)
+                apply_category(Categories.BANK, item)
+            else:
+                apply_category(Categories.ATM, item)  # standalone ATM keeps the display label as name
+
+            yield item
+
+    def extract_page_contacts(self, response: Response) -> dict[str, Any] | None:
+        settings_marker = "jQuery.extend(Drupal.settings,"
+        if (settings_start := response.text.find(settings_marker)) == -1:
+            return None
+        data_start = response.text.find("{", settings_start)
+        if data_start == -1:
+            return None
+
+        settings, _ = json.JSONDecoder().raw_decode(response.text[data_start:])
+        return settings.get("dnb_contacts")
+
+    def clean_branch(self, branch: str | None) -> str | None:
+        if not branch:
+            return None
+        return branch.split("|", 1)[0].strip()
+
+    def get_city(self, location: dict[str, Any], contacts: dict[str, Any]) -> str | None:
+        town = location.get("town", {})
+        towns = contacts.get("towns_tree") or contacts.get("towns") or {}
+        county = self.get_town(towns, town.get("county"))
+        if not county:
+            return None
+        if child := self.get_town(county.get("children", []), town.get("town")):
+            return child.get("name")
+        return None
+
+    def get_town(self, towns: Any, town_id: Any) -> dict[str, Any] | None:
+        if town_id is None:
+            return None
+        if isinstance(towns, dict):
+            return towns.get(str(town_id)) or towns.get(town_id)
+        if isinstance(towns, list):
+            for town in towns:
+                if str(town.get("id")) == str(town_id):
+                    return town
+        return None


### PR DESCRIPTION
Adds **Luminor Bank** in Latvia ([Q28966957](https://www.wikidata.org/wiki/Q28966957)), 6 branches + 132 ATMs, from the same Drupal `dnb_contacts` map data as the merged `luminor_lt`.

### Source
`https://www.luminor.lv/lv/musu-tikls` (local-language network page); locations are embedded in `Drupal.settings` → `dnb_contacts.map_objects`. Cloudflare serves a JS challenge to datacenter IPs (incl. `robots.txt`), so `requires_proxy = True` and `ROBOTSTXT_OBEY = False` (as in `luminor_lt`).

### Modelling
- `object_type` 74 → branch (`amenity=bank`); these also carry ATM types (70/71) → `atm=yes` (one item, not a duplicate ATM node). Everything else → standalone `amenity=atm`.

### Sample
```json
[
  {"type":"Feature",
"properties":{
"ref":"11721",
"amenity":"bank",
"name":"Luminor Bank",
"branch":"KLIENTU APKALPOŠANAS CENTRS \"DAUGAVPILS\"",
"atm":"yes",
"addr:street_address":"Cietokšņa iela 48",
"addr:city":"Daugavpils",
"brand":"Luminor Bank",
"brand:wikidata":"Q28966957"},
"geometry":{"type":"Point","coordinates":[26.5194987,55.8716992]}},

  {"type":"Feature",
"properties":{
"ref":"11720",
"amenity":"atm",
"branch":"RIMI DAUGAVPILS",
"addr:street_address":"18.novembra iela 136",
"addr:city":"Daugavpils",
"brand":"Luminor Bank",
"brand:wikidata":"Q28966957"},
"geometry":{"type":"Point","coordinates":[26.5511134,55.876953]}}
]
```
Json stats
```
{"item_scraped_count": 138, 
"atp/category/amenity/bank": 6, 
"atp/category/amenity/atm": 132, 
"atp/nsi/match_perfect": 138, 
"atp/field/country/from_spider_name": 138, 
"finish_reason": "finished"}
```