### PR TITLE
[Bankomat SE] Add spider

### DIFF
--- a/locations/spiders/bankomat_se.py
+++ b/locations/spiders/bankomat_se.py
@@ -1,0 +1,34 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class BankomatSESpider(Spider):
+    name = "bankomat_se"
+    item_attributes = {"brand": "Bankomat", "brand_wikidata": "Q10426078"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield JsonRequest(url="https://www.bankomat.se/proxy.php?service=places")
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.json():
+            item = DictParser.parse(location)  # maps identifier->ref, city, zipcode->postcode, address1->street_address
+            item["geometry"] = location["point"]
+
+            # When address2 is present, address1 is the host venue (e.g. "Avesta galleria") and address2 the street.
+            if location.get("address2"):
+                item["located_in"] = location["address1"]
+                item["street_address"] = location["address2"]
+
+            services = {service["identifier"] for service in location.get("services", []) if service.get("available")}
+            apply_yes_no(Extras.CASH_IN, item, "deposit" in services)
+            apply_yes_no(PaymentMethods.CONTACTLESS, item, "NFC" in services)
+            if {machine.get("opening_hours") for machine in location.get("machines", [])} == {"Dygnet runt"}:
+                item["opening_hours"] = "24/7"  # "Dygnet runt" = around the clock; other freeform hours are skipped
+
+            apply_category(Categories.ATM, item)
+            yield item


### PR DESCRIPTION
Bankomat (Q10426078) — Sweden's shared/interbank ATM network. amenity=atm.

Source: the map's JSON API, https://www.bankomat.se/proxy.php?service=places — a flat list of 970 ATMs. Parsed with DictParser (identifier→ref, city, zipcode→postcode, address1→street); point is GeoJSON [lon,lat], used as the geometry.

Fields:

Address / located_in — when address2 is present, address1 is the host venue (Coop, Avesta galleria, Bensinstationen) → located_in, with address2 as the street; otherwise address1 is the street. (Follows the kontanten_se / cash_be ATM convention — host venue is located_in, never name.)
cash_in=yes from the deposit service; payment:contactless=yes from the NFC service (both only when available).
opening_hours=24/7 when every machine reads Dygnet runt (around-the-clock); the other machines' freeform Swedish hours / "same as the mall" strings aren't reliably convertible, so they're left unset.
addr:country=SE from the spider name; ref = source identifier.

Robots allows the endpoint, and it returns the same JSON to a default request, so no proxy / custom headers. No per-ATM phone/email in the feed.

NSI: matches bankomat-adfc2b (amenity=atm, brand "Bankomat", {include:[se]}) — 970/970 match_perfect.

Full stats
```{
  "item_scraped_count": 970,
  "atp/brand/Bankomat": 970,
  "atp/brand_wikidata/Q10426078": 970,
  "atp/category/amenity/atm": 970,
  "atp/country/SE": 970,
  "atp/field/country/from_spider_name": 970,
  "atp/field/opening_hours/missing": 295,
  "atp/nsi/match_perfect": 970
}
```
(970 items = 449 named host-venues + 521 street-only; 675 with 24/7; cash_in 415; payment:contactless 956; 0 dropped, no geometry errors.)

Sample POIs
```[
  {
    "type": "Feature",
    "properties": {
      "ref": "FC3E30656280F28499E85F0E48087DB3", "amenity": "atm",
      "cash_in": "yes", "payment:contactless": "yes", "opening_hours": "24/7",
      "located_in": "Coop",
      "addr:street_address": "Örebrogatan 32", "addr:city": "HELSINGBORG", "addr:postcode": "25250", "addr:country": "SE",
      "brand": "Bankomat", "brand:wikidata": "Q10426078", "nsi_id": "bankomat-adfc2b"
    },
    "geometry": { "type": "Point", "coordinates": [12.72069, 56.04444] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "3E7224F770F3EF7A946B6D6769B322AA", "amenity": "atm",
      "payment:contactless": "yes", "opening_hours": "24/7", "located_in": "Bensinstationen",
      "addr:street_address": "Norgevägen 6", "addr:city": "GÄDDEDE", "addr:postcode": "83090", "addr:country": "SE",
      "brand": "Bankomat", "brand:wikidata": "Q10426078", "nsi_id": "bankomat-adfc2b"
    },
    "geometry": { "type": "Point", "coordinates": [14.14065, 64.49907] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "8362596029A82F45BEF62A57DE5C5111", "amenity": "atm",
      "payment:contactless": "yes", "opening_hours": "24/7",
      "addr:street_address": "Prästgårdsängen 1", "addr:city": "GÖTEBORG", "addr:postcode": "41271", "addr:country": "SE",
      "brand": "Bankomat", "brand:wikidata": "Q10426078", "nsi_id": "bankomat-adfc2b"
    },
    "geometry": { "type": "Point", "coordinates": [12.00693, 57.70472] }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Bankomat ATM locations in Sweden.
  * Location listings include addresses, host venues, available services, contactless payment details, and opening hours.
  * Locations operating continuously are displayed as open 24/7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->