### PR TITLE
[itsu GB] Fix spider

### DIFF
--- a/locations/spiders/itsu_gb.py
+++ b/locations/spiders/itsu_gb.py
@@ -8,12 +8,14 @@ class ItsuGBSpider(SitemapSpider):
     name = "itsu_gb"
     item_attributes = {"brand": "itsu", "brand_wikidata": "Q6094914"}
     sitemap_urls = ["https://www.itsu.com/sitemap_pages.xml"]
-    sitemap_rules = [("/location/", "parse")]
+    sitemap_rules = [(r"/location/[^/]+/[^/]+/", "parse")]
 
     def parse(self, response, **kwargs):
         item = Feature()
         item["branch"] = response.xpath('//h1[@class="title"]/text()').get()
-        item["addr_full"] = ", ".join(filter(None, map(str.strip, response.xpath("//address/text()").getall())))
+        item["addr_full"] = ", ".join(
+            filter(None, map(str.strip, response.xpath("//address[not(@class)]/text()").getall()))
+        )
         extract_google_position(item, response)
         item["ref"] = item["website"] = response.url
         return item


### PR DESCRIPTION
`addr_full` concatenated the store's own address with four "nearby stores" widget addresses on each page. The xpath now restricts to the store's own unclassed `<address>` tag.

Also tightened `sitemap_rules` to only match `region/store` pages, dropping six region hub/index pages that were being emitted as address-less, coordinate-less POIs. Now yields 75 UK stores, all with address and coordinates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location page filtering to process only valid location URLs.
  * Improved address extraction by ignoring classified address elements and removing excess whitespace.
  * Address details are now combined more consistently when multiple text elements are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->