### PR TITLE
[Smiggle] Fix spider

### DIFF
--- a/locations/spiders/smiggle.py
+++ b/locations/spiders/smiggle.py
@@ -16,6 +16,7 @@ class SmiggleSpider(JSONBlobSpider):
     start_urls = ["https://www.smiggle.co.uk/shop/en/smiggleuk/stores"]
     drop_attributes = {"facebook", "twitter"}
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    requires_proxy = True
 
     def extract_json(self, response: Response) -> Any:
         js_blob = "[" + response.text.split("const storeData = [", 1)[1].split("]", 1)[0] + "]"

--- a/locations/spiders/smiggle.py
+++ b/locations/spiders/smiggle.py
@@ -1,7 +1,13 @@
-from chompjs import parse_js_object
+from typing import Any
 
+from chompjs import parse_js_object
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import clean_address
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class SmiggleSpider(JSONBlobSpider):
@@ -9,15 +15,21 @@ class SmiggleSpider(JSONBlobSpider):
     item_attributes = {"brand": "Smiggle", "brand_wikidata": "Q7544536"}
     start_urls = ["https://www.smiggle.co.uk/shop/en/smiggleuk/stores"]
     drop_attributes = {"facebook", "twitter"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
-    def extract_json(self, response):
+    def extract_json(self, response: Response) -> Any:
         js_blob = "[" + response.text.split("const storeData = [", 1)[1].split("]", 1)[0] + "]"
         return parse_js_object(js_blob)
 
-    def post_process_item(self, item, response, location):
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Any:
         item["branch"] = item.pop("name")
         item["ref"] = location["locId"]
-        item["phone"].replace("  ", "")
-        item["postcode"].replace("  ", "").replace(".", "")
+        item["website"] = location["storeURL"]
+        apply_category(Categories.SHOP_STATIONERY, item)
+        if item["phone"]:
+            item["phone"] = item["phone"].strip()
+        if item["postcode"]:
+            postcode = item["postcode"].strip()
+            item["postcode"] = postcode if postcode != "." else None
         item["street_address"] = clean_address([location["shopAddress"], location["streetAddress"]])
         yield item


### PR DESCRIPTION
The store page is served a bot challenge to the default user agent and returns no store data, so the spider produced 0 features against 273 in the previous run. It now requests the page as a browser.

Separately, the phone and postcode clean up discarded its own result, and raised on the stores that report no phone, which would have ended the crawl early even once the page loaded. Both are now assigned, and the postcode placeholder "." is dropped rather than collected.

The category and the per store website are now collected.

A full live crawl returns all 273 stores with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added website links to Smiggle store listings.
  * Classified stores under the stationery shop category.

* **Bug Fixes**
  * Improved phone number and postcode formatting.
  * Correctly handles missing or invalid postcode values.
  * Standardized browser identification when retrieving store information.
  * Improved the reliability of store information updates through supported network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->