### PR TITLE
[Citadele EE-LT-LV] Add spider  

### DIFF
--- a/locations/spiders/citadele_ee_lt_lv.py
+++ b/locations/spiders/citadele_ee_lt_lv.py
@@ -1,0 +1,82 @@
+import re
+from functools import lru_cache
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
+from locations.geo import city_locations
+from locations.items import Feature
+
+# Local-language "branch"/"office"/"service point" wording (and the legal-entity prefix) removed from
+# branch labels so only the distinguishing part remains.
+BRANCH_NOISE = re.compile(
+    r"\b(as\s+citadele\s+banka|fili(?:āle|aal|alas)|skyrius|"
+    r"klientu apkalpošanas centrs|mobilās apkalpošanas punkts)\b",
+    re.IGNORECASE,
+)
+# "(contactless)" service suffix on ATM names in the three languages; already captured by payment:contactless.
+CONTACTLESS = re.compile(r"\s*\((?:bekontaktis|bezkontaktai|bezkontakta|kontaktivaba)\)\s*$", re.IGNORECASE)
+
+
+@lru_cache
+def baltic_cities() -> list[tuple[float, float, str]]:
+    return [
+        (float(city["latitude"]), float(city["longitude"]), cc.upper())
+        for cc in ("ee", "lt", "lv")
+        for city in city_locations(cc)
+    ]
+
+
+class CitadeleEELTLVSpider(Spider):
+    name = "citadele_ee_lt_lv"
+    item_attributes = {"brand": "Citadele bank", "brand_wikidata": "Q14239556"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # Every national site serves the same pan-Baltic list, localised to its own language and with no
+        # per-location country. Each site is crawled and only its own country's locations are kept (see
+        # parse), so every POI keeps a native-language name and gets the correct country.
+        for country, language in {"ee": "et", "lt": "lt", "lv": "lv"}.items():
+            yield Request(url=f"https://www.citadele.{country}/{language}/map/", cb_kwargs={"country": country.upper()})
+
+    def parse(self, response: Response, country: str, **kwargs: Any) -> Any:
+        # Source is HTML (locations sit in <li> data-* attributes) so fields are read with XPath rather
+        # than DictParser, which targets JSON/dict sources.
+        for location in response.xpath('//li[contains(@class, "location-details")]'):
+            lat = float(location.xpath("@data-latitude").get())
+            lon = float(location.xpath("@data-longitude").get())
+            if self.nearest_country(lat, lon) != country:
+                continue  # a foreign location localised into this site's language; kept from its own site
+
+            name = location.xpath('normalize-space(.//h3[@class="title"])').get()
+
+            item = Feature(ref=location.xpath("@data-id").get(), lat=lat, lon=lon, country=country)
+            item["addr_full"] = location.xpath('normalize-space(.//p[@class="address"])').get()
+
+            if location.xpath("@data-type").get() == "branch":
+                if "leasing" in name.casefold():
+                    continue  # Citadele Leasing offices provide only leasing services, not banking
+                item["branch"] = self.clean_branch(name)
+                apply_category(Categories.BANK, item)
+            else:
+                options = (location.xpath("@data-options").get() or "").split()
+                apply_yes_no(Extras.CASH_IN, item, "cash_deposit_atm" in options)
+                apply_yes_no(
+                    PaymentMethods.CONTACTLESS, item, "contactless_atm" in options or bool(CONTACTLESS.search(name))
+                )
+                venue = CONTACTLESS.sub("", name)
+                if "citadele" not in venue.casefold():  # drop "at the Citadele branch" style brand-only labels
+                    item["name"] = venue
+                apply_category(Categories.ATM, item)
+
+            yield item
+
+    @staticmethod
+    def clean_branch(name: str) -> str | None:
+        branch = BRANCH_NOISE.sub("", name).strip(' "“”„-')
+        return None if branch.casefold() == "citadele" else branch or None
+
+    @staticmethod
+    def nearest_country(lat: float, lon: float) -> str:
+        return min(baltic_cities(), key=lambda city: (lat - city[0]) ** 2 + (lon - city[1]) ** 2)[2]


### PR DESCRIPTION
Citadele bank (Q14239556) branches and ATMs across Estonia, Lithuania and Latvia:  sibling to seb_ee_lt_lv / swedbank_ee_lt_lv.

Data source: the map page https://www.citadele.{ee,lt,lv}/{et,lt,lv}/map/ server-renders every POI as li class="location-details" with data-id, data-latitude/longitude, data-type (branch/atm) and data-options (service flags). Robots allows /map/; no proxy/custom-UA needed.

Why it crawls all three sites and filters by country: each national site serves the same pan-Baltic list, fully localized to that site's language, with no per-location country field (e.g. one Vilnius ATM is Autobusų stotis on .lt, Bussijaam on .ee, Autoosta on .lv; cities get exonyms, Vilnius→Viļņa on .lv). To give every POI its native-language name and a correct country, the spider crawls all three and keeps each location only on its home-country site, assigning country by nearest known city (geo.city_locations). Net output is every unique POI exactly once, full coverage, not a subset.

Why not DictParser: the source is HTML (data in li attributes, read via XPath), not a JSON/dict API: same as the seb_ee_lt_lv sibling.

Address is addr_full (not split): the address is free-form and the last comma-token is not reliably the city: e.g. Kauno gatvė 18a, Ežerėlis, Kauno r. sav. (last token is a municipality), Endla 45 (Prisma juures, vasakpoolne…), Tallinn (comma inside a parenthetical), …, Muhu vald, Liiva küla. Splitting would produce wrong cities, so per the "don't split unless proven" rule it stays addr_full.

Modelling:

Branches → amenity=bank. Label goes to branch after cleaning the local-language office word and any brand mention (Filiāle "Citadele" → dropped as brand-only; Daugavpils filiāle → Daugavpils; Vilniaus Akropolio skyrius → Vilniaus Akropolio; AS Citadele banka Eesti filiaal → Eesti). NSI supplies name.
ATMs → amenity=atm, keeping the native venue label as name. cash_in=yes from cash_deposit_atm; payment:contactless=yes from contactless_atm or a (Bekontaktis/bezkontakta/…) name suffix (the two signals are disjoint in the source) — and that suffix is stripped from the name. ATM labels that are just "at the Citadele branch" (Citadeles filiālē, In Citadele branch, …) are dropped, since they carry only the brand.
Scope: the 2 Citadele Leasing offices (tikai līzinga pakalpojumi / tik lizingo paslaugos, leasing only, not banking) are excluded as they aren't amenity=bank.

Opening hours skipped: the source's first hours entry is a relative "today" (crawl-day dependent) and the rest use per-country localized day abbreviations, not reliably convertible.

NSI: LV is in the bundled snapshot (159 match_perfect). EE/LT currently match_failed only because ATP's bundled nsi.json hasn't synced the merged expansion [name-suggestion-index #12363](https://github.com/osmlab/name-suggestion-index/pull/12363) (adds EE + LT to Q14239556); they'll match on the next [Core] Update NSI.

Stats
```
{
  "item_scraped_count": 653,
  "atp/category/amenity/atm": 634,
  "atp/category/amenity/bank": 19,
  "atp/country/EE": 96,
  "atp/country/LT": 398,
  "atp/country/LV": 159,
  "atp/nsi/match_perfect": 159,
  "atp/nsi/match_failed": 494
}
```
Sample POIs
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "644", "amenity": "bank", "branch": "Vilniaus Akropolio",
      "addr:full": "Ozo gatvė 25, Vilnius", "addr:country": "LT",
      "brand": "Citadele bank", "brand:wikidata": "Q14239556"
    },
    "geometry": { "type": "Point", "coordinates": [25.263766, 54.710079] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "555", "amenity": "atm", "name": "\"Rimi\" veikalā",
      "addr:full": "Tilta iela 32, Rīga", "addr:country": "LV",
      "brand": "Citadele bank", "brand:wikidata": "Q14239556",
      "operator": "Citadele bank", "operator:wikidata": "Q14239556", "nsi_id": "citadelebank-ea222c"
    },
    "geometry": { "type": "Point", "coordinates": [24.12988, 56.99547] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "1026", "amenity": "atm", "name": "Haapsalu Kaubamaja", "cash_in": "yes",
      "addr:full": "Tallinna str. 1 (Parkla poolsel küljel), Haapsalu", "addr:country": "EE",
      "brand": "Citadele bank", "brand:wikidata": "Q14239556"
    },
    "geometry": { "type": "Point", "coordinates": [23.541983, 58.940353] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "619", "amenity": "atm", "cash_in": "yes",
      "addr:full": "Narva mnt. 63/1, Tallinn", "addr:country": "EE",
      "brand": "Citadele bank", "brand:wikidata": "Q14239556"
    },
    "geometry": { "type": "Point", "coordinates": [24.780728, 59.439793] }
  }
]
```