### PR TITLE
[Maif] Add spider

### DIFF
--- a/locations/spiders/maif_fr.py
+++ b/locations/spiders/maif_fr.py
@@ -5,6 +5,6 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class MaifFRSpider(SitemapSpider, StructuredDataSpider):
     name = "maif_fr"
-    item_attributes = {"brand": "MAIF", "brand_wikidata": "Q3331029"}
+    item_attributes = {"brand": "Maif", "brand_wikidata": "Q3331029"}
     sitemap_urls = ["https://agence.maif.fr/sitemap_pois.xml"]
     sitemap_rules = [(r"/details$", "parse_sd")]

--- a/locations/spiders/maif_fr.py
+++ b/locations/spiders/maif_fr.py
@@ -1,0 +1,10 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MaifFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "maif_fr"
+    item_attributes = {"brand": "MAIF", "brand_wikidata": "Q3331029"}
+    sitemap_urls = ["https://agence.maif.fr/sitemap_pois.xml"]
+    sitemap_rules = [(r"/details$", "parse_sd")]


### PR DESCRIPTION
Adds a spider for MAIF (French insurance company), using the sitemap of agency pages plus the InsuranceAgency structured data embedded on each page.

closes #17793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and extracting MAIF location information from sitemap entries.
  * Added parsing of structured location details, including MAIF brand metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->