### PR TITLE
[Spar PL] Fix spider

### DIFF
--- a/locations/spiders/spar_pl.py
+++ b/locations/spiders/spar_pl.py
@@ -1,50 +1,77 @@
-from typing import AsyncIterator
+import re
+from typing import Any, AsyncIterator
 
-from scrapy import Spider
+from scrapy import Request, Spider
 from scrapy.http import FormRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.hours import OpeningHours
+from locations.geo import country_iseadgg_centroids
+from locations.hours import DAYS, OpeningHours
 from locations.spiders.spar_aspiag import SPAR_SHARED_ATTRIBUTES
+
+FORMATS = {
+    "EUROSPAR": ("Eurospar", Categories.SHOP_SUPERMARKET),
+    "SPAR EXPRESS": ("Spar Express", Categories.SHOP_CONVENIENCE),
+    "SPAR mini": ("Spar Mini", Categories.SHOP_CONVENIENCE),
+    "SPAR": ("Spar", Categories.SHOP_CONVENIENCE),
+}
+
+DAY_KEYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
 
 
 class SparPLSpider(Spider):
     name = "spar_pl"
     item_attributes = SPAR_SHARED_ATTRIBUTES
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        yield FormRequest(
-            url="https://spar.pl/wp-admin/admin-ajax.php",
-            formdata={
-                "action": "shopsincity",
-                "lat": "51",
-                "lng": "19",
-                "distance": "500000",
-            },
-        )
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request("https://spar.pl/nasze-sklepy/", callback=self.parse_nonce)
 
-    def parse(self, response: Response, **kwargs):
-        for shop in response.json()["locations"]:
-            if shop["permalink"].endswith("-2/"):
+    def parse_nonce(self, response: Response, **kwargs: Any) -> Any:
+        nonce = re.search(r'"nonce":"([0-9a-f]+)"', response.text).group(1)
+        self.seen_ids = set()
+        for lat, lon in country_iseadgg_centroids("PL", 48):
+            yield FormRequest(
+                url="https://spar.pl/wp-admin/admin-ajax.php",
+                formdata={
+                    "action": "storemap_search",
+                    "nonce": nonce,
+                    "lat": str(lat),
+                    "lng": str(lon),
+                    "radius": "50",
+                },
+                callback=self.parse,
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for shop in response.json()["data"]["stores"]:
+            if shop["id"] in self.seen_ids:
                 continue
+            self.seen_ids.add(shop["id"])
+
             item = DictParser.parse(shop)
-            item["postcode"] = shop["kod"]
-            item["street_address"] = shop["adres"]
+            item["country"] = "PL"
+            item["website"] = f'https://spar.pl/sklep/{shop["post_name"]}/'
+
             item["opening_hours"] = OpeningHours()
-            days = ["poniedzialek", "wtorek", "sroda", "czwartek", "piatek", "sobota", "niedziela"]
-            for day in days:
-                item["opening_hours"].add_ranges_from_string(f"{day} {shop[day]}")
-            if shop["format"] == "EUROSPAR":
-                item["name"] = "Eurospar"
-                apply_category(Categories.SHOP_SUPERMARKET, item)
-            elif shop["format"] == "SPAR EXPRESS":
-                item["name"] = "Spar Express"
-                apply_category(Categories.SHOP_CONVENIENCE, item)
-            elif shop["format"] == "SPAR mini":
-                item["name"] = "Spar Mini"
-                apply_category(Categories.SHOP_CONVENIENCE, item)
-            elif shop["format"] == "SPAR":
-                item["name"] = "Spar"
-                apply_category(Categories.SHOP_CONVENIENCE, item)
+            for day, key in zip(DAYS, DAY_KEYS):
+                hours = shop.get(key, "").strip()
+                if not hours:
+                    continue
+                if hours.lower() == "nieczynne":
+                    item["opening_hours"].set_closed(day)
+                    continue
+                if hours.upper() == "24H":
+                    item["opening_hours"].add_range(day, "00:00", "23:59")
+                    continue
+                open_time, close_time = hours.replace("–", "-").replace("—", "-").split("-")
+                item["opening_hours"].add_range(day, open_time.strip(), close_time.strip())
+
+            if fmt := FORMATS.get(shop["format"]):
+                name, category = fmt
+                item["name"] = name
+                apply_category(category, item)
+            else:
+                self.crawler.stats.inc_value(f'atp/{self.name}/unknown_format/{shop["format"]}')
+
             yield item


### PR DESCRIPTION
The site changed store locator plugins. The `shopsincity` action the spider used is gone and now answers 400, leaving 0 features against 170 in the previous run.

The replacement plugin answers `storemap_search` and needs a nonce, which the store locator page carries. The spider now reads the nonce and searches from a grid of points covering Poland, as the server caps each search at 50km however large a radius is requested.

Store formats are recorded as before, with Eurospar as a supermarket and the Spar, Spar Express and Spar Mini formats as convenience stores. Opening hours cover the closed and 24 hour values the source uses, and both dash characters it separates ranges with.

A full live crawl returns 178 stores with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved discovery of SPAR stores across Poland using regional searches.
  - Added support for store formats, categories, Polish-specific metadata, and direct store links.
  - Improved parsing of opening hours, including special values and English day labels.

- **Bug Fixes**
  - Prevented duplicate store listings.
  - Added tracking for unrecognized opening-hour formats to improve data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->