### PR TITLE
[solidcore US] Fix spider

### DIFF
--- a/locations/spiders/solidcore_us.py
+++ b/locations/spiders/solidcore_us.py
@@ -1,12 +1,25 @@
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Any, Iterable
 
-from locations.categories import Categories
-from locations.structured_data_spider import StructuredDataSpider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class SolidcoreUSSpider(SitemapSpider, StructuredDataSpider):
+class SolidcoreUSSpider(JSONBlobSpider):
     name = "solidcore_us"
-    item_attributes = {"brand": "[solidcore]", "brand_wikidata": "Q124429271", "extras": Categories.GYM.value}
-    sitemap_urls = ["https://www.solidcore.co/studio-sitemap.xml"]
-    sitemap_rules = [(r"co/\w\w/[^/]+/[^/]+/$", "parse")]
-    wanted_types = ["LocalBusiness"]
+    item_attributes = {"brand": "[solidcore]", "brand_wikidata": "Q124429271"}
+    start_urls = ["https://prod.api.bluespringhq.com/locations?siteId=5737724"]
+    locations_key = "Locations"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Iterable[Feature]:
+        if feature.get("Address") in (None, "Coming soon"):
+            return
+        item["ref"] = f"{feature['SiteID']}-{feature['Id']}"
+        item["branch"] = re.sub(r"^[A-Z]{2}, ", "", item.pop("name"))
+        item["street_address"] = item.pop("addr_full", None)
+        item["state"] = feature.get("StateProvCode")
+        apply_category(Categories.GYM, item)
+        yield item


### PR DESCRIPTION
The `studio-sitemap.xml` now 404s and the studio pages no longer expose structured data, so the spider produced no items. Rebuilt as a `JSONBlobSpider` reading all studios from the BlueSpring locations API in a single request. Skips not-yet-open studios (empty or `Coming soon` address), and uses a composite site/location id as the ref since the location id alone is not unique.

Restores ~181 studios with coordinates, address, phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location retrieval from the Solidcore U.S. service.
  * Excluded locations without valid addresses or marked as “Coming soon.”
  * Standardized location names, addresses, states, references, and gym categories.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->