### PR TITLE
[Marcs] Fix Spider

### DIFF
--- a/locations/spiders/marcs.py
+++ b/locations/spiders/marcs.py
@@ -1,49 +1,20 @@
-import json
-
+from requests_cache import Iterable
+from scrapy.http import TextResponse
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class MarcsSpider(CrawlSpider):
+class MarcsSpider(CrawlSpider, StructuredDataSpider):
     name = "marcs"
     item_attributes = {"brand": "Marc's", "brand_wikidata": "Q17080259"}
     allowed_domains = ["marcs.com"]
-    start_urls = ["https://www.marcs.com/store-finder"]
-    rules = [Rule(LinkExtractor(allow="store-finder/"), callback="parse")]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    start_urls = ["https://www.marcs.com/Store-Finder"]
+    rules = [Rule(LinkExtractor(allow="store-finder/"), callback="parse_sd")]
 
-    def find_between(self, text, first, last):
-        start = text.index(first) + len(first)
-        end = text.index(last, start)
-        return text[start:end]
-
-    def parse(self, response):
-        ldjson = response.xpath('//script[@type="application/ld+json"]/text()[contains(.,\'"Store"\')]').get()
-        data = json.decoder.JSONDecoder().raw_decode(ldjson, ldjson.index("{"))[0]
-
-        lmjson = response.xpath('//script[@type="text/javascript"]/text()[contains(.,"initMap()")]').get()
-
-        open_hour_filtered = [row for row in data.get("openingHours") if ":" in row]
-        oh = LinkedDataParser.parse_opening_hours({"openingHours": open_hour_filtered})
-
-        properties = {
-            "ref": response.url,
-            "name": data.get("name"),
-            "phone": data.get("telephone"),
-            "street_address": data.get("address", {}).get("streetAddress"),
-            "city": data.get("address", {}).get("addressLocality"),
-            "state": data.get("address", {}).get("addressRegion"),
-            "country": data.get("address", {}).get("addressCountry"),
-            "lat": self.find_between(lmjson, "lat = '", "';").strip(),
-            "lon": self.find_between(lmjson, "lng = '", "';").strip(),
-            "website": response.url,
-            "opening_hours": oh,
-        }
-
-        item = Feature(**properties)
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item

--- a/locations/spiders/marcs.py
+++ b/locations/spiders/marcs.py
@@ -16,5 +16,6 @@ class MarcsSpider(CrawlSpider, StructuredDataSpider):
     rules = [Rule(LinkExtractor(allow="store-finder/"), callback="parse_sd")]
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Marc's ")
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item


### PR DESCRIPTION
```python
{"atp/brand/Marc's": 25,
 'atp/brand_wikidata/Q17080259': 25,
 'atp/category/shop/supermarket': 25,
 'atp/country/US': 25,
 'atp/field/branch/missing': 25,
 'atp/field/email/missing': 25,
 'atp/field/geometry/missing': 25,
 'atp/field/housenumber/missing': 25,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 25,
 'atp/field/operator_wikidata/missing': 25,
 'atp/field/postcode/missing': 25,
 'atp/field/street/missing': 25,
 'atp/field/unit/missing': 25,
 'atp/item_scraped_host_count/www.marcs.com': 25,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 25,
 'downloader/request_bytes': 93432,
 'downloader/request_count': 120,
 'downloader/request_method_count/GET': 120,
 'downloader/response_bytes': 1674744,
 'downloader/response_count': 120,
 'downloader/response_status_count/200': 61,
 'downloader/response_status_count/301': 59,
 'elapsed_time_seconds': 141.35320243000024,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 3, 10, 1, 31, 118796, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 2966338,
 'httpcompression/response_count': 61,
 'item_scraped_count': 25,
 'items_per_minute': 10.638297872340425,
 'log_count/DEBUG': 145,
 'log_count/INFO': 5,
 'log_count/WARNING': 1,
 'memusage/max': 428752896,
 'memusage/startup': 293654528,
 'request_depth_max': 1,
 'response_received_count': 61,
 'responses_per_minute': 25.95744680851064,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 119,
 'scheduler/dequeued/memory': 119,
 'scheduler/enqueued': 119,
 'scheduler/enqueued/memory': 119,
 'start_time': datetime.datetime(2026, 8, 3, 9, 59, 9, 765589, tzinfo=datetime.timezone.utc)}
```