### PR TITLE
[Pam Golding] Fix CodeRabbit-flagged issues

### DIFF
--- a/locations/spiders/pam_golding.py
+++ b/locations/spiders/pam_golding.py
@@ -6,6 +6,50 @@ from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
+# ISO 3166-2 subdivision codes for the provinces/regions observed in this
+# spider's data, keyed by the raw "countryName" values returned by the API.
+# Countries or provinces without an unambiguous subdivision code (e.g.
+# Mozambique's "Maputo", which is ambiguous between Maputo City and Maputo
+# Province, or Seychelles/Mauritius regions that aren't ISO subdivisions) are
+# intentionally omitted so item["state"] is left unset rather than storing a
+# raw display name.
+STATE_CODES = {
+    "South Africa": {
+        "Eastern Cape": "EC",
+        "Free State": "FS",
+        "Gauteng": "GP",
+        "KwaZulu-Natal": "KZN",
+        "Limpopo Province": "LP",
+        "Mpumalanga": "MP",
+        "North West Province": "NW",
+        "Northern Cape": "NC",
+        "Western Cape": "WC",
+    },
+    "United Arab Emirates": {
+        "Dubai": "DU",
+    },
+    "Zimbabwe": {
+        "Harare": "HA",
+        "Matabeleland South": "MS",
+    },
+    "Namibia": {
+        "Erongo": "ER",
+        "Khomas": "KH",
+    },
+    "Botswana": {
+        "South East": "SE",
+    },
+    "Zambia": {
+        "Lusaka": "09",
+    },
+    "Uganda": {
+        "Central": "C",
+    },
+    "Kenya": {
+        "Nairobi": "30",
+    },
+}
+
 
 class PamGoldingSpider(JSONBlobSpider):
     name = "pam_golding"
@@ -27,9 +71,19 @@ class PamGoldingSpider(JSONBlobSpider):
         item["addr_full"] = location.get("address")
         item["lat"] = location["geoPoint"]["lat"]
         item["lon"] = location["geoPoint"]["lon"]
-        item["state"] = location["location"]["provinceName"]
-        item["country"] = location["location"]["countryName"]
-        item["phone"] = location["number"]
-        item["email"] = location["email"]
+
+        country_name = location["location"]["countryName"]
+        province_name = location["location"]["provinceName"]
+        # item["country"] is left as the raw display name here: the
+        # CountryCodeCleanUpPipeline (which runs on every item) resolves it
+        # to an ISO alpha-2 code via the same country name matching logic
+        # exposed by locations.country_utils.CountryUtils, so all countries
+        # observed in this dataset already come out correctly as e.g. "ZA".
+        item["country"] = country_name
+        if state := STATE_CODES.get(country_name, {}).get(province_name):
+            item["state"] = state
+
+        item["phone"] = location.get("number")
+        item["email"] = location.get("email")
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item


### PR DESCRIPTION
Addresses three CodeRabbit findings from #17756 that were never resolved before merge:

- Guard `location.get("number")` / `location.get("email")` instead of unguarded key access, avoiding a `KeyError` if an office is missing either field.
- Normalize `provinceName` to an ISO 3166-2 subdivision code via a local mapping covering the countries/provinces this data source actually returns (South Africa, UAE, Zimbabwe, Namibia, Botswana, Zambia, Uganda, Kenya). State is omitted where no unambiguous mapping exists (e.g. Mozambique's "Maputo", which is ambiguous between Maputo City and Maputo Province, and Seychelles/Mauritius regions that aren't ISO subdivisions).
- Verified `item["country"]` already comes out as an ISO alpha-2 code (e.g. `ZA`) via the repo's existing `CountryCodeCleanUpPipeline`, which runs on every item and resolves country display names through `CountryUtils.to_iso_alpha2_country_code`. Confirmed via a local crawl that all 11 countries in this dataset resolve correctly, so no spider-level change was needed there.

Verified locally with `uv run scrapy crawl pam_golding -o pam_golding.geojson` (239 items, all countries ISO alpha-2, states correctly coded for the mapped countries) and `uv run pre-commit run --files locations/spiders/pam_golding.py` (all checks pass).