### PR TITLE
[Kinleigh Folkard & Hayward GB] Fix missing name field

### DIFF
--- a/locations/spiders/kinleigh_folkard_hayward_gb.py
+++ b/locations/spiders/kinleigh_folkard_hayward_gb.py
@@ -14,7 +14,7 @@ class KinleighFolkardHaywardGBSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item, response, ld_data, **kwargs):
         branch = response.xpath("//h1/text()").get()
         item["branch"] = (branch or "").removesuffix(" Estate Agents") or None
-        item["name"] = None
+        item["name"] = self.item_attributes["brand"]
         item["street_address"] = None
         item["addr_full"] = ld_data.get("address", {}).get("streetAddress")
 


### PR DESCRIPTION
- Every item shipped with a blank \`name\` because \`post_process_item\` explicitly set it to \`None\` after \`branch\` was already populated from the page's \`<h1>\`. There's no \`brand_wikidata\` for this spider so NSI can't backfill the name.
- Set \`item["name"]\` to the brand string instead.