### PR TITLE
[GreenWay PL/SK] Use a coarser search grid to cut redundant requests

### DIFF
--- a/locations/spiders/greenway_pl_sk.py
+++ b/locations/spiders/greenway_pl_sk.py
@@ -13,7 +13,15 @@ class GreenwayPLSKSpider(Spider):
     item_attributes = {"brand": "GreenWay", "brand_wikidata": "Q116450281"}
 
     async def start(self) -> AsyncIterator[JsonRequest]:
-        for lat, lon in country_iseadgg_centroids(["PL", "SK"], 48):
+        # The API ignores spanLat/spanLng and instead always returns the
+        # (up to 500) locations nearest to the requested point, regardless
+        # of how tight or wide a span is requested. With only ~1,200
+        # stations across PL+SK, a fine-grained search grid causes almost
+        # total overlap between requests (~97% duplicate drop rate at
+        # radius=48). A much coarser grid still finds every station, since
+        # each request's nearest-500 cutoff comfortably covers a wide area
+        # of this sparse network.
+        for lat, lon in country_iseadgg_centroids(["PL", "SK"], 315):
             yield JsonRequest(
                 url=f"https://api.greenwaypolska.pl/api/location/map?max_power[from]=1&connector_type[ccs_plug]=1&connector_type[chademo_plug]=1&connector_type[type2_plug]=1&connector_type[type2_socket]=1&latitude={lat}&longitude={lon}&spanLat=1&spanLng=1",
             )


### PR DESCRIPTION
- The `location/map` API ignores `spanLat`/`spanLng` entirely and always returns the up-to-500 locations nearest to the requested point, regardless of the requested span (verified: identical result sets for `span=0.05` through `span=5` at the same coordinates).
- With only ~1,200 GreenWay stations across PL+SK, the previous radius=48 grid (87 query points) produced almost total overlap between requests — ~97% of fetched items were dropped as duplicates.
- Switching to radius=315 (6 query points) still finds every station (1213 unique items locally, matching the ~1210 from production) while cutting requests from 87 to 6 and reducing the duplicate-drop rate from ~97% to ~60%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location search coverage across Poland and Slovakia by expanding the search grid spacing.
  * Request formatting and result parsing remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->