### PR TITLE
[585 Gold RU] Fix spider

### DIFF
--- a/locations/spiders/zoloto_585_ru.py
+++ b/locations/spiders/zoloto_585_ru.py
@@ -1,27 +1,40 @@
-from typing import Any
+from typing import Iterable
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy.http import TextResponse
 
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS_RU, NAMED_DAY_RANGES_RU, OpeningHours
 from locations.items import Feature
-from locations.user_agents import BROWSER_DEFAULT
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class Zoloto585RUSpider(SitemapSpider):
+class Zoloto585RUSpider(JSONBlobSpider):
     name = "zoloto_585_ru"
     item_attributes = {"brand_wikidata": "Q125730875"}
-    sitemap_urls = ["https://zoloto585.ru/robots.txt"]
-    sitemap_rules = [(r"/about/address/[^/]+/[^/]+/$", "parse")]
-    custom_settings = {"DOWNLOAD_TIMEOUT": 30, "USER_AGENT": BROWSER_DEFAULT}
+    start_urls = ["https://backend.zoloto585.ru/api/stores?blocked=0&active=1"]
+    custom_settings = {"DOWNLOAD_TIMEOUT": 30, "ROBOTSTXT_OBEY": False}
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        item = Feature()
-        item["ref"] = item["website"] = response.url
-        item["lat"], item["lon"] = response.xpath("//@data-geo").get().split(",")
-        item["street_address"] = response.xpath(
-            '//div[@class="shop-info__item shop-info__item--address"]/span/text()'
-        ).get()
-        item["image"] = response.urljoin(
-            response.xpath('//div[contains(@class, "address-block__shop-gallery")]/img/@src').get()
+    def pre_process_data(self, feature: dict) -> None:
+        feature["ref"] = feature.pop("xmlId", None)
+        feature.pop("name", None)
+        feature["street_address"] = feature.pop("address", None)
+        feature["addr_full"] = feature.pop("addressFull", None)
+        feature["city"] = (feature.pop("city", None) or {}).get("name")
+        feature.pop("phone", None)
+        if email := feature.pop("email", None):
+            feature["email"] = email.split(",")[0].strip()
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        if feature.get("isOnlyLombard"):
+            self.crawler.stats.inc_value(f"atp/{self.name}/lombard_only_skipped")
+            return
+        if photos := feature.get("photos"):
+            item["image"] = photos[0]
+
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(
+            feature.get("displaySchedule") or "", days=DAYS_RU, named_day_ranges=NAMED_DAY_RANGES_RU
         )
+
+        apply_category(Categories.SHOP_JEWELRY, item)
         yield item

--- a/locations/spiders/zoloto_585_ru.py
+++ b/locations/spiders/zoloto_585_ru.py
@@ -18,7 +18,7 @@ class Zoloto585RUSpider(JSONBlobSpider):
         feature["ref"] = feature.pop("xmlId", None)
         feature.pop("name", None)
         feature["street_address"] = feature.pop("address", None)
-        feature["addr_full"] = feature.pop("addressFull", None)
+        feature.pop("addressFull", None)
         feature["city"] = (feature.pop("city", None) or {}).get("name")
         feature.pop("phone", None)
         if email := feature.pop("email", None):


### PR DESCRIPTION
The sitemap no longer lists per-store pages (only the address index, which server-renders a single city), so the spider produced 0 features in recent runs.

Rewrote as a `JSONBlobSpider` against the JSON API the site's own frontend uses, which returns all stores in one request. Pawnshop-only points are skipped and counted; phones are dropped (only 6 unique numbers across the network — central lines), while per-store email, image, opening hours and full address are collected. `ROBOTSTXT_OBEY` is disabled for this spider: the API lives on a backend subdomain with a blanket `Disallow: /`, while being the data source for the site's public store locator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store listings are now retrieved directly from the provider’s data service.
  * Listings include normalized store details, the first available photo, opening hours, and the jewelry-shop category.
  * Lombard-only locations are excluded from results.
* **Bug Fixes**
  * Improved handling of Russian opening hours and store information.
  * Removed outdated sitemap-based extraction that could produce incomplete or inconsistent listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->