### PR TITLE
[H&R Block] Fix spider

### DIFF
--- a/locations/spiders/h_r_block.py
+++ b/locations/spiders/h_r_block.py
@@ -1,18 +1,21 @@
+from typing import Any
+
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import apply_category
 from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.structured_data_spider import StructuredDataSpider
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class HRBlockSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
+class HRBlockSpider(SitemapSpider, PlaywrightSpider):
     name = "h_r_block"
     item_attributes = {"brand": "H&R Block", "brand_wikidata": "Q5627799"}
     sitemap_urls = ["https://www.hrblock.com/sitemap.xml"]
-    sitemap_rules = [(r"/tax-office-near-me/[^/]+/[^/]+/\d+/?$", "parse_sd")]
+    sitemap_rules = [(r"/tax-office-near-me/[^/]+/[^/]+/\d+/?$", "parse_office")]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
         "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 180 * 1000,
         "METAREFRESH_ENABLED": False,
@@ -20,10 +23,28 @@ class HRBlockSpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
         "ROBOTSTXT_OBEY": False,
     }
     sitemap_follow = ["opp"]
-    drop_attributes = {"image"}
 
-    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+    def parse_office(self, response: Response, **kwargs: Any) -> Any:
+        item = Feature()
         item["ref"] = response.xpath("//@data-office-id").get()
         item["lat"] = response.xpath("//@data-latitude").get()
         item["lon"] = response.xpath("//@data-longitude").get()
+        item["website"] = response.url
+        item["phone"] = response.xpath('//a[contains(@class, "phone-num")]/text()').get()
+
+        address_lines = [
+            "".join(span.xpath(".//text()").getall()).strip()
+            for span in response.xpath('//div[@class="lbl-address"]/span')
+        ]
+        address_lines = [line for line in address_lines if line]
+        if len(address_lines) >= 4:
+            item["postcode"] = address_lines[-1]
+            item["state"] = address_lines[-2]
+            item["city"] = address_lines[-3].rstrip(",").strip()
+            item["country"] = "US"
+
+            item["street_address"] = merge_address_lines(address_lines[:-3])
+
+        apply_category({"office": "tax_advisor"}, item)
+
         yield item


### PR DESCRIPTION
The LocalBusiness ld+json on every office page is one closing brace short, so it cannot be parsed and no structured data is produced. The pages themselves return 200, and the spider yielded a single feature with 259 errors.

Office details are now read from the page markup instead: the `data-office-id`, `data-latitude` and `data-longitude` attributes the spider already used, plus the address block and phone link. As no structured data is read any more, the spider no longer derives from `StructuredDataSpider`. The category is set explicitly.

Opening hours are not collected. The hours block is filled by a later request, and the ld+json carried an empty `openingHours` list even before it broke, so nothing is lost.

A capped live crawl returns 56 offices with full geometry, addresses and phones, and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of H&R Block office details from location pages.
  * Address information is now parsed more reliably, including street address, city, state, and postal code.
  * Office listings now include consistent tax advisor categorization, phone numbers, websites, and map coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->