### PR TITLE
[Beev GB] Fix spider

### DIFF
--- a/locations/spiders/beev_gb.py
+++ b/locations/spiders/beev_gb.py
@@ -1,4 +1,3 @@
-import json
 from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
@@ -20,7 +19,7 @@ class BeevGBSpider(PlaywrightSpider):
         )
 
     def parse(self, response, **kwargs):
-        for location in json.loads(response.xpath("//pre//text()").get()):
+        for location in response.json():
             if location["status"] == 4:
                 continue  # Upcoming
 
@@ -28,10 +27,10 @@ class BeevGBSpider(PlaywrightSpider):
             item["ref"] = location["siteId"]
             item["lat"] = location["coordinates"]["lat"]
             item["lon"] = location["coordinates"]["long"]
-            item["name"] = location["name"]
+            item["branch"] = location["name"]
             item["postcode"] = location["formattedAddress"]["postCode"]
 
-            apply_yes_no(Extras.FEE, item, location["tariff"]["amount"] == "0.00", False)
+            apply_yes_no(Extras.FEE, item, location["tariff"]["amount"] != "0.00", False)
             item["extras"]["charge"] = "{} {}/kWh".format(location["tariff"]["amount"], location["tariff"]["currency"])
 
             apply_category(Categories.CHARGING_STATION, item)


### PR DESCRIPTION
`parse` unwraps the API response out of the browser's JSON viewer markup:

```python
for location in json.loads(response.xpath("//pre//text()").get()):
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

Two further corrections while here:

* The `fee` flag was inverted, marking a charge point as free whenever it had a tariff. 597 of 599 charge points were affected.
* The per-site name is now collected as `branch` rather than `name`, which NSI populates from the brand.

A full live crawl returns 599 charge points with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location data parsing for more reliable results.
  * Corrected location name mapping.
  * Updated fee detection to accurately identify locations with nonzero tariffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->