### PR TITLE
[GANT] Fix spider

### DIFF
--- a/locations/spiders/gant.py
+++ b/locations/spiders/gant.py
@@ -1,10 +1,10 @@
 import json
-import re
-from typing import Any
+from typing import Any, AsyncIterator
 
-from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import FormRequest, JsonRequest, Response
+from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
@@ -13,41 +13,58 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class GantSpider(Spider):
     name = "gant"
     item_attributes = {"brand": "GANT", "brand_wikidata": "Q1493667"}
-    start_urls = [
-        "https://www.gant.dk/store-locator",
-        "https://www.gant.be/nl-be/store-locator",
-        "https://www.gant.at/store-locator",
-        "https://www.gant.fr/store-locator",
-        "https://www.gant.co.uk/store-locator",
-        "https://www.gant.pt/store-locator",
-        "https://www.gant.es/store-locator",
+    organization_id = "f_ecom_bfln_prd"
+    site_ids = [
+        "Gant-UK",
+        "Gant-NORDIC",
+        "Gant-DACH",
+        "Gant-FR",
+        "Gant-BE",
+        "Gant-ES",
+        "Gant-PT",
+        "Gant-NL",
+        "Gant-IT",
+        "Gant-US",
+        "Gant-CN",
     ]
 
+    async def start(self) -> AsyncIterator[FormRequest]:
+        yield FormRequest(
+            url=f"https://www.gant.co.uk/mobify/slas/private/shopper/auth/v1/organizations/{self.organization_id}/oauth2/token",
+            formdata={"grant_type": "client_credentials", "channel_id": "Gant-UK"},
+        )
+
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        raw_data = json.loads(re.search(r"data\":(\[.*?\]),\"offset", response.text).group(1))
-        if raw_data:
-            for location in raw_data:
-                item = DictParser.parse(location)
-                if location.get("address2"):
-                    item["street_address"] = merge_address_lines(
-                        [
-                            location.get("address2"),
-                            item["street_address"],
-                        ]
-                    )
-                try:
-                    oh = OpeningHours()
-                    for day, time in json.loads(location["storeHours"]).items():
-                        if day == "holidayHours":
-                            continue
-                        if time.get("isClosed"):
-                            oh.set_closed(day)
-                        else:
-                            for open_close_time in time["openIntervals"]:
-                                open_time = open_close_time["start"]
-                                close_time = open_close_time["end"]
-                                oh.add_range(day=day, open_time=open_time, close_time=close_time)
-                    item["opening_hours"] = oh
-                except:
-                    pass
-                yield item
+        token = response.json()["access_token"]
+        for site_id in self.site_ids:
+            yield JsonRequest(
+                url=f"https://www.gant.co.uk/mobify/proxy/api/store/shopper-stores/v1/organizations/{self.organization_id}/store-search?distanceUnit=km&latitude=48&longitude=10&maxDistance=20012&siteId={site_id}&offset=0&limit=200",
+                headers={"Authorization": f"Bearer {token}"},
+                callback=self.parse_location,
+            )
+
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json().get("data", []):
+            item = DictParser.parse(location)
+            item["street_address"] = merge_address_lines([location.get("address1"), location.get("address2")])
+            item["branch"] = item.pop("name").removeprefix("GANT ")
+            item["opening_hours"] = self.parse_hours(location.get("storeHours"))
+            apply_category(Categories.SHOP_CLOTHES, item)
+            yield item
+
+    def parse_hours(self, store_hours: str | None) -> OpeningHours:
+        oh = OpeningHours()
+        if not store_hours:
+            return oh
+        try:
+            for day, rules in json.loads(store_hours).items():
+                if day == "holidayHours":
+                    continue
+                if rules.get("isClosed"):
+                    oh.set_closed(day)
+                else:
+                    for interval in rules.get("openIntervals", []):
+                        oh.add_range(day=day, open_time=interval["start"], close_time=interval["end"])
+        except (ValueError, KeyError, AttributeError):
+            pass
+        return oh


### PR DESCRIPTION
GANT moved its store locator to Salesforce Commerce Cloud (PWA Kit). The embedded `data":[…],"offset` store JSON the spider parsed no longer exists in the page, so it produced zero items. Rebuilt against the SFCC `store-search` shopper API, iterating the storefront's site IDs.

Restores ~180 stores across GB, the Nordics, DACH, FR, ES, PT, NL and BE (broader coverage than the previous per-country pages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated GANT store listings to use regional site data from the Mobify API.
  * Improved store details with normalized addresses, consistent branch names, and clothing categorization.
  * Added more reliable opening-hours handling, including support for missing or malformed data.

* **Bug Fixes**
  * Replaced legacy HTML-based store extraction with structured JSON processing.
  * Improved authentication and regional store retrieval for more complete location results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->