### PR TITLE
[Tiffany] Fix spider

### DIFF
--- a/locations/spiders/tiffany.py
+++ b/locations/spiders/tiffany.py
@@ -14,6 +14,8 @@ class TiffanySpider(YextAnswersSpider):
     def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
         if location.get("closed") or location.get("comingSoon"):
             return
+
+        item["email"] = None
         item["branch"] = location["address"].get("extraDescription")
         if website := item.get("website"):
             item["website"] = website.split("?", 1)[0]

--- a/locations/spiders/tiffany.py
+++ b/locations/spiders/tiffany.py
@@ -1,59 +1,25 @@
-import urllib
-from typing import AsyncIterator
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
-
-from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
-from locations.pipelines.address_clean_up import clean_address
-from locations.user_agents import FIREFOX_LATEST
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.yext_answers import YextAnswersSpider
 
 
-class TiffanySpider(Spider):
+class TiffanySpider(YextAnswersSpider):
     name = "tiffany"
     item_attributes = {"brand": "Tiffany & Company", "brand_wikidata": "Q1066858"}
-    allowed_domains = ["www.tiffany.com"]
-    start_urls = ["https://www.tiffany.com/content/tiffany-n-co/_jcr_content/servlets/storeslist.1.json"]
-    custom_settings = {"USER_AGENT": FIREFOX_LATEST}  # ATP and older user agents are blocked.
-    requires_proxy = True  # Data centre netblocks appear to be blocked.
+    api_key = "7a20022b59c1f54cf9bfa431c1edee2e"
+    experience_key = "international-locator-search"
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for url in self.start_urls:
-            yield JsonRequest(url=url)
+    def parse_item(self, location: dict, item: Feature) -> Iterable[Feature]:
+        if location.get("closed") or location.get("comingSoon"):
+            return
+        item["branch"] = location["address"].get("extraDescription")
+        if website := item.get("website"):
+            item["website"] = website.split("?", 1)[0]
+        if photos := location.get("photoGallery"):
+            item["image"] = photos[0]["image"]["url"]
 
-    def parse(self, response):
-        for location in response.json()["resultDto"]:
-            item = DictParser.parse(location["store"])
-            if "TEMPORARILY CLOSED" in item["name"].upper():
-                continue
-            item["lat"] = location["store"]["geoCodeLattitude"]
-            item["lon"] = location["store"]["geoCodeLongitude"]
-            item["street_address"] = clean_address(
-                [
-                    location["store"].get("address1"),
-                    location["store"].get("address2"),
-                    location["store"].get("address3"),
-                ]
-            )
-            item["phone"] = location["store"]["phone"].split("/", 1)[0].strip()
-            item["website"] = (
-                "https://www.tiffany.com/jewelry-stores/" + location["storeSeoAttributes"][0]["canonicalUrlkeyword"]
-            )
-            if location["store"]["storePhoto"] != "/shared/images/stores/store_location.jpg":
-                item["image"] = urllib.parse.quote(
-                    "https://www.tiffany.com" + location["store"]["storePhoto"], safe=":/?=&"
-                )
-            opening_soon = False
-            for store_hours in location["storeHours"]:
-                if store_hours.get("storeHourTypeId", 0) == 1:
-                    if "OPENING SOON" in store_hours["storeHours"].upper():
-                        opening_soon = True
-                        break
-                    item["opening_hours"] = OpeningHours()
-                    item["opening_hours"].add_ranges_from_string(
-                        store_hours["storeHours"].replace("<br>", "").replace(".", "")
-                    )
-            if opening_soon:
-                continue
-            yield item
+        is_cafe = "Blue Box Cafe" in item.pop("name")
+        apply_category(Categories.CAFE if is_cafe else Categories.SHOP_JEWELRY, item)
+        yield item


### PR DESCRIPTION
```
{'atp/brand/Tiffany & Company': 369,
 'atp/brand_wikidata/Q1066858': 369,
 'atp/category/amenity/cafe': 1,
 'atp/category/shop/jewelry': 368,
 'atp/cdn/cloudflare/response_count': 9,
 'atp/cdn/cloudflare/response_status_count/200': 8,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/branch': 1,
 'atp/country/AE': 6,
 'atp/country/AT': 1,
 'atp/country/AU': 11,
 'atp/country/AW': 1,
 'atp/country/AZ': 1,
 'atp/country/BE': 1,
 'atp/country/BH': 1,
 'atp/country/BR': 7,
 'atp/country/CA': 10,
 'atp/country/CH': 3,
 'atp/country/CL': 1,
 'atp/country/CN': 36,
 'atp/country/CZ': 1,
 'atp/country/DE': 8,
 'atp/country/DK': 1,
 'atp/country/DO': 1,
 'atp/country/ES': 3,
 'atp/country/FR': 7,
 'atp/country/GB': 12,
 'atp/country/GU': 1,
 'atp/country/HK': 9,
 'atp/country/ID': 2,
 'atp/country/IE': 1,
 'atp/country/IN': 2,
 'atp/country/IT': 8,
 'atp/country/JP': 60,
 'atp/country/KR': 24,
 'atp/country/KW': 2,
 'atp/country/KZ': 3,
 'atp/country/MC': 1,
 'atp/country/MO': 5,
 'atp/country/MX': 10,
 'atp/country/MY': 3,
 'atp/country/NL': 2,
 'atp/country/NZ': 1,
 'atp/country/PH': 3,
 'atp/country/PR': 1,
 'atp/country/QA': 4,
 'atp/country/RU': 2,
 'atp/country/SA': 4,
 'atp/country/SE': 1,
 'atp/country/SG': 5,
 'atp/country/TH': 4,
 'atp/country/TR': 3,
 'atp/country/TW': 6,
 'atp/country/UA': 1,
 'atp/country/US': 86,
 'atp/country/VN': 3,
 'atp/field/branch/missing': 4,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 363,
 'atp/field/housenumber/missing': 369,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 369,
 'atp/field/operator_wikidata/missing': 369,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 39,
 'atp/field/state/missing': 36,
 'atp/field/street/missing': 369,
 'atp/field/twitter/missing': 365,
 'atp/field/unit/missing': 369,
 'atp/item_scraped_host_count/liveapi.yext.com': 369,
 'atp/lineage': 'S_?',
 'atp/nsi/category_unknown': 1,
 'atp/nsi/match_failed': 1,
 'atp/nsi/match_perfect': 368,
 'downloader/request_bytes': 8250,
 'downloader/request_count': 9,
 'downloader/request_method_count/GET': 9,
 'downloader/response_bytes': 1139820,
 'downloader/response_count': 9,
 'downloader/response_status_count/200': 8,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 17.407000000000153,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 17, 7, 6, 35, 820712, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 8624443,
 'httpcompression/response_count': 8,
 'item_scraped_count': 369,
 'items_per_minute': 1302.3529411764707,
 'log_count/DEBUG': 378,
 'log_count/INFO': 3,
 'request_depth_max': 7,
 'response_received_count': 9,
 'responses_per_minute': 31.764705882352942,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 8,
 'scheduler/dequeued/memory': 8,
 'scheduler/enqueued': 8,
 'scheduler/enqueued/memory': 8,
 'start_time': datetime.datetime(2026, 8, 17, 7, 6, 18, 414914, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for locations provided through the Yext-powered location experience.
  * Improved location details, including normalized website links, branch information, and photos.
  * Separated cafés from jewelry stores for more accurate categorization.
  * Location listings now provide more consistent information across supported locations.

* **Bug Fixes**
  * Excluded closed and coming-soon locations from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->