### PR TITLE
[Bricorama FR] Add spider

### DIFF
--- a/locations/spiders/bricorama_fr.py
+++ b/locations/spiders/bricorama_fr.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+import re
 
 from scrapy.spiders import SitemapSpider
 
@@ -6,6 +6,8 @@ from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 from locations.structured_data_spider import StructuredDataSpider
+
+STORE_URL_RE = re.compile(r"^https://www\.bricorama\.fr/magasin/[\w\-]+/(\d+)$")
 
 
 class BricoramaFRSpider(SitemapSpider, StructuredDataSpider, CamoufoxSpider):
@@ -18,16 +20,20 @@ class BricoramaFRSpider(SitemapSpider, StructuredDataSpider, CamoufoxSpider):
     captcha_type = "cloudflare_turnstile"
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        # Some sitemap URLs redirect to a rebranded store on the sibling
-        # Bricomarché site (same corporate group, shared JSON-LD template).
-        # Skip those rather than mislabelling them as Bricorama.
-        if urlparse(response.url).hostname != "www.bricorama.fr":
+        # A small number of sitemap URLs redirect elsewhere instead of
+        # loading the store page: either to the generic "/magasins" store
+        # locator (e.g. a delisted store ID), which still carries a stray
+        # LocalBusiness JSON-LD block, or to a rebranded store on the
+        # sibling Bricomarché site (same corporate group, shared JSON-LD
+        # template). Only keep items that landed on a genuine store URL.
+        match = STORE_URL_RE.match(response.url)
+        if not match:
             return
 
         # The JSON-LD "@id" is the same generic store-locator URL for every
         # store, so LinkedDataParser's ref ends up non-unique. Use the
         # numeric store code from the URL instead.
-        item["ref"] = response.url.rstrip("/").rsplit("/", 1)[-1]
+        item["ref"] = match.group(1)
 
         apply_category(Categories.SHOP_DOITYOURSELF, item)
         yield item

--- a/locations/spiders/bricorama_fr.py
+++ b/locations/spiders/bricorama_fr.py
@@ -1,0 +1,33 @@
+from urllib.parse import urlparse
+
+from scrapy.spiders import SitemapSpider
+
+from locations.camoufox_spider import CamoufoxSpider
+from locations.categories import Categories, apply_category
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class BricoramaFRSpider(SitemapSpider, StructuredDataSpider, CamoufoxSpider):
+    name = "bricorama_fr"
+    item_attributes = {"brand": "Bricorama", "brand_wikidata": "Q2925146"}
+    allowed_domains = ["www.bricorama.fr"]
+    sitemap_urls = ["https://www.bricorama.fr/sitemap/Store-BR-fr-EUR"]
+    sitemap_rules = [(r"^https:\/\/www\.bricorama\.fr\/magasin\/[\w\-]+\/\d+$", "parse_sd")]
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    captcha_type = "cloudflare_turnstile"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        # Some sitemap URLs redirect to a rebranded store on the sibling
+        # Bricomarché site (same corporate group, shared JSON-LD template).
+        # Skip those rather than mislabelling them as Bricorama.
+        if urlparse(response.url).hostname != "www.bricorama.fr":
+            return
+
+        # The JSON-LD "@id" is the same generic store-locator URL for every
+        # store, so LinkedDataParser's ref ends up non-unique. Use the
+        # numeric store code from the URL instead.
+        item["ref"] = response.url.rstrip("/").rsplit("/", 1)[-1]
+
+        apply_category(Categories.SHOP_DOITYOURSELF, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Bricorama (FR), a French home improvement store chain. Uses the store sitemap (https://www.bricorama.fr/sitemap/Store-BR-fr-EUR) combined with StructuredDataSpider to parse per-store JSON-LD. The site sits behind Cloudflare Turnstile, so this uses CamoufoxSpider with the click-solver enabled.

Two data-quality issues found and fixed:
- A handful of sitemap URLs redirect to the generic `/magasins` locator page (delisted store IDs) or to a rebranded store on the sibling Bricomarché site (same corporate group, shared JSON-LD template). Only items landing on a genuine `/magasin/<slug>/<id>` URL are kept.
- The JSON-LD `@id` is identical across every store, so the default `ref` extraction was non-unique; `ref` is now taken from the numeric store code in the URL instead.

Verified locally: 81 stores, all with coordinates and addresses, unique refs, and no shared/duplicate phone or email across stores.

closes #17792