### PR TITLE
[Ameriprise Financial US] Fix spider

### DIFF
--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -1,8 +1,11 @@
 import json
+from typing import Any
 
 import scrapy
+from scrapy.http import Response
 from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -11,32 +14,29 @@ class AmeripriseUSSpider(Spider):
     name = "ameriprise_us"
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
     start_urls = ["https://www.ameripriseadvisors.com/find-a-financial-advisor-by-state/"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response):
-        # Extract list of states
-        state_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
-        for state in state_list:
-            state_url = response.urljoin(state)
-            yield scrapy.Request(url=state_url, callback=self.parse_city, cb_kwargs={"state": state})
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for state in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
+            yield scrapy.Request(url=response.urljoin(state), callback=self.parse_city, cb_kwargs={"state": state})
 
-    def parse_city(self, response, state):
-        # Extract list of cities for the given state
-        city_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
-        for city in city_list:
-            payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "50", "searchType": "city, state"}
+    def parse_city(self, response: Response, state: str) -> Any:
+        for city in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
+            payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "250", "searchType": "city, state"}
             yield scrapy.FormRequest(
-                url="https://www.ameripriseadvisors.com/webservices/advisorSearch.aspx",
+                url="https://www.ameripriseadvisors.com/api/locatorsearch/search/",
                 formdata={"criteria": json.dumps(payload)},
-                headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
-                method="POST",
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                    "Accept": "application/json",
+                },
                 callback=self.parse_details,
             )
 
-    def parse_details(self, response):
+    def parse_details(self, response: Response) -> Any:
         for advisor in response.json().get("locatorResultModels", []):
             for location in advisor.get("locations", []):
                 item = DictParser.parse(location)
                 item.pop("name")
                 item["ref"] = item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
+                apply_category(Categories.OFFICE_FINANCIAL_ADVISOR, item)
                 yield item


### PR DESCRIPTION
The per-city advisor search POSTed to `webservices/advisorSearch.aspx`, which was decommissioned (404), so the spider produced no items.

Repointed to the current endpoint `/api/locatorsearch/search/`. This endpoint is content-negotiated, so the request now sends `Accept: application/json` (the default `Accept` returns XML). Raised `numberOfRowsToReturn` to the API max of 250 to capture all advisors in large cities, added an explicit `financial_advisor` category, and removed `ROBOTSTXT_OBEY=False` which was only needed for the old robots-disallowed `/webservices/` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ameriprise location results are now categorized as financial-advisor offices.
  * City searches can retrieve up to 250 locations per request.

* **Bug Fixes**
  * Improved handling of location search responses in JSON format.
  * Removed an override that bypassed robots.txt rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->