### PR TITLE
[BENU] Add spider

### DIFF
--- a/locations/spiders/benu_cz.py
+++ b/locations/spiders/benu_cz.py
@@ -1,0 +1,29 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BenuCZSpider(SitemapSpider, StructuredDataSpider):
+    name = "benu_cz"
+    item_attributes = {"brand": "BENU", "brand_wikidata": "Q58170509"}
+    requires_proxy = True
+    # Pharmacy pages do not follow a consistent URL pattern, so crawl the
+    # entire page sitemap and rely on StructuredDataSpider filtering by
+    # wanted_types to pick out only the pharmacy pages.
+    sitemap_urls = [
+        "https://www.benu.cz/sitemap_page_001.xml",
+        "https://www.benu.cz/sitemap_fresh_page_001.xml",
+    ]
+    sitemap_rules = [(r"", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        # Parcel pickup boxes/lockers and pure e-shop collection points share
+        # the same LocalBusiness structured data as full pharmacies but are
+        # not pharmacies themselves, so skip them.
+        if "vydejni-box" in response.url or "e-shop" in response.url:
+            return
+
+        item["country"] = "CZ"
+        apply_category(Categories.PHARMACY, item)
+        yield item

--- a/locations/spiders/benu_cz.py
+++ b/locations/spiders/benu_cz.py
@@ -1,7 +1,15 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
+
+# The generic national customer-service line, embedded in every page's
+# structured data rather than a branch-specific number. Compared digits-only
+# since the raw phone string's formatting varies before PhoneCleanUpPipeline
+# normalizes it.
+NATIONAL_HOTLINE_DIGITS = "420212812811"
 
 
 class BenuCZSpider(SitemapSpider, StructuredDataSpider):
@@ -25,9 +33,7 @@ class BenuCZSpider(SitemapSpider, StructuredDataSpider):
             return
 
         item["country"] = "CZ"
-        # This is a generic national customer-service line embedded in every
-        # page's structured data, not a branch-specific number.
-        if item.get("phone") == "+420 212 812 811":
+        if re.sub(r"\D", "", item.get("phone") or "").endswith(NATIONAL_HOTLINE_DIGITS):
             item["phone"] = None
         apply_category(Categories.PHARMACY, item)
         yield item

--- a/locations/spiders/benu_cz.py
+++ b/locations/spiders/benu_cz.py
@@ -25,5 +25,9 @@ class BenuCZSpider(SitemapSpider, StructuredDataSpider):
             return
 
         item["country"] = "CZ"
+        # This is a generic national customer-service line embedded in every
+        # page's structured data, not a branch-specific number.
+        if item.get("phone") == "+420 212 812 811":
+            item["phone"] = None
         apply_category(Categories.PHARMACY, item)
         yield item


### PR DESCRIPTION
Adds a spider for BENU pharmacies in Czechia.

closes #17166

The store finder (`/lekarny`) and individual pharmacy pages are behind a Cloudflare challenge, so `requires_proxy = True` is set. Pharmacy page URLs don't follow a consistent slug pattern, so the spider crawls the full page sitemap and relies on `StructuredDataSpider`'s `wanted_types` filtering to pick out the `LocalBusiness` rich-snippet blocks that only exist on pharmacy pages.

Parcel pickup boxes/lockers and pure e-shop collection points (`vydejni-box-*`, `*-e-shop-*` URLs) reuse the same structured data markup as full pharmacies but are not staffed pharmacies, so those are filtered out in `post_process_item`.

Verified the structured-data parsing offline against archived copies of sample pages (live fetches return 403 without a working proxy in this environment); addresses, coordinates, phone, email, and opening hours all parsed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting BENU pharmacy locations in the Czech Republic.
  * Pharmacy listings now include structured location details and pharmacy category metadata.
  * Parcel lockers and e-shop collection points are excluded from location results.
  * Generic national hotline numbers are omitted when detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->