### PR TITLE
[Starbucks PE] Fix spider

### DIFF
--- a/locations/spiders/starbucks_pe.py
+++ b/locations/spiders/starbucks_pe.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator
 from scrapy.http import JsonRequest
 
 from locations.geo import city_locations
-from locations.spiders.starbucks_us import HEADERS, STORELOCATOR, StarbucksUSSpider
+from locations.spiders.starbucks_us import API_SERVER_REACH_MILES, HEADERS, STORELOCATOR, StarbucksUSSpider
 
 
 class StarbucksPESpider(StarbucksUSSpider):
@@ -16,5 +16,5 @@ class StarbucksPESpider(StarbucksUSSpider):
             yield JsonRequest(
                 url=STORELOCATOR.format(city["latitude"], city["longitude"]),
                 headers=HEADERS,
-                meta={"distance": 1},
+                meta={"half_width_miles": API_SERVER_REACH_MILES, "depth_level": 0},
             )

--- a/locations/spiders/starbucks_pe.py
+++ b/locations/spiders/starbucks_pe.py
@@ -1,8 +1,9 @@
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
 from locations.geo import city_locations
+from locations.items import Feature
 from locations.spiders.starbucks_us import API_SERVER_REACH_MILES, HEADERS, STORELOCATOR, StarbucksUSSpider
 
 
@@ -12,9 +13,25 @@ class StarbucksPESpider(StarbucksUSSpider):
     country_filter = ["PE"]
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for city in city_locations("PE", 15000):
+        # Nearby cities see the same stores, so only seed cities outside the reach of
+        # every already-seeded (more populous) city; subdivision covers the rest.
+        seeds: list[dict] = []
+        for city in sorted(city_locations("PE", 15000), key=lambda c: c["population"], reverse=True):
+            if any(
+                self._miles_between(city["latitude"], city["longitude"], seed["latitude"], seed["longitude"])
+                < API_SERVER_REACH_MILES
+                for seed in seeds
+            ):
+                continue
+            seeds.append(city)
             yield JsonRequest(
                 url=STORELOCATOR.format(city["latitude"], city["longitude"]),
                 headers=HEADERS,
                 meta={"half_width_miles": API_SERVER_REACH_MILES, "depth_level": 0},
             )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for result in super().parse(response, **kwargs):
+            if isinstance(result, Feature):
+                result["phone"] = None
+            yield result


### PR DESCRIPTION
#17621 changed `StarbucksUSSpider.parse()` to read `meta["half_width_miles"]`, but this subclass's `start()` still passed the old `meta={"distance": 1}`, so every response raised KeyError and recent runs produced 0 features.

Updated the seed requests to the new meta contract. A full crawl returns 129 locations, in line with the 128 from the last healthy run.

Also, following the test-run results: phones are dropped (the API only carries a few central numbers for Peru, not per-store phones), and city seeds within the locator's reach of a more populous city are skipped, cutting the duplicate fetches from overlapping queries (~14k → ~1.1k dropped duplicates in a full crawl, 412 → 96 requests) with an identical set of 129 locations returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated location searches to use the configured search range and appropriate search depth.
  * Improved search coverage by selecting well-spaced cities based on population.
  * Cleared phone values when unavailable in location search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->