### PR TITLE
Add hteao_us spider (190 locations)

### DIFF
--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -1,5 +1,6 @@
 import html
 import re
+from typing import ClassVar
 
 import chompjs
 from scrapy.http import Response
@@ -9,13 +10,14 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.pipelines.state_clean_up import StateCodeCleanUpPipeline
 
 
 class HteaoUSSpider(SitemapSpider):
     name = "hteao_us"
-    item_attributes = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
-    sitemap_urls = ["https://hteao.com/wpsl_stores-sitemap.xml"]
-    sitemap_rules = [(r"/locations/[^/]+/$", "parse")]
+    item_attributes: ClassVar[dict[str, str]] = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
+    sitemap_urls: ClassVar[list[str]] = ["https://hteao.com/wpsl_stores-sitemap.xml"]
+    sitemap_rules: ClassVar[list[tuple[str, str]]] = [(r"/locations/[^/]+/$", "parse")]
     locations_regex = re.compile(r'"locations":\s*(\[.*?\])\s*,\s*"mapOptions"', re.DOTALL)
 
     def parse(self, response: Response):
@@ -35,12 +37,16 @@ class HteaoUSSpider(SitemapSpider):
         item.pop("addr_full", None)
         if street_address := merge_address_lines([location.get("address1"), location.get("address2")]):
             item["street_address"] = street_address
+        item["country"] = "US"
+        if state := item.get("state"):
+            item["state"] = StateCodeCleanUpPipeline.clean_state(state, "US") or state
 
         item["opening_hours"] = OpeningHours()
         for row in response.xpath('//table[contains(@class, "wpsl-opening-hours")]/tr'):
-            item["opening_hours"].add_ranges_from_string(
-                f'{row.xpath("td[1]//text()").get("")} {row.xpath("td[2]//text()").get("")}'
-            )
+            day = row.xpath("td[1]//text()").get("")
+            for hours in row.xpath("td[2]//text()").getall():
+                if hours.strip():
+                    item["opening_hours"].add_ranges_from_string(f"{day} {hours}")
 
         apply_category(Categories.CAFE, item)
 

--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -10,7 +10,7 @@ from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class HTeaOUSSpider(SitemapSpider):
+class HteaoUSSpider(SitemapSpider):
     name = "hteao_us"
     item_attributes = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
     sitemap_urls = ["https://hteao.com/wpsl_stores-sitemap.xml"]

--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -1,4 +1,5 @@
 import html
+import re
 
 import chompjs
 from scrapy.http import Response
@@ -15,12 +16,12 @@ class HteaoUSSpider(SitemapSpider):
     item_attributes = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
     sitemap_urls = ["https://hteao.com/wpsl_stores-sitemap.xml"]
     sitemap_rules = [(r"/locations/[^/]+/$", "parse")]
+    locations_regex = re.compile(r'"locations":\s*(\[.*?\])\s*,\s*"mapOptions"', re.DOTALL)
 
     def parse(self, response: Response):
-        js_blob = response.xpath('//script[contains(., "CONFIGURATION")]/text()').re_first(
-            r'"locations":\s*(\[.*?\])\s*,\s*"mapOptions"'
-        )
+        js_blob = response.xpath('//script[contains(., "CONFIGURATION")]/text()').re_first(self.locations_regex)
         if not js_blob:
+            self.logger.warning(f"No location data found on {response.url}")
             return
         location = chompjs.parse_js_object(js_blob)[0]
         if "on wheels" in location["title"].lower():
@@ -29,9 +30,11 @@ class HteaoUSSpider(SitemapSpider):
 
         item = DictParser.parse(location)
         item["ref"] = item["website"] = response.url
-        item["name"] = html.unescape(location["title"])
+        item.pop("name", None)
+        item["branch"] = html.unescape(location["title"])
         item.pop("addr_full", None)
-        item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
+        if street_address := merge_address_lines([location.get("address1"), location.get("address2")]):
+            item["street_address"] = street_address
 
         item["opening_hours"] = OpeningHours()
         for row in response.xpath('//table[contains(@class, "wpsl-opening-hours")]/tr'):

--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -1,6 +1,4 @@
-import html
 import re
-from typing import ClassVar
 
 import chompjs
 from scrapy.http import Response
