### PR TITLE
[Matmut] Add spider

### DIFF
--- a/locations/spiders/matmut_fr.py
+++ b/locations/spiders/matmut_fr.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MatmutFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "matmut_fr"
+    item_attributes = {"brand": "Matmut", "brand_wikidata": "Q3299185"}
+    allowed_domains = ["agences.matmut.fr"]
+    sitemap_urls = ["https://agences.matmut.fr/sitemap.xml"]
+    sitemap_rules = [(r"/matmut-assurances-[^/]+$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.OFFICE_INSURANCE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Matmut (French mutual insurance provider) branch offices, sourced from the sitemap of https://agences.matmut.fr/ combined with the schema.org LocalBusiness structured data on each store page.

Verified locally: 465 items scraped, all with 200 responses, coordinates, addresses, opening hours, phone numbers, and per-location photos.

closes #18018