### PR TITLE
[Burger King RU] Fix spider

### DIFF
--- a/locations/spiders/burger_king_ru.py
+++ b/locations/spiders/burger_king_ru.py
@@ -1,9 +1,8 @@
-import json
 from typing import Any, AsyncIterator
 
 from scrapy.http import JsonRequest, Response
 
-from locations.categories import Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.playwright_spider import PlaywrightSpider
@@ -22,10 +21,11 @@ class BurgerKingRUSpider(PlaywrightSpider):
         yield JsonRequest(url=self.api_url, cookies={"spid": "", "spsc": ""})
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre/text()").get())["response"]:
+        for location in response.json()["response"]:
             item = DictParser.parse(location)
             item["street_address"] = item.pop("name", None)
             item["city"] = location["city"]["city_name"]
+            item["phone"] = None  # A single national number, varying only by extension
             try:
                 item["opening_hours"] = self.parse_opening_hours(location.get("timetable", []))
             except Exception as e:
@@ -33,6 +33,8 @@ class BurgerKingRUSpider(PlaywrightSpider):
 
             if location.get("features"):
                 apply_yes_no(Extras.DRIVE_THROUGH, item, location["features"].get("king_drive") is True, False)
+
+            apply_category(Categories.FAST_FOOD, item)
             yield item
 
     def parse_opening_hours(self, rules: list[dict]) -> OpeningHours:


### PR DESCRIPTION
`parse` unwraps the restaurant-search response out of the browser's JSON viewer markup:

```python
for location in json.loads(response.xpath("//pre/text()").get())["response"]:
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap. The category is set explicitly rather than left to be inferred, and the phone is dropped as every restaurant reports the same national number with only the extension varying.

A full live crawl returns 923 restaurants with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Burger King location data processing from the API.
  * Corrected phone number handling and consistently classified locations as fast-food establishments.
  * Preserved location details, opening hours, and drive-through information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->