### PR TITLE
[WorldCat] Fix spider

### DIFF
--- a/locations/spiders/worldcat.py
+++ b/locations/spiders/worldcat.py
@@ -1,3 +1,4 @@
+import re
 from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
@@ -46,9 +47,10 @@ class WorldcatSpider(JSONBlobSpider):
 
         item["street_address"] = clean_address([location.get("street1"), location.get("street2")])
 
-        if "emails" in location:
-            item["email"] = "; ".join(location["emails"])
-        if "homePageUrl" in location:
-            item["website"] = location["homePageUrl"]
+        if emails := location.get("emails"):
+            if address := re.search(r"[-\w.+]+@[-\w]+\.[-\w.]+", emails[0]):
+                item["email"] = address.group(0)
+        if website := location.get("homePageUrl"):
+            item["website"] = re.sub(r"^(https?):/(?!/)", r"\1://", website)
 
         yield item


### PR DESCRIPTION
Some libraries publish their home page with a single-slash scheme, which fails validation. Separately, the API returns `emails` as a list and the spider joined it into one string, so any library with more than one address ended up with no email at all.

The scheme is now repaired without changing http to https, and a single address is taken from the list, matched by pattern so entries that carry a second address or a trailing note still yield a usable value. A sample crawl of 3050 libraries returns no errors or warnings, where the same sample previously produced three errors and 83 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email extraction to select the first valid email address.
  * Corrected malformed website links by normalizing incomplete HTTP and HTTPS prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->