### PR TITLE
[dreams_donuts] Add spider (111 items)

### DIFF
--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,6 +1,6 @@
 import json
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, DAYS
 from locations.items import set_closed
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -50,6 +50,12 @@ class DreamsDonutsSpider(JSONBlobSpider):
                         day.get("openDay"),
                         str(day.get("openTime").get("hours")) + ":" + str(openMinutes),
                         str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes))
+
+            # the front end of the website explicitly displays  days that do not have openingHours in the API.
+            for day in DAYS:
+                if day not in item["opening_hours"].day_hours:
+                    item["opening_hours"].set_closed(day)
+            return hours
 
 
         apply_category(Categories.SHOP_PASTRY, item)

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -18,18 +18,18 @@ class DreamsDonutsSpider(JSONBlobSpider):
 
         oh = OpeningHours()
 
-        if(location.get("openingHours") != None ):
+        if(location.get("openingHours") is not None ):
             print(str(location.get("openingHours")))
 
             for day in location["openingHours"]:
-                if(day.get("openDay") != None 
-                and day.get("openTime") != None 
-                and day.get("closeTime") != None
-                and day.get("openTime").get("hours") != None 
-                and day.get("closeTime").get("hours") != None):
+                if(day.get("openDay") is not None 
+                    and day.get("openTime") is not None 
+                    and day.get("closeTime") is not None
+                    and day.get("openTime").get("hours") is not None 
+                    and day.get("closeTime").get("hours") is not None):
 
                     openMinutes= day.get("openTime").get("minutes") or '00'
-                    closeMinutes= day.get("openTime").get("minutes") or '00'
+                    closeMinutes= day.get("closeTime").get("minutes") or '00'
 
                     oh.add_ranges_from_string(day.get("openDay") 
                     + " " 
@@ -37,7 +37,6 @@ class DreamsDonutsSpider(JSONBlobSpider):
                     + "-" 
                     + str(day.get("closeTime").get("hours"))+":" + str(closeMinutes))
 
-        print(oh.as_opening_hours())
         item["opening_hours"] = oh
         apply_category(Categories.SHOP_PASTRY, item)
         yield item

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,7 +1,6 @@
 from locations.categories import Categories, apply_category
-from locations.json_blob_spider import JSONBlobSpider
 from locations.hours import OpeningHours
-
+from locations.json_blob_spider import JSONBlobSpider
 
 
 class DreamsDonutsSpider(JSONBlobSpider):
@@ -11,31 +10,39 @@ class DreamsDonutsSpider(JSONBlobSpider):
         "brand_wikidata": "Q141142873",
     }
     start_urls = ["https://boutiques.dreamsdonuts.com/_next/data/0fZaY95cqqjf19_M8VcLX/index.json"]
-    locations_key = ["pageProps","data","stores"]
+    locations_key = ["pageProps", "data", "stores"]
 
     def post_process_item(self, item, response, location):
         item["name"] = "Dreams Donuts"
 
         oh = OpeningHours()
 
-        if(location.get("openingHours") != None ):
+        if location.get("openingHours") != None:
             print(str(location.get("openingHours")))
 
             for day in location["openingHours"]:
-                if(day.get("openDay") != None 
-                and day.get("openTime") != None 
-                and day.get("closeTime") != None
-                and day.get("openTime").get("hours") != None 
-                and day.get("closeTime").get("hours") != None):
+                if (
+                    day.get("openDay") != None
+                    and day.get("openTime") != None
+                    and day.get("closeTime") != None
+                    and day.get("openTime").get("hours") != None
+                    and day.get("closeTime").get("hours") != None
+                ):
 
-                    openMinutes= day.get("openTime").get("minutes") or '00'
-                    closeMinutes= day.get("openTime").get("minutes") or '00'
+                    openMinutes = day.get("openTime").get("minutes") or "00"
+                    closeMinutes = day.get("openTime").get("minutes") or "00"
 
-                    oh.add_ranges_from_string(day.get("openDay") 
-                    + " " 
-                    + str(day.get("openTime").get("hours")) + ":" + str(openMinutes)  
-                    + "-" 
-                    + str(day.get("closeTime").get("hours"))+":" + str(closeMinutes))
+                    oh.add_ranges_from_string(
+                        day.get("openDay")
+                        + " "
+                        + str(day.get("openTime").get("hours"))
+                        + ":"
+                        + str(openMinutes)
+                        + "-"
+                        + str(day.get("closeTime").get("hours"))
+                        + ":"
+                        + str(closeMinutes)
+                    )
 
         print(oh.as_opening_hours())
         item["opening_hours"] = oh

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,7 +1,7 @@
 import json
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours, DAYS
+from locations.hours import DAYS, OpeningHours
 from locations.items import set_closed
 from locations.json_blob_spider import JSONBlobSpider
 
