### PR TITLE
[National Seating & Mobility] Fix spider

### DIFF
--- a/locations/spiders/national_seating_mobility.py
+++ b/locations/spiders/national_seating_mobility.py
@@ -18,5 +18,6 @@ class NationalSeatingMobilitySpider(SitemapSpider, StructuredDataSpider):
         item["lat"] = ld_data.get("latitude")
         item["lon"] = ld_data.get("longitude")
         item.pop("name", None)
+        item.pop("image", None)
         apply_category(Categories.SHOP_MEDICAL_SUPPLY, item)
         yield item

--- a/locations/spiders/national_seating_mobility.py
+++ b/locations/spiders/national_seating_mobility.py
@@ -1,8 +1,22 @@
-from locations.storefinders.store_locator_plus_cloud import StoreLocatorPlusCloudSpider
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class NationalSeatingMobilitySpider(StoreLocatorPlusCloudSpider):
+class NationalSeatingMobilitySpider(SitemapSpider, StructuredDataSpider):
     name = "national_seating_mobility"
     item_attributes = {"brand": "National Seating & Mobility", "brand_wikidata": "Q116770969"}
-    slp_dataset = "thegeneral_at_5by5agency_dot_com"
-    slp_key = "myslp.982692489c53b1cb2b7209e3fe46a9650e9edca8026c572c989bbc9942a8d560"
+    sitemap_urls = ["https://locations.nsm-seating.com/sitemap.xml"]
+    sitemap_rules = [(r"^https://locations\.nsm-seating\.com/[a-z]{2}/[^/]+/[^/]+$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["lat"] = ld_data.get("latitude")
+        item["lon"] = ld_data.get("longitude")
+        item.pop("name", None)
+        apply_category(Categories.SHOP_MEDICAL_SUPPLY, item)
+        yield item


### PR DESCRIPTION
The StoreLocatorPlus dataset the spider queried is gone (404), so recent runs produced 0 features. The brand's locator now lives on a Yext-hosted site.

Rewrote as a `SitemapSpider` + `StructuredDataSpider` over that site's sitemap. The pages' JSON-LD carries coordinates at the top level rather than in a `geo` object, so they are assigned in `post_process_item`.