### PR TITLE
[JalouCity] Add spider

### DIFF
--- a/locations/spiders/jaloucity_de.py
+++ b/locations/spiders/jaloucity_de.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, apply_category
+from locations.linked_data_parser import LinkedDataParser
+
+
+class JaloucityDESpider(CrawlSpider):
+    name = "jaloucity_de"
+    item_attributes = {"brand": "JalouCity", "brand_wikidata": "Q113686657"}
+    allowed_domains = ["www.jaloucity.de"]
+    start_urls = ["https://www.jaloucity.de/filialen.html"]
+    rules = [Rule(LinkExtractor(allow=r"/filialen/[\w-]+\.html$"), callback="parse_store", follow=False)]
+
+    def parse_store(self, response: Response, **kwargs: Any) -> Any:
+        if item := LinkedDataParser.parse(response, "LocalBusiness"):
+            item["ref"] = response.url
+            apply_category(Categories.SHOP_WINDOW_BLIND, item)
+            yield item


### PR DESCRIPTION
Crawls the branch listing at `/filialen.html` and follows each `/filialen/<slug>.html` link, parsing the `LocalBusiness` JSON-LD present on each real branch page (address, phone, email, geo, opening hours all genuinely unique per branch). Four "city hub" pages (berlin, hamburg, koeln, essen) are also matched by the link pattern but contain no `LocalBusiness` markup, so they correctly yield no item, leaving the 37 real branches.

`www.jaloucity.de` is currently unreachable from my sandbox (TCP connect to port 443 times out consistently, confirmed via curl, raw TCP, a separate WebFetch network path, and `scrapy runspider` itself), so I could not do a live end-to-end run. This matches the issue's own history (previously closed as "DNS no longer resolves", then reopened when it recovered), suggesting the site has intermittent uptime. I verified the parser logic offline instead, feeding the most recent Wayback Machine snapshot (2026-05-15) through `LinkedDataParser` and `LinkExtractor` directly — link discovery correctly finds all 41 candidate URLs, and structured-data extraction correctly produces clean items for sample branches (Aachen, München, Wiesbaden, Leipzig, Hannover) with distinct addresses, coordinates, phone numbers, emails, and opening hours.

Reviewer should double check CI actually reaches the live site before merging, given I couldn't confirm this locally.

closes #9293