### PR TITLE
[Bargain Books ZA] Fix spider

### DIFF
--- a/locations/spiders/bargain_books_za.py
+++ b/locations/spiders/bargain_books_za.py
@@ -1,8 +1,11 @@
+import re
 from typing import Any
 
+import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -10,27 +13,71 @@ from locations.items import Feature
 class BargainBooksZASpider(Spider):
     name = "bargain_books_za"
     item_attributes = {"brand": "Bargain Books", "brand_wikidata": "Q116741024"}
-    start_urls = ["https://www.bargainbooks.co.za/locations/"]
+    start_urls = ["https://www.bargainbooks.co.za/stores"]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.xpath('//*[@id="bb-grid"]//*[@class="bb-card"]'):
-            item = Feature()
-            item["branch"] = item["ref"] = location.xpath(".//@data-name").get()
-            item["state"] = location.xpath(".//@data-province").get()
-            item["addr_full"] = location.xpath(".//@data-address").get()
-            item["phone"] = location.xpath('.//*[contains(@href,"tel:")]/text()').get()
-            item["email"] = location.xpath('.//*[contains(@href,"mailto:")]/text()').get()
-            oh = OpeningHours()
-            for day_time in location.xpath('.//*[@class="bb-hours"]//tr'):
-                day = day_time.xpath('.//*[@class="bb-day"]/text()').get()
-                time = day_time.xpath('.//*[@class="bb-time "]//text()').get()
+        for match in re.finditer(r'\$R\[\d+\]=(\{id:"[0-9a-f-]{8}-)', response.text):
+            store_str = self.extract_balanced_object(response.text, match.start(1))
+            if not store_str:
+                continue
+            store = chompjs.parse_js_object(re.sub(r"\$R\[\d+\]=", "", store_str))
 
-                if not day or day == "Public" or not time:
+            if "head office" in store["name"].lower():
+                continue
+
+            item = Feature()
+            item["ref"] = store["id"]
+            item["lat"] = store["lat"]
+            item["lon"] = store["lng"]
+            item["branch"] = store["name"]
+            item["addr_full"] = store["address"]
+            item["city"] = store["city"]
+            item["state"] = store["province"]
+            item["phone"] = store["phone"]
+
+            item["opening_hours"] = OpeningHours()
+            for days, hours_key in [
+                (["Mo", "Tu", "We", "Th", "Fr"], "hours_weekday"),
+                (["Sa"], "hours_saturday"),
+                (["Su"], "hours_sunday"),
+            ]:
+                hours = store.get(hours_key)
+                if not hours:
                     continue
-                if time.strip().lower() == "closed":
-                    oh.set_closed(day)
-                else:
-                    open_time, close_time = time.strip().replace(".", ":").replace(" ", "-").split("-")
-                    oh.add_range(day=day, open_time=open_time.strip(), close_time=close_time.strip())
-            item["opening_hours"] = oh
+                if hours.lower() == "closed":
+                    item["opening_hours"].set_closed(days)
+                    continue
+                open_time, close_time = hours.split("-")
+                if close_time <= open_time:
+                    continue
+                for day in days:
+                    item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time)
+
+            apply_category(Categories.SHOP_BOOKS, item)
+
             yield item
+
+    @staticmethod
+    def extract_balanced_object(text: str, start: int) -> str | None:
+        depth = 0
+        in_string = False
+        escape = False
+        for i in range(start, len(text)):
+            char = text[i]
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        return text[start : i + 1]
+        return None


### PR DESCRIPTION
The site has been rebuilt. The locations page now redirects to a store finder whose markup no longer carries the store cards the spider read, so it produced 0 features against 87 in the previous run.

The stores are still rendered into the page, as JavaScript objects rather than markup, so the spider reads those instead. Each carries coordinates, address, phone and opening hours for weekdays, Saturday and Sunday.

The head office is not collected, as it is not a shop.

A full live crawl returns 88 stores with complete geometry and no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bargain Books store discovery using the current stores page.
  * Added more accurate store coordinates and provincial information.
  * Improved opening-hours parsing, including closed periods and invalid time ranges.
  * Excluded head-office entries from store listings.
  * Classified locations under the books category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->