### PR TITLE
[Frankston City Council] Fix toilets spider

### DIFF
--- a/locations/spiders/infrastructure/frankston_city_council_toilets_au.py
+++ b/locations/spiders/infrastructure/frankston_city_council_toilets_au.py
@@ -19,14 +19,8 @@ class FrankstonCityCouncilToiletsAUSpider(VectorFileSpider):
     start_urls = ["https://connect.pozi.com/userdata/frankston-publisher/Community/Public_Toilet.fgb"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        item["name"] = feature["Facility_Name"]
+        item["name"] = feature["Name"]
         apply_category(Categories.TOILETS, item)
-        match feature.get("Facility_Occupier"):
-            case "FCC" | "Public":
-                item["extras"]["access"] = "yes"
-            case "Club/Org":
-                item["extras"]["access"] = "customers"
-            case _:
-                self.logger.warning("Unknown public toilet access type: {}".format(feature.get("Facility_Occupier")))
+        item["extras"]["access"] = "yes"
         item["extras"]["fee"] = "no"
         yield item


### PR DESCRIPTION
- The Pozi-hosted FlatGeobuf source changed its schema: \`Facility_Name\` became \`Name\`, and the \`Facility_Occupier\` field (used to distinguish public vs. club/org access) is gone entirely. Spider now crashes with \`KeyError: 'Facility_Name'\`, seen in #17275.
- Updated field name and simplified access to \`yes\` for all 84 features (matches the pattern used by sibling spiders \`hobsons_bay_city_council_toilets_au\` and \`glen_eira_city_council_toilets_au\`, since the source no longer flags any locations as club/org-restricted).
- Verified locally: 84 items scraped with name, addr_full, lat/lon populated correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected toilet listing names sourced from Frankston City Council.
  * Updated toilet access information to consistently display as available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->