### PR TITLE
[LasikPlus US] Fix spider

### DIFF
--- a/locations/spiders/lasik_plus_us.py
+++ b/locations/spiders/lasik_plus_us.py
@@ -28,6 +28,7 @@ class LasikPlusUSSpider(JSONBlobSpider):
         item["ref"] = str(feature["id"])
         item["branch"] = item.pop("name")
         item["street_address"] = merge_address_lines([feature.get("address"), feature.get("address_2")])
+        item["addr_full"] = None
         item["website"] = feature.get("link")
         apply_category(Categories.CLINIC, item)
         apply_healthcare_specialities([HealthcareSpecialities.OPHTHALMOLOGY], item)

--- a/locations/spiders/lasik_plus_us.py
+++ b/locations/spiders/lasik_plus_us.py
@@ -2,26 +2,33 @@ import json
 import re
 from typing import Any
 
-from requests import Response
+from scrapy.http import Response
 
-from locations.storefinders.stockinstore import DictParser, Spider
+from locations.categories import Categories, HealthcareSpecialities, apply_category, apply_healthcare_specialities
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import merge_address_lines
 
 
-class LasikPlusUSSpider(Spider):
+class LasikPlusUSSpider(JSONBlobSpider):
     name = "lasik_plus_us"
     item_attributes = {"brand": "LasikPlus", "brand_wikidata": "Q126111242"}
     start_urls = ["https://www.lasikplus.com/locations/"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        json_data = json.loads(
+    def extract_json(self, response: Response) -> list[dict]:
+        return json.loads(
             re.search(
-                r"locationsData\s*=\s*(\[.+\]);\s*\/\/",
-                response.xpath('//*[@ id="meta-locations-map-js-extra"]/text()').get(),
+                r"locationsData\s*=\s*(\[.+?\]);",
+                response.xpath('//*[@id="meta-locations-map-js-extra"]/text()').get(),
+                re.DOTALL,
             ).group(1)
         )
-        for location in json_data:
-            item = DictParser.parse(location)
-            item["street_address"] = item.pop("addr_full")
-            item["branch"] = item.pop("name")
-            item["website"] = location.get("link")
-            yield item
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Any:
+        item["ref"] = str(feature["id"])
+        item["branch"] = item.pop("name")
+        item["street_address"] = merge_address_lines([feature.get("address"), feature.get("address_2")])
+        item["website"] = feature.get("link")
+        apply_category(Categories.CLINIC, item)
+        apply_healthcare_specialities([HealthcareSpecialities.OPHTHALMOLOGY], item)
+        yield item


### PR DESCRIPTION
The spider produced no items. The `/locations/` page embeds a `locationsData` JSON array of all centres, but the extraction used an invalid xpath (`@ id`) and incorrect imports. Rebuilt as a `JSONBlobSpider` that reads that array, and set the ophthalmology clinic category.

Restores the 48 centres.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of LasikPlus US location data from updated page formats.
  * Normalized location details, including merged address lines and consistent website and classification information.
  * Improved processing and display of clinic and ophthalmology locations for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->