### PR TITLE
[Zumiez] Fix spider

### DIFF
--- a/locations/spiders/zumiez.py
+++ b/locations/spiders/zumiez.py
@@ -4,6 +4,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -12,7 +13,7 @@ from locations.json_blob_spider import JSONBlobSpider
 class ZumiezSpider(JSONBlobSpider):
     name = "zumiez"
     item_attributes = {"brand": "Zumiez", "brand_wikidata": "Q8075252"}
-    start_urls = ["https://www.zumiez.com/graphql?hash=505530338"]
+    start_urls = ['https://www.zumiez.com/graphql?hash=3361022132&storeId_1="default"']
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def extract_json(self, response: Response) -> dict | list[dict]:
@@ -31,4 +32,6 @@ class ZumiezSpider(JSONBlobSpider):
             item["opening_hours"] = oh
         except Exception as e:
             self.logger.warning(f"Failed to parse opening hours: {e}")
+
+        apply_category(Categories.SHOP_CLOTHES, item)
         yield item

--- a/locations/spiders/zumiez_us.py
+++ b/locations/spiders/zumiez_us.py
@@ -10,8 +10,8 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class ZumiezSpider(JSONBlobSpider):
-    name = "zumiez"
+class ZumiezUSSpider(JSONBlobSpider):
+    name = "zumiez_us"
     item_attributes = {"brand": "Zumiez", "brand_wikidata": "Q8075252"}
     start_urls = ['https://www.zumiez.com/graphql?hash=3361022132&storeId_1="default"']
     custom_settings = {"ROBOTSTXT_OBEY": False}

--- a/locations/spiders/zumiez_us.py
+++ b/locations/spiders/zumiez_us.py
@@ -21,6 +21,7 @@ class ZumiezUSSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
+        item["street_address"] = item.pop("street")
         if feature.get("has_store_page"):
             item["website"] = f"https://www.zumiez.com/stores/{feature.get('identifier')}"
         try:


### PR DESCRIPTION
- Old GraphQL persisted-query hash returns 410; use the current hash (559 stores).
- Apply shop=clothes.