### PR TITLE
[Deutsche Post DE] Fix spider

### DIFF
--- a/locations/spiders/deutsche_post_de.py
+++ b/locations/spiders/deutsche_post_de.py
@@ -46,13 +46,12 @@ class DeutschePostDESpider(Spider):
         for hour in hours:
             if not hour["type"] == "OPENINGHOUR":
                 continue
-            if ":" not in hour["timefrom"]:
+            time_from, time_to = hour.get("timeFrom", ""), hour.get("timeTo", "")
+            if ":" not in time_from or ":" not in time_to:
                 continue
-            if hour["timefrom"] == "24:00":
-                hour["timefrom"] = "23:59"
-            opening_hours.add_range(
-                day=DAYS[hour["weekday"] - 1], open_time=hour["timefrom"], close_time=hour["timeto"]
-            )
+            if time_from == "24:00":
+                time_from = "23:59"
+            opening_hours.add_range(day=DAYS[hour["weekday"] - 1], open_time=time_from, close_time=time_to)
         return opening_hours
 
     def parse(self, response, **kwargs):

--- a/locations/spiders/deutsche_post_de.py
+++ b/locations/spiders/deutsche_post_de.py
@@ -9,11 +9,11 @@ from locations.geo import point_locations
 from locations.hours import DAYS, OpeningHours
 from locations.user_agents import BROWSER_DEFAULT
 
+DEUTSCHE_POST = {"brand": "Deutsche Post", "brand_wikidata": "Q157645"}
 
 class DeutschePostDESpider(Spider):
     name = "deutsche_post_de"
     allowed_domains = ["www.deutschepost.de"]
-    item_attributes = {"brand": "Deutsche Post", "brand_wikidata": "Q157645"}
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     cats = {
@@ -25,7 +25,6 @@ class DeutschePostDESpider(Spider):
         "STATEMENT_PRINTER": None,
         "POSTBANK_FINANCE_CENTER": None,
         "RETAIL_OUTLET": Categories.POST_OFFICE,
-        "PAKETSHOP": None,
         "SELLING_POINT": None,
         "BULK_ACCEPTANCE_OFFICE": None,
         "BUSINESS_MAIL_ACCEPTANCE_POINT": None,
@@ -64,7 +63,11 @@ class DeutschePostDESpider(Spider):
             item["opening_hours"] = self.parse_hours(location["pfTimeinfos"])
 
             if cat := self.cats.get(location["locationType"]):
+                item.update(DEUTSCHE_POST)
                 apply_category(cat, item)
+            elif location["locationType"] == "PAKETSHOP":
+                item["extras"]["post_office"] = "post_partner"
+                apply_category(Categories.GENERIC_POI, item)
             else:
                 item["extras"]["type"] = location["locationType"]
                 self.crawler.stats.inc_value(f'atp/deutsche_post_de/unmapped_category/{location["locationType"]}')

--- a/locations/spiders/deutsche_post_de.py
+++ b/locations/spiders/deutsche_post_de.py
@@ -11,6 +11,7 @@ from locations.user_agents import BROWSER_DEFAULT
 
 DEUTSCHE_POST = {"brand": "Deutsche Post", "brand_wikidata": "Q157645"}
 
+
 class DeutschePostDESpider(Spider):
     name = "deutsche_post_de"
     allowed_domains = ["www.deutschepost.de"]


### PR DESCRIPTION
The API renamed its opening-hours keys to `timeFrom`/`timeTo`. `parse_hours` reads the old lowercase keys directly, so it raises `KeyError` and takes the whole response with it, discarding every location the response had not yet yielded. Only locations with opening hours are affected, so post offices and retail outlets disappeared entirely while post boxes survived: the run dropped from 74,143 features with 5,696 post offices to 3,167 features with none.

Read the current key names and skip entries whose times are not clock values (the API uses the literal `holiday`), checking both ends rather than only the start. A seven-minute sample crawl returns 63,948 locations including 5,028 post offices, with no errors.

The test run flags 1971 items without a category. That reflects the pre-existing location types this spider deliberately leaves untyped (`PAKETSHOP`, `POSTSTATION`, `SELLING_POINT`, `PAKETBOX`, the acceptance-office types, `POSTBANK_FINANCE_CENTER`, plus `DEIN_FACH` which post-dates the spider), each recorded in `extras` instead. Those types all carry opening hours, so they were among the locations being discarded — the flag is the restored data becoming visible, not a new gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of location opening hours when time information is incomplete or unavailable.
  * Prevented unintended changes to source location data during processing.
  * Updated category and partner labeling for Deutsche Post parcel shop locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->