### PR TITLE
[VodafoneZiggo NL] Add spider

### DIFF
--- a/locations/spiders/vodafoneziggo_nl.py
+++ b/locations/spiders/vodafoneziggo_nl.py
@@ -1,0 +1,43 @@
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS_EN, OpeningHours
+from locations.items import Feature
+
+
+class VodafoneziggoNLSpider(scrapy.Spider):
+    name = "vodafoneziggo_nl"
+    item_attributes = {"brand": "VodafoneZiggo", "brand_wikidata": "Q55640416"}
+    start_urls = [
+        "https://api.localistico.com/clients/v1/businesses/694cbc6c-9274-48b0-b509-f989f7febed2/locations/45bca548-ee7a-4640-94dc-22d919f3f5ce.json?access_token=U0UsaiI5Tv4bHvizsfJGXdqlL6Il11lCMFjJaUmc8_exoYaIx7zzNbRdygnTIg7viBQ"
+    ]
+
+    def parse(self, response):
+        for location in response.json():
+            if location.get("close") != "no":
+                continue
+
+            item = Feature()
+            item["ref"] = location["location_code"]
+            item["name"] = location["location_name"]
+            item["street_address"] = location["street_address"]
+            item["postcode"] = location["postcode"]
+            item["city"] = location["locality"]
+            item["state"] = location["region"]
+            item["country"] = location["country_code"]
+            item["lat"] = location["location_lat"]
+            item["lon"] = location["location_lng"]
+
+            item["opening_hours"] = OpeningHours()
+            for day_hours in location.get("hours", "").split("|"):
+                day, _, times = day_hours.partition(":")
+                if not times:
+                    continue
+                for interval in times.split(","):
+                    open_time, _, close_time = interval.partition("-")
+                    if open_time and close_time:
+                        item["opening_hours"].add_range(DAYS_EN.get(day, day), open_time, close_time)
+
+            apply_category(Categories.SHOP_MOBILE_PHONE, item)
+
+            yield item


### PR DESCRIPTION
Adds a spider for VodafoneZiggo store locations in the Netherlands (combined Vodafone + Ziggo shops).

The store finder widget on vodafone.nl fetches a Localistico-hosted JSON export. The export filename is timestamped and changes over time, but the widget resolves it via a stable Localistico API redirect URL (`api.localistico.com/clients/v1/businesses/<business_id>/locations/<id>.json?access_token=...`), which the spider uses directly to always get the current export.

Closed/temporarily-closed locations (63 of 151 records) are filtered out. The generic support phone number (identical across all records) and a generic storefinder website URL (same across all records) were dropped as non-branch-specific. Verified locally: 85 items, all within the NL bounding box, addr:state populated with real province names, opening_hours parsed for all records.

closes #17118