### PR TITLE
[Howard Hanna] Fix spider

### DIFF
--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -5,26 +5,19 @@ import scrapy
 from scrapy import Request
 from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import BROWSER_DEFAULT
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 
-class HowardHannaSpider(PlaywrightSpider):
+class HowardHannaSpider(CamoufoxSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "DEFAULT_REQUEST_HEADERS": {
-            "Accept": "application/json, text/javascript, */*; q=0.01",
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "X-Requested-With": "XMLHttpRequest",
-            "Origin": "https://www.howardhanna.com",
-            "Referer": "https://www.howardhanna.com/Office/Map",
-            "User-Agent": BROWSER_DEFAULT,
-        },
-    }
+    captcha_type = "cloudflare_turnstile"
+    captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    handle_httpstatus_list = [403]
 
     async def start(self) -> AsyncIterator[Request]:
         url = "https://www.howardhanna.com/Office/MapOffices"


### PR DESCRIPTION
- The office map site is fully behind a Cloudflare managed challenge (`cf-mitigated: challenge`), including static HTML pages, so the previous plain `PlaywrightSpider` POST approach was blocked with 403s (seen in #17891).
- Rewrote as a `CamoufoxSpider` with `DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE`, same pattern as `odeon_gb` and `northside_hospital_us`. The original `FormRequest` POST to `Office/MapOffices` is unchanged; Camoufox's fingerprint passes the challenge without needing a proxy.
- Verified locally: single request returns 200 with 475 offices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Howard Hanna listing retrieval when Cloudflare protection or CAPTCHA challenges are encountered.
  * Added handling for HTTP 403 responses to improve scraping reliability.
  * Updated browser and request behavior to better support protected pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->