### PR TITLE
[Talisman Hire] Fix spider

### DIFF
--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -15,7 +15,7 @@ class TalismanHireSpider(WPStoreLocatorSpider):
     name = "talisman_hire"
     item_attributes = {"brand": "Talisman Hire", "brand_wikidata": "Q120885726"}
     allowed_domains = ["www.talisman.co.za"]
-    drop_attributes = {"facebook"}
+    drop_attributes = {"email", "facebook"}
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         item["branch"] = re.sub(r"\s*\(in(?:side)? .+?\)$", "", item.pop("name"))

--- a/locations/spiders/talisman_hire.py
+++ b/locations/spiders/talisman_hire.py
@@ -1,41 +1,47 @@
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+import re
+from typing import Iterable
 
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
 from locations.items import Feature
 from locations.spiders.buco_na_za import BucoNAZASpider
 from locations.spiders.builders import BuildersSpider
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
 
 
-class TalismanHireSpider(SitemapSpider, StructuredDataSpider):
+class TalismanHireSpider(WPStoreLocatorSpider):
     name = "talisman_hire"
     item_attributes = {"brand": "Talisman Hire", "brand_wikidata": "Q120885726"}
     allowed_domains = ["www.talisman.co.za"]
-    sitemap_urls = ["https://www.talisman.co.za/googlesitemap"]
-    sitemap_rules = [(r"talisman\.co\.za/[-\w]+/[-\w]+/talisman-hire-[-\w]+$", "parse_sd")]
-    skip_auto_cc_spider_name = True
-    skip_auto_cc_domain = True
-    drop_attributes = {"facebook", "twitter"}
+    drop_attributes = {"facebook"}
 
-    def pre_process_data(self, ld_data: dict, **kwargs):
-        ld_data.get("address", {}).pop("addressCountry", None)  # It's always ZA, which isn't true
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["branch"] = re.sub(r"\s*\(in(?:side)? .+?\)$", "", item.pop("name"))
+        item["opening_hours"] = OpeningHours()
+        item["opening_hours"].add_ranges_from_string(
+            "; ".join(
+                f"{days}: {feature[key]}"
+                for days, key in [("Mo-Fr", "hours_weekdays"), ("Sa", "hours_saturday"), ("Su", "hours_sunday")]
+                if feature.get(key)
+            )
+        )
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
-        item["branch"] = item.pop("name").removeprefix("Talisman Hire ")
-        if item.get("state") == "Mpumalanga":  # country wrongly reverse geocoded as SZ
-            item["country"] = "ZA"
+        if host := re.search(r"-in(?:side)?-(.+)$", item["website"].rstrip("/").rsplit("/", 1)[-1]):
+            match host.group(1):
+                case "builders":
+                    item["located_in"] = BuildersSpider.item_attributes["brand"]
+                    item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
+                case "builders-express":
+                    item["located_in"] = "Builders Express"
+                    item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
+                case "buco":
+                    item["located_in"] = BucoNAZASpider.item_attributes["brand"]
+                    item["located_in_wikidata"] = BucoNAZASpider.item_attributes["brand_wikidata"]
+                case _:
+                    item["located_in"] = host.group(1).replace("-", " ").title()
 
-        if "inside-" in response.url:
-            located_in_location = response.url.split("inside-")[-1].strip("/")
-            if located_in_location == "buco":
-                item["located_in"] = BucoNAZASpider.item_attributes["brand"]
-                item["located_in_wikidata"] = BucoNAZASpider.item_attributes["brand_wikidata"]
-            elif located_in_location == "builders":
-                item["located_in"] = BuildersSpider.item_attributes["brand"]
-                item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
-            elif located_in_location == "builders-express":
-                item["located_in"] = located_in_location.replace("-", " ").title()
-                item["located_in_wikidata"] = BuildersSpider.item_attributes["brand_wikidata"]
-            else:
-                item["located_in"] = located_in_location.replace("-", " ").title()
+        apply_category(Categories.SHOP_TOOL_HIRE, item)
+
         yield item


### PR DESCRIPTION
```
{'atp/brand/Talisman Hire': 151,
 'atp/brand_wikidata/Q120885726': 151,
 'atp/category/shop/tool_hire': 151,
 'atp/cdn/cloudflare/response_count': 2,
 'atp/cdn/cloudflare/response_status_count/200': 2,
 'atp/country/BW': 1,
 'atp/country/NA': 2,
 'atp/country/ZA': 147,
 'atp/country/ZM': 1,
 'atp/field/email/missing': 151,
 'atp/field/housenumber/missing': 151,
 'atp/field/name/missing': 2,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 151,
 'atp/field/operator_wikidata/missing': 151,
 'atp/field/phone/invalid': 5,
 'atp/field/postcode/missing': 150,
 'atp/field/state/missing': 149,
 'atp/field/street/missing': 151,
 'atp/field/twitter/missing': 151,
 'atp/field/unit/missing': 151,
 'atp/item_scraped_host_count/www.talisman.co.za': 151,
 'atp/lineage': 'S_?',
 'atp/located_in/BUCO': 3,
 'atp/located_in/Builders': 44,
 'atp/located_in/Builders Express': 2,
 'atp/located_in/Kouestroom Hardware': 1,
 'atp/located_in/Lumber City': 1,
 'atp/located_in_wikidata/Q116771533': 3,
 'atp/located_in_wikidata/Q116819137': 46,
 'atp/nsi/location_unknown': 2,
 'atp/nsi/match_failed': 2,
 'atp/nsi/match_perfect': 149,
 'downloader/request_bytes': 948,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 16769,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.2970000000000255,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 19, 6, 26, 34, 193197, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 191317,
 'httpcompression/response_count': 2,
 'item_scraped_count': 151,
 'items_per_minute': 2265.0,
 'log_count/DEBUG': 153,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 19, 6, 26, 29, 885235, tzinfo=datetime.timezone.utc)}
```