### PR TITLE
[Free FR] Add spider

### DIFF
--- a/locations/spiders/free_fr.py
+++ b/locations/spiders/free_fr.py
@@ -1,0 +1,19 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class FreeFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "free_fr"
+    item_attributes = {"brand": "Free", "brand_wikidata": "Q2467627"}
+    sitemap_urls = ["https://www.free.fr/sitemap.xml"]
+    sitemap_rules = [(r"/boutiques/boutique-\d+$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Boutique Free ")
+        item["name"] = self.item_attributes["brand"]
+        apply_category(Categories.SHOP_TELECOMMUNICATION, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Free (French telecom/ISP, Iliad group physical "Free Center" stores), closes #17822.

Uses the sitemap at https://www.free.fr/sitemap.xml plus embedded schema.org structured data on each boutique page. Verified locally: 31/31 sample items scraped with correct addresses/coordinates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting structured location data from Free retail branches in France.
  * Captured branch names and categorized locations as telecommunications shops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->