### PR TITLE
[Tatra Banka SK] Fix spider

### DIFF
--- a/locations/spiders/tatra_banka_sk.py
+++ b/locations/spiders/tatra_banka_sk.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, AsyncIterator
 
 from scrapy import FormRequest
@@ -49,7 +48,7 @@ class TatraBankaSKSpider(PlaywrightSpider):
         )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in json.loads(response.xpath("//pre//text()").get()).get("places", []):
+        for location in response.json().get("places", []):
             if not location.get("active", True) or location.get("temporarilyClosed"):
                 continue
 
@@ -84,9 +83,9 @@ class TatraBankaSKSpider(PlaywrightSpider):
         item["lon"] = location.get("positionE")
         item["city"] = location.get("city", {}).get("name")
         item.pop("website", None)
-
-        if branch := item.pop("name", None):
-            item["branch"] = branch
+        item.pop("name", None)
+        item["phone"] = None
+        item["email"] = None
 
         return item
 


### PR DESCRIPTION
`parse` unwraps the API response out of the browser's JSON viewer markup:

```python
for location in json.loads(response.xpath("//pre//text()").get()).get("places", []):
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

Three field corrections while here:

* `branch` held the street address, which is already collected as `addr:street`, `addr:housenumber` and `addr:city`. The source offers no branch name.
* The phone was a single national number shared by all 387 locations.
* The emails were regional addresses shared between locations.

A full live crawl returns 387 locations (302 ATMs, 85 branches) with complete geometry and no errors.