### PR TITLE
[Mediamarkt] Fix Spider

### DIFF
--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -1,8 +1,8 @@
-import json
 import re
 
+from scrapy.spiders import SitemapSpider
+
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
 from locations.structured_data_spider import StructuredDataSpider
 
 MEDIAMARKT = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
@@ -10,7 +10,7 @@ MEDIAWORLD = {"brand": "MediaWorld", "brand_wikidata": "Q125054068"}
 SATURN = {"brand": "Saturn", "brand_wikidata": "Q2543504"}
 
 
-class MediamarktSpider(StructuredDataSpider):
+class MediamarktSpider(SitemapSpider, StructuredDataSpider):
     name = "mediamarkt"
     requires_proxy = True
     allowed_domains = [
@@ -25,18 +25,20 @@ class MediamarktSpider(StructuredDataSpider):
         "mediamarkt.pl",
         "www.saturn.de",
     ]
-    start_urls = [
-        "https://www.mediamarkt.at/de/store/store-finder",
-        "https://www.mediamarkt.be/fr/store/store-finder",
-        "https://www.mediamarkt.ch/de/store/store-finder",
-        "https://www.mediamarkt.de/de/store/store-finder",
-        "https://www.mediamarkt.es/es/store/store-finder",
-        "https://www.mediamarkt.hu/hu/store/store-finder",
-        "https://www.mediamarkt.nl/nl/store/store-finder",
-        "https://www.mediaworld.it/it/store/store-finder",
-        "https://mediamarkt.pl/pl/store/store-finder",
-        "https://www.saturn.de/de/store/store-finder",
+    sitemap_urls = [
+        "https://www.mediamarkt.at/sitemaps/sitemap-marketpages.xml",
+        "https://www.mediamarkt.be/sitemaps/fr/sitemap-marketpages.xml",
+        "https://www.mediamarkt.ch/sitemaps/fr/sitemap-marketpages.xml",
+        "https://www.mediamarkt.de/sitemaps/sitemap-marketpages.xml",
+        "https://www.mediamarkt.es/sitemaps/sitemap-marketpages.xml",
+        "https://www.mediamarkt.hu/sitemaps/sitemap-marketpages.xml",
+        "https://www.mediamarkt.nl/sitemaps/sitemap-marketpages.xml",
+        "https://www.mediaworld.it/sitemaps/sitemap-marketpages.xml",
+        "https://www.saturn.de/sitemaps/sitemap-marketpages.xml",
+        "https://mediamarkt.pl/sitemaps/sitemap-marketpages.xml",
     ]
+    sitemap_rules = [("/store/", "parse_sd")]
+
     brands = {
         "www.mediamarkt.at": MEDIAMARKT,
         "www.mediamarkt.be": MEDIAMARKT,
@@ -50,24 +52,12 @@ class MediamarktSpider(StructuredDataSpider):
         "www.saturn.de": SATURN,
     }
 
-    def parse(self, response, **kwargs):
-        base_path = response.url.rsplit("/", 1)[0]
-
-        script = response.xpath('//script[contains(text(), "storeName")]/text()').get()
-
-        if json_match := re.search(r'JSON\.parse\("(.+?)"\)', script):
-            data = json.loads(json.loads(f'"{json_match.group(1)}"'))
-
-            for stores in DictParser.iter_matching_keys(data, "regionStores"):
-                for store in stores:
-                    if (uid := store.get("uid")) and uid != "store-finder":
-                        yield response.follow(f"{base_path}/{uid}", callback=self.parse_sd)
-
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["ref"] = response.url.split("/")[-1]
         host = response.url.split("/")[2]
         item.update(self.brands[host])
-        item["branch"] = item.get("name", "").removeprefix(f"{item['brand']} ")
+        item["branch"] = item.pop("name", "").replace(f"{item['brand']} ", "")
+        item["name"] = item["brand"]
         if phone := item.get("phone"):
             item["phone"] = re.sub(r"[^0-9+]", "", phone)
         apply_category(Categories.SHOP_ELECTRONICS, item)

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -39,23 +39,15 @@ class MediamarktSpider(SitemapSpider, StructuredDataSpider):
     ]
     sitemap_rules = [("/store/", "parse_sd")]
 
