### PR TITLE
[OTP Banka HR] Fix spider

### DIFF
--- a/locations/spiders/otp_banka_hr.py
+++ b/locations/spiders/otp_banka_hr.py
@@ -1,130 +1,73 @@
-import re
 from typing import Any, AsyncIterator
 
-from scrapy import Spider
-from scrapy.http import Request, Response
+from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
-from locations.hours import DAYS_HR, OpeningHours
+from locations.hours import DAYS, DAYS_FULL, OpeningHours
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
+
+BRANCHES_URL = "https://www.otpbanka.hr/sw/json/branches.json"
+PRIVATE_BRANCHES_URL = "https://www.otpbanka.hr/sw/json/private-branches.json"
+ATMS_URL = "https://www.otpbanka.hr/sw/json/atms.json"
+
+
+def fix_coordinate(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) > 2:
+        value = parts[0] + "." + "".join(parts[1:])
+    return value
 
 
 class OtpBankaHRSpider(Spider):
     name = "otp_banka_hr"
     item_attributes = {"brand": "OTP banka", "brand_wikidata": "Q31198593"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    async def start(self) -> AsyncIterator[Any]:
-        yield Request(
-            url="https://www.otpbanka.hr/poslovnice/print",
-            cb_kwargs={"location_type": "branch"},
-        )
-        yield Request(
-            url="https://www.otpbanka.hr/atms/print",
-            cb_kwargs={"location_type": "atm"},
-        )
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(BRANCHES_URL, callback=self.parse_branches)
+        yield Request(PRIVATE_BRANCHES_URL, callback=self.parse_branches)
+        yield Request(ATMS_URL, callback=self.parse_atms)
 
-    def parse(self, response: Response, location_type: str, **kwargs: Any) -> Any:
-        for row in response.xpath('//table[contains(@class, "views-table")]//tbody/tr'):
-            item = self.parse_location(row, response)
+    def parse_branches(self, response: Response, **kwargs: Any) -> Any:
+        for row in response.json():
+            item = Feature()
+            item["ref"] = row["branchCode"]
+            item["branch"] = row["branch"].removeprefix("Poslovnica").strip()
+            item["street_address"] = row["address"]
+            item["city"] = row["city"]
+            item["lat"] = fix_coordinate(row["y"])
+            item["lon"] = fix_coordinate(row["x"])
+            item["phone"] = row["phone"]
 
-            if location_type == "branch":
-                self.parse_hours(item, row)
-                apply_yes_no(
-                    Extras.WHEELCHAIR,
-                    item,
-                    row.xpath('normalize-space(.//*[contains(@class, "views-field-field-pristup-za-invalide")])')
-                    .get("")
-                    .strip()
-                    == "Pristup za invalide",
-                    False,
-                )
-                apply_category(Categories.BANK, item)
-            elif location_type == "atm":
-                apply_yes_no(
-                    Extras.CASH_IN,
-                    item,
-                    row.xpath('normalize-space(.//*[contains(@class, "views-field-field-vrsta-bankomata-tablica")])')
-                    .get("")
-                    .strip()
-                    == "Uplatno-isplatni bankomat",
-                    False,
-                )
-                apply_category(Categories.ATM, item)
-            else:
-                self.logger.error("Unexpected location type: {}".format(location_type))
-                continue
+            item["opening_hours"] = OpeningHours()
+            for day, day_name in zip(DAYS, DAYS_FULL):
+                hours = row[day_name.lower()].strip()
+                if hours.lower() == "ne radi":
+                    item["opening_hours"].set_closed(day)
+                elif "-" in hours:
+                    item["opening_hours"].add_range(day, *hours.split("-", 1))
+                else:
+                    self.logger.warning("Unexpected opening hours value: {}".format(hours))
+
+            apply_yes_no(Extras.WHEELCHAIR, item, row["access"] == "1", False)
+            apply_yes_no(Extras.WIFI, item, row["wifi"] == "YES", False)
+            apply_category(Categories.BANK, item)
 
             yield item
 
-    def parse_hours(self, item: Feature, row: Any) -> None:
-        rules = row.xpath(
-            './/*[contains(@class, "views-field-field-radno-vrijeme")]'
-            '//*[contains(concat(" ", normalize-space(@class), " "), " oh-display ")]'
-        )
-        if not rules:
-            return
+    def parse_atms(self, response: Response, **kwargs: Any) -> Any:
+        for row in response.json():
+            item = Feature()
+            item["ref"] = row["tid"]
+            item["branch"] = row["name"].removeprefix("Poslovnica").strip()
+            item["street_address"] = row["address"]
+            item["city"] = row["place"]
+            item["lat"] = row["y"]
+            item["lon"] = row["x"]
 
-        days_hr = DAYS_HR | {
-            "Pon": "Mo",
-            "Uto": "Tu",
-            "Sri": "We",
-            "\u010cet": "Th",
-            "Pet": "Fr",
-            "Sub": "Sa",
-            "Ned": "Su",
-        }
-        oh = OpeningHours()
-        try:
-            for rule in rules:
-                day = days_hr[
-                    rule.xpath(
-                        'normalize-space(.//*[contains(concat(" ", normalize-space(@class), " "), " oh-display-label ")])'
-                    )
-                    .get("")
-                    .rstrip(":")
-                    .strip()
-                ]
-                hours = (
-                    rule.xpath(
-                        'normalize-space(.//*[contains(concat(" ", normalize-space(@class), " "), " oh-display-times ")])'
-                    )
-                    .get("")
-                    .strip()
-                )
-                if hours == "Zatvoreno":
-                    oh.set_closed(day)
-                elif "-" in hours:
-                    oh.add_range(day, *hours.split("-", 1))
-                else:
-                    raise ValueError("Unexpected opening hours value: {}".format(hours))
-            item["opening_hours"] = oh
-        except Exception:
-            self.logger.warning("Failed to parse hours for {}".format(item.get("ref")))
+            apply_yes_no(Extras.CASH_IN, item, row["type"] == "2", False)
+            apply_category(Categories.ATM, item)
 
-    @staticmethod
-    def parse_location(row: Any, response: Response) -> Feature:
-        # Source rows are HTML tables rather than JSON, so DictParser is not applicable.
-        item = Feature()
-
-        if href := row.xpath('.//a[contains(@href, "/offices-atms/")]/@href').get():
-            if match := re.search(r"/offices-atms/(\d+)", href):
-                item["ref"] = match.group(1)
-            item["website"] = response.urljoin(href)
-
-        if branch := row.xpath("normalize-space(./td[2])").get():
-            item["branch"] = branch.removeprefix("Poslovnica ").strip()
-        item["street_address"] = row.xpath('normalize-space(.//*[contains(@class, "street-address")])').get()
-        item["city"] = row.xpath('normalize-space(.//*[contains(@class, "views-field-city")]//a)').get()
-        if phone := row.xpath(
-            'normalize-space(.//*[contains(@class, "views-field-field-telefon")]//a[contains(@href, "tel:")])'
-        ).get():
-            item["phone"] = phone
-
-        if match := re.match(
-            r"(?P<lat>-?\d+(?:\.\d+)?)\s*,\s*(?P<lon>-?\d+(?:\.\d+)?)",
-            row.xpath('normalize-space(.//*[contains(@class, "views-field-coordinates")]//a)').get(""),
-        ):
-            item["lat"] = match.group("lat")
-            item["lon"] = match.group("lon")
-
-        return item
+            yield item


### PR DESCRIPTION
The Drupal print views the spider read, `/poslovnice/print` and `/atms/print`, were retired and now redirect to a rendered page, so the spider returned nothing — 0 features against 555 in the previous run.

The locator reads three JSON files instead, referenced from the site's own `portal.js`: `branches.json`, `private-branches.json` and `atms.json`. The spider now uses those. A browser user agent is required, as the site's gateway rejects other agents on every path.

Branch coordinates are repaired where the source writes them with an extra separator, as in `"15.681.524"` for Obrovac. Eight of ninety six branches are affected; ATM coordinates are unaffected.

A full live crawl returns 556 locations, 96 branches and 460 ATMs, with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP Bank Croatia location data collection for branches and ATMs.
  * Corrected malformed geographic coordinates.
  * Improved accuracy of opening hours, location categories, and available features.
  * Added support for private branches and more complete weekday schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->