@@ -51,7 +51,8 @@ class DreamsDonutsSpider(JSONBlobSpider):
                     item["opening_hours"].add_range(
                         day.get("openDay"),
                         str(day.get("openTime").get("hours")) + ":" + str(openMinutes),
-                        str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes))
+                        str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes),
+                    )
 
             # the front end of the website explicitly displays  days that do not have openingHours in the API.
             for day in DAYS:

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -28,6 +28,8 @@ class DreamsDonutsSpider(JSONBlobSpider):
         if location.get("businessStatus") == "CLOSED_PERMANENTLY":
             set_closed(item)
 
+        if location.get("slug") is not None:
+            item["website"] = "https://boutiques.dreamsdonuts.com/"+location.get("slug")
 
         item["opening_hours"] = OpeningHours()
 

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,8 +1,10 @@
 import json
+
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import set_closed
 from locations.json_blob_spider import JSONBlobSpider
+
 
 class DreamsDonutsSpider(JSONBlobSpider):
     name = "dreams_donuts"
@@ -29,7 +31,7 @@ class DreamsDonutsSpider(JSONBlobSpider):
             set_closed(item)
 
         if location.get("slug") is not None:
-            item["website"] = "https://boutiques.dreamsdonuts.com/"+location.get("slug")
+            item["website"] = "https://boutiques.dreamsdonuts.com/" + location.get("slug")
 
         item["opening_hours"] = OpeningHours()
 
@@ -49,8 +51,8 @@ class DreamsDonutsSpider(JSONBlobSpider):
                     item["opening_hours"].add_range(
                         day.get("openDay"),
                         str(day.get("openTime").get("hours")) + ":" + str(openMinutes),
-                        str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes))
-
+                        str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes),
+                    )
 
         apply_category(Categories.SHOP_PASTRY, item)
         yield item

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,7 +1,8 @@
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
-
+from locations.items import set_closed
+import json
 
 class DreamsDonutsSpider(JSONBlobSpider):
     name = "dreams_donuts"
@@ -9,13 +10,26 @@ class DreamsDonutsSpider(JSONBlobSpider):
         "brand": "Dreams Donuts",
         "brand_wikidata": "Q141142873",
     }
-    start_urls = ["https://boutiques.dreamsdonuts.com/_next/data/0fZaY95cqqjf19_M8VcLX/index.json"]
-    locations_key = ["pageProps", "data", "stores"]
+
+    start_urls = ["https://boutiques.dreamsdonuts.com/"]
+
+    def extract_json(self, response):
+        data = response.css("script#__NEXT_DATA__::text").get()
+
+        if not data:
+            raise ValueError("__NEXT_DATA__ not found")
+
+        data = json.loads(data)
+        return data["props"]["pageProps"]["data"]["stores"]
 
     def post_process_item(self, item, response, location):
-        item["name"] = "Dreams Donuts"
+        item["branch"] = item.pop("name", "").removeprefix("Dreams Donuts ")
 
-        oh = OpeningHours()
+        if location.get("businessStatus") == "CLOSED_PERMANENTLY":
+            set_closed(item)
+
+
+        item["opening_hours"] = OpeningHours()
 
         if location.get("openingHours") is not None:
             for day in location["openingHours"]:
@@ -30,7 +44,7 @@ class DreamsDonutsSpider(JSONBlobSpider):
                     openMinutes = day.get("openTime").get("minutes") or "00"
                     closeMinutes = day.get("closeTime").get("minutes") or "00"
 
