### PR TITLE
[Pommesfreunde AT DE] Fix spider

### DIFF
--- a/locations/spiders/pommesfreunde_at_de.py
+++ b/locations/spiders/pommesfreunde_at_de.py
@@ -1,6 +1,4 @@
-import html
 import json
-import re
 from typing import Any, Iterable
 
 from scrapy import Request, Spider
@@ -20,7 +18,7 @@ class PommesfreundeATDESpider(Spider):
         yield Request("https://pommesfreunde.de/standorte", callback=self.parse_markers, meta={"stores": stores})
 
     def parse_markers(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        markers = json.loads(html.unescape(re.search(r'data-markers="(.*?)"', response.text, re.DOTALL).group(1)))
+        markers = json.loads(response.xpath("//@data-markers").get())
         for marker in markers:
             if not (store := response.meta["stores"].get(marker["id"])):
                 continue

--- a/locations/spiders/pommesfreunde_at_de.py
+++ b/locations/spiders/pommesfreunde_at_de.py
@@ -12,6 +12,7 @@ class PommesfreundeATDESpider(Spider):
     name = "pommesfreunde_at_de"
     item_attributes = {"brand": "Pommesfreunde", "brand_wikidata": "Q117083946"}
     start_urls = ["https://pommesfreunde.de/wp-json/wp/v2/lieferservice?per_page=100&_fields=id,title,link"]
+    skip_auto_cc_domain = True
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
         stores = {store["id"]: store for store in response.json()}

--- a/locations/spiders/pommesfreunde_at_de.py
+++ b/locations/spiders/pommesfreunde_at_de.py
@@ -1,7 +1,34 @@
-from locations.storefinders.wp_go_maps import WpGoMapsSpider
+import html
+import json
+import re
+from typing import Any, Iterable
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 
 
-class PommesfreundeATDESpider(WpGoMapsSpider):
+class PommesfreundeATDESpider(Spider):
     name = "pommesfreunde_at_de"
     item_attributes = {"brand": "Pommesfreunde", "brand_wikidata": "Q117083946"}
-    allowed_domains = ["pommesfreunde.de"]
+    start_urls = ["https://pommesfreunde.de/wp-json/wp/v2/lieferservice?per_page=100&_fields=id,title,link"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
+        stores = {store["id"]: store for store in response.json()}
+        yield Request("https://pommesfreunde.de/standorte", callback=self.parse_markers, meta={"stores": stores})
+
+    def parse_markers(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        markers = json.loads(html.unescape(re.search(r'data-markers="(.*?)"', response.text, re.DOTALL).group(1)))
+        for marker in markers:
+            if not (store := response.meta["stores"].get(marker["id"])):
+                continue
+            item = Feature()
+            item["ref"] = str(marker["id"])
+            item["lat"] = marker["latLang"]["lat"]
+            item["lon"] = marker["latLang"]["lng"]
+            item["branch"] = store["title"]["rendered"]
+            item["website"] = store["link"]
+            apply_category(Categories.FAST_FOOD, item)
+            yield item


### PR DESCRIPTION
- WP Go Maps plugin removed; its API 404s.
- Join the `lieferservice` REST list with the `/standorte` map markers for coordinates (56 stores).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved location data collection for Pommesfreunde Austria and Germany.
  * Store listings now include categorized location, branch, website, and reference details.
  * Store metadata and map markers are matched to provide more complete and accurate location information.
  * Location results are retrieved from both store information and embedded map data for broader coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->