### PR TITLE
[UW Credit Union] Add spider

### DIFF
--- a/locations/spiders/uw_credit_union_us.py
+++ b/locations/spiders/uw_credit_union_us.py
@@ -1,0 +1,58 @@
+import re
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.google_url import extract_google_position
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class UwCreditUnionUSSpider(SitemapSpider):
+    name = "uw_credit_union_us"
+    item_attributes = {
+        "brand": "UW Credit Union",
+        "brand_wikidata": "Q7876156",
+        "extras": Categories.BANK.value,
+    }
+    sitemap_urls = ["https://www.uwcu.org/sitemap.xml"]
+    sitemap_rules = [(r"/branches-and-atms/(?!find-an-atm$)[^/]+$", "parse")]
+
+    def parse(self, response: Response):
+        address_p = response.xpath('//h2[text()="Address"]/following-sibling::p[1]')
+        lines = [line.strip() for line in address_p.xpath(".//text()").getall() if line.strip()]
+        if not lines:
+            return
+
+        item = Feature()
+        item["ref"] = item["website"] = response.url
+        item["branch"] = re.sub(r"\s*Branch\s*$", "", response.xpath("//h1/text()").get("").strip())
+        if len(lines) > 1 and (m := re.match(r"(.+),\s*([A-Z]{2})\s*(\d{5}(?:-\d{4})?)$", lines[-1])):
+            item["street_address"] = merge_address_lines(lines[:-1])
+            item["city"], item["state"], item["postcode"] = m.group(1), m.group(2), m.group(3)
+            item["country"] = "US"
+        else:
+            item["street_address"] = merge_address_lines(lines)
+
+        extract_google_position(item, response)
+
+        if hours_text := self.extract_hours_block(response, "Lobby Hours"):
+            oh = OpeningHours()
+            oh.add_ranges_from_string(hours_text)
+            item["opening_hours"] = oh
+
+        if drive_up_text := self.extract_hours_block(response, "Drive Up Hours"):
+            oh = OpeningHours()
+            oh.add_ranges_from_string(drive_up_text)
+            if oh.as_opening_hours():
+                item["extras"]["opening_hours:drive_through"] = oh.as_opening_hours()
+
+        yield item
+
+    @staticmethod
+    def extract_hours_block(response: Response, heading: str) -> str:
+        p = response.xpath(f'//h3[text()="{heading}"]/following-sibling::p[1]')
+        lines = [line.strip() for line in p.xpath(".//text()").getall() if line.strip()]
+        return "\n".join(lines)

--- a/locations/spiders/uw_credit_union_us.py
+++ b/locations/spiders/uw_credit_union_us.py
@@ -3,7 +3,7 @@ import re
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.google_url import extract_google_position
 from locations.hours import OpeningHours
 from locations.items import Feature
@@ -15,7 +15,6 @@ class UwCreditUnionUSSpider(SitemapSpider):
     item_attributes = {
         "brand": "UW Credit Union",
         "brand_wikidata": "Q7876156",
-        "extras": Categories.BANK.value,
     }
     sitemap_urls = ["https://www.uwcu.org/sitemap.xml"]
     sitemap_rules = [(r"/branches-and-atms/(?!find-an-atm$)[^/]+$", "parse")]
@@ -48,6 +47,8 @@ class UwCreditUnionUSSpider(SitemapSpider):
             oh.add_ranges_from_string(drive_up_text)
             if oh.as_opening_hours():
                 item["extras"]["opening_hours:drive_through"] = oh.as_opening_hours()
+
+        apply_category(Categories.BANK, item)
 
         yield item
 


### PR DESCRIPTION
Adds a spider for UW Credit Union (Q7876156), a Madison/Milwaukee, Wisconsin-based credit union. The store finder at uwcu.org/branches-and-atms links to individual branch pages listed in the sitemap, each with a plain-HTML address/hours block and a Google Maps embed iframe encoding lat/lon in the `!2d...!3d...` format, parsed via `extract_google_position`. No JSON-LD or API endpoint was available, so this scrapes the raw HTML.

Verified locally: 35 items, all with unique coordinates within Wisconsin, correctly split address components (including one multi-line address with a suite line), and parsed lobby/drive-through opening hours. Brand string matches NSI exactly and `test_item_attributes_brand_strings_match_nsi` passes.