### PR TITLE
[Azpetrol AZ] Add spider

### DIFF
--- a/locations/spiders/azpetrol_az.py
+++ b/locations/spiders/azpetrol_az.py
@@ -1,0 +1,43 @@
+import json
+from typing import Any, AsyncIterator
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class AzpetrolAZSpider(Spider):
+    name = "azpetrol_az"
+    item_attributes = {"brand": "Azpetrol", "brand_wikidata": "Q4034661"}
+
+    async def start(self) -> AsyncIterator[Any]:
+        # The unprefixed locale is Azeri. The "RSC" header returns the Next.js flight payload
+        # (text/x-component) carrying the station JSON, instead of the fully rendered HTML page.
+        yield Request(url="https://azpetrol.az/service-network", headers={"RSC": "1"})
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Stations are embedded in the flight payload as a Strapi collection under locations.content.data.
+        marker = '"locations":{"content":{"data":'
+        if (start := response.text.find(marker)) == -1:
+            self.logger.error("Azpetrol station data not found")
+            return
+        stations, _ = json.JSONDecoder().raw_decode(response.text[start + len(marker) :])
+
+        for station in stations:
+            item = DictParser.parse(station["attributes"])  # title->name, address->addr_full, lat/lng, phone
+            item["ref"] = str(station["id"])
+            item["branch"] = item.pop("name")
+
+            services = [
+                category["attributes"]["title"]
+                for category in (station["attributes"].get("network_categories") or {}).get("data", [])
+            ]
+            apply_yes_no(Extras.ATM, item, "Bankomat" in services)
+            apply_yes_no(Extras.CAR_WASH, item, "Avtoyuma" in services)
+            apply_yes_no(Fuel.CNG, item, "CNG qaz (Metan)" in services)
+            apply_yes_no(Fuel.LPG, item, "Maye qaz postu (LPG)" in services or "QDM (Propan-Butan)" in services)
+            apply_yes_no(Fuel.ELECTRIC, item, "Elektromobillərin doldurma xidməti" in services)
+            apply_category(Categories.FUEL_STATION, item)
+            yield item


### PR DESCRIPTION
Azpetrol (Q4034661) — fuel-station network in Azerbaijan. amenity=fuel.

Source: the service-network page is a Next.js app; the station data (a Strapi collection) is delivered in the RSC flight payload. The spider requests https://azpetrol.az/service-network with the RSC: 1 header (returns text/x-component) and extracts the locations.content.data array. Content is in Azeri (the unprefixed default locale). No standalone Strapi API is exposed (/api/* → 404).

Fields: DictParser maps title→branch (via name), address→addr:full (free-form Azeri, not split), lat/lng, phone (pipeline normalizes to +994 …); ref = source id; NSI provides name=Azpetrol.

Services / fuel types from each station's network_categories (peer convention apply_yes_no(Fuel/Extras, …), positive-only):

fuel:cng ← CNG qaz (Metan)
fuel:lpg ← Maye qaz postu (LPG) / QDM (Propan-Butan)
fuel:electricity ← Elektromobillərin doldurma xidməti (EV charging as a service — same pattern as ace_parking_us/avia_eu/bp)
atm ← Bankomat
car_wash ← Avtoyuma

Other listed services (Market/Avtomarket, Motel/Otel, Kafe, car repair/lube, payment terminals, loyalty cards) are not mapped — they'd require top-level shop=/tourism= tags that break NSI matching, or have no standard OSM fuel-station tag.

NSI: matches azpetrol-0dbc25 (amenity=fuel, az) — 111/111 match_perfect.
Full stats
```{
  "item_scraped_count": 111,
  "atp/brand/Azpetrol": 111,
  "atp/brand_wikidata/Q4034661": 111,
  "atp/category/amenity/fuel": 111,
  "atp/country/AZ": 111,
  "atp/field/country/from_spider_name": 111,
  "atp/nsi/match_perfect": 111
}
```
Attribute counts: fuel:electricity 51, car_wash 66, atm 47, fuel:lpg 6, fuel:cng 5. (phone/invalid 4 — malformed source numbers.)

Sample POIs
```[
  {
    "type": "Feature",
    "properties": {
      "ref": "373", "amenity": "fuel", "name": "Azpetrol", "branch": "Babək",
      "atm": "yes", "fuel:cng": "yes", "fuel:electricity": "yes",
      "phone": "+994 12 480 50 18",
      "addr:full": "Bakı şəhəri, Nizami rayonu, Babək prospekti, ev 2276-77, AZ 1142", "addr:country": "AZ",
      "brand": "Azpetrol", "brand:wikidata": "Q4034661", "nsi_id": "azpetrol-0dbc25"
    },
    "geometry": { "type": "Point", "coordinates": [49.90804, 40.39118] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "424", "amenity": "fuel", "name": "Azpetrol", "branch": "Babək 2",
      "fuel:lpg": "yes", "phone": "+994 12 480 50 16",
      "addr:full": "Bakı şəhəri, Nizami rayonu, Babək prospekti, ev 2276-77, AZ 1142", "addr:country": "AZ",
      "brand": "Azpetrol", "brand:wikidata": "Q4034661", "nsi_id": "azpetrol-0dbc25"
    },
    "geometry": { "type": "Point", "coordinates": [49.90792, 40.39114] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "277", "amenity": "fuel", "name": "Azpetrol", "branch": "Spartak",
      "atm": "yes", "car_wash": "yes", "fuel:electricity": "yes",
      "phone": "+994 12 436 95 37",
      "addr:full": "Bakı şəhəri, Nəsimi rayonu, Moskva prospekti, ev 1013-cü məhəllə, AZ 1102", "addr:country": "AZ",
      "brand": "Azpetrol", "brand:wikidata": "Q4034661", "nsi_id": "azpetrol-0dbc25"
    },
    "geometry": { "type": "Point", "coordinates": [49.82626, 40.38916] }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for Azpetrol fuel stations in Azerbaijan.
  * Station listings now include names, locations, identifiers, available services, fuel availability, and fuel-station categorization.
  * Handles unavailable station data gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->