### PR TITLE
[D'Agostino] Rewrite spider against Instacart Connected Stores GraphQL API

### DIFF
--- a/locations/spiders/dagostino_us.py
+++ b/locations/spiders/dagostino_us.py
@@ -1,10 +1,33 @@
-from locations.storefinders.freshop import FreshopSpider
+from typing import Iterable
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.instacart_connected_stores import InstacartConnectedStoresSpider
 
 
-class DagostinoUSSpider(FreshopSpider):
+class DagostinoUSSpider(InstacartConnectedStoresSpider):
     name = "dagostino_us"
     item_attributes = {
         "brand_wikidata": "Q20656844",
         "brand": "D'Agostino",
     }
-    app_key = "dagostino"
+    storefront_root = "https://order.dagnyc.com"
+    retailer_slug = "dagnyc"
+    # D'Agostino operates only within Manhattan. A single, centrally located seed point was found
+    # (2026-08) to return all locations even when queried from the opposite end of the island, but
+    # a few extra seed points spread around the borough are used here as a hedge in case the
+    # search radius used by the upstream API changes in the future.
+    search_points = [
+        ("10014", 40.733698, -74.007033),  # Greenwich Village
+        ("10021", 40.7692, -73.9596),  # Upper East Side
+        ("10024", 40.7870, -73.9754),  # Upper West Side
+        ("10032", 40.8417, -73.9393),  # Washington Heights
+    ]
+
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        name = item.pop("name", None) or ""
+        item["branch"] = name.removeprefix("D'Agostino at ").strip()
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/storefinders/instacart_connected_stores.py
+++ b/locations/storefinders/instacart_connected_stores.py
@@ -87,7 +87,7 @@ class InstacartConnectedStoresSpider(Spider):
         if not hasattr(self, "_seen_location_ids"):
             self._seen_location_ids: set[str] = set()
 
-        payload = response.json()
+        payload = json.loads(response.body)
         for error in payload.get("errors") or []:
             self.logger.warning("GraphQL error from %s: %s", response.url, error.get("message"))
 

--- a/locations/storefinders/instacart_connected_stores.py
+++ b/locations/storefinders/instacart_connected_stores.py
@@ -1,0 +1,130 @@
+import json
+import re
+from typing import Any, AsyncIterator, Iterable
+from urllib.parse import urlencode
+
+from scrapy import Request, Spider
+from scrapy.http import Response
+
+from locations.items import Feature
+
+# Persisted (server-registered) GraphQL query hash for "AvailableRetailerLocationsServices" as
+# observed on order.dagnyc.com in 2026-08. Instacart's Connected Stores backend only accepts
+# queries it has already registered server-side (referenced only by this SHA-256 hash of the
+# query text), so the query itself cannot be customised by a client - but since the query is
+# shared by the whole platform rather than being retailer-specific, the same hash is expected to
+# work for other retailers hosted on Connected Stores. If this spider starts receiving
+# PersistedQueryNotFound errors, the hash will need to be re-extracted from a fresh network trace.
+AVAILABLE_RETAILER_LOCATIONS_SERVICES_HASH = "bea786dfccd6e730e72f43616dd2f23ec3bb008659becb18a026129f06e8d543"
+
+CITY_STATE_POSTCODE_RE = re.compile(r"^(?P<city>.+?),\s*(?P<state>[A-Z]{2})\s+(?P<postcode>[0-9-]+)$")
+
+
+class InstacartConnectedStoresSpider(Spider):
+    """
+    Instacart operates a white-label "Connected Stores" storefront platform used by a number of
+    grocery/retail chains to run online ordering on their own domain (e.g. D'Agostino's
+    https://order.dagnyc.com/). Although hosted on the retailer's own domain, the storefront is a
+    GraphQL single-page app served by Instacart's shared backend.
+
+    The storefront does not expose a simple "list all stores" endpoint. Instead, a
+    "AvailableRetailerLocationsServices" persisted GraphQL query returns the retailer's locations
+    within a (apparently large, likely delivery/service-area driven) radius of a supplied
+    postcode/coordinate. Querying from one or more seed points and merging/deduplicating the
+    results is therefore used here to discover all of a retailer's locations. For a geographically
+    compact chain, a single, centrally-located seed point may return every location; spread
+    multiple points around for chains with a wider footprint.
+
+    Calling the GraphQL query requires only an anonymous "guest" session cookie
+    (`__Host-instacart_sid`), which is issued simply by loading any storefront HTML page - no
+    login, API key, or JavaScript execution is required.
+
+    To use this spider, specify:
+    - storefront_root: the scheme + host of the retailer's storefront, e.g. "https://order.dagnyc.com"
+    - retailer_slug: the retailer's slug as used in the storefront URL, e.g. "dagnyc"
+    - search_points: a list of (postal_code, latitude, longitude) tuples used as search origins
+
+    Override `parse_item` to tweak or discard individual items, similar to other store finders.
+    """
+
+    dataset_attributes: dict = {"source": "api", "api": "instacart-connected-stores"}
+    # Connected Stores storefronts have been observed to ship a robots.txt that blanket-disallows
+    # all crawlers other than a named allowlist of search engine bots, seemingly targeting generic
+    # scraping/crawling rather than this specific, lightweight store-locator lookup.
+    custom_settings: dict = {"ROBOTSTXT_OBEY": False}
+    storefront_root: str
+    retailer_slug: str
+    search_points: list[tuple[str, float, float]] = []
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield Request(
+            url=f"{self.storefront_root}/store/{self.retailer_slug}/storefront",
+            callback=self.parse_storefront,
+        )
+
+    def parse_storefront(self, response: Response) -> Iterable[Request]:
+        # Loading this page is sufficient to obtain the guest session cookie required by the
+        # GraphQL API below; Scrapy's cookie middleware carries it forward automatically.
+        for postal_code, lat, lon in self.search_points:
+            variables = {
+                "postalCode": postal_code,
+                "coordinates": {"latitude": lat, "longitude": lon},
+                "retailerIds": [],
+            }
+            extensions = {"persistedQuery": {"version": 1, "sha256Hash": AVAILABLE_RETAILER_LOCATIONS_SERVICES_HASH}}
+            params = {
+                "operationName": "AvailableRetailerLocationsServices",
+                "variables": json.dumps(variables, separators=(",", ":")),
+                "extensions": json.dumps(extensions, separators=(",", ":")),
+            }
+            yield Request(
+                url=f"{self.storefront_root}/graphql?{urlencode(params)}",
+                headers={"Accept": "application/json"},
+                callback=self.parse_locations,
+            )
+
+    def parse_locations(self, response: Response) -> Iterable[Feature]:
+        if not hasattr(self, "_seen_location_ids"):
+            self._seen_location_ids: set[str] = set()
+
+        payload = response.json()
+        for error in payload.get("errors") or []:
+            self.logger.warning("GraphQL error from %s: %s", response.url, error.get("message"))
+
+        groups = (payload.get("data") or {}).get("availableRetailerLocationsServices") or {}
+        for group in groups.get("retailerServiceableLocations") or []:
+            for location in group.get("locations") or []:
+                location_id = str(location["id"])
+                if location_id in self._seen_location_ids:
+                    continue
+                self._seen_location_ids.add(location_id)
+
+                item = self.item_from_location(location)
+                yield from self.parse_item(item, location) or [item]
+
+    def item_from_location(self, location: dict) -> Feature:
+        item = Feature()
+        item["ref"] = str(location["id"])
+
+        coordinates = location.get("coordinates") or {}
+        item["lat"] = coordinates.get("latitude")
+        item["lon"] = coordinates.get("longitude")
+
+        item["street_address"] = location.get("streetAddress")
+        item["postcode"] = location.get("postalCode")
+
+        view_section = location.get("viewSection") or {}
+        item["name"] = view_section.get("locationDisplayNameString")
+        item["phone"] = view_section.get("phoneNumberString")
+
+        line_two = (view_section.get("address") or {}).get("lineTwoString") or ""
+        if m := CITY_STATE_POSTCODE_RE.match(line_two):
+            item["city"] = m.group("city")
+            item["state"] = m.group("state")
+            if not item.get("postcode"):
+                item["postcode"] = m.group("postcode")
+
+        return item
+
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        yield item


### PR DESCRIPTION
D'Agostino's old Freshop integration is dead (the `dagostino` app_key now only returns a placeholder record - the Freshop account was decommissioned). D'Agostino's current online store locator runs through `order.dagnyc.com`, which is Instacart's white-label "Connected Stores" storefront platform.

This rewrites the spider against Connected Stores' `AvailableRetailerLocationsServices` persisted GraphQL query, which returns nearby store locations (id, name, address, coordinates, phone) for a given search point. A guest session cookie obtained just by loading any storefront HTML page is enough to authorize the query - no login or JS execution required. Since the query is radius-limited from each search point rather than listing every store, the spider queries from a few points spread around Manhattan and deduplicates by location id.

Verified locally against the live API: returns all 11 current Manhattan locations with correct addresses, coordinates, and (for at least one store) phone number, matching D'Agostino's own site and third-party listings.

Added a reusable `locations/storefinders/instacart_connected_stores.py` base class rather than a one-off implementation, since Instacart's Connected Stores platform is used by other grocery/retail chains for white-label online ordering and may be reusable for future spiders on the same backend.

`order.dagnyc.com`'s robots.txt blanket-disallows generic crawlers (allowing only a named list of search engine bots), so `ROBOTSTXT_OBEY: False` is set as a default on the new base class, consistent with how many existing ATP spiders already handle sites with similarly broad disallow rules.

Seen in #17768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location discovery through Instacart Connected Stores.
  * Added support for retailer storefronts, addresses, coordinates, contact details, and store locations.
  * Added duplicate-location filtering and handling for service errors.
  * Updated D’Agostino store listings to use the new location source.
  * D’Agostino listings now include supermarket categorization and improved branch identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->