### PR TITLE
[Luminor Bank EE] Add spider

### DIFF
--- a/locations/spiders/luminor_ee.py
+++ b/locations/spiders/luminor_ee.py
@@ -1,0 +1,100 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
+
+
+class LuminorEESpider(Spider):
+    name = "luminor_ee"
+    item_attributes = {"brand": "Luminor Bank", "brand_wikidata": "Q28966957"}
+    # luminor.ee is behind Cloudflare (403 to datacenter IPs); the /kontaktid contacts page is
+    # rendered client-side from this JSON document.
+    contacts_url = "https://luminor.ee/dc/render/v1/ee/page?alias=%2Fkontaktid&language=et"
+    requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url=self.contacts_url)
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        if not (contacts := self.extract_contacts(response)):
+            self.logger.error("Unable to find Luminor contacts data")
+            return
+
+        object_types = contacts["object_types"]  # {"36": {"type": "branch", ...}, "34": {"type": "atm", ...}}
+        towns = self.town_names(contacts.get("towns") or {})
+
+        for location in contacts["objects"]:
+            type_ids = location.get("object_types") or []
+            kinds = {object_types.get(str(type_id), {}).get("type") for type_id in type_ids}
+            if not kinds & {"branch", "atm"}:
+                continue
+
+            item = DictParser.parse(location)  # maps title->name, geolocation->lat/lon, address->addr_full
+            item["ref"] = item.get("name")  # feed has no id; the venue/branch title is unique across the dataset
+            item["street_address"] = item.pop("addr_full", None)
+            item["city"] = towns.get((location.get("town") or {}).get("town"))  # DictParser leaves the raw id dict
+
+            if "branch" in kinds:
+                item["branch"] = item.pop("name")  # NSI supplies name=Luminor Bank
+                apply_yes_no(Extras.ATM, item, "atm" in kinds)  # branches co-host ATMs; keep as one POI
+                item["opening_hours"] = self.parse_hours(location, self.types_of_kind(object_types, type_ids, "branch"))
+                apply_category(Categories.BANK, item)
+            else:
+                # A "raha sisse ja välja" (cash in and out) ATM is deposit-capable; "raha välja" is withdrawal only.
+                cash_in = any("sisse" in object_types.get(str(type_id), {}).get("title", "") for type_id in type_ids)
+                apply_yes_no(Extras.CASH_IN, item, cash_in)
+                item["opening_hours"] = self.parse_hours(location, self.types_of_kind(object_types, type_ids, "atm"))
+                apply_category(Categories.ATM, item)
+
+            yield item
+
+    @staticmethod
+    def extract_contacts(response: Response) -> dict[str, Any] | None:
+        for container in response.json().get("containers", []):
+            for widget in container.get("widgets", []):
+                contacts = (widget.get("widget_settings") or {}).get("contacts")
+                if isinstance(contacts, dict) and "objects" in contacts:
+                    return contacts
+        return None
+
+    @staticmethod
+    def types_of_kind(object_types: dict, type_ids: list, kind: str) -> list:
+        return [type_id for type_id in type_ids if object_types.get(str(type_id), {}).get("type") == kind]
+
+    @staticmethod
+    def town_names(towns: dict) -> dict:
+        names = {}
+        for county in towns.values():
+            names[county.get("id")] = county.get("name")
+            for child in county.get("children") or []:
+                names[child.get("id")] = child.get("name")
+        return names
+
+    def parse_hours(self, location: dict, type_ids: list) -> str | None:
+        working_time = location.get("working_time") or {}
+        hours = OpeningHours()
+        for type_id in type_ids:
+            for entry in working_time.get(str(type_id)) or []:
+                day, start, end = (
+                    (entry or {}).get("day"),
+                    (entry or {}).get("starthours"),
+                    (entry or {}).get("endhours"),
+                )
+                if day is None or start is None or end is None:
+                    continue
+                end = 2400 if end == 0 else end  # a midnight closing time is encoded as 0
+                try:
+                    hours.add_range(DAYS[day], self.as_time(start), self.as_time(end))
+                except (ValueError, IndexError):
+                    continue
+        return hours.as_opening_hours() or None
+
+    @staticmethod
+    def as_time(value: int) -> str:
+        hours, minutes = divmod(value, 100)
+        return "{:02d}:{:02d}".format(hours, minutes)


