### PR TITLE
[Starbucks AE] Fix spider

### DIFF
--- a/locations/spiders/starbucks_ae.py
+++ b/locations/spiders/starbucks_ae.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
@@ -9,16 +11,10 @@ class StarbucksAESpider(SitemapSpider, StructuredDataSpider):
     name = "starbucks_ae"
     item_attributes = {"brand": "ستاربكس", "brand_wikidata": "Q37158"}
     sitemap_urls = ["https://locations.starbucks.ae/robots.txt"]
-    sitemap_rules = [(r"ae/directory/[^/]+/[^/]+$", "parse")]
+    sitemap_rules = [(r"starbucks\.ae/(?!ar/)[^/]+/[^/]+$", "parse")]
     wanted_types = ["Restaurant"]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["image"] = None
-        item["branch"] = item.pop("name").removeprefix("Starbucks ")
-
-        item["website"] = item["extras"]["website:ar"] = response.urljoin(
-            response.xpath('//a[@class="Header-langOption"][text()="Arabic"]/@href').get()
-        )
-        item["extras"]["website:en"] = response.url
-
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["branch"] = response.xpath("//h1/text()").get("").removeprefix("Starbucks ")
+        item["website"] = response.url
         yield item

--- a/locations/spiders/starbucks_ae.py
+++ b/locations/spiders/starbucks_ae.py
@@ -11,7 +11,7 @@ class StarbucksAESpider(SitemapSpider, StructuredDataSpider):
     name = "starbucks_ae"
     item_attributes = {"brand": "ستاربكس", "brand_wikidata": "Q37158"}
     sitemap_urls = ["https://locations.starbucks.ae/robots.txt"]
-    sitemap_rules = [(r"starbucks\.ae/(?!ar/)[^/]+/[^/]+$", "parse")]
+    sitemap_rules = [(r"^https://locations\.starbucks\.ae/(?!ar/)[^/]+/[^/]+$", "parse")]
     wanted_types = ["Restaurant"]
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:

--- a/locations/spiders/starbucks_ae.py
+++ b/locations/spiders/starbucks_ae.py
@@ -3,6 +3,7 @@ from typing import Any
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
@@ -17,4 +18,5 @@ class StarbucksAESpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         item["branch"] = response.xpath("//h1/text()").get("").removeprefix("Starbucks ")
         item["website"] = response.url
+        apply_category(Categories.CAFE, item)
         yield item


### PR DESCRIPTION
- Site rebuilt; old `ae/directory/…` sitemap pattern matches nothing.
- Match the new `/<city>/<slug>` store URLs (excluding Arabic duplicates); take branch from the page heading (328 stores).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UAE Starbucks location data accuracy by matching the correct location pages.
  - Branch names are now captured more reliably from page headings.
  - Website links now point directly to each location’s source page.
  - Existing location images are preserved during updates.
  - Removed redundant language-specific website entries for cleaner location details.
  - Starbucks locations are now consistently categorized as cafés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->