### PR TITLE
[Fust CH] Re-enable CH proxy for DataDome block

### DIFF
--- a/locations/spiders/fust_ch.py
+++ b/locations/spiders/fust_ch.py
@@ -17,6 +17,7 @@ class FustCHSpider(JSONBlobSpider):
         "country": "CH",
     }
     start_urls = ["https://www.fust.ch/store-finder"]
+    requires_proxy = "CH"  # DataDome blocks data-centre IP ranges
 
     def extract_json(self, response: Response) -> list[dict]:
         scripts = response.xpath('//script[contains(text(), "pointOfService")]/text()').getall()


### PR DESCRIPTION
- The store-finder page is fronted by DataDome (see CSP references to `datadome.co` / `captcha-delivery.com`). Requests from CI datacentre IPs get 403, while a residential-IP curl with any UA (including our own) returns 200 with the embedded `pointOfService` JSON intact.
- Adds `requires_proxy = "CH"` so requests route through a Zyte CH proxy, following the same pattern used for `livique_ch` and other DataDome/Akamai/Cloudflare-blocked sites.

seen in #17276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Fust Switzerland listings by routing requests through an appropriate Swiss connection.
  * Reduced request blocks caused by data-centre IP restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->