### PR TITLE
[Mcdonalds HK] Fix spider

### DIFF
--- a/locations/spiders/mcdonalds_hk.py
+++ b/locations/spiders/mcdonalds_hk.py
@@ -6,7 +6,7 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_EN, OpeningHours
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.react_server_components import parse_rsc
 from locations.spiders.mcdonalds import McdonaldsSpider
@@ -27,6 +27,8 @@ class McdonaldsHKSpider(Spider):
 
         for store in DictParser.get_nested_key(data, "restaurants"):
             item = DictParser.parse(store)
+            # DictParser maps the feed's region onto state
+            item.pop("state", None)
             item["ref"] = store["rid"]
             item["branch"] = item.pop("name")
             item["website"] = "https://www.mcdonalds.com.hk/en/find-a-restaurant/{}/".format(store["storeNo"])
@@ -36,9 +38,9 @@ class McdonaldsHKSpider(Spider):
                 for rule in schedule["hours"]:
                     if rule["start"] == "00:00" and rule["end"] == "00:00":
                         # The website renders this range as "Open 24 Hours", not as a closed day.
-                        item["opening_hours"].add_range(DAYS_EN[rule["day"]], "00:00", "24:00")
+                        item["opening_hours"].add_range(rule["day"], "00:00", "24:00")
                     elif "$undefined" not in (rule["start"], rule["end"]):
-                        item["opening_hours"].add_range(DAYS_EN[rule["day"]], rule["start"], rule["end"])
+                        item["opening_hours"].add_range(rule["day"], rule["start"], rule["end"])
 
             apply_category(Categories.FAST_FOOD, item)
 

--- a/locations/spiders/mcdonalds_hk.py
+++ b/locations/spiders/mcdonalds_hk.py
@@ -1,27 +1,46 @@
-from typing import Any, AsyncIterator
+from typing import Any, Iterable
 
+from chompjs import chompjs
 from scrapy import Spider
-from scrapy.http import FormRequest, Response
+from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
 from locations.spiders.mcdonalds import McdonaldsSpider
-from locations.user_agents import BROWSER_DEFAULT
 
 
 class McdonaldsHKSpider(Spider):
     name = "mcdonalds_hk"
     item_attributes = McdonaldsSpider.item_attributes
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT, "DOWNLOAD_TIMEOUT": 180}
+    allowed_domains = ["www.mcdonalds.com.hk"]
+    start_urls = ["https://www.mcdonalds.com.hk/en/find-a-restaurant/"]
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        yield FormRequest(
-            url="https://www.mcdonalds.com.hk/wp-admin/admin-ajax.php?action=get_restaurants", formdata={"type": "init"}
-        )
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        objs = [
+            chompjs.parse_js_object(s)
+            for s in response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        ]
+        data = dict(parse_rsc("".join([s for n, s in objs]).encode()))
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for index, store in enumerate(response.json()["restaurants"]):
+        for store in DictParser.get_nested_key(data, "restaurants"):
             item = DictParser.parse(store)
-            item["branch"] = store["title"]
-            item["name"] = self.item_attributes["brand"]
-            item["ref"] = index
+            item["state"] = None
+            item["ref"] = store["rid"]
+            item["branch"] = item.pop("name")
+            item["website"] = "https://www.mcdonalds.com.hk/en/find-a-restaurant/{}/".format(store["storeNo"])
+
+            item["opening_hours"] = OpeningHours()
+            for schedule in store["openingHours"]:
+                for rule in schedule["hours"]:
+                    if rule["start"] == "00:00" and rule["end"] == "00:00":
+                        # The website renders this range as "Open 24 Hours", not as a closed day.
+                        item["opening_hours"].add_range(rule["day"], "00:00", "24:00")
+                    elif "$undefined" not in (rule["start"], rule["end"]):
+                        item["opening_hours"].add_range(rule["day"], rule["start"], rule["end"])
+
+            apply_category(Categories.FAST_FOOD, item)
+
             yield item

--- a/locations/spiders/mcdonalds_hk.py
+++ b/locations/spiders/mcdonalds_hk.py
@@ -6,7 +6,7 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
 from locations.react_server_components import parse_rsc
 from locations.spiders.mcdonalds import McdonaldsSpider
@@ -27,7 +27,6 @@ class McdonaldsHKSpider(Spider):
 
         for store in DictParser.get_nested_key(data, "restaurants"):
             item = DictParser.parse(store)
-            item["state"] = None
             item["ref"] = store["rid"]
             item["branch"] = item.pop("name")
             item["website"] = "https://www.mcdonalds.com.hk/en/find-a-restaurant/{}/".format(store["storeNo"])
@@ -37,9 +36,9 @@ class McdonaldsHKSpider(Spider):
                 for rule in schedule["hours"]:
                     if rule["start"] == "00:00" and rule["end"] == "00:00":
                         # The website renders this range as "Open 24 Hours", not as a closed day.
-                        item["opening_hours"].add_range(rule["day"], "00:00", "24:00")
+                        item["opening_hours"].add_range(DAYS_EN[rule["day"]], "00:00", "24:00")
                     elif "$undefined" not in (rule["start"], rule["end"]):
-                        item["opening_hours"].add_range(rule["day"], rule["start"], rule["end"])
+                        item["opening_hours"].add_range(DAYS_EN[rule["day"]], rule["start"], rule["end"])
 
             apply_category(Categories.FAST_FOOD, item)
 


### PR DESCRIPTION
When the spider is run on the US network, it fails. This fix ensures that the spider continues to produce results in future weekly runs.

```
{"atp/brand/McDonald's": 268,
 'atp/brand_wikidata/Q38076': 268,
 'atp/category/amenity/fast_food': 268,
 'atp/clean_strings/addr_full': 2,
 'atp/clean_strings/branch': 1,
 'atp/clean_strings/phone': 1,
 'atp/country/HK': 268,
 'atp/field/country/from_spider_name': 268,
 'atp/field/email/missing': 268,
 'atp/field/housenumber/missing': 268,
 'atp/field/name/missing': 268,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 268,
 'atp/field/operator_wikidata/missing': 268,
 'atp/field/phone/missing': 4,
 'atp/field/postcode/missing': 268,
 'atp/field/state/missing': 268,
 'atp/field/street/missing': 268,
 'atp/field/street_address/missing': 268,
 'atp/field/twitter/missing': 268,
 'atp/field/unit/missing': 268,
 'atp/item_scraped_host_count/www.mcdonalds.com.hk': 268,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 268,
 'atp/nsi/multiple_matches': 268,
 'downloader/request_bytes': 687,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 536654,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.109000000000151,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 12, 13, 24, 30, 133503, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 268,
 'items_per_minute': 5360.0,
 'log_count/DEBUG': 270,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 12, 13, 24, 27, 15501, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Updated Hong Kong restaurant listings with more complete location information.
- Added restaurant references, branch details, website links, operating states, and fast-food categorization.
- Added opening hours, including support for restaurants operating 24 hours.
- Improved restaurant data reliability by using information embedded in the official website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->