### PR TITLE
[Common Cents Stores] Add spider

### DIFF
--- a/locations/spiders/common_cents_stores_us.py
+++ b/locations/spiders/common_cents_stores_us.py
@@ -46,6 +46,7 @@ class CommonCentsStoresUSSpider(Spider):
 
             item = Feature()
             item["ref"] = str(store["store_number"])
+            item["name"] = self.item_attributes["brand"]
             item["branch"] = store["hs_name"]
             item["lat"] = store.get("latitude")
             item["lon"] = store.get("longitude")

--- a/locations/spiders/common_cents_stores_us.py
+++ b/locations/spiders/common_cents_stores_us.py
@@ -1,0 +1,66 @@
+import json
+import re
+from typing import Iterable
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+# The HubDB table backing this map mixes in rows that are not "Common Cents"
+# convenience stores: a corporate office (no store_number), liquor stores
+# licensed separately from the adjoining fuel store, and stand-alone
+# restaurant concepts (Danielle Rivers) and duplicate/mis-geocoded car wash
+# and Kwik Lube listings (Kraig Crawford) that repeat the address of a store
+# already listed under a real store manager. Every row kept here carries
+# both "convenience" and "gas" in its own includesfilters, confirming it's
+# a genuine Common Cents c-store/fuel site.
+EXCLUDED_MANAGERS = {None, "Danielle Rivers", "Kraig Crawford"}
+
+# Several addresses run the street straight into the city with no space
+# (e.g. "Jackson BlvdRapid City, SD 57702"), so a full street/city split
+# isn't reliable across the dataset; only the trailing "ST ZIPCODE" is
+# consistently well-formed, so that's all that gets pulled out structured.
+STATE_ZIP_RE = re.compile(r"(?P<state>[A-Z]{2})\s+(?P<zip>\d{5})$")
+
+
+class CommonCentsStoresUSSpider(Spider):
+    name = "common_cents_stores_us"
+    item_attributes = {"brand": "Common Cents"}
+    start_urls = ["https://commoncentsstores.com/locations"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def parse(self, response: Response) -> Iterable[Feature]:
+        # Store data is pre-rendered server-side into a JS array literal
+        # (window.storeMapConfig.storeData) rather than served from an API.
+        for values_json in re.findall(r"^\s*values: (\{.*\})\s*$", response.text, re.M):
+            store = json.loads(values_json)
+
+            if not store.get("store_number"):
+                continue  # e.g. the corporate office, not a public store
+            if store.get("manager") in EXCLUDED_MANAGERS:
+                continue
+            if "Liquor Store" in (store.get("hs_name") or ""):
+                continue
+
+            item = Feature()
+            item["ref"] = str(store["store_number"])
+            item["branch"] = store["hs_name"]
+            item["lat"] = store.get("latitude")
+            item["lon"] = store.get("longitude")
+            item["phone"] = (store.get("phone") or "").strip() or None
+
+            address = store.get("address") or ""
+            item["addr_full"] = address
+            if m := STATE_ZIP_RE.search(address):
+                item["state"] = m.group("state")
+                item["postcode"] = m.group("zip")
+
+            # The "email" field is the regional manager's personal mailbox,
+            # shared across every store they manage, not a branch contact.
+
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+            apply_category(Categories.FUEL_STATION, item)
+
+            yield item


### PR DESCRIPTION
Common Cents is a convenience store/fuel chain anchored in South Dakota (Rapid City, Custer, Lead, Belle Fourche, Wall, etc.) with locations also in NE, WY, and UT. There was no GitHub issue for this one; built from the brand's store finder at https://commoncentsstores.com/locations.

The locator page is a HubSpot CMS page that pre-renders the full HubDB table server-side into a `window.storeMapConfig.storeData` JS array literal (the HubDB REST API itself returns 403, "table not publicly available"), so the spider fetches the page and regex-extracts each `values: {...}` row from the HTML.

The table mixes in rows that aren't Common Cents c-stores: a corporate office (no store_number), liquor stores licensed separately from the adjoining fuel store, stand-alone restaurant concepts, and duplicate/mis-geocoded car wash & Kwik Lube listings that repeat another store's address under a different regional manager. These are filtered out; every row kept has both "convenience" and "gas" in its own `includesfilters`, confirming it's a genuine c-store/fuel site. The source's "email" field is the regional manager's personal mailbox shared across every store they manage, not a branch contact, so it's left off. Street/city text is inconsistently formatted (missing separators between street and city on some rows), so only the reliably well-formed trailing state+zip is parsed out structured, with the full original address kept in `addr_full`.

No Wikidata entity exists for this specific chain (only unrelated "Common Cents" non-profit and paper entities), so `brand_wikidata` is omitted.

Verified locally: 28 items, coordinates fall correctly across SD/NE/WY/UT.