### PR TITLE
[Beev GB] Fix Spider

### DIFF
--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -16,7 +16,7 @@ class BeevGBSpider(PlaywrightSpider):
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(
-            url="https://be-ev.co.uk/api/sites/GetMarkersWithFilters?ConnectorType=type2:0,ccs:0,chademo:0&ChargerType=f:0,r:0&Availability=a:0,o:0,u:0,cs:0&PaymentOptions=cless:0&AccessibilityFeatures=wpb:0,ac:0,sfk:0,sfc:0,fg:0&MultiChargerLocations=one:0,two:0,three:0,fourplus:0&SpecialistGroups=taxi:0&DifferentOperators=diffops:0&OffPeakPricing=opp:0&source=fuuse",
+            url="https://be-ev.co.uk/api/sites/GetMarkersWithFilters?Availability=o:0,a:0,&ChargerType=f:0,r:0,ur:0&ConnectorType=type2:0,ccs:0,chademo:0&Facilities=RESTAURANT:0,PARKING_LOT:0,SPORT:0,CAFE:0,HOTEL:0,MALL:0,SUPERMARKET:0,TRAIN_STATION:0,RECREATION_AREA:0,NATURE:0&source=fuuse",
         )
 
     def parse(self, response, **kwargs):


### PR DESCRIPTION
```python
{'atp/brand/Be.EV': 600,
 'atp/brand_wikidata/Q118263083': 600,
 'atp/category/amenity/charging_station': 600,
 'atp/clean_strings/name': 6,
 'atp/clean_strings/postcode': 3,
 'atp/country/GB': 600,
 'atp/field/branch/missing': 600,
 'atp/field/city/missing': 600,
 'atp/field/country/from_spider_name': 600,
 'atp/field/email/missing': 600,
 'atp/field/housenumber/missing': 600,
 'atp/field/opening_hours/missing': 600,
 'atp/field/phone/missing': 600,
 'atp/field/state/missing': 600,
 'atp/field/street/missing': 600,
 'atp/field/street_address/missing': 600,
 'atp/field/twitter/missing': 600,
 'atp/field/unit/missing': 600,
 'atp/item_scraped_host_count/be-ev.co.uk': 600,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 600,
 'atp/operator/Iduna': 600,
 'atp/operator_wikidata/Q118263083': 600,
 'downloader/request_bytes': 588,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 1172838,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 35.572520175000136,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 7, 6, 43, 53, 843571, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 600,
 'items_per_minute': 1028.5714285714284,
 'log_count/DEBUG': 605,
 'log_count/INFO': 7,
 'memusage/max': 294862848,
 'memusage/startup': 294862848,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 1.7142857142857142,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 7, 6, 43, 18, 271043, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Be.EV location retrieval to use the latest availability, charger type, connector type, and facility filters.
  * Improved the accuracy of available charging location results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->