### PR TITLE
[Namco JP] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -42,6 +42,7 @@ class Categories(Enum):
     BUS_STATION = {"amenity": "bus_station", "public_transport": "station"}
     TRAIN_STATION = {"railway": "station"}
 
+    AMUSEMENT_ARCADE = {"leisure": "amusement_arcade"}
     BOWLING = {"leisure": "bowling_alley"}
     GYM = {"leisure": "fitness_centre"}
     SAUNA = {"leisure": "sauna"}

--- a/locations/spiders/namco_jp.py
+++ b/locations/spiders/namco_jp.py
@@ -6,7 +6,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class NamcoJPSpider(SitemapSpider, StructuredDataSpider):
     name = "namco_jp"
-    item_attributes = {"brand": "namco", "brand_wikidata": "Q111516144"}
+    item_attributes = {"brand": "NAMCO", "brand_wikidata": "Q111516144"}
     sitemap_urls = ["https://bandainamco-am.co.jp/sitemap_game_center.xml"]
     sitemap_rules = [(r"^https://bandainamco-am\.co\.jp/game_center/loc/([\w-]+)/$", "parse_sd")]
     wanted_types = ["EntertainmentBusiness"]

--- a/locations/spiders/namco_jp.py
+++ b/locations/spiders/namco_jp.py
@@ -1,0 +1,35 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NamcoJPSpider(SitemapSpider, StructuredDataSpider):
+    name = "namco_jp"
+    item_attributes = {"brand": "namco", "brand_wikidata": "Q111516144"}
+    sitemap_urls = ["https://bandainamco-am.co.jp/sitemap_game_center.xml"]
+    sitemap_rules = [(r"^https://bandainamco-am\.co\.jp/game_center/loc/([\w-]+)/$", "parse_sd")]
+    wanted_types = ["EntertainmentBusiness"]
+
+    def pre_process_data(self, ld_data: dict, **kwargs) -> None:
+        # "PublicHolidays" is not a real day of the week and blows up
+        # OpeningHours.add_range() for the whole item if left in, so
+        # discard any rule that specifies it.
+        if spec := ld_data.get("openingHoursSpecification"):
+            if isinstance(spec, list):
+                ld_data["openingHoursSpecification"] = [
+                    rule
+                    for rule in spec
+                    if isinstance(rule, dict) and "publicholidays" not in str(rule.get("dayOfWeek", "")).lower()
+                ]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        # This site also lists sibling brands (VS PARK, Tondemi, AZ PARK,
+        # in-store "game corners" under other retailers' names, etc). Only
+        # keep locations branded as "namco".
+        if not (item["name"] or "").lower().startswith("namco"):
+            return
+
+        apply_category(Categories.AMUSEMENT_ARCADE, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for namco (Bandai Namco Amusement), a chain of amusement arcades in Japan.

closes #17207

Data source: `EntertainmentBusiness` JSON-LD structured data on each store page, discovered via `sitemap_game_center.xml`. The sitemap/domain also lists sibling brands (VS PARK, Tondemi, AZ PARK, and in-store "game corner" concessions branded under other retailers), which are filtered out — only locations named with the "namco" storefront brand are kept (194 of 254 listed locations).

Adds a new `Categories.AMUSEMENT_ARCADE` (`leisure=amusement_arcade`) entry since one didn't already exist.