### PR TITLE
[Gulf GE] Add spider

### DIFF
--- a/locations/spiders/gulf_ge.py
+++ b/locations/spiders/gulf_ge.py
@@ -1,0 +1,40 @@
+import json
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class GulfGESpider(Spider):
+    name = "gulf_ge"
+    item_attributes = {"brand": "გალფი", "brand_wikidata": "Q5617505"}
+    start_urls = ["https://gulf.ge/ge/map"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Stations are embedded as a JS object keyed by id; the Google Maps script only renders them.
+        if not (pins := re.search(r"var pins\s*=\s*(\{.*?\});", response.text, re.DOTALL)):
+            self.logger.error("Gulf station data not found")
+            return
+        for pin in json.loads(pins.group(1)).values():
+            if "GAS" not in (pin.get("poi_types") or []):
+                continue  # a couple of non-fuel objects carry poi_types "OB"
+
+            item = DictParser.parse(pin)  # id->ref, name, latitude/longitude->lat/lon
+            item.pop("state", None)  # DictParser maps the "region" filter flag here; it is not an address region
+            item["branch"] = item.pop("name")
+            if address := re.search(r"\(([^()]+)\)\s*$", pin.get("description") or ""):  # "<name> (<address>)"
+                item["addr_full"] = address.group(1).strip()
+
+            fuels = pin.get("fuel_types") or []
+            apply_yes_no(Fuel.DIESEL, item, any(fuel in fuels for fuel in ("ED", "GFED", "DE")))
+            # Petrol grades (Euro Regular, G-Force Regular/Super/Premium) carry no octane numbers.
+            apply_yes_no(Fuel.GASOLINE, item, any(fuel in fuels for fuel in ("ER", "GFER", "GFS", "GFP")))
+            # In fuel_types, "CNG" is გაზი (gas); the "CNG" in poi_types is instead the "Gulf +" format.
+            apply_yes_no(Fuel.CNG, item, "CNG" in fuels)
+            apply_yes_no(Extras.FAST_FOOD, item, bool(pin.get("food_types")))
+            apply_category(Categories.FUEL_STATION, item)
+            yield item


### PR DESCRIPTION
Gulf (გალფი, Q5617505) fuel stations in Georgia, operated by Sun Petroleum Georgia. amenity=fuel.

Source: https://gulf.ge/ge/map (Georgian locale) embeds all stations as a var pins JS object (id, name, latitude/longitude, description, fuel_types, poi_types, food_types). The Google Maps script only renders the markers — the coordinates are the site's own embedded data. Parsed with DictParser; the region value (a region/tbilisi map-filter flag) is dropped rather than kept as addr:state.

Fields: branch = station label; addr:full from the description's trailing parenthetical (ქალაქი <city>, ქუჩა <street>, N <no> or რაიონი <district>, სოფელი <village> — free-form Georgian, not split); ref = source id.

Attributes mapped (via the apply_yes_no(Fuel.…/Extras.…) convention):

fuel:diesel — Euro Diesel / G-Force Diesel / Diesel Economy (ED/GFED/DE)
fuel:gasoline — the petrol grades Euro Regular + G-Force Regular/Super/Premium (ER/GFER/GFS/GFP). The source names the grades but gives no octane numbers, so they're mapped to generic fuel:gasoline (same as circle_k) rather than guessed fuel:octane_*.
fast_food — the food_types (coffee/hotdog/sandwich/ice-cream), per the rosneft_ru/axion_ar convention.

Not mapped: poi_types SHP (shop), SC (service center) and the Gulf + format have no fuel-station attribute tag in ATP (a station's convenience shop is emitted as a separate SHOP_CONVENIENCE POI by other spiders, never as a flag — and a top-level shop= would break NSI matching). The 2 OB (oil terminal) objects are filtered out.

NSI: Georgia has a dedicated entry gulf-7489db (brand=გალფი, operator=სან პეტროლიუმ ჯორჯია, {ge}); the global Gulf entry excludes ge. Result: 152/152 match_perfect, with brand, operator, and all name:*/brand:*/operator:* language variants applied automatically.

Full stats
```
{
  "item_scraped_count": 152,
  "atp/brand/გალფი": 152,
  "atp/brand_wikidata/Q5617505": 152,
  "atp/operator/სან პეტროლიუმ ჯორჯია": 152,
  "atp/category/amenity/fuel": 152,
  "atp/country/GE": 152,
  "atp/field/country/from_spider_name": 152,
  "atp/nsi/match_perfect": 152
}
```
Attribute counts: fuel:diesel 152, fuel:gasoline 152, fast_food 123.

Sample POIs
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "6781", "amenity": "fuel", "name": "გალფი", "branch": "ლია",
      "fuel:diesel": "yes", "fuel:gasoline": "yes", "fast_food": "yes",
      "operator": "სან პეტროლიუმ ჯორჯია",
      "addr:full": "რაიონი წალენჯიხა, სოფელი ლია", "addr:country": "GE",
      "brand": "გალფი", "brand:wikidata": "Q5617505", "nsi_id": "gulf-7489db"
    },
    "geometry": { "type": "Point", "coordinates": [42.0004614951647, 42.6509820952101] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "6849", "amenity": "fuel", "name": "გალფი", "branch": "ხონი",
      "fuel:diesel": "yes", "fuel:gasoline": "yes",
      "operator": "სან პეტროლიუმ ჯორჯია",
      "addr:full": "რაიონი ხონი, სოფელი კონტუათი", "addr:country": "GE",
      "brand": "გალფი", "brand:wikidata": "Q5617505", "nsi_id": "gulf-7489db"
    },
    "geometry": { "type": "Point", "coordinates": [42.4323892774043, 42.3474637743527] }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Gulf Georgia fuel stations.
  * Captures station details, addresses, available gasoline, diesel, CNG, and fast-food availability.
  * Classifies discovered locations as fuel stations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->