### PR TITLE
[Playwright/Camoufox] Wire proxy support into browser launch options

### DIFF
--- a/locations/camoufox_spider.py
+++ b/locations/camoufox_spider.py
@@ -9,6 +9,9 @@ from locations.playwright_spider import PlaywrightSpider
 
 
 class CamoufoxSpider(PlaywrightSpider):
+    # See PlaywrightSpider._apply_zyte_proxy_launch_options().
+    _proxy_launch_options_setting = "CAMOUFOX_LAUNCH_OPTIONS"
+
     @staticmethod
     async def click_solver(page: Page, request: Request, spider: Spider) -> None:
         """

--- a/locations/middlewares/playwright_middleware.py
+++ b/locations/middlewares/playwright_middleware.py
@@ -106,10 +106,12 @@ class PlaywrightMiddleware:
             return
         if not os.environ.get("ZYTE_API_KEY"):
             return
-        requires_proxy = getattr(self.crawler.spider, "requires_proxy", False)
+        if not (spider := self.crawler.spider):
+            return
+        requires_proxy = getattr(spider, "requires_proxy", False)
         if not requires_proxy:
             return
-        if not (country_code := get_proxy_location(requires_proxy, self.crawler.spider.name)):
+        if not (country_code := get_proxy_location(requires_proxy, spider.name)):
             return
 
         context_kwargs = request.meta.setdefault(context_kwargs_meta_key, {})

--- a/locations/middlewares/playwright_middleware.py
+++ b/locations/middlewares/playwright_middleware.py
@@ -1,3 +1,5 @@
+import os
+
 from scrapy import Selector
 from scrapy.crawler import Crawler
 from scrapy.http import Request, Response, TextResponse
@@ -6,6 +8,7 @@ from scrapy_camoufox.page import PageMethod
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.captcha_solvers import click_solver
+from locations.middlewares.zyte_api_by_country import get_proxy_location
 from locations.playwright_spider import PlaywrightSpider
 
 
@@ -20,7 +23,9 @@ class PlaywrightMiddleware:
         return cls(crawler)
 
     def process_request(self, request: Request) -> None:
+        context_kwargs_meta_key = None
         if issubclass(type(self.crawler.spider), CamoufoxSpider):
+            context_kwargs_meta_key = "camoufox_context_kwargs"
             if "camoufox" not in request.meta:
                 request.meta["camoufox"] = True
             if "camoufox_page_event_handlers" not in request.meta.keys():
@@ -38,6 +43,7 @@ class PlaywrightMiddleware:
         ):
             # TODO: remove "is_playwright_spider" check once fully deprecated
             # and removed from all ATP spiders.
+            context_kwargs_meta_key = "playwright_context_kwargs"
             if "playwright" not in request.meta:
                 request.meta["playwright"] = True
             if "playwright_page_event_handlers" not in request.meta.keys():
@@ -46,6 +52,8 @@ class PlaywrightMiddleware:
             # Spider does not want Camoufox/Playwright to be used. Skip this
             # middleware and do nothing to the request.
             return
+
+        self._apply_zyte_proxy_geolocation(request, context_kwargs_meta_key)
 
         if issubclass(type(self.crawler.spider), SitemapSpider) or issubclass(type(self.crawler.spider), XMLFeedSpider):
             # Workaround for Firefox always wanting to transform XML documents
@@ -74,6 +82,39 @@ class PlaywrightMiddleware:
                 request.meta["playwright_page_event_handlers"][
                     "response"
                 ] = "detect_xml_document_from_playwright_response"
+
+    def _apply_zyte_proxy_geolocation(self, request: Request, context_kwargs_meta_key: str | None) -> None:
+        """
+        When a spider sets `requires_proxy`, PlaywrightSpider.update_settings()
+        (see locations/playwright_spider.py) has already pointed
+        PLAYWRIGHT_LAUNCH_OPTIONS/CAMOUFOX_LAUNCH_OPTIONS at Zyte API's
+        proxy-mode endpoint. That only selects a Zyte-managed IP; to ask Zyte
+        for an IP in a specific country, a "Zyte-Geolocation" request header
+        also needs to be sent (see
+        https://docs.zyte.com/zyte-api/usage/proxy-mode.html). We inject it
+        via the browser context's extra_http_headers, using the same country
+        resolution logic (spider name suffix, e.g. "_us") as
+        ZyteApiByCountryMiddleware uses for non-browser requests.
+
+        NOTE: this is unverified against a real Zyte account (no credentials
+        in dev sandboxes) — if Zyte doesn't honour this header for
+        proxy-mode/CONNECT-tunnelled traffic, this becomes a no-op and Zyte
+        will just pick whatever IP it considers best, same as
+        `requires_proxy = True` with no resolvable country today.
+        """
+        if not context_kwargs_meta_key:
+            return
+        if not os.environ.get("ZYTE_API_KEY"):
+            return
+        requires_proxy = getattr(self.crawler.spider, "requires_proxy", False)
+        if not requires_proxy:
+            return
+        if not (country_code := get_proxy_location(requires_proxy, self.crawler.spider.name)):
+            return
+
+        context_kwargs = request.meta.setdefault(context_kwargs_meta_key, {})
+        extra_http_headers = context_kwargs.setdefault("extra_http_headers", {})
+        extra_http_headers["Zyte-Geolocation"] = country_code.upper()
 
     def process_response(self, request: Request, response: Response) -> Response:
         if (

--- a/locations/playwright_spider.py
+++ b/locations/playwright_spider.py
@@ -1,10 +1,55 @@
+import os
+
 from playwright.async_api import Response as PlaywrightResponse
 from scrapy import Spider
+from scrapy.settings import BaseSettings
+
+# Zyte API's proxy-mode endpoint, used to route Playwright/Camoufox browser
+# traffic through a Zyte-managed IP when a spider sets `requires_proxy`. See
+# https://docs.zyte.com/zyte-api/usage/proxy-mode.html
+ZYTE_API_PROXY_SERVER = "http://api.zyte.com:8011"
 
 
 class PlaywrightSpider(Spider):
     _last_scrapy_request_url: str | None = None
     _last_observed_xml_document: str | None = None
+
+    # True, a 2-letter country code, or unset/False (default, no proxy).
+    # Mirrors locations.middlewares.zyte_api_by_country.ZyteApiByCountryMiddleware,
+    # which only applies to non-browser (Zyte API REST) requests. Playwright
+    # and Camoufox launch a browser once per crawl, so proxying has to be
+    # wired into *_LAUNCH_OPTIONS (below) instead of per-request.
+    requires_proxy: bool | str = False
+
+    # The settings key holding launch options for this spider's browser
+    # automation backend. Overridden by CamoufoxSpider.
+    _proxy_launch_options_setting = "PLAYWRIGHT_LAUNCH_OPTIONS"
+
+    @classmethod
+    def update_settings(cls, settings: BaseSettings) -> None:
+        super().update_settings(settings)
+        cls._apply_zyte_proxy_launch_options(settings)
+
+    @classmethod
+    def _apply_zyte_proxy_launch_options(cls, settings: BaseSettings) -> None:
+        """
+        Playwright/Camoufox launch a browser once per crawl, so the proxy
+        server must be configured in PLAYWRIGHT_LAUNCH_OPTIONS/
+        CAMOUFOX_LAUNCH_OPTIONS at settings-merge time (here, before Scrapy
+        freezes settings and the browser launches) rather than per-request.
+        This only fires when the spider sets `requires_proxy`, so spiders
+        that don't need a proxy aren't silently routed (and billed) through
+        one.
+        """
+        if not (api_key := os.environ.get("ZYTE_API_KEY")):
+            return
+        if not getattr(cls, "requires_proxy", False):
+            return
+
+        proxy = {"server": ZYTE_API_PROXY_SERVER, "username": api_key, "password": ""}
+        launch_options = dict(settings.getdict(cls._proxy_launch_options_setting))
+        launch_options["proxy"] = proxy
+        settings.set(cls._proxy_launch_options_setting, launch_options, priority="spider")
 
     async def detect_xml_document_from_playwright_response(self, response: PlaywrightResponse) -> None:
         """

--- a/locations/spiders/grainger_us.py
+++ b/locations/spiders/grainger_us.py
@@ -14,6 +14,7 @@ from locations.user_agents import BROWSER_DEFAULT
 class GraingerUSSpider(PlaywrightSpider):
     name = "grainger_us"
     item_attributes = {"brand": "Grainger", "brand_wikidata": "Q1627894"}
+    requires_proxy = True
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
 
     async def start(self) -> AsyncIterator[JsonRequest]:

--- a/locations/spiders/howard_hanna.py
+++ b/locations/spiders/howard_hanna.py
@@ -5,26 +5,20 @@ import scrapy
 from scrapy import Request
 from scrapy.http import Response
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
-from locations.user_agents import BROWSER_DEFAULT
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 
-class HowardHannaSpider(PlaywrightSpider):
+class HowardHannaSpider(CamoufoxSpider):
     name = "howard_hanna"
     item_attributes = {"brand": "Howard Hanna", "brand_wikidata": "Q119573413"}
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
-        "DEFAULT_REQUEST_HEADERS": {
-            "Accept": "application/json, text/javascript, */*; q=0.01",
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "X-Requested-With": "XMLHttpRequest",
-            "Origin": "https://www.howardhanna.com",
-            "Referer": "https://www.howardhanna.com/Office/Map",
-            "User-Agent": BROWSER_DEFAULT,
-        },
-    }
+    captcha_type = "cloudflare_turnstile"
+    captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    handle_httpstatus_list = [403]
+    requires_proxy = "US"
 
     async def start(self) -> AsyncIterator[Request]:
         url = "https://www.howardhanna.com/Office/MapOffices"


