### PR TITLE
[Travel-IQ] Fix camera discovery fallback when developer docs page is gone

### DIFF
--- a/locations/storefinders/traveliq.py
+++ b/locations/storefinders/traveliq.py
@@ -45,9 +45,25 @@ class TravelIQSpider(Spider):
 
     async def start(self) -> AsyncIterator[Request]:
         url_parts = urlparse(self.api_endpoint)
-        yield Request(url=f"{url_parts.scheme}://{url_parts.netloc}/developers/doc", callback=self.parse_feature_types)
+        yield Request(
+            url=f"{url_parts.scheme}://{url_parts.netloc}/developers/doc",
+            callback=self.parse_feature_types,
+            meta={"handle_httpstatus_list": [404]},
+        )
 
     def parse_feature_types(self, response: Response) -> Iterable[JsonRequest]:
+        if response.status == 404:
+            # Many Travel-IQ deployments have removed the developer
+            # documentation page used to discover available feature types.
+            # Fall back to probing directly for the only feature type
+            # currently extracted by this storefinder.
+            yield JsonRequest(
+                url=f"{self.api_endpoint}get/groupedcameras?key={self.api_key}",
+                callback=self.parse_probed_cameras,
+                meta={"handle_httpstatus_list": [404]},
+            )
+            return
+
         feature_types = response.xpath('//td[@class="api-name"]/a/text()').getall()
 
         if ("Cameras" in feature_types or "Traffic Cameras" in feature_types) and "Grouped Cameras" in feature_types:
@@ -96,6 +112,14 @@ class TravelIQSpider(Spider):
                     self.logger.warning(
                         "New type of feature detected for Travel-IQ storefinder: {}".format(feature_type)
                     )
+
+    def parse_probed_cameras(self, response: TextResponse) -> Iterable[JsonRequest | Feature]:
+        if response.status == 404:
+            # This deployment does not support "Grouped Cameras", fall back
+            # to plain "Cameras" instead.
+            yield JsonRequest(url=f"{self.api_endpoint}get/cameras?key={self.api_key}", callback=self.parse_cameras)
+            return
+        yield from self.parse_cameras(response)
 
     def parse_cameras(self, response: TextResponse) -> Iterable[Feature]:
         cameras = response.json()


### PR DESCRIPTION
- The Travel-IQ storefinder discovers available feature types by scraping \`{host}/developers/doc\`. That page now returns 404 on every Travel-IQ deployment currently in the repo (checked all 8 US state DOT hosts using this storefinder), so the discovery request is silently dropped by scrapy's default 404 handling and no data is fetched (0 items, 0 errors — matching the observed symptom).
- The underlying \`get/cameras\` and \`get/groupedcameras\` endpoints still work fine with the existing keys on every deployment tested.
- Since "Cameras"/"Grouped Cameras" are the only feature types this storefinder actually extracts, fall back to probing \`get/groupedcameras\` directly (using HTTP status to detect route availability: 404 = unsupported, 400 = needs auth = supported) and then \`get/cameras\` when the docs page 404s.
- Verified locally against \`florida_department_of_transportation_us\` (4872 cameras, was 0) and \`idaho_transportation_department_us\` (457 cameras, was 0). This fixes all Travel-IQ-based spiders, not just Florida.

seen in #17151