### PR TITLE
[PUMB UA] Add spider

### DIFF
--- a/locations/spiders/pumb_ua.py
+++ b/locations/spiders/pumb_ua.py
@@ -1,0 +1,73 @@
+import re
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_WEEKDAY, OpeningHours
+
+HOURS_RANGE = re.compile(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$")
+
+
+class PumbUASpider(Spider):
+    name = "pumb_ua"
+    item_attributes = {"brand": "ПУМБ", "brand_wikidata": "Q4341156"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url="https://about.pumb.ua/home/getbankomats")
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json()["bankomats"]:
+            if location.get("IsBankomatRadius"):
+                continue  # shared "Radius" network ATMs operated by other banks, not PUMB
+            if not self.valid_coordinates(location):
+                continue  # a few feed rows have malformed Lat/Lng (e.g. "30.220-8", "51.510648, ")
+            # DictParser maps Id->ref, Title->name, Lat/Lng->lat/lon, Address->addr_full, CityName->city
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full", None)  # "Address" is a street + house-number line
+            if location.get("IsBranch"):
+                item["branch"] = self.clean_branch(item.pop("name"))  # location label, brand stripped
+                item["opening_hours"] = self.parse_hours(location.get("WorkTimeFull"))
+                apply_category(Categories.BANK, item)
+            elif location.get("IsBankomatPumb"):
+                item.pop("name", None)  # Title is the bank's legal name, not a location label
+                apply_category(Categories.ATM, item)
+            elif location.get("IsPTKS"):
+                item.pop("name", None)  # Title is a generic "self-service terminal" label
+                apply_category({"amenity": "payment_terminal"}, item)
+            else:
+                continue  # points of sale / agent desks hosted in third-party shops, out of scope
+            yield item
+
+    @staticmethod
+    def valid_coordinates(location: dict[str, Any]) -> bool:
+        try:
+            lat, lon = float(location["Lat"]), float(location["Lng"])
+        except (KeyError, TypeError, ValueError):
+            return False
+        return -90 <= lat <= 90 and -180 <= lon <= 180 and (lat or lon)
+
+    @staticmethod
+    def clean_branch(title: str | None) -> str | None:
+        # Titles are "ВІДДІЛЕННЯ №N ПУМБ [ЕКСПРЕС] В М. <city>"; drop the embedded brand so branch holds
+        # the location-specific label only (NSI supplies name=ПУМБ), as DATA_FORMAT expects.
+        return re.sub(r"\s+ПУМБ(\s+ЕКСПРЕС)?\s+", " ", title).strip() if title else None
+
+    @staticmethod
+    def parse_hours(work_time_full: str | None) -> str | None:
+        # WorkTimeFull is "Mon-Fri | Sat | Sun | break | <cashier fields...>". The first three are the
+        # branch's own daily hours (a HH:MM-HH:MM range, or "вихідний"/blank when closed/unknown); the
+        # trailing cashier/break fields are inconsistent and ignored, so lunch breaks are not captured.
+        parts = [part.strip() for part in (work_time_full or "").split("|")]
+        if len(parts) < 3:
+            return None
+        hours = OpeningHours()
+        try:
+            for days, value in ((DAYS_WEEKDAY, parts[0]), (["Sa"], parts[1]), (["Su"], parts[2])):
+                if match := HOURS_RANGE.match(value):
+                    hours.add_days_range(days, match.group(1), match.group(2))
+        except ValueError:
+            return None
+        return hours.as_opening_hours() or None


### PR DESCRIPTION
Adds **PUMB / First Ukrainian International Bank** (ПУМБ, [Q4341156](https://www.wikidata.org/wiki/Q4341156)) — 204 branches, 454 ATMs, 358 self-service payment terminals.

### Source
`GET https://about.pumb.ua/home/getbankomats` returns the full map dataset (`bankomats` array) with coordinates, address and city.

### Scope / modelling
The feed mixes PUMB-owned points with a shared **"Radius" partner ATM network operated by other banks** (МТБ Банк, Полтава-Банк, …) and PUMB **agent points inside third-party shops**. Only PUMB-owned locations are emitted, by flag:
- `IsBranch` → `amenity=bank` (branch label → `branch`; NSI supplies `name=ПУМБ`)
- `IsBankomatPumb` → `amenity=atm` (Title is the bank's legal name, so no `name`; NSI's ATM entry has none)
- `IsPTKS` → `amenity=payment_terminal` (`name=ПУМБ` from NSI)
- `IsBankomatRadius` (partner ATMs) and `Точка Експрес`/`Точка продажу` agent points → **excluded**.

Address (`Address`) → `addr:street_address`, `CityName` → `addr:city`. Opening hours are present but in an ambiguous `WorkTimeFull` layout (weekday/weekend/cashier/break fields inconsistently interleaved), so they are not parsed to avoid unreliable data.

### Sample
```json
{
  "type": "Feature",
  "properties": {
    "ref": "7223",
    "amenity": "bank",
    "name": "ПУМБ",
    "branch": "ВІДДІЛЕННЯ №1 В М. КРОЛЕВЕЦЬ",
    "opening_hours": "Mo-Fr 09:00-18:00; Sa 09:00-14:00",
    "addr:street_address": "вул. Лесі Українки, 9",
    "addr:city": "Кролевець",
    "brand": "ПУМБ",
    "brand:wikidata": "Q4341156"
  },
  "geometry": { "type": "Point", "coordinates": [33.380071, 51.551755] }
}
```
stats
```
{
  "item_scraped_count": 1009,
  "atp/category/amenity/bank": 203,
  "atp/category/amenity/atm": 453,
  "atp/category/amenity/payment_terminal": 353,
  "atp/nsi/match_perfect": 1009,
  "atp/field/country/from_spider_name": 1009,
  "finish_reason": "finished"
}
```