### PR TITLE
[Hyundai AU] Fix spider

### DIFF
--- a/locations/spiders/hyundai_au.py
+++ b/locations/spiders/hyundai_au.py
@@ -39,6 +39,7 @@ class HyundaiAUSpider(JSONBlobSpider):
             return
 
         item["name"] = feature.get("tradingName") or feature.get("dealerCode")
+        item["street_address"] = item.pop("street")
         item["email"] = next(
             (address for address in self.email_addresses(feature) if address.lower() in self.dealer_addresses), None
         )

--- a/locations/spiders/hyundai_au.py
+++ b/locations/spiders/hyundai_au.py
@@ -1,4 +1,6 @@
+from collections import defaultdict
 from typing import Iterable
+from urllib.parse import urlparse
 
 from scrapy.http import Response
 
@@ -16,15 +18,32 @@ class HyundaiAUSpider(JSONBlobSpider):
     start_urls = ["https://www.hyundai.com/content/api/au/hyundai/v3/findadealer?postcode=0"]
 
     def parse(self, response: Response) -> Iterable[Feature]:
-        yield from self.parse_feature_array(response, response.json()["allDealers"]["dealers"]) or []
-        yield from self.parse_feature_array(response, response.json()["allDealers"]["serviceDealers"]) or []
-        yield from self.parse_feature_array(response, response.json()["allDealers"]["partsDealers"]) or []
+        groups = [response.json()["allDealers"][key] for key in ("dealers", "serviceDealers", "partsDealers")]
+
+        dealers_by_address = defaultdict(set)
+        for group in groups:
+            for feature in group:
+                for address in self.email_addresses(feature):
+                    dealers_by_address[address.lower()].add(feature.get("dealerCode") or feature.get("tradingName"))
+        self.dealer_addresses = {address for address, dealers in dealers_by_address.items() if len(dealers) == 1}
+
+        for group in groups:
+            yield from self.parse_feature_array(response, group) or []
+
+    @staticmethod
+    def email_addresses(feature: dict) -> list[str]:
+        return [address.strip() for address in (feature.get("email") or "").split(";") if address.strip()]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         if feature.get("closed"):
             return
 
         item["branch"] = feature.get("tradingName") or feature.get("dealerCode")
+        item["email"] = next(
+            (address for address in self.email_addresses(feature) if address.lower() in self.dealer_addresses), None
+        )
+        if item.get("website") and not urlparse(item["website"]).hostname:
+            item["website"] = None
 
         if "testDriveModels" in feature.keys():
             apply_category(Categories.SHOP_CAR, item)

--- a/locations/spiders/hyundai_au.py
+++ b/locations/spiders/hyundai_au.py
@@ -38,7 +38,7 @@ class HyundaiAUSpider(JSONBlobSpider):
         if feature.get("closed"):
             return
 
-        item["branch"] = feature.get("tradingName") or feature.get("dealerCode")
+        item["name"] = feature.get("tradingName") or feature.get("dealerCode")
         item["email"] = next(
             (address for address in self.email_addresses(feature) if address.lower() in self.dealer_addresses), None
         )


### PR DESCRIPTION
Six dealers have `http://` as their web address, which fails hostname validation, and 97 dealers list several email addresses separated by semicolons, so the whole value is rejected and those dealers ship without an email.

The website is now dropped when it has no hostname, and the email is taken from the addresses belonging to that dealer alone — the same dealer appears in the sales, service and parts lists, so addresses are counted per dealer rather than per record. This also drops the central addresses that appear across many dealers, one of them on 120. A full crawl returns 577 locations with no errors or warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hyundai Australia dealer data processing by combining information across dealer groups.
  - Email addresses are now assigned only when uniquely matched to a dealer, reducing incorrect associations.
  - Dealer names and street addresses are now displayed in the correct fields.
  - Invalid website entries without a valid hostname are cleared.
  - Closed dealers remain excluded, while branch selection and category handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->