### PR TITLE
[Manufaktura] Fix spider

### DIFF
--- a/locations/spiders/manufaktura.py
+++ b/locations/spiders/manufaktura.py
@@ -29,7 +29,8 @@ class ManufakturaSpider(CrawlSpider):
         item["street_address"] = address_lines[0].strip(",")  # strip trailing comma
         item["postcode"] = re.match(r"\d{3}\s?\d{2}", address_lines[1].strip())[0]
         item["city"] = address_lines[1].strip().removeprefix(item["postcode"]).strip()
-        item["image"] = response.xpath("//*[@class='seller-gallery-item']/img/@src").get()
+        if image := response.xpath("//*[@class='seller-gallery-item']/img/@src").get():
+            item["image"] = response.urljoin(image)
         extract_phone(item, response)
         extract_mapy_cz_position(item, response)
         apply_category(Categories.SHOP_COSMETICS, item)


### PR DESCRIPTION
The store pages give their gallery image as a site-relative path, so the value fails validation and all fifty stores report an error and ship without an image.

The path is now resolved against the page URL. A full crawl returns the same fifty stores with no errors, each with its own image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Store images now load correctly when their source URLs are relative rather than complete web addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->