### PR TITLE
[Hubo NL] Fix spider

### DIFF
--- a/locations/spiders/hubo_nl.py
+++ b/locations/spiders/hubo_nl.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
@@ -12,9 +12,8 @@ from locations.items import Feature
 
 class HuboNLSpider(Spider):
     name = "hubo_nl"
-    item_attributes = {"brand": "Hubo", "brand_wikidata": "Q5473953", "extras": Categories.SHOP_DOITYOURSELF.value}
+    item_attributes = {"brand": "Hubo", "brand_wikidata": "Q5473953"}
     start_urls = ["https://www.hubo.nl/winkels"]
-    requires_proxy = True
 
     def parse(self, response: Response) -> Iterable[Feature]:
         for script in response.xpath("//script/text()").getall():
@@ -33,5 +32,6 @@ class HuboNLSpider(Spider):
                             oh.add_range(day, rule[f"from{i}"], rule[f"to{i}"])
                 item["opening_hours"] = oh
 
+                apply_category(Categories.SHOP_DOITYOURSELF, item)
                 yield item
             return


### PR DESCRIPTION
The store page is reachable directly but not through the proxy, which the spider was requiring. Every run failed with a "Website Ban" from the proxy on the spider's single request, so it returned nothing — 0 features against 158 in the runs before.

The proxy requirement is dropped. A live crawl returns all 158 stores with complete geometry and no errors.

The category is also applied explicitly rather than through `item_attributes` extras.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Product listings from Hubo Netherlands are now consistently classified under the DIY shop category.
  - Updated listing retrieval to operate without requiring proxy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->