### PR TITLE
[Nandos SG] Fix spider

### DIFF
--- a/locations/spiders/nandos_my.py
+++ b/locations/spiders/nandos_my.py
@@ -1,32 +1,64 @@
-import re
+from typing import Any, Iterable
 
-from scrapy.spiders import SitemapSpider
+from scrapy import Request
+from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
+from locations.google_url import url_to_coords
+from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
 
 
-class NandosMYSpider(SitemapSpider):
+class NandosMYSpider(JSONBlobSpider):
     name = "nandos_my"
     item_attributes = NANDOS_SHARED_ATTRIBUTES
-    allowed_domains = ["nandos.com.my"]
-    sitemap_urls = ["https://nandos.com.my/wp-sitemap.xml"]
-    sitemap_follow = ["restaurants"]
-    sitemap_rules = [("/restaurants/", "parse_store")]
+    start_urls = ["https://nandos.com.my/restaurants/__data.json"]
 
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-        restaurant_data = response.xpath(
-            '//div[@class="restaurant-details-wrapper"]/script[contains(text(),"var restaurant")]'
-        ).extract_first()
-        lat, lon = re.search(r"var restaurant = {.*: (.*), .*: (.*)}", restaurant_data).groups()
+    def extract_json(self, response: Response) -> list[dict]:
+        features = []
+        for node in response.json()["nodes"]:
+            if not node or "data" not in node:
+                continue
+            root = self.resolve(node["data"], 0)
+            for group in (root or {}).get("restaurantsByState") or []:
+                features.extend(group["restaurants"])
+        return features
 
-        properties = {
-            "ref": ref,
-            "country": "MY",
-            "lat": lat,
-            "lon": lon,
-            "website": response.url,
-        }
+    def resolve(self, data: list, index: Any) -> Any:
+        """Resolve a value from a SvelteKit "devalue" indexed payload."""
+        if not isinstance(index, int) or not 0 <= index < len(data):
+            return None
+        value = data[index]
+        if isinstance(value, dict):
+            return {key: self.resolve(data, i) for key, i in value.items()}
+        if isinstance(value, list):
+            return [self.resolve(data, i) for i in value]
+        return value
 
-        yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request | Feature]:
+        item["branch"] = item.pop("name")
+        item["phone"] = feature.get("storeContactNumber")
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(
+            (feature.get("storeOpeningHours") or "").replace("Everyday", "Mo-Su")
+        )
+        apply_category(Categories.RESTAURANT, item)
+        if maps_url := feature.get("googleMapsUrl"):
+            yield Request(
+                url=maps_url,
+                meta={"item": item, "dont_redirect": True, "handle_httpstatus_list": [301, 302]},
+                callback=self.parse_coordinates,
+                dont_filter=True,
+            )
+        else:
+            yield item
+
+    def parse_coordinates(self, response: Response) -> Iterable[Feature]:
+        item = response.meta["item"]
+        if location := response.headers.get("Location"):
+            coordinates = url_to_coords(location.decode())
+            if coordinates != (None, None):
+                item["lat"], item["lon"] = coordinates
+        yield item

--- a/locations/spiders/nandos_sg.py
+++ b/locations/spiders/nandos_sg.py
@@ -1,40 +1,8 @@
-import re
-from typing import Any
-
-import scrapy
-from scrapy.http import Response
-
-from locations.items import Feature
 from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
+from locations.spiders.nandos_my import NandosMYSpider
 
 
-class NandosSGSpider(scrapy.Spider):
+class NandosSGSpider(NandosMYSpider):
     name = "nandos_sg"
-    item_attributes = NANDOS_SHARED_ATTRIBUTES
-    allowed_domains = ["nandos.com.sg"]
-    start_urls = ["https://www.nandos.com.sg/restaurants/"]
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        urls = response.xpath('//div[@class="restaurant col-xs-12 col-sm-6 col-md-4"]/a/@href').extract()
-
-        for url in urls:
-            yield scrapy.Request(url=url, callback=self.parse_store)
-
-    def parse_store(self, response):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-        restaurant_data = response.xpath(
-            '//div[@class="restaurant-details-wrapper"]/script[contains(text(),"var restaurant")]'
-        ).extract_first()
-        lat, lon = re.search(r"var restaurant = {.*: (.*), .*: (.*)}", restaurant_data).groups()
-
-        properties = {
-            "ref": ref,
-            "name": response.xpath('//div[@class="promo-pane-title"]/h2/text()').extract_first(),
-            "addr_full": response.xpath('//div[@class="copy"]/h5/text()').extract_first(),
-            "country": "SG",
-            "lat": lat,
-            "lon": lon,
-            "website": response.url,
-        }
-
-        yield Feature(**properties)
+    item_attributes = NANDOS_SHARED_ATTRIBUTES | {"country": "SG"}
+    start_urls = ["https://www.nandos.com.sg/restaurants/__data.json"]


### PR DESCRIPTION
- Site rebuilt on SvelteKit like nandos.com.my; the old HTML parse finds nothing.
- Reuse `NandosMYSpider` against the SG site's `__data.json` (6 stores).

Note: stacks on #17568.