### PR DESCRIPTION
## The bug

`DEFAULT_PLAYWRIGHT_SETTINGS` and `DEFAULT_CAMOUFOX_SETTINGS` in `locations/settings.py` fully replace `DOWNLOAD_HANDLERS`/`DOWNLOADER_MIDDLEWARES`, which drops `ZyteApiByCountryMiddleware` — the only thing that reads a spider's `requires_proxy` and applies proxy routing. Result: any `PlaywrightSpider`/`CamoufoxSpider` with `requires_proxy` set gets **zero** actual proxying — the browser launches straight from the CI host's real IP.

Most Playwright/Camoufox spiders with `requires_proxy` (hilton, tesco_gb, carrefour_pl, rei_us, etc.) have been unaffected in practice because their blocks are fingerprint-based and Camoufox's realistic fingerprint alone gets through — they don't actually need a different source IP. But it's the exact blocker for two spiders with genuine IP-reputation blocks:

- `grainger_us` — seen in #17772. PR #17982 added `requires_proxy = True`; CI still got 403 on all 77 requests, confirming `requires_proxy` is a no-op for Playwright spiders.
- `howard_hanna` — seen in #17891. PR #17988 rewrote it as a `CamoufoxSpider`, which worked perfectly from a residential IP (475 items) but CI's datacenter IP got served a harder, non-interactive Cloudflare Managed Challenge that the click-solver can't beat.

