### PR TITLE
[Hyundai UY] Fix blank item name for parts-only branches

### DIFF
--- a/locations/spiders/hyundai_uy.py
+++ b/locations/spiders/hyundai_uy.py
@@ -43,6 +43,7 @@ class HyundaiUYSpider(JSONBlobSpider):
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name", None)
+        item["name"] = self.item_attributes["brand"]
 
         if item.get("email") in (None, "", BLANK_PLACEHOLDER, "<br>"):
             item["email"] = None


### PR DESCRIPTION
- \`item["branch"] = item.pop("name", None)\` never reassigns \`item["name"]\` afterward.
- NSI happens to backfill the missing name for \`shop=car\` and \`shop=car_repair\` from its global Hyundai entries, but not for \`shop=car_parts\`, so parts-only dealer branches shipped with a blank name. Now sets \`item["name"]\` explicitly from the brand so it's correct for all three category branches regardless of NSI coverage.