### PR TITLE
[Electro Depot FR] Apply category via apply_category

### DIFF
--- a/locations/spiders/electro_depot_fr.py
+++ b/locations/spiders/electro_depot_fr.py
@@ -1,6 +1,6 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -9,9 +9,12 @@ class ElectroDepotFRSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {
         "brand": "Électro Dépôt",
         "brand_wikidata": "Q2388060",
-        "extras": Categories.SHOP_ELECTRONICS.value,
     }
     sitemap_urls = ["https://magasins.electrodepot.fr/sitemap_pois.xml"]
     sitemap_rules = [(r"https://magasins\.electrodepot\.fr/fr/france-FR/[^/]+/[^/]+/[^/]+$", "parse_sd")]
     wanted_types = ["LocalBusiness", "ElectronicsStore"]
     drop_attributes = {"image", "twitter"}
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_ELECTRONICS, item)
+        yield item


### PR DESCRIPTION
- The spider set the shop category via a class-level `item_attributes["extras"]` entry instead of the standard `apply_category()` call; this worked because the pipeline merges it in, but it's inconsistent with repo convention.
- Refactored to call `apply_category(Categories.SHOP_ELECTRONICS, item)` in `post_process_item` instead; no output data change intended.