### PR TITLE
[T2 AU] Fix spider

### DIFF
--- a/locations/spiders/t2_au.py
+++ b/locations/spiders/t2_au.py
@@ -1,10 +1,16 @@
-from locations.storefinders.stockinstore import StockInStoreSpider
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.stockist import StockistSpider
 
 
-class T2AUSpider(StockInStoreSpider):
+class T2AUSpider(StockistSpider):
     name = "t2_au"
     item_attributes = {"brand": "T2", "brand_wikidata": "Q48802134"}
-    api_site_id = "10024"
-    api_widget_id = "31"
-    api_widget_type = "sis"
-    api_origin = "https://www.t2tea.com"
+    key = "map_4q6r4m5q"
+
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("T2 - ")
+        apply_category(Categories.SHOP_TEA, item)
+        yield item


### PR DESCRIPTION
T2 moved its store locator off StockInStore (which now rejects the old site with `{"response":"not allowed"}`) to Stockist. Switched to the shared `StockistSpider` base with the site's Stockist key.

Restores ~58 stores (AU + NZ) with coordinates, address and tea-shop category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved T2 Australia location listings by using updated store locator data.
  * Removed the “T2 -” prefix from branch names for cleaner display.
  * Applied the correct tea shop category to listed locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->