### PR TITLE
[Apina JP] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -77,6 +77,7 @@ class Categories(Enum):
     INDUSTRIAL_WAREHOUSE = {"landuse": "industrial", "industrial": "warehouse"}
     RESIDENTIAL_APARTMENTS = {"landuse": "residential", "residential": "apartments"}
 
+    LEISURE_AMUSEMENT_ARCADE = {"leisure": "amusement_arcade"}
     LEISURE_GARDEN = {"leisure": "garden"}
     LEISURE_DOG_PARK = {"leisure": "dog_park"}
     LEISURE_FITNESS_STATION = {"leisure": "fitness_station"}

--- a/locations/categories.py
+++ b/locations/categories.py
@@ -77,7 +77,6 @@ class Categories(Enum):
     INDUSTRIAL_WAREHOUSE = {"landuse": "industrial", "industrial": "warehouse"}
     RESIDENTIAL_APARTMENTS = {"landuse": "residential", "residential": "apartments"}
 
-    LEISURE_AMUSEMENT_ARCADE = {"leisure": "amusement_arcade"}
     LEISURE_GARDEN = {"leisure": "garden"}
     LEISURE_DOG_PARK = {"leisure": "dog_park"}
     LEISURE_FITNESS_STATION = {"leisure": "fitness_station"}

