### PR TITLE
[Olive Garden] Fix spider

### DIFF
--- a/locations/spiders/olive_garden.py
+++ b/locations/spiders/olive_garden.py
@@ -12,7 +12,6 @@ class OliveGardenSpider(JSONBlobSpider):
     name = "olive_garden"
     item_attributes = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
     allowed_domains = ["olivegarden.com"]
-    requires_proxy = True
     locations_key = "restaurants"
 
     async def start(self) -> AsyncIterator[JsonRequest]:

--- a/locations/spiders/olive_garden.py
+++ b/locations/spiders/olive_garden.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Iterable
+from typing import AsyncIterator, ClassVar, Iterable
 
 from scrapy.http import JsonRequest, TextResponse
 
@@ -10,8 +10,8 @@ from locations.json_blob_spider import JSONBlobSpider
 
 class OliveGardenSpider(JSONBlobSpider):
     name = "olive_garden"
-    item_attributes = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
-    allowed_domains = ["olivegarden.com"]
+    item_attributes: ClassVar[dict[str, str]] = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
+    allowed_domains: ClassVar[list[str]] = ["olivegarden.com"]
     requires_proxy = True
     locations_key = "restaurants"
 

--- a/locations/spiders/olive_garden.py
+++ b/locations/spiders/olive_garden.py
@@ -6,13 +6,17 @@ from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class OliveGardenSpider(JSONBlobSpider):
+class OliveGardenSpider(JSONBlobSpider, PlaywrightSpider):
     name = "olive_garden"
     item_attributes = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
     allowed_domains = ["olivegarden.com"]
     locations_key = "restaurants"
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url="https://www.olivegarden.com/api/restaurants", headers={"X-Source-Channel": "WEB"})

--- a/locations/spiders/olive_garden.py
+++ b/locations/spiders/olive_garden.py
@@ -6,18 +6,14 @@ from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import BROWSER_DEFAULT
 
 
-class OliveGardenSpider(JSONBlobSpider, PlaywrightSpider):
+class OliveGardenSpider(JSONBlobSpider):
     name = "olive_garden"
     item_attributes = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
     allowed_domains = ["olivegarden.com"]
-    locations_key = "restaurants"
-    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
     requires_proxy = True
+    locations_key = "restaurants"
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url="https://www.olivegarden.com/api/restaurants", headers={"X-Source-Channel": "WEB"})

--- a/locations/spiders/olive_garden.py
+++ b/locations/spiders/olive_garden.py
@@ -16,7 +16,8 @@ class OliveGardenSpider(JSONBlobSpider, PlaywrightSpider):
     item_attributes = {"brand": "Olive Garden", "brand_wikidata": "Q3045312"}
     allowed_domains = ["olivegarden.com"]
     locations_key = "restaurants"
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT} | DEFAULT_PLAYWRIGHT_SETTINGS
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(url="https://www.olivegarden.com/api/restaurants", headers={"X-Source-Channel": "WEB"})


### PR DESCRIPTION
Working fine from `US` as well. 

```python
{'atp/brand/Olive Garden': 1007,
 'atp/brand_wikidata/Q3045312': 1007,
 'atp/category/amenity/restaurant': 1007,
 'atp/clean_strings/city': 2,
 'atp/country/BR': 6,
 'atp/country/CA': 9,
 'atp/country/CR': 2,
 'atp/country/EC': 1,
 'atp/country/GU': 1,
 'atp/country/MX': 12,
 'atp/country/MY': 2,
 'atp/country/PA': 1,
 'atp/country/PR': 2,
 'atp/country/SV': 1,
 'atp/country/US': 969,
 'atp/field/city/missing': 1,
 'atp/field/country/missing': 1,
 'atp/field/email/missing': 1007,
 'atp/field/geometry/missing': 2,
 'atp/field/housenumber/missing': 1007,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 1007,
 'atp/field/operator_wikidata/missing': 1007,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 9,
 'atp/field/postcode/missing': 2,
 'atp/field/state/missing': 1,
 'atp/field/street/missing': 1007,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 1007,
 'atp/field/unit/missing': 1007,
 'atp/item_scraped_host_count/www.olivegarden.com': 1007,
 'atp/lineage': 'S_?',
 'atp/nsi/country_missing': 1,
 'atp/nsi/match_imperfect': 1,
 'atp/nsi/match_perfect': 1006,
 'downloader/request_bytes': 312,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 3254990,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 14.734000000004016,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 18, 13, 35, 45, 190004, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 1007,
 'items_per_minute': 4315.714285714285,
 'log_count/DEBUG': 1012,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 1,
 'playwright/page_count/closed': 1,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 1,
 'playwright/request_count/method/GET': 1,
 'playwright/request_count/navigation': 1,
 'playwright/request_count/resource_type/document': 1,
 'playwright/response_count': 1,
 'playwright/response_count/method/GET': 1,
 'playwright/response_count/resource_type/document': 1,
 'response_received_count': 1,
 'responses_per_minute': 4.285714285714286,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 18, 13, 35, 30, 468617, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined Olive Garden location data collection by removing unnecessary browser-based processing.
  - Simplified configuration while preserving the existing request flow and restaurant metadata handling.
- **Bug Fixes**
  - No customer-visible behavior changes are expected; location retrieval continues to operate as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->