### PR TITLE
[Sofia Urban Mobility Center BG] Fix spider

### DIFF
--- a/locations/spiders/sofia_urban_mobility_center_bg.py
+++ b/locations/spiders/sofia_urban_mobility_center_bg.py
@@ -23,7 +23,7 @@ class SofiaUrbanMobilityCenterBGSpider(JSONBlobSpider):
         feature["name_en"] = names.get("en")
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
-        item["branch"] = item.pop("name")
+        item["extras"]["branch:bg"] = item["branch"] = item.pop("name")
         if feature.get("name_en"):
             item["extras"]["branch:en"] = feature["name_en"]
 

--- a/locations/spiders/sofia_urban_mobility_center_bg.py
+++ b/locations/spiders/sofia_urban_mobility_center_bg.py
@@ -1,46 +1,40 @@
-import re
-from typing import Any, Iterable
+from typing import Iterable
 
-import chompjs
-from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import DAYS_WEEKDAY, OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class SofiaUrbanMobilityCenterBGSpider(Spider):
+class SofiaUrbanMobilityCenterBGSpider(JSONBlobSpider):
     name = "sofia_urban_mobility_center_bg"
     item_attributes = {
         "brand": "Център за градска мобилност",
         "brand_wikidata": "Q7553668",
     }
-    start_urls = ["https://webportal.sofiatraffic.bg/bg/contacts"]
+    start_urls = ["https://webportal.sofiatraffic.bg/sales-points"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        if bundle_path := response.xpath('//script[@type="module"]/@src').get():
-            yield response.follow(bundle_path, callback=self.parse_bundle)
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("location"))
+        names = feature.pop("name")
+        feature["name"] = names["bg"]
+        feature["name_en"] = names.get("en")
 
-    def parse_bundle(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        if not (anchor := re.search(r"=\{1:\{name:\{bg:", response.text)):
-            return
-        for office in chompjs.parse_js_object(response.text[anchor.start() + 1 :]).values():
-            office.update(office.pop("location"))
-            office["name"] = office["name"].get("en") or office["name"]["bg"]
-            item = DictParser.parse(office)
-            item["branch"] = item.pop("name")
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        if feature.get("name_en"):
+            item["extras"]["branch:en"] = feature["name_en"]
 
-            hours = office["workingHours"]
-            item["opening_hours"] = OpeningHours()
-            for day in ["Mo", "Tu", "We", "Th", "Fr"]:
-                if hours.get("weekday"):
-                    item["opening_hours"].add_range(day, *hours["weekday"].split("-"))
-            if hours.get("saturday"):
-                item["opening_hours"].add_range("Sa", *hours["saturday"].split("-"))
-            if hours.get("sunday"):
-                item["opening_hours"].add_range("Su", *hours["sunday"].split("-"))
+        hours = feature.get("workingHours") or {}
+        item["opening_hours"] = OpeningHours()
+        if hours.get("weekday"):
+            item["opening_hours"].add_days_range(DAYS_WEEKDAY, *hours["weekday"].split("-"))
+        if hours.get("saturday"):
+            item["opening_hours"].add_range("Sa", *hours["saturday"].split("-"))
+        if hours.get("sunday"):
+            item["opening_hours"].add_range("Su", *hours["sunday"].split("-"))
 
-            apply_category(Categories.SHOP_TICKET, item)
-            yield item
+        apply_category(Categories.SHOP_TICKET, item)
+        yield item


### PR DESCRIPTION
The site was rebuilt and no longer embeds the ticket-office data in its JS bundle, so the spider's anchor regex matched nothing and recent runs produced 0 features.

Rewrote as a `JSONBlobSpider` against the site's `/sales-points` JSON API. `branch` now carries the Bulgarian name, with English in `branch:en`, as in other multilingual spiders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sofia Urban Mobility Center sales-point listings.
  * Added clearer Bulgarian and English branch names.
  * Improved handling of weekday and weekend opening hours.
  * Prevented missing working-hours information from disrupting listings.
  * Applied the ticket-shop category consistently to sales points.
  * Refreshed sales-point data to provide more complete and reliable location details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->