### PR TITLE
[Caseys General Store US] Fix spider

### DIFF
--- a/locations/spiders/caseys_general_store_us.py
+++ b/locations/spiders/caseys_general_store_us.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, AsyncIterator
 
 from scrapy.http import JsonRequest, TextResponse
@@ -79,7 +78,7 @@ class CaseysGeneralStoreUSSpider(PlaywrightSpider):
             yield JsonRequest(url=url, data=payload)
 
     def parse(self, response: TextResponse, **kwargs):
-        for location in json.loads(response.xpath("//pre//text()").get())["data"]["storesByCoordinate"]:
+        for location in response.json()["data"]["storesByCoordinate"]:
             location.update(location.pop("store"))
             item = DictParser.parse(location)
             item["ref"] = item.pop("name")


### PR DESCRIPTION
`parse` unwraps the GraphQL response out of the browser's JSON viewer markup:

```python
for location in json.loads(response.xpath("//pre//text()").get())["data"]["storesByCoordinate"]:
```

That raises `ValueError: Cannot use xpath on a Selector of type 'json'`, because the response arrives typed as JSON rather than as a `<pre>`-wrapped HTML document. The spider produced 0 features with 3,407 errors in the most recent run — one per request — against 3,803 in the one before.

It now calls `response.json()` directly and drops the `import json` that only served the unwrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location data parsing by reading API responses directly.
  * Resolved issues caused by relying on embedded response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->