@@ -10,14 +8,13 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.pipelines.state_clean_up import StateCodeCleanUpPipeline
 
 
 class HteaoUSSpider(SitemapSpider):
     name = "hteao_us"
-    item_attributes: ClassVar[dict[str, str]] = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
-    sitemap_urls: ClassVar[list[str]] = ["https://hteao.com/wpsl_stores-sitemap.xml"]
-    sitemap_rules: ClassVar[list[tuple[str, str]]] = [(r"/locations/[^/]+/$", "parse")]
+    item_attributes = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
+    sitemap_urls = ["https://hteao.com/wpsl_stores-sitemap.xml"]
+    sitemap_rules = [(r"/locations/[^/]+/$", "parse")]
     locations_regex = re.compile(r'"locations":\s*(\[.*?\])\s*,\s*"mapOptions"', re.DOTALL)
 
     def parse(self, response: Response):
@@ -32,14 +29,8 @@ class HteaoUSSpider(SitemapSpider):
 
         item = DictParser.parse(location)
         item["ref"] = item["website"] = response.url
-        item.pop("name", None)
-        item["branch"] = html.unescape(location["title"])
-        item.pop("addr_full", None)
-        if street_address := merge_address_lines([location.get("address1"), location.get("address2")]):
-            item["street_address"] = street_address
-        item["country"] = "US"
-        if state := item.get("state"):
-            item["state"] = StateCodeCleanUpPipeline.clean_state(state, "US") or state
+        item["branch"] = item.pop("name", None)
+        item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
 
         item["opening_hours"] = OpeningHours()
         for row in response.xpath('//table[contains(@class, "wpsl-opening-hours")]/tr'):

--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -8,6 +8,7 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.structured_data_spider import extract_facebook
 
 
 class HteaoUSSpider(SitemapSpider):
@@ -31,6 +32,7 @@ class HteaoUSSpider(SitemapSpider):
         item["ref"] = item["website"] = response.url
         item["branch"] = item.pop("name", None)
         item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
+        extract_facebook(item, response)
 
         item["opening_hours"] = OpeningHours()
         for row in response.xpath('//table[contains(@class, "wpsl-opening-hours")]/tr'):

--- a/locations/spiders/hteao_us.py
+++ b/locations/spiders/hteao_us.py
@@ -1,0 +1,44 @@
+import html
+
+import chompjs
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class HTeaOUSSpider(SitemapSpider):
+    name = "hteao_us"
+    item_attributes = {"brand": "HTeaO", "brand_wikidata": "Q129814206"}
+    sitemap_urls = ["https://hteao.com/wpsl_stores-sitemap.xml"]
+    sitemap_rules = [(r"/locations/[^/]+/$", "parse")]
+
+    def parse(self, response: Response):
+        js_blob = response.xpath('//script[contains(., "CONFIGURATION")]/text()').re_first(
+            r'"locations":\s*(\[.*?\])\s*,\s*"mapOptions"'
+        )
+        if not js_blob:
+            return
+        location = chompjs.parse_js_object(js_blob)[0]
+        if "on wheels" in location["title"].lower():
+            # Mobile trailer units with no fixed address, e.g. "See Socials for Updates!"
+            return
+
+        item = DictParser.parse(location)
+        item["ref"] = item["website"] = response.url
+        item["name"] = html.unescape(location["title"])
+        item.pop("addr_full", None)
+        item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
+
+        item["opening_hours"] = OpeningHours()
+        for row in response.xpath('//table[contains(@class, "wpsl-opening-hours")]/tr'):
+            item["opening_hours"].add_ranges_from_string(
+                f'{row.xpath("td[1]//text()").get("")} {row.xpath("td[2]//text()").get("")}'
+            )
+
+        apply_category(Categories.CAFE, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for HTeaO (iced tea drive-thru chain, US-only).

Crawls the WP Store Locator sitemap for all 192 store pages; excludes 2 "HTeaO On Wheels" mobile trailer listings that have no fixed address, leaving 190 real locations. Includes name, address, coordinates, phone, per-day opening hours, and brand Wikidata (Q129814206). NSI match: 192/192.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering HTeaO cafe locations across the United States.
  * Location listings now include normalized names, addresses, categories, opening hours, and Facebook details.
  * Mobile trailer locations are excluded from the results.
  * Pages without available location details are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->