### PR TITLE
[Tobu Park] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -26,6 +26,7 @@ class Categories(Enum):
     KICK_SCOOTER_RENTAL = {"amenity": "kick-scooter_rental"}
     LEFT_LUGGAGE = {"amenity": "left_luggage"}
     LUGGAGE_LOCKER = {"amenity": "luggage_locker"}
+    MOTORCYCLE_PARKING = {"amenity": "motorcycle_parking"}
     MOTORCYCLE_RENTAL = {"amenity": "motorcycle_rental"}
     PARKING = {"amenity": "parking"}
     PARKING_SPACE = {"amenity": "parking_space"}

--- a/locations/spiders/tobu_park_jp.py
+++ b/locations/spiders/tobu_park_jp.py
@@ -1,0 +1,52 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+# A single facility page can list more than one type (e.g. a bicycle park
+# that also has a motorcycle section), so one item is yielded per type
+# found rather than picking a single amenity for the whole page.
+CATEGORY_MAP = {
+    "car-parking": Categories.PARKING,
+    "bicycle-parking": Categories.BICYCLE_PARKING,
+    "bike-parking": Categories.MOTORCYCLE_PARKING,
+    "bicycle-rental": Categories.BICYCLE_RENTAL,
+}
+
+
+class TobuParkJPSpider(SitemapSpider):
+    name = "tobu_park_jp"
+    item_attributes = {"brand": "TOBU PARK", "brand_wikidata": "Q131275047"}
+    sitemap_urls = ["https://www.tobu-re-parking.jp/parking-sitemap.xml"]
+
+    def parse(self, response):
+        name = response.css("h1.title-h1__jp::text").get()
+        center = response.css("gmp-map::attr(center)").get()
+        if not name or not center:
+            return
+        lat, _, lon = center.partition(",")
+
+        address = " ".join(
+            t.strip() for t in response.xpath('//tr[th[normalize-space()="所在地"]]/td//text()').getall() if t.strip()
+        )
+
+        post_id = response.url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".html")
+
+        for li in response.css("ul.tag-type li"):
+            slug = li.attrib.get("class", "").removeprefix("tag-type__")
+            category = CATEGORY_MAP.get(slug)
+            if not category:
+                continue
+
+            item = Feature()
+            item["ref"] = f"{post_id}_{slug}"
+            item["name"] = name.strip()
+            item["lat"] = lat
+            item["lon"] = lon
+            item["addr_full"] = address
+            item["country"] = "JP"
+            item["website"] = response.url
+
+            apply_category(category, item)
+
+            yield item


### PR DESCRIPTION
Adds a spider for Tobu Park (TOBU PARK), a Japanese parking/bicycle-parking operator run by Tobu Real Estate (東武不動産).

The store finder (https://www.tobu-re-parking.jp/search.php) is a WordPress site with an XML sitemap listing 811 facility detail pages under a `parking` custom post type. Each detail page has no schema.org structured data, but exposes a `<gmp-map center="lat,lng">` element for coordinates and an HTML table with address, nearest station, capacity, and fee info. Facility pages list one or more facility types via `<li class="tag-type__...">` tags: `car-parking`, `bicycle-parking`, `bike-parking` (motorcycle), and `bicycle-rental`, matching the four amenity types in the issue. Since a single facility page can offer more than one type at the same site (e.g. bicycle + motorcycle parking), the spider yields one item per type found, all sharing the same coordinates/address but distinguished by ref and category — `amenity=parking`, `amenity=bicycle_parking`, `amenity=motorcycle_parking`, `amenity=bicycle_rental` respectively.

`Categories.MOTORCYCLE_PARKING` didn't exist yet, so it's added alongside the existing `MOTORCYCLE_RENTAL`/`PARKING` entries (checked for an existing duplicate under a different name first — none found).

The issue's supplied Wikidata QID (Q11527477, "Tobu Group") is the wrong entity — it's the parent conglomerate, not the parking operator. Verified via Wikidata search and the site's own footer link (which points to tobu-re.co.jp) that the operating company is "Tobu Real Estate" (Q131275047, 東武不動産), which I used for `brand_wikidata` instead. There's no separate Wikidata item for the "TOBU PARK" brand itself.

Verified locally: 858 items from 813 requests (all 200 OK, no errors) — 541 `parking`, 216 `bicycle_parking`, 99 `motorcycle_parking`, 2 `bicycle_rental`. Spot-checked multi-type pages (46 of them) confirm identical coordinates with distinct refs/categories per type, and all items have non-empty name/address with coordinates inside Japan's bounding box.

closes #9040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for discovering TOBU PARK facilities in Japan.
  - Added motorcycle parking as a recognized facility category.
  - Facility listings include names, locations, addresses, websites, brands, and supported categories.
  - Pages with incomplete information or unsupported facility types are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->