### PR TITLE
[Ameriprise US] Fix Spider

### DIFF
--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -1,7 +1,8 @@
 import json
+from typing import Any
 
 import scrapy
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
@@ -14,26 +15,20 @@ class AmeripriseUSSpider(Spider):
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
     start_urls = ["https://www.ameripriseadvisors.com/find-a-financial-advisor-by-state/"]
 
-    def parse(self, response):
-        # Extract list of states
-        state_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
-        for state in state_list:
-            state_url = response.urljoin(state)
-            yield scrapy.Request(url=state_url, callback=self.parse_city, cb_kwargs={"state": state})
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for state in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
+            yield scrapy.Request(url=response.urljoin(state), callback=self.parse_city, cb_kwargs={"state": state})
 
-    def parse_city(self, response, state):
-        # Extract list of cities for the given state
-        city_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
-        for city in city_list:
+    def parse_city(self, response: Response, state: str) -> Any:
+        for city in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
             payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "50", "searchType": "city, state"}
             yield JsonRequest(
                 url="https://www.ameripriseadvisors.com/api/locatorsearch/search/",
                 data={"criteria": json.dumps(payload)},
-                method="POST",
                 callback=self.parse_details,
             )
 
-    def parse_details(self, response):
+    def parse_details(self, response: Response) -> Any:
         for advisor in response.json().get("locatorResultModels", []):
             for location in advisor.get("locations", []):
                 item = DictParser.parse(location)

--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -13,7 +13,6 @@ class AmeripriseUSSpider(Spider):
     name = "ameriprise_us"
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
     start_urls = ["https://www.ameripriseadvisors.com/find-a-financial-advisor-by-state/"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
 
     def parse(self, response):
         # Extract list of states

--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -1,11 +1,9 @@
 import json
-from typing import Any
 
 import scrapy
-from scrapy.http import Response
+from scrapy.http import JsonRequest
 from scrapy.spiders import Spider
 
-from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -14,29 +12,31 @@ class AmeripriseUSSpider(Spider):
     name = "ameriprise_us"
     item_attributes = {"brand": "Ameriprise Financial", "brand_wikidata": "Q2843129"}
     start_urls = ["https://www.ameripriseadvisors.com/find-a-financial-advisor-by-state/"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for state in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
-            yield scrapy.Request(url=response.urljoin(state), callback=self.parse_city, cb_kwargs={"state": state})
+    def parse(self, response):
+        # Extract list of states
+        state_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
+        for state in state_list:
+            state_url = response.urljoin(state)
+            yield scrapy.Request(url=state_url, callback=self.parse_city, cb_kwargs={"state": state})
 
-    def parse_city(self, response: Response, state: str) -> Any:
-        for city in response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall():
-            payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "250", "searchType": "city, state"}
-            yield scrapy.FormRequest(
+    def parse_city(self, response, state):
+        # Extract list of cities for the given state
+        city_list = response.xpath('//*[@class="public-sitemap-list"]//a/text()').getall()
+        for city in city_list:
+            payload = {"searchTerm": f"{city}, {state}", "numberOfRowsToReturn": "50", "searchType": "city, state"}
+            yield JsonRequest(
                 url="https://www.ameripriseadvisors.com/api/locatorsearch/search/",
-                formdata={"criteria": json.dumps(payload)},
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-                    "Accept": "application/json",
-                },
+                data={"criteria": json.dumps(payload)},
+                method="POST",
                 callback=self.parse_details,
             )
 
-    def parse_details(self, response: Response) -> Any:
+    def parse_details(self, response):
         for advisor in response.json().get("locatorResultModels", []):
             for location in advisor.get("locations", []):
                 item = DictParser.parse(location)
                 item.pop("name")
                 item["ref"] = item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
-                apply_category(Categories.OFFICE_FINANCIAL_ADVISOR, item)
                 yield item

--- a/locations/spiders/ameriprise_us.py
+++ b/locations/spiders/ameriprise_us.py
@@ -4,6 +4,7 @@ import scrapy
 from scrapy.http import JsonRequest
 from scrapy.spiders import Spider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
 
@@ -39,4 +40,5 @@ class AmeripriseUSSpider(Spider):
                 item = DictParser.parse(location)
                 item.pop("name")
                 item["ref"] = item["street_address"] = merge_address_lines([location["address1"], location["address2"]])
+                apply_category(Categories.OFFICE_FINANCIAL_ADVISOR, item)
                 yield item


### PR DESCRIPTION
```python
{'atp/brand/Ameriprise Financial': 3184,
 'atp/brand_wikidata/Q2843129': 3184,
 'atp/category/office/financial_advisor': 3184,
 'atp/country/US': 3184,
 'atp/duplicate_count': 24600,
 'atp/field/branch/missing': 3184,
 'atp/field/country/from_spider_name': 3184,
 'atp/field/email/missing': 1374,
 'atp/field/housenumber/missing': 3184,
 'atp/field/opening_hours/missing': 3184,
 'atp/field/operator/missing': 3184,
 'atp/field/operator_wikidata/missing': 3184,
 'atp/field/phone/missing': 26,
 'atp/field/street/missing': 3184,
 'atp/field/twitter/missing': 3184,
 'atp/field/unit/missing': 3184,
 'atp/item_scraped_host_count/www.ameripriseadvisors.com': 27795,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/category_missing': 3184,
 'atp/nsi/match_imperfect': 3184,
 'downloader/exception_count': 23,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 23,
 'downloader/request_bytes': 1826802,
 'downloader/request_count': 2195,
 'downloader/request_method_count/GET': 103,
 'downloader/request_method_count/POST': 2092,
 'downloader/response_bytes': 82758558,
 'downloader/response_count': 2172,
 'downloader/response_status_count/200': 2121,
 'downloader/response_status_count/301': 51,
 'elapsed_time_seconds': 4012.2834694619996,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 13, 9, 16, 31, 845464, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 24600,
 'item_dropped_reasons_count/DropItem': 24600,
 'item_scraped_count': 3184,
 'items_per_minute': 47.61714855433699,
 'log_count/DEBUG': 29976,
 'log_count/ERROR': 17,
 'log_count/INFO': 69,
 'memusage/max': 443981824,
 'memusage/startup': 302108672,
 'request_depth_max': 2,
 'response_received_count': 2121,
 'responses_per_minute': 31.71984047856431,
 'retry/count': 20,
 'retry/max_reached': 3,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 20,
 'scheduler/dequeued': 2195,
 'scheduler/dequeued/memory': 2195,
 'scheduler/enqueued': 2195,
 'scheduler/enqueued/memory': 2195,
 'start_time': datetime.datetime(2026, 8, 13, 8, 9, 39, 561990, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved city location searches to return up to 50 matching offices.
  * Updated search handling to provide more reliable and consistent location results.
  * Improved processing of city and state search criteria while preserving existing location details.
  * Enhanced request processing for location searches to reduce missed or incomplete office results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->