### PR TITLE
[Roche Bobois] Add spider

### DIFF
--- a/locations/spiders/roche_bobois.py
+++ b/locations/spiders/roche_bobois.py
@@ -1,0 +1,42 @@
+from pprint import pprint
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import apply_category, Categories
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class RocheBoboisSpider(SitemapSpider, StructuredDataSpider):
+    name = "roche_bobois"
+    item_attributes = {"brand": "Roche Bobois", "brand_wikidata": "Q3437504"}
+    sitemap_urls = ["https://www.roche-bobois.com/en-GB/sitemap_index.xml"]
+    sitemap_rules = [(r"com/en-GB/showrooms/[^/]+/\w(\d+)\.html$", "parse")]
+    wanted_types = ["FurnitureStore"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+
+        try:
+            oh = OpeningHours()
+            for rule in ld_data["openingHours"]:
+                day, times = rule.split(" ", 1)
+                if times == "Closed":
+                    oh.set_closed(day)
+                else:
+                    for time in times.split(" / "):
+                        oh.add_range(day, *time.split(" - "), time_format="%I:%M %p")
+            item["opening_hours"] = oh
+        except Exception:
+            pass
+
+        item["website"] = item["extras"]["website:en"] = response.xpath(
+            '//link[@rel="alternate"][@hreflang="en"]/@href'
+        ).get()
+        item["extras"]["website:fr"] = response.xpath('//link[@rel="alternate"][@hreflang="fr-fr"]/@href').get()
+
+        apply_category(Categories.SHOP_FURNITURE, item)
+        yield item

--- a/locations/spiders/roche_bobois.py
+++ b/locations/spiders/roche_bobois.py
@@ -1,10 +1,9 @@
-from pprint import pprint
 from typing import Iterable
 
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import apply_category, Categories
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider


### PR DESCRIPTION
Fixes #17833

```python
{'atp/brand/Roche Bobois': 266,
 'atp/brand_wikidata/Q3437504': 266,
 'atp/category/shop/furniture': 266,
 'atp/cdn/cloudflare/response_count': 273,
 'atp/cdn/cloudflare/response_status_count/200': 273,
 'atp/country/AE': 1,
 'atp/country/AR': 2,
 'atp/country/AT': 2,
 'atp/country/AU': 1,
 'atp/country/BE': 3,
 'atp/country/BH': 1,
 'atp/country/CA': 8,
 'atp/country/CH': 7,
 'atp/country/CI': 1,
 'atp/country/CN': 27,
 'atp/country/CO': 1,
 'atp/country/CR': 1,
 'atp/country/DE': 8,
 'atp/country/DZ': 1,
 'atp/country/ES': 16,
 'atp/country/FR': 70,
 'atp/country/GB': 8,
 'atp/country/GP': 1,
 'atp/country/GR': 1,
 'atp/country/HK': 1,
 'atp/country/HU': 1,
 'atp/country/IE': 1,
 'atp/country/IL': 1,
 'atp/country/IN': 2,
 'atp/country/IT': 8,
 'atp/country/JO': 1,
 'atp/country/JP': 2,
 'atp/country/KR': 7,
 'atp/country/KW': 1,
 'atp/country/KZ': 1,
 'atp/country/LB': 1,
 'atp/country/LU': 1,
 'atp/country/MA': 4,
 'atp/country/MU': 1,
 'atp/country/MX': 5,
 'atp/country/MY': 1,
 'atp/country/NL': 1,
 'atp/country/PA': 1,
 'atp/country/PE': 1,
 'atp/country/PH': 1,
 'atp/country/PT': 2,
 'atp/country/QA': 1,
 'atp/country/RE': 1,
 'atp/country/RO': 1,
 'atp/country/RU': 4,
 'atp/country/SA': 2,
 'atp/country/SG': 2,
 'atp/country/TN': 1,
 'atp/country/TR': 3,
 'atp/country/UA': 2,
 'atp/country/US': 40,
 'atp/country/VE': 1,
 'atp/country/VN': 1,
 'atp/country/ZA': 2,
 'atp/field/country/from_reverse_geocoding': 23,
 'atp/field/email/missing': 266,
 'atp/field/housenumber/missing': 266,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 266,
 'atp/field/operator_wikidata/missing': 266,
 'atp/field/phone/invalid': 12,
 'atp/field/phone/missing': 3,
 'atp/field/postcode/missing': 16,
 'atp/field/state/from_reverse_geocoding': 48,
 'atp/field/state/missing': 197,
 'atp/field/street/missing': 266,
 'atp/field/twitter/missing': 266,
 'atp/field/unit/missing': 266,
 'atp/item_scraped_host_count/www.roche-bobois.com': 266,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/match_perfect': 266,
 'downloader/request_bytes': 229242,
 'downloader/request_count': 273,
 'downloader/request_method_count/GET': 273,
 'downloader/response_bytes': 7890560,
 'downloader/response_count': 273,
 'downloader/response_status_count/200': 273,
 'elapsed_time_seconds': 4.698691102999874,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 17, 9, 41, 32, 852673, tzinfo=datetime.timezone.utc),
 'httpcache/hit': 273,
 'httpcompression/response_bytes': 76638384,
 'httpcompression/response_count': 273,
 'item_scraped_count': 266,
 'items_per_minute': 3990.0,
 'log_count/ERROR': 1,
 'log_count/INFO': 3,
 'log_count/WARNING': 262,
 'memusage/max': 306855936,
 'memusage/startup': 306855936,
 'request_depth_max': 2,
 'response_received_count': 273,
 'responses_per_minute': 4095.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 272,
 'scheduler/dequeued/memory': 272,
 'scheduler/enqueued': 272,
 'scheduler/enqueued/memory': 272,
 'start_time': datetime.datetime(2026, 8, 17, 9, 41, 28, 153980, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Roche Bobois showroom location coverage.
  * Showroom listings now include branch names, opening hours, brand details, furniture categorization, and English/French website links.
  * Opening-hours parsing gracefully handles unavailable or invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->