### PR TITLE
[solidcore US] Skip blank addresses

### DIFF
--- a/locations/spiders/solidcore_us.py
+++ b/locations/spiders/solidcore_us.py
@@ -15,7 +15,8 @@ class SolidcoreUSSpider(JSONBlobSpider):
     locations_key = "Locations"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Iterable[Feature]:
-        if feature.get("Address") in (None, "Coming soon"):
+        address = feature.get("Address")
+        if not address or address.strip().casefold() == "coming soon":
             return
         item["ref"] = f"{feature['SiteID']}-{feature['Id']}"
         item["branch"] = re.sub(r"^[A-Z]{2}, ", "", item.pop("name"))


### PR DESCRIPTION
CodeRabbit flagged in #17752 that the address-skip check in `solidcore_us.py` only matched `None` or the literal string `"Coming soon"`, so an empty or whitespace-only `Address` field would slip through and produce a location with a blank address. This was never addressed before that PR merged.

This updates the check to treat any falsy/blank address, or "coming soon" (case-insensitively, trimmed), as a reason to skip the feature.