### PR TITLE
[Bureau Vallée FR] Add spider

### DIFF
--- a/locations/spiders/bureau_vallee_fr.py
+++ b/locations/spiders/bureau_vallee_fr.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BureauValleeFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "bureau_vallee_fr"
+    item_attributes = {
+        "brand": "Bureau Vallée",
+        "brand_wikidata": "Q18385014",
+        "extras": Categories.SHOP_STATIONERY.value,
+    }
+    sitemap_urls = ["https://magasins.bureau-vallee.fr/sitemap_pois.xml"]
+    sitemap_rules = [(r"https://magasins\.bureau-vallee\.fr/fr/france-FR/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    wanted_types = ["LocalBusiness", "OfficeEquipmentStore"] 
+    drop_attributes = {"image", "twitter"}

--- a/locations/spiders/bureau_vallee_fr.py
+++ b/locations/spiders/bureau_vallee_fr.py
@@ -13,5 +13,5 @@ class BureauValleeFRSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://magasins.bureau-vallee.fr/sitemap_pois.xml"]
     sitemap_rules = [(r"https://magasins\.bureau-vallee\.fr/fr/france-FR/[^/]+/[^/]+/[^/]+$", "parse_sd")]
-    wanted_types = ["LocalBusiness", "OfficeEquipmentStore"] 
+    wanted_types = ["LocalBusiness", "OfficeEquipmentStore"]
     drop_attributes = {"image", "twitter"}


### PR DESCRIPTION
New spider for the french stationery retail chain in France.
Includes email, phone number, website and opening hours.

```
{'atp/brand/Bureau Vallée': 317,
 'atp/brand_wikidata/Q18385014': 317,
 'atp/category/shop/stationery': 317,
 'atp/country/FR': 317,
 'atp/field/branch/missing': 317,
 'atp/field/email/invalid': 2,
 'atp/field/housenumber/missing': 317,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 317,
 'atp/field/operator_wikidata/missing': 317,
 'atp/field/state/missing': 317,
 'atp/field/street/missing': 317,
 'atp/field/twitter/missing': 317,
 'atp/field/unit/missing': 317,
 'atp/item_scraped_host_count/magasins.bureau-vallee.fr': 317,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 317,
 'downloader/request_bytes': 177646,
 'downloader/request_count': 391,
 'downloader/request_method_count/GET': 391,
 'downloader/response_bytes': 15060217,
 'downloader/response_count': 391,
 'downloader/response_status_count/200': 319,
 'downloader/response_status_count/500': 72,
 'elapsed_time_seconds': 468.78743087500334,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 19, 14, 22, 3, 728446, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 100765485,
 'httpcompression/response_count': 391,
 'httperror/response_ignored_count': 13,
 'httperror/response_ignored_status_count/500': 13,
 'item_scraped_count': 317,
 'items_per_minute': 40.64102564102564,
 'log_count/DEBUG': 708,
 'log_count/ERROR': 13,
 'log_count/INFO': 23,
 'log_count/WARNING': 2,
 'memusage/max': 383500288,
 'memusage/startup': 180535296,
 'request_depth_max': 1,
 'response_received_count': 332,
 'responses_per_minute': 42.56410256410256,
 'retry/count': 59,
 'retry/max_reached': 13,
 'retry/reason_count/500 Internal Server Error': 59,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 390,
 'scheduler/dequeued/memory': 390,
 'scheduler/enqueued': 390,
 'scheduler/enqueued/memory': 390,
 'start_time': datetime.datetime(2026, 8, 19, 14, 14, 14, 934365, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Bureau Vallée France store locations.
  * Store listings now include relevant brand, stationery, and business-type information.
  * Improved processing of structured store details for more complete and consistent location listings.
  * Excluded unnecessary image and social media attributes from store information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->