### PR TITLE
[MACIF] Add spider

### DIFF
--- a/locations/spiders/macif_fr.py
+++ b/locations/spiders/macif_fr.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MacifFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "macif_fr"
+    item_attributes = {"brand": "Macif", "brand_wikidata": "Q3331021"}
+    sitemap_urls = ["https://agences.macif.fr/sitemap_pois.xml"]
+    sitemap_rules = [(r"/details$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.OFFICE_INSURANCE, item)
+        # Phone number is a shared national hotline, identical across all branches
+        item["phone"] = None
+        yield item


### PR DESCRIPTION
Adds a spider for MACIF (French insurance mutual), using the same platform (Solocal/Uberall widget) as the existing MAIF spider. Pulls store URLs from the sitemap and parses schema.org `InsuranceAgency` structured data on each `/details` page.

Verified locally: 426 items, 0 duplicates, opening hours parsed for all but 5 locations. The `phone` field is a shared national hotline identical across every branch, so it is nulled out rather than presented as branch-specific data.

closes #18019