### PR TITLE
Add maaf_fr spider (492 locations)

### DIFF
--- a/locations/spiders/maaf_fr.py
+++ b/locations/spiders/maaf_fr.py
@@ -1,0 +1,119 @@
+import random
+
+from scrapy.downloadermiddlewares.retry import get_retry_request
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MaafFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "maaf_fr"
+    item_attributes = {"brand": "MAAF", "brand_wikidata": "Q3331028"}
+    sitemap_urls = ["https://www.maaf.fr/fr/sitemap-agences.xml"]
+    # Only flat "/fr/assurance-<slug>" URLs are individual agency pages -
+    # this same sitemap also lists the 17 region pages and ~101 department
+    # pages, which this pattern deliberately excludes (confirmed: filtering
+    # this way yields the same 492 agencies as crawling all 17 region
+    # pages' own listings, so the sitemap is not stale here).
+    sitemap_rules = [(r"/fr/assurance-([\w-]+)$", "parse")]
+    custom_settings = {
+        # Anti-bot protection intermittently serves a decoy 404 instead of
+        # the real page (~15-20% of requests in testing), even through
+        # Zyte's browserHtml rendering. A retry almost always succeeds.
+        # Same pattern as locations/spiders/exxon_mobil.py for its own
+        # intermittent-block symptom, just a different status code.
+        "RETRY_HTTP_CODES": [404],
+        "RETRY_TIMES": 5,
+        # A handful of stubborn URLs still failed all 5 retries in one
+        # batch run, all within the same second - the retries for a given
+        # URL were firing back-to-back with nothing else left in the queue
+        # to interleave with, giving the anti-bot layer no real variation
+        # between attempts. A per-request delay (randomised by Scrapy's
+        # default RANDOMIZE_DOWNLOAD_DELAY) spaces consecutive attempts out
+        # in time; see also the randomised retry priority below, which
+        # spaces them out in queue order too.
+        "DOWNLOAD_DELAY": 3,
+    }
+
+    def _parse_sitemap(self, response):
+        # Plain Zyte proxying (requires_proxy) is not enough here: the
+        # site's anti-bot protection returns a ban response even through
+        # Zyte's automatic anti-ban handling. Forcing Zyte's headless
+        # browser rendering (browserHtml) is required to get past the JS
+        # challenge, same approach as locations/spiders/intermarche.py.
+        for request in super()._parse_sitemap(response):
+            request.meta["zyte_api"] = {
+                "browserHtml": True,
+                "geolocation": "FR",
+                "javascript": True,
+            }
+            yield request
+
+    def parse(self, response: TextResponse, **kwargs):
+        # Zyte's browserHtml occasionally returns the page before it has
+        # fully rendered client-side - sometimes so early that even the
+        # InsuranceAgency JSON-LD script hasn't loaded yet, which makes
+        # parse_sd() yield nothing at all for an otherwise-200 response.
+        # Retry rather than silently lose the location.
+        yielded = False
+        for result in self.parse_sd(response):
+            yielded = True
+            yield result
+        if not yielded and response.request is not None:
+            if retry := get_retry_request(
+                response.request,
+                spider=self,
+                max_retry_times=5,
+                reason="no structured data extracted",
+                priority_adjust=random.randint(-20, -1),
+            ):
+                yield retry
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs):
+        if item.get("name"):
+            item["branch"] = item.pop("name").removeprefix("Agence MAAF ")
+
+        # MAAF nests "email" inside the JSON-LD "address" block, which
+        # LinkedDataParser does not check (it only looks for "telephone" there).
+        if not item.get("email"):
+            if addr := LinkedDataParser.get_case_insensitive(ld_data, "address"):
+                if isinstance(addr, list):
+                    addr = addr[0]
+                if isinstance(addr, dict):
+                    item["email"] = LinkedDataParser.get_case_insensitive(addr, "email")
+
+        # Coordinates are published as separate schema.org/Place microdata
+        # elsewhere on the page, not inside the InsuranceAgency JSON-LD block.
+        item["lat"] = response.xpath('//*[@itemprop="latitude"]/@content').get()
+        item["lon"] = response.xpath('//*[@itemprop="longitude"]/@content').get()
+
+        if not item["lat"] or not item["lon"]:
+            # Same incomplete-render symptom as in parse(), but here the
+            # JSON-LD did load, just not (yet) the geo widget further down
+            # the page. Retry instead of yielding a location with no
+            # coordinates.
+            if response.request is not None:
+                if retry := get_retry_request(
+                    response.request,
+                    spider=self,
+                    max_retry_times=5,
+                    reason="missing geo microdata",
+                    priority_adjust=random.randint(-20, -1),
+                ):
+                    yield retry
+            return
+
+        # openingHours uses "09H00" instead of "09:00", which the framework's
+        # default parser does not match (it requires a colon separator), so
+        # it silently yields no hours. Normalise and reparse it here instead.
+        if hours := LinkedDataParser.get_case_insensitive(ld_data, "openingHours"):
+            if isinstance(hours, list):
+                hours = " ".join(hours)
+            item["opening_hours"] = OpeningHours()
+            item["opening_hours"].add_ranges_from_string(hours.replace("H", ":"))
+
+        yield item

