### PR TITLE
[Waffle Factory] Add spider

### DIFF
--- a/locations/spiders/waffle_factory.py
+++ b/locations/spiders/waffle_factory.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WaffleFactorySpider(SitemapSpider, StructuredDataSpider):
+    name = "waffle_factory"
+    item_attributes = {"brand": "Waffle Factory", "brand_wikidata": "Q105426923"}
+    sitemap_urls = ["https://restaurants.wafflefactory.com/fr/sitemap.xml"]
+    sitemap_rules = [(r"/(waffle-factory-[^/]+)$", "parse_sd")]
+    search_for_facebook = False
+    search_for_twitter = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["name"] = item["image"] = None
+        apply_category(Categories.FAST_FOOD, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Waffle Factory, a French waffle/dessert fast-food chain.

Store data comes from `application/ld+json` (`FastFoodRestaurant`) structured data on each store page, discovered via the sitemap at https://restaurants.wafflefactory.com/fr/sitemap.xml. Produces 89 items with coordinates, addresses, and opening hours across FR, BE, and a handful of other territories (MA, LU, CH, RE).

closes #17796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Waffle Factory restaurant locations from structured website data.
  * Locations are categorized as fast food and enriched with Waffle Factory branding.
  * Social-profile searches are disabled for these locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->