### PR TITLE
[Mcdonalds] Fix spider

### DIFF
--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -1,6 +1,6 @@
+import json
 from typing import AsyncIterator, Iterable
 
-from scrapy import Spider
 from scrapy.http import Request, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
@@ -9,16 +9,19 @@ from locations.geo import city_locations, country_iseadgg_centroids
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class McdonaldsSpider(Spider):
+class McdonaldsSpider(PlaywrightSpider):
     name = "mcdonalds"
     item_attributes = {
         "brand": "McDonald's",
         "brand_wikidata": "Q38076",
-        "extras": Categories.FAST_FOOD.value,
     }
     allowed_domains = ["www.mcdonalds.com"]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     ISEADGG_COUNTRIES = {"AU", "CA", "NZ", "US"}
 
@@ -73,7 +76,7 @@ class McdonaldsSpider(Spider):
     def parse_major_api(self, response: Response, country: str, locale: str) -> Iterable[Feature]:
         if len(response.body) == 0:
             return
-        stores = response.json()["features"]
+        stores = json.loads(response.xpath("//pre/text()").get())["features"]
         for store in stores:
             properties = store["properties"]
             store_identifier = properties["identifierValue"]


### PR DESCRIPTION
The `API` recently became unreachable by the spider. Updated the spider to use `Playwright` to ensure the API remains accessible and the scraping flow works as expected.

Summary created for a limited number of items.

```python
{'atp/brand/McCafé': 80,
 "atp/brand/McDonald's": 103,
 'atp/brand_wikidata/Q3114287': 80,
 'atp/brand_wikidata/Q38076': 103,
 'atp/category/amenity/cafe': 80,
 'atp/category/amenity/fast_food': 103,
 'atp/clean_strings/city': 1,
 'atp/country/AU': 183,
 'atp/duplicate_count': 2,
 'atp/field/email/missing': 181,
 'atp/field/housenumber/missing': 183,
 'atp/field/opening_hours/missing': 143,
 'atp/field/operator/missing': 183,
 'atp/field/operator_wikidata/missing': 183,
 'atp/field/phone/missing': 17,
 'atp/field/postcode/missing': 6,
 'atp/field/street/missing': 183,
 'atp/field/twitter/missing': 183,
 'atp/field/unit/missing': 183,
 'atp/item_scraped_host_count/www.mcdonalds.com': 185,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 183,
 'downloader/request_bytes': 87406,
 'downloader/request_count': 203,
 'downloader/request_method_count/GET': 203,
 'downloader/response_bytes': 640197,
 'downloader/response_count': 203,
 'downloader/response_status_count/200': 203,
 'elapsed_time_seconds': 260.9380000000001,
 'finish_reason': 'closespider_itemcount',
 'finish_time': datetime.datetime(2026, 8, 12, 5, 28, 26, 1154, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 2,
 'item_dropped_reasons_count/DropItem': 2,
 'item_scraped_count': 183,
 'items_per_minute': 42.23076923076923,
 'log_count/DEBUG': 2212,
 'log_count/INFO': 11,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 203,
 'playwright/page_count/closed': 203,
 'playwright/page_count/max_concurrent': 3,
 'playwright/request_count': 809,
 'playwright/request_count/aborted': 606,
 'playwright/request_count/method/GET': 809,
 'playwright/request_count/navigation': 203,
 'playwright/request_count/resource_type/document': 203,
 'playwright/request_count/resource_type/font': 606,
 'playwright/response_count': 203,
 'playwright/response_count/method/GET': 203,
 'playwright/response_count/resource_type/document': 203,
 'response_received_count': 203,
 'responses_per_minute': 46.84615384615385,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 202,
 'scheduler/dequeued/memory': 202,
 'scheduler/enqueued': 8154,
 'scheduler/enqueued/memory': 8154,
 'start_time': datetime.datetime(2026, 8, 12, 5, 24, 5, 72392, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved McDonald’s location data retrieval for more reliable API responses.
  * Preserved fast-food categorization during location parsing.
  * Enhanced compatibility with browser-rendered responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->