### PR TITLE
[Free FR] Null shared national hotline phone number

### DIFF
--- a/locations/spiders/free_fr.py
+++ b/locations/spiders/free_fr.py
@@ -15,5 +15,8 @@ class FreeFRSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Boutique Free ")
         item["name"] = self.item_attributes["brand"]
+        # The only "telephone" present is the generic national hotline (3244), shared by
+        # every boutique, not a branch specific number.
+        item["phone"] = None
         apply_category(Categories.SHOP_TELECOMMUNICATION, item)
         yield item


### PR DESCRIPTION
- The `telephone` field in each boutique page's JSON-LD is not a branch-specific number — it's Free's generic national customer-service short code (`3244`), embedded identically on every store page.
- Verified live against 15 boutique pages sampled across the full range of boutique IDs (10 through 2146): all 15 returned exactly `"telephone":"3244"`, with no exceptions. `post_process_item` now unconditionally sets `item["phone"] = None`, following the same pattern used in `france_travail_fr.py` for its own generic national hotline.