### PR TITLE
[Lilly RS] Fix Spider

### DIFF
--- a/locations/spiders/lilly_rs.py
+++ b/locations/spiders/lilly_rs.py
@@ -1,24 +1,26 @@
+import json
 from typing import Any
 
 from requests_cache import Response
-from scrapy import Spider
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class LillyRSSpider(Spider):
+class LillyRSSpider(PlaywrightSpider):
     name = "lilly_rs"
     item_attributes = {"brand": "Lilly", "brand_wikidata": "Q111764460"}
     allowed_domains = ["www.lilly.rs"]
     start_urls = ["https://www.lilly.rs/locations/index/index?name="]
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     requires_proxy = "RS"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json():
+        for location in json.loads(response.xpath("//pre//text()").get()):
             item = DictParser.parse(location)
             item["ref"] = item.pop("name").removeprefix("Apoteka ")
             item["street_address"] = item.pop("addr_full")


### PR DESCRIPTION
```python 
{'atp/brand/Lilly': 247,
 'atp/brand_wikidata/Q111764460': 247,
 'atp/category/shop/chemist': 247,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/phone': 19,
 'atp/clean_strings/street_address': 1,
 'atp/country/RS': 247,
 'atp/duplicate_count': 1,
 'atp/field/branch/missing': 247,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 247,
 'atp/field/email/missing': 247,
 'atp/field/housenumber/missing': 247,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 247,
 'atp/field/operator_wikidata/missing': 247,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 247,
 'atp/field/state/missing': 247,
 'atp/field/street/missing': 247,
 'atp/field/twitter/missing': 247,
 'atp/field/unit/missing': 247,
 'atp/item_scraped_host_count/www.lilly.rs': 248,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 247,
 'downloader/request_bytes': 541,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 164213,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 35.819409952,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 10, 8, 14, 48, 816831, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 1,
 'item_dropped_reasons_count/DropItem': 1,
 'item_scraped_count': 247,
 'items_per_minute': 423.4285714285714,
 'log_count/DEBUG': 307,
 'log_count/INFO': 7,
 'memusage/max': 302407680,
 'memusage/startup': 302407680,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 3.4285714285714284,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 10, 8, 14, 12, 997418, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of location data from the Lilly website.
  * Increased compatibility with browser-rendered responses and updated response parsing for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->