### PR TITLE
[Paz IL] Add spider (264 locations)

### DIFF
--- a/locations/spiders/paz_il.py
+++ b/locations/spiders/paz_il.py
@@ -1,0 +1,90 @@
+from typing import Any, Iterable
+
+from chompjs import chompjs
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.items import Feature
+from locations.react_server_components import parse_rsc
+
+
+class PazILSpider(Spider):
+    name = "paz_il"
+    item_attributes = {"brand": "פז", "brand_wikidata": "Q2211731"}
+    allowed_domains = ["www.paz.co.il"]
+    start_urls = ["https://www.paz.co.il/service-locator"]
+    requires_proxy = True  # Radware Bot Manager blocks direct requests.
+
+    # metaData service label (Hebrew) -> tag.
+    SERVICES = {
+        "פז wash": Extras.CAR_WASH,  # Paz wash
+        "כספומט": Extras.ATM,  # ATM
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # The service locator is a Next.js app; the stations are nested in the streamed RSC
+        # flight payload (self.__next_f.push([1, "<chunk>"]) calls) with $-prefixed references.
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        chunks = [obj[1] for obj in map(chompjs.parse_js_object, scripts) if len(obj) > 1 and isinstance(obj[1], str)]
+        data = dict(parse_rsc("".join(chunks).encode()))
+
+        def resolve(value):
+            # RSC references are "$<hex row id>"; other "$"-prefixed tokens (e.g. "$L1",
+            # "$undefined", the escaped literal "$$") are left as-is.
+            while isinstance(value, str) and len(value) > 1 and value[0] == "$" and value[1] != "$":
+                ref = value[1:]
+                if not all(c in "0123456789abcdefABCDEF" for c in ref) or (nxt := data.get(int(ref, 16))) is None:
+                    break
+                value = nxt
+            return value
+
+        for station in self.find_stations(data, resolve):
+            # type 1 = fuel station; 2/7 = Paz-owned supermarkets, 10 = standalone EV charger.
+            if station.get("type") != 1:
+                continue
+
+            item = DictParser.parse(station)  # id->ref, geoLocation->lat/lon, address->addr_full
+            item["ref"] = str(item["ref"])
+            item["branch"] = item.pop("name", None)  # brand name comes from NSI
+            item["street_address"] = item.pop("addr_full", None)
+            item.pop("state", None)  # "region" is a Paz marketing zone (incl. a city), not addr:state
+            apply_category(Categories.FUEL_STATION, item)
+
+            apply_yes_no(Fuel.OCTANE_98, item, station.get("product98"))
+            apply_yes_no(Fuel.LPG, item, station.get("productGas"))  # גפ"מ autogas
+            apply_yes_no(Fuel.ADBLUE, item, station.get("productUrea"))  # אוריאה
+            apply_yes_no(Fuel.ELECTRIC, item, station.get("isElectric"))
+
+            for service in station.get("metaData") or []:
+                if tag := self.SERVICES.get(service.get("name")):
+                    apply_yes_no(tag, item, True)
+
+            yield item
+
+    @classmethod
+    def find_stations(cls, data: dict, resolve) -> list:
+        # The station list sits deep in the RSC component tree; find it by shape (a list
+        # whose items carry a geoLocation) rather than a brittle fixed key path.
+        for value in data.values():
+            if found := cls._find_list(resolve(value), resolve, 0):
+                return found
+        return []
+
+    @classmethod
+    def _find_list(cls, value: Any, resolve, depth: int) -> list | None:
+        if depth > 40:
+            return None
+        value = resolve(value)
+        if isinstance(value, list):
+            if len(value) >= 20 and isinstance(first := resolve(value[0]), dict) and "geoLocation" in first:
+                return [resolve(v) for v in value]
+            for item in value:
+                if found := cls._find_list(item, resolve, depth + 1):
+                    return found
+        elif isinstance(value, dict):
+            for item in value.values():
+                if found := cls._find_list(item, resolve, depth + 1):
+                    return found
+        return None


### PR DESCRIPTION
Adds a spider for Paz (פז, Q2211731), an Israeli fuel brand. Stations come from paz.co.il/service-locator, a Next.js site; the data is embedded in the RSC flight payload (parsed with the shared parse_rsc helper). Scoped to fuel stations (type == 1, 264 of 338 — the rest are Paz-owned supermarkets and a standalone EV charger). The site is behind Radware Bot Manager, so requires_proxy = True. 
All 264 match NSI perfectly. Captured: octane 98, LPG (autogas), AdBlue, EV charging, car wash, ATM, phone, and Hebrew branch/address.

Stats:
```
{
  "atp/brand/פז": 264,
  "atp/brand_wikidata/Q2211731": 264,
  "atp/category/amenity/fuel": 264,
  "atp/country/IL": 264,
  "atp/field/country/from_spider_name": 264,
  "atp/nsi/match_perfect": 264,
  "item_scraped_count": 264
}
```
Attribute counts: fuel:electricity 122, fuel:octane_98 105, fuel:adblue 86, fuel:lpg 21; car_wash 30, atm 74; phone 256 valid.

Samples:
```
[
  {"type":"Feature","properties":{"ref":"62","amenity":"fuel","fuel:octane_98":"yes","fuel:lpg":"yes","fuel:adblue":"yes","fuel:electricity":"yes","car_wash":"yes","atm":"yes","name":"פז","branch":"עד הלום","brand:en":"Paz","brand:he":"פז","addr:street_address":"א.ת. עד-הלום כביש אשדוד אשקלון","addr:city":"אשדוד","addr:country":"IL","phone":"+972 8-855-6927","brand":"פז","brand:wikidata":"Q2211731","nsi_id":"paz-bb4acb"},"geometry":{"type":"Point","coordinates":[34.6664046,31.7660602]}},
  {"type":"Feature","properties":{"ref":"1112","amenity":"fuel","name":"פז","branch":"דלית אל כרמל","brand:en":"Paz","brand:he":"פז","addr:city":"דאלית אל-כרמל","addr:country":"IL","phone":"+972 54-330-9069","brand":"פז","brand:wikidata":"Q2211731","nsi_id":"paz-bb4acb"},"geometry":{"type":"Point","coordinates":[35.0604685,32.6869624]}}
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for discovering Paz fuel stations through the online service locator.
  - Station listings now include location details, available fuel types, electric charging availability, contact information, and supported services.
  - Added station metadata and proxy support to improve the reliability and consistency of collected listings.
  - Non-fuel locations are automatically excluded from the station results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->