### PR TITLE
[Ministop JP] Fix Spider

### DIFF
--- a/locations/spiders/ministop_jp.py
+++ b/locations/spiders/ministop_jp.py
@@ -14,6 +14,8 @@ class MinistopJPSpider(JSONBlobSpider):
     locations_key = "shops"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if feature["openStatus"] != "IS_ALREADY_OPEN":
+            return
 
         if feature["nameKanji"].startswith("ミニストップ"):
             item["branch"] = feature["nameKanji"].removeprefix("ミニストップ").strip()  # "Ministop"

--- a/locations/spiders/ministop_jp.py
+++ b/locations/spiders/ministop_jp.py
@@ -1,6 +1,6 @@
-from typing import AsyncIterator, Iterable
+from typing import Iterable
 
-from scrapy.http import Request, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
@@ -10,21 +10,10 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class MinistopJPSpider(JSONBlobSpider):
     name = "ministop_jp"
-    allowed_domains = ["map.ministop.co.jp"]
-    start_urls = ["https://map.ministop.co.jp/"]
-    locations_key = ["pageProps", "allShopsData", "shops"]
-
-    async def start(self) -> AsyncIterator[Request]:
-        yield Request(url=self.start_urls[0], callback=self.parse_nextjs_build_id)
-
-    def parse_nextjs_build_id(self, response: Response) -> Iterable[Request]:
-        nextjs_build_manifest = response.xpath('//script[contains(@src, "/_buildManifest.js")]/@src').get()
-        nextjs_build_id = nextjs_build_manifest.split("/static/", 1)[1].split("/_buildManifest.js", 1)[0]
-        yield Request(url=f"https://map.ministop.co.jp/_next/data/{nextjs_build_id}/map.json")
+    start_urls = ["https://api.site.can-ly.com/v2/directories/94/shops/search"]
+    locations_key = "shops"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if feature["businessStatus"] != "OPEN":
-            return
 
         if feature["nameKanji"].startswith("ミニストップ"):
             item["branch"] = feature["nameKanji"].removeprefix("ミニストップ").strip()  # "Ministop"


### PR DESCRIPTION
```python
{'atp/brand/MINISOF': 7,
 'atp/brand/Ministop': 1658,
 'atp/brand/cisca': 3,
 'atp/brand_wikidata/Q1038929': 1658,
 'atp/brand_wikidata/Q134958024': 7,
 'atp/brand_wikidata/Q134958099': 3,
 'atp/category/amenity/cafe': 3,
 'atp/category/amenity/ice_cream': 7,
 'atp/category/shop/convenience': 1658,
 'atp/country/JP': 1668,
 'atp/field/city/missing': 1668,
 'atp/field/country/from_spider_name': 1668,
 'atp/field/email/missing': 1668,
 'atp/field/housenumber/missing': 1668,
 'atp/field/name/missing': 10,
 'atp/field/opening_hours/missing': 1131,
 'atp/field/operator/missing': 1668,
 'atp/field/operator_wikidata/missing': 1668,
 'atp/field/state/missing': 1668,
 'atp/field/street/missing': 1668,
 'atp/field/street_address/missing': 1668,
 'atp/field/twitter/missing': 1668,
 'atp/field/unit/missing': 1668,
 'atp/item_scraped_host_count/api.site.can-ly.com': 1668,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_unknown': 10,
 'atp/nsi/match_failed': 10,
 'atp/nsi/match_perfect': 1658,
 'downloader/request_bytes': 694,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 267325,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 371.18893498299803,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 6, 10, 49, 37, 273234, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 6306465,
 'httpcompression/response_count': 1,
 'item_scraped_count': 1668,
 'items_per_minute': 269.7574123989218,
 'log_count/DEBUG': 1671,
 'log_count/INFO': 9,
 'memusage/max': 478924800,
 'memusage/startup': 302678016,
 'response_received_count': 2,
 'responses_per_minute': 0.32345013477088946,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 6, 10, 43, 26, 84293, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store-location data retrieval by using the updated shops search service.
  * Updated location parsing to correctly process the current API response format.
  * Store eligibility now reflects the latest opening-status information.
  * Removed obsolete request handling that could prevent reliable location updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->