### PR TITLE
[Government Data for fuel stations in Argentina AR] Fix Spider

### DIFF
--- a/locations/spiders/government/gov_precios_surtidor_ar.py
+++ b/locations/spiders/government/gov_precios_surtidor_ar.py
@@ -1,9 +1,7 @@
-import csv
-from io import StringIO
-from typing import Any
+from typing import Any, AsyncIterator
 
 from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Fuel, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
@@ -19,18 +17,18 @@ class GovPreciosSurtidorARSpider(Spider):
         "use:commercial": "permit",
     }
     custom_settings = {
-        "DOWNLOAD_TIMEOUT": 300,
         # Multi-operator open data: count operators rather than brands.
-        "ITEM_PIPELINES": ITEM_PIPELINES | {"locations.pipelines.count_operators.CountOperatorsPipeline": None},
+        "ITEM_PIPELINES": ITEM_PIPELINES
+        | {"locations.pipelines.count_operators.CountOperatorsPipeline": None},
     }
     # Argentina's Secretaría de Energía publishes every service station's current fuel
-    # prices (CC-BY-4.0, commercial use permitted with attribution). The CSV has one
-    # row per station x product x day/night schedule, so we group the rows of each
-    # station (idempresa) into one POI and derive the fuel types it sells.
-    start_urls = [
-        "https://datos.energia.gob.ar/dataset/1c181390-5045-475e-94dc-410429be4b17/resource/"
-        "80ac25de-a44a-4445-9215-090cf55cfda5/download/precios-en-surtidor-resolucin-3142016.csv"
-    ]
+    # prices (CC-BY-4.0, commercial use permitted with attribution). We read it from the
+    # CKAN datastore API in pages rather than downloading the ~9 MB CSV in one request,
+    # so each fetch is small. The data has one row per station x product x day/night
+    # schedule, so we group the rows of each station (idempresa) into one POI and derive
+    # the fuel types it sells.
+    resource_id = "80ac25de-a44a-4445-9215-090cf55cfda5"
+    page_size = 2000
 
     # idproducto -> OSM fuel tag. Argentine grades: "súper" (92-95 RON) is the common
     # unleaded, "premium" (>95 RON) the high-octane one; both gas-oil grades are diesel.
@@ -42,10 +40,9 @@ class GovPreciosSurtidorARSpider(Spider):
         "21": Fuel.DIESEL,  # Gas Oil Grado 3 (premium diesel)
     }
 
-    # empresabandera -> brand. Wikidata codes are the NSI fuel-brand entries. Dapsa has
-    # no Wikidata item, so its name is set explicitly (NSI can't supply it); the others
-    # leave name unset so NSI fills it. Flags not listed here fall through to a raw
-    # brand=name mapping with an unmapped_brand stat so they can be added to NSI.
+    # empresabandera -> brand. Wikidata codes are the NSI fuel-brand entries; name is left
+    # unset so NSI fills it. Flags not listed here fall through to a raw brand=name mapping
+    # with an unmapped_brand stat so they can be added to NSI.
     BRANDS = {
         "YPF": {"brand": "YPF", "brand_wikidata": "Q2006989"},
         "SHELL C.A.P.S.A.": {"brand": "Shell", "brand_wikidata": "Q110716465"},
@@ -53,22 +50,42 @@ class GovPreciosSurtidorARSpider(Spider):
         "PUMA": {"brand": "Puma", "brand_wikidata": "Q7259769"},
         "GULF": {"brand": "Gulf", "brand_wikidata": "Q5617505"},
         "REFINOR": {"brand": "Refinor", "brand_wikidata": "Q10358460"},
-        "DAPSA S.A.": {"brand": "Dapsa", "name": "Dapsa"},
+        "DAPSA S.A.": {"brand": "DAPSA", "brand_wikidata": "Q140480567"},
+        "VOY": {"brand": "Voy con Energía", "brand_wikidata": "Q140480520"},
     }
 
     # White-pump / unbranded independents: genuinely have no brand, so leave it unset.
     UNBRANDED = {"BLANCA", "SIN EMPRESA BANDERA"}
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        stations: dict[str, dict] = {}
-        for row in csv.DictReader(StringIO(response.text)):
-            station = stations.setdefault(row["idempresa"], {"row": row, "products": set()})
-            station["products"].add(row["idproducto"])
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        self.stations: dict[Any, dict] = {}
+        yield self.page_request(0)
 
-        for ref, station in stations.items():
+    def page_request(self, offset: int) -> JsonRequest:
+        url = "https://datos.energia.gob.ar/api/3/action/datastore_search" "?resource_id={}&limit={}&offset={}".format(
+            self.resource_id, self.page_size, offset
+        )
+        return JsonRequest(url=url, cb_kwargs={"offset": offset})
+
+    def parse(self, response: Response, offset: int = 0, **kwargs: Any) -> Any:
+        result = response.json()["result"]
+        for row in result["records"]:
+            station = self.stations.setdefault(row["idempresa"], {"row": row, "products": set()})
+            station["products"].add(str(row["idproducto"]))
+
+        if offset + self.page_size < result["total"]:
+            yield self.page_request(offset + self.page_size)
+            return
+
+        for ref, station in self.stations.items():
             row = station["row"]
             item = DictParser.parse(row)  # maps latitud/longitud -> lat/lon and direccion -> addr_full
