### PR TITLE
[Landmark Credit Union] Add spider

### DIFF
--- a/locations/spiders/landmark_credit_union_us.py
+++ b/locations/spiders/landmark_credit_union_us.py
@@ -1,0 +1,39 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class LandmarkCreditUnionUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "landmark_credit_union_us"
+    item_attributes = {"brand": "Landmark Credit Union", "brand_wikidata": "Q16999087"}
+    sitemap_urls = ["https://www.landmarkcu.com/robots.txt"]
+    sitemap_rules = [(r"/atm-branch-locations/.+", "parse_sd")]
+    wanted_types = ["BankOrCreditUnion"]
+    drop_attributes = {"image", "phone"}  # image is an unresolved template placeholder; phone is a shared hotline
+
+    def pre_process_data(self, ld_data: dict, **kwargs):
+        # Saturday hours are only present nested under "department", not in the
+        # top-level openingHoursSpecification, so merge them in before parsing.
+        specs = ld_data.get("openingHoursSpecification") or []
+        if not isinstance(specs, list):
+            specs = [specs]
+        for department in ld_data.get("department", []):
+            if dept_spec := department.get("openingHoursSpecification"):
+                specs.append(dept_spec)
+        ld_data["openingHoursSpecification"] = specs
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
+        item["branch"] = item.pop("name").removeprefix("Landmark Credit Union - ").removesuffix(" Branch")
+        item["name"] = self.item_attributes["brand"]
+
+        if item.get("lon") is not None and item["lon"] > 0:
+            # Wauwatosa branch publishes longitude == latitude on the source page; drop rather than ship garbage
+            item["lat"] = None
+            item["lon"] = None
+
+        apply_category(Categories.BANK, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Landmark Credit Union (New Berlin, WI), a Wisconsin-based credit union. No feature-request issue existed for this brand; built from a bare brand name + store finder.

Data source: `schema.org/BankOrCreditUnion` JSON-LD on each branch page under landmarkcu.com, enumerated via the site's sitemap. `SitemapSpider` + `StructuredDataSpider`.

Fixes applied:
- Saturday hours are only present nested under a `department` object rather than the top-level `openingHoursSpecification`; merged them in via `pre_process_data` so hours come through complete (e.g. `Mo-Fr 09:00-17:00; Sa 09:00-13:00`).
- `image` is an unresolved template placeholder (`{{bankorcreditunion.image}}`) on every branch, and `phone` is an identical national hotline number (`12627964500`) on every branch — both dropped via `drop_attributes`.
- The Wauwatosa branch's own page publishes `longitude == latitude` (an impossible coordinate pair); coordinates are blanked for that one record rather than shipping garbage.

Verified locally: 34 items, all matching NSI (`brand:wikidata` Q16999087, `brand` "Landmark Credit Union"), all categorized as `amenity=bank`, addresses/opening hours/coordinates spot-checked across multiple branches.