### PR TITLE
[Nandos SG] Fix spider

### DIFF
--- a/locations/spiders/nandos_sg.py
+++ b/locations/spiders/nandos_sg.py
@@ -1,22 +1,8 @@
-from typing import Any
-
-import scrapy
-from scrapy.http import Response
-
-from locations.items import Feature
 from locations.spiders.nandos import NANDOS_SHARED_ATTRIBUTES
+from locations.spiders.nandos_my import NandosMYSpider
 
 
-class NandosSGSpider(scrapy.Spider):
+class NandosSGSpider(NandosMYSpider):
     name = "nandos_sg"
-    item_attributes = NANDOS_SHARED_ATTRIBUTES
-    allowed_domains = ["nandos.com.sg"]
-    start_urls = ["https://www.nandos.com.sg/restaurants/"]
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//*[contains(@class,"flex flex-col gap-3 ")]'):
-            item = Feature()
-            item["branch"] = item["ref"] = location.xpath("./h3/text()").get()
-            item["addr_full"] = location.xpath(".//p/text()").get()
-            item["phone"] = location.xpath('.//*[contains(@href,"tel:")]/text()').get()
-            yield item
+    item_attributes = NANDOS_SHARED_ATTRIBUTES | {"country": "SG"}
+    start_urls = ["https://www.nandos.com.sg/restaurants/__data.json"]


### PR DESCRIPTION
The Singapore site was rebuilt on SvelteKit, so the HTML the spider parsed no longer exists and recent runs produced no features.

The Malaysian spider already reads that platform's data payload, so Singapore now subclasses it and points at its own `__data.json`. A full crawl returns six restaurants with coordinates, phone numbers and opening hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Singapore restaurant data collection to use the shared Nando’s data source and processing approach.
  * Singapore listings now use the correct country designation and restaurant data endpoint.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->