### PR TITLE
[Cellarbrations AU] Re-enable AU proxy

### DIFF
--- a/locations/spiders/cellarbrations_au.py
+++ b/locations/spiders/cellarbrations_au.py
@@ -5,6 +5,7 @@ class CellarbrationsAUSpider(StorefrontgatewaySpider):
     name = "cellarbrations_au"
     item_attributes = {"brand": "Cellarbrations", "brand_wikidata": "Q109807592"}
     allowed_domains = ["storefrontgateway.cellarbrations.com.au"]
+    requires_proxy = "AU"
     start_urls = [
         "https://storefrontgateway.cellarbrations.com.au/api/near/-33.867778/151.21/20000/20000/stores",
     ]


### PR DESCRIPTION
- The storefrontgateway API returns a static Cloudflare WAF block page (\"Attention Required!\", no interactive challenge) from datacenter/non-AU IPs; requesting the same endpoint with an AU-routed IP returns 522 stores normally.
- Same pattern as the sibling `bws_au` / `dan_murphys_au` alcohol-retailer spiders, which already carry `requires_proxy = "AU"` for the same reason.

seen in #17766