### PR TITLE
[Mitsubishi BR] Document lack of per-function dealer data

### DIFF
--- a/locations/spiders/mitsubishi_br.py
+++ b/locations/spiders/mitsubishi_br.py
@@ -13,5 +13,12 @@ class MitsubishiBRSpider(StructuredDataSpider):
     start_urls = ["https://www.mitsubishimotors.com.br/concessionarias"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # The previous spider (pre-#17782) queried a dealer API that flagged each
+        # location with newCars/postSalesServices/kitCarParts, letting us split
+        # dealers into separate sales/service/parts items. That API is now
+        # unreachable, and the AutoDealer entries in this page's structured data
+        # (both the ld+json block and the embedded Next.js RSC payload) no longer
+        # carry any equivalent per-function flags, so that split can't be
+        # reconstructed from this source. All dealers are tagged as SHOP_CAR only.
         apply_category(Categories.SHOP_CAR, item)
         yield item


### PR DESCRIPTION
Addresses the CodeRabbit finding on #17782, which asked to restore separate sales/service/parts items per dealership (as the pre-#17782 spider did using flags from the old dealer API).

I investigated whether that granularity is still available from the new source (`https://www.mitsubishimotors.com.br/concessionarias`, used since #17782):

- The old dealer API (`api.mitsubishimotors.com.br/search/api/dealer/v1.0/nearest`) that used to supply the `newCars`/`postSalesServices`/`kitCarParts` flags is now unreachable (connection times out), which is presumably why #17782 switched to `StructuredDataSpider` in the first place.
- The `concessionarias` page's `ld+json` `AutoDealer` entries only include name, address, geo, telephone, email, sameAs, openingHoursSpecification, and areaServed — no service/parts/sales distinction.
- The embedded Next.js RSC flight payload carries the identical structured data, with no additional hidden fields.
- There's no separate API call, filter UI, or alternate page (e.g. for parts or service locators) that exposes this distinction either.

Since the site itself no longer distinguishes dealer functions anywhere in its data, splitting into separate sales/service/parts items can't be reconstructed from this source, so `Categories.SHOP_CAR` applied uniformly is correct as-is. I added a code comment explaining this so the reasoning isn't lost and future contributors (or bots) don't re-flag it without checking the source data first.