### PR TITLE
[MAX&Co.] Fix spider

### DIFF
--- a/locations/spiders/max_and_company.py
+++ b/locations/spiders/max_and_company.py
@@ -1,6 +1,7 @@
 import html
-import json
+import re
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours, sanitise_day
 from locations.playwright_spider import PlaywrightSpider
@@ -18,9 +19,11 @@ class MaxAndCompanySpider(PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response, **kwargs):
-        for location in json.loads(response.xpath("//pre//text()").get())["features"]:
+        for location in response.json()["features"]:
             item = DictParser.parse(location["properties"])
-            item["name"] = html.unescape(location["properties"]["displayName"])
+            item.pop("name", None)
+            branch = html.unescape(location["properties"]["displayName"])
+            item["branch"] = re.sub(r"^max\s*&\s*co\.?\s*", "", branch, flags=re.IGNORECASE) or None
             item["addr_full"] = location["properties"]["formattedAddress"]
             item["state"] = location["properties"]["prov"]
 
@@ -31,6 +34,7 @@ class MaxAndCompanySpider(PlaywrightSpider):
                         start_time, end_time = time.split(" - ")
                         if end_time == "24.00":
                             end_time = "23.59"
-                        item["opening_hours"].add_range(day, start_time, end_time, time_format="%H.%M %p")
+                        item["opening_hours"].add_range(day, start_time, end_time, time_format="%I.%M %p")
 
+            apply_category(Categories.SHOP_CLOTHES, item)
             yield item


### PR DESCRIPTION
`parse` unwraps the API response out of the browser's JSON viewer markup:

```python
for location in json.loads(response.xpath("//pre//text()").get())["features"]:
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

Three further corrections while here:

* Opening hours were read with a 24 hour format against 12 hour source times, so an evening closing time was taken as morning and the range was recorded as running overnight. Hours are now read as 12 hour times, correcting every afternoon closing time and raising coverage from 194 to 237 stores.
* The per-store name is now collected as `branch` with the brand stripped, leaving `name` to NSI.
* The category is set explicitly rather than left to be inferred.

A full live crawl returns all 302 stores with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location data accuracy by processing store information more reliably.
  - Standardized branch names for clearer location listings.
  - Correctly categorizes stores as clothing retailers.
  - Improved parsing of opening hours displayed in 12-hour format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->