### PR TITLE
[Lacoste] Localise store URLs by country

### DIFF
--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -3,9 +3,38 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.country_utils import CountryUtils
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.user_agents import FIREFOX_LATEST
+
+# Only markets lacoste.com actually serves a localised site for; anything
+# else falls back to /us. Add a code here if a store URL 404s.
+LOCALISED_MARKETS = {
+    "AT",
+    "BE",
+    "CH",
+    "CN",
+    "CZ",
+    "DE",
+    "DK",
+    "ES",
+    "FI",
+    "FR",
+    "GR",
+    "HU",
+    "IT",
+    "JP",
+    "KR",
+    "NL",
+    "NO",
+    "PL",
+    "PT",
+    "RO",
+    "SE",
+    "TR",
+    "TW",
+}
 
 
 class LacosteSpider(JSONBlobSpider):
@@ -20,7 +49,6 @@ class LacosteSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["street_address"] = item.pop("addr_full")
-        item["website"] = f'https://www.lacoste.com/us/stores{feature["url"]}'
         item["name"] = html.unescape(item["name"]).strip()
         country = feature["url"].split("/")[1]
         if "taiwan" in country:
@@ -28,5 +56,8 @@ class LacosteSpider(JSONBlobSpider):
         elif country.startswith("china"):
             item["country"] = "CN"
         else:
-            item["country"] = country.title()
+            item["country"] = CountryUtils().to_iso_alpha2_country_code(country.replace("-", " ")) or country.title()
+        market = item["country"] if item["country"] in LOCALISED_MARKETS else "us"
+        item["website"] = f'https://www.lacoste.com/{market.lower()}/stores{feature["url"]}'
+        item["extras"]["@source_uri"] = item["website"]
         yield item


### PR DESCRIPTION
Use the country's ISO code to align the store website with the correct country.
For now, every feature around the world have /us website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized market support for Lacoste store listings.
  * Website and source links now use the selected country or region when available.
  * Unsupported markets continue to use the US storefront as a fallback.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->