### PR TITLE
[LasikPlus US] Fix Spider

### DIFF
--- a/locations/spiders/lasik_plus_us.py
+++ b/locations/spiders/lasik_plus_us.py
@@ -1,25 +1,27 @@
-from scrapy.spiders import SitemapSpider
+import json
+import re
+from typing import Any
 
-from locations.items import SocialMedia, get_social_media, set_social_media
-from locations.structured_data_spider import StructuredDataSpider
+from requests import Response
+
+from locations.storefinders.stockinstore import DictParser, Spider
 
 
-class LasikPlusUSSpider(SitemapSpider, StructuredDataSpider):
+class LasikPlusUSSpider(Spider):
     name = "lasik_plus_us"
     item_attributes = {"brand": "LasikPlus", "brand_wikidata": "Q126111242"}
-    sitemap_urls = ["https://www.lasikplus.com/robots.txt"]
-    sitemap_follow = ["lasik_location.xml"]
-    sitemap_rules = [(r"/location/([^/]+-lasik-center)/$", "parse")]
-    requires_proxy = True
+    start_urls = ["https://www.lasikplus.com/locations/"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = response.url
-
-        if get_social_media(item, SocialMedia.FACEBOOK) == "https://www.facebook.com/LasikPlus/":
-            return  # SEO spam
-
-        yelp, fb, *_ = get_social_media(item, SocialMedia.FACEBOOK).split(", ")
-        set_social_media(item, SocialMedia.YELP, yelp)
-        set_social_media(item, SocialMedia.FACEBOOK, fb)
-
-        yield item
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        json_data = json.loads(
+            re.search(
+                r"locationsData\s*=\s*(\[.+\]);\s*\/\/",
+                response.xpath('//*[@ id="meta-locations-map-js-extra"]/text()').get(),
+            ).group(1)
+        )
+        for location in json_data:
+            item = DictParser.parse(location)
+            item["street_address"] = item.pop("addr_full")
+            item["branch"] = item.pop("name")
+            item["website"] = location.get("link")
+            yield item


### PR DESCRIPTION
```python
{'atp/brand/LasikPlus': 48,
 'atp/brand_wikidata/Q126111242': 48,
 'atp/category/amenity/clinic': 48,
 'atp/category/multiple': 48,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/US': 48,
 'atp/field/country/from_spider_name': 48,
 'atp/field/email/missing': 48,
 'atp/field/housenumber/missing': 48,
 'atp/field/opening_hours/missing': 48,
 'atp/field/operator/missing': 48,
 'atp/field/operator_wikidata/missing': 48,
 'atp/field/phone/missing': 48,
 'atp/field/street/missing': 48,
 'atp/field/twitter/missing': 48,
 'atp/field/unit/missing': 48,
 'atp/item_scraped_host_count/www.lasikplus.com': 48,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 48,
 'atp/nsi/match_imperfect': 48,
 'downloader/request_bytes': 670,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 41312,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 2.7399116969991155,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 7, 31, 10, 39, 51, 640921, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 368722,
 'httpcompression/response_count': 2,
 'item_scraped_count': 48,
 'items_per_minute': 1440.0,
 'log_count/DEBUG': 50,
 'log_count/INFO': 3,
 'memusage/max': 301785088,
 'memusage/startup': 301785088,
 'response_received_count': 2,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 7, 31, 10, 39, 48, 901007, tzinfo=datetime.timezone.utc)}

```