### PR DESCRIPTION
luminor_ee: Luminor Bank Estonia (Q28966957), the Estonian sibling to the existing luminor_lt. Both share the same brand/wikidata and NSI entry (locationSet covers ee/lt/lv, bank + auto-generated ATM).

Source: the /kontaktid contacts page is rendered client-side from a single JSON document (https://luminor.ee/dc/render/v1/ee/page?alias=%2Fkontaktid&language=et). luminor.ee sits behind Cloudflare (403 to datacenter IPs), so requires_proxy = True + ROBOTSTXT_OBEY = False, same as luminor_lt.

Modelling

- 94 POIs = 3 amenity=bank + 91 amenity=atm.
- Locations carry an object_types list mapped via the feed's own taxonomy (type: branch/atm).
- Branches (Pangakontor) co-host ATMs → emitted as a single bank POI with atm=yes (no duplicate ATM POI). branch = source title; NSI supplies name=Luminor Bank.
- Standalone ATMs keep their host-venue display label as name. cash_in=yes when the ATM is "raha sisse ja välja" (deposit-capable, 52) vs withdrawal-only (39).
- DictParser maps title→name, nested geolocation→lat/lon, address→addr_full; only city (a {county,town} id dict) is resolved from the feed's towns tree.
- Opening hours parsed from working_time (day 0=Mo…6=Su; a 0 closing time = end-of-day → 24:00).

Sample POIs
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "Kristiine kontor",
      "amenity": "bank",
      "name": "Luminor Bank",
      "branch": "Kristiine kontor",
      "atm": "yes",
      "opening_hours": "Mo-Fr 10:00-18:00",
      "addr:street_address": "Endla 45",
      "addr:city": "Tallinn",
      "addr:country": "EE",
      "brand": "Luminor Bank",
      "brand:wikidata": "Q28966957",
      "nsi_id": "luminorbank-3ce14c"
    },
    "geometry": { "type": "Point", "coordinates": [24.72455, 59.42708] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "Arsenali keskus",
      "amenity": "atm",
      "name": "Arsenali keskus",
      "cash_in": "yes",
      "opening_hours": "Mo-Su 10:00-20:00",
      "addr:street_address": "Erika 14",
      "addr:city": "Tallinn",
      "addr:country": "EE",
      "brand": "Luminor Bank",
      "brand:wikidata": "Q28966957",
      "operator": "Luminor Bank",
      "operator:wikidata": "Q28966957",
      "nsi_id": "luminorbank-82bd77"
    },
    "geometry": { "type": "Point", "coordinates": [24.7173716, 59.4512135] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "Aardla Selver",
      "amenity": "atm",
      "name": "Aardla Selver",
      "opening_hours": "Mo-Su 09:00-22:00",
      "addr:street_address": "Võru 77",
      "addr:city": "Tartu",
      "addr:country": "EE",
      "brand": "Luminor Bank",
      "brand:wikidata": "Q28966957",
      "operator": "Luminor Bank",
      "operator:wikidata": "Q28966957",
      "nsi_id": "luminorbank-82bd77"
    },
    "geometry": { "type": "Point", "coordinates": [26.721409524724, 58.357383810114] }
  }
]
```
Json stats
```{
  "features": 94,
  "amenity=bank": 3,
  "amenity=atm": 91,
  "atm cash_in=yes": 52,
  "matched to NSI (nsi_id set)": 94,
  "operator set (ATMs)": 91,
  "with opening_hours": 94,
  "with addr:city": 94,
  "with addr:country": 94,
  "with addr:street_address": 94,
  "duplicate refs": 0
}
```