### PR TITLE
[Waffle Factory] Fix missing name field

### DIFF
--- a/locations/spiders/waffle_factory.py
+++ b/locations/spiders/waffle_factory.py
@@ -17,7 +17,8 @@ class WaffleFactorySpider(SitemapSpider, StructuredDataSpider):
     search_for_twitter = False
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        item["name"] = item["image"] = None
+        item["branch"] = item["name"].removeprefix(f"{self.item_attributes['brand']} - ").strip()
+        item["image"] = None
         apply_category(Categories.FAST_FOOD, item)
 
         yield item


### PR DESCRIPTION
- Every item shipped with a blank `name` (and `image`) because `post_process_item` explicitly cleared `item["name"]` to `None` right after `StructuredDataSpider` had already populated it from the page's JSON-LD, discarding real per-location data like "Waffle Factory - Paris Forum des Halles".
- Keep the JSON-LD `name` and derive `branch` from it by stripping the "Waffle Factory - " prefix (a handful of newer/unnamed stores have JSON-LD name = the bare brand name, which falls through to name = branch = "Waffle Factory" as a reasonable fallback).
- `item["image"]` stays cleared since the source returns a list of gallery photos rather than a single representative image.
