### PR TITLE
[Pizzalonga Away IT] Fix spider

### DIFF
--- a/locations/spiders/pizzalonga_away_it.py
+++ b/locations/spiders/pizzalonga_away_it.py
@@ -33,7 +33,6 @@ class PizzalongaAwayITSpider(JSONBlobSpider):
         return chompjs.parse_js_object(pois)
 
     def pre_process_data(self, location):
-        location["lat"], location["lon"] = re.findall(r"(\d+\.\d+)", location["position"])
         location["address"] = location.pop("caddress")
         location["phone"] = location.pop("cphone")
 
@@ -44,11 +43,11 @@ class PizzalongaAwayITSpider(JSONBlobSpider):
         item["city"] = item["branch"] = item.pop("name")
 
         item["opening_hours"] = OpeningHours()
-        hours = location["copenings"].replace("<br/>", " ").replace("|", ",")
+        hours = re.sub(r"<br\s*/?>", " ", location["copenings"]).replace("|", ",")
         add_it_ranges(item["opening_hours"], hours)
 
         deliver = OpeningHours()
-        delivery = location["cdelivery"].replace("<br/>", " ").replace("|", ",")
+        delivery = re.sub(r"<br\s*/?>", " ", location["cdelivery"]).replace("|", ",")
         add_it_ranges(deliver, delivery)
         if deliver:
             item["extras"]["delivery"] = deliver.as_opening_hours()


### PR DESCRIPTION
The embedded `pois` array dropped the `position` string (which was regex-split into lat/lon) in favour of separate `lat`/`lng` fields, causing `KeyError: 'position'` and zero items. Dropped the obsolete parse so DictParser maps the coordinates, and made the opening-hours `<br>` replacement tag-agnostic (the source now emits `<br>` rather than `<br/>`).

Restores the ~81 locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening-hours and delivery-hours formatting by consistently converting line breaks to spaces.
  * Removed latitude and longitude extraction from location processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->