### PR TITLE
[Whole Foods] Fix spider

### DIFF
--- a/locations/spiders/whole_foods.py
+++ b/locations/spiders/whole_foods.py
@@ -1,21 +1,50 @@
+import json
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
-from locations.structured_data_spider import StructuredDataSpider
+from locations.dict_parser import DictParser
+from locations.hours import DAYS, OpeningHours
 
 
-class WholeFoodsSpider(SitemapSpider, StructuredDataSpider):
+class WholeFoodsSpider(SitemapSpider):
     name = "whole_foods"
     item_attributes = {"brand": "Whole Foods Market", "brand_wikidata": "Q1809448"}
     allowed_domains = ["wholefoodsmarket.com"]
     sitemap_urls = ["https://www.wholefoodsmarket.com/robots.txt"]
     sitemap_rules = [(r"/stores/([^/]+)$", "parse")]
-    wanted_types = ["Store"]
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["image"] = None
-        item["branch"] = response.xpath("//h1/text()").get().strip()
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        script = response.xpath('//script[contains(@data-a-state, "detail-page-state")]/text()').get()
+        if not script:
+            return
+        location = json.loads(script)["location"]
+        geocode = location.get("geocode") or {}
+        location["latitude"], location["longitude"] = geocode.get("latitude"), geocode.get("longitude")
+
+        item = DictParser.parse(location)
+        item["ref"] = location.get("storeCode")
+        item["branch"] = item.pop("name", None)
+        item["street_address"] = ", ".join((location.get("address") or {}).get("addressLines") or [])
+        item["website"] = response.url
+        item["opening_hours"] = self.parse_hours(location)
+
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item
+
+    def parse_hours(self, location: dict) -> OpeningHours:
+        oh = OpeningHours()
+        timezone = (location.get("locationFacets") or [{}])[0].get("timeZone")
+        if not timezone:
+            return oh
+        tz = ZoneInfo(timezone)
+        for day in location.get("operationalDailyHours") or []:
+            for period in day.get("operatingHours") or []:
+                start = datetime.fromisoformat(period["startTime"].replace("Z", "+00:00")).astimezone(tz)
+                end = datetime.fromisoformat(period["endTime"].replace("Z", "+00:00")).astimezone(tz)
+                oh.add_range(DAYS[start.weekday()], start.strftime("%H:%M"), end.strftime("%H:%M"))
+        return oh


### PR DESCRIPTION
Whole Foods removed the `ld+json` from its store pages, so the `StructuredDataSpider` parse produced no items even though every store page was fetched. Read each store's details from the embedded page-state JSON (`data-a-state` script) instead, keeping the sitemap crawl of `/stores/` URLs.

Restores the ~500 US stores with coordinates, address, phone and opening hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Whole Foods store data collection by reading details directly from store pages.
  * Store listings now include more accurate addresses, identifiers, branch names, websites, locations, categories, and opening hours.
  * Opening hours are converted to each store’s local timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->