### PR TITLE
[FNB ZA] Re-enable ZA proxy

### DIFF
--- a/locations/spiders/fnb_banks_za.py
+++ b/locations/spiders/fnb_banks_za.py
@@ -12,6 +12,7 @@ from locations.items import Feature
 class FnbBanksZASpider(Spider):
     name = "fnb_banks_za"
     item_attributes = {"brand": "FNB", "brand_wikidata": "Q3072956"}
+    requires_proxy = "ZA"  # Radware Bot Manager (validate.perfdrive.com) blocks direct requests
 
     async def start(self) -> AsyncIterator[Request]:
         # Search claims to accept search by province, in practice this returns barely any results


### PR DESCRIPTION
- The branch locator (`https://www.fnb.co.za/Controller?nav=locators.BranchLocatorSearch`) now sits behind Radware Bot Manager (ShieldSquare) — a direct POST redirects (302) to `validate.perfdrive.com` with a device-fingerprint challenge, even with a real Chrome UA and no prior request volume, so this isn't a UA or crawl-volume issue.
- Same vendor/pattern already handled in `paz_il` via `requires_proxy`; using the `"ZA"` country code here per repo convention for other South African spiders (`dis_chem`, `side_step`, `studio_88`, `outdoor_warehouse_na_za`).
- Not verifiable locally without proxy credentials — seen in #17153, trusting CI to confirm items are returned.