### PR TITLE
[SpeeDee US] Fix spider

### DIFF
--- a/locations/spiders/speedee_us.py
+++ b/locations/spiders/speedee_us.py
@@ -1,17 +1,21 @@
-from typing import Iterable
+from typing import Any, Iterable
 
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class SpeedeeUSSpider(AgileStoreLocatorSpider):
+class SpeedeeUSSpider(SitemapSpider, StructuredDataSpider):
     name = "speedee_us"
     item_attributes = {"brand": "SpeeDee", "brand_wikidata": "Q120537032"}
-    allowed_domains = ["www.speedeeoil.com"]
+    sitemap_urls = ["https://www.speedeeoil.com/location-sitemap.xml"]
+    sitemap_rules = [(r"/locations/[a-z]{2}/[^/]+/[^/]+/$", "parse_sd")]
+    wanted_types = ["AutoRepair"]
 
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if " - #" in item["name"]:
-            item["name"], item["ref"] = item["name"].split(" - #", 1)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item.pop("name", None)
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION
- The site removed the Agile Store Locator plugin, so its ajax endpoint now returns an unknown-action response and the spider yielded zero features.
- Read the per-location pages' `AutoRepair` structured data from the location sitemap instead; the sitemap contains exactly 100 store pages and all 100 are captured.