### PR TITLE
[Take 5 US] Fix spider

### DIFF
--- a/locations/spiders/take_5_us.py
+++ b/locations/spiders/take_5_us.py
@@ -7,7 +7,10 @@ from locations.structured_data_spider import StructuredDataSpider
 class Take5USSpider(SitemapSpider, StructuredDataSpider):
     name = "take_5_us"
     item_attributes = {"brand": "Take 5", "brand_wikidata": "Q112359190"}
-    sitemap_urls = ["https://www.take5.com/sitemap.xml"]
+    sitemap_urls = [
+        "https://www.take5.com/sitemap/en.xml",
+        "https://www.take5carwashes.com/sitemap.xml",
+    ]
     sitemap_rules = [(r"/locations/[a-z-]+/[a-z0-9-]+/\d+/?$", "parse_sd")]
     wanted_types = ["AutoRepair", "AutoWash"]
     search_for_facebook = False

--- a/locations/spiders/take_5_us.py
+++ b/locations/spiders/take_5_us.py
@@ -8,7 +8,7 @@ class Take5USSpider(SitemapSpider, StructuredDataSpider):
     name = "take_5_us"
     item_attributes = {"brand": "Take 5", "brand_wikidata": "Q112359190"}
     sitemap_urls = ["https://www.take5.com/sitemap.xml"]
-    sitemap_rules = [(r"/locations/oil-change", "parse_sd"), (r"/locations/car-wash", "parse_sd")]
+    sitemap_rules = [(r"/locations/[a-z-]+/[a-z0-9-]+/\d+/?$", "parse_sd")]
     wanted_types = ["AutoRepair", "AutoWash"]
     search_for_facebook = False
     search_for_twitter = False

--- a/locations/spiders/take_5_us.py
+++ b/locations/spiders/take_5_us.py
@@ -21,5 +21,6 @@ class Take5USSpider(SitemapSpider, StructuredDataSpider):
         if ld_data["@type"] == "AutoWash":
             apply_category(Categories.CAR_WASH, item)
         else:
+            item["ref"] = item.pop("name").removeprefix("Take 5 #")
             apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION
- Sitemap moved and store URLs restructured; match the new `/locations/<state>/<city>/<id>` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location discovery across separate oil-change and car-wash sitemaps.
  * Expanded support for location URLs with varying city, slug, and ID formats.
  * Corrected oil-change location names by removing redundant “Take 5 #” prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->