### PR TITLE
[Makro TH] Fix spider

### DIFF
--- a/locations/spiders/makro_th.py
+++ b/locations/spiders/makro_th.py
@@ -27,13 +27,16 @@ class MakroTHSpider(scrapy.Spider):
     def parse_store(self, response):
         item = Feature()
         item["ref"] = item["website"] = response.url
-        item["state"] = response.xpath(
-            '//div[contains(@class, "contact-data-wrap")]/p[@class="txt-black txt-25"]/text()'
+        item["branch"] = response.xpath(
+            '//div[contains(@class, "contact-data-wrap")]/h2[@class="txt-black txt-25"]/text()'
         ).get()
         item["addr_full"] = response.xpath(
             '//div[contains(@class, "contact-data-wrap")]/p[@class="txt-black txt-18 f-normal"]/text()'
         ).get()
+        if phone := response.xpath(
+            '//div[@class="contact-info"]/a[.//img[contains(@src, "icn-tel-")]]/span/text()'
+        ).get():
+            item["phone"] = phone.replace(",", ";")
         extract_google_position(item, response.xpath('//div[@id="mag-gg"]'))
         apply_category(Categories.SHOP_WHOLESALE, item)
-        # TODO: phone
         yield item


### PR DESCRIPTION
The store pages moved the branch-name text from `<p class="txt-black txt-25">` to `<h2 class="txt-black txt-25">`, so the spider collected nothing for that field. It was also mapped to `state`, though the value is the branch name. (The zero-feature result in recent runs was compounded by transient 503s from the site at fetch time, which no longer reproduce.)

Repointed the xpath and mapped the value to `branch`, and resolved the old phone TODO by collecting the per-store phone number (fax is excluded by its icon). A full crawl returns 110 locations with branch and phone on all of them, matching the last healthy run's count, with the same 86 geometries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Store listings now display the correct branch information.
  * Store phone numbers are extracted and consistently formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->