### PR TITLE
[Netto Les Mousquetaires] Fix Spider

### DIFF
--- a/locations/spiders/netto_fr.py
+++ b/locations/spiders/netto_fr.py
@@ -1,7 +1,7 @@
 from locations.storefinders.uberall import UberallSpider
 
 
-class NettoLesMousquetairesSpider(UberallSpider):
-    name = "netto_les_mousquetaires"
+class NettoFRSpider(UberallSpider):
+    name = "netto_fr"
     item_attributes = {"brand": "Netto", "brand_wikidata": "Q2720988"}
     key = "OWc3zgl9ql555j9wvYm0ecrD94vaeK"

--- a/locations/spiders/netto_les_mousquetaires.py
+++ b/locations/spiders/netto_les_mousquetaires.py
@@ -1,11 +1,7 @@
-from scrapy.spiders import SitemapSpider
-
-from locations.structured_data_spider import StructuredDataSpider
+from locations.storefinders.uberall import UberallSpider
 
 
-class NettoLesMousquetairesSpider(SitemapSpider, StructuredDataSpider):
+class NettoLesMousquetairesSpider(UberallSpider):
     name = "netto_les_mousquetaires"
     item_attributes = {"brand": "Netto", "brand_wikidata": "Q2720988"}
-    sitemap_urls = ["https://magasin.netto.fr/sitemap.xml"]
-    sitemap_follow = ["locationsitemap"]
-    sitemap_rules = [("", "parse_sd")]
+    key = "OWc3zgl9ql555j9wvYm0ecrD94vaeK"


### PR DESCRIPTION
```python
{'atp/brand/Netto': 401,
 'atp/brand_wikidata/Q2720988': 401,
 'atp/category/shop/supermarket': 401,
 'atp/country/FR': 401,
 'atp/field/branch/missing': 401,
 'atp/field/email/missing': 401,
 'atp/field/housenumber/missing': 401,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 401,
 'atp/field/operator_wikidata/missing': 401,
 'atp/field/street/missing': 401,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 401,
 'atp/field/unit/missing': 401,
 'atp/item_scraped_host_count/uberall.com': 401,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 401,
 'atp/nsi/match_imperfect': 401,
 'downloader/request_bytes': 724,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 53473,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 6.60899999999674,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 20, 6, 33, 52, 990065, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 388886,
 'httpcompression/response_count': 2,
 'item_scraped_count': 401,
 'items_per_minute': 4010.0,
 'log_count/DEBUG': 403,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 20.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 20, 6, 33, 46, 378345, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location data support for Netto France stores.
* **Refactor**
  * Updated the Netto Les Mousquetaires location integration to use the Uberall data source.
  * Replaced the previous sitemap-based location collection and parsing approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->