### PR TITLE
[Zeelab Pharmacy IN] Fix spider

### DIFF
--- a/locations/spiders/zeelab_pharmacy_in.py
+++ b/locations/spiders/zeelab_pharmacy_in.py
@@ -1,7 +1,8 @@
-from typing import AsyncIterator
+import re
+from typing import Any, AsyncIterator
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
@@ -12,32 +13,32 @@ class ZeelabPharmacyINSpider(Spider):
     item_attributes = {"brand": "Zeelab Pharmacy", "brand_wikidata": "Q123015627"}
     no_refs = True
 
-    def make_requests(self, page: int) -> JsonRequest:
-        return JsonRequest(
-            url="https://app.zeelabgeneric.com/api/query/stores/web",
-            data={"query": "", "page_id": page},
+    def make_requests(self, page: int) -> Request:
+        return Request(
+            url=f"https://zeelabpharmacy.com/store-location_list?query=&page_id={page}",
             cb_kwargs={"page": page},
         )
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
+    async def start(self) -> AsyncIterator[Request]:
         yield self.make_requests(1)
 
-    def parse(self, response, **kwargs):
+    def parse(self, response: Response, **kwargs: Any) -> Any:
         if stores := response.json().get("response_obj"):
             for store in stores:
                 store["street_address"] = store.pop("address", "")
                 item = DictParser.parse(store)
                 item["branch"] = (
-                    item.pop("name")
-                    .replace("ZEELAB Pharmacy ", "")
-                    .replace("Zeelab Pharmacy ", "")
-                    .lstrip()
-                    .replace("-", "")
-                    .lstrip()
+                    re.sub(
+                        r"^\s*zeelab\s*(arogya\s*generic\s*)?phar\w*\s*[-,]?\s*",
+                        "",
+                        item.pop("name"),
+                        flags=re.IGNORECASE,
+                    ).strip()
+                    or None
                 )
                 item["phone"] = store.get("contact")
                 item["postcode"] = store.get("pincode")
-                item["website"] = "https://zeelabpharmacy.com/store-locator"
+                item["website"] = None
                 apply_category(Categories.PHARMACY, item)
                 yield item
             yield self.make_requests(kwargs["page"] + 1)


### PR DESCRIPTION
The store API moved. `app.zeelabgeneric.com/api/query/stores/web` now answers every POST with `{"response_code":"-1"}` and the spider returned nothing — 0 features against 316 in the previous run. The store locator itself reads `zeelabpharmacy.com/store-location_list`, a plain paginated GET needing no token, so the spider now uses that.

Two field corrections while here:

* The brand was only stripped from `branch` in two exact spellings, leaving it on stores the source spells differently, including the misspellings "Pharamcy" and "Pharmcay". Stripping is now case insensitive and tolerates those variants.
* The website was a link to the store locator index, identical for every store. The source offers no per-store page, and its `url` field is a Google Maps link rather than a website, so no website is collected.

A full live crawl returns 300 pharmacies with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pharmacy store-location data collection using the current endpoint.
  * Standardized branch names by removing pharmacy prefixes regardless of capitalization.
  * Corrected website information for locations without a dedicated website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->