### PR TITLE
[Barrique] Fix blank name field

### DIFF
--- a/locations/spiders/barrique_de_nl.py
+++ b/locations/spiders/barrique_de_nl.py
@@ -29,6 +29,7 @@ class BarriqueDENLSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("Barrique ").strip()
+        item["name"] = self.item_attributes["brand"]
         item["website"] = response.url
         item["country"] = "NL" if "Nederland" in item["addr_full"] else "DE"
         apply_category(Categories.SHOP_WINE, item)


### PR DESCRIPTION
- \`item[\"branch\"] = item.pop(\"name\")\` in #18054 popped \`name\` off the item but never reassigned it, so every item shipped with a blank \`name\`. Now sets \`item[\"name\"] = self.item_attributes[\"brand\"]\` explicitly rather than relying on NSI backfill.
- Left \`Categories.SHOP_WINE\` as-is rather than switching to NSI's \`shop=alcohol\` tagging for Q114133164. Relying on NSI backfill wouldn't have masked the blank-name bug here anyway, since NSI's own tag for this brand doesn't match what the spider applies — so the category mismatch is a separate, deliberate divergence: barrique.de frames itself specifically as a wine retailer/importer, not a general off-license/alcohol shop, which \`shop=wine\` better reflects.

Verified locally: 24 items scraped, \`name\` now populated with \`Barrique\` on every item, \`branch\` holds the location suffix (e.g. \`Aichtal\`, \`Den Bosch\`), and \`shop/wine\` category still applied.