### PR TITLE
[Wissol GE] Add spider 

### DIFF
--- a/locations/spiders/wissol_ge.py
+++ b/locations/spiders/wissol_ge.py
@@ -1,0 +1,41 @@
+import json
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class WissolGESpider(Spider):
+    name = "wissol_ge"
+    item_attributes = {"brand": "ვისოლი", "brand_wikidata": "Q8027737"}
+    start_urls = ["https://wissol.ge/ka/map"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # Stations are a GeoJSON FeatureCollection embedded in `const allLocations = JSON.parse('...')`.
+        if not (match := re.search(r"const allLocations = JSON\.parse\('(.+?)'\);", response.text, re.DOTALL)):
+            self.logger.error("Wissol station data not found")
+            return
+        for feature in json.loads(json.loads('"' + match.group(1).replace("\\'", "'") + '"')):
+            properties = feature["properties"]
+            services = [(service.get("name") or {}).get("en") for service in properties.get("services") or []]
+            # The map also lists non-fuel Wissol locations (Smart markets, Winto/Truck service centres, the
+            # head office); keep only markers that actually dispense fuel.
+            if not any(service in services for service in ("Standart", "Self Service", "CNG")):
+                continue
+
+            item = DictParser.parse(properties)  # id->ref, address->addr_full
+            item["ref"] = str(properties["id"])
+            item["geometry"] = feature["geometry"]
+            if properties.get("working_hours") == "24/7":  # every Wissol station is open round the clock
+                item["opening_hours"] = "24/7"
+
+            # "CNG" (natural gas) and "Power Charger" (EV) are explicit fuel products; the "Standart"/
+            # "Self Service" labels are only station formats, so no undifferentiated petrol/diesel tag.
+            apply_yes_no(Fuel.CNG, item, "CNG" in services)
+            apply_yes_no(Fuel.ELECTRIC, item, "Power Charger" in services)
+            apply_category(Categories.FUEL_STATION, item)
+            yield item


### PR DESCRIPTION
Description:

Wissol (ვისოლი, Q8027737) fuel stations in Georgia, operated by Wissol Petroleum Georgia. amenity=fuel.

Source: https://wissol.ge/ka/map embeds a GeoJSON FeatureCollection in const allLocations = JSON.parse('…'). The map mixes several Wissol-group location types (fuel stations, Smart convenience markets, Winto/Truck service centers, the head office, Smart-Pay kiosks); the spider keeps only markers that actually dispense fuel — those carrying a Standart, Self Service, or CNG service (the fuel-pump / natural-gas services in the site's own taxonomy). That drops the 81 non-fuel markers, leaving 148 stations.

Fields: DictParser (id→ref, address→addr:full, free-form Georgian); geometry from the feature; opening_hours=24/7 (all). No per-station name → NSI supplies name=ვისოლი. office/hotline are generic call-center numbers (3 shared across all) → omitted. fuel:cng ← CNG (14), fuel:electricity ← Power Charger (12). Petrol/diesel aren't distinguished per-station in the feed.

NSI: matches wissol-7489db (ვისოლი + operator ვისოლ პეტროლიუმ ჯორჯია, {ge}) — 148/148 match_perfect, brand/operator (+operator:wikidata) and all language variants applied automatically.

Full stats:
```
{
  "item_scraped_count": 148,
  "atp/brand/ვისოლი": 148,
  "atp/brand_wikidata/Q8027737": 148,
  "atp/operator/ვისოლ პეტროლიუმ ჯორჯია": 148,
  "atp/category/amenity/fuel": 148,
  "atp/country/GE": 148,
  "atp/field/country/from_spider_name": 148,
  "atp/nsi/match_perfect": 148
}
```
Attribute counts: fuel:cng 14, fuel:electricity 12.

Sample POIs:
```[
  {
    "type": "Feature",
    "properties": {
      "ref": "12", "amenity": "fuel", "name": "ვისოლი", "fuel:gasoline": "yes", "opening_hours": "24/7",
      "operator": "ვისოლ პეტროლიუმ ჯორჯია",
      "addr:full": "დავით აღმაშენებლის ხეივანი N145", "addr:country": "GE",
      "brand": "ვისოლი", "brand:wikidata": "Q8027737", "nsi_id": "wissol-7489db"
    },
    "geometry": { "type": "Point", "coordinates": [44.7709024, 41.7940579] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "172", "amenity": "fuel", "name": "ვისოლი", "fuel:cng": "yes", "opening_hours": "24/7",
      "operator": "ვისოლ პეტროლიუმ ჯორჯია",
      "addr:full": "ილია ვეკუას ქუჩა N 42", "addr:country": "GE",
      "brand": "ვისოლი", "brand:wikidata": "Q8027737", "nsi_id": "wissol-7489db"
    },
    "geometry": { "type": "Point", "coordinates": [44.8263011, 41.8014632] }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added support for collecting Wissol Georgia fuel station locations.
- Captures station details, addresses, coordinates, opening hours, available fuel types, and services.
- Filters out non-fuel locations to provide more relevant station results.
- Handles unavailable or incomplete station data gracefully.
- Includes station categories to improve the organization of fuel and service information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->