### PR TITLE
[Bank SinoPac TW] Fix spider and rename

### DIFF
--- a/locations/spiders/bank_sinopac_tw.py
+++ b/locations/spiders/bank_sinopac_tw.py
@@ -16,6 +16,9 @@ class BankSinopacTWSpider(JSONBlobSpider):
     ]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        if item["lat"] and item["lon"] and abs(float(item["lat"])) > 90:
+            item["lat"], item["lon"] = item["lon"], item["lat"]
+
         if "Branch" in response.url:
             item["addr_full"] = feature["vicinity"]
             item["branch"] = item.pop("name", None)

--- a/locations/spiders/bank_sinopac_tw.py
+++ b/locations/spiders/bank_sinopac_tw.py
@@ -7,8 +7,8 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
-class BankSinopacSpider(JSONBlobSpider):
-    name = "bank_sinopac"
+class BankSinopacTWSpider(JSONBlobSpider):
+    name = "bank_sinopac_tw"
     item_attributes = {"brand": "永豐商業銀行", "brand_wikidata": "Q11132721"}
     start_urls = [
         "https://bank.sinopac.com/search/BranchListJson.ashx?callback=callForJsonp5",
@@ -18,8 +18,10 @@ class BankSinopacSpider(JSONBlobSpider):
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         if "Branch" in response.url:
             item["addr_full"] = feature["vicinity"]
+            item["branch"] = item.pop("name", None)
             apply_category(Categories.BANK, item)
         elif "ATM" in response.url:
-            item["street"] = feature["location"]
+            item.pop("name", None)
+            item["branch"] = feature.get("location")
             apply_category(Categories.ATM, item)
         yield item


### PR DESCRIPTION
The ATM feed occasionally contains a record with no `location` key, which was read directly. The resulting error abandoned the rest of that response, so the spider kept only the branches parsed from the other URL — 135 features against 598 in the previous run.

`location` is now read safely. Two further corrections while here:

* `location` was being collected as the street, but it names the venue an ATM stands in, such as a branch, department store or golf course. It is now collected as `branch`, as branch rows already do. The address is unaffected, being populated separately.
* The ATM feed's `locname` field was being matched to `name`, but it describes the type of site rather than the location, with only fourteen distinct values across the whole feed. It is no longer collected.

The spider only covers Taiwan, so it is renamed to `bank_sinopac_tw`.

A full live crawl returns 600 locations, 135 branches and 465 ATMs, with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch and ATM location data consistency.
  * Corrected latitude and longitude values when coordinates are reversed.
  * Branch records now correctly identify the branch name.
  * ATM records now use the appropriate branch or location information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->