### PR TITLE
[Laser Clinics] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -105,6 +105,7 @@ class Categories(Enum):
     SHOP_BAKERY = {"shop": "bakery"}
     SHOP_BATHROOM_FURNISHING = {"shop": "bathroom_furnishing"}
     SHOP_BEAUTY = {"shop": "beauty"}
+    SHOP_BEAUTY_LASER_HAIR_REMOVAL = {"shop": "beauty", "beauty": "laser_hair_removal"}
     SHOP_BEAUTY_SPA = {"shop": "beauty", "beauty": "spa"}
     SHOP_BED = {"shop": "bed"}
     SHOP_BEVERAGES = {"shop": "beverages"}

--- a/locations/spiders/laser_clinics_au.py
+++ b/locations/spiders/laser_clinics_au.py
@@ -1,0 +1,63 @@
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
+
+LASER_CLINICS_SHARED_ATTRIBUTES = {"brand": "Laser Clinics", "brand_wikidata": "Q126539797"}
+
+# Page coordinates are only available inside a Next.js RSC flight chunk, as a
+# JSON string escaped within a <script> tag, e.g. \"center\":{\"lat\":1,\"lng\":2}
+COORDS_RE = re.compile(r'\\"center\\":\{\\"lat\\":(-?[\d.]+),\\"lng\\":(-?[\d.]+)\}')
+
+
+class LaserClinicsSpider(SitemapSpider):
+    item_attributes = LASER_CLINICS_SHARED_ATTRIBUTES
+    sitemap_rules = [(r"/skin-care-clinics?/[^/]+/?$", "parse")]
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT, "ROBOTSTXT_OBEY": False}
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        if "closed-clinic" in response.url:
+            return
+
+        item = Feature()
+        item["ref"] = response.url.rstrip("/").rsplit("/", 1)[-1]
+        item["website"] = response.url
+
+        h1 = response.xpath("//h1/text()").get("")
+        item["branch"] = h1.rsplit(" - ", 1)[-1].strip() if " - " in h1 else h1.strip()
+
+        item["addr_full"] = response.xpath(
+            '//div[@id="clinic-location"]//h5[text()="Address"]/following-sibling::p[1]/text()'
+        ).get()
+
+        if phone := response.xpath(
+            '//div[@id="clinic-location"]//h5[text()="Call us"]/following-sibling::p[1]/text()'
+        ).get():
+            item["phone"] = phone.replace("Ph:", "").strip()
+
+        if m := COORDS_RE.search(response.text):
+            item["lat"], item["lon"] = m.group(1), m.group(2)
+
+        oh = OpeningHours()
+        days = response.xpath('//div[@id="clinic-location"]//ul/li/span[1]/text()').getall()
+        hours = response.xpath('//div[@id="clinic-location"]//ul/li/span[2]/text()').getall()
+        for day, time_range in zip(days, hours):
+            oh.add_ranges_from_string(f"{day}: {time_range}")
+        item["opening_hours"] = oh
+
+        apply_category(Categories.SHOP_BEAUTY_LASER_HAIR_REMOVAL, item)
+        yield item
+
+
+class LaserClinicsAUSpider(LaserClinicsSpider):
+    name = "laser_clinics_au"
+    item_attributes = {**LASER_CLINICS_SHARED_ATTRIBUTES, "country": "AU"}
+    allowed_domains = ["www.laserclinics.com.au"]
+    sitemap_urls = ["https://www.laserclinics.com.au/sitemap.xml"]
+    requires_proxy = "AU"  # Vercel security checkpoint blocks datacentre IPs

--- a/locations/spiders/laser_clinics_ca.py
+++ b/locations/spiders/laser_clinics_ca.py
@@ -1,0 +1,9 @@
+from locations.spiders.laser_clinics_au import LASER_CLINICS_SHARED_ATTRIBUTES, LaserClinicsSpider
+
+
+class LaserClinicsCASpider(LaserClinicsSpider):
+    name = "laser_clinics_ca"
+    item_attributes = {**LASER_CLINICS_SHARED_ATTRIBUTES, "country": "CA"}
+    allowed_domains = ["www.laserclinics.ca"]
+    sitemap_urls = ["https://www.laserclinics.ca/sitemap.xml"]
+    requires_proxy = "CA"  # Vercel security checkpoint blocks datacentre IPs

