### PR TITLE
[Kinleigh Folkard & Hayward GB] Add spider

### DIFF
--- a/locations/spiders/kinleigh_folkard_hayward_gb.py
+++ b/locations/spiders/kinleigh_folkard_hayward_gb.py
@@ -1,0 +1,26 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class KinleighFolkardHaywardGBSpider(SitemapSpider, StructuredDataSpider):
+    name = "kinleigh_folkard_hayward_gb"
+    item_attributes = {"brand": "Kinleigh Folkard & Hayward", "country": "GB"}
+    sitemap_urls = ["https://www.kfh.co.uk/sitemap-pages.xml"]
+    sitemap_rules = [(r"^https://www\.kfh\.co\.uk/branch-finder/[^/]+$", "parse_sd")]
+    wanted_types = ["RealEstateAgent"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        branch = response.xpath("//h1/text()").get()
+        item["branch"] = (branch or "").removesuffix(" Estate Agents") or None
+        item["name"] = None
+        item["street_address"] = None
+        item["addr_full"] = ld_data.get("address", {}).get("streetAddress")
+
+        if opening_hours := ld_data.get("openingHours"):
+            item["opening_hours"].add_ranges_from_string(opening_hours)
+
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Kinleigh Folkard & Hayward (KFH), a UK estate agent chain, closes #17910.

Branch pages are discovered via the sitemap and each carries `RealEstateAgent` structured data with coordinates, address, phone, and opening hours (parsed from the free-text `openingHours` string).

50 branches found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for discovering Kinleigh Folkard & Hayward branch locations across the UK.
  - Captures branch names, street addresses, opening hours, and estate-agent office classification.
  - Improves handling of generic location details to provide more accurate branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->