### PR TITLE
[Penningtons CA] Fix spider

### DIFF
--- a/locations/spiders/penningtons_ca.py
+++ b/locations/spiders/penningtons_ca.py
@@ -1,22 +1,26 @@
-from typing import Iterable
+from typing import Any
 
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.storefinders.uberall import UberallSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PenningtonsCASpider(UberallSpider):
+class PenningtonsCASpider(SitemapSpider, StructuredDataSpider):
     name = "penningtons_ca"
-    item_attributes = {
-        "brand_wikidata": "Q16956527",
-        "brand": "Penningtons",
-    }
-    key = "plEhL7SEWWjub5NBhsr8Iidzl8GgaX"
+    item_attributes = {"brand": "Penningtons", "brand_wikidata": "Q16956527"}
+    sitemap_urls = ["https://locations.penningtons.com/sitemap.xml"]
+    sitemap_rules = [(r"/[a-z]{2}/[^/]+/[^/]+$", "parse_sd")]
+    wanted_types = ["ClothingStore"]
+    time_format = "%I:%M %p"
+    search_for_facebook = False
+    search_for_twitter = False
+    search_for_image = False
 
-    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
-        item["ref"] = location["ref"].removeprefix("Store ")
-        item["website"] = (
-            f'https://locations.penningtons.com/{item["state"]}-{item["city"]}-{item["ref"]}'.lower().replace(" ", "-")
-        )
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["branch"] = item.pop("name")
+        item.pop("image", None)
+        apply_category(Categories.SHOP_CLOTHES, item)
         yield item


### PR DESCRIPTION
The Uberall storefinder key now returns an empty locations list. Penningtons moved its store locator to a Reitmans-hosted local-pages site; rebuilt as a `SitemapSpider` + `StructuredDataSpider` reading the `ClothingStore` ld+json on each store page.

Restores the ~86 locations and adds opening hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location data collection from the retailer’s sitemap and structured website data.
  * Standardized branch names and category information for clothing-store locations.
  * Removed unnecessary image details from location listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->