### PR TITLE
[Pinch A Penny US] Fix spider

### DIFF
--- a/locations/spiders/pinch_a_penny_us.py
+++ b/locations/spiders/pinch_a_penny_us.py
@@ -3,7 +3,8 @@ from typing import Any
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
+from locations.dict_parser import DictParser
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -11,16 +12,11 @@ class PinchAPennyUSSpider(StructuredDataSpider):
     name = "pinch_a_penny_us"
     item_attributes = {"brand": "Pinch A Penny", "brand_wikidata": "Q121436109"}
     start_urls = ["https://pinchapenny.com/api/store/search?lat=28.5&lng=-81.4"]
-    wanted_types = ["LocalBusiness"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json()["data"]:
-            yield response.follow(store["url"], callback=self.parse_sd)
-
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
-        item["ref"] = ld_data.get("branchCode")
-        item["branch"] = item.pop("name")
-        item["lat"] = response.xpath("//@data-lat").get()
-        item["lon"] = response.xpath("//@data-lng").get()
-        apply_category(Categories.SHOP_SWIMMING_POOL, item)
-        yield item
+            item = DictParser.parse(store)
+            item["name"] = None
+            item["street_address"] = merge_address_lines([item.pop("addr_full"), store["address_extended"]])
+            apply_category(Categories.SHOP_SWIMMING_POOL, item)
+            yield item

--- a/locations/spiders/pinch_a_penny_us.py
+++ b/locations/spiders/pinch_a_penny_us.py
@@ -1,18 +1,26 @@
-from scrapy.spiders import SitemapSpider
+from typing import Any
 
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class PinchAPennyUSSpider(SitemapSpider, StructuredDataSpider):
+class PinchAPennyUSSpider(StructuredDataSpider):
     name = "pinch_a_penny_us"
     item_attributes = {"brand": "Pinch A Penny", "brand_wikidata": "Q121436109"}
-    sitemap_urls = ["https://pinchapenny.com/sitemap.xml"]
-    sitemap_rules = [(r"com/stores/[^\\]+\-\w\w\-(\d+)$", "parse")]
+    start_urls = ["https://pinchapenny.com/api/store/search?lat=28.5&lng=-81.4"]
     wanted_types = ["LocalBusiness"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for store in response.json()["data"]:
+            yield response.follow(store["url"], callback=self.parse_sd)
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Any:
+        item["ref"] = ld_data.get("branchCode")
         item["branch"] = item.pop("name")
         item["lat"] = response.xpath("//@data-lat").get()
         item["lon"] = response.xpath("//@data-lng").get()
-
+        apply_category(Categories.SHOP_SWIMMING_POOL, item)
         yield item


### PR DESCRIPTION
The sitemap the spider crawled returns a persistent 500, so recent runs produced 0 features. The store pages themselves still carry full `LocalBusiness` microdata.

Replaced the sitemap discovery with the site's locator API, which returns all stores in one request, and kept the structured-data parse. `ref` now comes from the microdata `branchCode`, and the swimming-pool shop category is applied explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store discovery by retrieving locations directly from the store search service.
  * Enhanced location records with consolidated address details and swimming-pool shop categorization.
  * Improved consistency of imported store information by removing outdated branch and coordinate processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->