### PR TITLE
[Putka PL] Fix spider

### DIFF
--- a/locations/spiders/putka_pl.py
+++ b/locations/spiders/putka_pl.py
@@ -22,7 +22,7 @@ class PutkaPLSpider(StructuredDataSpider):
             yield response.follow(bakery["details"]["bakery_link"], callback=self.parse_sd)
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
-        item["branch"] = item.pop("name")
+        item["name"] = None
         item["website"] = response.url
         apply_category(Categories.SHOP_BAKERY, item)
         yield item

--- a/locations/spiders/putka_pl.py
+++ b/locations/spiders/putka_pl.py
@@ -1,58 +1,28 @@
+import json
 import re
-from urllib.parse import quote, urljoin
+from typing import Any
 
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS_PL, OpeningHours
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PutkaPLSpider(CrawlSpider):
+class PutkaPLSpider(StructuredDataSpider):
     name = "putka_pl"
     item_attributes = {"brand": "Putka", "brand_wikidata": "Q113093586"}
-    start_urls = ["https://www.putka.pl/sklepy-firmowe"]
-    rules = [
-        Rule(LinkExtractor(r"/sklepy-firmowe/\d+$")),
-        Rule(LinkExtractor(r"/sklepy-firmowe/\d+/\d+/$")),
-        Rule(LinkExtractor(r"/sklepy-firmowe/\d+/\d+/(\d+)$"), "parse_store"),
-    ]
+    start_urls = ["https://www.putka.pl/nasze-piekarnie"]
+    wanted_types = ["Bakery"]
 
-    def parse_store(self, response, **kwargs):
-        store_details = response.xpath("//div[contains(@class, 'sklep-details')]")
-        street_address, post_code_city, phone = store_details.xpath("//table/tr[2]/td/text()").getall()
-        post_code = post_code_city.split(" ")[0].strip()
-        city = " ".join(post_code_city.strip().split(" ")[1:])
-        phone = phone.strip().removeprefix("tel: ")
-        image_path = store_details.xpath("//img[contains(@src, 'upload/sklepy')]/@src").get()
-        opening_hours = OpeningHours()
-        opening_hours_texts = store_details.xpath("//tr[5]/td/text()").getall()
-        half_opening_hours_len = len(opening_hours_texts) // 2
-        for i in range(half_opening_hours_len):
-            opening_hours_text = (
-                opening_hours_texts[i].strip().replace(".", "")
-                + ": "
-                + opening_hours_texts[half_opening_hours_len + i].strip()
-            )
-            opening_hours.add_ranges_from_string(ranges_string=opening_hours_text, days=DAYS_PL)
-        properties = {
-            "street_address": street_address.strip(),
-            "city": city,
-            "phone": phone,
-            "postcode": post_code,
-            "opening_hours": opening_hours,
-        }
-        if image_path:
-            properties["image"] = urljoin("https://www.putka.pl/", quote(image_path))
-        properties.update(kwargs)
-        item = Feature(**properties)
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        raw = response.xpath('//script[@id="bakery-finder-script-js-extra"]/text()').get()
+        data = json.loads(re.search(r"var bakeryFinderData = ({.*?});", raw, re.DOTALL).group(1))
+        for bakery in data["bakeries"]:
+            yield response.follow(bakery["details"]["bakery_link"], callback=self.parse_sd)
 
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["branch"] = item.pop("name")
         item["website"] = response.url
-        item["ref"] = response.url.rsplit("/", 1)[1]
-
-        if m := re.search(r"LatLng\((-?\d+\.\d+), (-?\d+\.\d+)\)", response.text):
-            item["lat"], item["lon"] = m.groups()
-
         apply_category(Categories.SHOP_BAKERY, item)
         yield item


### PR DESCRIPTION
The old store-locator URL now redirects to the online shop. Putka rebuilt its site on WordPress; the locator moved to `/nasze-piekarnie`, which embeds every bakery and links to per-store pages carrying full `Bakery` schema.org data. Rebuilt as a `StructuredDataSpider` that seeds a request per bakery from that blob and parses the structured data on each page.

Restores the locations (~283 bakeries) and adds full weekly opening hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated bakery location listings using structured information from Putka’s bakery directory and individual bakery pages.
  - Improved consistency and accuracy of displayed bakery names, websites, and bakery category classification.
  - Expanded coverage of Putka bakery locations available through the `/nasze-piekarnie` directory.
  - Removed reliance on older manual page parsing for more reliable location results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->