--- a/tests/data/maaf_fr.html
+++ b/tests/data/maaf_fr.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<title>Assurance ST BRIEUC - MAAF Assurances</title>
+<script type="application/ld+json">
+{
+    "@context":"https://schema.org",
+    "@type": "InsuranceAgency",
+    "name": "Agence MAAF St Brieuc",
+    "url": "https://www.maaf.fr/fr/assurance-st-brieuc",
+    "logo": "https://www.maaf.fr/fr/files/live/sites/maaf/files/Iconographie/Logo/logo-header-desktop.jpg",
+    "image": "https://www.maaf.fr/fr/files/live/sites/maaf/files/Iconographie/Logo/logo-header-desktop.jpg",
+    "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "25 RUE DE PARIS ",
+        "addressLocality": "ST BRIEUC",
+        "postalCode": "22000",
+        "telephone": "0296618155",
+        "email": "Agence.STBRIEUC@maaf.fr"
+    },
+    "openingHours": "Mo 09H00-17H30 Tu 10H00-17H30 We 09H00-17H30 Th 09H00-17H30 Fr 09H00-17H30"
+}
+</script>
+</head>
+<body>
+<div class="col-sm-6 block-droite">
+    <div itemscope itemtype="http://schema.org/Place">
+        <div itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">
+            <meta itemprop="latitude" content="48.50547359999999">
+            <meta itemprop="longitude" content="-2.7438086">
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/tests/test_maaf_fr_spider.py
+++ b/tests/test_maaf_fr_spider.py
@@ -1,0 +1,74 @@
+from scrapy import Request
+from scrapy.http import HtmlResponse
+from scrapy.utils.test import get_crawler
+
+from locations.spiders.maaf_fr import MaafFRSpider
+
+
+def make_spider():
+    spider = MaafFRSpider()
+    spider.crawler = get_crawler()
+    return spider
+
+
+def test_parse_agency_page():
+    with open("./tests/data/maaf_fr.html") as f:
+        body = f.read()
+
+    response = HtmlResponse(url="https://www.maaf.fr/fr/assurance-st-brieuc", body=body, encoding="utf-8")
+    items = list(make_spider().parse(response))
+
+    assert len(items) == 1
+    item = items[0]
+    assert item["ref"] == "st-brieuc"
+    assert item["branch"] == "St Brieuc"
+    assert item["street_address"] == "25 RUE DE PARIS"
+    assert item["city"] == "ST BRIEUC"
+    assert item["postcode"] == "22000"
+    assert item["phone"] == "0296618155"
+    # Nested inside the JSON-LD "address" block, not at the top level -
+    # LinkedDataParser only handles "telephone" being nested like this, not
+    # "email", so the spider extracts it itself.
+    assert item["email"] == "Agence.STBRIEUC@maaf.fr"
+    assert item["lat"] == "48.50547359999999"
+    assert item["lon"] == "-2.7438086"
+    # Source uses "09H00" instead of "09:00", which the framework's default
+    # opening hours parser does not match; also checks that identical
+    # consecutive days get grouped ("We-Fr") while the differing Tuesday
+    # does not.
+    assert item["opening_hours"].as_opening_hours() == "Mo 09:00-17:30; Tu 10:00-17:30; We-Fr 09:00-17:30"
+
+
+def test_parse_retries_when_geo_missing():
+    # Zyte's browserHtml occasionally returns the page before the geo
+    # widget (loaded separately from the JSON-LD) has rendered. The spider
+    # should retry rather than yield a location with no coordinates.
+    body = """<html><head><script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"InsuranceAgency","name":"Agence MAAF St Brieuc",
+    "address":{"@type":"PostalAddress","streetAddress":"25 RUE DE PARIS","addressLocality":"ST BRIEUC",
+    "postalCode":"22000","telephone":"0296618155","email":"Agence.STBRIEUC@maaf.fr"},
+    "openingHours":"Mo 09H00-17H30"}
+    </script></head><body></body></html>"""
+    request = Request("https://www.maaf.fr/fr/assurance-st-brieuc")
+    response = HtmlResponse(url=request.url, body=body, encoding="utf-8", request=request)
+
+    results = list(make_spider().parse(response))
+
+    assert len(results) == 1
+    assert isinstance(results[0], Request)
+    assert results[0].url == request.url
+
+
+def test_parse_retries_when_structured_data_missing():
+    # An even earlier incomplete render: the JSON-LD script itself hasn't
+    # loaded yet, so parse_sd() yields nothing at all for a 200 response.
+    request = Request("https://www.maaf.fr/fr/assurance-st-brieuc")
+    response = HtmlResponse(
+        url=request.url, body="<html><head></head><body></body></html>", encoding="utf-8", request=request
+    )
+
+    results = list(make_spider().parse(response))
+
+    assert len(results) == 1
+    assert isinstance(results[0], Request)
+    assert results[0].url == request.url


### PR DESCRIPTION
Adds a spider for MAAF (`Q3331028`), a French insurance mutual, sourcing all 492 agencies from the dedicated `sitemap-agences.xml` sitemap.

## Notes
- Data comes from per-agency JSON-LD (`InsuranceAgency`) plus a separate `schema.org/Place` microdata block for coordinates (not present in the JSON-LD itself).
- The site's anti-bot layer intermittently serves a decoy 404, or a page that hasn't finished client-side rendering yet, even through Zyte's `browserHtml`. Handled with targeted retries (`RETRY_HTTP_CODES`, plus explicit retries when the JSON-LD or geo microdata is missing) rather than relying on `requires_proxy` alone, which was not sufficient on its own (confirmed via direct testing - Zyte returned `520 Website Ban` with the default `httpResponseBody` automap).
- `office=insurance`/`brand`/`brand:wikidata` tags are applied automatically by NSI matching (single NSI entry for this brand), not via `apply_category`.
- `atp/field/phone/invalid` will show ~8 items: these are all DOM-TOM agencies (Guadeloupe/Guyane/La Réunion) with genuine, correctly-formatted local numbers that the `phonenumbers` library doesn't validate under the `FR` region - not a data quality issue.

Verified with a full local run (`492/492` agencies, 100% field completeness on address/phone/email/hours/coordinates) before opening this PR.

🤖 Generated with Claude Code