### PR TITLE
Add US National Register of Historic Places spider (71,976 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -13,6 +13,7 @@ from locations.items import Feature
 # of lots of string bashing. If ever NSI / ATP were to change / augment the category scheme
 # then the level of indirection provided here may also be of help!
 class Categories(Enum):
+    GENERIC_HISTORIC = {"historic": "yes"}
     GENERIC_POI = {"amenity": "yes"}
     GENERIC_SHOP = {"shop": "yes"}
 
@@ -335,6 +336,8 @@ class Categories(Enum):
     GRAVE = {"cemetery": "grave"}
     GRIT_BIN = {"amenity": "grit_bin"}
     HIGHWAY_SERVICES = {"highway": "services"}
+    HISTORIC_BUILDING = {"historic": "building"}
+    HISTORIC_DISTRICT = {"historic": "district"}
     HOSPICE = {"healthcare": "hospice"}
     HOSPITAL = {"amenity": "hospital"}
     HOTEL = {"tourism": "hotel"}

--- a/locations/licenses.py
+++ b/locations/licenses.py
@@ -83,3 +83,10 @@ class Licenses(Enum):
         "attribution": "optional",
         "use:commercial": "yes",
     }
+    US_PUBLIC_DOMAIN = {
+        "license": "United States Government Work",
+        "license:website": "https://www.usa.gov/government-works",
+        "license:wikidata": "Q60671452",
+        "attribution": "optional",
+        "use:commercial": "permit",
+    }

