### PR TITLE
[Proper Job GB] Enable proxy to fix spider

### DIFF
--- a/locations/spiders/proper_job_gb.py
+++ b/locations/spiders/proper_job_gb.py
@@ -17,6 +17,7 @@ class ProperJobGBSpider(SitemapSpider):
     item_attributes = {"brand": "Proper Job", "brand_wikidata": "Q83741810"}
     sitemap_urls = ["https://www.properjob.biz/wpsl_stores-sitemap.xml"]
     sitemap_rules = [(r"/stores/[^/]+/$", "parse")]
+    requires_proxy = True
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         location = chompjs.parse_js_object(response.text[response.text.index("wpslMap_0") :])["locations"][0]


### PR DESCRIPTION
```
{'atp/brand/Proper Job': 20,
 'atp/brand_wikidata/Q83741810': 20,
 'atp/category/shop/hardware': 20,
 'atp/country/GB': 20,
 'atp/field/email/missing': 20,
 'atp/field/housenumber/missing': 20,
 'atp/field/operator/missing': 20,
 'atp/field/operator_wikidata/missing': 20,
 'atp/field/state/missing': 8,
 'atp/field/street/missing': 20,
 'atp/field/twitter/missing': 20,
 'atp/field/unit/missing': 20,
 'atp/item_scraped_host_count/www.properjob.biz': 20,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 20,
 'downloader/request_bytes': 9348,
 'downloader/request_count': 23,
 'downloader/request_method_count/GET': 23,
 'downloader/response_bytes': 736084,
 'downloader/response_count': 23,
 'downloader/response_status_count/200': 23,
 'elapsed_time_seconds': 30.54700000000048,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 14, 10, 28, 11, 464384, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5615140,
 'httpcompression/response_count': 23,
 'item_scraped_count': 20,
 'items_per_minute': 40.0,
 'log_count/DEBUG': 43,
 'log_count/INFO': 3,
 'request_depth_max': 1,
 'response_received_count': 23,
 'responses_per_minute': 46.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 22,
 'scheduler/dequeued/memory': 22,
 'scheduler/enqueued': 22,
 'scheduler/enqueued/memory': 22,
 'start_time': datetime.datetime(2026, 8, 14, 10, 27, 40, 915633, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated job listing retrieval to require proxy access for improved connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->