### PR TITLE
[Gridserve GB] Fix spider

### DIFF
--- a/locations/spiders/gridserve_gb.py
+++ b/locations/spiders/gridserve_gb.py
@@ -1,33 +1,25 @@
-from typing import AsyncIterator, Iterable
+from typing import Any
 
-from scrapy.http import JsonRequest, Request, Response
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.json_blob_spider import JSONBlobSpider
 
 
-class GridserveGBSpider(JSONBlobSpider):
+class GridserveGBSpider(SitemapSpider):
     name = "gridserve_gb"
     item_attributes = {"operator": "Gridserve", "operator_wikidata": "Q89575318"}
-    allowed_domains = ["dnms-api.gridserve.com", "electrichighway.gridserve.com"]
-    start_urls = ["https://dnms-api.gridserve.com/api/v1/locations/1/All?searchText=&sort=&orderType=asc"]
-    locations_key = "data"
+    sitemap_urls = ["https://www.gridserve.com/location-sitemap.xml"]
+    sitemap_rules = [(r"/location/[^/]+/$", "parse")]
 
-    async def start(self) -> AsyncIterator[Request]:
-        yield Request(url="https://electrichighway.gridserve.com/", callback=self.parse_js_files)
-
-    def parse_js_files(self, response: Response) -> Iterable[Request]:
-        js_blob = response.xpath('//script[contains(text(), ":static/chunks/app/page-")]/text()').get()
-        page_js_id = js_blob.split(":static/chunks/app/page-", 1)[1].split(".js", 1)[0]
-        page_js_url = f"https://electrichighway.gridserve.com/_next/static/chunks/app/page-{page_js_id}.js"
-        yield Request(url=page_js_url, callback=self.parse_auth_token)
-
-    def parse_auth_token(self, response: Response) -> Iterable[JsonRequest]:
-        auth_token = "eyJ" + response.text.split('="eyJ', 1)[1].split('"', 1)[0]
-        yield JsonRequest(url=self.start_urls[0], headers={"Authorization": f"Bearer {auth_token}"})
-
-    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["ref"] = str(item["ref"])
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
+        item["ref"] = response.xpath("//*[@data-location]/@data-location").get()
+        item["branch"] = response.xpath("//*[contains(@class, 'location__name')]/text()").get()
+        item["addr_full"] = response.xpath("//*[contains(@class, 'location__address')]/text()").get()
+        item["lat"] = response.xpath("//div[@class='gmap']/@data-lat").get()
+        item["lon"] = response.xpath("//div[@class='gmap']/@data-lng").get()
+        item["website"] = response.url
         apply_category(Categories.CHARGING_STATION, item)
         yield item


### PR DESCRIPTION
`electrichighway.gridserve.com` now 301-redirects to `www.gridserve.com/find-a-charger/` (off the spider's allowed domains), and GRIDSERVE folded the charger map into its WordPress site, dropping the token API the spider relied on — so it produced zero items. Rebuilt as a `SitemapSpider` over the location sitemap, reading each charger's coordinates and address directly from the page (no auth token required).

Restores ~202 charging locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gridserve location discovery by using sitemap data.
  * Location results now include identifiers, names, addresses, coordinates, and source URLs.
  * Removed reliance on authentication tokens and JavaScript-based discovery, improving resilience of location updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->