### PR TITLE
Allowlist rivian_us for low download delay

### DIFF
--- a/tests/test_download_delay.py
+++ b/tests/test_download_delay.py
@@ -29,6 +29,7 @@ def test_spiders_do_not_use_lower_download_delay_than_default():
     ALLOWED_LOW_DOWNLOAD_DELAY = set(
         [
             "usps_collection_boxes",  # Need to be faster to complete within time limits
+            "rivian_us",  # Crawls a large grid of public vector map tiles; needs to be faster to complete within time limits
         ]
     )
 


### PR DESCRIPTION
rivian_us (added in #17856) sets DOWNLOAD_DELAY=0 to crawl a large grid of public vector map tiles within time limits, but wasn't added to ALLOWED_LOW_DOWNLOAD_DELAY in tests/test_download_delay.py, so pytest currently fails on master and every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated download-delay test coverage to permit the Rivian US spider to use a shorter delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->