### PR TITLE
[Ministop JP] Fix spider

### DIFF
--- a/locations/spiders/ministop_jp.py
+++ b/locations/spiders/ministop_jp.py
@@ -1,6 +1,6 @@
-from typing import AsyncIterator, Iterable
+from typing import Any, Iterable
 
-from scrapy.http import Request, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
@@ -10,39 +10,34 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class MinistopJPSpider(JSONBlobSpider):
     name = "ministop_jp"
-    allowed_domains = ["map.ministop.co.jp"]
-    start_urls = ["https://map.ministop.co.jp/"]
-    locations_key = ["pageProps", "allShopsData", "shops"]
+    locations_key = "shops"
+    start_urls = [
+        f"https://api.site.can-ly.com/v2/directories/94/shops/search?location_filter=true&sort=off&map_view_geohash={geohash}"
+        for geohash in ("w", "x")
+    ]
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield Request(url=self.start_urls[0], callback=self.parse_nextjs_build_id)
-
-    def parse_nextjs_build_id(self, response: Response) -> Iterable[Request]:
-        nextjs_build_manifest = response.xpath('//script[contains(@src, "/_buildManifest.js")]/@src').get()
-        nextjs_build_id = nextjs_build_manifest.split("/static/", 1)[1].split("/_buildManifest.js", 1)[0]
-        yield Request(url=f"https://map.ministop.co.jp/_next/data/{nextjs_build_id}/map.json")
-
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if feature["businessStatus"] != "OPEN":
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Iterable[Feature]:
+        if feature["openStatus"] != "IS_ALREADY_OPEN":
             return
 
-        if feature["nameKanji"].startswith("ミニストップ"):
-            item["branch"] = feature["nameKanji"].removeprefix("ミニストップ").strip()  # "Ministop"
+        name = feature["nameKanji"]
+        if name.startswith("ミニストップ"):
+            item["branch"] = name.removeprefix("ミニストップ").strip()
             item["brand"] = "Ministop"
             item["brand_wikidata"] = "Q1038929"
             apply_category(Categories.SHOP_CONVENIENCE, item)
-        elif feature["nameKanji"].startswith("MINI SOF"):
-            item["branch"] = feature["nameKanji"].removeprefix("MINI SOF").strip()
+        elif name.startswith("MINI SOF"):
+            item["branch"] = name.removeprefix("MINI SOF").strip()
             item["brand"] = "MINISOF"
             item["brand_wikidata"] = "Q134958024"
             apply_category(Categories.ICE_CREAM, item)
-        elif feature["nameKanji"].startswith("cisca"):
-            item["branch"] = feature["nameKanji"].removeprefix("cisca").strip()
+        elif name.startswith("cisca"):
+            item["branch"] = name.removeprefix("cisca").strip()
             item["brand"] = "cisca"
             item["brand_wikidata"] = "Q134958099"
             apply_category(Categories.CAFE, item)
         else:
-            self.logger.warning("Unknown brand name as prefix to location name: {}".format(feature["nameKanji"]))
+            self.logger.warning(f"Unknown brand name as prefix to location name: {name}")
 
         item["ref"] = str(feature["storeCode"])
         item["extras"]["alt_ref"] = str(feature["storeId"])
@@ -50,8 +45,11 @@ class MinistopJPSpider(JSONBlobSpider):
 
         item["opening_hours"] = OpeningHours()
         for day_hours in feature["businessHours"]:
-            item["opening_hours"].add_range(
-                day_hours["name"], day_hours["openTime"], day_hours["closeTime"], "%H:%M:%S"
-            )
+            if day_hours["hourType"] == 2:
+                item["opening_hours"].add_range(day_hours["name"], "00:00", "24:00")
+            else:
+                item["opening_hours"].add_range(
+                    day_hours["name"], day_hours["openTime"], day_hours["closeTime"], "%H:%M:%S"
+                )
 
         yield item


### PR DESCRIPTION
- Store data moved off the Next.js page props to a Canly locator API.
- Query it across two geohashes covering Japan (1,668 stores); handle the 24-hour stores.