### PR TITLE
[Marvin's Building Materials] Add spider

### DIFF
--- a/locations/spiders/marvins_building_materials_us.py
+++ b/locations/spiders/marvins_building_materials_us.py
@@ -1,0 +1,55 @@
+import re
+
+import scrapy
+
+from locations.categories import Categories
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class MarvinsBuildingMaterialsUSSpider(scrapy.Spider):
+    name = "marvins_building_materials_us"
+    item_attributes = {
+        "brand": "Marvin's Building Materials",
+        "brand_wikidata": "Q109395525",
+        "extras": Categories.SHOP_DOITYOURSELF.value,
+    }
+    start_urls = ["https://www.marvinsbuildingmaterials.com/locations"]
+
+    def parse(self, response):
+        for h6 in response.css("h6.font_6"):
+            title = h6.xpath("string(.)").get("").strip()
+            if not re.fullmatch(r"[^,]+,\s*[A-Z]{2}", title):
+                continue
+
+            container = h6.xpath("ancestor::div[@data-mesh-id][1]")
+            paragraphs = [p.xpath("string(.)").get("").strip() for p in container.css("p.font_8")]
+            if len(paragraphs) < 1:
+                continue
+
+            addr_lines = [line.strip() for line in paragraphs[0].split("\n") if line.strip()]
+            if len(addr_lines) < 3:
+                continue
+            street_address, city_state_zip, phone = addr_lines[0], addr_lines[1], addr_lines[2]
+
+            m = re.match(r"^(?P<city>.+),\s*(?P<state>[A-Z]{2})\s*(?P<postcode>\d{5})$", city_state_zip)
+            if not m:
+                continue
+
+            item = Feature()
+            item["ref"] = title
+            item["street_address"] = street_address
+            item["city"] = m.group("city")
+            item["state"] = m.group("state")
+            item["postcode"] = m.group("postcode")
+            item["phone"] = phone
+            item["website"] = response.url
+
+            if len(paragraphs) > 1:
+                details = paragraphs[1]
+                hours_text = details.split("Hours:", 1)[-1] if "Hours:" in details else ""
+                hours_text = hours_text.replace("M-Sat", "Mon-Sat").replace("\n", " ")
+                item["opening_hours"] = OpeningHours()
+                item["opening_hours"].add_ranges_from_string(hours_text)
+
+            yield item

--- a/locations/spiders/marvins_building_materials_us.py
+++ b/locations/spiders/marvins_building_materials_us.py
@@ -2,7 +2,7 @@ import re
 
 import scrapy
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
@@ -12,7 +12,6 @@ class MarvinsBuildingMaterialsUSSpider(scrapy.Spider):
     item_attributes = {
         "brand": "Marvin's Building Materials",
         "brand_wikidata": "Q109395525",
-        "extras": Categories.SHOP_DOITYOURSELF.value,
     }
     start_urls = ["https://www.marvinsbuildingmaterials.com/locations"]
 
@@ -51,5 +50,7 @@ class MarvinsBuildingMaterialsUSSpider(scrapy.Spider):
                 hours_text = hours_text.replace("M-Sat", "Mon-Sat").replace("\n", " ")
                 item["opening_hours"] = OpeningHours()
                 item["opening_hours"].add_ranges_from_string(hours_text)
+
+            apply_category(Categories.SHOP_DOITYOURSELF, item)
 
             yield item


### PR DESCRIPTION
Adds a spider for Marvin's Building Materials, a building materials/hardware chain in AL, MS, TN, SC and GA (US).

The store finder at https://www.marvinsbuildingmaterials.com/locations is a Wix-hosted page that server-side renders each store's address, phone and hours directly into the HTML as plain rich text (no JSON-LD, no API). The spider parses each location block by anchoring on the `<h6>` city/state title and pulling the following address/phone paragraph and store-manager/hours paragraph. No coordinates are published anywhere on the page (only Google Maps directions links without lat/lon), so lat/lon is left blank.

Verified locally: 27 items, all with unique refs, correctly split addresses, branch-specific phone numbers, and parsed opening hours (`Mo-Sa 07:00-19:00; Su 10:00-18:00`, consistent across all stores per the source).

closes #8810