### PR TITLE
[Grainger] Re-enable US proxy

### DIFF
--- a/locations/spiders/grainger_us.py
+++ b/locations/spiders/grainger_us.py
@@ -14,6 +14,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class GraingerUSSpider(PlaywrightSpider):
     name = "grainger_us"
     item_attributes = {"brand": "Grainger", "brand_wikidata": "Q1627894"}
+    requires_proxy = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
- All 77 requests to grainger.com's branch-locator API return 403, including in a Playwright-driven browser context (seen in #17772).
- Direct testing (curl, both Chrome UA and python-requests UA) shows Akamai bot management blocking every path on www.grainger.com, including the homepage — this is a full-domain shield, not a UA-based or endpoint-specific block.
- The spider already uses PlaywrightSpider but lacks `requires_proxy`, unlike sibling US spiders behind similar full-site shields (`caseys_general_store_us`, `rei_us`, `essex_us`). Adding `requires_proxy = True` follows that established pattern.
- Untested locally (Playwright browser not installed in this environment); trusting CI/Zyte proxy to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grainger US data collection to use a proxy connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->