### PR TITLE
[Pam Golding ZA] Fix spider

### DIFF
--- a/locations/spiders/pam_golding.py
+++ b/locations/spiders/pam_golding.py
@@ -1,70 +1,44 @@
-import re
+from collections import Counter
+from typing import Any, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
-from scrapy.linkextractors import LinkExtractor
+from scrapy.http import JsonRequest, Response
 
-from locations.hours import OpeningHours
+from locations.categories import Categories, apply_category
+from locations.country_utils import CountryUtils
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class PamGoldingSpider(Spider):
+class PamGoldingSpider(JSONBlobSpider):
     name = "pam_golding"
     item_attributes = {
         "brand": "Pam Golding Properties",
         "brand_wikidata": "Q65051429",
     }
-    start_urls = [
-        "https://www.pamgolding.co.za/contact-us/offices",
-        "https://www.pamgolding.co.za/contact-us/international-offices",
-    ]
+    skip_auto_cc_domain = True
+    country_utils = CountryUtils()
 
-    def parse(self, response):
-        links = LinkExtractor(
-            allow=r"^https:\/\/www\.pamgolding\.co\.za\/contact-us\/office-details/.+/\d+$"
-        ).extract_links(response)
-        for link in links:
-            ref = re.sub(r"^https:\/\/www\.pamgolding\.co\.za\/contact-us\/office-details/.+/(\d+)$", r"\1", link.url)
-            json_url = f"https://www.pamgolding.co.za/customapi/ContactUs/GetOfficeById/{ref}"
-            yield JsonRequest(url=json_url, callback=self.parse_item, meta={"ref": ref, "website": link.url})
+    async def start(self) -> Any:
+        yield JsonRequest("https://webapi.pamgolding.co.za/api/agentsoffices/search-offices", data={})
 
-    def parse_item(self, response):
-        location = response.json()
-        item = Feature()
+    def extract_json(self, response: Response) -> list[dict]:
+        offices = [
+            office for country in response.json() for section in country["sections"] for office in section["offices"]
+        ]
+        self.unique_phones = {k for k, v in Counter(o.get("number") for o in offices).items() if v == 1}
+        self.unique_emails = {k for k, v in Counter(o.get("email") for o in offices).items() if v == 1}
+        return offices
 
-        item["ref"] = response.meta["ref"]
-        item["website"] = response.meta["website"]
-        item["lat"] = location.get("decLatitude")
-        item["lon"] = location.get("decLongitude")
-
-        item["branch"] = location.get("nvcName")
-        item["email"] = location.get("nvcEmailAddress")
-        item["phone"] = location.get("nvcTelephoneNumber")
-        item["extras"]["fax"] = location.get("nvcFaxNumber")
-
-        address = location.get("dtlAddress")
-        item["addr_full"] = address.get("nvcSingleLineDisplayAddress")
-        item["housenumber"] = address.get("nvcStreetNumber")
-        item["street"] = address.get("nvcStreetName")
-        item["postcode"] = address.get("nvcPostalCode")
-        item["city"] = address.get("nvcCity")
-        item["state"] = address.get("nvcProvince")
-        item["country"] = address.get("nvcCountry")
-
-        item["opening_hours"] = OpeningHours()
-        for day in location["dtlOfficeOperatingTimes"]:
-            if day["bitIsActive"]:
-                item["opening_hours"].add_ranges_from_string(
-                    day["refOperatingTimeType"]["nvcOperatingTImeType"]
-                    + " "
-                    + day["tmeOpeningTime"]
-                    + " - "
-                    + day["tmeClosingTime"]
-                )
-            else:
-                try:
-                    item["opening_hours"].set_closed(day["refOperatingTimeType"]["nvcOperatingTImeType"])
-                except ValueError:
-                    pass
-
+    def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["ref"] = str(location["id"])
+        item["branch"] = item.pop("name")
+        item["website"] = "https://www.pamgolding.co.za" + location["url"]
+        item["addr_full"] = location.get("address")
+        item["lat"] = location["geoPoint"]["lat"]
+        item["lon"] = location["geoPoint"]["lon"]
+        item["state"] = location["location"]["provinceName"]
+        item["country"] = self.country_utils.to_iso_alpha2_country_code(location["location"]["countryName"])
+        item["phone"] = location["number"] if location.get("number") in self.unique_phones else None
+        item["email"] = location["email"] if location.get("email") in self.unique_emails else None
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item

--- a/locations/spiders/pam_golding.py
+++ b/locations/spiders/pam_golding.py
@@ -11,23 +11,16 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class PamGoldingSpider(JSONBlobSpider):
     name = "pam_golding"
-    item_attributes = {
-        "brand": "Pam Golding Properties",
-        "brand_wikidata": "Q65051429",
-    }
+    item_attributes = {"brand": "Pam Golding Properties", "brand_wikidata": "Q65051429"}
     skip_auto_cc_domain = True
-    country_utils = CountryUtils()
 
     async def start(self) -> Any:
         yield JsonRequest("https://webapi.pamgolding.co.za/api/agentsoffices/search-offices", data={})
 
     def extract_json(self, response: Response) -> list[dict]:
-        offices = [
+        return [
             office for country in response.json() for section in country["sections"] for office in section["offices"]
         ]
-        self.unique_phones = {k for k, v in Counter(o.get("number") for o in offices).items() if v == 1}
-        self.unique_emails = {k for k, v in Counter(o.get("email") for o in offices).items() if v == 1}
-        return offices
 
     def post_process_item(self, item: Feature, response: Response, location: dict, **kwargs: Any) -> Iterable[Feature]:
         item["ref"] = str(location["id"])
@@ -37,8 +30,8 @@ class PamGoldingSpider(JSONBlobSpider):
         item["lat"] = location["geoPoint"]["lat"]
         item["lon"] = location["geoPoint"]["lon"]
         item["state"] = location["location"]["provinceName"]
-        item["country"] = self.country_utils.to_iso_alpha2_country_code(location["location"]["countryName"])
-        item["phone"] = location["number"] if location.get("number") in self.unique_phones else None
-        item["email"] = location["email"] if location.get("email") in self.unique_emails else None
+        item["country"] = location["location"]["countryName"]
+        item["phone"] = location["number"]
+        item["email"] = location["email"]
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item

--- a/locations/spiders/pam_golding.py
+++ b/locations/spiders/pam_golding.py
@@ -1,10 +1,8 @@
-from collections import Counter
 from typing import Any, Iterable
 
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
-from locations.country_utils import CountryUtils
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 


### PR DESCRIPTION
The office listing pages no longer expose office-detail links and the `customapi/ContactUs/GetOfficeById` endpoint was decommissioned (404), so the spider produced no items.

Rewrote against the Nuxt backend, which returns every office (with coordinates) from a single POST to `webapi.pamgolding.co.za/api/agentsoffices/search-offices`. Now yields 239 offices across 11 countries and sets an explicit `estate_agent` category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Pam Golding location listings with more consistent branch, website, address, coordinate, province, country, phone, and email information.
  * Reduced duplicate contact information across listings.
  * Standardized estate-agent categorization for locations.
  * Improved coverage and consistency by using the consolidated offices search service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->