### PR TITLE
[Madewell US] Fix Spider

### DIFF
--- a/locations/spiders/madewell_us.py
+++ b/locations/spiders/madewell_us.py
@@ -1,17 +1,9 @@
-from scrapy.spiders import SitemapSpider
-
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.yext import YextSpider
 
 
-class MadewellUSSpider(SitemapSpider, StructuredDataSpider):
+class MadewellUSSpider(YextSpider):
     name = "madewell_us"
     item_attributes = {"brand": "Madewell", "brand_wikidata": "Q64026213"}
-    sitemap_urls = ["https://stores.madewell.com/robots.txt"]
-    sitemap_rules = [(r"^https://stores\.madewell\.com/\w\w/\w\w/[-.\w]+/[-.'\w]+$", "parse")]
-    drop_attributes = {"image"}
-
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        item["branch"] = item.pop("name")
-        item["phone"] = response.xpath('//div[@id="phone-main"]/a/@href').get()
-
-        yield item
+    api_key = "c0963a72b0de0906e149ff1daac427d0"
+    api_version = "20240514"
+    search_filter = '{"$and":[{"c_storeChannel":{"$eqAny":["Madewell"]}},{"closed":{"$eq":false}}]}'


### PR DESCRIPTION
```python
{'atp/brand/Madewell': 160,
 'atp/brand_wikidata/Q64026213': 160,
 'atp/category/shop/clothes': 160,
 'atp/cdn/cloudflare/response_count': 5,
 'atp/cdn/cloudflare/response_status_count/200': 4,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/country/US': 160,
 'atp/field/branch/missing': 160,
 'atp/field/email/missing': 14,
 'atp/field/housenumber/missing': 160,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 160,
 'atp/field/operator_wikidata/missing': 160,
 'atp/field/street/missing': 160,
 'atp/field/twitter/missing': 6,
 'atp/field/unit/missing': 160,
 'atp/item_scraped_host_count/cdn.yextapis.com': 160,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 160,
 'atp/nsi/match_imperfect': 160,
 'downloader/request_bytes': 3487,
 'downloader/request_count': 5,
 'downloader/request_method_count/GET': 5,
 'downloader/response_bytes': 210286,
 'downloader/response_count': 5,
 'downloader/response_status_count/200': 4,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 5.961677883000448,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 3, 8, 1, 5, 726960, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2334832,
 'httpcompression/response_count': 4,
 'item_scraped_count': 160,
 'items_per_minute': 1920.0,
 'log_count/DEBUG': 165,
 'log_count/INFO': 3,
 'memusage/max': 293707776,
 'memusage/startup': 293707776,
 'request_depth_max': 3,
 'response_received_count': 5,
 'responses_per_minute': 60.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 4,
 'scheduler/dequeued/memory': 4,
 'scheduler/enqueued': 4,
 'scheduler/enqueued/memory': 4,
 'start_time': datetime.datetime(2026, 8, 3, 8, 0, 59, 765279, tzinfo=datetime.timezone.utc)}
```