### PR TITLE
[Millets GB] Fix spider

### DIFF
--- a/locations/spiders/millets_gb.py
+++ b/locations/spiders/millets_gb.py
@@ -17,13 +17,12 @@ class MilletsGBSpider(Spider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store_id in json.loads(
-            response.xpath('//*[@id="app-store-locator"]//*[@type="application/json"]//text()').get()
-        )["stores"]:
-            yield JsonRequest(
-                url=f"https://integrations-c3f9339ff060a907cbd8.o2.myshopify.dev/api/stores?fid={store_id['id']}",
-                callback=self.parse_location,
-            )
+        config = json.loads(response.xpath('//*[@id="app-store-locator"]//*[@type="application/json"]//text()').get())
+        store_ids = ",".join(store["id"] for store in config["stores"])
+        yield JsonRequest(
+            url=f'{config["api"]["origin"]}{config["api"]["pathname"]}?fid={store_ids}',
+            callback=self.parse_location,
+        )
 
     def parse_location(self, response: Response, **kwargs: Any) -> Any:
         for raw_data in response.json()["stores"]:


### PR DESCRIPTION
The per-store API moved off the old `myshopify.dev` host (which now returns no data), and issuing one request per store tripped Cloudflare rate limiting (429), producing zero items. Read the current API origin from the page's store-locator config and fetch every store in a single request, as the site's own front end does.

Restores the locations (26 stores).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store location retrieval by using the configured API endpoint.
  * Combined store identifiers into a single request for more consistent and efficient results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->