### PR TITLE
[P&K Equipment] Fix spider

### DIFF
--- a/locations/spiders/pk_equipment.py
+++ b/locations/spiders/pk_equipment.py
@@ -1,29 +1,21 @@
 import re
+from typing import Iterable
 
-import scrapy
+from scrapy.http import TextResponse
 
-from locations.structured_data_spider import StructuredDataSpider
+from locations.hours import DAYS_EN
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class PkEquipmentSpider(StructuredDataSpider):
+class PkEquipmentSpider(WPStoreLocatorSpider):
     name = "pk_equipment"
     item_attributes = {"brand": "P&K Equipment", "extras": {"shop": "tractor"}}
-    allowed_domains = ["pkequipment.com"]
-    start_urls = ("https://www.pkequipment.com/about-us/locations/",)
+    allowed_domains = ["www.pkequipment.com"]
+    days = DAYS_EN
 
-    def parse(self, response):
-        urls = response.xpath('//div[@class="li-text"]/h2/a/@href').extract()
-
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url), callback=self.parse_sd)
-
-    def post_process_item(self, item, response, ld_data):
-        ref = re.search(r".+/(.+?)/?(?:\.html|$)", response.url).group(1)
-        mapdata = response.xpath('//div[@class="clearfix map_equipment"]/script[2]').extract_first()
-        lat = re.search(r'(?:lat":)(-?\d+\.\d+),.*(?:long":)(-?\d*.\d*)', mapdata).group(1)
-        lon = re.search(r'(?:lat":)(-?\d+\.\d+),.*(?:long":)(-?\d*.\d*)', mapdata).group(2)
-        item["ref"] = ref
-        item["lat"] = float(lat)
-        item["lon"] = float(lon)
-
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        slug = re.sub(r"[^a-z0-9]+", "-", feature["store"].lower()).strip("-")
+        item["website"] = f"https://www.pkequipment.com/{slug}/"
         yield item

--- a/locations/spiders/pk_equipment_us.py
+++ b/locations/spiders/pk_equipment_us.py
@@ -3,6 +3,7 @@ from typing import Iterable
 
 from scrapy.http import TextResponse
 
+from locations.categories import apply_category
 from locations.hours import DAYS_EN
 from locations.items import Feature
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
@@ -10,7 +11,7 @@ from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 class PkEquipmentUSSpider(WPStoreLocatorSpider):
     name = "pk_equipment_us"
-    item_attributes = {"brand": "P&K Equipment", "extras": {"shop": "tractor"}}
+    item_attributes = {"brand": "P&K Equipment"}
     allowed_domains = ["www.pkequipment.com"]
     days = DAYS_EN
 
@@ -18,4 +19,5 @@ class PkEquipmentUSSpider(WPStoreLocatorSpider):
         item["branch"] = item.pop("name")
         slug = re.sub(r"[^a-z0-9]+", "-", feature["store"].lower()).strip("-")
         item["website"] = f"https://www.pkequipment.com/{slug}/"
+        apply_category({"shop": "tractor"}, item)
         yield item

--- a/locations/spiders/pk_equipment_us.py
+++ b/locations/spiders/pk_equipment_us.py
@@ -8,8 +8,8 @@ from locations.items import Feature
 from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class PkEquipmentSpider(WPStoreLocatorSpider):
-    name = "pk_equipment"
+class PkEquipmentUSSpider(WPStoreLocatorSpider):
+    name = "pk_equipment_us"
     item_attributes = {"brand": "P&K Equipment", "extras": {"shop": "tractor"}}
     allowed_domains = ["www.pkequipment.com"]
     days = DAYS_EN


### PR DESCRIPTION
The site was rebuilt: the locations index the spider started from 404s, and the new store pages carry no structured data or embedded coordinates, so recent runs produced 0 features.

Rewrote as a `WPStoreLocatorSpider` against the site's WP Store Locator endpoint, which returns all 20 stores with coordinates, addresses and opening hours in one request. The store name now populates `branch`, and `website` is constructed from the store slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added store location support for P&K Equipment’s U.S. locations.
  * Added standardized English weekday information to location listings.

* **Improvements**
  * Improved branch naming and store-specific website links.
  * Enhanced location processing for more consistent and reliable store locator results.
  * Updated location details with clearer categorization for tractor-related services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->