### PR TITLE
[Nandos MY] Fix spider

### DIFF
--- a/locations/spiders/nandos_my.py
+++ b/locations/spiders/nandos_my.py
@@ -1,32 +1,64 @@
-import re
+from typing import Any, Iterable
 
-from scrapy.spiders import SitemapSpider
+from scrapy import Request
+from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
+from locations.google_url import url_to_coords
+from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
 
 
-class NandosMYSpider(SitemapSpider):
+class NandosMYSpider(JSONBlobSpider):
     name = "nandos_my"
     item_attributes = NANDOS_SHARED_ATTRIBUTES
-    allowed_domains = ["nandos.com.my"]
-    sitemap_urls = ["https://nandos.com.my/wp-sitemap.xml"]
-    sitemap_follow = ["restaurants"]
-    sitemap_rules = [("/restaurants/", "parse_store")]
+    start_urls = ["https://nandos.com.my/restaurants/__data.json"]
 
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-        restaurant_data = response.xpath(
-            '//div[@class="restaurant-details-wrapper"]/script[contains(text(),"var restaurant")]'
-        ).extract_first()
-        lat, lon = re.search(r"var restaurant = {.*: (.*), .*: (.*)}", restaurant_data).groups()
+    def extract_json(self, response: Response) -> list[dict]:
+        features = []
+        for node in response.json()["nodes"]:
+            if not node or "data" not in node:
+                continue
+            root = self.resolve(node["data"], 0)
+            for group in (root or {}).get("restaurantsByState") or []:
+                features.extend(group["restaurants"])
+        return features
 
-        properties = {
-            "ref": ref,
-            "country": "MY",
-            "lat": lat,
-            "lon": lon,
-            "website": response.url,
-        }
+    def resolve(self, data: list, index: Any) -> Any:
+        """Resolve a value from a SvelteKit "devalue" indexed payload."""
+        if not isinstance(index, int) or not 0 <= index < len(data):
+            return None
+        value = data[index]
+        if isinstance(value, dict):
+            return {key: self.resolve(data, i) for key, i in value.items()}
+        if isinstance(value, list):
+            return [self.resolve(data, i) for i in value]
+        return value
 
-        yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request | Feature]:
+        item["branch"] = item.pop("name")
+        item["phone"] = feature.get("storeContactNumber")
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(
+            (feature.get("storeOpeningHours") or "").replace("Everyday", "Mo-Su")
+        )
+        apply_category(Categories.RESTAURANT, item)
+        if maps_url := feature.get("googleMapsUrl"):
+            yield Request(
+                url=maps_url,
+                meta={"item": item, "dont_redirect": True, "handle_httpstatus_list": [301, 302]},
+                callback=self.parse_coordinates,
+                dont_filter=True,
+            )
+        else:
+            yield item
+
+    def parse_coordinates(self, response: Response) -> Iterable[Feature]:
+        item = response.meta["item"]
+        if location := response.headers.get("Location"):
+            coordinates = url_to_coords(location.decode())
+            if coordinates != (None, None):
+                item["lat"], item["lon"] = coordinates
+        yield item


### PR DESCRIPTION
- Site rebuilt on SvelteKit; the old WordPress sitemap 404s.
- Parse `/restaurants/__data.json` instead; coords resolved from each store's Google Maps short link (76 stores).