### PR TITLE
[Church of Scotland GB] Fix Spider

### DIFF
--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -26,6 +26,8 @@ class ChurchOfScotlandGBSpider(Spider):
             return
         for church in data:
             item = DictParser.parse(church)
+            if email := item.get("email"):
+                item["email"] = email.replace("|", ";")
             item["name"] = church["church_name"]
             item.pop("website")
             apply_category(Categories.PLACE_OF_WORSHIP, item)

--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -22,13 +22,14 @@ class ChurchOfScotlandGBSpider(Spider):
 
     def parse(self, response, **kwargs):
         data = xmltodict.parse(response.text, attr_prefix="").get("churches", []).get("church", [])
-        if data:
-            for church in data:
-                item = DictParser.parse(church)
-                item["name"] = church["church_name"]
-                item.pop("website")
-                apply_category(Categories.PLACE_OF_WORSHIP, item)
-                item["extras"]["religion"] = "christian"
-                item["extras"]["denomination"] = "presbyterian"
-                yield item
-            yield self.make_request(kwargs["offset"] + 50)
+        if not data:
+            return
+        for church in data:
+            item = DictParser.parse(church)
+            item["name"] = church["church_name"]
+            item.pop("website")
+            apply_category(Categories.PLACE_OF_WORSHIP, item)
+            item["extras"]["religion"] = "christian"
+            item["extras"]["denomination"] = "presbyterian"
+            yield item
+        yield self.make_request(kwargs["offset"] + 50)

--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -28,8 +28,11 @@ class ChurchOfScotlandGBSpider(Spider):
             item = DictParser.parse(church)
             if email := item.get("email"):
                 item["email"] = email.replace("|", ";")
+            if website := item.get("website"):
+                if not website.startswith("http"):
+                    item["website"] = "https://{}".format(website)
             item["name"] = church["church_name"]
-            item.pop("website")
+
             apply_category(Categories.PLACE_OF_WORSHIP, item)
             item["extras"]["religion"] = "christian"
             item["extras"]["denomination"] = "presbyterian"

--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -1,5 +1,7 @@
+from typing import AsyncIterator
+
 import xmltodict
-from scrapy import Spider
+from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -8,16 +10,24 @@ from locations.dict_parser import DictParser
 class ChurchOfScotlandGBSpider(Spider):
     name = "church_of_scotland_gb"
     item_attributes = {"operator": "Church of Scotland", "operator_wikidata": "Q922480"}
-    start_urls = [
-        "https://cos.churchofscotland.org.uk/church-finder/phpsqlsearch_genxml?latitude=56.1&longitude=-3.9&radius=1000&limit=2000"
-    ]
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield self.make_request(0)
+
+    def make_request(self, offset: int) -> Request:
+        return Request(
+            f"https://cos.churchofscotland.org.uk/church-finder/phpsqlsearch_genxml_contacts?latitude=56.06754&longitude=-3.77201&radius=10000000&limit=100&start={offset}",
+            cb_kwargs={"offset": offset},
+        )
 
     def parse(self, response, **kwargs):
-        data = xmltodict.parse(response.text, attr_prefix="")
-        for church in data["churches"]["church"]:
-            item = DictParser.parse(church)
-            item["name"] = church["church_name"]
-            apply_category(Categories.PLACE_OF_WORSHIP, item)
-            item["extras"]["religion"] = "christian"
-            item["extras"]["denomination"] = "presbyterian"
-            yield item
+        data = xmltodict.parse(response.text, attr_prefix="").get("churches").get("church")
+        if data:
+            for church in data:
+                item = DictParser.parse(church)
+                item["name"] = church["church_name"]
+                apply_category(Categories.PLACE_OF_WORSHIP, item)
+                item["extras"]["religion"] = "christian"
+                item["extras"]["denomination"] = "presbyterian"
+                yield item
+            yield self.make_request(kwargs["offset"] + 50)

