### PR TITLE
[Adriatic Furniture AU] Re-enable AU proxy

### DIFF
--- a/locations/spiders/adriatic_furniture_au.py
+++ b/locations/spiders/adriatic_furniture_au.py
@@ -17,6 +17,7 @@ class AdriaticFurnitureAUSpider(CrawlSpider):
     item_attributes = {"brand": "Adriatic Furniture", "brand_wikidata": "Q117856796"}
     allowed_domains = ["www.adriatic.com.au"]
     start_urls = ["https://www.adriatic.com.au/pages/store-locator"]
+    requires_proxy = "AU"
 
     rules = [Rule(LinkExtractor(allow=r"/pages/[a-z0-9\-]+$"), follow=False, callback="parse_store")]
 


### PR DESCRIPTION
- All requests from the ATP crawler IP (including \`robots.txt\`) got 429 from this Shopify/Cloudflare store, while direct curl requests (Chrome UA, python-requests UA, and the exact ATP bot UA) all returned 200 without issue — this is IP-reputation based rate-limiting, not a UA blacklist or challenge page.
- Site is small (~7 AU store pages under \`/pages/\`), so a single-country proxy is cheap. Verified locally that the spider parses all 7 stores correctly once requests succeed.

seen in #17765