### PR TITLE
[Gémo] Add spider

### DIFF
--- a/locations/spiders/gemo_fr.py
+++ b/locations/spiders/gemo_fr.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class GemoFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "gemo_fr"
+    item_attributes = {"brand": "Gémo", "brand_wikidata": "Q3122954"}
+    allowed_domains = ["www.gemo.fr"]
+    sitemap_urls = ["https://www.gemo.fr/Assets/Rbs/Seo/100199/fr_FR/Rbs_Store_Store.1.xml"]
+    sitemap_rules = [(r"/magasin/", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    time_format = "%H:%M:%S"
+    drop_attributes = {"facebook", "twitter"}  # brand-wide social links, not store specific
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Gémo (French shoe/clothing retailer) using their store sitemap (425 URLs) plus schema.org `LocalBusiness` structured data on each store page. Opening hours use `HH:MM:SS` time format so `time_format` is overridden accordingly. Facebook/Twitter fields are dropped since they're brand-wide social links repeated identically on every page rather than store-specific data.

Verified locally: 425 items scraped, mostly mainland France with a handful of overseas territories (Réunion, Guadeloupe, Martinique, New Caledonia, etc.), Switzerland, Spain, Tunisia and Côte d'Ivoire. Coordinates and opening hours present for the large majority of stores; a small number of stores lack coordinates/hours in the source data and are left blank.

closes #18014