### PR TITLE
[Bun Burgers] Add spider

### DIFF
--- a/locations/spiders/bun_burgers.py
+++ b/locations/spiders/bun_burgers.py
@@ -18,12 +18,7 @@ class BunBurgersSpider(AgileStoreLocatorSpider):
         if addr := item.get("street_address"):
             item["street_address"] = unescape(addr)
         item["branch"] = (
-            item.pop("name", "")
-            .strip()
-            .removeprefix("Bun Burgers - ")
-            .removeprefix("Bun Burgers ")
-            .strip()
-            or None
+            item.pop("name", "").strip().removeprefix("Bun Burgers - ").removeprefix("Bun Burgers ").strip() or None
         )
         item["website"] = "https://bunburgers.com/dove-siamo/"
         item.pop("state", None)

--- a/locations/spiders/bun_burgers.py
+++ b/locations/spiders/bun_burgers.py
@@ -1,0 +1,32 @@
+from html import unescape
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.agile_store_locator import AgileStoreLocatorSpider
+
+
+class BunBurgersSpider(AgileStoreLocatorSpider):
+    name = "bun_burgers"
+    item_attributes = {"brand": "Bun Burgers", "brand_wikidata": "Q140876293"}
+    allowed_domains = ["bunburgers.com"]
+    skip_auto_cc_domain = True
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if addr := item.get("street_address"):
+            item["street_address"] = unescape(addr)
+        item["branch"] = (
+            item.pop("name", "")
+            .strip()
+            .removeprefix("Bun Burgers - ")
+            .removeprefix("Bun Burgers ")
+            .strip()
+            or None
+        )
+        item["website"] = "https://bunburgers.com/dove-siamo/"
+        item.pop("state", None)
+        apply_category(Categories.FAST_FOOD, item)
+        apply_category({"cuisine": "burger"}, item)
+        yield item


### PR DESCRIPTION
Added a new spider for Bun Burgers (Italy).

Brand: Bun Burgers
Store locator used: https://bunburgers.com/dove-siamo/
Includes Wikidata ID (Q140876293)
Coordinates, addresses, and opening hours.
Ran locally via `scrapy crawl bun_burgers` without errors (27 locations extracted).

Checklist:
- [x] Tested the spider locally and it's working
- [x] Included Wikidata ID for the brand
- [x] Set standard tags (amenity, cuisine)
