### PR TITLE
[Strack & Van Til US] Fix spider

### DIFF
--- a/locations/spiders/strack_and_van_til_us.py
+++ b/locations/spiders/strack_and_van_til_us.py
@@ -1,18 +1,28 @@
-from locations.storefinders.store_locator_plus_self import StoreLocatorPlusSelfSpider
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class StrackAndVanTilUSSpider(StoreLocatorPlusSelfSpider):
+class StrackAndVanTilUSSpider(JSONBlobSpider):
     name = "strack_and_van_til_us"
-    item_attributes = {
-        "brand_wikidata": "Q17108969",
-        "brand": "Strack & Van Til",
-    }
-    allowed_domains = ["strackandvantil.com"]
-    iseadgg_countries_list = ["US"]
-    search_radius = 500
-    max_results = 100
+    item_attributes = {"brand": "Strack & Van Til", "brand_wikidata": "Q17108969"}
+    start_urls = ["https://www.strackandvantil.com/wp-content/themes/svt/svt-ajax.php?action=get_locations"]
 
-    def parse_item(self, item, location):
-        if branch_name := item.pop("name", None):
-            item["branch"] = branch_name
+    def pre_process_data(self, feature: dict) -> None:
+        feature.pop("email", None)
+        feature.pop("webUrl", None)
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["uniqueName"]
+        item["branch"] = item.pop("name")
+        item["street_address"] = item.pop("street", None)
+        item["opening_hours"] = OpeningHours()
+        for rule in feature.get("operatingHours") or []:
+            item["opening_hours"].add_ranges_from_string(f"{rule['day']}: {rule['hours']}")
+        apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item

--- a/locations/spiders/strack_and_van_til_us.py
+++ b/locations/spiders/strack_and_van_til_us.py
@@ -21,8 +21,12 @@ class StrackAndVanTilUSSpider(JSONBlobSpider):
         item["ref"] = feature["uniqueName"]
         item["branch"] = item.pop("name")
         item["street_address"] = item.pop("street", None)
+        item["website"] = "https://www.strackandvantil.com/location/?store={}".format(item["ref"])
+
         item["opening_hours"] = OpeningHours()
         for rule in feature.get("operatingHours") or []:
             item["opening_hours"].add_ranges_from_string(f"{rule['day']}: {rule['hours']}")
+
         apply_category(Categories.SHOP_SUPERMARKET, item)
+
         yield item


### PR DESCRIPTION
- Site dropped the Store Locator Plus plugin, so the spider finds nothing.
- Parse the theme's `get_locations` AJAX endpoint instead (22 stores).