### PR TITLE
[O'Tacos] Fix spider

### DIFF
--- a/locations/spiders/o_tacos.py
+++ b/locations/spiders/o_tacos.py
@@ -1,25 +1,45 @@
-from string import capwords
-from typing import Any, AsyncIterator
+import json
+import re
+from typing import Any, Iterable
 
-from scrapy import Spider
-from scrapy.http import FormRequest, Response
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
+from locations.hours import DAYS_FROM_SUNDAY, OpeningHours
+from locations.items import Feature
 
 
-class OTacosSpider(Spider):
+class OTacosSpider(SitemapSpider):
     name = "o_tacos"
     item_attributes = {"brand": "O'Tacos", "brand_wikidata": "Q28494040"}
+    sitemap_urls = ["https://restaurants.o-tacos.com/sitemap.xml"]
+    sitemap_rules = [(r"^https://restaurants\.o-tacos\.com(?:/[^/]+){5}$", "parse")]
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        yield FormRequest(
-            "https://www.o-tacos.fr/ajax",
-            formdata={"action": "store_wpress_listener", "method": "display_map", "nb_display": "5000"},
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        payload = "".join(
+            json.loads(chunk)
+            for chunk in re.findall(r'self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*")\]\)', response.text)
         )
+        if (start := payload.find('"place":{"id":"loc_')) < 0:
+            return
+        place = json.JSONDecoder().raw_decode(payload, start + len('"place":'))[0]
+        place.update(place.pop("address"))
+        place["phone"] = (place.pop("contact", None) or {}).get("mainPhone")
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json()["locations"]:
-            item = DictParser.parse(location)
-            item["branch"] = capwords(item.pop("name"))
+        item = DictParser.parse(place)
+        item.pop("name", None)
+        item["branch"] = place.get("shortName")
+        item["street_address"] = place.get("line1")
+        item["website"] = response.url
 
-            yield item
+        item["opening_hours"] = OpeningHours()
+        for day in (place.get("openings") or {}).get("businessOpenings") or []:
+            for timetable in day["timetables"]:
+                item["opening_hours"].add_range(
+                    DAYS_FROM_SUNDAY[day["dayOfWeek"] - 1], timetable["open"], timetable["close"]
+                )
+
+        apply_category(Categories.FAST_FOOD, item)
+        yield item


### PR DESCRIPTION
The endpoint the spider posted to is gone and `o-tacos.fr` no longer completes a TLS handshake, so recent runs produced no features. The brand's locator now lives at `restaurants.o-tacos.com`.

Rewrote as a `SitemapSpider` over the new site. Its JSON-LD has no coordinates, so the store record is read from the page payload instead, which carries the address with latitude and longitude, the phone number and the weekly schedule. A full crawl returns 448 restaurants across eleven countries, all with coordinates and 435 with opening hours. The shared customer-service email address is not collected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restaurant location discovery using the official sitemap.
  * Added more reliable extraction and normalization of addresses, contact details, websites, and branch information.
  * Improved opening-hours and category data for restaurant listings.
  * Removed reliance on the legacy location search process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->