### PR TITLE
[Bulgari Hotels] Add spider

### DIFF
--- a/locations/spiders/bulgari_hotels.py
+++ b/locations/spiders/bulgari_hotels.py
@@ -1,0 +1,51 @@
+import re
+
+from scrapy import Request
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+# Coordinates on the /location sub-page default to this bogus placeholder
+# (somewhere off the coast of Nova Scotia) when the real value hasn't been
+# set for a property, so it must be discarded rather than used.
+BROKEN_DEFAULT_LOCATION = ("45.088530", "-64.367951")
+
+
+class BulgariHotelsSpider(StructuredDataSpider):
+    name = "bulgari_hotels"
+    item_attributes = {"brand": "Bulgari Hotels & Resorts", "brand_wikidata": "Q91602871"}
+    start_urls = [
+        f"https://www.bulgarihotels.com/en_US/{slug}"
+        for slug in ["rome", "milan", "paris", "london", "dubai", "bali", "tokyo", "beijing", "shanghai"]
+    ]
+
+    def pre_process_data(self, ld_data, **kwargs):
+        if address := ld_data.get("address"):
+            if address.get("addressCountry") == "UAE":
+                address["addressCountry"] = "United Arab Emirates"
+                # Dubai has no postal code system, so "00000" is a placeholder.
+                address["postalCode"] = None
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.HOTEL, item)
+
+        # The postcode from JSON-LD is sometimes truncated (e.g. Tokyo's
+        # "0028" instead of "104-0028"); prefer a fuller value found in the
+        # street address if one is present there.
+        if item.get("postcode") and item.get("street_address"):
+            if m := re.search(r"\b(\d{3}-\d{4})\b", item["street_address"]):
+                item["postcode"] = m.group(1)
+
+        yield Request(
+            url=response.urljoin(f"{response.url}/location"),
+            callback=self.parse_location,
+            cb_kwargs={"item": item},
+        )
+
+    def parse_location(self, response, item):
+        lat = response.xpath("//div[@data-location-latitude]/@data-location-latitude").get()
+        lon = response.xpath("//div[@data-location-longitude]/@data-location-longitude").get()
+        if lat and lon and (lat, lon) != BROKEN_DEFAULT_LOCATION:
+            item["lat"] = lat
+            item["lon"] = lon
+        yield item


### PR DESCRIPTION
Adds a spider for Bulgari Hotels & Resorts, a luxury hotel chain with 9 currently-open properties (Rome, Milan, Paris, London, Dubai, Bali, Tokyo, Beijing, Shanghai). Five additional properties listed on the site (Abu Dhabi, Bodrum, Miami Beach, Cave Cay, Ranfushi) are future openings (2027-2030) with no address data yet, so they're excluded.

Data source is JSON-LD (`Hotel` type) on each hotel's own page, parsed via `StructuredDataSpider`. Coordinates come from a `data-location-latitude`/`data-location-longitude` attribute on each hotel's `/location` sub-page; 4 of the 9 properties (Rome, Milan, London, Tokyo) have a broken placeholder value there (a spot off the coast of Nova Scotia) that's filtered out rather than used, so those are left without coordinates.

A couple of source data quality issues are fixed in the spider: Dubai's `addressCountry` is the non-standard abbreviation "UAE" (normalized so the country code pipeline can resolve it) and its postcode is a placeholder "00000" (Dubai has no postal codes, so it's dropped); Tokyo's postcode is truncated in the JSON-LD ("0028") but the full value is recoverable from the street address ("104-0028").

Note: the issue's `brand_wikidata` (Q752515) is the Bulgari fashion house, not the hotel chain, so I used Q91602871 ("Bulgari Hotels & Resorts", luxury hotel chain) instead.

Verified locally: 9 items, all with unique names/images/phones, correct country codes, and plausible coordinates for the 5 properties that have them.

closes #17108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Bulgari Hotels location information.
  * Hotel listings now include normalized addresses, categories, postal codes, and geographic coordinates.
  * Improved handling of UAE addresses, Japanese postal codes, and invalid placeholder coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->