### PR TITLE
[Montepio PT] Add spider

### DIFF
--- a/locations/spiders/montepio_pt.py
+++ b/locations/spiders/montepio_pt.py
@@ -1,0 +1,76 @@
+import re
+from typing import Any
+from urllib.parse import unquote
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.hours import DAYS_WEEKDAY, OpeningHours
+from locations.items import Feature
+
+TIME_RANGE = re.compile(r"(\d{1,2})h(\d{2})\s*-\s*(\d{1,2})h(\d{2})")
+POSTCODE = re.compile(r"^(\d{4}-\d{3})\s+(.+)$")
+
+
+class MontepioPTSpider(Spider):
+    name = "montepio_pt"
+    item_attributes = {"brand": "Montepio", "brand_wikidata": "Q1946091"}
+    start_urls = ["https://www.bancomontepio.pt/onde-estamos"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for card in response.xpath('//*[@id="map__tabpanel--atms"]//div[@data-latitude]'):
+            item = self.parse_card(card)  # standalone ATM keeps the host-venue title as name
+            apply_category(Categories.ATM, item)
+            yield item
+
+        # balcoes + business/social centres are branches; "atms" is handled above and the foreign
+        # "banco-montepio-no-mundo" offices are out of scope for a PT spider.
+        for section in ("balcoes", "centros-economia-social", "centros-empresas"):
+            for card in response.xpath('//*[@id="map__tabpanel--{}"]//div[@data-latitude]'.format(section)):
+                item = self.parse_card(card)
+                item["branch"] = item.pop("name")  # NSI supplies name=Montepio
+                if phone := card.xpath('.//a[starts-with(@href, "tel:")]/@href').get():
+                    item["phone"] = unquote(phone.removeprefix("tel:"))  # href is percent-encoded
+                if email := card.xpath('.//a[starts-with(@href, "mailto:")]/@href').get():
+                    item["email"] = email.removeprefix("mailto:")
+                item["opening_hours"] = self.parse_hours(card)
+                services = " ".join(card.xpath(".//text()").getall())
+                apply_yes_no(Extras.ATM, item, "ATM" in services or "Chave24" in services)
+                apply_category(Categories.BANK, item)
+                yield item
+
+    def parse_card(self, card: Any) -> Feature:
+        lat = card.xpath("@data-latitude").get()
+        lon = card.xpath("@data-longitude").get()
+        name = card.xpath('normalize-space(.//*[contains(@class, "detailed-card__title")])').get()
+        item = Feature(ref="/".join([lat, lon, name or ""]), lat=lat, lon=lon, name=name)
+        # Address is two lines: "<street, number>" then "<postcode> <city>" (Portuguese NNNN-NNN).
+        address = [
+            t.strip()
+            for t in card.xpath('.//*[contains(@class, "detailed-card__address")]//text()').getall()
+            if t.strip()
+        ]
+        if len(address) >= 2:
+            item["street_address"] = address[0]
+            if match := POSTCODE.match(address[1]):
+                item["postcode"], item["city"] = match.groups()
+            else:
+                item["city"] = address[1]
+        elif address:
+            item["addr_full"] = address[0]
+        return item
+
+    @staticmethod
+    def parse_hours(card: Any) -> str | None:
+        # "Horário Dias úteis: 08h30 - 15h00" (weekdays); a trailing "por agendamento" (by appointment)
+        # range is ignored by taking the first time range only.
+        text = " ".join(card.xpath('.//*[contains(@class, "detailed-card__schedule")]//text()').getall())
+        if not (match := TIME_RANGE.search(text)):
+            return None
+        try:
+            hours = OpeningHours()
+            hours.add_days_range(DAYS_WEEKDAY, "{}:{}".format(match[1], match[2]), "{}:{}".format(match[3], match[4]))
+            return hours.as_opening_hours()
+        except ValueError:
+            return None


### PR DESCRIPTION
Adds **Montepio** (Portugal, [Q1946091](https://www.wikidata.org/wiki/Q1946091)), 250 branches + 357 ATMs, from the server-rendered cards on `https://www.bancomontepio.pt/onde-estamos`.

### Modelling
The page groups cards into tab-panels by `@id`:
- `map__tabpanel--balcoes` + `--centros-economia-social` + `--centros-empresas` → `amenity=bank` (branch label → `branch`; NSI supplies `name=Montepio`). Per-branch `phone`, `email`, `opening_hours` (weekday `Horário`), and `atm=yes` where the card lists an on-site ATM/Chave24.
- `map__tabpanel--atms` → `amenity=atm` (host-venue title kept as `name`).
- `map__tabpanel--banco-montepio-no-mundo` (8 foreign representative offices) is excluded, a PT spider would mis-tag them.

Address is two lines (`<street>` / `<postcode> <city>`, Portuguese `NNNN-NNN`). `tel:` hrefs are percent-encoded and are decoded.

### Sample
```json
[
  {
    "type": "Feature",
    "properties": {
      "ref": "38.7117734/-9.1390023/Lisboa - Rua do Ouro",
      "amenity": "bank",
      "name": "Montepio",
      "branch": "Lisboa - Rua do Ouro",
      "atm": "yes",
      "phone": "+351 21 324 8200",
      "email": "mg000@bancomontepio.pt",
      "opening_hours": "Mo-Fr 08:30-15:00",
      "addr:street_address": "Rua Áurea, 219 - 241",
      "addr:postcode": "1100-062",
      "addr:city": "Lisboa",
      "addr:country": "PT",
      "brand": "Montepio",
      "brand:wikidata": "Q1946091"
    },
    "geometry": { "type": "Point", "coordinates": [-9.1390023, 38.7117734] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "38.75676/-9.26203/Sintra - Papelaria Golfinho Colorido",
      "amenity": "atm",
      "name": "Sintra - Papelaria Golfinho Colorido",
      "addr:street_address": "Rua Timor, 4 - 6",
      "addr:postcode": "2745-225",
      "addr:city": "Queluz",
      "addr:country": "PT",
      "brand": "Montepio",
      "brand:wikidata": "Q1946091"
    },
    "geometry": { "type": "Point", "coordinates": [-9.26203, 38.75676] }
  }
]
```
stats
```{
  "item_scraped_count": 607,
  "atp/category/amenity/bank": 250,
  "atp/category/amenity/atm": 357,
  "atp/nsi/match_perfect": 607,
  "atp/field/country/from_spider_name": 607
}