### PR TITLE
[1825 Interiors] Add spider

### DIFF
--- a/locations/spiders/interiors_1825_au.py
+++ b/locations/spiders/interiors_1825_au.py
@@ -1,0 +1,31 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class Interiors1825AUSpider(SitemapSpider, StructuredDataSpider):
+    name = "interiors_1825_au"
+    item_attributes = {"brand": "1825 Interiors", "brand_wikidata": "Q111080640"}
+    sitemap_urls = ["https://www.1825interiors.com.au/sitemap.xml"]
+    sitemap_follow = [r"/sitemap_pages_"]
+    sitemap_rules = [(r"/pages/", "parse_sd")]
+    wanted_types = ["FurnitureStore"]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        # The "/pages/contact" page carries FurnitureStore markup for the head
+        # office/warehouse, which is not a public retail store.
+        if "Head Office" in item["name"]:
+            return
+
+        item["branch"] = item.pop("name").removeprefix("1825 Interiors").strip(" -")
+        apply_category(Categories.SHOP_FURNITURE, item)
+
+        # The only image present is a generic brand logo shared across every store.
+        item["image"] = None
+
+        yield item


### PR DESCRIPTION
Adds a spider for 1825 Interiors, an Australian furniture retail chain, using the site's sitemap plus per-store `FurnitureStore` JSON-LD structured data (`SitemapSpider` + `StructuredDataSpider`).

The store-locations page lists 9 entries, but two of them (a "clearance outlet" and a "head office & warehouse", both at the same Wetherill Park address) actually route to the same non-store `/pages/contact` page, whose structured data explicitly names it "1825 Interiors Wetherill Park Head Office" — not a public retail location, so it's filtered out in `post_process_item`. The remaining 7 store pages (Bathurst, Campbelltown, Fyshwick, Penrith, Rutherford, Tamworth, Wagga Wagga) each have their own dedicated page with coordinates, address, phone, and opening hours. The generic brand logo image (identical across all locations) is dropped.

Verified locally: 7 items scraped, brand string matches NSI exactly.

closes #8537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location coverage for 1825 Interiors in Australia.
  * Automatically captures furniture store branches from structured website data.
  * Excludes the head office and removes irrelevant shared branding from listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->