### PR TITLE
[Juice Press US] Fix spider

### DIFF
--- a/locations/spiders/juice_press_us.py
+++ b/locations/spiders/juice_press_us.py
@@ -29,7 +29,7 @@ class JuicePressUSSpider(Spider):
             item["image"] = store["image"]
             item["ref"] = store["selector"]
 
-            if float(item["lon"]) > 0:
+            if item.get("lon") and float(item["lon"]) > 0:
                 item["lon"] = float(item["lon"]) * -1
 
             if "Equinox" in item["street_address"]:


### PR DESCRIPTION
- Guard the longitude sign-flip so a store with no coordinates can't abort the parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location data processing by safely handling entries without longitude values.
  * Ensured positive longitudes are correctly converted to their expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->