### PR TITLE
[Paul ZA] Fix spider

### DIFF
--- a/locations/spiders/paul_za.py
+++ b/locations/spiders/paul_za.py
@@ -1,12 +1,22 @@
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.spiders.paul_fr import PAUL_SHARED_ATTRIBUTES
-from locations.storefinders.yext_search import YextSearchSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class PaulZASpider(YextSearchSpider):
+class PaulZASpider(SitemapSpider, StructuredDataSpider):
     name = "paul_za"
     item_attributes = PAUL_SHARED_ATTRIBUTES
-    host = "https://location.paulsa.co.za"
+    sitemap_urls = ["https://locations.paulsa.co.za/sitemap.xml"]
+    sitemap_rules = [(r"/restaurants-[^/]+$", "parse_sd")]
 
-    def parse_item(self, location, item):
-        item["website"] = location["profile"]["c_pagesURL"]
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["branch"] = (item.pop("name") or "").removeprefix("PAUL").strip()
+        item.pop("image", None)
+        apply_category(Categories.SHOP_BAKERY, item)
         yield item


### PR DESCRIPTION
The Yext locator host the spider queried no longer resolves, so recent runs produced 0 features. The brand's South African locator moved to a new site.

Rewrote as a `SitemapSpider` + `StructuredDataSpider` over the new sitemap, whose pages carry complete `Restaurant` JSON-LD including weekly hours. The store name populates `branch`, and the shared brand image is not collected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved restaurant location extraction from sitemap entries and structured data.
  * Automatically assigns bakery category information to extracted locations.
  * Derives branch details from restaurant names.

* **Bug Fixes**
  * Improved location data consistency by removing unnecessary image information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->