--- a/locations/spiders/laser_clinics_gb.py
+++ b/locations/spiders/laser_clinics_gb.py
@@ -1,0 +1,9 @@
+from locations.spiders.laser_clinics_au import LASER_CLINICS_SHARED_ATTRIBUTES, LaserClinicsSpider
+
+
+class LaserClinicsGBSpider(LaserClinicsSpider):
+    name = "laser_clinics_gb"
+    item_attributes = {**LASER_CLINICS_SHARED_ATTRIBUTES, "country": "GB"}
+    allowed_domains = ["www.laserclinics.co.uk"]
+    sitemap_urls = ["https://www.laserclinics.co.uk/sitemap.xml"]
+    requires_proxy = "GB"  # Vercel security checkpoint blocks datacentre IPs

--- a/locations/spiders/laser_clinics_nz.py
+++ b/locations/spiders/laser_clinics_nz.py
@@ -1,0 +1,9 @@
+from locations.spiders.laser_clinics_au import LASER_CLINICS_SHARED_ATTRIBUTES, LaserClinicsSpider
+
+
+class LaserClinicsNZSpider(LaserClinicsSpider):
+    name = "laser_clinics_nz"
+    item_attributes = {**LASER_CLINICS_SHARED_ATTRIBUTES, "country": "NZ"}
+    allowed_domains = ["www.laserclinicsnewzealand.co.nz"]
+    sitemap_urls = ["https://www.laserclinicsnewzealand.co.nz/sitemap.xml"]
+    requires_proxy = "NZ"  # Vercel security checkpoint blocks datacentre IPs

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -38,7 +38,7 @@ def test_apply_yes_no():
 
 def test_shop_tag_sanity():
     for cat in Categories:
-        if cat in {Categories.SHOP_E_CIGARETTE, Categories.SHOP_BEAUTY_SPA}:
+        if cat in {Categories.SHOP_E_CIGARETTE, Categories.SHOP_BEAUTY_SPA, Categories.SHOP_BEAUTY_LASER_HAIR_REMOVAL}:
             continue
         if cat.name.startswith("SHOP_"):
             shop_name = cat.name.split("_", 1)[1].lower()


### PR DESCRIPTION
Adds spiders for Laser Clinics in AU, CA, GB and NZ (`laser_clinics_au`, `laser_clinics_ca`, `laser_clinics_gb`, `laser_clinics_nz`), sharing parsing logic since all four sites run the same Next.js codebase and page layout.

All four sites sit behind Vercel's "Security Checkpoint" (blocks datacentre IPs, returns HTTP 429 even for `robots.txt`/`sitemap.xml`), confirmed with a real Chrome UA and with Camoufox — so each spider uses `requires_proxy` with the matching country geolocation, the same fix already used for `evgo_us.py`.

Clinic pages are server-rendered with a clean HTML block (`#clinic-location`) containing address, phone and a per-day opening-hours list, which is parsed with XPath. Coordinates are only present inside a React Server Components flight chunk embedded in a `<script>` tag (`\"center\":{\"lat\":...,\"lng\":...}`), extracted via regex — no geocoding involved. Closed-clinic pages (slug prefix `closed-clinic-`, present in the sitemap) are filtered out.

Verified selectors and the full `parse()` output against an archived copy of a sample AU clinic page (opening hours parse correctly to `Mo-Th 08:30-18:00; Fr 08:30-20:45; Sa 08:30-17:00; Su 11:00-17:00`, address/phone/coords all extracted). Also verified the sitemap URL-filtering regex and closed-clinic exclusion against an archived AU sitemap (134 clinic URLs matched, 9 correctly excluded as closed). Live proxy-gated crawls could not be run locally (no Zyte credentials in this environment) — CI should confirm end-to-end item counts for all four countries.

Added `Categories.SHOP_BEAUTY_LASER_HAIR_REMOVAL` (`shop=beauty`, `beauty=laser_hair_removal`) since no existing category fit.

closes #14892