### PR TITLE
Add skip_auto_cc_spider_name_check flag to spider naming checker

### DIFF
--- a/ci/check_spider_naming_consistency.py
+++ b/ci/check_spider_naming_consistency.py
@@ -143,7 +143,7 @@ COUNTRYCODE_COMPONENTS = {
 }
 
 
-def snake_to_camel(snake_str: str) -> str:
+def snake_to_camel(snake_str: str, skip_auto_cc_spider_name_check: bool = False) -> str:
     components = snake_str.split("_")
 
     # If the first component is a number, spell it out
@@ -154,12 +154,14 @@ def snake_to_camel(snake_str: str) -> str:
     for i, component in enumerate(components):
         components[i] = component.capitalize()
 
-    # Allow consecutive country codes at the end of the spider name
-    for i in range(len(components) - 1, 0, -1):
-        if components[i].upper() not in COUNTRYCODE_COMPONENTS:
-            break
+    # Allow consecutive country codes at the end of the spider name, unless the spider has opted out
+    # because a trailing component happens to collide with a country code (e.g. "..._and_co").
+    if not skip_auto_cc_spider_name_check:
+        for i in range(len(components) - 1, 0, -1):
+            if components[i].upper() not in COUNTRYCODE_COMPONENTS:
+                break
 
-        components[i] = components[i].upper()
+            components[i] = components[i].upper()
 
     return "".join(components)
 
@@ -242,17 +244,19 @@ def check_file(file_path: Path) -> Tuple[Path, List[str]]:
         if isinstance(node, ast.ClassDef):
             class_name = node.name
             spider_name = None
+            skip_auto_cc_spider_name_check = False
 
-            # Look for an assignment to the spider_name variable
+            # Look for an assignment to the spider_name variable, and to the
+            # skip_auto_cc_spider_name_check opt-out flag.
             for item in node.body:
                 if isinstance(item, ast.Assign):
                     for target in item.targets:
                         if isinstance(target, ast.Name) and target.id == "name":
                             if isinstance(item.value, ast.Constant):
                                 spider_name = item.value.value
-                            break
-                    if spider_name:
-                        break
+                        elif isinstance(target, ast.Name) and target.id == "skip_auto_cc_spider_name_check":
+                            if isinstance(item.value, ast.Constant):
+                                skip_auto_cc_spider_name_check = bool(item.value.value)
 
             if spider_name:
                 # Spider names should be lowercase or digits and only use underscores.
@@ -261,7 +265,7 @@ def check_file(file_path: Path) -> Tuple[Path, List[str]]:
                         f"Spider name '{spider_name}' should only use lowercase letters/digits and underscores"
                     )
 
-                expected_class_name = snake_to_camel(spider_name) + "Spider"
+                expected_class_name = snake_to_camel(spider_name, skip_auto_cc_spider_name_check) + "Spider"
                 expected_file_name = spider_name
 
                 if class_name != expected_class_name:


### PR DESCRIPTION
`ci/check_spider_naming_consistency.py` auto-capitalizes a spider name's trailing components when they match a known country code (e.g. `teboil_fi` -> `TeboilFISpider`). This produces a false positive for spider names where a trailing component collides with a country code but isn't one, e.g. `basilic_and_co` -> `BasilicAndCOSpider` (treating "Co" as Colombia's ISO code), as seen in #17950.

This adds an opt-out class attribute, `skip_auto_cc_spider_name_check = True`, that a spider can set to skip the country-code capitalization step for its own name. This is a new, dedicated flag rather than reusing the existing `skip_auto_cc_spider_name` (which already controls a different, unrelated behavior — whether `CountryCodeCleanUpPipeline` auto-derives an item's `country` field from the spider name at runtime). Reusing that flag would have forced renaming several already-correctly-named spiders (`CrocsEUSpider`, `AsicsEUSpider`, `OrangeFRSpider`, etc.) that set it for the unrelated pipeline behavior.

Verified `ci/check_spider_naming_consistency.py` still passes with no errors against the current spider directory.

seen in #17952, #17950