### PR TITLE
[Versace] Fix spider

### DIFF
--- a/locations/spiders/versace.py
+++ b/locations/spiders/versace.py
@@ -1,6 +1,8 @@
+import json
+import re
 from typing import Iterable
 
-from scrapy.http import Response
+from scrapy.http import Response, TextResponse
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
@@ -16,10 +18,17 @@ class VersaceSpider(JSONBlobSpider, CamoufoxSpider):
     item_attributes = {"brand": "Versace", "brand_wikidata": "Q696376"}
     allowed_domains = ["www.versace.com"]
     start_urls = ["https://www.versace.com/on/demandware.store/Sites-US-Site/en_US/Stores-Search"]
-    locations_key = "stores"
     custom_settings = DEFAULT_CAMOUFOX_SETTINGS
 
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        return json.loads(response.xpath("//pre/text()").get())["stores"]
+
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = (
+            re.compile(r"^(?:(?:young versace|versace jeans couture|versace outlet|versace)\b\s*)+", re.IGNORECASE)
+            .sub("", item.pop("name", ""))
+            .strip()
+        )
         item["street_address"] = merge_address_lines([feature.get("address1"), feature.get("address2")])
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(feature.get("storeHours"))


### PR DESCRIPTION
```
{'atp/brand/Versace': 242,
 'atp/brand_wikidata/Q696376': 242,
 'atp/category/shop/clothes': 242,
 'atp/clean_strings/email': 16,
 'atp/country/AE': 4,
 'atp/country/AT': 1,
 'atp/country/AU': 5,
 'atp/country/BE': 1,
 'atp/country/CA': 5,
 'atp/country/CH': 3,
 'atp/country/CN': 62,
 'atp/country/CZ': 1,
 'atp/country/DE': 10,
 'atp/country/ES': 5,
 'atp/country/FR': 5,
 'atp/country/GB': 3,
 'atp/country/HK': 5,
 'atp/country/ID': 1,
 'atp/country/IN': 2,
 'atp/country/IT': 13,
 'atp/country/JP': 21,
 'atp/country/KH': 2,
 'atp/country/KR': 10,
 'atp/country/KW': 1,
 'atp/country/MC': 1,
 'atp/country/MM': 2,
 'atp/country/MO': 5,
 'atp/country/MY': 4,
 'atp/country/NL': 2,
 'atp/country/NZ': 1,
 'atp/country/PH': 2,
 'atp/country/PR': 1,
 'atp/country/PT': 1,
 'atp/country/QA': 3,
 'atp/country/SG': 3,
 'atp/country/TH': 7,
 'atp/country/TW': 5,
 'atp/country/US': 38,
 'atp/country/VN': 4,
 'atp/country/ZA': 3,
 'atp/field/email/missing': 34,
 'atp/field/housenumber/missing': 242,
 'atp/field/operator/missing': 242,
 'atp/field/operator_wikidata/missing': 242,
 'atp/field/phone/missing': 14,
 'atp/field/postcode/missing': 21,
 'atp/field/state/missing': 60,
 'atp/field/street/missing': 242,
 'atp/field/twitter/missing': 242,
 'atp/field/unit/missing': 242,
 'atp/item_scraped_host_count/www.versace.com': 242,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 242,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 1,
 'camoufox/request_count/method/GET': 1,
 'camoufox/request_count/navigation': 1,
 'camoufox/request_count/resource_type/document': 1,
 'camoufox/response_count': 1,
 'camoufox/response_count/method/GET': 1,
 'camoufox/response_count/resource_type/document': 1,
 'downloader/request_bytes': 376,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 465464,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 71.96799999999985,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 3, 6, 3, 24, 780056, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 242,
 'items_per_minute': 204.50704225352112,
 'log_count/DEBUG': 247,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.8450704225352113,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 3, 6, 2, 12, 819042, tzinfo=datetime.timezone.utc)}
```