### PR TITLE
[Long John Silver's] Fix spider

### DIFF
--- a/locations/spiders/ljsilvers.py
+++ b/locations/spiders/ljsilvers.py
@@ -2,7 +2,7 @@ from chompjs import chompjs
 from scrapy.spiders import SitemapSpider
 
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.hours import CLOSED_EN, OpeningHours
 
 
 class LjsilversSpider(SitemapSpider):
@@ -18,17 +18,19 @@ class LjsilversSpider(SitemapSpider):
         ):
             item = DictParser.parse(data)
             item["ref"] = item["website"] = response.url
-            item["name"] = "Long John Silver's"
+            item.pop("name", None)
             item["opening_hours"] = OpeningHours()
             for row in response.xpath(r'//*[@class="hours"]/div'):
                 day = row.xpath(".//p[1]/text()").get()
-                if time := row.xpath(".//p[2]/text()").get():
-                    open_time, close_time = time.split("-")
-                    item["opening_hours"].add_range(
-                        day=day, open_time=open_time.strip(), close_time=close_time.strip(), time_format="%I:%M %p"
-                    )
-                else:
+                if not (time := row.xpath(".//p[2]/text()").get()):
                     continue
+                if time.strip().lower() in CLOSED_EN:
+                    item["opening_hours"].set_closed(day)
+                    continue
+                open_time, close_time = time.split("-")
+                item["opening_hours"].add_range(
+                    day=day, open_time=open_time.strip(), close_time=close_time.strip(), time_format="%I:%M %p"
+                )
 
             item["street_address"] = item.pop("addr_full", None)
             yield item


### PR DESCRIPTION
A day marked `Closed` has no time range to split, so unpacking it raised `ValueError` and the whole store was discarded — six locations lost per run.

Closed days are now recorded with `set_closed`. The hardcoded brand name is also removed: the page payload carries only a minified placeholder for the name, so the value is left for the name-suggestion index, which supplies the name, category and cuisine. A full crawl returns 492 locations with no errors, matching the count before the breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location-hours handling for closed periods.
  * Ensured closed hours are displayed as closed instead of being treated as time ranges.
  * Improved consistency when processing location names and operating hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->