### PR TITLE
[Fine Wine & Good Spirits] Re-enable US proxy

### DIFF
--- a/locations/spiders/fine_wine_good_spirits_us.py
+++ b/locations/spiders/fine_wine_good_spirits_us.py
@@ -18,6 +18,7 @@ class FineWineGoodSpiritsUSSpider(SitemapSpider):
     item_attributes = {"brand": "Fine Wine & Good Spirits", "brand_wikidata": "Q64514776"}
     sitemap_urls = ["https://www.finewineandgoodspirits.com/productSitemap.xml"]
     sitemap_rules = [(r"/product/store-\d+", "parse")]
+    requires_proxy = "US"  # Akamai Bot Manager blocks datacentre IPs
 
     def parse(self, response: Response) -> Iterable[Feature]:
         location = next(


### PR DESCRIPTION
- Akamai Bot Manager blocks the ATP scraper's datacentre IPs on this domain — the production run gets a 403 on robots.txt and sitemap requests alike (seen in #17771)
- Requesting the same URLs with the production user agent from a residential IP returns 200 with valid data, confirming the block is IP-reputation based rather than a UA or challenge issue
- Adding `requires_proxy = "US"` routes requests through a US residential proxy; verified locally that the parsing logic still works against live data (25 items scraped from ~566 store pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Fine Wine & Good Spirits US location data by routing requests through a US-based connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->