### PR TITLE
[Remax FR] Fix spider

### DIFF
--- a/locations/spiders/remax_fr.py
+++ b/locations/spiders/remax_fr.py
@@ -1,69 +1,24 @@
-import re
-from json import dumps
-from typing import AsyncIterator
+from typing import Any
 
-from scrapy import Spider
-from scrapy.http import Request
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.user_agents import BROWSER_DEFAULT
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class RemaxFRSpider(Spider):
+class RemaxFRSpider(SitemapSpider, StructuredDataSpider):
     name = "remax_fr"
-    item_attributes = {
-        "brand": "RE/MAX",
-        "brand_wikidata": "Q965845",
-    }
-    allowed_domains = ["remax.fr", "s.maxwork.fr"]
+    item_attributes = {"brand": "RE/MAX", "brand_wikidata": "Q965845"}
+    sitemap_urls = ["https://remax.fr/sitemap.xml"]
+    sitemap_follow = ["offices_details_fr"]
+    sitemap_rules = [(r"/fr/agence/[^/]+/(\d+)$", "parse_sd")]
 
-    async def start(self) -> AsyncIterator[Request]:
-        url = "https://www.remax.fr/Api/Office/Search?size=2000"
-        payload = dumps(
-            {
-                "filters": [
-                    {"field": "OfficeName", "type": 0, "fuzziness": None},
-                    {"field": "Region2ID", "type": 0},
-                    {"field": "LanguagesSpokenIds", "type": 0},
-                ]
-            }
-        )
-        headers = {
-            "content-type": "application/json",
-            "languageid": "2",
-            "user-agent": BROWSER_DEFAULT,
-        }
-        yield Request(url=url, headers=headers, method="POST", body=payload, callback=self.parse)
-
-    def parse(self, response):
-        url = "https://s.maxwork.fr/site/static/2/offices/details_V2/{}.html"
-        for data in response.json().get("results"):
-            yield Request(
-                url=url.format(data.get("officeNumber")), callback=self.parse_agence, cb_kwargs={"properties": data}
-            )
-
-    def parse_agence(self, response, properties):
-        street_address = (
-            response.xpath('//p[contains(@class, "location-info-address hide-info-fr")]/text()[2]').get().strip()
-        )
-        postcode_city = response.xpath('//p[contains(@class, "location-info-address hide-info-fr")]/text()[3]').get()
-        postcode = (re.findall("[0-9]{5}|[A-Z0-9]{3} [A-Z0-9]{3}", postcode_city)[0:1] or (None,))[0]
-        city = postcode_city.replace(postcode, "").replace(",", "").replace(" ", "") if postcode else None
-        lat, lon = (
-            response.xpath('//a[@class="see-maps"]/@href')
-            .get()
-            .strip()
-            .replace("https://www.google.com/maps/search/?api=1&query=", "")
-            .split(",")
-        )
-        properties = {
-            "ref": properties.get("officeNumber"),
-            "name": properties.get("officeName"),
-            "phone": properties.get("phoneNumber"),
-            "street_address": street_address,
-            "lat": lat,
-            "lon": lon,
-            "city": city,
-            "postcode": postcode,
-        }
-        yield Feature(**properties)
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["ref"] = response.url.rsplit("/", 1)[-1]
+        item["branch"] = (item.pop("name") or "").removeprefix("RE/MAX").strip()
+        if city := item.get("city"):
+            item["city"] = city.split(",")[-1].strip()
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+        yield item


### PR DESCRIPTION
The site was rebuilt: the office-search API the spider POSTed to 404s and the static detail pages it scraped are gone, so recent runs produced 0 features.

Rewrote as a `SitemapSpider` + `StructuredDataSpider` over the new offices sitemap, whose agency pages carry complete `RealEstateAgent` JSON-LD. The agency name now populates `branch`, `city` is extracted from the site's packed locality value, and refs keep the same office numbers as before.