### PR TITLE
[Lacoste] Build localised store URLs from the slug

### DIFF
--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -1,4 +1,27 @@
+from typing import Iterable
+
+from locations.items import Feature
 from locations.storefinders.yext_answers import YextAnswersSpider
+
+# Markets lacoste.com serves a localised site for, mapped from the store's country.
+# Anything else keeps the default /us site.
+LOCALISED_MARKETS = {
+    "AT": "at",
+    "BE": "be",
+    "BR": "br",
+    "CH": "ch",
+    "DE": "de",
+    "DK": "dk",
+    "ES": "es",
+    "FR": "fr",
+    "IT": "it",
+    "KR": "kr",
+    "MC": "fr",
+    "MX": "mx",
+    "NL": "nl",
+    "PT": "pt",
+    "SE": "se",
+}
 
 
 class LacosteSpider(YextAnswersSpider):
@@ -9,3 +32,12 @@ class LacosteSpider(YextAnswersSpider):
     environment = "PRODUCTION"
     experience_key = "locator-search-eu"
     locale = "en-US"
+
+    def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
+        # websiteUrl is missing on some stores and malformed on others ("//us/", utm
+        # parameters), so build the URL from the slug and localise it by country.
+        path = location["slug"].strip("/").removeprefix("us/stores/")
+        market = LOCALISED_MARKETS.get(item["country"], "us")
+        item["website"] = f"https://www.lacoste.com/{market}/stores/{path}"
+        item["extras"]["@source_uri"] = item["website"]
+        yield item

--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -1,5 +1,6 @@
 from typing import Iterable
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.yext_answers import YextAnswersSpider
 
@@ -34,6 +35,7 @@ class LacosteSpider(YextAnswersSpider):
     locale = "en-US"
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_CLOTHES, item)
         # c_liveOnPages marks stores that have no page on lacoste.com; both their
         # websiteUrl and their slug point at URLs that do not exist.
         if not location.get("c_liveOnPages"):

--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -1,3 +1,4 @@
+import re
 from typing import Iterable
 
 from locations.items import Feature
@@ -36,7 +37,8 @@ class LacosteSpider(YextAnswersSpider):
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         # websiteUrl is missing on some stores and malformed on others ("//us/", utm
         # parameters), so build the URL from the slug and localise it by country.
-        path = location["slug"].strip("/").removeprefix("us/stores/")
+        # Most slugs are "us/stores/<path>", a few are "stores/en_us/<path>".
+        path = re.sub(r"^(us/)?stores/(en_us/)?", "", location["slug"].strip("/"))
         market = LOCALISED_MARKETS.get(item["country"], "us")
         item["website"] = f"https://www.lacoste.com/{market}/stores/{path}"
         item["extras"]["@source_uri"] = item["website"]

--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -47,5 +47,4 @@ class LacosteSpider(YextAnswersSpider):
         path = location["slug"].strip("/").removeprefix("us/stores/")
         market = LOCALISED_MARKETS.get(item["country"], "us")
         item["website"] = f"https://www.lacoste.com/{market}/stores/{path}"
-        item["extras"]["@source_uri"] = item["website"]
         yield item

--- a/locations/spiders/lacoste.py
+++ b/locations/spiders/lacoste.py
@@ -1,4 +1,3 @@
-import re
 from typing import Iterable
 
 from locations.items import Feature
@@ -35,10 +34,17 @@ class LacosteSpider(YextAnswersSpider):
     locale = "en-US"
 
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
-        # websiteUrl is missing on some stores and malformed on others ("//us/", utm
-        # parameters), so build the URL from the slug and localise it by country.
-        # Most slugs are "us/stores/<path>", a few are "stores/en_us/<path>".
-        path = re.sub(r"^(us/)?stores/(en_us/)?", "", location["slug"].strip("/"))
+        # c_liveOnPages marks stores that have no page on lacoste.com; both their
+        # websiteUrl and their slug point at URLs that do not exist.
+        if not location.get("c_liveOnPages"):
+            item["website"] = None
+            yield item
+            return
+
+        # websiteUrl is unusable even for live stores: absent on some, and elsewhere
+        # pointing at /us with utm parameters and sometimes a doubled slash. Build the
+        # URL from the slug instead and localise it by country.
+        path = location["slug"].strip("/").removeprefix("us/stores/")
         market = LOCALISED_MARKETS.get(item["country"], "us")
         item["website"] = f"https://www.lacoste.com/{market}/stores/{path}"
         item["extras"]["@source_uri"] = item["website"]


### PR DESCRIPTION
websiteUrl from the Yext feed is unusable: missing on some stores, and otherwise pointing at /us with utm tracking parameters and sometimes a doubled slash. Build the URL from the slug instead, and map the store country to the matching lacoste.com market. The country and website's language are now aligned.

Also set @source_uri to the store page rather than the Yext endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store listings now link directly to the appropriate Lacoste market website based on country.
  * Added localized market handling for supported countries, with a US fallback when no specific market is available.
  * Store source links now consistently reflect the correct localized page.
  * Website links are removed for stores that are not marked as live.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->