### PR TITLE
[Barbeques Galore AU] Fix spider

### DIFF
--- a/locations/spiders/barbeques_galore_au.py
+++ b/locations/spiders/barbeques_galore_au.py
@@ -1,37 +1,40 @@
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
+from typing import Any
 
+from scrapy.http import Response
+
+from locations.categories import apply_category
 from locations.hours import OpeningHours
-from locations.structured_data_spider import StructuredDataSpider
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+DAY_HOURS_KEYS = {
+    "Mo": "hours_mon",
+    "Tu": "hours_tue",
+    "We": "hours_wed",
+    "Th": "hours_thu",
+    "Fr": "hours_fri",
+    "Sa": "hours_sat",
+    "Su": "hours_sun",
+}
 
 
-class BarbequesGaloreAUSpider(CrawlSpider, StructuredDataSpider):
+class BarbequesGaloreAUSpider(JSONBlobSpider):
     name = "barbeques_galore_au"
     item_attributes = {"brand": "Barbeques Galore", "brand_wikidata": "Q4859570"}
-    allowed_domains = ["www.barbequesgalore.com.au"]
-    start_urls = ["https://www.barbequesgalore.com.au/stores/franchises.html"]
-    rules = [Rule(LinkExtractor(allow=r".*/stores/[a-z\-]+"), callback="parse_sd")]
+    start_urls = ["https://www.barbequesgalore.com.au/rts/vibe-code/public/site/e1f27517/published/api/stores"]
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Any:
         item["branch"] = item.pop("name")
-        item.pop("facebook")
-        item["ref"] = response.xpath('//div[contains(@class, "store-details")]/@data-store-id').extract_first()
+        item["website"] = f"https://www.barbequesgalore.com.au/stores/{feature['slug']}"
+
         item["opening_hours"] = OpeningHours()
-        hours_raw = (
-            " ".join(
-                response.xpath(
-                    '//div[contains(@class, "open-section")][1]/div[contains(@class, "open-hour")]/span/text()'
-                ).extract()
-            )
-            .replace("Closed", "0:00am - 0:00am")
-            .replace("-", "")
-            .replace(")", "")
-            .replace("(", "")
-            .split()
-        )
-        hours_raw = [hours_raw[n : n + 3] for n in range(0, len(hours_raw), 3)]
-        for day in hours_raw:
-            if day[1] == "0:00am" and day[2] == "0:00am":
+        for day, key in DAY_HOURS_KEYS.items():
+            hours_raw = feature.get(key, "").strip()
+            if not hours_raw or hours_raw.lower() == "closed":
+                item["opening_hours"].set_closed(day)
                 continue
-            item["opening_hours"].add_range(day[0], day[1].upper(), day[2].upper(), "%I:%M%p")
+            open_time, close_time = [part.strip() for part in hours_raw.replace("–", "-").split("-")]
+            item["opening_hours"].add_range(day, open_time, close_time, "%I:%M%p")
+
+        apply_category({"shop": "bbq"}, item)
         yield item


### PR DESCRIPTION
The site has been rebuilt and the franchises page no longer lists any stores, so the spider produced 0 features against 27 in the previous run.

The new site publishes its stores as JSON, including coordinates, address, phone, email and hours for each day, so the spider reads that instead. The summary weekday hours field the API also provides is ignored, as it disagrees with the per day values on two stores.

A full live crawl returns all 26 stores the API lists, with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Accuracy**
  * Store listings now come directly from the published store API.
  * Branch websites and names are mapped more consistently.
  * Opening hours now support weekday-specific schedules, closed days, and en-dash time ranges.
  * Stores are categorized as BBQ shops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->