### PR TITLE
[Azbuka Vkusa RU] Add RU proxy requirement

### DIFF
--- a/locations/spiders/azbuka_vkusa_ru.py
+++ b/locations/spiders/azbuka_vkusa_ru.py
@@ -16,6 +16,7 @@ class AzbukaVkusaRUSpider(JSONBlobSpider):
         "brand_wikidata": "Q4058209",
     }
     locations_key = "data"
+    requires_proxy = "RU"
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
         item.pop("name")


### PR DESCRIPTION
Sets `requires_proxy = "RU"` on the Azbuka Vkusa spider.

The data API at `https://services-api.av.ru/shops/byChannel/offline` is behind ServicePipe, a Russian anti-bot CDN doing IP-reputation/VPN detection — it returns HTTP 460 ("Looks like you're using a VPN") to requests from non-RU-residential IPs. Routing through an RU proxy is the standard fix for this pattern (see `fix_price.py`, `vkusno_i_tochka_ru.py`, `gazpromneft_ru.py`).

seen in #17058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Azbuka Vkusa location data by routing requests through a Russian proxy when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->