### PR TITLE
[Ionna US] Fix spider

### DIFF
--- a/locations/spiders/ionna_us.py
+++ b/locations/spiders/ionna_us.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import scrapy
 
@@ -39,8 +40,9 @@ class IonnaUSSpider(scrapy.Spider):
         json_data = json.loads(locations)
 
         for location_id, location in json_data.items():
-            # Skip locations that are coming soon. They indicate this with "Coming Soon" in the note field.
-            if "Coming Soon" in location["note"]:
+            # Skip locations that are not yet open. They indicate this with "Coming Soon" or
+            # "Opening Soon" in the note field.
+            if "Coming Soon" in location["note"] or "Opening Soon" in location["note"]:
                 continue
 
             item = Feature(
@@ -68,12 +70,17 @@ class IonnaUSSpider(scrapy.Spider):
             # "<div class="find_map_info_specs"><strong>Connectors</strong>4 NACS | 6 CCS</div>"
             specs = extract_text_between(location["specs"], "<strong>Connectors</strong>", "</div>")
             if specs:
-                nacs_text, ccs_text = specs.split(" | ")
-                nacs_count = nacs_text.rstrip(" NACS")
-                ccs_count = ccs_text.rstrip(" CCS")
+                nacs_count = 0
+                ccs_count = 0
+                for part in specs.split(" | "):
+                    part = part.strip()
+                    if m := re.match(r"(\d+)\s*NACS", part):
+                        nacs_count = int(m.group(1))
+                    elif m := re.match(r"(\d+)\s*CCS", part):
+                        ccs_count = int(m.group(1))
 
-                item["extras"]["socket:type1_combo"] = ccs_count
-                item["extras"]["socket:nacs"] = nacs_count
-                item["extras"]["capacity"] = str(int(ccs_count) + int(nacs_count))
+                item["extras"]["socket:type1_combo"] = str(ccs_count)
+                item["extras"]["socket:nacs"] = str(nacs_count)
+                item["extras"]["capacity"] = str(ccs_count + nacs_count)
             apply_category(Categories.CHARGING_STATION, item)
             yield item


### PR DESCRIPTION
- Ionna's store locator changed the pre-launch status text from \"Coming Soon\" to \"Opening Soon\". The spider's filter only matched the old text, so all 79 not-yet-open locations started flowing through.
- One of those locations has only \"4 NACS\" in its connectors spec (no CCS), which crashed \`specs.split(\" | \")\` with an unhandled \`ValueError\`. Since \`parse\` is a generator, that exception silently truncated the crawl (128 of 236 locations yielded, no error surfaced beyond one log line).
- Updated the skip filter to also match \"Opening Soon\", and rewrote the connector-count parsing with regex so it can't crash on a single-connector-type or reordered spec string.
- Verified locally: 236 total locations in the JSON blob, 79 filtered as not-yet-open, 157 yielded cleanly with no exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Locations marked “Opening Soon” are no longer listed as available.
  * Connector counts are now parsed more reliably across different specifications, including entries with missing connector types.
  * Capacity and connector details are reported consistently for NACS and CCS connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->