### PR TITLE
[Franck Provost] Add spider

### DIFF
--- a/locations/spiders/franck_provost.py
+++ b/locations/spiders/franck_provost.py
@@ -1,0 +1,53 @@
+import json
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+
+class FranckProvostSpider(SitemapSpider):
+    name = "franck_provost"
+    item_attributes = {"brand": "Franck Provost", "brand_wikidata": "Q62805922"}
+    sitemap_urls = ["https://www.franckprovost.com/sitemaps/sitemap-hairdressers.xml"]
+    sitemap_rules = [(r"/salons/", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # The salon object is embedded (quote-escaped) inside a Next.js RSC flight chunk.
+        payload = "".join(
+            json.loads(chunk)
+            for chunk in re.findall(r'self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*")\]\)', response.text)
+        )
+        if (start := payload.find('"hairdresser":{')) < 0:
+            return
+        salon = json.JSONDecoder().raw_decode(payload, start + len('"hairdresser":'))[0]
+
+        common = salon.get("common") or {}
+
+        item = Feature()
+        item["ref"] = salon.get("code") or str(salon.get("id"))
+        item["name"] = "Franck Provost"
+        item["branch"] = common.get("brand") or ""
+        item["addr_full"] = ", ".join(filter(None, [common.get("addressLine2"), common.get("addressLine1")]))
+        item["city"] = salon.get("city")
+        item["phone"] = common.get("tel")
+        item["email"] = (salon.get("infos") or {}).get("email")
+        item["website"] = response.url
+
+        if geo := (salon.get("pictureAndMap") or {}).get("map"):
+            item["lat"] = geo.get("latitude")
+            item["lon"] = geo.get("longitude")
+
+        item["opening_hours"] = OpeningHours()
+        for day in (salon.get("toBeComputed") or {}).get("openUntil", {}).get("hours") or []:
+            if day.get("closed") or not (day.get("opening") and day.get("closing")):
+                continue
+            item["opening_hours"].add_range(DAYS[day["day"] - 1], day["opening"], day["closing"])
+
+        apply_category(Categories.SHOP_HAIRDRESSER, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Franck Provost, the French hairdresser/salon chain. Each salon page (`/salons/<slug>`, enumerated via `sitemaps/sitemap-hairdressers.xml`) embeds the full salon record as JSON inside a Next.js RSC flight chunk (`self.__next_f.push([1, "..."])`); the spider extracts and JSON-decodes that payload directly rather than scraping HTML.

Verified locally: 621 items from 621 valid sitemap URLs (2 of 623 were a stray `:slug` placeholder 404 and one page with no salon payload). Coordinates, phone, per-branch email and opening hours parse correctly for the large majority of records; a handful of records genuinely lack hours/coordinates in the source data and are left blank. The sitemap currently only contains live salons in FR (bulk), ES, IT, CH, AU, BE and a scattering of other countries — no NL/PL/PT salons currently exist on the site despite those being listed in the issue's scope, so the spider naturally omits them until such salons appear.

closes #18016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Franck Provost salon locations.
  * Captures salon names, addresses, contact details, websites, coordinates, categories, and available opening hours.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->