### PR TITLE
[Mcdonalds] Fix spider

### DIFF
--- a/locations/spiders/mcdonalds.py
+++ b/locations/spiders/mcdonalds.py
@@ -1,4 +1,3 @@
-import json
 from typing import AsyncIterator, Iterable
 
 from scrapy.http import Request, Response
@@ -76,7 +75,7 @@ class McdonaldsSpider(PlaywrightSpider):
     def parse_major_api(self, response: Response, country: str, locale: str) -> Iterable[Feature]:
         if len(response.body) == 0:
             return
-        stores = json.loads(response.xpath("//pre/text()").get())["features"]
+        stores = response.json()["features"]
         for store in stores:
             properties = store["properties"]
             store_identifier = properties["identifierValue"]


### PR DESCRIPTION
`parse_major_api` unwraps the API response out of the browser's JSON viewer markup:

```python
stores = json.loads(response.xpath("//pre/text()").get())["features"]
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. The spider produced 0 features with 8,354 errors in the most recent run, against 25,008 in the one before.

It now calls `response.json()` directly, as it did before #17762, and drops the `import json` that only served the unwrap.

A capped live crawl returns 656 features with full geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved McDonald’s location data retrieval by parsing API responses directly.
  * Increased reliability when processing location information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->