### PR TITLE
[Baby-Walz DE] Add proxy for Vercel security checkpoint

### DIFF
--- a/locations/spiders/baby_walz_de.py
+++ b/locations/spiders/baby_walz_de.py
@@ -8,6 +8,7 @@ from scrapy.http import Response
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BabyWalzDESpider(Spider):
@@ -18,6 +19,8 @@ class BabyWalzDESpider(Spider):
     name = "baby_walz_de"
     item_attributes = {"brand": "baby-walz", "brand_wikidata": "Q108004413"}
     start_urls = ["https://www.baby-walz.de/filialen/"]
+    requires_proxy = "DE"  # Vercel security checkpoint blocks datacentre IPs
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
 
     # RSC pattern: lat, lon, "email@domain", "https://maps.url", ...
     _STORE_RE = re.compile(


### PR DESCRIPTION
- Every path on www.baby-walz.de, including /robots.txt, returns 429 with `x-vercel-mitigated: challenge` and a Vercel Security Checkpoint page — datacentre IPs are blocked outright.
- Added `requires_proxy = "DE"` and a browser UA, following the same fix used for `evgo_us` (also behind Vercel's checkpoint).
- Seen in #17471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to location data by using a browser-like user agent and a German proxy.
  * Updated crawling behavior to prevent robots.txt restrictions from blocking data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->