### PR TITLE
[Tesla] Limit spider to dealer locations only

### DIFF
--- a/locations/spiders/tesla.py
+++ b/locations/spiders/tesla.py
@@ -19,6 +19,14 @@ class TeslaSpider(Spider):
     requires_proxy = True
     custom_settings = {"DOWNLOAD_TIMEOUT": 60, "USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
 
+    DEALER_CATEGORIES = {"sales", "service", "bodyshop", "gallery"}
+    CHARGER_CATEGORIES = {"supercharger", "nacs", "party"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.expected_dealers: set[str] = set()
+        self.scraped_dealers: set[str] = set()
+
     async def start(self) -> AsyncIterator[Request]:
         yield Request(
             "https://www.tesla.com/api/findus/get-locations?country=US&view=map",
@@ -29,12 +37,17 @@ class TeslaSpider(Spider):
         json_data = self.extract_json(response)
         locations = self.select_locations(json_data["data"]["data"])
         for slug, types in locations.items():
-            yield Request(
-                url=f"https://www.tesla.com/api/findus/get-location-details?locationSlug={slug}&functionTypes={','.join(types)}&locale=en_US&isInHkMoTw=false",
-                callback=self.parse_location,
-            )
+            # Scraping only dealers and chargers within dealers,
+            # since the spider gets blocked after attempting to scrape every charger.
+            if bool(self.DEALER_CATEGORIES.intersection(types)):
+                self.expected_dealers.add(slug)
+                yield Request(
+                    url=f"https://www.tesla.com/api/findus/get-location-details?locationSlug={slug}&functionTypes={','.join(types)}&locale=en_US&isInHkMoTw=false",
+                    callback=self.parse_location,
+                    cb_kwargs={"slug": slug},
+                )
 
-    def parse_location(self, response: Response) -> Iterable[Feature]:
+    def parse_location(self, response: Response, slug: str) -> Iterable[Feature]:
         location = self.extract_json(response)
         data = location.get("data", {})
         if data.get("sales_function"):
@@ -43,6 +56,8 @@ class TeslaSpider(Spider):
             yield self.build_service(data)
         if data.get("supercharger_function"):
             yield self.build_supercharger(data)
+        if data.get("sales_function") or data.get("service_function"):
+            self.scraped_dealers.add(slug)
 
     def extract_json(self, response: Response) -> dict | list[dict]:
         # For some reason, the scrapy_zyte_api library doesn't detect this as a ScrapyTextResponse, so we have to do the text encoding ourselves.
@@ -147,7 +162,7 @@ class TeslaSpider(Spider):
     # Selection only those in categories list
     # Merge same slugs into one entry, combining types
     def select_locations(self, locations: list[dict]) -> dict[str, list[str]]:
-        categories = {"sales", "service", "bodyshop", "gallery", "supercharger", "nacs", "party"}
+        categories = self.DEALER_CATEGORIES | self.CHARGER_CATEGORIES
         slug_mapping: dict[str, list[str]] = {}
         for loc in locations:
             if not isinstance(loc, dict):
@@ -161,3 +176,18 @@ class TeslaSpider(Spider):
                 if category not in existing:
                     existing.append(category)
         return slug_mapping
+
+    def closed(self, reason: str) -> None:
+        expected, scraped = len(self.expected_dealers), len(self.scraped_dealers)
+        missing = sorted(self.expected_dealers - self.scraped_dealers)
+        stats = self.crawler.stats
+        stats.set_value(f"atp/{self.name}/dealers_expected", expected)
+        stats.set_value(f"atp/{self.name}/dealers_scraped", scraped)
+        stats.set_value(f"atp/{self.name}/dealers_missing", len(missing))
+        if missing:
+            self.logger.warning(
+                f"Dealer coverage incomplete ({reason}): {scraped}/{expected} scraped, "
+                f"{len(missing)} missing, first 20: {', '.join(missing[:20])}"
+            )
+        else:
+            self.logger.info(f"Dealer coverage complete: {expected}/{expected} scraped")

--- a/locations/spiders/tesla.py
+++ b/locations/spiders/tesla.py
@@ -26,6 +26,7 @@ class TeslaSpider(Spider):
         super().__init__(*args, **kwargs)
         self.expected_dealers: set[str] = set()
         self.scraped_dealers: set[str] = set()
+        self.location_discovery_succeeded: bool = False
 
     async def start(self) -> AsyncIterator[Request]:
         yield Request(
@@ -36,6 +37,8 @@ class TeslaSpider(Spider):
     def parse_json_subrequest(self, response: Response) -> Iterable[Request]:
         json_data = self.extract_json(response)
         locations = self.select_locations(json_data["data"]["data"])
+        if locations:
+            self.location_discovery_succeeded = True
         for slug, types in locations.items():
             # Scraping only dealers and chargers within dealers,
             # since the spider gets blocked after attempting to scrape every charger.
@@ -184,7 +187,9 @@ class TeslaSpider(Spider):
         stats.set_value(f"atp/{self.name}/dealers_expected", expected)
         stats.set_value(f"atp/{self.name}/dealers_scraped", scraped)
         stats.set_value(f"atp/{self.name}/dealers_missing", len(missing))
-        if missing:
+        if not self.location_discovery_succeeded:
+            self.logger.error("Dealer coverage unavailable: location discovery failed")
+        elif missing:
             self.logger.warning(
                 f"Dealer coverage incomplete ({reason}): {scraped}/{expected} scraped, "
                 f"{len(missing)} missing, first 20: {', '.join(missing[:20])}"


### PR DESCRIPTION
Only scraping dealers and the chargers associated with dealers, since the spider gets blocked when attempting to scrape every charger. In this case, we can retrieve all car / car_repair POIs consistently.
```
{
 "atp/brand/Tesla": 2475,
 "atp/brand/Tesla Supercharger": 140,
 "atp/brand_wikidata/Q17089620": 140,
 "atp/brand_wikidata/Q478214": 2475,
 "atp/category/amenity/charging_station": 140,
 "atp/category/shop/car": 1411,
 "atp/category/shop/car_repair": 1064,
 "atp/clean_strings/city": 12,
 "atp/clean_strings/email": 1,
 "atp/clean_strings/name": 34,
 "atp/clean_strings/phone": 57,
 "atp/clean_strings/postcode": 18,
 "atp/clean_strings/state": 5,
 "atp/clean_strings/website": 17,
 "atp/country/AE": 7,
 "atp/country/AT": 17,
 "atp/country/AU": 52,
 "atp/country/BE": 15,
 "atp/country/CA": 73,
 "atp/country/CH": 25,
 "atp/country/CL": 5,
 "atp/country/CN": 1045,
 "atp/country/CO": 4,
 "atp/country/CZ": 5,
 "atp/country/DE": 79,
 "atp/country/DK": 18,
 "atp/country/EE": 1,
 "atp/country/ES": 33,
 "atp/country/FI": 9,
 "atp/country/FR": 62,
 "atp/country/GB": 93,
 "atp/country/GR": 5,
 "atp/country/HK": 11,
 "atp/country/HR": 3,
 "atp/country/HU": 3,
 "atp/country/IE": 8,
 "atp/country/IL": 8,
 "atp/country/IN": 9,
 "atp/country/IS": 3,
 "atp/country/IT": 24,
 "atp/country/JO": 1,
 "atp/country/JP": 88,
 "atp/country/KR": 32,
 "atp/country/LT": 2,
 "atp/country/LU": 2,
 "atp/country/MA": 1,
 "atp/country/MO": 3,
 "atp/country/MX": 12,
 "atp/country/MY": 12,
 "atp/country/NL": 27,
 "atp/country/NO": 52,
 "atp/country/NZ": 11,
 "atp/country/PH": 2,
 "atp/country/PL": 10,
 "atp/country/PR": 2,
 "atp/country/PT": 7,
 "atp/country/QA": 2,
 "atp/country/RO": 6,
 "atp/country/SA": 5,
 "atp/country/SE": 19,
 "atp/country/SG": 6,
 "atp/country/SI": 2,
 "atp/country/SK": 2,
 "atp/country/TH": 11,
 "atp/country/TR": 11,
 "atp/country/TW": 25,
 "atp/country/US": 644,
 "atp/country/UY": 1,
 "atp/field/branch/missing": 2615,
 "atp/field/city/missing": 48,
 "atp/field/email/missing": 1973,
 "atp/field/housenumber/missing": 2615,
 "atp/field/name/missing": 1,
 "atp/field/opening_hours/missing": 224,
 "atp/field/operator/missing": 2475,
 "atp/field/operator_wikidata/missing": 2475,
 "atp/field/phone/invalid": 11,
 "atp/field/phone/missing": 304,
 "atp/field/postcode/missing": 54,
 "atp/field/state/missing": 206,
 "atp/field/street/missing": 2615,
 "atp/field/street_address/missing": 1,
 "atp/field/twitter/missing": 2615,
 "atp/field/unit/missing": 2615,
 "atp/item_scraped_host_count/www.tesla.com": 2615,
 "atp/lineage": "S_?",
 "atp/nsi/match_perfect": 2615,
 "atp/operator/Tesla": 140,
 "atp/operator_wikidata/Q478214": 140,
 "atp/tesla/dealers_expected": 1788,
 "atp/tesla/dealers_missing": 2,
 "atp/tesla/dealers_scraped": 1786,
 "downloader/exception_count": 2,
 "downloader/exception_type_count/zyte_api._errors.RequestError": 2,
 "downloader/request_bytes": 789966,
 "downloader/request_count": 1789,
 "downloader/request_method_count/GET": 1789,
 "downloader/response_bytes": 20700496,
 "downloader/response_count": 1787,
 "downloader/response_status_count/200": 1787,
 "elapsed_time_seconds": 124.21800000000076,
 "finish_reason": "finished",
 "finish_time": "2026-08-19T19:56:52.640730+00:00",
 "httpcache/hit": 1787,
 "httpcache/miss": 2,
 "item_scraped_count": 2615,
 "items_per_minute": 1265.3225806451612,
 "log_count/ERROR": 2,
 "log_count/INFO": 5,
 "log_count/WARNING": 4,
 "request_depth_max": 1,
 "response_received_count": 1787,
 "responses_per_minute": 864.6774193548387,
 "scheduler/dequeued": 1789,
 "scheduler/dequeued/memory": 1789,
 "scheduler/enqueued": 1789,
 "scheduler/enqueued/memory": 1789,
 "scrapy-zyte-api/429": 0,
 "scrapy-zyte-api/attempts": 8,
 "scrapy-zyte-api/error_ratio": 1.0,
 "scrapy-zyte-api/error_types/download/website-ban": 8,
 "scrapy-zyte-api/errors": 8,
 "scrapy-zyte-api/fatal_errors": 2,
 "scrapy-zyte-api/mean_connection_seconds": 21.182367250000425,
 "scrapy-zyte-api/mean_response_seconds": 0.0,
 "scrapy-zyte-api/processed": 2,
 "scrapy-zyte-api/request_args/customHttpRequestHeaders": 2,
 "scrapy-zyte-api/request_args/httpResponseBody": 2,
 "scrapy-zyte-api/request_args/httpResponseHeaders": 2,
 "scrapy-zyte-api/request_args/url": 2,
 "scrapy-zyte-api/status_codes/520": 8,
 "scrapy-zyte-api/success": 0,
 "scrapy-zyte-api/success_ratio": 0.0,
 "scrapy-zyte-api/throttle_ratio": 0.0,
 "start_time": "2026-08-19T19:54:48.420607+00:00"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Tesla dealer location data collection for greater accuracy and completeness.
  - Reduced unrelated location results by distinguishing dealer and charger locations more reliably.
  - Added coverage tracking to identify dealer locations that may be missing from collected results.
- **Improvements**
  - Enhanced handling of dealer sales and service information during location updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->