### PR TITLE
[Mitsubishi MA] Fix spider

### DIFF
--- a/locations/spiders/mitsubishi_ma.py
+++ b/locations/spiders/mitsubishi_ma.py
@@ -19,7 +19,6 @@ class MitsubishiMASpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["ref"] = str(feature["id"])
-        item["branch"] = item.pop("name")
         item["street_address"] = item.pop("addr_full")
         item.pop("phone", None)
 

--- a/locations/spiders/mitsubishi_ma.py
+++ b/locations/spiders/mitsubishi_ma.py
@@ -1,40 +1,36 @@
+import json
 from copy import deepcopy
-from typing import Any
+from typing import Iterable
 
-import scrapy
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.google_url import extract_google_position
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class MitsubishiMASpider(scrapy.Spider):
+class MitsubishiMASpider(JSONBlobSpider):
     name = "mitsubishi_ma"
     item_attributes = {"brand": "Mitsubishi", "brand_wikidata": "Q36033"}
-    start_urls = ["http://www.mitsubishi-motors.ma/succursale"]
+    start_urls = ["https://www.mitsubishi-motors.ma/reseau"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//*[@class="item-list"]//li'):
-            item = Feature()
-            item["ref"] = location.xpath('.//*[contains(@class,"more-infos")]/@id').get("")
-            item["branch"] = location.xpath(".//h3/text()").get()
-            item["street_address"] = location.xpath('.//*[@class="adrs"]//p/text()[1]').get("").strip()
-            item["city"] = location.xpath('.//*[@class="adrs"]//p/text()[2]').get("").strip()
-            item["phone"] = location.xpath('.//*[contains(@href,"tel:")]/text()').get()
-            extract_google_position(item, location)
+    def extract_json(self, response: Response) -> list[dict]:
+        return json.loads(response.xpath('//*[@id="map"]/@data-branches').get())
 
-            has_sales = bool(location.xpath('.//*[contains(@class,"vente")]'))
-            has_services = bool(location.xpath('.//*[contains(@class,"services")]'))
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = str(feature["id"])
+        item["branch"] = item.pop("name")
+        item["street_address"] = item.pop("addr_full")
+        item.pop("phone", None)
 
-            if has_sales:
-                sales_item = deepcopy(item)
-                sales_item["ref"] = f"{item['ref']}-sales"
-                apply_category(Categories.SHOP_CAR, sales_item)
-                yield sales_item
+        if "vente" in feature["services"]:
+            sales_item = deepcopy(item)
+            sales_item["ref"] = f"{item['ref']}-sales"
+            apply_category(Categories.SHOP_CAR, sales_item)
+            yield sales_item
 
-            if has_services:
-                service_item = deepcopy(item)
-                service_item["ref"] = f"{item['ref']}-service"
-                apply_category(Categories.SHOP_CAR_REPAIR, service_item)
-                yield service_item
+        if "sav" in feature["services"]:
+            service_item = deepcopy(item)
+            service_item["ref"] = f"{item['ref']}-service"
+            apply_category(Categories.SHOP_CAR_REPAIR, service_item)
+            yield service_item


### PR DESCRIPTION
The old `/succursale` page now 404s. The dealer network moved to `/reseau`, which carries all dealer data (including coordinates) in a `data-branches` JSON attribute. Rebuilt as a `JSONBlobSpider` reading that array, keeping the sales/service split driven by the per-dealer `services` list.

Restores the locations (~50 sales/service items across 26 dealers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Updates**
  * Updated Mitsubishi Motors branch listings using the latest network data.
  * Improved branch details and location information for greater accuracy.
  * Sales and service locations are now listed separately where applicable.
  * Phone information has been removed from these listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->