### PR TITLE
[JA Bank JP] Add spider

### DIFF
--- a/locations/spiders/ja_bank_jp.py
+++ b/locations/spiders/ja_bank_jp.py
@@ -1,0 +1,54 @@
+from typing import Any, AsyncIterator
+
+import scrapy
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class JaBankJPSpider(scrapy.Spider):
+    name = "ja_bank_jp"
+    item_attributes = {
+        "brand": "JAバンク",
+        "brand_wikidata": "Q10854594",
+        "extras": {"brand:en": "JA Bank", "brand:ja": "JAバンク"},
+    }
+    # job_role_id "1" = counter + ATM, "5" = counter only. "3" (ATM only) is
+    # out of scope for this amenity=bank spider.
+    JOB_ROLES = {"1": "yes", "5": "no"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request("https://map.jabank.org/assets/data/list.json", callback=self.parse_prefectures)
+
+    def parse_prefectures(self, response: Response, **kwargs: Any) -> Any:
+        for pref in response.json()["data"]["prefecture"]:
+            # mode=0 with an empty bank code returns every branch/ATM in the
+            # prefecture in a single request, regardless of which of the many
+            # (often 50-100+) local JA co-operatives operates it.
+            yield scrapy.FormRequest(
+                url="https://map.jabank.org/api/search_cond",
+                formdata={"prefcode": pref["pref"], "mode": "0", "bank": ""},
+                callback=self.parse_shops,
+            )
+
+    def parse_shops(self, response: Response, **kwargs: Any) -> Any:
+        for shop in response.json()["data"]["shop_list"]:
+            atm = self.JOB_ROLES.get(shop["job_role_id"])
+            if atm is None:
+                continue
+
+            item = Feature()
+            item["ref"] = shop["code"]
+            item["name"] = shop["name"]
+            item["operator"] = shop["official_name"]
+            item["lat"] = shop["lat"]
+            item["lon"] = shop["lng"]
+            item["addr_full"] = shop["address"]
+            item["postcode"] = shop["zip_code"]
+            item["phone"] = shop["phone_number"]
+
+            apply_category(Categories.BANK, item)
+            item["extras"]["atm"] = atm
+
+            yield item


### PR DESCRIPTION
Adds a spider for JA Bank (JAバンク), Japan's agricultural cooperative banking network.

Data source: the store finder at https://map.jabank.org/ exposes `assets/data/list.json` for the 47 prefecture codes, then a POST to `api/search_cond` with `mode=0` and an empty `bank` parameter returns every branch/ATM in that prefecture in a single request (verified this matches the sum of iterating each individual local co-op's `bank` code, e.g. Kyoto: 128 records either way, Hokkaido: 344 records either way — no per-query cap). This needs only 47 requests total instead of iterating hundreds of per-prefecture bank codes.

Locations are filtered to `job_role_id` 1 (counter + ATM) and 5 (counter only), which are actual bank branches; standalone ATM-only records (`job_role_id` 3) are excluded as out of scope for this amenity=bank spider. `atm=yes`/`no` is set accordingly. Brand string `JAバンク` matches NSI exactly.

Verified locally: 6074 items, all with unique refs, valid coordinates, and per-branch phone numbers (no generic/duplicated contact info detected).

closes #8674