### PR TITLE
[Douglas PL] Fix spider

### DIFF
--- a/locations/spiders/douglas_pl.py
+++ b/locations/spiders/douglas_pl.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from scrapy.http import Response
@@ -20,7 +19,7 @@ class DouglasPLSpider(PlaywrightSpider):
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for data in json.loads(response.xpath("//pre//text()").get()).get("stores"):
+        for data in response.json().get("stores"):
             data.update(data.pop("address"))
             item = DictParser.parse(data)
             item["phone"] = None


### PR DESCRIPTION
`parse` unwraps the store API response out of the browser's JSON viewer markup:

```python
for data in json.loads(response.xpath("//pre//text()").get()).get("stores"):
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. As this is the spider's only request, the whole crawl yielded nothing.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

A full live crawl returns all 173 stores with complete geometry and no errors.