### PR TITLE
[SsangYong AU] Fix spider

### DIFF
--- a/locations/spiders/ssangyong_au.py
+++ b/locations/spiders/ssangyong_au.py
@@ -50,12 +50,8 @@ class SsangyongAUSpider(JSONBlobSpider):
             service_item["phone"] = feature.get(f"{prefix}Telephone")
             service_item["email"] = feature.get(f"{prefix}Email")
             service_item["opening_hours"] = OpeningHours()
-            service_item["opening_hours"].add_ranges_from_string(
-                "Mon-Fri: {}, Sat: {}, Sun: {}".format(
-                    feature.get(f"{prefix}OpenMonFri") or "closed",
-                    feature.get(f"{prefix}OpenSaturday") or "closed",
-                    feature.get(f"{prefix}OpenSunday") or "closed",
-                )
-            )
+            for days, key in [("Mon-Fri", "OpenMonFri"), ("Sat", "OpenSaturday"), ("Sun", "OpenSunday")]:
+                if hours := feature.get(f"{prefix}{key}"):
+                    service_item["opening_hours"].add_ranges_from_string(f"{days}: {hours}")
             apply_category(category, service_item)
             yield service_item

--- a/locations/spiders/ssangyong_au.py
+++ b/locations/spiders/ssangyong_au.py
@@ -1,85 +1,61 @@
+import re
 from typing import Iterable
 
 from chompjs import parse_js_object
-from scrapy import Spider
-from scrapy.http import Request, Response
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 from locations.spiders.ssangyong_kr import SSANGYONG_SHARED_ATTRIBUTES
 
 
-class SsangyongAUSpider(Spider):
+class SsangyongAUSpider(JSONBlobSpider):
     name = "ssangyong_au"
     item_attributes = SSANGYONG_SHARED_ATTRIBUTES
     allowed_domains = ["kgm.com.au"]
     start_urls = ["https://kgm.com.au/dealers"]
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        for external_script in response.xpath('//script[contains(@src, "/_next/static/chunks/")]/@src').getall():
-            yield Request(
-                url="https://{}{}".format(self.allowed_domains[0], external_script), callback=self.parse_js_file
-            )
+    services = [
+        ("IsSalesStore", "Sales", "Dealer", Categories.SHOP_CAR),
+        ("IsServiceStore", "Service", "Service", Categories.SHOP_CAR_REPAIR),
+        ("IsPartsStore", "Parts", "Parts", Categories.SHOP_CAR_PARTS),
+    ]
 
