### PR TITLE
[Cadence Bank US] Add proxy

### DIFF
--- a/locations/spiders/cadence_bank_us.py
+++ b/locations/spiders/cadence_bank_us.py
@@ -12,6 +12,7 @@ class CadenceBankUSSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://cadencebank.com/sitemap.xml"]
     sitemap_rules = [("/find-a-location/", "parse_sd")]
     time_format = "%H:%M:%S"
+    requires_proxy = "US"  # Cloudflare WAF blocks datacentre IPs on every path, including robots.txt
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         apply_category(Categories.BANK, item)


### PR DESCRIPTION
- Every path on cadencebank.com (including /robots.txt and the homepage) now returns a 403 with a custom-branded Cloudflare block page (\`::CLOUDFLARE_ERROR_1000S_BOX::\` template marker), even with a real Chrome UA — this is Cloudflare WAF blocking datacentre IPs, not a UA blacklist. The site appears to have moved from Akamai (per the original dead-spider report) to Cloudflare since.
- Adding \`requires_proxy = "US"\` routes the crawl through a residential-quality proxy to clear the WAF block. Single sitemap crawl of ~390 stores, so proxy cost is moderate.

seen in #17581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Cadence Bank US location information by routing requests through an appropriate regional connection.
  * Reduced failures caused by website security protections blocking automated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->