### PR TITLE
[Cost Cutters] Add spider

### DIFF
--- a/locations/spiders/cost_cutters.py
+++ b/locations/spiders/cost_cutters.py
@@ -1,0 +1,53 @@
+from typing import AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Request
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class CostCuttersSpider(Spider):
+    name = "cost_cutters"
+    item_attributes = {"brand": "Cost Cutters", "brand_wikidata": "Q62029366"}
+    allowed_domains = ["api.regiscorp.com"]
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(
+            "https://api.regiscorp.com/sis/api/salon/get-states-by-brand?brand=coc",
+            callback=self.parse_index,
+        )
+
+    def parse_index(self, response):
+        for country in response.json().values():
+            for state in country:
+                st = state["state_abbreviation"].lower()
+                yield JsonRequest(
+                    "https://api.regiscorp.com/sis/api/salon/search-by-location?brand=coc&state={}".format(st),
+                    callback=self.parse_state,
+                )
+
+    def parse_state(self, response):
+        for salon in response.json():
+            yield Request(
+                url="https://api.regiscorp.com/sis/api/salon?salon-number={}".format(int(salon["salonId"])),
+                callback=self.parse_salon,
+            )
+
+    def parse_salon(self, response):
+        data = response.json()
+        item = DictParser.parse(data)
+        item["ref"] = data["salon_number"]
+        item["branch"] = (
+            item.pop("name").replace(str(data["salon_number"]) + "-", "").replace(str(data["salon_number"]) + " - ", "")
+        )
+        if address2 := data["address2"]:
+            item["street_address"] = merge_address_lines([item["street_address"], address2])
+        item["website"] = data["booking_url"]
+        item["opening_hours"] = OpeningHours()
+        for day, time in data["store_hours"].items():
+            open_time = time["open"]
+            close_time = time["close"]
+            item["opening_hours"].add_range(day=day, open_time=open_time, close_time=close_time, time_format="%I:%M %p")
+        yield item


### PR DESCRIPTION
Adds a spider for Cost Cutters, a Regis Corporation hair-salon banner. Regis operates several salon banners (Supercuts, SmartStyle, First Choice, Cost Cutters, etc.) on a shared platform at api.regiscorp.com; this follows the same two-stage pattern already used by the existing `supercuts.py` spider (get-states-by-brand -> search-by-location per state -> per-salon detail fetch for coordinates/hours), just with the Cost Cutters brand code (`coc`).

Verified locally: 366 items across 32 US states (78 in Wisconsin), all with unique phone numbers, coordinates, and parsed opening hours. `name` and `shop=hairdresser` are populated automatically via NSI match on brand_wikidata (Q62029366, verified against Wikidata directly), matching the existing NSI entry `costcutters-28f1a5` whose `brand` tag is exactly "Cost Cutters".