### PR TITLE
[Barrique DE/NL] Add spider

### DIFF
--- a/locations/spiders/barrique_de_nl.py
+++ b/locations/spiders/barrique_de_nl.py
@@ -1,0 +1,35 @@
+import json
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+
+class BarriqueDENLSpider(JSONBlobSpider):
+    name = "barrique_de_nl"
+    item_attributes = {"brand": "Barrique", "brand_wikidata": "Q114133164"}
+    start_urls = ["https://www.barrique.de/ladengeschaefte"]
+
+    def extract_json(self, response: Response, **kwargs: Any) -> Any:
+        return json.loads(response.css("div.maps2::attr(data-pois)").get())
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature["ref"] = feature["uid"]
+        # Emails are unreliable: the mailto href is stale/mismatched on several store pages
+        # (e.g. uid 38's href points to a different store than its own display text), so
+        # email is intentionally not extracted here.
+        if phone := re.search(
+            r"(?:Tel(?:efon)?\.?:?|T:)(?:&nbsp;|\s)*([+(\d][\d\s/().-]*\d)", feature["infoWindowContent"]
+        ):
+            feature["phone"] = phone.group(1).replace("/", " ")
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Barrique ").strip()
+        item["website"] = response.url
+        item["country"] = "NL" if "Nederland" in item["addr_full"] else "DE"
+        apply_category(Categories.SHOP_WINE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Barrique, a German/Dutch wine shop chain. Store locations are embedded as a JSON blob in the `data-pois` attribute of a TYPO3 maps2 extension `div` on the store finder page (https://www.barrique.de/ladengeschaefte) — no JS rendering or API call needed.

Phone numbers are parsed out of the `infoWindowContent` HTML snippet (format varies: "Telefon:", "Tel.", "Tel:", and Dutch "T:"). Email addresses are intentionally not extracted — several `mailto:` hrefs on the source site are stale and don't match their own displayed link text (e.g. Bad Freienwalde's href points to a different store), so scraping them would ship wrong data.

Verified 24 items locally (23 DE, 1 NL), each with a name, address, and coordinates in the right place; 22/24 have a correctly parsed phone number (the other two genuinely have none listed on the source page).

closes #6995