### PR TITLE
[The Interiors Group NZ] Fix spider

### DIFF
--- a/locations/spiders/the_interiors_group_nz.py
+++ b/locations/spiders/the_interiors_group_nz.py
@@ -1,31 +1,46 @@
-from locations.categories import Categories
-from locations.hours import OpeningHours
-from locations.storefinders.stockist import StockistSpider
+from typing import Any, Iterable
 
-CARPET_COURT = {"brand": "Carpet Court", "brand_wikidata": "Q137908618", "extras": Categories.SHOP_CARPET.value}
-CURTAIN_STUDIO = {"brand": "Curtain Studio", "brand_wikidata": "Q137908226", "extras": Categories.SHOP_CURTAIN.value}
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+BRANDS = {
+    "carpetcourt.nz": {
+        "brand": "Carpet Court",
+        "brand_wikidata": "Q137908618",
+        "category": Categories.SHOP_CARPET,
+        "prefix": "Carpet Court",
+    },
+    "curtainstudio.co.nz": {
+        "brand": "Curtain Studio",
+        "brand_wikidata": "Q137908226",
+        "category": Categories.SHOP_CURTAIN,
+        "prefix": "Curtain Studio",
+    },
+}
 
 
-class TheInteriorsGroupNZSpider(StockistSpider):
+class TheInteriorsGroupNZSpider(SitemapSpider, StructuredDataSpider):
     name = "the_interiors_group_nz"
-    key = "map_93wgrpn3"
+    allowed_domains = ["carpetcourt.nz", "curtainstudio.co.nz"]
+    sitemap_urls = [
+        "https://carpetcourt.nz/sitemap_stores.xml",
+        "https://curtainstudio.co.nz/sitemap_stores.xml",
+    ]
+    sitemap_rules = [(r"/our-locations/[^/]+$", "parse_sd")]
+    wanted_types = ["HomeGoodsStore"]
+    search_for_facebook = False
 
-    def parse_item(self, item, location):
-        match location["filters"][0]["name"]:
-            case "Carpet Court":
-                item.update(CARPET_COURT)
-                item["branch"] = item.pop("name").removeprefix("Carpet Court ")
-                item["website"] = f"https://carpetcourt.nz{location['custom_fields'][1]['value']}"
-            case "Curtain Studio":
-                item.update(CURTAIN_STUDIO)
-                item["branch"] = item.pop("name").removeprefix("Curtain Studio ")
-                item["website"] = f"https://curtainstudio.co.nz{location['custom_fields'][1]['value']}"
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        brand = next(v for k, v in BRANDS.items() if k in response.url)
 
-        item["opening_hours"] = OpeningHours()
-        oh_string = location["custom_fields"][0]["value"].replace("\n ", "\n")
+        item["brand"] = brand["brand"]
+        item["brand_wikidata"] = brand["brand_wikidata"]
+        apply_category(brand["category"], item)
 
-        for lines in oh_string.split("\n"):
-            if lines.split(":")[0] in ["Mon-Fri", "Sat", "Sun"]:
-                item["opening_hours"].add_ranges_from_string(oh_string)
+        item["branch"] = item.pop("name").removeprefix(brand["prefix"]).strip(" -")
 
         yield item


### PR DESCRIPTION
The Stockist widget the spider read has been disabled at source: its own `widget.js` reports the account as disabled and the overview returns no geohashes, so the spider produced 0 features against 119 in the previous run.

Both brands now run their own locators with a store page per branch, each carrying a `HomeGoodsStore` block with coordinates, address, opening hours, phone and email. The spider reads those from the two store sitemaps instead, setting the brand, wikidata and category per site.

A full live crawl returns all 119 stores, 61 Carpet Court and 58 Curtain Studio, with complete geometry and opening hours and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location discovery for Carpet Court and Curtain Studio through website sitemaps and structured store data.
  * Added brand and category details to store listings.
  * Improved branch naming based on structured store information.

* **Bug Fixes**
  * Filtered results to include only valid home-goods store locations.
  * Removed outdated stockist parsing and unreliable website and opening-hours extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->