### PR TITLE
[Hamleys] Fix spider

### DIFF
--- a/locations/spiders/hamleys.py
+++ b/locations/spiders/hamleys.py
@@ -2,6 +2,7 @@ from chompjs import parse_js_object
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
 
@@ -27,7 +28,7 @@ class HamleysSpider(CrawlSpider):
         else:
             return
         item = DictParser.parse(location)
-        item["branch"] = item.pop("name")
+        item["branch"] = item.pop("name").removeprefix("Hamleys ")
         item["street_address"] = item.pop("addr_full")
         item["website"] = response.url
         item["ref"] = item["website"]
@@ -37,5 +38,7 @@ class HamleysSpider(CrawlSpider):
 
         item["opening_hours"] = OpeningHours()
         item["opening_hours"].add_ranges_from_string(response.xpath('string(.//ul[@class="opening-hours"])').get())
+
+        apply_category(Categories.SHOP_TOYS, item)
 
         yield item

--- a/locations/spiders/hamleys.py
+++ b/locations/spiders/hamleys.py
@@ -4,6 +4,7 @@ from scrapy.spiders import CrawlSpider, Rule
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.user_agents import BROWSER_DEFAULT
 
 HAMLEYS_SHARED_ATTRIBUTES = {"brand": "Hamleys", "brand_wikidata": "Q60299"}
 
@@ -18,7 +19,7 @@ class HamleysSpider(CrawlSpider):
     # TODO: global stores: https://www.hamleys.com/our-stores-global but only addresses and no other info
     item_attributes = HAMLEYS_SHARED_ATTRIBUTES
     rules = [Rule(LinkExtractor(allow="/stores/"), callback="parse")]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response):
         if location_js := response.xpath("//div/@data-locations").get():

--- a/locations/spiders/hamleys.py
+++ b/locations/spiders/hamleys.py
@@ -4,7 +4,6 @@ from scrapy.spiders import CrawlSpider, Rule
 
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
-from locations.user_agents import BROWSER_DEFAULT
 
 HAMLEYS_SHARED_ATTRIBUTES = {"brand": "Hamleys", "brand_wikidata": "Q60299"}
 
@@ -19,7 +18,8 @@ class HamleysSpider(CrawlSpider):
     # TODO: global stores: https://www.hamleys.com/our-stores-global but only addresses and no other info
     item_attributes = HAMLEYS_SHARED_ATTRIBUTES
     rules = [Rule(LinkExtractor(allow="/stores/"), callback="parse")]
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = True
 
     def parse(self, response):
         if location_js := response.xpath("//div/@data-locations").get():


### PR DESCRIPTION
The site returns 403 to the default user agent, so both store-listing pages were blocked and the spider scraped no stores. Set a browser user agent (`BROWSER_DEFAULT`).

Restores the GB + Europe stores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hamleys locations are now categorized as toy shops for more consistent browsing and filtering.
* **Data Improvements**
  * Branch names are cleaner and no longer include the redundant “Hamleys” prefix.
* **Bug Fixes**
  * Improved reliability when collecting Hamleys location information, including support for proxy-based access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->