### PR TITLE
[Burger King CO] Fix spider

### DIFF
--- a/locations/spiders/burger_king_co.py
+++ b/locations/spiders/burger_king_co.py
@@ -11,19 +11,10 @@ from locations.spiders.burger_king import BURGER_KING_SHARED_ATTRIBUTES
 class BurgerKingCOSpider(JSONBlobSpider):
     name = "burger_king_co"
     item_attributes = BURGER_KING_SHARED_ATTRIBUTES
-    # Stores share a global id space across all Tillster tenants, so scan the
-    # block covering "bk-co" and keep only that tenant's outlets.
-    # The current bk-co block ids 96-138, scan a little beyond for future store additions.
     start_urls = [
-        f"https://api.bk.com.co/mobilem8-web-service/rest/storeinfo/store/{store_id}?tenant=bk-co"
-        for store_id in range(96, 150)
+        "https://api.bk.com.co/mobilem8-web-service/rest/storeinfo/distance?tenant=bk-co&latitude=4.65&longitude=-74.06&radius=5000&maxResults=500"
     ]
-
-    def extract_json(self, response: TextResponse) -> list[dict]:
-        store = response.json().get("getStoreResult", {}).get("store")
-        if store.get("tenantId") != "bk-co" or store.get("storeName") == "GENERIC":
-            return []
-        return [store]
+    locations_key = ["getStoresResult", "stores"]
 
     def post_process_item(self, item: Feature, response: TextResponse, store: dict) -> Iterable[Feature]:
         item["ref"] = item.pop("name").split("-")[-1]


### PR DESCRIPTION
Scanning store ids one request at a time raises `AttributeError` on the five ids in the range that return a null store, giving five errors every run.

The distance endpoint returns the whole store list in one request when `maxResults` is supplied — without it the API responds `maxResults is required`, which is why the ranged scan was introduced. Switched back to it: the same 37 locations with identical field values, no null handling, no hardcoded id range to widen as stores are added, and 54 requests reduced to one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Burger King store retrieval for more reliable location results.
  * Updated store data parsing to support the latest bulk location response format.
  * Removed outdated per-store request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->