### PR TITLE
[Inditex] Handle playwright default timeout

### DIFF
--- a/locations/spiders/inditex.py
+++ b/locations/spiders/inditex.py
@@ -26,6 +26,7 @@ class InditexSpider(PlaywrightSpider):
     # Each site has the same multi-brand catalogue JSON, could have picked any site!
     start_urls = ["https://www.massimodutti.com/itxrest/2/web/seo/config?appId=1"]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000,
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
         "CONCURRENT_REQUESTS": 1,


### PR DESCRIPTION
Spider is working fine from `US`. Added protection against timeout by increasing playwright default timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading Inditex location pages by allowing more time for navigation to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->