### PR TITLE
Add torchys_tacos_us spider (120 locations)

### DIFF
--- a/locations/spiders/torchys_tacos_us.py
+++ b/locations/spiders/torchys_tacos_us.py
@@ -1,7 +1,7 @@
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 

--- a/locations/spiders/torchys_tacos_us.py
+++ b/locations/spiders/torchys_tacos_us.py
@@ -1,0 +1,28 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TorchysTacosUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "torchys_tacos_us"
+    item_attributes = {"brand": "Torchy's Tacos", "brand_wikidata": "Q106769573"}
+    sitemap_urls = ["https://torchystacos.com/sitemap.xml"]
+    # Each location has a single public page, its online-ordering page.
+    sitemap_rules = [(r"^https://torchystacos\.com/([^/]+)/order$", "parse_sd")]
+    wanted_types = ["Restaurant"]
+    # The site's twitter:site meta tag contains "Torchy's Tacos", not a handle.
+    search_for_twitter = False
+    # og:image/twitter:image are the same generic brand logo on every page, not a store photo.
+    search_for_image = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        # JSON-LD "name" is the location name only, e.g. "Kyle" / "88th & Wads".
+        item["branch"] = item.pop("name")
+        item["ref"] = response.url.removesuffix("/order").rsplit("/", 1)[-1]
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "tex-mex"
+        apply_yes_no(Extras.TAKEAWAY, item, True)
+        yield item

--- a/locations/spiders/torchys_tacos_us.py
+++ b/locations/spiders/torchys_tacos_us.py
@@ -21,8 +21,9 @@ class TorchysTacosUSSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         # JSON-LD "name" is the location name only, e.g. "Kyle" / "88th & Wads".
         item["branch"] = item.pop("name")
-        item["ref"] = response.url.removesuffix("/order").rsplit("/", 1)[-1]
+        source_url = next(iter(response.meta.get("redirect_urls", ())), response.url)
+        item["ref"] = source_url.removesuffix("/order").rsplit("/", 1)[-1]
         apply_category(Categories.FAST_FOOD, item)
-        item["extras"]["cuisine"] = "tex-mex"
+        apply_category({"cuisine": "tex-mex"}, item)
         apply_yes_no(Extras.TAKEAWAY, item, True)
         yield item

--- a/locations/spiders/torchys_tacos_us.py
+++ b/locations/spiders/torchys_tacos_us.py
@@ -24,6 +24,4 @@ class TorchysTacosUSSpider(SitemapSpider, StructuredDataSpider):
         source_url = next(iter(response.meta.get("redirect_urls", ())), response.url)
         item["ref"] = source_url.removesuffix("/order").rsplit("/", 1)[-1]
         apply_category(Categories.FAST_FOOD, item)
-        apply_category({"cuisine": "tex-mex"}, item)
-        apply_yes_no(Extras.TAKEAWAY, item, True)
         yield item


### PR DESCRIPTION
## Summary
- Adds a spider for Torchy's Tacos US locations
- Sitemap-driven: discovers each location's `/{slug}/order` page from `https://torchystacos.com/sitemap.xml`, then extracts the embedded schema.org `Restaurant` JSON-LD (address, geo, phone, opening hours)
- `brand_wikidata` set to Q106769573 per NSI entry `torchystacos-4d2ff4`

## Test plan
- [x] `uv run scrapy crawl torchys_tacos_us` — 120/120 items, `nsi/match_perfect: 120`, no errors/warnings
- [x] Spot-checked multiple locations (Kyle TX, 88th & Wads CO) against live pages
- [x] `isort` / `autoflake8` / `black` / `flake8` clean
- [x] `uv run pytest tests/` — 317 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdXXkMd84vgJ9iigpuZuRy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for Torchy’s Tacos restaurant locations across the United States.
  * Restaurant listings now include branch names, reference details, brand information, and fast-food categorization.
  * Location data is sourced from online ordering pages and restaurant metadata.
  * Listings now provide more consistent location details for discovery and browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->