### PR TITLE
[Mango] Fix spider

### DIFF
--- a/locations/spiders/mango.py
+++ b/locations/spiders/mango.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Iterable
 
 import chompjs
@@ -6,6 +5,7 @@ from scrapy import Request
 from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import (
     DAYS_AR,
@@ -75,7 +75,7 @@ class MangoSpider(PlaywrightSpider):
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for country in json.loads(response.xpath("//pre/text()").get())["countries"]:
+        for country in response.json()["countries"]:
             if not country.get("hasOnlineAccess"):  # Skip countries with no available stores
                 continue
             country_code = country.get("mangoIso")
@@ -114,6 +114,8 @@ class MangoSpider(PlaywrightSpider):
                 item["opening_hours"] = self.parse_opening_hours(store.get("timeSchedule", []), language)
             except Exception as e:
                 self.logger.error(f'Failed to parse opening hours:{store.get("timeSchedule")} {e}')
+
+            apply_category(Categories.SHOP_CLOTHES, item)
             yield item
 
     def parse_opening_hours(self, rules: list[dict], language: str) -> OpeningHours:


### PR DESCRIPTION
`parse` unwraps the country-list response out of the browser's JSON viewer markup:

```python
for country in json.loads(response.xpath("//pre/text()").get())["countries"]:
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only start request, the whole crawl yielded nothing — 0 features against 1,846 in the previous run.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap. The shop category is also set explicitly rather than left to be inferred.

A live crawl returns 709 stores across 28 countries with full geometry and no parse errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store location data processing for more reliable country information.
  * Ensured store listings are categorized as clothing shops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->