### PR TITLE
[USC] Fix spider

### DIFF
--- a/locations/spiders/usc.py
+++ b/locations/spiders/usc.py
@@ -1,25 +1,69 @@
-from typing import Any
+import re
+from typing import AsyncIterator, Iterable
 
-from scrapy.http import Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.http import JsonRequest, Response
 
-from locations.linked_data_parser import LinkedDataParser
-from locations.microdata_parser import MicrodataParser
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class UscSpider(CrawlSpider):
+class UscSpider(JSONBlobSpider):
     name = "usc"
     item_attributes = {"brand": "USC", "brand_wikidata": "Q7866331"}
-    allowed_domains = ["www.usc.co.uk"]
-    start_urls = ["https://www.usc.co.uk/stores/all"]
-    rules = [Rule(LinkExtractor(allow=".*-store-.*"), callback="parse", follow=False)]
+    locations_key = ["data", "getStoresByLocation"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        MicrodataParser.convert_to_json_ld(response)
-        if item := LinkedDataParser.parse(response, "LocalBusiness"):
-            item["name"] = "USC"
-            item["ref"] = response.url
-            item["lat"] = response.xpath("//@data-latitude").get()
-            item["lon"] = response.xpath("//@data-longitude").get()
-            yield item
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        graphql_query = """
+        query getStoresByLocation($countryCode: String!, $distanceUnit: DistanceUnit!, $latitude: String!, $longitude: String!, $maxDistance: Int!, $storeKey: String!) {
+          getStoresByLocation(
+            countryCode: $countryCode
+            distanceUnit: $distanceUnit
+            latitude: $latitude
+            longitude: $longitude
+            maxDistance: $maxDistance
+            storeKey: $storeKey
+          ) {
+            address { country countryCode postCode town address }
+            code
+            latitude
+            longitude
+            name
+            openingHours { day openingTime closingTime }
+            phoneNumber
+          }
+        }
+        """
+
+        for country_code, latitude, longitude in [("GB", "54.5", "-3.0"), ("IE", "53.3", "-7.7")]:
+            yield JsonRequest(
+                url="https://api-prem.prd.frasersgroup.services/graphql?op=getStoresByLocation",
+                method="POST",
+                data={
+                    "query": graphql_query,
+                    "variables": {
+                        "countryCode": country_code,
+                        "distanceUnit": "Miles",
+                        "latitude": latitude,
+                        "longitude": longitude,
+                        "maxDistance": 500,
+                        "storeKey": "USC",
+                    },
+                },
+            )
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["code"]
+        # Names carry a suffix for the hosting store estate, e.g. "Carlisle DW".
+        item["branch"] = re.sub(r" (?:SD|DW|FRA|HE)$", "", item.pop("name", ""))
+        item["phone"] = feature.get("phoneNumber")
+        if address := feature.get("address"):
+            item["street_address"] = address.get("address")
+
+        item["opening_hours"] = OpeningHours()
+        for rule in feature.get("openingHours") or []:
+            item["opening_hours"].add_range(DAYS[int(rule["day"])], rule["openingTime"], rule["closingTime"])
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
- Site rebuilt on the Frasers Group platform; the old `/stores/all` page 404s.
- Query the group's GraphQL store API instead, adding IE coverage (220 stores GB+IE).