### PR TITLE
[New Seasons Market US] Fix Spider

### DIFF
--- a/locations/spiders/new_seasons_market_us.py
+++ b/locations/spiders/new_seasons_market_us.py
@@ -1,17 +1,25 @@
-from scrapy.spiders import SitemapSpider
+from scrapy.http import Response
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class NewSeasonsMarketUSSpider(SitemapSpider, StructuredDataSpider):
+class NewSeasonsMarketUSSpider(JSONBlobSpider):
     name = "new_seasons_market_us"
     item_attributes = {"brand": "New Seasons Market", "brand_wikidata": "Q7011463"}
-    sitemap_urls = ["https://www.newseasonsmarket.com/robots.txt"]
-    sitemap_rules = [(r"/find-a-store/[\w-]+$", "parse_sd")]
-    wanted_types = ["GroceryStore"]
-    search_for_facebook = False
+    start_urls = ["https://www.newseasonsmarket.com/find-a-store"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = response.xpath('//h1[@class="h2"]/text()').get()
-
-        yield item
+    def parse(self, response: Response):
+        for location in response.xpath('//*[@id="store"]//*[@class="sr-list"]'):
+            item = Feature()
+            item["branch"] = location.xpath(".//@data-store-name").get()
+            item["lat"] = location.xpath(".//@data-latitude").get()
+            item["lon"] = location.xpath(".//@data-longitude").get()
+            item["state"] = location.xpath(".//@data-state-name").get()
+            item["ref"] = location.xpath(".//@id").get()
+            item["phone"] = location.xpath('.//*[contains(@href,"tel:")]/@href').get().replace("tel:", "")
+            item["street_address"] = location.xpath('.//*[@class="store-addressdetails"]/text()').get()
+            item["city"] = location.xpath('.//*[@class="store-city"]/text()').get()
+            item["postcode"] = location.xpath('.//*[@class="store-zipcode"]/text()').get()
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/New Seasons Market': 22,
 'atp/brand_wikidata/Q7011463': 22,
 'atp/category/shop/supermarket': 22,
 'atp/country/US': 22,
 'atp/field/country/from_spider_name': 22,
 'atp/field/email/missing': 22,
 'atp/field/housenumber/missing': 22,
 'atp/field/opening_hours/missing': 22,
 'atp/field/operator/missing': 22,
 'atp/field/operator_wikidata/missing': 22,
 'atp/field/street/missing': 22,
 'atp/field/twitter/missing': 22,
 'atp/field/unit/missing': 22,
 'atp/item_scraped_host_count/www.newseasonsmarket.com': 22,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 22,
 'atp/nsi/match_imperfect': 22,
 'downloader/request_bytes': 344,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 351172,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 2.332942285000172,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 29, 8, 3, 18, 32504, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 22,
 'items_per_minute': 660.0,
 'log_count/DEBUG': 23,
 'log_count/INFO': 3,
 'memusage/max': 302366720,
 'memusage/startup': 302366720,
 'response_received_count': 1,
 'responses_per_minute': 30.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 29, 8, 3, 15, 699559, tzinfo=datetime.timezone.utc)}
```