### PR TITLE
[La Foir'Fouille] Add spider

### DIFF
--- a/locations/spiders/la_foirfouille_fr.py
+++ b/locations/spiders/la_foirfouille_fr.py
@@ -1,0 +1,15 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LaFoirfouilleFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "la_foirfouille_fr"
+    item_attributes = {"brand": "La Foir'Fouille", "brand_wikidata": "Q3209040"}
+    sitemap_urls = ["https://www.lafoirfouille.fr/magasins.xml"]
+    sitemap_rules = [(r"/la-?foir-?fouille", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_VARIETY_STORE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for La Foir'Fouille (French discount variety store chain), closes #17897.

Uses the sitemap at https://www.lafoirfouille.fr/magasins.xml plus embedded schema.org Store JSON-LD on each store page (a Partoo-powered store locator) via `StructuredDataSpider`. Tested locally: 242 items scraped, all with coordinates, addresses, phone numbers, and opening hours; 232/242 matched perfectly against Name Suggestion Index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering La Foir’Fouille store locations from its sitemap.
  * Store listings now include brand metadata and variety-store categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->