### PR TITLE
[Maif FR] Null shared national hotline phone number

### DIFF
--- a/locations/spiders/maif_fr.py
+++ b/locations/spiders/maif_fr.py
@@ -1,6 +1,14 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from locations.structured_data_spider import StructuredDataSpider
+
+# The generic national customer-service line, embedded in the structured
+# data of "associations-collectivites-entreprises" agency pages rather than
+# a branch-specific number. Compared digits-only since the raw phone
+# string's formatting varies before PhoneCleanUpPipeline normalizes it.
+NATIONAL_HOTLINE_DIGITS = "0978979899"
 
 
 class MaifFRSpider(SitemapSpider, StructuredDataSpider):
@@ -8,3 +16,8 @@ class MaifFRSpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Maif", "brand_wikidata": "Q3331029"}
     sitemap_urls = ["https://agence.maif.fr/sitemap_pois.xml"]
     sitemap_rules = [(r"/details$", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if re.sub(r"\D", "", item.get("phone") or "").endswith(NATIONAL_HOTLINE_DIGITS):
+            item["phone"] = None
+        yield item


### PR DESCRIPTION
- The 14 \"MAIF Associations Collectivités Entreprises\" agency pages (e.g. `/C33M/maif-associations-collectivites-entreprises-bordeaux/details`) all embed the same national hotline number `09 78 97 98 99` in their structured data, rather than a branch-specific phone number. Sampled all 14 of these pages live and every single one returned that identical number.
- Regular `maif-assurances-*` agency pages have genuine, distinct per-branch numbers (verified via a spread sample of 10 pages, all different, none matching the hotline), so the fix nulls the phone only when it matches the hotline (digit-only comparison), following the `benu_cz.py` convention, instead of unconditionally nulling every item's phone.