### PR TITLE
[7-Eleven] Fix spider

### DIFF
--- a/locations/spiders/seven_eleven_ca_us.py
+++ b/locations/spiders/seven_eleven_ca_us.py
@@ -1,11 +1,13 @@
-import re
-from typing import Any
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
+from locations.geo import point_locations
+from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
 from locations.spiders.speedway_us import SpeedwayUSSpider
 
@@ -24,35 +26,43 @@ FUEL_TYPES_MAPPING = {
 STRIPES = {"brand": "Stripes", "brand_wikidata": "Q7624135"}
 
 
-# SitemapSpider no longer works properly for US, getting identified as a bot and served with a page without data
 class SevenElevenCAUSSpider(Spider):
     name = "seven_eleven_ca_us"
-    start_urls = [
-        "https://www.7-eleven.com/locations/tx/frisco/11065-fm-720-33117"  # Get access token from any store page
-    ]
-    api = "https://api.7-eleven.com/v4/stores"
-    token = ""
-    offset = 0
-    page_size = 500
+    api = "https://www.7-eleven.com/api/v5/stores/search"
+    search_radius = 100
+    max_results = 1000
+    searchable_points_files = ["us_centroids_100mile_radius_state.csv", "ca_centroids_100mile_radius.csv"]
 
-    def next_request(self) -> JsonRequest:
-        return JsonRequest(
-            url=f"{self.api}?offset={self.offset}&limit={self.page_size}",
-            headers={"Authorization": f"Bearer {self.token}"},
-            callback=self.parse_stores,
-        )
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.seen_ids: set[int] = set()
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:  # parse token
-        self.token = re.search(r"access_token\\\":\\\"(.+?)\\\"", response.text).group(1)
-        yield self.next_request()
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for lat, lon in point_locations(self.searchable_points_files):
+            yield JsonRequest(
+                url=self.api,
+                data={"token": "", "lat": lat, "lon": lon, "radius": self.search_radius, "limit": self.max_results},
+                callback=self.parse_stores,
+            )
 
-    def parse_stores(self, response: Response, **kwargs: Any):
+    def parse_stores(self, response: Response, **kwargs: Any) -> Any:
         for location in response.json()["results"]:
+            if location["id"] in self.seen_ids:
+                continue
+            self.seen_ids.add(location["id"])
+
             item = DictParser.parse(location)
             item["name"] = None
             item["street_address"] = item.pop("addr_full")
             item["website"] = location.get("seo_web_url")
-            item["extras"]["ref:google:place_id"] = location.get("google_place_id")
+
+            hours = location.get("hours") or {}
+            if hours.get("message") == "Open 24/7":
+                item["opening_hours"] = "24/7"
+            elif rules := hours.get("operating"):
+                item["opening_hours"] = OpeningHours()
+                for rule in rules:
+                    item["opening_hours"].add_ranges_from_string("{} {}".format(rule["key"], rule["detail"]))
 
             apply_yes_no(Extras.ATM, item, "ATM" in location.get("features_display", []))
             apply_yes_no(Extras.CAR_WASH, item, "Car Wash" in location.get("features_display", []))
@@ -61,11 +71,11 @@ class SevenElevenCAUSSpider(Spider):
             brand = location.get("brand_info") or {}
             shop = item.deepcopy()
             shop["ref"] = "{}_SHOP".format(shop["ref"])
-            if brand.get("title") == "Stripes":
+            if brand.get("title") == "stripes":
                 shop.update(STRIPES)
-            elif brand.get("title") == "7-Eleven":
+            elif brand.get("title") == "7-eleven":
                 shop.update(SEVEN_ELEVEN_SHARED_ATTRIBUTES)
-            elif location.get("name") == "Speedway Store":
+            elif brand.get("title") == "speedway" or location.get("name") == "Speedway Store":
                 shop.update(SpeedwayUSSpider.item_attributes)
             else:
                 shop.update(SEVEN_ELEVEN_SHARED_ATTRIBUTES)
@@ -75,35 +85,19 @@ class SevenElevenCAUSSpider(Spider):
             yield shop
 
             if "Fuel" in location.get("features_display", []):
-                if location["fuel_brand"] == 1:
-                    item.update(SEVEN_ELEVEN_SHARED_ATTRIBUTES)
-                elif location["fuel_brand"] == 10002:
-                    pass  # Conoco/Phillips 66/76
-                elif location["fuel_brand"] == 10035:
-                    item.update(SpeedwayUSSpider.item_attributes)
-                elif location["fuel_brand"] == 10068:
-                    pass  # Mainly Exxon but some Mobil
-                else:
-                    pass  # Mainly Sunoco
-
                 apply_category(Categories.FUEL_STATION, item)
                 self.parse_fuel_types(item, location)
 
                 yield item
 
-        if len(response.json()["results"]) == self.page_size:
-            self.offset += self.page_size
-            yield self.next_request()
-
-    def parse_fuel_types(self, item, store):
+    def parse_fuel_types(self, item: Feature, store: dict) -> None:
         apply_yes_no(Fuel.DIESEL, item, "Diesel" in store.get("features_display", []))
         apply_yes_no(Fuel.PROPANE, item, "Propane" in store.get("features_display", []))
-        if fuel_data := store.get("fuel_data", {}):
+        if fuel_data := store.get("fuel_data") or {}:
             if grades := fuel_data.get("grades", []):
                 for grade in grades:
                     fuel_name = grade.get("name")
                     if tag := FUEL_TYPES_MAPPING.get(fuel_name):
                         apply_yes_no(tag, item, True)
                     else:
-                        # self.logger.warning(f"Unknown fuel type: {fuel_name}")
                         self.crawler.stats.inc_value(f"atp/7_11/fuel/failed/{fuel_name}")


### PR DESCRIPTION
The store pages stopped inlining the `access_token` the spider read, so every request to `api.7-eleven.com/v4/stores` went unauthenticated and the spider returned nothing — 0 features against 15,499 in the previous run.

The store locator now calls a same origin route, `/api/v5/stores/search`, which serves results without authentication, so no token is needed. That route searches by radius rather than listing every store, so results are gathered over the existing US and Canada centroid grids and deduplicated by store id.

Opening hours are now collected. The new payload reports either a 24/7 flag or a list of per day ranges, covering 94% of stores.

The fuel brand of standalone fuel sites and the Google place id are no longer served, and are dropped rather than guessed.

A capped live crawl returns 3,216 stores from 19 of the 1,868 grid points with full geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved store discovery using broader geographic searches and configurable result limits.
  * Added support for asynchronous location requests and expanded searchable areas.
  * Enhanced store-hours parsing, including recognition of 24/7 locations.
  * Improved brand matching, including Speedway locations identified by brand or store name.
  * Preserved detailed fuel-type and grade information, with improved handling for missing data.
  * Added duplicate prevention to ensure each location appears only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->