### PR TITLE
[85°C Bakery Cafe AU] Switch to Camoufox for Cloudflare Turnstile

### DIFF
--- a/locations/spiders/eighty_five_degrees_c_au.py
+++ b/locations/spiders/eighty_five_degrees_c_au.py
@@ -2,18 +2,21 @@ from typing import Any
 
 from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.items import Feature
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 
-class EightyFiveDegreesCAUSpider(PlaywrightSpider):
+class EightyFiveDegreesCAUSpider(CamoufoxSpider):
     name = "eighty_five_degrees_c_au"
     item_attributes = {"brand": "85°C Bakery Cafe", "brand_wikidata": "Q4644852"}
     start_urls = ["https://www.85cafe.com.au/store-finder/"]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    captcha_type = "cloudflare_turnstile"
+    captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    handle_httpstatus_list = [403]
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for store in response.xpath("//div[@class='card mb-2']"):


### PR DESCRIPTION
- The store finder page (https://www.85cafe.com.au/store-finder/) returns a Cloudflare managed challenge (\`cf-mitigated: challenge\`, \`Just a moment...\` title) to plain Playwright/requests requests, seen in #17065.
- Switches the spider from \`PlaywrightSpider\` to \`CamoufoxSpider\` with \`DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE\`, matching the pattern used in \`wsp.py\` / \`odeon_gb.py\`.
- Verified locally: 15 items scraped successfully (all AU store locations), no proxy required.