### PR TITLE
[Erciyes Anadolu Holding TR] Fix spider

### DIFF
--- a/locations/spiders/erciyes_anadolu_holding_tr.py
+++ b/locations/spiders/erciyes_anadolu_holding_tr.py
@@ -15,7 +15,7 @@ BRANDS = {
 
 class ErciyesAnadoluHoldingTRSpider(scrapy.Spider):
     name = "erciyes_anadolu_holding_tr"
-    custom_settings = {"DOWNLOAD_DELAY": 2}
+    requires_proxy = "TR"
     start_urls = ["https://brandapi.erciyes.com/api/ContactApi/GetCities"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:

--- a/locations/spiders/erciyes_anadolu_holding_tr.py
+++ b/locations/spiders/erciyes_anadolu_holding_tr.py
@@ -15,7 +15,7 @@ BRANDS = {
 
 class ErciyesAnadoluHoldingTRSpider(scrapy.Spider):
     name = "erciyes_anadolu_holding_tr"
-    custom_settings = {"DOWNLOAD_DELAY": 3}
+    custom_settings = {"DOWNLOAD_DELAY": 2}
     start_urls = ["https://brandapi.erciyes.com/api/ContactApi/GetCities"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
@@ -31,11 +31,12 @@ class ErciyesAnadoluHoldingTRSpider(scrapy.Spider):
         brand = BRANDS[kwargs["brand"]]
         for details in response.json():
             details["city"] = details.pop("Province")
-            details["name"] = details.pop("FirmName")
             details["address"] = details.pop("Adres")
             ref = f"{brand['brand']}-{details['Coordinates']}"
+            branch = details.pop("FirmName")
             item = DictParser.parse(details)
             item.update(brand)
+            item["branch"] = branch
             item["ref"] = ref
             apply_category(Categories.SHOP_FURNITURE, item)
             yield item

--- a/locations/spiders/erciyes_anadolu_holding_tr.py
+++ b/locations/spiders/erciyes_anadolu_holding_tr.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import scrapy
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -15,7 +18,7 @@ class ErciyesAnadoluHoldingTRSpider(scrapy.Spider):
     custom_settings = {"DOWNLOAD_DELAY": 3}
     start_urls = ["https://brandapi.erciyes.com/api/ContactApi/GetCities"]
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         for brand in BRANDS.keys():
             for city in response.json():
                 yield scrapy.Request(
@@ -24,13 +27,15 @@ class ErciyesAnadoluHoldingTRSpider(scrapy.Spider):
                     cb_kwargs={"brand": brand},
                 )
 
-    def parse_store(self, response, **kwargs):
+    def parse_store(self, response: Response, **kwargs: Any) -> Any:
+        brand = BRANDS[kwargs["brand"]]
         for details in response.json():
             details["city"] = details.pop("Province")
             details["name"] = details.pop("FirmName")
             details["address"] = details.pop("Adres")
-            details["email"] = details.pop("EMailAddress")
+            ref = f"{brand['brand']}-{details['Coordinates']}"
             item = DictParser.parse(details)
-            item.update(BRANDS[kwargs["brand"]])
+            item.update(brand)
+            item["ref"] = ref
             apply_category(Categories.SHOP_FURNITURE, item)
             yield item


### PR DESCRIPTION
The `GetProvBrFirms` API dropped the `EMailAddress` field, so the unconditional `pop("EMailAddress")` raised `KeyError` on every record and the spider produced no items.

Removed the email field, and set a `ref` from brand + coordinates (the API exposes no id field, so items were being collapsed by the duplicate filter). Now yields dealers across all three brands (İstikbal, Bellona, Mondi) with coordinates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Store listings now include more consistent branch names.
  * Brand information is applied more reliably to listings and categorization.
  * Store references are generated more consistently using brand and location details.
  * Store listing retrieval is faster, with reduced waiting between requests.
  * Store data processing is more reliable for supported locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->