### PR TITLE
[Godot & Fils] Fix missing name field

### DIFF
--- a/locations/spiders/godot_et_fils_fr.py
+++ b/locations/spiders/godot_et_fils_fr.py
@@ -140,6 +140,7 @@ class GodotEtFilsFRSpider(Spider):
 
             item = Feature()
             item["ref"] = ref
+            item["name"] = self.item_attributes["brand"]
             item["branch"] = name.removeprefix("GODOT & FILS ").strip()
             item["addr_full"] = addr_full
             item["phone"] = phone or None


### PR DESCRIPTION
- Every item shipped with a blank \`name\` because it was never set in \`parse_cards\` (only \`branch\` was populated from the card title). There's no \`brand_wikidata\` for this spider so NSI can't backfill the name.
- Set \`item["name"]\` to the brand string.