--- a/locations/spiders/government/national_register_of_historic_places.py
+++ b/locations/spiders/government/national_register_of_historic_places.py
@@ -1,0 +1,111 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import apply_category
+from locations.items import Feature
+from locations.licenses import Licenses
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
+
+
+class NationalRegisterOfHistoricPlacesSpider(ArcGISFeatureServerSpider):
+    name = "national_register_of_historic_places"
+    # Works of the US federal government are not subject to copyright within
+    # the United States, and the NPS confirms its own material is public
+    # domain: https://www.nps.gov/aboutus/disclaimer.htm
+    dataset_attributes = (
+        ArcGISFeatureServerSpider.dataset_attributes
+        | Licenses.US_PUBLIC_DOMAIN.value
+        | {
+            "attribution:name": "Cultural Resources GIS, National Park Service",
+            "attribution:website": "https://www.nps.gov/subjects/nationalregister/index.htm",
+        }
+    )
+    host = "mapservices.nps.gov"
+    context_path = "arcgis"
+    service_id = "cultural_resources/nrhp_locations"
+    server_type = "MapServer"
+    layer_id = "0"
+    # Layer 1 of this service holds boundary polygons, mostly for historic
+    # districts and other properties too large to map as a point. It is a
+    # largely separate set: of its 19,405 listings only 451 also appear in the
+    # point layer consumed here, so this spider covers roughly 70,500 of the
+    # ~89,500 listings the service publishes.
+    field_names = ["GEOM_ID", "NRIS_Refnum", "RESNAME", "ResType", "Address", "City", "State", "Is_NHL"]
+    # STATUS is one of "Listed", "Removed" or null. Properties removed from the
+    # register (usually following demolition) are excluded, as are the small
+    # number of records with no status at all.
+    where_query = "STATUS = 'Listed'"
+
+    # NRHP resource types mapped onto OpenStreetMap `historic` values. "site"
+    # and "structure" each span too much (battlefields, landscapes and ruins;
+    # bridges, dams and ships) for a more specific tag to be correct.
+    resource_types = {
+        "building": {"historic": "building"},
+        "district": {"historic": "district"},
+        "object": {"historic": "monument"},
+        "site": {"historic": "yes"},
+        "structure": {"historic": "yes"},
+    }
+
+    # The register covers US states and territories, a handful of properties in
+    # countries the United States formerly administered, and one in Morocco.
+    # Territories and former territories have their own ISO 3166-1 codes, so
+    # the spider name deliberately carries no country suffix and each item gets
+    # an explicit country instead.
+    countries = {
+        "AMERICAN SAMOA": "AS",
+        "FED. STATES": "FM",
+        "GUAM": "GU",
+        "MARSHALL ISLANDS": "MH",
+        "MOROCCO": "MA",
+        "N. MARIANA ISLANDS": "MP",
+        "PALAU": "PW",
+        "PUERTO RICO": "PR",
+        "VIRGIN ISLANDS": "VI",
+    }
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # A single register listing can be mapped as several points, so the
+        # NRHP reference number is not unique here (it collides for roughly
+        # 1,500 of the points in this layer and would silently lose them to
+        # the duplicate filter). GEOM_ID identifies one mapped location.
+        item["ref"] = feature["GEOM_ID"].strip("{}")
+        item["name"] = feature["RESNAME"]
+        item["city"] = feature["City"]
+        if country := self.countries.get(feature["State"]):
+            # For these the source "State" names the territory itself, which
+            # the country field already records. StateCodeCleanUpPipeline only
+            # abbreviates US and Canadian states, so keeping it would emit raw
+            # values such as "FED. STATES" next to country=FM.
+            item["country"] = country
+            item["state"] = None
+        else:
+            item["country"] = "US"
+            item["state"] = feature["State"]
+        item["website"] = "https://npgallery.nps.gov/AssetDetail/NRIS/{}".format(feature["NRIS_Refnum"])
+
+        # DictParser maps the source "Address" field onto addr_full, but it
+        # only ever holds the street portion of an address, so move it to
+        # street_address. Values are descriptive rather than postal ("Jct. of
+        # US 1 and SR 44") and are withheld for a few sensitive sites.
+        item["addr_full"] = None
+        address = feature["Address"]
+        if address and "restricted" not in address.lower():
+            item["street_address"] = address
+
+        if category := self.resource_types.get(feature["ResType"]):
+            apply_category(category, item)
+        else:
+            self.logger.warning("Unknown NRHP resource type `{}`.".format(feature["ResType"]))
+            self.crawler.stats.inc_value("atp/{}/unhandled_resource_type/{}".format(self.name, feature["ResType"]))
+            apply_category({"historic": "yes"}, item)
+
+        # https://wiki.openstreetmap.org/wiki/Key:heritage - the National
+        # Register is a national level designation, as is the National Historic
+        # Landmark subset of it.
+        item["extras"]["heritage"] = "2"
+        item["extras"]["heritage:operator"] = "nhl;nrhp" if feature["Is_NHL"] == "X" else "nrhp"
+        item["extras"]["ref:nrhp"] = feature["NRIS_Refnum"]
+
+        yield item

--- a/locations/spiders/government/national_register_of_historic_places.py
+++ b/locations/spiders/government/national_register_of_historic_places.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.categories import apply_category
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.licenses import Licenses
 from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
@@ -41,11 +41,11 @@ class NationalRegisterOfHistoricPlacesSpider(ArcGISFeatureServerSpider):
     # and "structure" each span too much (battlefields, landscapes and ruins;
     # bridges, dams and ships) for a more specific tag to be correct.
     resource_types = {
-        "building": {"historic": "building"},
-        "district": {"historic": "district"},
-        "object": {"historic": "monument"},
-        "site": {"historic": "yes"},
-        "structure": {"historic": "yes"},
+        "building": Categories.HISTORIC_BUILDING,
+        "district": Categories.HISTORIC_DISTRICT,
+        "object": Categories.MONUMENT,
+        "site": Categories.GENERIC_HISTORIC,
+        "structure": Categories.GENERIC_HISTORIC,
     }
 
     # The register covers US states and territories, a handful of properties in
@@ -99,7 +99,7 @@ class NationalRegisterOfHistoricPlacesSpider(ArcGISFeatureServerSpider):
         else:
             self.logger.warning("Unknown NRHP resource type `{}`.".format(feature["ResType"]))
             self.crawler.stats.inc_value("atp/{}/unhandled_resource_type/{}".format(self.name, feature["ResType"]))
