### PR TITLE
[Mister Donut JP] Add spider

### DIFF
--- a/locations/spiders/mister_donut_jp.py
+++ b/locations/spiders/mister_donut_jp.py
@@ -1,0 +1,74 @@
+import json
+import re
+from typing import Iterable
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+# The store list is served from a single wide "tile" (x=63&y=18) which
+# encompasses the whole of Japan, rather than needing to be paginated
+# through many individual map tiles like some other Mapion based sites.
+LIST_URL = "https://md.mapion.co.jp/b/misterdonut/attr/?t=attr_con&x=63&y=18&start={}"
+
+
+class MisterDonutJPSpider(Spider):
+    name = "mister_donut_jp"
+    item_attributes = {"brand": "ミスタードーナツ", "brand_wikidata": "Q1065819"}
+    allowed_domains = ["md.mapion.co.jp"]
+    start_urls = [LIST_URL.format(1)]
+
+    def parse(self, response: Response) -> Iterable[Request]:
+        if m := re.search(r'pager-num">\d+/(\d+)', response.text):
+            if response.url == self.start_urls[0]:
+                for page in range(2, int(m.group(1)) + 1):
+                    yield Request(LIST_URL.format(page), callback=self.parse)
+
+        for href in response.xpath('//li[@class="list-item"]//a[h2]/@href').getall():
+            yield response.follow(href, callback=self.parse_store)
+
+    def parse_store(self, response: Response) -> Iterable[Feature]:
+        m = re.search(r"window\.infoJSON\s*=\s*(\{.*?\});", response.text)
+        if not m:
+            return
+        data = json.loads(m.group(1))
+
+        item = Feature()
+        item["ref"] = data.get("id")
+        item["name"] = self.item_attributes["brand"]
+        item["branch"] = data.get("map_name")
+        item["addr_full"] = data.get("full_address")
+        item["postcode"] = data.get("zip_code")
+        item["website"] = response.url
+
+        if tel := data.get("tel"):
+            item["phone"] = "+81 " + tel
+
+        # The site's own JS data (and the store list page) expose store
+        # coordinates in the old Tokyo Datum, ~300-400m away from their
+        # true location. The corrected WGS84 coordinates are only found
+        # in this page's schema.org GeoCoordinates microdata.
+        item["lat"] = response.xpath(
+            '//div[@itemtype="https://schema.org/GeoCoordinates"]/meta[@itemprop="latitude"]/@content'
+        ).get()
+        item["lon"] = response.xpath(
+            '//div[@itemtype="https://schema.org/GeoCoordinates"]/meta[@itemprop="longitude"]/@content'
+        ).get()
+
+        if (open_time := data.get("open_time")) and (close_time := data.get("close_time")):
+            # close_time occasionally has a trailing free-text exception note
+            # (e.g. "23:00<br>Fri/Sat open until 0:30") tacked on; keep just
+            # the base daily hours which the site displays as the headline
+            # opening hours for the store.
+            if close_match := re.match(r"\d{1,2}:\d{2}", close_time):
+                oh = OpeningHours()
+                oh.add_days_range(DAYS, open_time, close_match.group())
+                item["opening_hours"] = oh.as_opening_hours()
+
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "donut"
+
+        yield item


### PR DESCRIPTION
Adds a spider for Mister Donut (ミスタードーナツ) in Japan, sourced from their Mapion-based store finder at md.mapion.co.jp. Store lists are paginated (~54 pages, 20 stores per page) from a single wide map tile that already covers all of Japan. Each detail page's schema.org microdata provides accurate WGS84 coordinates — the site's own JS data (`window.infoJSON`) and the list page's `data-lat`/`data-lng` attributes are in the old Tokyo Datum, roughly 300-400m off, so those are deliberately not used for coordinates.

Verified locally with 1077 items scraped, all with unique refs, complete addresses/postcodes/phone numbers, opening hours parsed for all but one location, and coordinates spanning the expected Japan bounding box. Brand string matches NSI exactly (`misterdonut-3e7699`, 1077/1077 perfect matches).

closes #8967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Mister Donut Japan location coverage.
  - Store listings now include names, addresses, contact details, opening hours, and accurate geographic coordinates.
  - Locations are categorized as donut fast-food features.
  - Supports paginated store listings for broader coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->