### PR TITLE
Fix AttributeErrors due to renamed Extras

### DIFF
--- a/locations/spiders/citroen.py
+++ b/locations/spiders/citroen.py
@@ -61,7 +61,7 @@ class CitroenSpider(scrapy.Spider):
             car_repair = re.findall("'type': 'service'", services)
             if len(car_dealer) > 0 and len(car_repair) > 0:
                 apply_category(Categories.SHOP_CAR, item)
-                apply_yes_no(Extras.CAR_REPAIR, item, True)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, item, True)
             elif car_dealer:
                 apply_category(Categories.SHOP_CAR, item)
             elif car_repair:

--- a/locations/spiders/hyundai_bw_ls_na_sz_za.py
+++ b/locations/spiders/hyundai_bw_ls_na_sz_za.py
@@ -32,9 +32,9 @@ class HyundaiBWLSNASZZASpider(JSONBlobSpider):
             shop = deepcopy(item)
             apply_category(Categories.SHOP_CAR, shop)
             if feature.get("Service") or feature.get("CommercialService"):
-                apply_yes_no(Extras.CAR_REPAIR, shop, True)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, shop, True)
             if feature.get("Parts") or feature.get("CommercialParts"):
-                apply_yes_no(Extras.CAR_PARTS, shop, True)
+                apply_yes_no(Extras.VEHICLE_CAR_PARTS_SALES, shop, True)
             yield shop
 
         if feature.get("Service") or feature.get("CommercialService"):
@@ -42,7 +42,7 @@ class HyundaiBWLSNASZZASpider(JSONBlobSpider):
             service["ref"] = f"{item['ref']}_service"
             apply_category(Categories.SHOP_CAR_REPAIR, service)
             if feature.get("Parts") or feature.get("CommercialParts"):
-                apply_yes_no(Extras.CAR_PARTS, service, True)
+                apply_yes_no(Extras.VEHICLE_CAR_PARTS_SALES, service, True)
             yield service
 
         if feature.get("Parts") or feature.get("CommercialParts"):

--- a/locations/spiders/hyundai_th.py
+++ b/locations/spiders/hyundai_th.py
@@ -55,7 +55,7 @@ class HyundaiTHSpider(JSONBlobSpider):
             sales_item = deepcopy(item)
             sales_item["ref"] = f"{item['ref']}-sales"
             apply_category(Categories.SHOP_CAR, sales_item)
-            apply_yes_no(Extras.CAR_REPAIR, sales_item, has_service)
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, has_service)
             yield sales_item
 
         if has_service:

--- a/locations/spiders/mitsubishi.py
+++ b/locations/spiders/mitsubishi.py
@@ -215,7 +215,7 @@ class MitsubishiSpider(Spider):
         if sales_available:
             sales_item = self.build_sales_item(item)
             sales_item["opening_hours"] = self.parse_hours(sales_hours, item["country"])
-            apply_yes_no(Extras.CAR_REPAIR, sales_item, service_available)
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, service_available)
             yield sales_item
 
         if service_available:

--- a/locations/spiders/mitsubishi_au.py
+++ b/locations/spiders/mitsubishi_au.py
@@ -119,7 +119,7 @@ class MitsubishiAUSpider(Spider):
             if sales_available:
                 sales_item = self.build_sales_item(item)
                 sales_item["opening_hours"] = self.parse_hours(poi.get("trading_hours", {}))
-                apply_yes_no(Extras.CAR_REPAIR, sales_item, service_available)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, service_available)
                 yield sales_item
 
             if service_available:

--- a/locations/spiders/mitsubishi_by_ru.py
+++ b/locations/spiders/mitsubishi_by_ru.py
@@ -32,7 +32,7 @@ class MitsubishiBYRUSpider(JSONBlobSpider):
         if is_shop:
             shop_item = item.deepcopy()
             apply_category(Categories.SHOP_CAR, shop_item)
-            apply_yes_no(Extras.CAR_REPAIR, shop_item, is_repair)
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, shop_item, is_repair)
             yield shop_item
 
         if is_repair:

--- a/locations/spiders/mitsubishi_ch.py
+++ b/locations/spiders/mitsubishi_ch.py
@@ -26,7 +26,7 @@ class MitsubishiCHSpider(JSONBlobSpider):
             sales_item = deepcopy(item)
             sales_item["ref"] = f"{item['ref']}-sales"
             apply_category(Categories.SHOP_CAR, sales_item)
-            apply_yes_no(Extras.CAR_REPAIR, sales_item, mitsubishi.get("service", False))
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, mitsubishi.get("service", False))
             sales_item["opening_hours"] = self.parse_hours(opening_hours.get("sales"))
             yield sales_item
 

--- a/locations/spiders/mitsubishi_dk_se.py
+++ b/locations/spiders/mitsubishi_dk_se.py
@@ -29,7 +29,7 @@ class MitsubishiDKSESpider(JSONBlobSpider):
             shop_item = deepcopy(item)
             shop_item["ref"] = f"{item['ref']}-shop"
             apply_category(Categories.SHOP_CAR, shop_item)
-            apply_yes_no(Extras.CAR_REPAIR, shop_item, has_repair)
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, shop_item, has_repair)
             yield shop_item
 
         if has_repair:

--- a/locations/spiders/mitsubishi_id.py
+++ b/locations/spiders/mitsubishi_id.py
@@ -45,15 +45,15 @@ class MitsubishiIDSpider(JSONBlobSpider):
                 shop_item = deepcopy(item)
                 shop_item["ref"] = f"{item['ref']}-shop"
                 apply_category(Categories.SHOP_CAR, shop_item)
