### PR TITLE
[Groupe Casino] Re-enable FR proxy

### DIFF
--- a/locations/spiders/groupe_casino.py
+++ b/locations/spiders/groupe_casino.py
@@ -12,6 +12,7 @@ from locations.pipelines.address_clean_up import merge_address_lines
 
 class GroupeCasinoSpider(Spider):
     name = "groupe_casino"
+    requires_proxy = "FR"  # Wangsu BotGuard WAF blocks all direct requests, including robots.txt, with a static 403
     brands = {
         "30837": ("Casino PauseDéj", "Q89029249", Categories.SHOP_CONVENIENCE),
         "30838": ("Casino Shop", "Q89029601", Categories.SHOP_CONVENIENCE),


### PR DESCRIPTION
- All \`casino.fr\`/\`spar.casino.fr\` traffic (including \`/robots.txt\`) now returns a static 403 from a Wangsu BotGuard WAF (\`server: PWS/8.3.1.0.8\`, \`ws-action: bot\`, \`x-px:\` header, blocked image served from \`blocksrc.haplat.net\`), regardless of user agent — same result with default and real Chrome UAs, so this isn't a UA blacklist.
- No JS challenge is served, just a flat block page, consistent with IP-reputation based blocking. Adding \`requires_proxy = "FR"\` so the crawl routes through the proxy pool; this is a single paginated JSON API (~20-30 requests/run) so proxy cost is low.
- Could not verify the fix resolves it locally (no proxy configured in this environment) — trusting CI here, seen in #17773.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Groupe Casino location data by routing requests through a French proxy when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->