### PR TITLE
[Mercy Health US] Fix spider

### DIFF
--- a/locations/spiders/mercy_health_us.py
+++ b/locations/spiders/mercy_health_us.py
@@ -87,10 +87,10 @@ class MercyHealthUSSpider(Spider):
             else:
                 facility_type = location.get("FacilityType", {}).get("Name")
             if category := HEALTHCARE_CATEGORIES.get(facility_type):
-                for top_level_category, specialities in category:
-                    apply_category(top_level_category, item)
-                    if specialities:
-                        apply_healthcare_specialities(specialities, item)
+                top_level_category, specialities = category
+                apply_category(top_level_category, item)
+                if specialities:
+                    apply_healthcare_specialities(specialities, item)
                 if facility_type == "Home Health Care":
                     apply_yes_no("home_visit", item, True)
             else:

--- a/locations/spiders/mercy_health_us.py
+++ b/locations/spiders/mercy_health_us.py
@@ -19,6 +19,7 @@ HEALTHCARE_CATEGORIES = {
     "Behavioral and Mental Health": (Categories.PSYCHOTHERAPIST, [HealthcareSpecialities.PSYCHOTHERAPHY_BEHAVIOR]),
     "Breast Health Centers": (Categories.CLINIC, [HealthcareSpecialities.ONCOLOGY]),
     "Cancer Care and Oncology": (Categories.CLINIC, [HealthcareSpecialities.ONCOLOGY]),
+    "Dental Care": (Categories.DENTIST, []),
     "Dermatology": (Categories.CLINIC, [HealthcareSpecialities.DERMATOLOGY]),
     "Endocrinology and Diabetes": (Categories.CLINIC, [HealthcareSpecialities.ENDOCRINOLOGY]),
     "Ear, Nose and Throat (ENT)": (Categories.CLINIC, [HealthcareSpecialities.OTOLARYNGOLOGY]),
@@ -93,7 +94,7 @@ class MercyHealthUSSpider(Spider):
                     apply_healthcare_specialities(specialities, item)
                 if facility_type == "Home Health Care":
                     apply_yes_no("home_visit", item, True)
+                yield item
             else:
                 self.logger.warning("Unknown facility type: {}".format(facility_type))
                 self.crawler.stats.inc_value(f"atp/{self.name}/unmapped_category/{facility_type}")
-            yield item


### PR DESCRIPTION
The spider crashed with `TypeError: cannot unpack non-iterable Categories object`, yielding zero items. Each `HEALTHCARE_CATEGORIES` value is a single `(category, specialities)` tuple; unpack it directly instead of iterating over it.

Restores the full ~1,146 locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dental Care as a recognized facility category for Mercy Health locations.

* **Bug Fixes**
  * Improved facility classification so each location receives the correct top-level category and associated specialties.
  * Prevented category and specialty data from being applied multiple times during location processing.
  * Ensured only locations with recognized facility mappings are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->