### PR TITLE
[Helzberg Diamonds US] Fix spider

### DIFF
--- a/locations/spiders/helzberg_diamonds_us.py
+++ b/locations/spiders/helzberg_diamonds_us.py
@@ -21,5 +21,6 @@ class HelzbergDiamondsUSSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
         item["branch"] = item.pop("name")
         item["website"] = response.url
+        item.pop("image", None)
         apply_category(Categories.SHOP_JEWELRY, item)
         yield item

--- a/locations/spiders/helzberg_diamonds_us.py
+++ b/locations/spiders/helzberg_diamonds_us.py
@@ -1,52 +1,25 @@
-import re
 from typing import Any
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.hours import OpeningHours
+from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class HelzbergDiamondsUSSpider(SitemapSpider):
+class HelzbergDiamondsUSSpider(SitemapSpider, StructuredDataSpider):
     name = "helzberg_diamonds_us"
     item_attributes = {"brand": "Helzberg Diamonds", "brand_wikidata": "Q16995161"}
-    allowed_domains = ["helzberg.com"]
-    sitemap_urls = ["https://www.helzberg.com/sitemap_stores.xml"]
-    sitemap_rules = [("/store", "parse")]
+    sitemap_urls = ["https://www.helzberg.com/sitemap_stores-custom.xml"]
+    sitemap_rules = [(r"/stores/[a-z]{2}/[^/]+/[^/]+-\d+$", "parse_sd")]
+    wanted_types = ["JewelryStore"]
+    time_format = "%I:%M%p"
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
-        if ref := re.findall("[0-9]+", response.url):
-            item["ref"] = ref[0]
-            address = response.xpath('//p[contains(@class,"address")]/text()').extract()
-            item["branch"] = response.xpath('//h2[contains(@class,"store-name")]/text()').get()
-            item["phone"] = response.xpath('//a[@class="storelocator-phone"]/text()').get()
-            item["website"] = response.url
-            item["city"] = address[-3].replace("\n", "").split(",")[0]
-            item["postcode"] = re.findall("[0-9]+", address[-3].replace("\n", "").split(",")[1])[0]
-            item["state"] = re.findall("[A-Z]{2}", address[-3].replace("\n", "").split(",")[1])[0]
-            item["street_address"] = (
-                address[:-2][0].replace("\n", "") + address[:-2][1].replace("\n", "")
-                if len(address[:-2]) > 2
-                else address[:-2][0].replace("\n", "")
-            ).strip()
-            item["lat"], item["lon"] = re.findall(
-                "[0-9]+.+", response.xpath('//a[contains(@class,"store-map")]/@href').get()
-            )[0].split(",")
-            days = response.xpath('//div[contains(@class, "store-hours")]/p/text()').extract()
-            oh = OpeningHours()
-            for day in days:
-                if day is not None:
-                    if "Closed" in day:
-                        continue
-                    oh.add_range(
-                        day=re.findall(r"[-\w]+", day)[0],
-                        open_time=re.findall(r"[0-9]+.+", day)[0].split(" - ")[0],
-                        close_time=re.findall(r"[0-9]+.+", day)[0].split(" - ")[1],
-                        time_format="%I:%M%p",
-                    )
-            item["opening_hours"] = oh
-            yield item
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["branch"] = item.pop("name")
+        item["website"] = response.url
+        apply_category(Categories.SHOP_JEWELRY, item)
+        yield item


### PR DESCRIPTION
- Old store sitemap 404s; use the renamed `sitemap_stores-custom.xml`.
- Parse the store pages' ld+json (StructuredDataSpider) — 154 stores with coords, hours, phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy and consistency of Helzberg Diamonds store listings.
  * Store records now provide clearer branch names, website links, jewelry categorization, and opening hours.
  * Updated store discovery to include the latest available locations and reduce incomplete or inconsistent address and contact details.
  * Removed unreliable listing information that could result in missing or incorrectly formatted store data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->