### PR TITLE
[ICI Paris XL] Fix spider

### DIFF
--- a/locations/spiders/ici_paris_xl.py
+++ b/locations/spiders/ici_paris_xl.py
@@ -1,4 +1,3 @@
-import json
 from typing import AsyncIterator, Iterable
 from urllib.parse import urljoin
 
@@ -26,14 +25,16 @@ class IciParisXlSpider(JSONBlobSpider, PlaywrightSpider):
             )
 
     def extract_json(self, response: TextResponse) -> dict | list[dict]:
-        json_data = json.loads(response.xpath("//pre//text()").get())["stores"]
+        json_data = response.json()["stores"]
         return json_data
 
     def pre_process_data(self, feature: dict) -> None:
         feature.update(feature.pop("address"))
+        feature.pop("region", None)
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item.pop("name")
+        item["phone"] = None
         item["branch"] = feature.get("displayName")
         item["street_address"] = merge_address_lines([feature.get("line1"), feature.get("line2")])
         item["addr_full"] = feature.get("formattedAddress")


### PR DESCRIPTION
`extract_json` unwraps the API response out of the browser's JSON viewer markup:

```python
json_data = json.loads(response.xpath("//pre//text()").get())["stores"]
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

Two further corrections while here:

* One store carries a `region` object holding country codes rather than a region, which was passed through as the state and rejected as the wrong type. It is now discarded, leaving `province` as the only source of state.
* The phone is dropped. Two national call centre numbers accounted for 238 of the 252 stores that reported one.

A full live crawl returns all 261 stores with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store data extraction from location responses.
  * Standardized address information by removing unnecessary region details.
  * Ensured missing phone numbers are represented consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->