### PR TITLE
[Řeznictví RABBIT] Fix missing name field

### DIFF
--- a/locations/spiders/reznictvi_rabbit_cz.py
+++ b/locations/spiders/reznictvi_rabbit_cz.py
@@ -29,6 +29,7 @@ class ReznictviRabbitCZSpider(Spider):
         item = Feature()
         item["ref"] = item["website"] = response.url
         item["country"] = "CZ"
+        item["name"] = self.item_attributes["brand"]
 
         item["branch"] = response.xpath('//li[@class="last"]/text()').get("").strip()
 


### PR DESCRIPTION
- Every item shipped with a blank \`name\` because it was never set in \`parse_store\` (only \`branch\` was populated). The brand's \`brand_wikidata\` (Q140309856) has no NSI matches, so NSI can't backfill the name either.
- Set \`item["name"]\` to the brand string.