### PR TITLE
[Ever New / Forever New AU NZ] Drop Playwright and proxy

### DIFF
--- a/locations/spiders/ever_new_ca.py
+++ b/locations/spiders/ever_new_ca.py
@@ -1,11 +1,9 @@
-from locations.playwright_spider import PlaywrightSpider
 from locations.spiders.forever_new_au_nz import FOREVER_NEW_SHARED_ATTRIBUTES, ForeverNewAUNZSpider
 
 
-class EverNewCASpider(ForeverNewAUNZSpider, PlaywrightSpider):
+class EverNewCASpider(ForeverNewAUNZSpider):
     name = "ever_new_ca"
     item_attributes = {**FOREVER_NEW_SHARED_ATTRIBUTES, "brand": "Ever New"}
     start_urls = [
         "https://www.evernew.ca/locator/index/search/?address=vancouver&components[country]=CA&radius=10000000&type=all",
     ]
-    requires_proxy = True

--- a/locations/spiders/forever_new_au_nz.py
+++ b/locations/spiders/forever_new_au_nz.py
@@ -4,22 +4,19 @@ from scrapy.http import TextResponse
 
 from locations.hours import OpeningHours
 from locations.json_blob_spider import JSONBlobSpider
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 FOREVER_NEW_SHARED_ATTRIBUTES = {"brand": "Forever New", "brand_wikidata": "Q119221929"}
 
 
-class ForeverNewAUNZSpider(JSONBlobSpider, PlaywrightSpider):
+class ForeverNewAUNZSpider(JSONBlobSpider):
     name = "forever_new_au_nz"
     item_attributes = FOREVER_NEW_SHARED_ATTRIBUTES
     start_urls = [
         "https://www.forevernew.com.au/locator/index/search/?address=sydney&components[country]=AU&radius=1000000000&type=all",
         "https://www.forevernew.co.nz/locator/index/search/?address=wellington&components[country]=NZ&radius=1000000000&type=all",
     ]
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
-    requires_proxy = True
+    custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
 
     def extract_json(self, response: TextResponse):
         data = response.json()["results"]["results"]


### PR DESCRIPTION
- The locator endpoint (\`/locator/index/search/\`) returns plain JSON to a normal browser UA; it's only the literal Scrapy default UA string that gets a 403. No Cloudflare/Akamai challenge signature present. Switching to a plain \`JSONBlobSpider\` request with \`USER_AGENT: BROWSER_DEFAULT\` gets a 200 with no proxy needed.
- \`forever_new_au_nz\` and \`ever_new_ca\` share the same base spider and endpoint shape, so both are fixed here. \`ever_new_ca\` was verified locally (15 stores); \`forever_new_au_nz\` also verified locally (106+ stores, capped by item count).
- seen in #17148, also fixes the same root cause reported in #17154