### PR TITLE
[Apex Hotels] Fix spider

### DIFF
--- a/locations/spiders/apex_hotels.py
+++ b/locations/spiders/apex_hotels.py
@@ -15,6 +15,8 @@ class ApexHotelsSpider(SitemapSpider):
         item = LinkedDataParser.parse(response, "Hotel")
         if item:
             item["ref"] = response.url.split("/")[5]
+            if item.get("image"):
+                item["image"] = response.urljoin(item["image"])
 
             apply_category(Categories.HOTEL, item)
 


### PR DESCRIPTION
The hotel pages give their image as a site-relative path, so the value fails validation and every one of the nine hotels reports an error.

The path is now resolved against the page URL. A full crawl returns the same nine hotels with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hotel images now load correctly when their URLs are relative to the page address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->