-    brands = {
-        "www.mediamarkt.at": MEDIAMARKT,
-        "www.mediamarkt.be": MEDIAMARKT,
-        "www.mediamarkt.ch": MEDIAMARKT,
-        "www.mediamarkt.de": MEDIAMARKT,
-        "www.mediamarkt.es": MEDIAMARKT,
-        "www.mediamarkt.hu": MEDIAMARKT,
-        "www.mediamarkt.nl": MEDIAMARKT,
-        "www.mediaworld.it": MEDIAWORLD,
-        "mediamarkt.pl": MEDIAMARKT,
-        "www.saturn.de": SATURN,
-    }
-
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["ref"] = response.url.split("/")[-1]
         host = response.url.split("/")[2]
-        item.update(self.brands[host])
+        if "mediamarkt" in host:
+            item.update(MEDIAMARKT)
+        elif "mediaworld" in host:
+            item.update(MEDIAWORLD)
+        elif "saturn" in host:
+            item.update(SATURN)
         item["branch"] = item.pop("name", "").replace(f"{item['brand']} ", "")
         item["name"] = item["brand"]
         if phone := item.get("phone"):

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -12,7 +12,6 @@ SATURN = {"brand": "Saturn", "brand_wikidata": "Q2543504"}
 
 class MediamarktSpider(SitemapSpider, StructuredDataSpider):
     name = "mediamarkt"
