### PR TITLE
[Romans Pizza ZA] Fix spider

### DIFF
--- a/locations/spiders/romans_pizza.py
+++ b/locations/spiders/romans_pizza.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncIterator, Iterable
 from scrapy import Request
 from scrapy.http import JsonRequest, Response, TextResponse
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -41,6 +42,7 @@ class RomansPizzaSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Request]:
         item["branch"] = re.sub(r"^Roman[`'’]?s Pizza\s*", "", item.pop("name") or "").strip()
         item["website"] = f"https://romanspizza.co.za/store-locator/{item['ref']}"
+        apply_category(Categories.FAST_FOOD, item)
         yield Request(
             url=f"{API_ROOT}/api/customer/store/withDetails/{item['ref']}",
             headers=TENANT_HEADERS,

--- a/locations/spiders/romans_pizza.py
+++ b/locations/spiders/romans_pizza.py
@@ -1,51 +1,66 @@
-from typing import AsyncIterator
+import re
+from typing import Any, AsyncIterator, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy import Request
+from scrapy.http import JsonRequest, Response, TextResponse
 
-from locations.categories import Extras, apply_yes_no
-from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import merge_address_lines
+
+API_ROOT = "https://ecommerce-api-alt-g2euc.ondigitalocean.app"
+TENANT_HEADERS = {"Origin": "https://romanspizza.co.za"}
 
 
-class RomansPizzaSpider(Spider):
+class RomansPizzaSpider(JSONBlobSpider):
     name = "romans_pizza"
-    start_urls = ["https://romanspizza.co.za/api"]
     item_attributes = {"brand_wikidata": "Q65079427"}
+    locations_key = "stores"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(
-                url=url,
-                method="POST",
-                data={
-                    "query": "{\n  stores {\n    id\n    lat\n    lng\n    uuid\n    halaal\n    name\n    address\n    area\n    phone\n    phoneTwo\n    phoneThree\n    phoneFour\n    isOnline\n    isAuraOnline\n    isTabletConnected\n    deliveryEnabled\n    hasDevice\n    hasGenerator\n    isKdsEnabled\n    externalId\n    day_0\n    day_1\n    day_2\n    day_3\n    day_4\n    day_5\n    day_6\n    isOnTheGo\n    paymentGateway\n    isTemporarilyClosed\n    deliveryFee\n  }\n}\n",
-                },
-            )
+        yield JsonRequest(
+            url=f"{API_ROOT}/api/client/storeTags/public/stores",
+            method="POST",
+            headers=TENANT_HEADERS,
+            data={"channelType": "WEBSITE", "tagGroupItemIds": []},
+        )
 
-    def parse(self, response):
-        for location in response.json()["data"]["stores"]:
-            if location["isTemporarilyClosed"]:
-                continue
-            location["id"] = location.pop("uuid")
-            phones = [
-                location.get("phone"),
-                location.get("phoneTwo"),
-                location.get("phoneThree"),
-                location.get("phoneFour"),
-            ]
-            location["phone"] = "; ".join([p for p in phones if p != "0"])
+    def pre_process_data(self, feature: dict) -> None:
+        feature["id"] = feature.pop("uuid")
+        feature.update(feature.pop("location"))
+        address = feature.pop("addressInfo", {})
+        address.pop("id", None)
+        address["street_address"] = merge_address_lines(
+            [address.pop("shopNumber", None), address.pop("buildingName", None), address.pop("streetAddress", None)]
+        )
+        address["state"] = address.pop("province", None)
+        feature.update(address)
+        feature["phone"] = "; ".join(p for p in feature.pop("phoneNumbers", None) or [] if p and p != "0")
 
-            item = DictParser.parse(location)
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Request]:
+        item["branch"] = re.sub(r"^Roman[`'’]?s Pizza\s*", "", item.pop("name") or "").strip()
+        item["website"] = f"https://romanspizza.co.za/store-locator/{item['ref']}"
+        yield Request(
+            url=f"{API_ROOT}/api/customer/store/withDetails/{item['ref']}",
+            headers=TENANT_HEADERS,
+            callback=self.parse_hours,
+            errback=self.parse_hours_error,
+            cb_kwargs={"item": item},
+        )
 
-            item["branch"] = item.pop("name")
-            apply_yes_no(Extras.BACKUP_GENERATOR, item, location["hasGenerator"], False)
-            apply_yes_no(Extras.HALAL, item, location["halaal"], False)
-            apply_yes_no(Extras.DELIVERY, item, location["deliveryEnabled"], False)
+    def parse_hours(self, response: Response, item: Feature, **kwargs: Any) -> Iterable[Feature]:
+        item["opening_hours"] = OpeningHours()
+        for day in response.json().get("TradingHours") or []:
+            if day.get("is24Hours"):
+                item["opening_hours"].add_range(day["dayOfWeek"], "00:00", "23:59")
+            elif not day.get("open"):
+                item["opening_hours"].set_closed(day["dayOfWeek"])
+            else:
+                for timing in day.get("storeTiming") or []:
+                    open_time, _, close_time = timing.partition(" - ")
+                    item["opening_hours"].add_range(day["dayOfWeek"], open_time.strip(), close_time.strip())
+        yield item
 
-            oh = OpeningHours()
-            for i in range(7):
-                oh.add_ranges_from_string(location["day_" + str(i)])
-            item["opening_hours"] = oh
-
-            yield item
+    def parse_hours_error(self, failure) -> Iterable[Feature]:
+        yield failure.request.cb_kwargs["item"]


### PR DESCRIPTION
The GraphQL endpoint the spider queried is gone (404), so recent runs produced 0 features. The site moved to a new ordering platform with a JSON API.

Rewrote as a `JSONBlobSpider`: one request lists all stores with coordinates and addresses, and a per-store request adds weekly trading hours (explicit closed days and 24-hour days included; a store whose detail call fails is still yielded without hours). The old source's halal and generator flags no longer exist on the new platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Romans Pizza locations from the store API.
  * Included normalized addresses, branch details, phone numbers, store-locator links, and fast-food categorization.
  * Added trading-hours information, including 24-hour, closed, and timed schedules.

* **Bug Fixes**
  * Invalid phone numbers are now excluded.
  * Locations remain available when trading-hours data cannot be retrieved.
  * Removed outdated temporary-closure filtering and legacy location details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->