### PR TITLE
[Nextra AU] Fix blank name in unmatched-brand fallback

### DIFF
--- a/locations/spiders/nextra_au.py
+++ b/locations/spiders/nextra_au.py
@@ -41,6 +41,7 @@ class NextraAUSpider(WPStoreLocatorSpider):
                 break
         else:
             self.logger.warning("Could not determine brand for store name '%s'", branch_name)
+            item["name"] = branch_name
             item["branch"] = branch_name
 
         item.pop("addr_full", None)


### PR DESCRIPTION
- The brand-prefix matcher in `post_process_item` only set `item["name"]` in the matched branch of the `for...else`.
- The `for...else` fallback (unmatched store name — not currently triggered by real data, but a latent bug) left `item["name"]` blank; it now backfills it from the raw unprefixed store name.