### PR TITLE
[Australia Post AU] Fix spider

### DIFF
--- a/locations/spiders/australia_post_au.py
+++ b/locations/spiders/australia_post_au.py
@@ -12,7 +12,10 @@ from locations.pipelines.address_clean_up import merge_address_lines
 class AustraliaPostAUSpider(Spider):
     name = "australia_post_au"
     item_attributes = {"brand": "Australia Post", "brand_wikidata": "Q1142936"}
-    custom_settings = {"DOWNLOAD_DELAY": 2}  # Rate limiting appears to be used
+    custom_settings = {
+        "DOWNLOAD_DELAY": 2,  # Rate limiting appears to be used
+        "DOWNLOAD_TIMEOUT": 60,  # Responses reach several megabytes
+    }
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for lat, lon in [
@@ -38,14 +41,12 @@ class AustraliaPostAUSpider(Spider):
             )
             item["opening_hours"] = OpeningHours()
             for i in store["hours"]:
-                if i["type"] in ["CLOSED", "SPECIAL_CLOSED", "Closed", "SPECIAL_LUNCH", "", None]:
+                if i["type"] != "HOURS":
                     continue
-                day = DAYS[int(i["weekday"])]
-                open_time = i["start_time"]
                 close_time = i["end_time"]
                 if close_time == "23:59:59":
                     close_time = "23:59"
-                    item["opening_hours"].add_range(day, open_time.strip(), close_time.strip())
+                item["opening_hours"].add_range(DAYS[int(i["weekday"])], i["start_time"].strip(), close_time.strip())
 
             if store["type"] == "C_SPB":
                 apply_category(Categories.POST_BOX, item)


### PR DESCRIPTION
Opening hours were only added when a location closed at 23:59:59, because the call sat inside that condition. Post offices, which close at normal times, therefore lost their hours entirely: 17 of 4097 had any.

The call now runs for every regular entry, and only entries of type `HOURS` are used — the feed also carries lunch closures, parcel-hatch access times and date-bounded special hours, none of which belong in weekly opening hours. The download timeout is raised because responses reach several megabytes and were timing out at the 15 second default.

A full crawl returns the same 17173 locations, with hours now on 5547 of them including 4093 post offices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening-hours accuracy by processing only valid hours entries.
  * Standardized closing times displayed as `23:59:59` to `23:59`.
  * Added a 60-second response timeout while maintaining the existing request delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->