### PR TITLE
[Bupa GB] Fix spider

### DIFF
--- a/locations/spiders/bupa_gb.py
+++ b/locations/spiders/bupa_gb.py
@@ -1,19 +1,29 @@
 from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature, set_closed
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 BUPA = {"brand": "Bupa", "brand_wikidata": "Q931628"}
 
 
-class BupaGBSpider(SitemapSpider, StructuredDataSpider):
+class BupaGBSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "bupa_gb"
-    sitemap_urls = ["https://www.bupa.co.uk/robots.txt"]
-    sitemap_rules = [(r"/practices/([-\w]+)$", "parse_sd")]
+    start_urls = ["https://www.bupa.co.uk/dental/dental-care/practices"]
+    rules = [
+        Rule(LinkExtractor(r"/practices/([-\w]+)$"), "parse_sd"),
+        Rule(
+            LinkExtractor(r"/browse-by-region/[-\w]+$"),
+        ),
+    ]
     time_format = "%I:%M %p"
     requires_proxy = True
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if "Total Dental Care" in item["name"]:

--- a/locations/spiders/bupa_gb.py
+++ b/locations/spiders/bupa_gb.py
@@ -21,7 +21,6 @@ class BupaGBSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
             LinkExtractor(r"/browse-by-region/[-\w]+$"),
         ),
     ]
-    time_format = "%I:%M %p"
     requires_proxy = True
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 

--- a/locations/spiders/bupa_gb.py
+++ b/locations/spiders/bupa_gb.py
@@ -22,7 +22,11 @@ class BupaGBSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
         ),
     ]
     requires_proxy = True
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = {
+        "USER_AGENT": BROWSER_DEFAULT,
+        "CONCURRENT_REQUESTS": 1,
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000,
+    } | DEFAULT_PLAYWRIGHT_SETTINGS
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if "Total Dental Care" in item["name"]:


### PR DESCRIPTION
```python
{'atp/brand/Bupa': 276,
 'atp/brand/Total Dental Care': 1,
 'atp/brand_wikidata/Q931628': 276,
 'atp/category/amenity/dentist': 328,
 'atp/category/multiple': 276,
 'atp/country/GB': 328,
 'atp/field/branch/missing': 328,
 'atp/field/brand/missing': 51,
 'atp/field/brand_wikidata/missing': 52,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 328,
 'atp/field/email/missing': 328,
 'atp/field/housenumber/missing': 328,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 328,
 'atp/field/operator_wikidata/missing': 328,
 'atp/field/street/missing': 328,
 'atp/field/unit/missing': 328,
 'atp/item_scraped_host_count/www.bupa.co.uk': 328,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 52,
 'atp/nsi/match_failed': 52,
 'atp/nsi/match_perfect': 276,
 'downloader/request_bytes': 301202,
 'downloader/request_count': 497,
 'downloader/request_method_count/GET': 497,
 'downloader/response_bytes': 125410040,
 'downloader/response_count': 497,
 'downloader/response_status_count/200': 497,
 'dupefilter/filtered': 40,
 'elapsed_time_seconds': 10.2029999999977,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 30, 8, 12, 50, 477971, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 497,
 'item_scraped_count': 328,
 'items_per_minute': 1968.0,
 'log_count/DEBUG': 910,
 'log_count/INFO': 5,
 'request_depth_max': 2,
 'response_received_count': 497,
 'responses_per_minute': 2982.0,
 'robotstxt/request_count': 5,
 'robotstxt/response_count': 5,
 'robotstxt/response_status_count/200': 5,
 'scheduler/dequeued': 492,
 'scheduler/dequeued/memory': 492,
 'scheduler/enqueued': 492,
 'scheduler/enqueued/memory': 492,
 'start_time': datetime.datetime(2026, 7, 30, 8, 12, 40, 284631, tzinfo=datetime.timezone.utc)}
```