### PR TITLE
[Feu Vert FR] Add spider

### DIFF
--- a/locations/spiders/feu_vert_fr.py
+++ b/locations/spiders/feu_vert_fr.py
@@ -1,0 +1,33 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class FeuVertFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "feu_vert_fr"
+    item_attributes = {"brand": "Feu Vert", "brand_wikidata": "Q3070922"}
+    allowed_domains = ["www.feuvert.fr"]
+    sitemap_urls = ["https://www.feuvert.fr/sitemap/centres-auto.xml"]
+    sitemap_rules = [(r"/centres-auto/[^/]+/[^/]+/\d+\.html$", "parse_sd")]
+    wanted_types = ["AutoRepair"]
+    requires_proxy = True
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        # Coordinates are top-level "latitude"/"longitude" fields on the
+        # AutoRepair object rather than nested under "geo", which
+        # LinkedDataParser does not pick up automatically.
+        if lat := ld_data.get("latitude"):
+            item["lat"] = lat
+        if lon := ld_data.get("longitude"):
+            item["lon"] = lon
+
+        item.pop("image", None)  # Same generic illustration on every store, not a real photo
+
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Feu Vert's ~346 French auto centres (`www.feuvert.fr`).

Store URLs are enumerated from the `centres-auto.xml` sitemap, filtered to individual store pages (excludes department/city index pages). Each store page carries `AutoRepair` structured data (JSON-LD), including opening hours. Coordinates are published as flat `latitude`/`longitude` fields on the JSON-LD object rather than nested under `geo`, so `post_process_item` pulls them out manually. The generic per-store `image` (identical stock illustration on every location) is dropped.

The site is behind DataDome — every content page (including a plain Camoufox request) 403s from this sandbox, so `requires_proxy = True` is set and local verification could only confirm the sitemap enumeration/filtering and item shape (via cached copies of sample store pages). CI's Zyte proxy should be checked to confirm it clears the DataDome challenge.

closes #18013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for Feu Vert automotive repair center locations in France.
  * Location listings now include repair-center details, geographic coordinates, brand information, and the car-repair category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->