-            apply_category({"historic": "yes"}, item)
+            apply_category(Categories.GENERIC_HISTORIC, item)
 
         # https://wiki.openstreetmap.org/wiki/Key:heritage - the National
         # Register is a national level designation, as is the National Historic


### PR DESCRIPTION
**Data source:** National Park Service, Cultural Resources GIS — National Register of Historic Places (NRHP) dataset:
https://mapservices.nps.gov/arcgis/rest/services/cultural_resources/nrhp_locations/MapServer

**License:** Public domain. Works of the US federal government are not subject to copyright, and NPS confirms the same for its own material (https://www.nps.gov/aboutus/disclaimer.htm). No matching entry existed in `locations/licenses.py`, so this adds `Licenses.US_PUBLIC_DOMAIN` (`license:wikidata` Q60671452, attribution optional, commercial use permitted). 

**Structure:** Uses the existing `ArcGISFeatureServerSpider`. `where_query = "STATUS = 'Listed'"` excludes 525 delisted properties (usually demolished) and ~166 records with no status.

**Country:** No country suffix on the spider name, and `country` is set explicitly per item. The register is not US-only: alongside the 50 states it covers territories with their own ISO 3166-1 codes (PR 308, GU 67, VI 50, MP 20, AS 17), countries the US formerly administered (FM 20, MH 4, PW 1), and one property in Morocco. 

**Categories:** NRHP `ResType` mapped onto OSM `historic`:

| ResType | tag | count |
|---|---|---|
| building | `historic=building` | 62,562 |
| site, structure | `historic=yes` | 6,221 |
| district | `historic=district` | 2,745 |
| object | `historic=monument` | 448 |

`site` and `structure` each span too much for a more specific tag — battlefields, landscapes and ruins in one case; bridges, dams and ships in the other — so they take the `=yes` fallback per CATEGORIES.md. 

Every item also carries `heritage=2`, `heritage:operator=nrhp`, and `ref:nrhp`. The 1,111 National Historic Landmarks get `heritage:operator=nhl;nrhp`.

**Fields:** `DictParser` maps the source `Address` field onto `addr_full`, but it only ever holds the street portion (city and state are separate fields), so it is moved to `addr:street_address` and `addr_full` cleared. Addresses are the register's descriptive convention rather than postal — roughly 63% are a house number plus street, 21% name a street or route with no number, and 16% are relative ("Roughly bounded by…", "2 mi. S of Spring Green on WI 23"). `website` points at the per-property NPS record at npgallery.nps.gov.

**Examples:**

Thomas Alva Edison Birthplace
The small brick house where Edison was born in 1847, before the family moved to Michigan. Edison Dr., Milan, Ohio, at 41.29995, −82.60496.
https://npgallery.nps.gov/AssetDetail/NRIS/66000608

Fallingwater
Frank Lloyd Wright built it in 1935 for the Kaufmann family, cantilevered straight out over a waterfall on Bear Run. The address the federal data gives is charmingly vague — W of PA 381, Mill Run, Pennsylvania — at 39.90623, −79.46795.
https://npgallery.nps.gov/AssetDetail/NRIS/74001781

**No brand/operator Wikidata:** these are individually significant places rather than instances of a brand, and NPS administers the register without operating the properties, so setting `operator_wikidata` would be wrong. (For reference, 91% of these listings do have their own Wikidata item via P649 — but ATP has no per-feature field to carry that.)

**Verified with a local run:** 71,976 items, finished cleanly in 79s. 100% have geometry, name, website, ref, country and a category; 99.997% have a city.

**Known limitation:** layer 1 of the same service holds boundary polygons, mostly for historic districts and other properties too large to map as a point.

**Note:** This is my first PR here, and AI-assisted of course. Happy to make any tweaks desired!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added National Register of Historic Places listings from the National Park Service.
  * Listings now include historic categories, heritage details, identifiers, website links, and applicable U.S. state or territory information.
  * Restricted addresses are handled without exposing sensitive location details.
  * Added support for identifying United States Government Work licensing with optional attribution and commercial-use permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->