### PR TITLE
[Ackermans] Re-enable ZA proxy

### DIFF
--- a/locations/spiders/ackermans.py
+++ b/locations/spiders/ackermans.py
@@ -16,6 +16,7 @@ class AckermansSpider(scrapy.Spider):
         "brand_wikidata": "Q4674255",
     }
     start_urls = ["https://www.ackermans.co.za/pages/store-directory"]
+    requires_proxy = "ZA"
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         authorization_token = re.search(r"Authorization\s*:\s*\"([A-Za-z0-9\s]+)\"", response.text).group(1)


### PR DESCRIPTION
- Auto-issue reports repeated 429s on the initial `store-directory` page fetch (Cloudflare-fronted Shopify storefront), 5 consecutive weekly runs with 0 results.
- Fetching the same URL directly (residential IP, Chrome and python-requests UAs alike) returns 200 immediately, so this isn't a UA blacklist or challenge — it's IP-based rate limiting against the CI runner's egress IP, the same pattern already worked around on sibling ZA spiders (`dis_chem`, `outdoor_warehouse_na_za`, `side_step`, `studio_88`) via `requires_proxy = "ZA"`.
- Adds `requires_proxy = "ZA"` to route around it. Single-page + single-API-call spider (2 requests/run), so proxy cost is minimal.

seen in #17764