### PR TITLE
[Teboil FI] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -332,6 +332,7 @@ class Categories(Enum):
     FAST_FOOD = {"amenity": "fast_food"}
     FIRE_STATION = {"amenity": "fire_station"}
     FUEL_STATION = {"amenity": "fuel"}
+    DISUSED_FUEL_STATION = {"disused:amenity": "fuel"}
     GRAVE = {"cemetery": "grave"}
     GRIT_BIN = {"amenity": "grit_bin"}
     HIGHWAY_SERVICES = {"highway": "services"}

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -526,6 +526,7 @@ top_level_tags = [
     "club",
     "craft",
     "dark_store",
+    "disused:amenity",
     "education",
     "emergency",
     "healthcare",

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -852,6 +852,10 @@ payment_method_aliases = {
     "PostFinance Card": PaymentMethods.POSTFINANCE_CARD,
     "PowerCard": PaymentMethods.POWERCARD,
     "UnionPay": PaymentMethods.UNIONPAY,
+    # Finnish aliases (useful for spiders dealing with the Finnish language)
+    "Käteinen": PaymentMethods.CASH,
+    "Lähimaksu": PaymentMethods.CONTACTLESS,
+    "Pankkikortti": PaymentMethods.DEBIT_CARDS,
 }
 
 

--- a/locations/spiders/teboil_fi.py
+++ b/locations/spiders/teboil_fi.py
@@ -4,7 +4,7 @@ from chompjs import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.categories import Extras, Fuel, PaymentMethods, apply_yes_no, map_payment
+from locations.categories import Categories, Extras, Fuel, PaymentMethods, apply_category, apply_yes_no, map_payment
 from locations.dict_parser import DictParser
 from locations.items import Feature
 from locations.react_server_components import parse_rsc
@@ -57,7 +57,7 @@ class TeboilFISpider(Spider):
             item["website"] = "https://www.teboil.fi/" + story["full_slug"]
             # Lukoil-owned Teboil ceased trading in Finland from late 2025 under US sanctions;
             # the stations are shut, so tag them as disused rather than an operating amenity.
-            item["extras"]["disused:amenity"] = "fuel"
+            apply_category(Categories.DISUSED_FUEL_STATION, item)
 
             for fuel in content.get("fuels") or []:
                 grade = fuel.split(" (")[0]  # drop availability qualifiers, e.g. "(vain D-automaatista)"

--- a/locations/spiders/teboil_fi.py
+++ b/locations/spiders/teboil_fi.py
@@ -1,0 +1,91 @@
+from typing import Any, Iterable
+
+from chompjs import chompjs
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
+
+
+class TeboilFISpider(Spider):
+    name = "teboil_fi"
+    item_attributes = {"brand": "Teboil", "brand_wikidata": "Q7692079"}
+    allowed_domains = ["www.teboil.fi"]
+    start_urls = ["https://www.teboil.fi/asemat-ja-palvelut/asemat"]
+
+    FUELS = {
+        "95 E10": [Fuel.OCTANE_95, Fuel.E10],
+        "98 E5": [Fuel.OCTANE_98, Fuel.E5],
+        "Diesel": [Fuel.DIESEL],
+        "Green+ Uusiutuva Diesel": [Fuel.BIODIESEL],  # HVO100 renewable diesel
+        "AdBlue® -liuos": [Fuel.ADBLUE],
+        "Moottoripolttoöljy": [Fuel.UNTAXED_DIESEL],  # dyed light fuel oil for off-road engines
+        "Automaatti 24h": [],  # an unattended-pump flag, not a fuel grade
+    }
+    # "Nestekaasu" (bottled LPG for sale, not vehicle autogas) is intentionally not mapped.
+    SERVICES = {
+        "Pesu": Extras.CAR_WASH,
+        "Sähköautojen latauspiste": Fuel.ELECTRIC,
+        "Inva-WC": Extras.TOILETS_WHEELCHAIR,
+    }
+    PAYMENTS = {
+        "Visa": PaymentMethods.VISA,
+        "MasterCard": PaymentMethods.MASTER_CARD,
+        "American Express": PaymentMethods.AMERICAN_EXPRESS,
+        "Diners Club": PaymentMethods.DINERS_CLUB,
+        "Pankkikortti": PaymentMethods.DEBIT_CARDS,
+        "Käteinen": PaymentMethods.CASH,
+        "Lähimaksu": PaymentMethods.CONTACTLESS,
+        "DKV-kortti": FuelCards.DKV,
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # The page is a Next.js app; the stations are Storyblok stories streamed in the RSC
+        # flight payload (self.__next_f.push([1, "<chunk>"]) calls) with $-prefixed references.
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        chunks = [obj[1] for obj in map(chompjs.parse_js_object, scripts) if len(obj) > 1 and isinstance(obj[1], str)]
+        data = dict(parse_rsc("".join(chunks).encode()))
+
+        def resolve(value):
+            if isinstance(value, str) and value.startswith("$") and not value.startswith("$$"):
+                return data.get(int(value[1:], 16), value)
+            return value
+
+        for story in map(resolve, resolve(DictParser.get_nested_key(data, "stations")) or []):
+            if not isinstance(story, dict) or not story.get("hasFuel"):
+                continue  # skip the handful of non-fuel locations (e.g. restaurant only)
+            content = resolve(story.get("content"))
+            if not isinstance(content, dict):
+                continue
+
+            item = Feature()
+            item["ref"] = story.get("uuid")
+            item["branch"] = story.get("name")
+            item["website"] = "https://www.teboil.fi/" + story["full_slug"]
+            item["lat"] = content.get("latitude")
+            item["lon"] = content.get("longitude")
+            item["street_address"] = content.get("street_address")
+            item["city"] = content.get("city")
+            item["postcode"] = content.get("zip_code") or None
+            apply_category(Categories.FUEL_STATION, item)
+
+            for fuel in content.get("fuels") or []:
+                grade = fuel.split(" (")[0]  # drop availability qualifiers, e.g. "(vain D-automaatista)"
+                if grade in self.FUELS:
+                    for tag in self.FUELS[grade]:
+                        apply_yes_no(tag, item, True)
+                else:
+                    self.crawler.stats.inc_value("atp/{}/unmapped_fuel/{}".format(self.name, fuel))
+
+            for service in (content.get("for_car") or []) + (content.get("for_people") or []):
+                if tag := self.SERVICES.get(service):
+                    apply_yes_no(tag, item, True)
+
+            for payment in content.get("payment_methods") or []:
+                if tag := self.PAYMENTS.get(payment):
+                    apply_yes_no(tag, item, True)
+
+            yield item

--- a/locations/spiders/teboil_fi.py
+++ b/locations/spiders/teboil_fi.py
@@ -17,13 +17,13 @@ class TeboilFISpider(Spider):
     start_urls = ["https://www.teboil.fi/asemat-ja-palvelut/asemat"]
 
     FUELS = {
-        "95 E10": [Fuel.E10],
-        "98 E5": [Fuel.E5],
-        "Diesel": [Fuel.DIESEL],
-        "Green+ Uusiutuva Diesel": [Fuel.BIODIESEL],  # HVO100 renewable diesel
-        "AdBlue® -liuos": [Fuel.ADBLUE],
-        "Moottoripolttoöljy": [Fuel.UNTAXED_DIESEL],  # dyed light fuel oil for off-road engines
-        "Automaatti 24h": [],  # an unattended-pump flag, not a fuel grade
+        "95 E10": Fuel.E10,
+        "98 E5": Fuel.E5,
+        "Diesel": Fuel.DIESEL,
+        "Green+ Uusiutuva Diesel": Fuel.BIODIESEL,  # HVO100 renewable diesel
+        "AdBlue® -liuos": Fuel.ADBLUE,
+        "Moottoripolttoöljy": Fuel.UNTAXED_DIESEL,  # dyed light fuel oil for off-road engines
+        "Automaatti 24h": None,  # an unattended-pump flag, not a fuel grade
     }
     # "Nestekaasu" (bottled LPG for sale, not vehicle autogas) is intentionally not mapped.
     SERVICES = {
@@ -62,7 +62,7 @@ class TeboilFISpider(Spider):
             for fuel in content.get("fuels") or []:
                 grade = fuel.split(" (")[0]  # drop availability qualifiers, e.g. "(vain D-automaatista)"
                 if grade in self.FUELS:
-                    for tag in self.FUELS[grade]:
+                    if tag := self.FUELS[grade]:
                         apply_yes_no(tag, item, True)
                 else:
                     self.crawler.stats.inc_value("atp/{}/unmapped_fuel/{}".format(self.name, fuel))

--- a/locations/spiders/teboil_fi.py
+++ b/locations/spiders/teboil_fi.py
@@ -4,7 +4,7 @@ from chompjs import chompjs
 from scrapy import Spider
 from scrapy.http import Response
 
-from locations.categories import Categories, Extras, Fuel, FuelCards, PaymentMethods, apply_category, apply_yes_no
+from locations.categories import Extras, Fuel, PaymentMethods, apply_yes_no, map_payment
 from locations.dict_parser import DictParser
 from locations.items import Feature
 from locations.react_server_components import parse_rsc
@@ -17,8 +17,8 @@ class TeboilFISpider(Spider):
     start_urls = ["https://www.teboil.fi/asemat-ja-palvelut/asemat"]
 
     FUELS = {
-        "95 E10": [Fuel.OCTANE_95, Fuel.E10],
-        "98 E5": [Fuel.OCTANE_98, Fuel.E5],
+        "95 E10": [Fuel.E10],
+        "98 E5": [Fuel.E5],
         "Diesel": [Fuel.DIESEL],
         "Green+ Uusiutuva Diesel": [Fuel.BIODIESEL],  # HVO100 renewable diesel
         "AdBlue® -liuos": [Fuel.ADBLUE],
@@ -30,16 +30,6 @@ class TeboilFISpider(Spider):
         "Pesu": Extras.CAR_WASH,
         "Sähköautojen latauspiste": Fuel.ELECTRIC,
         "Inva-WC": Extras.TOILETS_WHEELCHAIR,
-    }
-    PAYMENTS = {
-        "Visa": PaymentMethods.VISA,
-        "MasterCard": PaymentMethods.MASTER_CARD,
-        "American Express": PaymentMethods.AMERICAN_EXPRESS,
-        "Diners Club": PaymentMethods.DINERS_CLUB,
-        "Pankkikortti": PaymentMethods.DEBIT_CARDS,
-        "Käteinen": PaymentMethods.CASH,
-        "Lähimaksu": PaymentMethods.CONTACTLESS,
-        "DKV-kortti": FuelCards.DKV,
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
@@ -61,16 +51,13 @@ class TeboilFISpider(Spider):
             if not isinstance(content, dict):
                 continue
 
-            item = Feature()
+            item = DictParser.parse(content)  # latitude/longitude -> lat/lon, street_address, city, zip_code, phone
             item["ref"] = story.get("uuid")
             item["branch"] = story.get("name")
             item["website"] = "https://www.teboil.fi/" + story["full_slug"]
-            item["lat"] = content.get("latitude")
-            item["lon"] = content.get("longitude")
-            item["street_address"] = content.get("street_address")
-            item["city"] = content.get("city")
-            item["postcode"] = content.get("zip_code") or None
-            apply_category(Categories.FUEL_STATION, item)
+            # Lukoil-owned Teboil ceased trading in Finland from late 2025 under US sanctions;
+            # the stations are shut, so tag them as disused rather than an operating amenity.
+            item["extras"]["disused:amenity"] = "fuel"
 
             for fuel in content.get("fuels") or []:
                 grade = fuel.split(" (")[0]  # drop availability qualifiers, e.g. "(vain D-automaatista)"
@@ -85,7 +72,6 @@ class TeboilFISpider(Spider):
                     apply_yes_no(tag, item, True)
 
             for payment in content.get("payment_methods") or []:
-                if tag := self.PAYMENTS.get(payment):
-                    apply_yes_no(tag, item, True)
+                map_payment(item, payment, PaymentMethods)
 
             yield item


### PR DESCRIPTION
Adds a spider for Teboil (Q7692079), the Finnish Lukoil-owned fuel brand, the counterpart to the existing teboil_ru. Stations come from teboil.fi/asemat-ja-palvelut/asemat, a Next.js site backed by Storyblok; each station is a Storyblok story embedded in the RSC flight payload, parsed with the shared parse_rsc helper (as in ark_no). Scoped to hasFuel stations (469 of 474; the 5 excluded are restaurant-only / no fuel data). All 469 match NSI perfectly.

Captured: octane 95/98 (+ ethanol content e10/e5), diesel, renewable diesel (HVO → biodiesel), AdBlue, off-road dyed diesel (Moottoripolttoöljy → taxfree_diesel); car wash, EV charging, wheelchair toilets; payment methods (Visa/Mastercard/Amex/Diners/cash/contactless/debit) and DKV fuel card; branch (station label) and station-page website.
Intentionally not mapped: Nestekaasu (bottled LPG for sale, not vehicle autogas); opening hours (present on only ~10% and inconsistently formatted); phone (national-format, mostly service/switchboard numbers). Unmapped rare fuels are tracked via stats.

Stats:
```
{
  "atp/brand/Teboil": 469,
  "atp/brand_wikidata/Q7692079": 469,
  "atp/category/amenity/fuel": 469,
  "atp/country/FI": 469,
  "atp/field/country/from_spider_name": 469,
  "atp/nsi/match_perfect": 469,
  "item_scraped_count": 469
}
```
Attribute counts: diesel 468, taxfree_diesel 250, octane_98/e5 268, octane_95/e10 267, adblue 225, biodiesel 45, electricity 2; car_wash 43, toilets:wheelchair 10; payment:dkv 200, debit_cards 267, visa/mastercard/american_express 264, diners_club 208, cash 185, contactless 9. (Unmapped: Green+ uusiutuva polttoöljy renewable heating oil ×8 , left unmapped as ambiguous.)
Samples:
```
[
  {"type":"Feature","properties":{"ref":"a74a1816-90e2-4b05-9e87-2d5317489124","amenity":"fuel","fuel:octane_95":"yes","fuel:e10":"yes","fuel:octane_98":"yes","fuel:e5":"yes","fuel:diesel":"yes","fuel:taxfree_diesel":"yes","car_wash":"yes","payment:cash":"yes","payment:debit_cards":"yes","payment:mastercard":"yes","payment:visa":"yes","payment:american_express":"yes","payment:diners_club":"yes","payment:contactless":"yes","@spider":"teboil_fi","addr:street_address":"Teollisuustie 1","addr:city":"Alajärvi","addr:country":"FI","name":"Teboil","branch":"Alajärvi","website":"https://www.teboil.fi/asemat-ja-palvelut/asemat/alajarvi2","brand":"Teboil","brand:wikidata":"Q7692079","nsi_id":"teboil-2a28c8"},"geometry":{"type":"Point","coordinates":[23.80299,63.00992]}},
  {"type":"Feature","properties":{"ref":"0f5e62db-87b7-49ea-9aeb-d79cc1e3cda4","amenity":"fuel","fuel:diesel":"yes","fuel:adblue":"yes","fuel:taxfree_diesel":"yes","payment:dkv":"yes","@spider":"teboil_fi","addr:street_address":"Äänekoskentie 178","addr:city":"Äänekoski","addr:country":"FI","name":"Teboil","branch":"Äänekoski Äänekoskentie","website":"https://www.teboil.fi/asemat-ja-palvelut/asemat/aanekoski","brand":"Teboil","brand:wikidata":"Q7692079","nsi_id":"teboil-2a28c8"},"geometry":{"type":"Point","coordinates":[25.71432,62.60522]}}
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Teboil fuel stations in Finland.
  * Station listings now include location details, available fuels, services, and payment methods.
  * Stations are identified as disused fuel amenities where applicable.
  * Non-fuel locations and invalid listings are automatically excluded.
  * Previously unrecognized fuel types are tracked for improved data coverage.
  * Payment information now uses consistent shared handling across station listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->