### PR TITLE
[Virgin Active IT] Fix spider

### DIFF
--- a/locations/spiders/virgin_active_it.py
+++ b/locations/spiders/virgin_active_it.py
@@ -1,5 +1,8 @@
+import re
 from html import unescape
+from typing import Any
 
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
@@ -11,7 +14,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class VirginActiveITSpider(CrawlSpider, StructuredDataSpider):
     name = "virgin_active_it"
     item_attributes = VIRGIN_ACTIVE_SHARED_ATTRIBUTES
-    allowed_domains = ["www.virginactive.it"]
+    allowed_domains = ["virginactive.it"]
     start_urls = ["https://www.virginactive.it/club"]
     rules = [
         Rule(LinkExtractor(allow=r"/club/[-\w]+/[-\w]+$"), follow=False, callback="parse"),
@@ -19,6 +22,11 @@ class VirginActiveITSpider(CrawlSpider, StructuredDataSpider):
     time_format = "%H.%M"
     search_for_facebook = False
     search_for_twitter = False
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        body = re.sub(r'("(?:latitude|longitude)":\s*-?\d+),(\d+)', r"\1.\2", response.text)
+        body = body.replace("vai-sitefinity-app-service.azurewebsites.net", "www.virginactive.it")
+        yield from self.parse_sd(response.replace(body=body))
 
     def post_process_item(self, item, response, ld_data):
         item["branch"] = item.pop("name")

--- a/locations/spiders/virgin_active_it.py
+++ b/locations/spiders/virgin_active_it.py
@@ -6,6 +6,7 @@ from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS_IT, OpeningHours
 from locations.spiders.virgin_active_bw_na_za import VIRGIN_ACTIVE_SHARED_ATTRIBUTES
 from locations.structured_data_spider import StructuredDataSpider
@@ -37,4 +38,5 @@ class VirginActiveITSpider(CrawlSpider, StructuredDataSpider):
                 item["opening_hours"].add_ranges_from_string(
                     f"{unescape(day)} {spec['opens']}-{spec['closes']}", DAYS_IT
                 )
+        apply_category(Categories.GYM, item)
         yield item


### PR DESCRIPTION
- Club links moved to the bare `virginactive.it` domain; widen `allowed_domains`.
- Repair the ld+json coordinates (Italian comma decimals) and the internal host in `url`/`image` so it parses.