### PR TITLE
[MAC Cosmetics] Fix spider

### DIFF
--- a/locations/spiders/mac_cosmetics.py
+++ b/locations/spiders/mac_cosmetics.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator
 from scrapy import Spider
 from scrapy.http import FormRequest, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, OpeningHours
 
@@ -12,7 +13,8 @@ from locations.hours import DAYS_EN, OpeningHours
 class MacCosmeticsSpider(Spider):
     name = "mac_cosmetics"
     item_attributes = {"brand": "MAC Cosmetics", "brand_wikidata": "Q2624442"}
-    allowed_domains = ["maccosmetics.com"]
+    allowed_domains = ["maccosmetics.ca"]
+    requires_proxy = True
     only_hour = re.compile(r"^(\d\d?)([ap]m)", re.IGNORECASE)
     colon_missing = re.compile(r"^(\d?\d)(\d\d[ap]m)", re.IGNORECASE)
     am_missing = re.compile(r"^(\d?\d(:\d\d)?)$")
@@ -45,7 +47,7 @@ class MacCosmeticsSpider(Spider):
             }
         ]
         yield FormRequest(
-            "https://www.maccosmetics.com/rpc/jsonrpc.tmpl?dbgmethod=locator.doorsandevents",
+            "https://www.maccosmetics.ca/rpc/jsonrpc.tmpl?dbgmethod=locator.doorsandevents",
             method="POST",
             formdata={"JSONRPC": dumps(jsonrpc)},
         )
@@ -73,6 +75,7 @@ class MacCosmeticsSpider(Spider):
                 item["opening_hours"] = opening_hours
             if any_open and not item["name"].endswith("- Closed"):
                 item["branch"] = item.pop("name").replace("M·A·C ", "").replace("MAC Cosmetics at ", "")
+                apply_category(Categories.SHOP_COSMETICS, item)
                 yield item
 
     def parse_opening_hours(self, feature):


### PR DESCRIPTION
The store locator moved. `www.maccosmetics.com` has migrated to Shopify and its jsonrpc endpoint now returns 404, so the spider returned nothing — 0 features against 6,161 in the previous run.

The other market sites still run the previous platform, and its shared backend still serves every market's stores from one call. The spider now asks `www.maccosmetics.ca`, which answers with the full global set. The site rejects requests that do not come through a proxy, so one is used; the whole dataset arrives in a single request.

The category is now set explicitly.

A full live crawl returns 6,160 stores across 60-plus countries with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated location data collection to use the Canadian MAC Cosmetics website.
  * Added proxy support for accessing the Canadian site.
  * Classified collected locations under the cosmetics category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->