### PR TITLE
[Cousins Subs US] Fix Spider

### DIFF
--- a/locations/spiders/cousins_subs_us.py
+++ b/locations/spiders/cousins_subs_us.py
@@ -1,5 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -11,10 +12,12 @@ class CousinsSubsUSSpider(SitemapSpider):
 
     def parse(self, response, **kwargs):
         item = Feature()
+        item["name"] = self.item_attributes["brand"]
         item["branch"] = response.xpath("//main//h1/text()").get()
         item["addr_full"] = response.xpath(
             '//*[@class="LocationDirectory_location_details_visit_address__w7TcQ"]/text()'
         ).get()
         item["ref"] = item["website"] = response.url
         item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        apply_category(Categories.FAST_FOOD, item)
         yield item

--- a/locations/spiders/cousins_subs_us.py
+++ b/locations/spiders/cousins_subs_us.py
@@ -1,16 +1,20 @@
-from scrapy import Spider
+from scrapy.spiders import SitemapSpider
 
-from locations.dict_parser import DictParser
+from locations.items import Feature
 
 
-class CousinsSubsUSSpider(Spider):
+class CousinsSubsUSSpider(SitemapSpider):
     name = "cousins_subs_us"
     item_attributes = {"brand": "Cousins Subs", "brand_wikidata": "Q5178843"}
-    start_urls = ["https://www.cousinssubs.com/api/restaurant/"]
+    sitemap_urls = ["https://www.cousinssubs.com/sitemap.xml"]
+    sitemap_rules = [(r"https://www.cousinssubs.com/locations-directory/[^/]+/[^/]+/[^/]+$", "parse")]
 
     def parse(self, response, **kwargs):
-        for location in response.json():
-            location["website"] = f'https://www.cousinssubs.com/order/{location["slug"]}'
-            location["street_address"] = location.pop("street")
-
-            yield DictParser.parse(location)
+        item = Feature()
+        item["branch"] = response.xpath("//main//h1/text()").get()
+        item["addr_full"] = response.xpath(
+            '//*[@class="LocationDirectory_location_details_visit_address__w7TcQ"]/text()'
+        ).get()
+        item["ref"] = item["website"] = response.url
+        item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Cousins Subs': 92,
 'atp/brand_wikidata/Q5178843': 92,
 'atp/category/amenity/fast_food': 92,
 'atp/country/US': 92,
 'atp/field/city/missing': 92,
 'atp/field/country/from_spider_name': 92,
 'atp/field/email/missing': 92,
 'atp/field/geometry/missing': 92,
 'atp/field/housenumber/missing': 92,
 'atp/field/opening_hours/missing': 92,
 'atp/field/operator/missing': 92,
 'atp/field/operator_wikidata/missing': 92,
 'atp/field/phone/missing': 1,
 'atp/field/postcode/missing': 92,
 'atp/field/state/missing': 92,
 'atp/field/street/missing': 92,
 'atp/field/street_address/missing': 92,
 'atp/field/twitter/missing': 92,
 'atp/field/unit/missing': 92,
 'atp/item_scraped_host_count/www.cousinssubs.com': 92,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/location_unknown': 92,
 'atp/nsi/match_failed': 92,
 'downloader/request_bytes': 42242,
 'downloader/request_count': 94,
 'downloader/request_method_count/GET': 94,
 'downloader/response_bytes': 2730357,
 'downloader/response_count': 94,
 'downloader/response_status_count/200': 94,
 'elapsed_time_seconds': 114.71395764299996,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 30, 12, 6, 29, 692614, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 15245886,
 'httpcompression/response_count': 94,
 'item_scraped_count': 92,
 'items_per_minute': 48.42105263157895,
 'log_count/DEBUG': 193,
 'log_count/INFO': 4,
 'memusage/max': 429981696,
 'memusage/startup': 302755840,
 'request_depth_max': 1,
 'response_received_count': 94,
 'responses_per_minute': 49.473684210526315,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 93,
 'scheduler/dequeued/memory': 93,
 'scheduler/enqueued': 93,
 'scheduler/enqueued/memory': 93,
 'start_time': datetime.datetime(2026, 7, 30, 12, 4, 34, 978652, tzinfo=datetime.timezone.utc)}
```