### PR TITLE
[Versace] Fix spider

### DIFF
--- a/locations/spiders/versace.py
+++ b/locations/spiders/versace.py
@@ -1,4 +1,3 @@
-import json
 import re
 from typing import Iterable
 
@@ -21,7 +20,7 @@ class VersaceSpider(JSONBlobSpider, CamoufoxSpider):
     custom_settings = DEFAULT_CAMOUFOX_SETTINGS
 
     def extract_json(self, response: TextResponse) -> list[dict]:
-        return json.loads(response.xpath("//pre/text()").get())["stores"]
+        return response.json()["stores"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = (


### PR DESCRIPTION
`extract_json` unwraps the store search response out of the browser's JSON viewer markup:

```python
return json.loads(response.xpath("//pre/text()").get())["stores"]
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

A full live crawl returns all 242 stores across 36 countries with complete geometry and no errors.