### PR TITLE
[Ozone.bg] Add spider

### DIFF
--- a/locations/spiders/ozone_bg.py
+++ b/locations/spiders/ozone_bg.py
@@ -8,6 +8,11 @@ from locations.structured_data_spider import StructuredDataSpider
 class OzoneBGSpider(CrawlSpider, StructuredDataSpider):
     name = "ozone_bg"
     item_attributes = {"brand": "Ozone.bg", "brand_wikidata": "Q120717332"}
+    # CI's datacenter IP gets a Cloudflare 403 even though the site has no
+    # challenge/fingerprint check locally (plain curl/Scrapy both work
+    # unproxied) — an IP-reputation block, which requires_proxy fixes since
+    # this is a plain (non-browser) spider.
+    requires_proxy = "BG"
     start_urls = ["https://www.ozone.bg/our-shops/"]
     rules = [
         Rule(

--- a/locations/spiders/ozone_bg.py
+++ b/locations/spiders/ozone_bg.py
@@ -1,0 +1,28 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class OzoneBGSpider(CrawlSpider, StructuredDataSpider):
+    name = "ozone_bg"
+    item_attributes = {"brand": "Ozone.bg", "brand_wikidata": "Q120717332"}
+    start_urls = ["https://www.ozone.bg/our-shops/"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"^https://www\.ozone\.bg/shop-[a-z0-9-]+/$"),
+            callback="parse_sd",
+        ),
+    ]
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        # "magazin-ozone-pro" (excluded via the shop- URL pattern above) carries stale
+        # structured data for an unrelated business ("ФотоПавилион"), not Ozone itself.
+        item["branch"] = item.pop("name", "").removeprefix("Магазин Ozone ").strip()
+        item["name"] = self.item_attributes["brand"]
+
+        apply_category(Categories.SHOP_GAMES, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Ozone.bg, a Bulgarian electronics/gaming retailer with physical shops in malls (Q120717332).

Each shop page (`/shop-*/`, linked from https://www.ozone.bg/our-shops/) embeds a `LocalBusiness` JSON-LD block with address, phone, opening hours and Google Maps-derived coordinates, so this uses a `CrawlSpider` + `StructuredDataSpider` combo. Verified locally: 10 items, all in BG, all with distinct phone numbers, coordinates within Bulgaria, and a perfect NSI brand-string match (`shop=games`, brand `Ozone.bg`).

Excluded `/magazin-ozone-pro/` from the crawl: although it's linked from the shop list, its JSON-LD block contains stale data for an unrelated business ("ФотоПавилион") at a different address/phone/email — not usable.

closes #9034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and collecting Ozone.bg shop locations.
  * Shop details are extracted from structured business data, with standardized branch names and brand categorization.
  * Excludes unrelated shop pages from location results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->