### PR TITLE
[au (JP)] Add spider

### DIFF
--- a/locations/spiders/au_jp.py
+++ b/locations/spiders/au_jp.py
@@ -1,0 +1,44 @@
+from typing import Any, Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+# UQ mobile is a separate KDDI-owned brand that shares this store locator
+# (storeClassification "9"); exclude it so only "au" branded shops remain.
+UQ_MOBILE_CLASSIFICATION = "9"
+
+
+class AuJPSpider(Spider):
+    name = "au_jp"
+    item_attributes = {"brand": "au", "brand_wikidata": "Q307110"}
+    allowed_domains = ["www.au.com"]
+    start_urls = [
+        "https://www.au.com/bin/wcm/au-com/storelocator.json"
+        "?northWestLat=46&northWestLng=120&northEastLat=46&northEastLng=156"
+        "&southWestLat=20&southWestLng=120&southEastLat=20&southEastLng=156&locale=ja"
+    ]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for shop in response.json():
+            if shop.get("storeClassification") == UQ_MOBILE_CLASSIFICATION:
+                continue
+
+            item = Feature()
+            item["ref"] = shop["shopNo"]
+            item["name"] = shop.get("storeNameDisp") or shop.get("storeName")
+            item["lat"] = shop.get("latitude")
+            item["lon"] = shop.get("longitude")
+            item["state"] = shop.get("address1")
+            item["city"] = shop.get("address2")
+            item["street_address"] = shop.get("address3")
+            item["postcode"] = shop.get("zipCode")
+            item["phone"] = shop.get("phoneNo") or shop.get("freeCall") or None
+            item["website"] = f"https://www.au.com/storelocator/detail/?shopId={shop['shopNo']}"
+            item["country"] = "JP"
+
+            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+
+            yield item


### PR DESCRIPTION
Adds a spider for au, KDDI's mobile phone retail brand in Japan. Data comes from the store locator's JSON API (`storelocator.json`), which returns all ~2,300 shops nationwide in a single bounding-box request without needing to tile the country. UQ mobile shops (a separate KDDI-owned brand sharing the same locator, flagged by `storeClassification == "9"`) are filtered out.

Verified locally: 2210 items, all with coordinates, unique refs, and unique per-store phone numbers. NSI brand matching is 100% (`aushop-0a8be9`).

closes #17129