### PR TITLE
[Citya] Add spider (291 locations)

### DIFF
--- a/locations/spiders/citya.py
+++ b/locations/spiders/citya.py
@@ -13,10 +13,7 @@ class CityaSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.citya.com/sitemap.agences.xml"]
     sitemap_rules = [(r"/agences-immobilieres/.*/[0-9]*$", "parse_sd")]
 
-
-
     drop_attributes = {"image", "twitter", "facebook"}
-    # wanted_types = ["GroceryStore"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
 
@@ -24,5 +21,4 @@ class CityaSpider(SitemapSpider, StructuredDataSpider):
             item.pop("email", None)
         
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
-
         yield item

--- a/locations/spiders/citya.py
+++ b/locations/spiders/citya.py
@@ -12,7 +12,7 @@ class CityaSpider(SitemapSpider, StructuredDataSpider):
     }
     sitemap_urls = ["https://www.citya.com/sitemap.agences.xml"]
     sitemap_rules = [(r"/agences-immobilieres/.*/[0-9]*$", "parse_sd")]
-
+    wanted_types = ["RealEstateAgent"]
     drop_attributes = {"image", "twitter", "facebook"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):

--- a/locations/spiders/citya.py
+++ b/locations/spiders/citya.py
@@ -17,7 +17,7 @@ class CityaSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item, response, ld_data, **kwargs):
 
-        if item["email"] in ["qualite@citya.com", "rgpd@citya.com"]:
+        if item.get("email") in ["qualite@citya.com", "rgpd@citya.com"]:
             item.pop("email", None)
 
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)

--- a/locations/spiders/citya.py
+++ b/locations/spiders/citya.py
@@ -1,0 +1,28 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class CityaSpider(SitemapSpider, StructuredDataSpider):
+    name = "citya"
+    item_attributes = {
+        "brand": "Citya",
+        "brand_wikidata": "Q2974597",
+    }
+    sitemap_urls = ["https://www.citya.com/sitemap.agences.xml"]
+    sitemap_rules = [(r"/agences-immobilieres/.*/[0-9]*$", "parse_sd")]
+
+
+
+    drop_attributes = {"image", "twitter", "facebook"}
+    # wanted_types = ["GroceryStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+
+        if item["email"] in ["qualite@citya.com", "rgpd@citya.com"]:
+            item.pop("email", None)
+        
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+
+        yield item

--- a/locations/spiders/citya.py
+++ b/locations/spiders/citya.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class CityaSpider(SitemapSpider, StructuredDataSpider):
@@ -19,6 +19,6 @@ class CityaSpider(SitemapSpider, StructuredDataSpider):
 
         if item["email"] in ["qualite@citya.com", "rgpd@citya.com"]:
             item.pop("email", None)
-        
+
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item


### PR DESCRIPTION
Adding the Citya (Q2974597) real estate agencies.
Source: https://www.citya.com
Resolves #17920 

Some agencies do not have an email address.

The output of the spider:
```
'atp/brand/Citya': 291,
'atp/brand_wikidata/Q2974597': 291,
'atp/category/office/estate_agent': 291,
'atp/country/BE': 3,
'atp/country/FR': 285,
'atp/country/MU': 3,
'atp/duplicate_count': 291,
'atp/field/branch/missing': 291,
'atp/field/email/missing': 73,
'atp/field/housenumber/missing': 291,
'atp/field/opening_hours/missing': 10,
'atp/field/operator/missing': 291,
'atp/field/operator_wikidata/missing': 291,
'atp/field/phone/invalid': 6,
'atp/field/state/missing': 291,
'atp/field/street/missing': 291,
'atp/field/twitter/missing': 291,
'atp/field/unit/missing': 291,
'atp/item_scraped_host_count/www.citya.com': 582,
```

Sample POIs:
```
    {
        "extras": {
            "office": "estate_agent",
            "@source_uri": "https://www.citya.com/agences-immobilieres/chateau-thierry-02400/615",
            "@spider": "citya"
        },
        "name": "Citya Native Ch\u00e2teau-Thierry",
        "street_address": "19 Grande Rue",
        "city": "Ch\u00e2teau-Thierry",
        "state": null,
        "postcode": "02400",
        "country": "FR",
        "phone": "+33 3 23 83 02 60",
        "email": "nbillion@citya.com",
        "website": "https://www.citya.com/agences-immobilieres/chateau-thierry-02400/615",
        "opening_hours": "Mo-Sa 09:00-12:00,14:00-18:00",
        "ref": "https://www.citya.com/agences-immobilieres/chateau-thierry-02400/615",
        "brand": "Citya",
        "brand_wikidata": "Q2974597",
        "geometry": {
            "type": "Point",
            "coordinates": [
                3.401432,
                49.045363
            ]
        }
    },
    {
        "extras": {
            "office": "estate_agent",
            "@source_uri": "https://www.citya.com/agences-immobilieres/istres-13047/284",
            "@spider": "citya"
        },
        "name": "Citya Les Carmes",
        "street_address": "4 boulevard Jean-Marie l'Huillier",
        "city": "Istres",
        "state": null,
        "postcode": "13807",
        "country": "FR",
        "phone": "+33 4 42 55 03 54",
        "email": "jfriviere@citya.com",
        "website": "https://www.citya.com/agences-immobilieres/istres-13047/284",
        "opening_hours": "Mo-Fr 09:00-12:00,14:00-18:00; Sa 09:00-12:00",
        "ref": "https://www.citya.com/agences-immobilieres/istres-13047/284",
        "brand": "Citya",
        "brand_wikidata": "Q2974597",
        "geometry": {
            "type": "Point",
            "coordinates": [
                4.985662,
                43.513465
            ]
        }
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Citya real estate agency listings from agency pages.
  * Listings are categorized automatically as real estate offices.
  * Structured agency information is collected while unnecessary social and image fields are excluded.
  * Generic contact addresses are filtered from collected listings.

* **Bug Fixes**
  * Improved reliability when agency listings do not include an email address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->