-    def parse_js_file(self, response: Response) -> Iterable[Feature]:
-        if '=JSON.parse(\'[{"ID":' in response.text:
-            js_blob = response.text.split("=JSON.parse('", 1)[1].split("')}", 1)[0]
-            features = parse_js_object(js_blob)
-            for feature in features:
-                properties = {
-                    "branch": feature.get("Dealership"),
-                    "lat": feature.get("DealerLatitude"),
-                    "lon": feature.get("DealerLongitude"),
-                    "addr_full": feature.get("DealerAddress"),
-                    "state": feature.get("DealerState"),
-                    "postcode": str(feature.get("DealerPostcode")),
-                    "website": feature.get("DealerWebsite"),
-                }
-                if properties["website"] and not properties["website"].startswith("http"):
-                    properties["website"] = "https://" + properties["website"]
-                if feature.get("IsSalesStore"):
-                    sales_item = Feature(**properties)
-                    sales_item["ref"] = str(feature["DealerCode"]) + "_Sales"
-                    sales_item["phone"] = feature.get("DealerTelephone")
-                    sales_item["email"] = feature.get("DealerEmail")
-                    sales_item["opening_hours"] = OpeningHours()
-                    sales_item["opening_hours"].add_ranges_from_string(
-                        "Mon-Fri: {}, Sat: {}, Sun: {}".format(
-                            feature.get("DealerOpenMonFri") or "closed",
-                            feature.get("DealerOpenSaturday") or "closed",
-                            feature.get("DealerOpenSunday") or "closed",
-                        )
-                    )
-                    apply_category(Categories.SHOP_CAR, sales_item)
-                    yield sales_item
-                if feature.get("IsServiceStore"):
-                    service_item = Feature(**properties)
-                    service_item["ref"] = str(feature["DealerCode"]) + "_Service"
-                    service_item["phone"] = feature.get("ServiceTelephone")
-                    service_item["email"] = feature.get("ServiceEmail")
-                    service_item["opening_hours"] = OpeningHours()
-                    service_item["opening_hours"].add_ranges_from_string(
-                        "Mon-Fri: {}, Sat: {}, Sun: {}".format(
-                            feature.get("ServiceOpenMonFri") or "closed",
-                            feature.get("ServiceOpenSaturday") or "closed",
-                            feature.get("ServiceOpenSunday") or "closed",
-                        )
-                    )
-                    apply_category(Categories.SHOP_CAR_REPAIR, service_item)
-                    yield service_item
-                if feature.get("IsPartsStore"):
-                    parts_item = Feature(**properties)
-                    parts_item["ref"] = str(feature["DealerCode"]) + "_Parts"
-                    parts_item["phone"] = feature.get("PartsTelephone")
-                    parts_item["email"] = feature.get("PartsEmail")
-                    parts_item["opening_hours"] = OpeningHours()
-                    parts_item["opening_hours"].add_ranges_from_string(
-                        "Mon-Fri: {}, Sat: {}, Sun: {}".format(
-                            feature.get("PartsOpenMonFri") or "closed",
-                            feature.get("PartsOpenSaturday") or "closed",
-                            feature.get("PartsOpenSunday") or "closed",
-                        )
-                    )
-                    apply_category(Categories.SHOP_CAR_PARTS, parts_item)
-                    yield parts_item
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        for script in response.xpath('//script[contains(text(), "self.__next_f.push([1,")]/text()').getall():
+            chunk = parse_js_object(script)
+            if len(chunk) > 1 and isinstance(chunk[1], str) and '"dealers":[' in chunk[1]:
+                return parse_js_object(chunk[1].split('"dealers":', 1)[1])
+        return []
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature["latitude"] = feature.pop("DealerLatitude", None)
+        feature["longitude"] = feature.pop("DealerLongitude", None)
+        feature["addr_full"] = feature.pop("DealerAddress", None)
+        feature["state"] = feature.pop("DealerState", None)
+        feature["postcode"] = str(feature.pop("DealerPostcode", "") or "")
+        feature["ref"] = feature.pop("DealerCode", None)
+        if website := feature.pop("DealerWebsite", None):
+            feature["website"] = website if website.startswith("http") else "https://" + website
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = re.sub(r"\s*\b(?:KGM|SsangYong)\b\s*", " ", feature.get("Dealership", "")).strip()
+        for flag, suffix, prefix, category in self.services:
+            if not feature.get(flag):
+                continue
+            service_item = item.deepcopy()
+            service_item["ref"] = f"{item['ref']}_{suffix}"
+            service_item["phone"] = feature.get(f"{prefix}Telephone")
+            service_item["email"] = feature.get(f"{prefix}Email")
+            service_item["opening_hours"] = OpeningHours()
+            service_item["opening_hours"].add_ranges_from_string(
+                "Mon-Fri: {}, Sat: {}, Sun: {}".format(
+                    feature.get(f"{prefix}OpenMonFri") or "closed",
+                    feature.get(f"{prefix}OpenSaturday") or "closed",
+                    feature.get(f"{prefix}OpenSunday") or "closed",
+                )
+            )
+            apply_category(category, service_item)
+            yield service_item


### PR DESCRIPTION
The kgm.com.au Next.js site moved its dealer data from external `_next/static/chunks/` scripts into the inline `__next_f.push` RSC stream on the dealers page, so the spider's chunk scan found nothing and recent runs produced 0 features.

Rewrote as a `JSONBlobSpider` extracting the `dealers` array from the RSC scripts, with the Sales/Service/Parts split consolidated into one loop. The "KGM"/"SsangYong" brand tokens are stripped from `branch`.

Following review: opening hours are now built only from values the source supplies, instead of marking missing days as closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dealer listings now include separate sales, service, and parts contact details, hours, references, and categories.
  * Dealer information is normalized more consistently, including website addresses and branding.

* **Bug Fixes**
  * Improved extraction of dealer data from embedded website content.
  * Removed duplicated service listings and excluded unavailable opening-hour ranges for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->