### PR TITLE
[Ster-Kinekor ZA] Fix spider

### DIFF
--- a/locations/spiders/ster_kinekor.py
+++ b/locations/spiders/ster_kinekor.py
@@ -1,30 +1,28 @@
-from scrapy.http import JsonRequest
+import json
+from typing import Any, Iterable
+from urllib.parse import unquote
 
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
-from locations.pipelines.address_clean_up import clean_address
 
 
 class SterKinekorSpider(JSONBlobSpider):
     name = "ster_kinekor"
     item_attributes = {"brand": "Ster-Kinekor", "brand_wikidata": "Q130179"}
-    start_urls = ["https://www.sterkinekor.com/middleware/api/v2/regions"]
+    start_urls = ["https://www.sterkinekor.com/locator"]
 
-    async def start(self):
-        for url in self.start_urls:
-            yield JsonRequest(
-                url=url,
-                headers={
-                    "X-SESSION": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJNZW1iZXJJZCI6bnVsbCwiVXNlclNlc3Npb25JZCI6IjQ0OWM1ZDUwOTY3ODRkZTM4NGEzMmFmZDBjMmY4Yzk4In0.awI61fej89WBEbnQ5Rzga0Q3JoWEMrSlvhmawSJGkZc"
-                },
-            )
+    def extract_json(self, response: Response) -> list[dict]:
+        blob = response.xpath('//script[contains(., "_blockName") and contains(., "cinemas")]/text()').re_first(
+            r'decodeURIComponent\("([^"]+)"\)'
+        )
+        return json.loads(unquote(blob))["cinemas"]
 
-    def extract_json(self, response):
-        return [
-            cinema | {"state": region["name"]} for region in response.json()["data"] for cinema in region["cinemas"]
-        ]
-
-    def post_process_item(self, item, response, location):
-        item["website"] = "https://www.sterkinekor.com/find-cinemas/" + location["slug"]
-        item["street_address"] = clean_address([location.get("address_1"), location.get("address_2")])
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
+        item["website"] = "https://www.sterkinekor.com/cinemas/" + location["linkToPage"]
+        item.pop("phone", None)
+        apply_category(Categories.CINEMA, item)
         yield item


### PR DESCRIPTION
The `/middleware/api/v2/regions` endpoint (called with a hardcoded `X-SESSION` header) now returns 404. The site was rebuilt and the cinema data is embedded as URL-encoded JSON in the `/locator` page.

Rewrote as a `JSONBlobSpider` that extracts the embedded `cinemas` JSON; now returns 35 cinemas (ZA, NA, ZM) with coordinates.