-    requires_proxy = True
     allowed_domains = [
         "www.mediamarkt.at",
         "www.mediamarkt.be",

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -12,6 +12,7 @@ SATURN = {"brand": "Saturn", "brand_wikidata": "Q2543504"}
 
 class MediamarktSpider(SitemapSpider, StructuredDataSpider):
     name = "mediamarkt"
+    requires_proxy = True
     allowed_domains = [
         "www.mediamarkt.at",
         "www.mediamarkt.be",
@@ -33,8 +34,8 @@ class MediamarktSpider(SitemapSpider, StructuredDataSpider):
         "https://www.mediamarkt.hu/sitemaps/sitemap-marketpages.xml",
         "https://www.mediamarkt.nl/sitemaps/sitemap-marketpages.xml",
         "https://www.mediaworld.it/sitemaps/sitemap-marketpages.xml",
-        "https://www.saturn.de/sitemaps/sitemap-marketpages.xml",
         "https://mediamarkt.pl/sitemaps/sitemap-marketpages.xml",
+        "https://www.saturn.de/sitemaps/sitemap-marketpages.xml",
     ]
     sitemap_rules = [("/store/", "parse_sd")]
 

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -6,7 +6,7 @@ from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 MEDIAMARKT = {"brand": "MediaMarkt", "brand_wikidata": "Q2381223"}
-MEDIAWORLD = {"brand": "MediaWorld", "brand_wikidata": "Q125054068"}
+MEDIAWORLD = {"brand": "MediaWorld", "brand_wikidata": "Q2381223"}
 SATURN = {"brand": "Saturn", "brand_wikidata": "Q2543504"}
 
 
@@ -49,7 +49,6 @@ class MediamarktSpider(SitemapSpider, StructuredDataSpider):
         elif "saturn" in host:
             item.update(SATURN)
         item["branch"] = item.pop("name", "").replace(f"{item['brand']} ", "")
-        item["name"] = item["brand"]
         if phone := item.get("phone"):
             item["phone"] = re.sub(r"[^0-9+]", "", phone)
         apply_category(Categories.SHOP_ELECTRONICS, item)

--- a/locations/spiders/mediamarkt.py
+++ b/locations/spiders/mediamarkt.py
@@ -41,14 +41,18 @@ class MediamarktSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         item["ref"] = response.url.split("/")[-1]
+
         host = response.url.split("/")[2]
         if "mediamarkt" in host:
             item.update(MEDIAMARKT)
+            item["branch"] = item.pop("name", "").removeprefix("MediaMarkt ")
         elif "mediaworld" in host:
             item.update(MEDIAWORLD)
+            item["branch"] = item.pop("name", "").removeprefix("MediaWorld ").removeprefix("Mediaworld ")
         elif "saturn" in host:
             item.update(SATURN)
-        item["branch"] = item.pop("name", "").replace(f"{item['brand']} ", "")
+            item["branch"] = item.pop("name", "").removeprefix("Saturn ")
+
         if phone := item.get("phone"):
             item["phone"] = re.sub(r"[^0-9+]", "", phone)
         apply_category(Categories.SHOP_ELECTRONICS, item)


### PR DESCRIPTION
```python
{'atp/brand/MediaMarkt': 795,
 'atp/brand/MediaWorld': 150,
 'atp/brand/Saturn': 30,
 'atp/brand_wikidata/Q125054068': 150,
 'atp/brand_wikidata/Q2381223': 795,
 'atp/brand_wikidata/Q2543504': 30,
 'atp/category/shop/electronics': 975,
 'atp/cdn/cloudflare/response_count': 1088,
 'atp/cdn/cloudflare/response_status_count/200': 1088,
 'atp/clean_strings/branch': 1,
 'atp/country/AT': 56,
 'atp/country/BE': 30,
 'atp/country/CH': 44,
 'atp/country/DE': 407,
 'atp/country/ES': 115,
 'atp/country/HU': 40,
 'atp/country/IT': 150,
 'atp/country/NL': 54,
 'atp/country/PL': 79,
 'atp/field/email/missing': 975,
 'atp/field/housenumber/missing': 975,
 'atp/field/opening_hours/missing': 12,
 'atp/field/operator/missing': 975,
 'atp/field/operator_wikidata/missing': 975,
 'atp/field/phone/missing': 113,
 'atp/field/state/missing': 457,
 'atp/field/street/missing': 975,
 'atp/field/twitter/missing': 860,
 'atp/field/unit/missing': 975,
 'atp/item_scraped_host_count/mediamarkt.pl': 79,
 'atp/item_scraped_host_count/www.mediamarkt.at': 56,
 'atp/item_scraped_host_count/www.mediamarkt.be': 30,
 'atp/item_scraped_host_count/www.mediamarkt.ch': 44,
 'atp/item_scraped_host_count/www.mediamarkt.de': 377,
 'atp/item_scraped_host_count/www.mediamarkt.es': 115,
 'atp/item_scraped_host_count/www.mediamarkt.hu': 40,
 'atp/item_scraped_host_count/www.mediamarkt.nl': 54,
 'atp/item_scraped_host_count/www.mediaworld.it': 150,
 'atp/item_scraped_host_count/www.saturn.de': 30,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 150,
 'atp/nsi/match_failed': 150,
 'atp/nsi/match_perfect': 825,
 'downloader/request_bytes': 753907,
 'downloader/request_count': 1121,
 'downloader/request_method_count/GET': 1121,
 'downloader/response_bytes': 124053685,
 'downloader/response_count': 1121,
 'downloader/response_status_count/200': 1088,
 'downloader/response_status_count/301': 33,
 'dupefilter/filtered': 19,
 'elapsed_time_seconds': 533.9357759570003,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 5, 9, 19, 54, 157597, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 888360804,
 'httpcompression/response_count': 1088,
 'item_scraped_count': 975,
 'items_per_minute': 109.75609756097562,
 'log_count/DEBUG': 2097,
 'log_count/INFO': 11,
 'memusage/max': 896749568,
 'memusage/startup': 301535232,
 'request_depth_max': 1,
 'response_received_count': 1088,
 'responses_per_minute': 122.4765478424015,
 'robotstxt/request_count': 10,
 'robotstxt/response_count': 10,
 'robotstxt/response_status_count/200': 10,
 'scheduler/dequeued': 1111,
 'scheduler/dequeued/memory': 1111,
 'scheduler/enqueued': 1111,
 'scheduler/enqueued/memory': 1111,
 'start_time': datetime.datetime(2026, 8, 5, 9, 11, 0, 221815, tzinfo=datetime.timezone.utc)}
```