### PR TITLE
[State Farm US] Fix spider

### DIFF
--- a/locations/spiders/state_farm_us.py
+++ b/locations/spiders/state_farm_us.py
@@ -15,6 +15,7 @@ class StateFarmUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.statefarm.com/sitemap-agents.xml"]
     sitemap_rules = [(r"/agent/us/\w\w/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["InsuranceAgency"]
+    requires_proxy = True
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
         "DOWNLOAD_DELAY": 2,

--- a/locations/spiders/state_farm_us.py
+++ b/locations/spiders/state_farm_us.py
@@ -26,6 +26,7 @@ class StateFarmUSSpider(SitemapSpider, StructuredDataSpider):
     }
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["name"] = item["image"] = None
         item["ref"] = response.url.rsplit("/", 1)[1]
         apply_category(Categories.OFFICE_INSURANCE, item)
         yield item

--- a/locations/spiders/state_farm_us.py
+++ b/locations/spiders/state_farm_us.py
@@ -1,7 +1,9 @@
-from copy import deepcopy
+from typing import Any, Iterable
 
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
@@ -12,7 +14,7 @@ class StateFarmUSSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "State Farm", "brand_wikidata": "Q2007336", "country": "US"}
     sitemap_urls = ["https://www.statefarm.com/sitemap-agents.xml"]
     sitemap_rules = [(r"/agent/us/\w\w/[^/]+/[^/]+$", "parse_sd")]
-    wanted_types = ["WebSite"]
+    wanted_types = ["InsuranceAgency"]
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
         "DOWNLOAD_DELAY": 2,
@@ -22,16 +24,7 @@ class StateFarmUSSpider(SitemapSpider, StructuredDataSpider):
         },
     }
 
-    def post_process_item(self, item: Feature, response, ld_data, **kwargs):
-        mainEntity = ld_data.get("mainEntity")
-        for office in mainEntity.get("geo", []):
-            # It can be more than one office for a single agent
-            item = deepcopy(item)
-            item["ref"] = item["ref"] + "-" + office.get("address", {}).get("postalCode")
-            item["lat"] = office.get("latitude")
-            item["lon"] = office.get("longitude")
-            item["city"] = office.get("address", {}).get("addressLocality")
-            item["state"] = office.get("address", {}).get("addressRegion")
-            item["postcode"] = office.get("address", {}).get("postalCode")
-            item["street_address"] = office.get("address", {}).get("streetAddress")
-            yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["ref"] = response.url.rsplit("/", 1)[1]
+        apply_category(Categories.OFFICE_INSURANCE, item)
+        yield item


### PR DESCRIPTION
- Agent pages no longer wrap their data in a `WebSite` node with a `mainEntity` geo list; they now expose a direct `InsuranceAgency` node, so the spider matched nothing and returned zero features.
- Match `InsuranceAgency` instead, take the agent code from the URL as the ref, and set the insurance-office category.