-            item["ref"] = ref
+            item["ref"] = str(ref)
+            # All items are emitted from the final page's callback, so pin a stable source
+            # URL (the resource's datastore endpoint) rather than that last page's offset URL.
+            item["extras"]["@source_uri"] = (
+                "https://datos.energia.gob.ar/api/3/action/datastore_search?resource_id=" + self.resource_id
+            )
             item["street_address"] = item.pop("addr_full", None)
             item["city"] = row["localidad"]
             item["state"] = row["provincia"]  # DictParser mismaps the macro-region ("region") to state


### PR DESCRIPTION
The spider downloaded the dataset as a single ~9 MB CSV in one request. This switches it to the same official source's CKAN datastore API (datastore_search), fetched in pages of 2,000 rows (~1 MB each, ~19 requests). This avoids the large single-file download, which is fragile behind size-limited proxies and prone to download timeouts.

Same provider, same fields, same output : one row per station × product × schedule, grouped by idempresa into one POI. Note the datastore API returns idempresa/idproducto as integers (the CSV had strings), so those are coerced to str for the fuel lookup and ref.

Stats (live crawl):
```
{
  "atp/brand/Axion": 546,
  "atp/brand/DAPSA": 123,
  "atp/brand/Gulf": 94,
  "atp/brand/OIL COMBUSTIBLES S.A.": 1,
  "atp/brand/Puma": 400,
  "atp/brand/Refinor": 59,
  "atp/brand/Shell": 898,
  "atp/brand/Voy con Energía": 34,
  "atp/brand/WICO": 1,
  "atp/brand/YPF": 1568,
  "atp/brand_wikidata/Q10358460": 59,
  "atp/brand_wikidata/Q110716465": 898,
  "atp/brand_wikidata/Q140480520": 34,
  "atp/brand_wikidata/Q140480567": 123,
  "atp/brand_wikidata/Q2006989": 1568,
  "atp/brand_wikidata/Q5617305": 94,
  "atp/brand_wikidata/Q62131749": 546,
  "atp/brand_wikidata/Q7259769": 400,
  "atp/category/amenity/fuel": 4621,
  "atp/clean_strings/city": 2,
  "atp/country/AR": 4621,
  "atp/field/brand/missing": 897,
  "atp/field/brand_wikidata/missing": 899,
  "atp/field/country/from_spider_name": 4621,
  "atp/field/geometry/missing": 3,
  "atp/field/name/missing": 897,
  "atp/gov_precios_surtidor_ar/unmapped_brand/OIL COMBUSTIBLES S.A.": 1,
  "atp/gov_precios_surtidor_ar/unmapped_brand/WICO": 1,
  "atp/item_scraped_host_count/datos.energia.gob.ar": 4621,
  "atp/nsi/brand_or_operator_missing": 899,
  "atp/nsi/match_failed": 899,
  "atp/nsi/match_perfect": 3722,
  "downloader/request_count": 44,
  "downloader/response_status_count/200": 19,
  "downloader/response_status_count/301": 20,
  "downloader/response_status_count/500": 1,
  "elapsed_time_seconds": 193.453,
  "finish_reason": "finished",
  "item_scraped_count": 4621,
  "response_received_count": 20,
  "retry/count": 4
}
```
Matches the original spider's ~4,626 (minor variance from hourly source updates).

Samples:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "1589", "amenity": "fuel",
      "fuel:octane_95": "yes", "fuel:octane_98": "yes", "fuel:diesel": "yes", "fuel:cng": "yes",
      "@spider": "gov_precios_surtidor_ar",
      "@source_uri": "https://datos.energia.gob.ar/api/3/action/datastore_search?resource_id=80ac25de-a44a-4445-9215-090cf55cfda5",
      "addr:street_address": "Las Heras 1740", "addr:city": "LOMAS DE ZAMORA", "addr:state": "BUENOS AIRES", "addr:country": "AR",
      "name": "YPF", "brand": "YPF", "brand:wikidata": "Q2006989",
      "operator": "ABANILLAS S.A.", "nsi_id": "ypf-dca697"
    },
    "geometry": { "type": "Point", "coordinates": [-58.41938, -34.74712] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "9764", "amenity": "fuel",
      "fuel:diesel": "yes", "fuel:octane_95": "yes", "fuel:octane_98": "yes",
      "@spider": "gov_precios_surtidor_ar",
      "@source_uri": "https://datos.energia.gob.ar/api/3/action/datastore_search?resource_id=80ac25de-a44a-4445-9215-090cf55cfda5",
      "addr:street_address": "9 Y 36 790", "addr:city": "25 DE MAYO", "addr:state": "BUENOS AIRES", "addr:country": "AR",
      "name": "Shell", "brand": "Shell", "brand:wikidata": "Q110716465",
      "operator": "25 ALVEAR S.R.L", "nsi_id": "shell-d42a8c"
    },
    "geometry": { "type": "Point", "coordinates": [-60.16962, -35.425] }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "2530", "amenity": "fuel",
      "fuel:cng": "yes", "fuel:octane_95": "yes", "fuel:diesel": "yes",
      "@spider": "gov_precios_surtidor_ar",
      "@source_uri": "https://datos.energia.gob.ar/api/3/action/datastore_search?resource_id=80ac25de-a44a-4445-9215-090cf55cfda5",
      "addr:street_address": "LA QUEMADA 2189", "addr:city": "FIRMAT", "addr:state": "SANTA FE", "addr:country": "AR",
      "operator": "4 GNC  S.A."
    },
    "geometry": { "type": "Point", "coordinates": [-61.49651, -33.46387] }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Improved retrieval of fuel station and product data for more reliable, complete results.
  * Added support for additional fuel brands, including DAPSA and Voy con Energía.
* **Bug Fixes**
  * Improved handling of large datasets by processing results in pages and consolidating station information accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->