### PR TITLE
[Seat DE] Fix spider

### DIFF
--- a/locations/spiders/seat_de.py
+++ b/locations/spiders/seat_de.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 
 import scrapy
@@ -23,7 +24,8 @@ class SeatDESpider(scrapy.Spider):
             item["postcode"] = data.get("PLZ")
             item["lat"] = data.get("XPOS")
             item["lon"] = data.get("YPOS")
-            item["website"] = data.get("URL")
+            if website := data.get("URL"):
+                item["website"] = "https://" + re.sub(r"^https?:/*", "", website)
             item["email"] = data.get("EMAIL")
             if data.get("HAENDLERVERTRAG") == "J":
                 shop_item = deepcopy(item)

--- a/locations/spiders/seat_de.py
+++ b/locations/spiders/seat_de.py
@@ -19,7 +19,7 @@ class SeatDESpider(scrapy.Spider):
             item["ref"] = data.get("NUMMER")
             item["name"] = data.get("NAME1")
             item["phone"] = data.get("TELEFON")
-            item["street"] = data.get("STRA\u00dfE")
+            item["street_address"] = data.get("STRA\u00dfE")
             item["city"] = data.get("ORT")
             item["postcode"] = data.get("PLZ")
             item["lat"] = data.get("XPOS")


### PR DESCRIPTION
Twenty dealers publish their website as a bare hostname or with a single-slash scheme, so the value fails validation and is reported as an error every run.

Any partial scheme is now stripped and `https://` applied. A full crawl returns the same 1280 locations with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dealer website links by standardizing URL formatting.
  * Prevented empty website fields from being populated when no URL is available.
  * Corrected dealer address details to display the street address accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->