### PR TITLE
[Jd Sports IT] Fix spider

### DIFF
--- a/locations/spiders/jd_sports_it.py
+++ b/locations/spiders/jd_sports_it.py
@@ -1,12 +1,24 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class JdSportsITSpider(CrawlSpider, StructuredDataSpider):
+class JdSportsITSpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "jd_sports_it"
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.it/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
-    requires_proxy = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
```
{'atp/brand/JD Sports': 100,
 'atp/brand_wikidata/Q6108019': 100,
 'atp/category/shop/clothes': 100,
 'atp/country/IT': 100,
 'atp/field/email/missing': 100,
 'atp/field/housenumber/missing': 100,
 'atp/field/operator/missing': 100,
 'atp/field/operator_wikidata/missing': 100,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 10,
 'atp/field/state/missing': 100,
 'atp/field/street/missing': 100,
 'atp/field/twitter/missing': 100,
 'atp/field/unit/missing': 100,
 'atp/item_scraped_host_count/www.jdsports.it': 100,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 100,
 'downloader/request_bytes': 44218,
 'downloader/request_count': 104,
 'downloader/request_method_count/GET': 104,
 'downloader/response_bytes': 126790641,
 'downloader/response_count': 104,
 'downloader/response_status_count/200': 104,
 'dupefilter/filtered': 2,
 'elapsed_time_seconds': 133.1869999999999,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 14, 9, 58, 38, 174492, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 100,
 'items_per_minute': 45.11278195488722,
 'log_count/DEBUG': 11630,
 'log_count/INFO': 9,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 104,
 'playwright/page_count/closed': 104,
 'playwright/page_count/max_concurrent': 4,
 'playwright/request_count': 5661,
 'playwright/request_count/aborted': 5555,
 'playwright/request_count/method/GET': 5661,
 'playwright/request_count/navigation': 104,
 'playwright/request_count/resource_type/document': 104,
 'playwright/request_count/resource_type/font': 618,
 'playwright/request_count/resource_type/script': 4529,
 'playwright/request_count/resource_type/stylesheet': 410,
 'playwright/response_count': 104,
 'playwright/response_count/method/GET': 104,
 'playwright/response_count/resource_type/document': 104,
 'request_depth_max': 1,
 'response_received_count': 104,
 'responses_per_minute': 46.9172932330827,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 103,
 'scheduler/dequeued/memory': 103,
 'scheduler/enqueued': 103,
 'scheduler/enqueued/memory': 103,
 'start_time': datetime.datetime(2026, 8, 14, 9, 56, 24, 993061, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved collection of JD Sports Italy location data using updated browsing support.
  - Location entries are now categorized as clothing.
  - Standardized location naming for clearer presentation.
  - Removed the requirement for proxy-based access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->