### PR TITLE
[Kafkas GR ] Fix Spider

### DIFF
--- a/locations/spiders/kafkas_gr.py
+++ b/locations/spiders/kafkas_gr.py
@@ -7,7 +7,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 class KafkasGRSpider(LighthouseSpider, PlaywrightSpider):
     name = "kafkas_gr"
-    item_attributes = {"brand_wikidata": "Q68201770"}
+    item_attributes = {"brand": "Καυκάς", "brand_wikidata": "Q68201770"}
     start_urls = ["https://www.kafkas.gr/about-us/katastimata/"]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 

--- a/locations/spiders/kafkas_gr.py
+++ b/locations/spiders/kafkas_gr.py
@@ -1,11 +1,15 @@
 from locations.categories import Categories, apply_category
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.storefinders.lighthouse import LighthouseSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class KafkasGRSpider(LighthouseSpider):
+class KafkasGRSpider(LighthouseSpider, PlaywrightSpider):
     name = "kafkas_gr"
     item_attributes = {"brand_wikidata": "Q68201770"}
     start_urls = ["https://www.kafkas.gr/about-us/katastimata/"]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse_item(self, item, location):
         item["ref"] = item["lat"]


### PR DESCRIPTION
```python
{'atp/brand/Καυκάς': 85,
 'atp/brand_wikidata/Q68201770': 85,
 'atp/category/shop/electronics': 85,
 'atp/clean_strings/phone': 3,
 'atp/country/GR': 85,
 'atp/field/city/missing': 2,
 'atp/field/country/from_spider_name': 85,
 'atp/field/housenumber/missing': 85,
 'atp/field/name/missing': 85,
 'atp/field/operator/missing': 85,
 'atp/field/operator_wikidata/missing': 85,
 'atp/field/phone/invalid': 2,
 'atp/field/state/missing': 85,
 'atp/field/street/missing': 85,
 'atp/field/street_address/missing': 85,
 'atp/field/twitter/missing': 85,
 'atp/field/unit/missing': 85,
 'atp/item_scraped_host_count/www.kafkas.gr': 85,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_unknown': 85,
 'atp/nsi/match_failed': 85,
 'downloader/request_bytes': 1019,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 859387,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 7.35011211300025,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 30, 8, 20, 26, 649914, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 85,
 'items_per_minute': 728.5714285714286,
 'log_count/DEBUG': 241,
 'log_count/INFO': 7,
 'log_count/WARNING': 85,
 'memusage/max': 303230976,
 'memusage/startup': 303230976,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 71,
 'playwright/request_count/aborted': 69,
 'playwright/request_count/method/GET': 71,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/image': 29,
 'playwright/request_count/resource_type/script': 34,
 'playwright/request_count/resource_type/stylesheet': 6,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 17.142857142857142,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 30, 8, 20, 19, 299797, tzinfo=datetime.timezone.utc)}
```