### PR TITLE
[Lili GR] Fix spider

### DIFF
--- a/locations/spiders/lili_gr.py
+++ b/locations/spiders/lili_gr.py
@@ -1,28 +1,28 @@
 import re
-from typing import AsyncIterator
+from typing import Any, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+import chompjs
+from scrapy.http import Response
 
-from locations.dict_parser import DictParser
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_GR, OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class LiliGRSpider(Spider):
+class LiliGRSpider(JSONBlobSpider):
     name = "lili_gr"
     item_attributes = {"brand": "Lili", "brand_wikidata": "Q111764460"}
-    allowed_domains = ["lilidrogerie.gr"]
-    start_urls = ["https://lilidrogerie.gr/wp-json/v1/get-store/?lang=el"]
-    no_refs = True
+    start_urls = ["https://lilidrogerie.gr/extension/module/locations_map"]
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def extract_json(self, response: Response) -> Any:
+        script = response.xpath('//script[contains(text(), "const locations = ")]/text()').get()
+        return chompjs.parse_js_object(script.split("const locations = ", 1)[1])
 
-    def parse(self, response):
-        for location in response.json()[0]["store"]:
-            item = DictParser.parse(location)
-            item["addr_full"] = re.sub(r"\s+", " ", location["address"].strip())
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(location["work_time"], DAYS_GR)
-            yield item
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = re.sub(r"^Lili( Drogerie)?( -)?\s*", "", item.pop("name").split(" | ")[0]).strip()
+        item["opening_hours"] = OpeningHours()
+        for segment in (feature.get("open") or "").split("|"):
+            item["opening_hours"].add_ranges_from_string(segment, days=DAYS_GR)
+        apply_category(Categories.SHOP_CHEMIST, item)
+        yield item


### PR DESCRIPTION
- Site migrated to OpenCart; the old WordPress store endpoint 404s.
- Parse the new stores page's embedded locations array instead (40 stores, refs and branches now collected).