### PR TITLE
[Tyrepower AU] Fix spider

### DIFF
--- a/locations/spiders/tyrepower_au.py
+++ b/locations/spiders/tyrepower_au.py
@@ -22,8 +22,8 @@ class TyrepowerAUSpider(Spider):
         for location in response.json()["all_stores"]:
             item = DictParser.parse(location)
             item["street_address"] = clean_address([location["address1"], location["address2"]])
-            if location.get("websiteUrl"):
-                item["website"] = location["websiteUrl"]
+            if website := location.get("websiteUrl"):
+                item["website"] = website if website.startswith("http") else f"https://{website}"
             elif location.get("url"):
                 item["website"] = "https://www.tyrepower.com.au/" + location["url"]
             yield item


### PR DESCRIPTION
Seven stores publish their web address without a scheme, so the value fails validation and is reported as an error every run.

The scheme is now added when it is missing. A full crawl returns the same 341 locations with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of location website links.
  * Automatically adds a secure HTTPS prefix when a website address lacks one.
  * Prevents errors when a website address is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->