### PR TITLE
[Liquorland NZ] Fix Spider

### DIFF
--- a/locations/spiders/liquorland_nz.py
+++ b/locations/spiders/liquorland_nz.py
@@ -11,6 +11,9 @@ class LiquorlandNZSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [(r"https://www.liquorland.co.nz/store-locations/[^/]+", "parse_sd")]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
+        item["addr_full"] = item.pop("street_address")
+        item["branch"] = item.pop("name").replace("Liquorland ", "")
+        item["website"] = response.url
         oh = OpeningHours()
         oh.add_ranges_from_string(",".join(ld_data.get("openingHours")))
         item["opening_hours"] = oh

--- a/locations/spiders/liquorland_nz.py
+++ b/locations/spiders/liquorland_nz.py
@@ -1,38 +1,17 @@
-import re
-from typing import AsyncIterator
+from scrapy.spiders import SitemapSpider
 
-from scrapy import Selector, Spider
-from scrapy.http import JsonRequest
-
-from locations.categories import Categories
-from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LiquorlandNZSpider(Spider):
+class LiquorlandNZSpider(SitemapSpider, StructuredDataSpider):
     name = "liquorland_nz"
-    item_attributes = {"brand": "Liquorland", "brand_wikidata": "Q110295342", "extras": Categories.SHOP_ALCOHOL.value}
-    allowed_domains = ["www.liquorland.co.nz"]
-    start_urls = ["https://www.liquorland.co.nz/store/GetStoreLocationsJsonFileForRegion?regionid=0"]
-    no_refs = True
+    item_attributes = {"brand": "Liquorland", "brand_wikidata": "Q110295342"}
+    sitemap_urls = ["https://www.liquorland.co.nz/content/sitemaps/sitemap-index.xml"]
+    sitemap_rules = [(r"https://www.liquorland.co.nz/store-locations/[^/]+", "parse_sd")]
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
-
-    def parse(self, response):
-        for location in response.json()["features"]:
-            item = DictParser.parse(location["properties"])
-            item["geometry"] = location["geometry"]
-            item["addr_full"] = re.sub(
-                r"\s?,(?=[^\s])",
-                ", ",
-                re.sub(r"\s+", " ", location["properties"]["address"].replace("<br>", ",")).strip(),
-            )
-            item["website"] = "https://www.liquorland.co.nz" + location["properties"]["url"]
-            hours_string = " ".join(
-                filter(None, map(str.strip, Selector(text=location["properties"]["hours"]).xpath("//text()").getall()))
-            )
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(hours_string)
-            yield item
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        oh = OpeningHours()
+        oh.add_ranges_from_string(",".join(ld_data.get("openingHours")))
+        item["opening_hours"] = oh
+        yield item


### PR DESCRIPTION
```python
{'atp/brand/Liquorland': 166,
 'atp/brand_wikidata/Q110295342': 166,
 'atp/category/shop/alcohol': 166,
 'atp/country/NZ': 166,
 'atp/field/email/missing': 166,
 'atp/field/housenumber/missing': 166,
 'atp/field/operator/missing': 166,
 'atp/field/operator_wikidata/missing': 166,
 'atp/field/phone/missing': 1,
 'atp/field/street/missing': 166,
 'atp/field/street_address/missing': 166,
 'atp/field/twitter/missing': 166,
 'atp/field/unit/missing': 166,
 'atp/item_scraped_host_count/www.liquorland.co.nz': 166,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 166,
 'atp/nsi/match_imperfect': 166,
 'downloader/request_bytes': 99915,
 'downloader/request_count': 173,
 'downloader/request_method_count/GET': 173,
 'downloader/response_bytes': 16062924,
 'downloader/response_count': 173,
 'downloader/response_status_count/200': 173,
 'elapsed_time_seconds': 212.44457787200008,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 31, 10, 16, 51, 238846, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 83951648,
 'httpcompression/response_count': 173,
 'item_scraped_count': 166,
 'items_per_minute': 46.9811320754717,
 'log_count/DEBUG': 339,
 'log_count/INFO': 6,
 'log_count/WARNING': 166,
 'memusage/max': 452337664,
 'memusage/startup': 293679104,
 'request_depth_max': 2,
 'response_received_count': 173,
 'responses_per_minute': 48.9622641509434,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 172,
 'scheduler/dequeued/memory': 172,
 'scheduler/enqueued': 172,
 'scheduler/enqueued/memory': 172,
 'start_time': datetime.datetime(2026, 7, 31, 10, 13, 18, 794265, tzinfo=datetime.timezone.utc)}
```