### PR TITLE
[Espaces Atypiques] Add spider (83 locations)

### DIFF
--- a/locations/spiders/espaces_atypiques.py
+++ b/locations/spiders/espaces_atypiques.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.structured_data_spider import StructuredDataSpider
+from locations.structured_data_spider import StructuredDataSpider, clean_facebook
 
 
 class EspacesAtypiquesSpider(SitemapSpider, StructuredDataSpider):
@@ -18,7 +18,8 @@ class EspacesAtypiquesSpider(SitemapSpider, StructuredDataSpider):
     drop_attributes = {"image", "twitter"}
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        if item.get("facebook") in ["https://www.facebook.com/espaces.atypiques"]:
+        item["branch"] = item.pop("name", "").removeprefix("Espaces Atypiques ")
+        if clean_facebook(item.get("facebook")) == "https://www.facebook.com/espaces.atypiques":
             item.pop("facebook")
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item

--- a/locations/spiders/espaces_atypiques.py
+++ b/locations/spiders/espaces_atypiques.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class EspacesAtypiquesSpider(SitemapSpider, StructuredDataSpider):

--- a/locations/spiders/espaces_atypiques.py
+++ b/locations/spiders/espaces_atypiques.py
@@ -1,0 +1,24 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class EspacesAtypiquesSpider(SitemapSpider, StructuredDataSpider):
+    name = "espaces_atypiques"
+    item_attributes = {
+        "brand": "Espaces Atypiques",
+        "brand_wikidata": "Q139386727",
+    }
+    sitemap_urls = ["https://www.espaces-atypiques.com/agence-sitemap.xml"]
+    sitemap_rules = [
+        (r".com/(?!en/)", "parse"),
+    ]
+    wanted_types = ["RealEstateAgent"]
+    drop_attributes = {"image", "twitter"}
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item.get("facebook") in ["https://www.facebook.com/espaces.atypiques"]:
+            item.pop("facebook")
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+        yield item


### PR DESCRIPTION
Real estate agent Espaces Atypiques

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for discovering Espaces Atypiques real-estate agencies from their website.
  - Agency listings now include structured business information, brand details, and the appropriate real-estate category.
  - Non-English agency pages are supported for broader location coverage.
  - Unavailable or irrelevant social-media and image details are excluded from listings.
  - Agency information is collected across the brand’s available website locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->