### PR TITLE
[Simonson Station Stores] Add spider

### DIFF
--- a/locations/spiders/simonson_station_stores_us.py
+++ b/locations/spiders/simonson_station_stores_us.py
@@ -1,0 +1,57 @@
+import re
+
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class SimonsonStationStoresUSSpider(scrapy.Spider):
+    name = "simonson_station_stores_us"
+    item_attributes = {"brand": "Simonson Station Stores"}
+    start_urls = ["https://gosimonson.com/home/locations/"]
+
+    def parse(self, response, **kwargs):
+        # Each store is rendered as an Elementor column containing an address,
+        # a phone number and a "Location Info" button linking to the store's
+        # own page. There is no structured data (JSON-LD) or geocoded map
+        # embed anywhere on this WordPress/Elementor site, so no coordinates
+        # are available for this spider.
+        buttons = response.xpath(
+            '//a[contains(@class, "elementor-button-link")][.//span[normalize-space(text())="Location Info"]]'
+        )
+        for button in buttons:
+            href = button.xpath("@href").get()
+            column = button.xpath('ancestor::div[contains(@class, "elementor-column")][1]')
+
+            address_lines = [line.strip() for line in column.xpath(".//p//text()").getall() if line.strip()]
+            if len(address_lines) < 2:
+                continue
+
+            street_address, city_state_zip = address_lines[0], address_lines[1]
+
+            phone_texts = column.xpath(
+                './/i[contains(@class, "fa-phone")]/ancestor::div[contains(@class, "elementor-icon-box-wrapper")]//h3//text()'
+            ).getall()
+            phone = next((t.strip() for t in phone_texts if t.strip()), None)
+
+            item = Feature()
+            item["name"] = self.item_attributes["brand"]
+            item["ref"] = response.urljoin(href)
+            item["website"] = response.urljoin(href)
+            item["street_address"] = street_address
+            if phone:
+                item["phone"] = phone
+
+            if m := re.match(r"^(.*),\s*([A-Z]{2})\s+(\d{5}(?:-\d{4})?)$", city_state_zip):
+                city = m.group(1)
+                if city == "Wiliston":  # typo on the source site's Williston listing
+                    city = "Williston"
+                item["city"], item["state"], item["postcode"] = city, m.group(2), m.group(3)
+                item["branch"] = item["city"]
+            else:
+                item["addr_full"] = f"{street_address}, {city_state_zip}"
+
+            apply_category(Categories.FUEL_STATION, item)
+
+            yield item


### PR DESCRIPTION
Adds a spider for Simonson Station Stores, a family-owned gas station/convenience store chain across North Dakota and Minnesota since 1933 (gosimonson.com).

The site is a WordPress/Elementor build with no JSON-LD or geocoded map data anywhere. The master locations page (https://gosimonson.com/home/locations/) lists every individual store as its own card (name, street address, city/state/zip, phone, and a link to the store's own page), so the spider parses that single page rather than the 11 messier per-city detail pages. Verified locally: 18 items, all with distinct addresses and phone numbers, city/state/postcode parsed correctly (including fixing an obvious "Wiliston" -> "Williston" typo present on the source page itself).

No brand_wikidata set — there is no Wikidata entity for this brand (checked, no match). No coordinates are available anywhere on the site (map embeds use a text address query, not lat/lon, and the sporadic Google Maps "directions" links are inconsistent/unreliable across pages), so lat/lon is left blank per repo convention rather than geocoding.