### PR TITLE
[Kia] Fix spider

### DIFF
--- a/locations/spiders/kia.py
+++ b/locations/spiders/kia.py
@@ -61,7 +61,7 @@ class KiaSpider(scrapy.Spider):
                 sales_item = item.deepcopy()
                 sales_item["ref"] = f"{item['ref']}-sales"
                 apply_category(Categories.SHOP_CAR, sales_item)
-                apply_yes_no(Extras.CAR_REPAIR, sales_item, "service" in dealer_type)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, "service" in dealer_type)
                 yield sales_item
 
             if "service" in dealer_type:


### PR DESCRIPTION
The spider referenced `Extras.CAR_REPAIR`, which was renamed to `Extras.VEHICLE_CAR_REPAIR_SERVICES` in #17327, so `parse()` raised an AttributeError on the first sales dealer of each locale and recent runs produced 0 features.

Updated the reference to the current member name. A full crawl now returns 3166 dealers across the 18 locales.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the classification of repair services for Kia sales dealer listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->