### PR TITLE
[OTP banka SI] Add spider

### DIFF
--- a/locations/spiders/otp_banka_si.py
+++ b/locations/spiders/otp_banka_si.py
@@ -21,7 +21,7 @@ class OtpBankaSISpider(Spider):
             # DictParser maps id->ref, title->name, address->addr_full, zip->postcode, city, lat/lng->lat/lon
             item = DictParser.parse(office)
             item["street_address"] = item.pop("addr_full", None)
-            item["branch"] = item.pop("name")  # "POSLOVALNICA <city>" label
+            item["branch"] = item.pop("name").removeprefix("POSLOVALNICA ")
             apply_category(Categories.BANK, item)
             yield item
         for atm in data["atms"]:

--- a/locations/spiders/otp_banka_si.py
+++ b/locations/spiders/otp_banka_si.py
@@ -1,0 +1,34 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class OtpBankaSISpider(Spider):
+    name = "otp_banka_si"
+    item_attributes = {"brand": "OTP banka", "brand_wikidata": "Q140373875"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url="https://www.otpbanka.si/jsonatmsoffices.ashx?localeid=sl-SI")
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        data = response.json()
+        # "pbsoffices" are Pošta Slovenije post offices (partner banking), not OTP branches -> skipped.
+        for office in data["nkbmoffices"]:
+            # DictParser maps id->ref, title->name, address->addr_full, zip->postcode, city, lat/lng->lat/lon
+            item = DictParser.parse(office)
+            item["street_address"] = item.pop("addr_full", None)
+            item["branch"] = item.pop("name")  # "POSLOVALNICA <city>" label
+            apply_category(Categories.BANK, item)
+            yield item
+        for atm in data["atms"]:
+            item = DictParser.parse(atm)  # standalone ATM keeps the host-venue title as name
+            item["street_address"] = item.pop("addr_full", None)
+            properties = atm.get("properties") or ""  # e.g. "rfid,automaticdeposit"
+            apply_yes_no(Extras.CASH_IN, item, "automaticdeposit" in properties)
+            apply_yes_no(PaymentMethods.CONTACTLESS, item, "rfid" in properties)
+            apply_category(Categories.ATM, item)
+            yield item


### PR DESCRIPTION
Adds **OTP banka** (Slovenia, [Q140373875](https://www.wikidata.org/wiki/Q140373875)), 69 branches + 386 ATM, from `https://www.otpbanka.si/jsonatmsoffices.ashx?localeid=sl-SI`.

### Scope / modelling
The feed returns several arrays; only OTP-owned ones are emitted:
- `nkbmoffices` → `amenity=bank` (branch label `POSLOVALNICA …` → `branch`; `name` from NSI).
- `atms` → `amenity=atm` (host-venue title kept as `name`; `automaticdeposit` → `cash_in=yes`).
- `pbsoffices` (Pošta Slovenije post offices / partner banking) and the empty `atmsskb`/`atmsabanka` (other banks) are excluded.

The feed exposes no phone, email, opening hours, or per-branch ATM flag (verified across all fields); ATM properties flags are mapped to cash_in (automaticdeposit) and payment:contactless (rfid).

### NSI
The brand was just added to NSI (`otpbanka-30392e`, `amenity=bank`, `si`); the `amenity=atm` counterpart is auto-generated. Until ATP's bundled `nsi.json` syncs, the run reports `match_failed`, after which branches gain `name="OTP banka"` and ATMs gain `operator="OTP banka"`.

json stats
```
{
  "item_scraped_count": 455,
  "atp/category/amenity/bank": 69,
  "atp/category/amenity/atm": 386,
  "atp/field/country/from_spider_name": 455
}
```
### Sample
```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "nkbmoffice_1258",
      "amenity": "bank",
      "branch": "POSLOVALNICA AJDOVŠČINA",
      "addr:street_address": "Goriška cesta 25",
      "addr:city": "Ajdovščina",
      "addr:postcode": "5270",
      "addr:country": "SI",
      "brand": "OTP banka",
      "brand:wikidata": "Q140373875"
    },
    "geometry": { "type": "Point", "coordinates": [13.9061869, 45.8865464] }
  },
  {
  "type": "Feature",
  "properties": {
    "ref": "atm_17725",
    "amenity": "atm",
    "name": "Poslovalnica Ajdovščina 1",
    "cash_in": "yes",
    "payment:contactless": "yes",
    "addr:street_address": "Goriška cesta 25",
    "addr:city": "Ajdovščina",
    "addr:postcode": "5270",
    "addr:country": "SI",
    "brand": "OTP banka",
    "brand:wikidata": "Q140373875"
  },
  "geometry": { "type": "Point", "coordinates": [13.906117, 45.886484] }
},
  {
    "type": "Feature",
    "properties": {
      "ref": "atm_17727",
      "amenity": "atm",
      "name": "Drogerija Trošt",
      "addr:street_address": "Tovarniška cesta 4a",
      "addr:city": "Ajdovščina",
      "addr:postcode": "5270",
      "addr:country": "SI",
      "brand": "OTP banka",
      "brand:wikidata": "Q140373875"
    },
    "geometry": { "type": "Point", "coordinates": [13.906052, 45.886997] }
  }
]
```