### PR TITLE
[Neuroth] Fix Spider

### DIFF
--- a/locations/spiders/neuroth.py
+++ b/locations/spiders/neuroth.py
@@ -1,37 +1,19 @@
-from typing import Any, AsyncIterator
+from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest, Response
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
 
-from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class NeurothSpider(Spider):
+class NeurothSpider(SitemapSpider, StructuredDataSpider):
     name = "neuroth"
     item_attributes = {"brand": "Neuroth", "brand_wikidata": "Q15836645"}
+    sitemap_urls = ["https://www.neuroth.com/robots.txt"]
+    sitemap_rules = [(r".+/filialen|lokacije|poslovnice|/[^/]+/$", "parse_sd")]
+    time_format = "%H:%M:%S"
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        for country in ["at", "ba", "ch", "de", "hr", "si", "rs"]:
-            yield JsonRequest("https://{}.neuroth.com/wp-json/neuroth/v1/appointments/stores".format(country))
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json():
-            item = Feature()
-            item["ref"] = location["code"]
-            item["website"] = location["permalink"]
-            item["addr_full"] = location["contact"]["formattedAddress"]
-            item["street_address"] = location["contact"]["address"]
-            item["postcode"] = location["contact"]["zip"]
-            item["city"] = location["contact"]["city"]
-            item["country"] = location["contact"]["country"]
-            item["phone"] = location["contact"]["phone"]
-            item["email"] = location["contact"]["email"]
-            item["extras"]["fax"] = location["contact"]["fax"]
-            item["lat"] = location["coordinates"]["latitude"]
-            item["lon"] = location["coordinates"]["longitude"]
-            item["opening_hours"] = OpeningHours()
-            for rule in location["openingHours"]["openingHoursEntries"]:
-                item["opening_hours"].add_range(DAYS[rule["weekday"] - 1], rule["opens"], rule["closes"], "%H:%M:%S")
-
-            yield item
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item.pop("name")
+        yield item

--- a/locations/spiders/neuroth.py
+++ b/locations/spiders/neuroth.py
@@ -13,6 +13,7 @@ class NeurothSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.neuroth.com/robots.txt"]
     sitemap_rules = [(r".+/filialen|lokacije|poslovnice|/[^/]+/$", "parse_sd")]
     time_format = "%H:%M:%S"
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item.pop("name")


### PR DESCRIPTION
```python
{'atp/brand/Neuroth': 382,
 'atp/brand_wikidata/Q15836645': 382,
 'atp/category/shop/hearing_aids': 382,
 'atp/cdn/cloudflare/response_count': 1090,
 'atp/cdn/cloudflare/response_status_count/200': 1086,
 'atp/cdn/cloudflare/response_status_count/307': 1,
 'atp/cdn/cloudflare/response_status_count/308': 1,
 'atp/cdn/cloudflare/response_status_count/403': 2,
 'atp/country/AT': 140,
 'atp/country/BA': 12,
 'atp/country/CH': 168,
 'atp/country/HR': 16,
 'atp/country/LI': 2,
 'atp/country/RS': 24,
 'atp/country/SI': 20,
 'atp/field/branch/missing': 382,
 'atp/field/email/missing': 2,
 'atp/field/housenumber/missing': 382,
 'atp/field/operator/missing': 382,
 'atp/field/operator_wikidata/missing': 382,
 'atp/field/state/missing': 72,
 'atp/field/street/missing': 382,
 'atp/field/twitter/missing': 382,
 'atp/field/unit/missing': 382,
 'atp/item_scraped_host_count/www.neuroth.com': 382,
 'atp/lineage': 'S_?',
 'atp/nsi/category_missing': 382,
 'atp/nsi/match_imperfect': 382,
 'downloader/request_bytes': 502472,
 'downloader/request_count': 1097,
 'downloader/request_method_count/GET': 1097,
 'downloader/response_bytes': 20405516,
 'downloader/response_count': 1097,
 'downloader/response_status_count/200': 1086,
 'downloader/response_status_count/307': 5,
 'downloader/response_status_count/308': 4,
 'downloader/response_status_count/403': 2,
 'dupefilter/filtered': 7,
 'elapsed_time_seconds': 1353.469000000001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 20, 7, 24, 4, 541233, tzinfo=datetime.timezone.utc),
 'httpcompression/response_count': 1088,
 'httperror/response_ignored_count': 4,
 'httperror/response_ignored_status_count/307': 1,
 'httperror/response_ignored_status_count/308': 1,
 'httperror/response_ignored_status_count/403': 2,
 'item_scraped_count': 382,
 'items_per_minute': 16.940133037694014,
 'log_count/DEBUG': 1488,
 'log_count/INFO': 30,
 'request_depth_max': 2,
 'response_received_count': 1090,
 'responses_per_minute': 48.3370288248337,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1096,
 'scheduler/dequeued/memory': 1096,
 'scheduler/enqueued': 1096,
 'scheduler/enqueued/memory': 1096,
 'start_time': datetime.datetime(2026, 8, 20, 7, 1, 30, 994129, tzinfo=datetime.timezone.utc)}
 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Neuroth location discovery to use site maps and structured page information.
  * Improved extraction of location details and opening hours directly from location pages.

* **Bug Fixes**
  * Removed reliance on country-specific appointment service responses.
  * Improved consistency and reliability of available Neuroth location information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->