### PR TITLE
[Marvins Building Materials US] Fix blank item name

### DIFF
--- a/locations/spiders/marvins_building_materials_us.py
+++ b/locations/spiders/marvins_building_materials_us.py
@@ -53,4 +53,6 @@ class MarvinsBuildingMaterialsUSSpider(scrapy.Spider):
 
             apply_category(Categories.SHOP_DOITYOURSELF, item)
 
+            item["name"] = self.item_attributes["brand"]
+
             yield item


### PR DESCRIPTION
- Every item yielded by this spider shipped with a blank `name`, since `parse()` never set `item["name"]`.
- The brand (Q109395525) has no NSI entry, so there's no downstream fallback to backfill the name. Now sets `item["name"]` from the spider's `brand` attribute.