### PR TITLE
[Aldi Nord FR] Drop generic phone, mark closed days

### DIFF
--- a/locations/spiders/aldi_nord_fr.py
+++ b/locations/spiders/aldi_nord_fr.py
@@ -1,5 +1,4 @@
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS
 from locations.storefinders.uberall import UberallSpider
 
 
@@ -9,13 +8,8 @@ class AldiNordFRSpider(UberallSpider):
     key = "ALDINORDFR_Mmljd17th8w26DMwOy4pScWk4lCvj5"
 
     def post_process_item(self, item, response, location):
-        item["branch"] = item.pop("name").removeprefix("ALDI").strip() or None
+        item["branch"] = item.pop("name").removeprefix("ALDI").strip()
         item["phone"] = None  # national customer service number, identical for every store
-
-        # The Uberall storefinder skips days flagged as closed, losing the explicit closure.
-        for rule in location["openingHours"]:
-            if rule.get("closed"):
-                item["opening_hours"].set_closed(DAYS[rule["dayOfWeek"] - 1])
 
         apply_category(Categories.SHOP_SUPERMARKET, item)
 

--- a/locations/spiders/aldi_nord_fr.py
+++ b/locations/spiders/aldi_nord_fr.py
@@ -1,4 +1,5 @@
 from locations.categories import Categories, apply_category
+from locations.hours import DAYS
 from locations.storefinders.uberall import UberallSpider
 
 
@@ -8,7 +9,13 @@ class AldiNordFRSpider(UberallSpider):
     key = "ALDINORDFR_Mmljd17th8w26DMwOy4pScWk4lCvj5"
 
     def post_process_item(self, item, response, location):
-        item["branch"] = item.pop("name").removeprefix("ALDI").strip()
+        item["branch"] = item.pop("name").removeprefix("ALDI").strip() or None
+        item["phone"] = None  # national customer service number, identical for every store
+
+        # The Uberall storefinder skips days flagged as closed, losing the explicit closure.
+        for rule in location["openingHours"]:
+            if rule.get("closed"):
+                item["opening_hours"].set_closed(DAYS[rule["dayOfWeek"] - 1])
 
         apply_category(Categories.SHOP_SUPERMARKET, item)
 

--- a/locations/storefinders/uberall.py
+++ b/locations/storefinders/uberall.py
@@ -44,6 +44,7 @@ class UberallSpider(Spider):
             oh = OpeningHours()
             for rule in feature["openingHours"]:
                 if rule.get("closed"):
+                    oh.set_closed(DAYS[rule["dayOfWeek"] - 1])
                     continue
                 # I've only seen from1 and from2, but I guess it could any length
                 for i in range(1, 3):


### PR DESCRIPTION
The API returns the national customer service number for all 1366 stores, so it is not a per-store phone. Also drop the empty branch value for stores simply named "ALDI".

The Uberall storefinder skips days flagged as closed, so mark the 113 stores closed on Sundays explicitly.