### PR TITLE
[NCP GB] Fix spider

### DIFF
--- a/locations/spiders/ncp_gb.py
+++ b/locations/spiders/ncp_gb.py
@@ -31,6 +31,7 @@ class NcpGBSpider(SitemapSpider):
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": BROWSER_DEFAULT,
         "DOWNLOAD_DELAY": 2,
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60 * 1000,
     }
 
     def parse_pois(self, response):


### PR DESCRIPTION
Car park pages regularly take longer than the default 30 second navigation timeout, so 404 of 481 requests failed with a Playwright TimeoutError and the spider returned 39 car parks against 161 in the previous run.

The navigation timeout is now 60 seconds, as `rewe_de` already sets for the same reason. A live crawl makes 262 requests with 253 responses and no timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-loading reliability by allowing up to 60 seconds for navigation to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->