### PR TITLE
[Toyota AU] Fix spider

### DIFF
--- a/locations/spiders/toyota_au.py
+++ b/locations/spiders/toyota_au.py
@@ -36,7 +36,8 @@ class ToyotaAUSpider(JSONBlobSpider, PlaywrightSpider):
         item["lon"] = feature["refX"]
         item["state"] = feature["state"]
         item["street_address"] = item.pop("addr_full", None)
-        item["website"] = feature["webSite"]
+        if website := feature.get("webSite"):
+            item["website"] = website if website.startswith("http") else f"https://{website}"
 
         if feature.get("sales"):
             sales = item.deepcopy()


### PR DESCRIPTION
Four dealers publish their web address without a scheme, and because each dealer yields separate sales, service and parts locations that produced twelve invalid website values per run.

The scheme is now added when it is missing. A full crawl returns the same 966 locations with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Toyota dealer website information when website values are missing or lack an HTTP prefix.
  * Existing HTTP and HTTPS website addresses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->