## What this does

Wires Zyte API's [proxy-mode endpoint](https://docs.zyte.com/zyte-api/usage/proxy-mode.html) (`api.zyte.com:8011`, HTTP CONNECT proxy, API key as Basic-auth username) into the actual browser launch, gated per-spider by `requires_proxy` so spiders that don't need it aren't silently routed through the proxy:

- `locations/playwright_spider.py`: `PlaywrightSpider` now has a `requires_proxy` attribute (mirroring `ZyteApiByCountryMiddleware`) and overrides `update_settings()` (a classmethod Scrapy calls once per crawl, before settings freeze and before the browser launches) to inject `{"server": ..., "username": <ZYTE_API_KEY>, "password": ""}` into `PLAYWRIGHT_LAUNCH_OPTIONS["proxy"]` when `requires_proxy` is set and `ZYTE_API_KEY` is present. `CamoufoxSpider` overrides a small `_proxy_launch_options_setting` class attribute to point the same logic at `CAMOUFOX_LAUNCH_OPTIONS` instead (Camoufox's `proxy` option is also launch-time, confirmed by reading `camoufox/utils.py`).
- `locations/middlewares/playwright_middleware.py`: `PlaywrightMiddleware.process_request` now also sets a `Zyte-Geolocation: <CC>` header via the browser context's `extra_http_headers` (`playwright_context_kwargs`/`camoufox_context_kwargs` request meta) when a country code resolves, reusing `get_proxy_location()` from `zyte_api_by_country.py` rather than reimplementing the country-suffix logic.
- Cost: both `DEFAULT_PLAYWRIGHT_SETTINGS`/`DEFAULT_CAMOUFOX_SETTINGS` already abort every non-"document" request client-side before it hits the network, so proxying is bounded to page-navigation requests only, not subresources — same rough cost profile as a plain `requires_proxy` REST spider.
- Test spiders: added `requires_proxy = True` to `grainger_us` and reapplied the closed-PR `CamoufoxSpider` rewrite (`#17988`) plus `requires_proxy = "US"` to `howard_hanna`.

Verified locally (no real Zyte account in this sandbox) that `update_settings()` correctly injects `proxy` into `PLAYWRIGHT_LAUNCH_OPTIONS`/`CAMOUFOX_LAUNCH_OPTIONS` for both spiders, is a no-op without `requires_proxy` or without `ZYTE_API_KEY`, and doesn't affect unrelated spiders — plus the full `pytest` suite and `pre-commit`.

## What's unverified — needs human sign-off before merge

**This cannot be verified locally — this sandbox has no Zyte API credentials.** Two things specifically need CI (which does have real Zyte credentials) to confirm:

1. That Zyte's proxy-mode endpoint actually works as a plain browser-launch proxy for Playwright/Camoufox at all (docs explicitly say "not optimized for use in combination with browser automation tools").
2. That the `Zyte-Geolocation` header sent via `extra_http_headers` is actually honored for HTTPS traffic tunneled through the CONNECT proxy — Zyte's docs don't document this for proxy-mode, and a plain CONNECT proxy is normally blind to encrypted request headers, so this may silently not select the intended country (falling back to Zyte's default IP selection) even if the proxy itself works.

If CI shows `grainger_us`/`howard_hanna` still 403ing or producing no output, that means the whole approach doesn't work as assumed here — please don't guess further on my end, just report the CI result back so we can decide next steps (e.g., dropping the geolocation header, or concluding proxy-mode genuinely isn't viable for browser automation).

Given the cost/architecture implications across the ~19 spiders currently setting `requires_proxy` on Playwright/Camoufox subclasses, **I'm not merging this myself even if CI is green** — flagging for explicit review.
