### PR TITLE
[Press Shop BE] Fix spider

### DIFF
--- a/locations/spiders/press_shop_be.py
+++ b/locations/spiders/press_shop_be.py
@@ -1,34 +1,64 @@
 import json
 import re
-from typing import Any
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import Response
+from chompjs import parse_js_object
+from scrapy.http import TextResponse
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.hours import CLOSED_NL, DAYS_FULL, OpeningHours
 from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class PressShopBESpider(Spider):
+class PressShopBESpider(JSONBlobSpider):
     name = "press_shop_be"
-    item_attributes = {"brand": "Press Shop", "brand_wikidata": "Q126196511", "extras": Categories.SHOP_NEWSAGENT.value}
-    start_urls = ["https://press-shop.be/nl/onze-winkels/press-shop"]
-    establishments_pattern = re.compile(r'"establishments":\s*(\[.+\]),\s*"moreinfo_block3"', re.DOTALL)
+    start_urls = ["https://www.press-shop.be/nl/winkels"]
+    brands = {
+        "Press Shop & More": ({"brand": "Press Shop", "brand_wikidata": "Q126196511"}, Categories.SHOP_NEWSAGENT),
+        "Press Shop": ({"brand": "Press Shop", "brand_wikidata": "Q126196511"}, Categories.SHOP_NEWSAGENT),
+        "Relay": ({"brand": "Relay", "brand_wikidata": "Q3424298"}, Categories.SHOP_NEWSAGENT),
+        "Vape Shop & More": ({"brand": "Vape Shop & More"}, Categories.SHOP_E_CIGARETTE),
+        "Sweet Shop & More": ({"brand": "Sweet Shop & More"}, Categories.SHOP_CONFECTIONERY),
+    }
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(
-            response.xpath('//script[contains(text(), "establishments")]/text()').re_first(self.establishments_pattern)
-        ):
-            item = Feature()
-            item["branch"] = location["title"].removeprefix("Press Shop ")
-            item["street_address"] = location["address"]
-            item["postcode"] = location["postal"]
-            item["city"] = location["city"]
-            item["state"] = location["region"]
-            item["lat"] = location["latitude"]
-            item["lon"] = location["longitude"]
-            item["phone"] = location["phone"].replace("/", "")
-            item["ref"] = location["id"]
-            # url is a lie
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        blob = ""
+        for script in response.xpath('//script[contains(text(), "self.__next_f.push([1,")]/text()').getall():
+            segment = script.split("self.__next_f.push([1,", 1)[1].rsplit("])", 1)[0].strip()
+            if segment.startswith('"'):
+                blob += json.loads(segment)
+        return parse_js_object(blob[blob.find('"shops":[') + len('"shops":') :])
 
-            yield item
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("latlong"))
+        feature["street_address"] = feature.pop("address", None)
+        feature["postcode"] = feature.pop("postal", None)
+        feature["state"] = feature.pop("region", None)
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        title = (item.pop("name") or "").strip()
+        for prefix, (attributes, category) in self.brands.items():
+            if title.startswith(prefix):
+                break
+        else:
+            self.crawler.stats.inc_value(f"atp/{self.name}/unknown_shop_type")
+            return
+        item.update(attributes)
+        item["branch"] = title.removeprefix(prefix).strip()
+        item["website"] = response.urljoin(feature["url"])
+
+        item["opening_hours"] = OpeningHours()
+        hours = feature.get("openingHours") or {}
+        for day in DAYS_FULL:
+            value = str(hours.get(day.lower()) or "").strip()
+            if not value:
+                continue
+            if value.lower() in CLOSED_NL:
+                item["opening_hours"].set_closed(day)
+            else:
+                for open_time, close_time in re.findall(r"(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})", value):
+                    item["opening_hours"].add_range(day, open_time, close_time)
+
+        apply_category(category, item)
+        yield item


### PR DESCRIPTION
The site was rebuilt and the old page with its embedded `establishments` JSON is gone, so recent runs produced 0 features. The replacement `/nl/winkels` page embeds the operator's whole Belgian network in the Next.js RSC stream.

Rewrote as a `JSONBlobSpider` parsing that stream. The spider now also yields the co-listed Relay Belgium stores (47, previously uncovered) and the Vape/Sweet Shop & More formats with their own brands and categories, and picks up opening hours (with explicit closed days) and per-shop websites. A handful of ambiguous shops (franchise hybrids, a cantina, generic "Shop & More") are skipped and counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Press Shop locations across multiple brands and categories.
  * Added normalized location details, website and branch information, opening hours, and applicable categories.

* **Bug Fixes**
  * Improved handling of Press Shop’s location data to provide more complete and consistent listings.
  * Added tracking for previously unrecognized shop types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->