### PR TITLE
[Culver's US] Reduce redundant requests

### DIFF
--- a/locations/spiders/culvers_us.py
+++ b/locations/spiders/culvers_us.py
@@ -8,8 +8,8 @@ from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
-from locations.geo import city_locations
-from locations.hours import OpeningHours
+from locations.geo import country_iseadgg_centroids
+from locations.hours import DAYS, OpeningHours
 from locations.items import set_closed
 
 
@@ -18,9 +18,15 @@ class CulversUSSpider(scrapy.Spider):
     item_attributes = {"brand": "Culver's", "brand_wikidata": "Q1143589"}
 
     async def start(self) -> Iterable[Request]:
-        for city in city_locations("US", 100000):
+        # The API silently caps each response at 100 results, regardless of the
+        # "limit" parameter, so a query radius must be small enough that no
+        # single query point has more than 100 real locations within it, even
+        # in Culver's densest area (Milwaukee/Chicago). 94km ISEADGG spacing
+        # empirically stays under that cap there (~74 results) while still
+        # using far fewer query points than one per 100k+ population city.
+        for lat, lon in country_iseadgg_centroids("US", 94):
             yield JsonRequest(
-                url=f'https://www.culvers.com/api/locator/getLocations?lat={city["latitude"]}&long={city["longitude"]}&radius=600000&limit=10000'
+                url=f"https://www.culvers.com/api/locator/getLocations?lat={lat}&long={lon}&radius=94000&limit=10000"
             )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
@@ -70,7 +76,7 @@ class CulversUSSpider(scrapy.Spider):
             return None
 
         oh = OpeningHours()
-        for day in ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]:
+        for day in DAYS:
             open_time = hours.get(f"{day}O")
             close_time = hours.get(f"{day}C")
             if not open_time or not close_time or open_time == "n/a" or close_time == "n/a":


### PR DESCRIPTION
The spider previously queried once per US city with population >=100k (357 points) at a 600km radius, causing massive geographic overlap — 93% of fetched items (15,112 of 16,203) were dropped as duplicates on the last full run.

Switched to `country_iseadgg_centroids("US", 94)` (554 points, 94km spacing) with a matching 94km query radius. The API silently caps each response at 100 results regardless of the `limit` parameter, so the query radius needed to be small enough that no single point (even in Culver's densest area, Milwaukee/Chicago) exceeds that cap — verified empirically (74 results at 94km near Milwaukee, vs. hitting the 100-cap at 120km+).

Also replaced a hand-coded day-abbreviation list in `parse_hours` with the existing `DAYS` constant from `locations.hours`.

Verified with a full local run: 1104 items (vs. the prior baseline of 1091), only 168 dropped by the dupe filter — down from 15,112.