### PR TITLE
[Aldi Sud IT] Fix spider

### DIFF
--- a/locations/spiders/aldi_sud_it.py
+++ b/locations/spiders/aldi_sud_it.py
@@ -1,24 +1,19 @@
-from scrapy.spiders import SitemapSpider
+from typing import Iterable
+
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
 
 
-class AldiSudITSpider(SitemapSpider, StructuredDataSpider):
+class AldiSudITSpider(UberallSpider):
     name = "aldi_sud_it"
     item_attributes = {"brand_wikidata": "Q41171672"}
-    sitemap_urls = ["https://www.aldi.it/sitemap.xml"]
-    sitemap_rules = [
-        (
-            r"https:\/\/www\.aldi\.it\/it\/trova-il-punto-vendita\/aldi-[-\w]+\/aldi-[-\w]+\.html$",
-            "parse_sd",
-        )
-    ]
-    drop_attributes = {"image"}
+    key = "J8f9erNQcUhg1nmo5Bhp8wy2A6mQkK"
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("ALDI ")
-
+        item["phone"] = None
         apply_category(Categories.SHOP_SUPERMARKET, item)
-
         yield item


### PR DESCRIPTION
ALDI Italy removed per-store pages from its sitemap and moved the store locator to Uberall, so the `SitemapSpider` URL rule matched nothing and the spider produced zero items. Switched to the shared `UberallSpider` base (as the other ALDI spiders use) with the site's storefinder key.

Restores ~199 stores and adds opening hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Aldi Süd Italy location data collection to use a more reliable source.
  * Improved location details by applying the supermarket category and removing unavailable phone information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->