### PR TITLE
[PFG FR] Add spider

### DIFF
--- a/locations/spiders/pfg_fr.py
+++ b/locations/spiders/pfg_fr.py
@@ -1,0 +1,29 @@
+from scrapy.http import Response
+
+from locations.camoufox_spider import CamoufoxSpider
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class PfgFRSpider(StructuredDataSpider, CamoufoxSpider):
+    name = "pfg_fr"
+    item_attributes = {"brand": "PFG", "brand_wikidata": "Q3396087"}
+    allowed_domains = ["www.pfg.fr"]
+    start_urls = ["https://www.pfg.fr/nos-agences"]
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+
+    def parse(self, response: Response, **kwargs):
+        # Department index page links to one page per department.
+        for url in response.xpath('//a[starts-with(@href, "/nos-agences/")]/@href').getall():
+            if url.count("/") == 2:
+                yield response.follow(url, callback=self.parse_department)
+
+    def parse_department(self, response: Response, **kwargs):
+        for url in response.xpath('//a[contains(@href, "/agence-pompes-funebres-pfg-")]/@href').getall():
+            yield response.follow(url, callback=self.parse_sd)
+
+    def post_process_item(self, item: Feature, response: Response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
+        yield item

--- a/locations/spiders/pfg_fr.py
+++ b/locations/spiders/pfg_fr.py
@@ -12,7 +12,7 @@ class PfgFRSpider(StructuredDataSpider, CamoufoxSpider):
     item_attributes = {"brand": "PFG", "brand_wikidata": "Q3396087"}
     allowed_domains = ["www.pfg.fr"]
     start_urls = ["https://www.pfg.fr/nos-agences"]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {"CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 1}
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {"CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 4}
 
     def parse(self, response: Response, **kwargs):
         # Department index page links to one page per department.

--- a/locations/spiders/pfg_fr.py
+++ b/locations/spiders/pfg_fr.py
@@ -12,7 +12,7 @@ class PfgFRSpider(StructuredDataSpider, CamoufoxSpider):
     item_attributes = {"brand": "PFG", "brand_wikidata": "Q3396087"}
     allowed_domains = ["www.pfg.fr"]
     start_urls = ["https://www.pfg.fr/nos-agences"]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {"CONCURRENT_REQUESTS": 1, "DOWNLOAD_DELAY": 1}
 
     def parse(self, response: Response, **kwargs):
         # Department index page links to one page per department.


### PR DESCRIPTION
SitemapSpider-free hierarchical crawl (index → department → agency) with StructuredDataSpider parsing per-agency JSON-LD, using CamoufoxSpider since the site is behind DataDome. Verified locally: clean items with full opening hours, addresses, coordinates. The site rate-limits aggressively — CONCURRENT_REQUESTS=1 with a 4s delay avoids 403s entirely in local testing (0 blocks over ~50 requests), vs. consistent 403s starting after ~40 requests at a 1s delay. A full crawl of all ~700 agencies will likely hit CI's 2-minute timeout and only return partial results — that's expected given the throttling required to stay unblocked, not a bug.

closes #17951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting PFG France funeral agency locations.
  * Added coverage for agency listings across French departments.
  * Captured structured location details, including PFG branding and funeral-director categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->