### PR TITLE
[Bern CH] Fix spider

### DIFF
--- a/locations/spiders/bern_ch.py
+++ b/locations/spiders/bern_ch.py
@@ -114,7 +114,7 @@ class BernCHSpider(Spider):
         item = self.parse_feature(f)
         apply_category(Categories.HIGHWAY_RESIDENTIAL, item)
         apply_yes_no("bicycle_road", item, True)
-        return item
+        return Feature(**item)
 
     def parse_bicycle_shop(self, f):
         item, props = self.parse_feature(f), f["properties"]


### PR DESCRIPTION
`parse_bicycle_road` returned a plain dict where the other parsers in this spider return a `Feature`. Since #17342 added the tag-duplicator pipeline, which calls `Feature.get_tag()`, those items raise `AttributeError` and the seven Velostrasse features are dropped from every run.

Returning a `Feature` restores them: a full crawl now yields 1118 locations with no errors, matching the count before the pipeline was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bicycle road location parsing to ensure results are returned in the expected feature format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->