### PR TITLE
[Mucho Burrito] Fix spider

### DIFF
--- a/locations/spiders/mucho_burrito.py
+++ b/locations/spiders/mucho_burrito.py
@@ -1,10 +1,20 @@
-from locations.storefinders.where2getit import Where2GetItSpider
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class MuchoBurritoSpider(Where2GetItSpider):
+class MuchoBurritoSpider(YextAnswersSpider):
     name = "mucho_burrito"
-    item_attributes = {
-        "brand_wikidata": "Q65148332",
-        "brand": "Mucho Burrito",
-    }
-    api_key = "F18F9C0C-3871-11EE-9ED6-49504A66C4B2"
+    item_attributes = {"brand": "Mucho Burrito", "brand_wikidata": "Q65148332"}
+    api_key = "207b6ad55fc7f257ee5c6e77d1107ec3"
+    experience_key = "locator-search"
+    feature_type = "location"
+    locale = "en-CA"
+
+    def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
+        if "Head Office" in (location.get("name") or ""):
+            return
+        apply_category(Categories.FAST_FOOD, item)
+        yield item

--- a/locations/spiders/mucho_burrito.py
+++ b/locations/spiders/mucho_burrito.py
@@ -16,5 +16,6 @@ class MuchoBurritoSpider(YextAnswersSpider):
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         if "Head Office" in (location.get("name") or ""):
             return
+        item["name"] = None
         apply_category(Categories.FAST_FOOD, item)
         yield item

--- a/locations/spiders/mucho_burrito_ca.py
+++ b/locations/spiders/mucho_burrito_ca.py
@@ -5,8 +5,8 @@ from locations.items import Feature
 from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class MuchoBurritoSpider(YextAnswersSpider):
-    name = "mucho_burrito"
+class MuchoBurritoCASpider(YextAnswersSpider):
+    name = "mucho_burrito_ca"
     item_attributes = {"brand": "Mucho Burrito", "brand_wikidata": "Q65148332"}
     api_key = "207b6ad55fc7f257ee5c6e77d1107ec3"
     experience_key = "locator-search"


### PR DESCRIPTION
The Where2GetIt appkey is no longer valid (`The appkey used is not a valid appkey`); Mucho Burrito moved its store locator to Yext. Switched to the `YextAnswersSpider` store finder, drop the non-store head office entry, and apply the fast food category.

Restores ~133 locations with coordinates, address, phone and hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Canadian location listings with Canadian English localization.
  * Updated Mucho Burrito location search to provide more reliable results.
* **Bug Fixes**
  * Excluded head-office entries from customer-facing location results.
  * Applied the fast-food category to eligible locations.
  * Improved location naming for Canadian listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->