-                    oh.add_ranges_from_string(
+                    item["opening_hours"].add_ranges_from_string(
                         day.get("openDay")
                         + " "
                         + str(day.get("openTime").get("hours"))
@@ -42,6 +56,5 @@ class DreamsDonutsSpider(JSONBlobSpider):
                         + str(closeMinutes)
                     )
 
-        item["opening_hours"] = oh
         apply_category(Categories.SHOP_PASTRY, item)
         yield item

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,8 +1,10 @@
+import json
+
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
-from locations.json_blob_spider import JSONBlobSpider
 from locations.items import set_closed
-import json
+from locations.json_blob_spider import JSONBlobSpider
+
 
 class DreamsDonutsSpider(JSONBlobSpider):
     name = "dreams_donuts"
@@ -27,7 +29,6 @@ class DreamsDonutsSpider(JSONBlobSpider):
 
         if location.get("businessStatus") == "CLOSED_PERMANENTLY":
             set_closed(item)
-
 
         item["opening_hours"] = OpeningHours()
 

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -17,16 +17,18 @@ class DreamsDonutsSpider(JSONBlobSpider):
 
         oh = OpeningHours()
 
-        if(location.get("openingHours") is not None ):
+        if location.get("openingHours") is not None:
             for day in location["openingHours"]:
-                if(day.get("openDay") is not None 
-                    and day.get("openTime") is not None 
+                if (
+                    day.get("openDay") is not None
+                    and day.get("openTime") is not None
                     and day.get("closeTime") is not None
-                    and day.get("openTime").get("hours") is not None 
-                    and day.get("closeTime").get("hours") is not None):
+                    and day.get("openTime").get("hours") is not None
+                    and day.get("closeTime").get("hours") is not None
+                ):
 
-                    openMinutes= day.get("openTime").get("minutes") or '00'
-                    closeMinutes= day.get("closeTime").get("minutes") or '00'
+                    openMinutes = day.get("openTime").get("minutes") or "00"
+                    closeMinutes = day.get("closeTime").get("minutes") or "00"
 
                     oh.add_ranges_from_string(
                         day.get("openDay")

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,0 +1,43 @@
+from locations.categories import Categories, apply_category
+from locations.json_blob_spider import JSONBlobSpider
+from locations.hours import OpeningHours
+
+
+
+class DreamsDonutsSpider(JSONBlobSpider):
+    name = "dreams_donuts"
+    item_attributes = {
+        "brand": "Dreams Donuts",
+        "brand_wikidata": "Q141142873",
+    }
+    start_urls = ["https://boutiques.dreamsdonuts.com/_next/data/0fZaY95cqqjf19_M8VcLX/index.json"]
+    locations_key = ["pageProps","data","stores"]
+
+    def post_process_item(self, item, response, location):
+        item["name"] = "Dreams Donuts"
+
+        oh = OpeningHours()
+
+        if(location.get("openingHours") != None ):
+            print(str(location.get("openingHours")))
+
+            for day in location["openingHours"]:
+                if(day.get("openDay") != None 
+                and day.get("openTime") != None 
+                and day.get("closeTime") != None
+                and day.get("openTime").get("hours") != None 
+                and day.get("closeTime").get("hours") != None):
+
+                    openMinutes= day.get("openTime").get("minutes") or '00'
+                    closeMinutes= day.get("openTime").get("minutes") or '00'
+
+                    oh.add_ranges_from_string(day.get("openDay") 
+                    + " " 
+                    + str(day.get("openTime").get("hours")) + ":" + str(openMinutes)  
+                    + "-" 
+                    + str(day.get("closeTime").get("hours"))+":" + str(closeMinutes))
+
+        print(oh.as_opening_hours())
+        item["opening_hours"] = oh
+        apply_category(Categories.SHOP_PASTRY, item)
+        yield item

--- a/locations/spiders/dreams_donuts.py
+++ b/locations/spiders/dreams_donuts.py
@@ -1,5 +1,5 @@
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.hours import OpeningHours, DAYS
 from locations.json_blob_spider import JSONBlobSpider
 from locations.items import set_closed
 import json
@@ -46,17 +46,11 @@ class DreamsDonutsSpider(JSONBlobSpider):
                     openMinutes = day.get("openTime").get("minutes") or "00"
                     closeMinutes = day.get("closeTime").get("minutes") or "00"
 
-                    item["opening_hours"].add_ranges_from_string(
-                        day.get("openDay")
-                        + " "
-                        + str(day.get("openTime").get("hours"))
-                        + ":"
-                        + str(openMinutes)
-                        + "-"
-                        + str(day.get("closeTime").get("hours"))
-                        + ":"
-                        + str(closeMinutes)
-                    )
+                    item["opening_hours"].add_range(
+                        day.get("openDay"),
+                        str(day.get("openTime").get("hours")) + ":" + str(openMinutes),
+                        str(day.get("closeTime").get("hours")) + ":" + str(closeMinutes))
+
 
         apply_category(Categories.SHOP_PASTRY, item)
         yield item


### PR DESCRIPTION
Adds dreams donuts pastry shops
```
{'atp/brand/Dreams Donuts': 111,
 'atp/brand_wikidata/Q141142873': 111,
 'atp/category/shop/pastry': 111,
 'atp/country/BE': 1,
 'atp/country/CH': 2,
 'atp/country/ES': 10,
 'atp/country/FR': 85,
 'atp/country/IT': 6,
 'atp/country/LU': 1,
 'atp/country/MQ': 1,
 'atp/country/NC': 1,
 'atp/country/PT': 1,
 'atp/country/RE': 3,
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Dreams Donuts locations.
  * Store details now include branch names, brand information, pastry shop categorization, and opening hours.
  * Permanently closed locations are now clearly marked.
  * Incomplete opening-hour entries continue to be safely excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->