### PR TITLE
[Tear JP] Add spider

### DIFF
--- a/locations/spiders/tear_jp.py
+++ b/locations/spiders/tear_jp.py
@@ -1,0 +1,32 @@
+import re
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TearJPSpider(SitemapSpider, StructuredDataSpider):
+    name = "tear_jp"
+    item_attributes = {"brand": "ティア", "brand_wikidata": "Q11318901"}
+    sitemap_urls = ["https://www.tear.co.jp/sitemap/hall.detail.xml"]
+    sitemap_rules = [(r"/hall/\d+$", "parse_sd")]
+
+    # A generic group-wide call centre number ("0120-549453", sometimes
+    # annotated "（ティアにつながります）" i.e. "connects to Tear") is used
+    # by around 60% of halls in place of a real direct line, so it's
+    # dropped rather than reported as branch-specific contact info.
+    GENERIC_PHONE_DIGITS = "0120549453"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item.get("phone"):
+            item["phone"] = re.sub(r"[（(].*[）)]\s*$", "", item["phone"]).strip()
+            if re.sub(r"\D", "", item["phone"]) == self.GENERIC_PHONE_DIGITS:
+                item["phone"] = None
+
+        if "noimage" in (item.get("image") or ""):
+            item["image"] = None
+
+        apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Tear (ティア, Q11318901), a Japanese funeral director chain, using their hall detail sitemap (`https://www.tear.co.jp/sitemap/hall.detail.xml`) combined with `LocalBusiness` structured data on each hall page.

Verified locally: 569/569 hall pages yield an item with coordinates, all within Japan's bounding box, all with unique refs. About 60% of halls report an identical `0120-549453` phone number annotated on-page as "connects to Tear" (a group-wide call centre line, not a direct line) — this is dropped as non-branch-specific rather than kept. A shared generic `noimage.png` placeholder (~10% of halls) is dropped from `image` for the same reason. Opening hours are present for locations that publish them (~36%) and left blank otherwise.

closes #17135