### PR TITLE
[Orchestra FR] Add spider

### DIFF
--- a/locations/spiders/orchestra_fr.py
+++ b/locations/spiders/orchestra_fr.py
@@ -1,0 +1,20 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.uberall import UberallSpider
+
+
+class OrchestraFRSpider(UberallSpider):
+    name = "orchestra_fr"
+    item_attributes = {"brand": "Orchestra", "brand_wikidata": "Q28042940"}
+    key = "fRYpR2RHA3bSUaYQIhuOkMIvP9eIVf"
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").title().removeprefix("Orchestra ")
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+
+        yield item


### PR DESCRIPTION
Orchestra (French children's clothing/maternity retailer) uses the Uberall store locator platform (`https://uberall.com/api/storefinders/fRYpR2RHA3bSUaYQIhuOkMIvP9eIVf/locations/all`), so this spider is a thin subclass of the existing `UberallSpider` base class.

Verified 240 items locally, all in France, with unique coordinates, phone numbers, and opening hours. `addr:state` is populated from the source's `province` field (actual French regions like "Occitanie", not a country code).

closes #18020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location data collection for Orchestra France.
  * Orchestra France locations now include branch names and clothing category information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->