### PR TITLE
[Hotel B&B] Route through Zyte proxy

### DIFF
--- a/locations/spiders/hotel_bb.py
+++ b/locations/spiders/hotel_bb.py
@@ -15,6 +15,8 @@ class HotelBbSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.hotel-bb.com/sitemap.xml"]
     sitemap_rules = [("/en/hotel/", "parse_sd")]
     custom_settings = {"ROBOTSTXT_OBEY": False, "USER_AGENT": BROWSER_DEFAULT}
+    # Akamai blocks requests from data centre IPs with a 403 "Access Denied"; route through Zyte proxy.
+    requires_proxy = True
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         if item["name"].upper().startswith("B&B HOTEL"):


### PR DESCRIPTION
- Sitemap/hotel pages return an Akamai edge 403 (\`errors.edgesuite.net\` \"Access Denied\") from ATP's runner IP even with the existing browser UA/robots override; the same requests succeed with a residential IP, confirming an IP-reputation block rather than a UA blacklist.
- Adds \`requires_proxy = True\`; plain \`SitemapSpider\`, not Playwright/Camoufox, so Zyte's proxy middleware applies normally.

seen in #17890