### PR TITLE
[Dixy RU] Add RU proxy requirement

### DIFF
--- a/locations/spiders/dixy_ru.py
+++ b/locations/spiders/dixy_ru.py
@@ -12,6 +12,7 @@ class DixyRUSpider(scrapy.Spider):
     item_attributes = {"brand": "Дикси", "brand_wikidata": "Q4161561"}
     start_urls = ["https://dixy.ru/ajax/stores-json.php"]
     custom_settings = {"ROBOTSTXT_OBEY": False}
+    requires_proxy = "RU"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.json():


### PR DESCRIPTION
- The store-locator endpoint (`https://dixy.ru/ajax/stores-json.php`) and even the homepage now return HTTP 200 with an HTML "Не удалось загрузить сайт" (failed to load site) page instead of JSON/normal content, from every path tested (including `/catalog/`). The page explicitly says "Possibly you have a VPN enabled or no internet connection" — a QRATOR-fronted IP-reputation block on non-RU IPs, same class of issue as azbuka_vkusa_ru (#17058).
- `requires_proxy = "RU"` matches the existing pattern used for other Russian retailers blocked this way (auchan_ru, perekryostok_ru, fix_price, etc).
- Not verified locally (needs a RU-resident IP); seen in #17063.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data collection reliability for the RU region by enabling proxy usage where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->