-                apply_yes_no(Extras.CAR_REPAIR, shop_item, has_service)
-                apply_yes_no(Extras.CAR_PARTS, shop_item, has_parts)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, shop_item, has_service)
+                apply_yes_no(Extras.VEHICLE_CAR_PARTS_SALES, shop_item, has_parts)
                 yield shop_item
 
             if has_service:
                 repair_item = deepcopy(item)
                 repair_item["ref"] = f"{item['ref']}-repair"
                 apply_category(Categories.SHOP_CAR_REPAIR, repair_item)
-                apply_yes_no(Extras.CAR_PARTS, repair_item, has_parts)
+                apply_yes_no(Extras.VEHICLE_CAR_PARTS_SALES, repair_item, has_parts)
                 yield repair_item
 
             if has_parts:

--- a/locations/spiders/mitsubishi_pl.py
+++ b/locations/spiders/mitsubishi_pl.py
@@ -50,7 +50,7 @@ class MitsubishiPLSpider(JSONBlobSpider):
         if sales_available:
             sales_item = self.build_sales_item(item)
             if service_available:
-                apply_yes_no(Extras.CAR_REPAIR, sales_item, True)
+                apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, True)
             yield sales_item
 
         if service_available:

--- a/locations/spiders/mitsubishi_ua.py
+++ b/locations/spiders/mitsubishi_ua.py
@@ -52,7 +52,7 @@ class MitsubishiUASpider(JSONBlobSpider):
                 oh.add_ranges_from_string(f'{rule["day"]} {rule["workhours"]}', days=DAYS_RU)
             sales_item["opening_hours"] = oh
             apply_category(Categories.SHOP_CAR, sales_item)
-            apply_yes_no(Extras.CAR_REPAIR, sales_item, SERVICE in departments)
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, sales_item, SERVICE in departments)
             yield sales_item
 
         if SERVICE in departments:

--- a/locations/spiders/nissan_eu.py
+++ b/locations/spiders/nissan_eu.py
@@ -61,7 +61,7 @@ class NissanEUSpider(Spider):
             if "car" in services:
                 apply_category(Categories.SHOP_CAR, item)
                 if "configure" in services:
-                    apply_yes_no(Extras.CAR_REPAIR, item, True)
+                    apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, item, True)
             elif "configure" in services:
                 apply_category(Categories.SHOP_CAR_REPAIR, item)
             else:

--- a/locations/spiders/porsche_holding.py
+++ b/locations/spiders/porsche_holding.py
@@ -84,7 +84,7 @@ class PorscheHoldingSpider(JSONBlobSpider):
         services = feature.get("contracts", {})
         if services.get("sales"):
             apply_category(Categories.SHOP_CAR, item)
-            apply_yes_no(Extras.CAR_REPAIR, item, services.get("service"))
+            apply_yes_no(Extras.VEHICLE_CAR_REPAIR_SERVICES, item, services.get("service"))
         elif services.get("service"):
             apply_category(Categories.SHOP_CAR_REPAIR, item)
 

--- a/locations/spiders/toyota_africa.py
+++ b/locations/spiders/toyota_africa.py
@@ -151,12 +151,20 @@ class ToyotaAfricaSpider(CrawlSpider):
         for category in categories:
             if category in self.CATEGORY_SALES_KEYS:
                 apply_category(Categories.SHOP_CAR, item)
-                apply_yes_no(Extras.CAR_REPAIR, item, any(extra in self.CATEGORY_SERVICE_KEYS for extra in categories))
-                apply_yes_no(Extras.CAR_PARTS, item, any(extra in self.CATEGORY_PARTS_KEYS for extra in categories))
+                apply_yes_no(
+                    Extras.VEHICLE_CAR_REPAIR_SERVICES,
+                    item,
+                    any(extra in self.CATEGORY_SERVICE_KEYS for extra in categories),
+                )
+                apply_yes_no(
+                    Extras.VEHICLE_CAR_PARTS_SALES, item, any(extra in self.CATEGORY_PARTS_KEYS for extra in categories)
+                )
                 break
             elif category in self.CATEGORY_SERVICE_KEYS:
                 apply_category(Categories.SHOP_CAR_REPAIR, item)
-                apply_yes_no(Extras.CAR_PARTS, item, any(extra in self.CATEGORY_PARTS_KEYS for extra in categories))
+                apply_yes_no(
+                    Extras.VEHICLE_CAR_PARTS_SALES, item, any(extra in self.CATEGORY_PARTS_KEYS for extra in categories)
+                )
                 break
             elif category in self.CATEGORY_PARTS_KEYS:
                 apply_category(Categories.SHOP_CAR_PARTS, item)


### PR DESCRIPTION
#17327 renamed `Extras.CAR_REPAIR` to `Extras.VEHICLE_CAR_REPAIR_SERVICES` and `Extras.CAR_PARTS` to `Extras.VEHICLE_CAR_PARTS_SALES`, but a number of spiders still reference the old names and raise AttributeError when those lines execute (the same failure #17784 fixed for kia).

Updated the remaining references — 14 files: `citroen`, `hyundai_bw_ls_na_sz_za`, `hyundai_th`, `nissan_eu`, `porsche_holding`, `toyota_africa` and 8 `mitsubishi_*` spiders. Verification crawls show this restores most of them outright; any spider with separate breakage will be fixed individually. `toyota_us` is left to #17744, which already covers its reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Accuracy**
  * Improved dealership listings by consistently classifying vehicle repair services and parts sales.
  * Updated sales and service locations across multiple automotive brands to display the appropriate service capabilities.
  * Toyota Africa locations now more accurately reflect repair-service and parts-sales availability based on their service categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->