--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -21,12 +21,12 @@ class ChurchOfScotlandGBSpider(Spider):
         )
 
     def parse(self, response, **kwargs):
-        data = xmltodict.parse(response.text, attr_prefix="").get("churches").get("church")
+        data = xmltodict.parse(response.text, attr_prefix="").get("churches", []).get("church", [])
         if data:
             for church in data:
                 item = DictParser.parse(church)
                 item["name"] = church["church_name"]
-                item.pop("website")"
+                item.pop("website")
                 apply_category(Categories.PLACE_OF_WORSHIP, item)
                 item["extras"]["religion"] = "christian"
                 item["extras"]["denomination"] = "presbyterian"

--- a/locations/spiders/church_of_scotland_gb.py
+++ b/locations/spiders/church_of_scotland_gb.py
@@ -26,6 +26,7 @@ class ChurchOfScotlandGBSpider(Spider):
             for church in data:
                 item = DictParser.parse(church)
                 item["name"] = church["church_name"]
+                item.pop("website")"
                 apply_category(Categories.PLACE_OF_WORSHIP, item)
                 item["extras"]["religion"] = "christian"
                 item["extras"]["denomination"] = "presbyterian"


### PR DESCRIPTION
```python
{'atp/category/amenity/place_of_worship': 1230,
 'atp/country/GB': 1230,
 'atp/field/branch/missing': 1230,
 'atp/field/brand/missing': 1230,
 'atp/field/brand_wikidata/missing': 1230,
 'atp/field/city/missing': 1230,
 'atp/field/country/from_spider_name': 1230,
 'atp/field/email/invalid': 10,
 'atp/field/email/missing': 146,
 'atp/field/housenumber/missing': 1230,
 'atp/field/opening_hours/missing': 1230,
 'atp/field/phone/invalid': 7,
 'atp/field/phone/missing': 196,
 'atp/field/postcode/missing': 24,
 'atp/field/state/missing': 1230,
 'atp/field/street/missing': 1230,
 'atp/field/street_address/missing': 1230,
 'atp/field/twitter/missing': 1230,
 'atp/field/unit/missing': 1230,
 'atp/field/website/invalid': 49,
 'atp/geometry/null_island': 19,
 'atp/item_scraped_host_count/cos.churchofscotland.org.uk': 1230,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_failed': 1230,
 'atp/nsi/operator_unknown': 1230,
 'atp/operator/Church of Scotland': 1230,
 'atp/operator_wikidata/Q922480': 1230,
 'downloader/request_bytes': 16100,
 'downloader/request_count': 27,
 'downloader/request_method_count/GET': 27,
 'downloader/response_bytes': 138827,
 'downloader/response_count': 27,
 'downloader/response_status_count/200': 27,
 'elapsed_time_seconds': 394.3828734890012,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 6, 8, 35, 43, 710711, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 774988,
 'httpcompression/response_count': 26,
 'item_scraped_count': 1230,
 'items_per_minute': 187.30964467005077,
 'log_count/DEBUG': 1257,
 'log_count/ERROR': 49,
 'log_count/INFO': 9,
 'log_count/WARNING': 10,
 'memusage/max': 421900288,
 'memusage/startup': 296009728,
 'request_depth_max': 25,
 'response_received_count': 27,
 'responses_per_minute': 4.111675126903553,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 26,
 'scheduler/dequeued/memory': 26,
 'scheduler/enqueued': 26,
 'scheduler/enqueued/memory': 26,
 'start_time': datetime.datetime(2026, 8, 6, 8, 29, 9, 327833, tzinfo=datetime.timezone.utc)}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved church directory collection by supporting asynchronous, paginated results.
  * Continues retrieving entries across successive result pages.
  * Safely handles responses with missing or empty church data.
  * Normalizes email separators and website URLs for more consistent listings.
  * Preserves existing church categorization and enrichment across all collected results.
  * Improves reliability when processing incomplete or unexpectedly structured responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->