### PR TITLE
[Hornbach] Fix spider

### DIFF
--- a/locations/spiders/hornbach.py
+++ b/locations/spiders/hornbach.py
@@ -29,12 +29,13 @@ class HornbachSpider(PlaywrightSpider):
         "https://www.hornbach.sk",
     ]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    requires_proxy = True  # Helps to skip anti bot protection
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         client_config = chompjs.parse_js_object(
-            response.xpath('//script[contains(text(), "OIDC_CLIENT_CONFIG")]/text()').get()
+            response.xpath('//script[contains(text(), "companyCode")]/text()').get()
         )
-        locale = client_config.get("ui_locales")
+        locale = client_config.get("locale")
         company_code = client_config.get("companyCode")
         if locale and company_code:
             yield JsonRequest(

--- a/locations/spiders/hornbach.py
+++ b/locations/spiders/hornbach.py
@@ -1,6 +1,7 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
 import chompjs
+from scrapy import Request
 from scrapy.http import JsonRequest, Response, TextResponse
 
 from locations.categories import Categories, apply_category
@@ -16,32 +17,42 @@ class HornbachSpider(PlaywrightSpider):
         "bodenhaus": {"name": "Bodenhaus", "brand": "Bodenhaus"},
         "hornbach": {"brand": "HORNBACH", "brand_wikidata": "Q685926"},
     }
-    start_urls = [
-        "https://www.bodenhaus.de",
-        "https://www.hornbach.de",
-        "https://www.hornbach.at",
-        "https://www.hornbach.ch",
-        "https://www.hornbach.lu",
-        "https://www.hornbach.cz",
-        "https://www.hornbach.nl",
-        "https://www.hornbach.ro",
-        "https://www.hornbach.se",
-        "https://www.hornbach.sk",
+    COUNTRY_MAP = [
+        # url, locale, company code
+        ("https://www.bodenhaus.de", "de_DE", "1060"),
+        ("https://www.hornbach.de", "de_DE", "1001"),
+        ("https://www.hornbach.at", "de_AT", "1124"),
+        ("https://www.hornbach.ch", "de_CH", "1043"),
+        ("https://www.hornbach.lu", "fr_LU", "1038"),
+        ("https://www.hornbach.cz", "cs_CZ", "1120"),
+        ("https://www.hornbach.nl", "nl_NL", "1042"),
+        ("https://www.hornbach.ro", "ro_RO", "1130"),
+        ("https://www.hornbach.se", "sv_SE", "1442"),
+        ("https://www.hornbach.sk", "sk_SK", "1123"),
     ]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
     requires_proxy = True  # Helps to skip anti bot protection
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        client_config = chompjs.parse_js_object(
-            response.xpath('//script[contains(text(), "companyCode")]/text()').get()
-        )
-        locale = client_config.get("locale")
-        company_code = client_config.get("companyCode")
-        if locale and company_code:
-            yield JsonRequest(
-                url=f"https://svc.hornbach.de/cmscontent-service/stores?language={locale.replace('-', '_')}&companyCode={company_code}",
-                callback=self.parse_locations,
+    async def start(self) -> AsyncIterator[Request]:
+        for url, locale, company_code in self.COUNTRY_MAP:
+            yield Request(url=url, cb_kwargs=dict(locale=locale, company_code=company_code))
+
+    def parse(self, response: Response, locale: str, company_code: str) -> Any:
+        # Anti-bot protection may return a page without the required data.
+        # Try to fetch updated API config values; if it fails, fall back to the default values.
+        try:
+            client_config = chompjs.parse_js_object(
+                response.xpath('//script[contains(text(), "companyCode")]/text()').get()
             )
+            locale = client_config["locale"]
+            company_code = client_config["companyCode"]
+        except Exception:
+            self.logger.warning(f"Failed to fetch updated API config values; using default values for: {response.url}")
+
+        yield JsonRequest(
+            url=f"https://svc.hornbach.de/cmscontent-service/stores?language={locale.replace('-', '_')}&companyCode={company_code}",
+            callback=self.parse_locations,
+        )
 
     def parse_locations(self, response: TextResponse) -> Any:
         for store in response.json():


### PR DESCRIPTION
```python
{'atp/brand/Bodenhaus': 3,
 'atp/brand/HORNBACH': 175,
 'atp/brand_wikidata/Q685926': 175,
 'atp/category/shop/doityourself': 175,
 'atp/category/shop/flooring': 3,
 'atp/clean_strings/street_address': 1,
 'atp/country/AT': 15,
 'atp/country/CH': 8,
 'atp/country/CZ': 10,
 'atp/country/DE': 100,
 'atp/country/LU': 1,
 'atp/country/NL': 19,
 'atp/country/RO': 11,
 'atp/country/SE': 8,
 'atp/country/SK': 6,
 'atp/field/brand_wikidata/missing': 3,
 'atp/field/country/from_website_url': 178,
 'atp/field/email/missing': 178,
 'atp/field/housenumber/missing': 178,
 'atp/field/operator/missing': 178,
 'atp/field/operator_wikidata/missing': 178,
 'atp/field/state/missing': 178,
 'atp/field/street/missing': 178,
 'atp/field/twitter/missing': 178,
 'atp/field/unit/missing': 178,
 'atp/item_scraped_host_count/svc.hornbach.de': 178,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 3,
 'atp/nsi/category_missing': 175,
 'atp/nsi/match_failed': 3,
 'atp/nsi/match_imperfect': 175,
 'downloader/request_bytes': 11805,
 'downloader/request_count': 31,
 'downloader/request_method_count/GET': 31,
 'downloader/response_bytes': 2723287,
 'downloader/response_count': 31,
 'downloader/response_status_count/200': 30,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 28.14099999999962,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 14, 10, 57, 11, 226181, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 178,
 'items_per_minute': 381.42857142857144,
 'log_count/DEBUG': 1103,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 31,
 'playwright/page_count/closed': 31,
 'playwright/page_count/max_concurrent': 10,
 'playwright/request_count': 431,
 'playwright/request_count/aborted': 400,
 'playwright/request_count/method/GET': 431,
 'playwright/request_count/navigation': 31,
 'playwright/request_count/resource_type/document': 31,
 'playwright/request_count/resource_type/font': 31,
 'playwright/request_count/resource_type/image': 82,
 'playwright/request_count/resource_type/media': 1,
 'playwright/request_count/resource_type/other': 10,
 'playwright/request_count/resource_type/script': 176,
 'playwright/request_count/resource_type/stylesheet': 100,
 'playwright/response_count': 31,
 'playwright/response_count/method/GET': 31,
 'playwright/response_count/resource_type/document': 31,
 'request_depth_max': 1,
 'response_received_count': 31,
 'responses_per_minute': 66.42857142857143,
 'robotstxt/request_count': 11,
 'robotstxt/response_count': 11,
 'robotstxt/response_status_count/200': 10,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 20,
 'scheduler/dequeued/memory': 20,
 'scheduler/enqueued': 20,
 'scheduler/enqueued/memory': 20,
 'start_time': datetime.datetime(2026, 8, 14, 10, 56, 43, 81134, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hornbach location retrieval by applying the correct regional language and company settings.
  * Updated request handling for regions requiring proxy access.
  * Increased reliability when loading store locations across supported countries.
  * Added fallback behavior to keep location results available when regional configuration data cannot be read.
  * Ensured location requests are issued consistently, including when regional settings need to be inferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->