### PR TITLE
[Karwei NL] Fix Spider

### DIFF
--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -5,6 +5,7 @@ from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
+
 class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "karwei_nl"
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -11,4 +11,3 @@ class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
     wanted_types = ["HardwareStore"]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
-    requires_proxy = True

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -3,7 +3,6 @@ from scrapy.spiders import SitemapSpider
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
@@ -11,4 +10,5 @@ class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
     wanted_types = ["HardwareStore"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS 
+    requires_proxy = True

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -3,11 +3,11 @@ from scrapy.spiders import SitemapSpider
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
-
+from locations.user_agents import BROWSER_DEFAULT
 
 class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "karwei_nl"
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
     wanted_types = ["HardwareStore"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -9,5 +9,6 @@ class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "karwei_nl"
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
+    sitemap_rules = [("", "parse_sd")]
     wanted_types = ["HardwareStore"]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -1,10 +1,13 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class KarweiNLSpider(SitemapSpider, StructuredDataSpider):
+class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     name = "karwei_nl"
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
     wanted_types = ["HardwareStore"]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS

--- a/locations/spiders/karwei_nl.py
+++ b/locations/spiders/karwei_nl.py
@@ -10,5 +10,5 @@ class KarweiNLSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     item_attributes = {"brand": "Karwei", "brand_wikidata": "Q2097480"}
     sitemap_urls = ["https://sitemap.karwei.nl/stores.xml"]
     wanted_types = ["HardwareStore"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS 
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
     requires_proxy = True


### PR DESCRIPTION
```python
{'atp/brand/Karwei': 128,
 'atp/brand_wikidata/Q2097480': 128,
 'atp/category/shop/doityourself': 128,
 'atp/country/NL': 128,
 'atp/field/branch/missing': 128,
 'atp/field/country/from_spider_name': 128,
 'atp/field/email/missing': 128,
 'atp/field/housenumber/missing': 128,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 128,
 'atp/field/operator_wikidata/missing': 128,
 'atp/field/state/missing': 128,
 'atp/field/street/missing': 128,
 'atp/field/twitter/missing': 128,
 'atp/field/unit/missing': 128,
 'atp/geometry/null_island': 1,
 'atp/item_scraped_host_count/www.karwei.nl': 128,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 128,
 'atp/nsi/match_imperfect': 128,
 'downloader/request_bytes': 50955,
 'downloader/request_count': 131,
 'downloader/request_method_count/GET': 131,
 'downloader/response_bytes': 5408073,
 'downloader/response_count': 131,
 'downloader/response_status_count/200': 130,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 186.375,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 28, 8, 24, 55, 77322, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 128,
 'items_per_minute': 41.29032258064516,
 'log_count/DEBUG': 5468,
 'log_count/INFO': 10,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 131,
 'playwright/page_count/closed': 131,
 'playwright/page_count/max_concurrent': 5,
 'playwright/request_count': 2521,
 'playwright/request_count/aborted': 2387,
 'playwright/request_count/method/GET': 2521,
 'playwright/request_count/navigation': 131,
 'playwright/request_count/resource_type/document': 131,
 'playwright/request_count/resource_type/font': 256,
 'playwright/request_count/resource_type/image': 1093,
 'playwright/request_count/resource_type/script': 913,
 'playwright/request_count/resource_type/stylesheet': 128,
 'playwright/response_count': 131,
 'playwright/response_count/method/GET': 131,
 'playwright/response_count/resource_type/document': 131,
 'request_depth_max': 1,
 'response_received_count': 131,
 'responses_per_minute': 42.25806451612903,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 129,
 'scheduler/dequeued/memory': 129,
 'scheduler/enqueued': 129,
 'scheduler/enqueued/memory': 129,
 'start_time': datetime.datetime(2026, 7, 28, 8, 21, 48, 703757, tzinfo=datetime.timezone.utc)}
```