--- a/locations/spiders/apina_jp.py
+++ b/locations/spiders/apina_jp.py
@@ -1,0 +1,180 @@
+import re
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.google_url import url_to_coords
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+# Japanese single-character day names mapped to OSM day abbreviations.
+DAY_CHARS = {"月": "Mo", "火": "Tu", "水": "We", "木": "Th", "金": "Fr", "土": "Sa", "日": "Su"}
+DAY_RANGE = re.compile(r"([月火水木金土日])-([月火水木金土日])")
+
+
+class ApinaJPSpider(Spider):
+    name = "apina_jp"
+    item_attributes = {"brand": "アピナ", "brand_wikidata": "Q55385192"}
+    allowed_domains = ["www.kyowa-corp.co.jp"]
+    # Only crawl stores tagged as "アミューズメント" (amusement) - a handful of
+    # Apina locations are pure bowling alleys or batting centres with no
+    # amusement arcade on site, and those are out of scope for this spider.
+    start_urls = ["https://www.kyowa-corp.co.jp/am/shop/?s=&howcat%5B%5D=amusement"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
+        for href in response.css("div.cont-lst a.item::attr(href)").getall():
+            yield response.follow(href, callback=self.parse_store)
+
+        if next_page := response.css("a.nextpostslink::attr(href)").get():
+            yield response.follow(next_page, callback=self.parse)
+
+    def parse_store(self, response: Response, **kwargs: Any) -> Iterable[Feature | Request]:
+        name = response.css("h2.cont-ttl span::text").get()
+        if not name:
+            return
+
+        ref_match = re.search(r"/shop/([^/]+)/?$", response.url)
+        if not ref_match:
+            return
+
+        details = {}
+        for row in response.css("div.left-box__lst div.lst-item"):
+            label = "".join(row.css("p.ttl ::text").getall())
+            label = re.sub(r"[\s\xa0]+", "", label)
+            details[label] = row.css("p.txt").get("")
+
+        item = Feature()
+        item["ref"] = ref_match.group(1)
+        item["name"] = name.strip()
+        item["website"] = response.url
+        item["country"] = "JP"
+
+        if phone_html := details.get("電話番号"):
+            item["phone"] = self._parse_phone(phone_html)
+
+        if addr_html := details.get("所在地"):
+            self._parse_address(item, addr_html)
+
+        if hours_html := details.get("営業時間"):
+            item["opening_hours"] = self._parse_hours(hours_html)
+
+        apply_category(Categories.LEISURE_AMUSEMENT_ARCADE, item)
+
+        if map_href := response.css("a.btn-map::attr(href)").get():
+            yield response.follow(
+                map_href,
+                callback=self._parse_map,
+                cb_kwargs={"item": item},
+                dont_filter=True,
+            )
+        else:
+            self.logger.warning("No Google Maps link found for %s, skipping (no coordinates)", response.url)
+
+    def _parse_map(self, response: Response, item: Feature) -> Iterable[Feature]:
+        lat, lon = url_to_coords(response.url)
+        if lat is None:
+            self.logger.warning("Could not extract coordinates from %s for %s", response.url, item["website"])
+            return
+        item["lat"] = lat
+        item["lon"] = lon
+        yield item
+
+    @staticmethod
+    def _clean_text(html: str) -> str:
+        return re.sub(r"<[^>]+>", " ", html).replace("\xa0", " ").strip()
+        # collapse runs of whitespace left behind by stripped tags
+
+    def _parse_phone(self, html: str) -> str | None:
+        # Occasionally the phone and fax numbers are both listed here,
+        # separated by a <br>, sometimes with a "TEL:" prefix - only the
+        # phone number is wanted.
+        for part in re.split(r"<br\s*/?>", html):
+            line = self._clean_text(part)
+            if not line or "FAX" in line.upper():
+                continue
+            return re.sub(r"^TEL[:：]?\s*", "", line, flags=re.IGNORECASE)
+        return None
+
+    def _parse_address(self, item: Feature, addr_html: str) -> None:
+        lines = [self._clean_text(part) for part in re.split(r"<br\s*/?>", addr_html)]
+        lines = [line for line in lines if line]
+
+        street_lines = []
+        postcode = None
+        for line in lines:
+            # The postcode is usually on its own line, but is occasionally
+            # followed by the first line of the street address on the same line
+            if m := re.match(r"〒(\d{3}-\d{4})\s*(.*)$", line):
+                postcode = m.group(1)
+                if remainder := m.group(2).strip():
+                    street_lines.append(remainder)
+            else:
+                street_lines.append(line)
+
+        if postcode:
+            item["postcode"] = postcode
+        if street_lines:
+            item["street_address"] = " ".join(street_lines)
+
+    def _parse_hours(self, raw_html: str) -> OpeningHours:
+        oh = OpeningHours()
+
+        for raw_line in re.split(r"<br\s*/?>", raw_html):
+            line = self._clean_text(raw_line)
+            if not line or line.startswith("※"):
+                continue
+            # Strip off any trailing note appended after a time range
+            line = line.split("※")[0]
+
+            # Normalise full/half-width punctuation and drop remaining whitespace
+            line = line.replace("：", ":").replace("～", "-").replace("〜", "-").replace("~", "-")
+            line = re.sub(r"\s", "", line)
+
+            time_match = re.search(r"(\d{1,2}:\d{2})-(\d{1,2}:\d{2})", line)
+            if not time_match:
+                continue
+
+            open_time, close_time = time_match.group(1), time_match.group(2)
+            day_label = line[: time_match.start()]
+
+            for day in self._parse_days(day_label):
+                oh.add_range(day, open_time, close_time)
+
+        return oh
+
+    @staticmethod
+    def _parse_days(label: str) -> list[str]:
+        if not label:
+            # No day prefix present means the hours apply every day of the week
+            return list(DAYS)
+
+        if "平日" in label:
+            return ["Mo", "Tu", "We", "Th", "Fr"]
+
+        # Strip holiday-related qualifiers that don't map onto a specific
+        # weekday (public holidays and the day preceding a public holiday
+        # aren't reliably expressible via the OpeningHours helper here).
+        stripped = label.replace("祝前日", "").replace("祝日", "").replace("曜日", "").replace("曜", "")
+        stripped = re.sub(r"[・、,]", "", stripped)
+
+        days: list[str] = []
+        while m := DAY_RANGE.search(stripped):
+            start = DAYS.index(DAY_CHARS[m.group(1)])
+            end = DAYS.index(DAY_CHARS[m.group(2)])
+            days.extend(DAYS[start : end + 1])
+            stripped = stripped[: m.start()] + stripped[m.end() :]
+
+        for char in stripped:
+            if char in DAY_CHARS:
+                days.append(DAY_CHARS[char])
+
+        # De-duplicate while preserving order
+        seen = set()
+        result = []
+        for day in days:
+            if day not in seen:
+                seen.add(day)
+                result.append(day)
+        return result

--- a/locations/spiders/apina_jp.py
+++ b/locations/spiders/apina_jp.py
@@ -60,7 +60,7 @@ class ApinaJPSpider(Spider):
         if hours_html := details.get("営業時間"):
             item["opening_hours"] = self._parse_hours(hours_html)
 
-        apply_category(Categories.LEISURE_AMUSEMENT_ARCADE, item)
+        apply_category(Categories.AMUSEMENT_ARCADE, item)
 
         if map_href := response.css("a.btn-map::attr(href)").get():
             yield response.follow(
@@ -84,7 +84,6 @@ class ApinaJPSpider(Spider):
     @staticmethod
     def _clean_text(html: str) -> str:
         return re.sub(r"<[^>]+>", " ", html).replace("\xa0", " ").strip()
-        # collapse runs of whitespace left behind by stripped tags
 
     def _parse_phone(self, html: str) -> str | None:
         # Occasionally the phone and fax numbers are both listed here,


### PR DESCRIPTION
Adds a spider for Apina (アピナ), a Japanese amusement arcade chain, closes #17206.

The store finder (https://www.kyowa-corp.co.jp/am/shop/) has no structured data, JSON API, or sitemap coverage of stores, so this scrapes the paginated HTML store listing/detail pages. Each store detail page provides name, phone, address, and opening hours as plain HTML, plus a `maps.app.goo.gl` short link that is followed to resolve coordinates from the redirected Google Maps URL.

Only stores tagged "アミューズメント" (amusement) in the site's own category filter are scraped - a handful of Apina locations are pure bowling alleys or batting centres with no arcade on site, which are out of scope for `leisure=amusement_arcade`.

Also adds a new `LEISURE_AMUSEMENT_ARCADE` category to `locations/categories.py`, as no equivalent entry existed yet.

77 locations produced locally, matching NSI brand `apina-c3bbfb` (`brand:wikidata=Q55385192`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Apina amusement arcade locations in Japan.
  * Captures store names, contact details, addresses, opening hours, categories, and map coordinates.
  * Supports paginated listings and handles Japanese address, phone, postcode, and hours formats.
  * Excludes incomplete or invalid listings that lack usable location information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->