### PR TITLE
[Kiko Milano] Add opening hours to existing spider (1230 items)

### DIFF
--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -26,10 +26,9 @@ class KikoMilanoSpider(JSONBlobSpider):
 
     def post_process_item(self, item, response, location):
 
-        oh = OpeningHours()
+        item["opening_hours"] = OpeningHours()
         for i in range(len(location["openingHours"])):
             hours = location["openingHours"][i]
             oh.add_ranges_from_string(DAYS[i] + " " + hours)
-        item["opening_hours"] = oh
 
         yield item

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -30,6 +30,6 @@ class KikoMilanoSpider(JSONBlobSpider):
         for i in range(len(location["openingHours"])):
             hours = location["openingHours"][i]
             oh.add_ranges_from_string(DAYS[i] + " " + hours)
-        item["opening_hours"] = oh.as_opening_hours()
+        item["opening_hours"] = oh
 
         yield item

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -30,6 +30,6 @@ class KikoMilanoSpider(JSONBlobSpider):
             split_hours = location["openingHours"][i].split(",")
             for hours in split_hours:
                 hour = hours.split("-")
-                if(len(hour) == 2):
-                    item["opening_hours"].add_range(DAYS[i], hour[0].replace(" ",""), hour[1].replace(" ",""))
+                if len(hour) == 2:
+                    item["opening_hours"].add_range(DAYS[i], hour[0].replace(" ", ""), hour[1].replace(" ", ""))
         yield item

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -25,10 +25,9 @@ class KikoMilanoSpider(JSONBlobSpider):
         )
 
     def post_process_item(self, item, response, location):
-
         item["opening_hours"] = OpeningHours()
         for i in range(len(location["openingHours"])):
-            hours = location["openingHours"][i]
-            oh.add_ranges_from_string(DAYS[i] + " " + hours)
-
+            hours = location["openingHours"][i].split("-")
+            if(len(hours) == 2):
+                item["opening_hours"].add_range(DAYS[i], hours[0], hours[1])
         yield item

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -2,9 +2,9 @@ from typing import AsyncIterator
 
 from scrapy.http import JsonRequest
 
+from locations.hours import DAYS, OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
 from locations.user_agents import BROWSER_DEFAULT
-from locations.hours import OpeningHours, DAYS
 
 
 class KikoMilanoSpider(JSONBlobSpider):

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -27,7 +27,9 @@ class KikoMilanoSpider(JSONBlobSpider):
     def post_process_item(self, item, response, location):
         item["opening_hours"] = OpeningHours()
         for i in range(len(location["openingHours"])):
-            hours = location["openingHours"][i].split("-")
-            if(len(hours) == 2):
-                item["opening_hours"].add_range(DAYS[i], hours[0], hours[1])
+            split_hours = location["openingHours"][i].split(",")
+            for hours in split_hours:
+                hour = hours.split("-")
+                if(len(hour) == 2):
+                    item["opening_hours"].add_range(DAYS[i], hour[0].replace(" ",""), hour[1].replace(" ",""))
         yield item

--- a/locations/spiders/kiko_milano.py
+++ b/locations/spiders/kiko_milano.py
@@ -4,6 +4,7 @@ from scrapy.http import JsonRequest
 
 from locations.json_blob_spider import JSONBlobSpider
 from locations.user_agents import BROWSER_DEFAULT
+from locations.hours import OpeningHours, DAYS
 
 
 class KikoMilanoSpider(JSONBlobSpider):
@@ -22,3 +23,13 @@ class KikoMilanoSpider(JSONBlobSpider):
                 "Referer": "https://kiko-stores.kikocosmetics.com/",
             },
         )
+
+    def post_process_item(self, item, response, location):
+
+        oh = OpeningHours()
+        for i in range(len(location["openingHours"])):
+            hours = location["openingHours"][i]
+            oh.add_ranges_from_string(DAYS[i] + " " + hours)
+        item["opening_hours"] = oh.as_opening_hours()
+
+        yield item


### PR DESCRIPTION
Adding the opening hours information to the Kiko Milano shops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that prevented Kiko Milano location listings from being processed correctly.
  * Improved opening-hours processing so valid weekday time ranges are captured and displayed accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->