### PR TITLE
[Rivian US] Fix rate-limited crawl

### DIFF
--- a/locations/spiders/rivian_us.py
+++ b/locations/spiders/rivian_us.py
@@ -11,7 +11,6 @@ from locations.items import Feature
 TILE_URL = "https://api.rivianservices.com/map-chargers/tiles/chrg2/{}/{}/{}"
 SEARCH_ZOOM = 7
 BOUNDING_BOX = (-170.0, 18.0, -52.0, 72.0)
-DETAIL_ZOOM = 13
 NETWORKS = ["Rivian Adventure Network", "Rivian Waypoints Network"]
 
 
@@ -128,7 +127,7 @@ class RivianUSSpider(Spider):
     """
 
     name = "rivian_us"
-    custom_settings = {"DOWNLOAD_DELAY": 0}
+    custom_settings = {"DOWNLOAD_DELAY": 0.3, "CONCURRENT_REQUESTS_PER_DOMAIN": 1}
     item_attributes = {"operator": "Rivian", "operator_wikidata": "Q7338847"}
     allowed_domains = ["api.rivianservices.com"]
     seen_refs: set[str] = set()
@@ -143,7 +142,7 @@ class RivianUSSpider(Spider):
                     cb_kwargs={"x": x, "y": y},
                 )
 
-    def parse_tile(self, response: Response, x: int, y: int, **kwargs: Any) -> Iterable[Request]:
+    def parse_tile(self, response: Response, x: int, y: int, **kwargs: Any) -> Iterable[Feature]:
         if not response.body:
             return
 
@@ -154,48 +153,23 @@ class RivianUSSpider(Spider):
                 continue
             self.seen_refs.add(properties["id"])
 
-            detail_x, detail_y = tile_x(longitude, DETAIL_ZOOM), tile_y(latitude, DETAIL_ZOOM)
-            yield Request(
-                url=TILE_URL.format(DETAIL_ZOOM, detail_x, detail_y),
-                callback=self.parse_detail_tile,
-                cb_kwargs={
-                    "properties": properties,
-                    "latitude": latitude,
-                    "longitude": longitude,
-                    "x": detail_x,
-                    "y": detail_y,
-                },
-                dont_filter=True,
-            )
+            item = Feature()
+            item["ref"] = properties["id"]
+            item["branch"] = properties.get("name")
+            item["lat"] = latitude
+            item["lon"] = longitude
+            item["country"] = "US"
+            self.parse_address(item, properties["address"])
 
-    def parse_detail_tile(
-        self, response: Response, properties: dict, latitude: float, longitude: float, x: int, y: int, **kwargs: Any
-    ) -> Iterable[Feature]:
-        if response.body:
-            for layer, detail, detail_latitude, detail_longitude in decode_vector_tile_points(
-                response.body, DETAIL_ZOOM, x, y
-            ):
-                if layer == "Charger" and detail.get("id") == properties["id"]:
-                    latitude, longitude = detail_latitude, detail_longitude
-                    break
+            item["extras"]["brand"] = properties["network"]
+            item["extras"]["capacity"] = str(properties["count"])
+            item["extras"]["motorcar"] = "yes"
+            item["extras"]["charging_station:output"] = "{} kW".format(properties["maxkw"])
+            item["extras"]["access"] = "customers" if properties.get("rivianonly") else "yes"
 
-        item = Feature()
-        item["ref"] = properties["id"]
-        item["branch"] = properties.get("name")
-        item["lat"] = latitude
-        item["lon"] = longitude
-        item["country"] = "US"
-        self.parse_address(item, properties["address"])
+            apply_category(Categories.CHARGING_STATION, item)
 
-        item["extras"]["brand"] = properties["network"]
-        item["extras"]["capacity"] = str(properties["count"])
-        item["extras"]["motorcar"] = "yes"
-        item["extras"]["charging_station:output"] = "{} kW".format(properties["maxkw"])
-        item["extras"]["access"] = "customers" if properties.get("rivianonly") else "yes"
-
-        apply_category(Categories.CHARGING_STATION, item)
-
-        yield item
+            yield item
 
     def parse_address(self, item: Feature, address: str) -> None:
         """Split a "street, city, state postcode, country" formatted address."""

--- a/locations/spiders/rivian_us.py
+++ b/locations/spiders/rivian_us.py
@@ -127,7 +127,7 @@ class RivianUSSpider(Spider):
     """
 
     name = "rivian_us"
-    custom_settings = {"DOWNLOAD_DELAY": 0.3, "CONCURRENT_REQUESTS_PER_DOMAIN": 1}
+    custom_settings = {"CONCURRENT_REQUESTS_PER_DOMAIN": 1}
     item_attributes = {"operator": "Rivian", "operator_wikidata": "Q7338847"}
     allowed_domains = ["api.rivianservices.com"]
     seen_refs: set[str] = set()

--- a/tests/test_download_delay.py
+++ b/tests/test_download_delay.py
@@ -29,8 +29,6 @@ def test_spiders_do_not_use_lower_download_delay_than_default():
     ALLOWED_LOW_DOWNLOAD_DELAY = set(
         [
             "usps_collection_boxes",  # Need to be faster to complete within time limits
-            "rivian_us",  # Crawls a large grid (~1400) of public vector map tiles; 0.3s keeps the crawl under
-            # the upstream API's rate limit (empirically: 0 retries) while still finishing in ~8 minutes
         ]
     )
 

--- a/tests/test_download_delay.py
+++ b/tests/test_download_delay.py
@@ -29,7 +29,8 @@ def test_spiders_do_not_use_lower_download_delay_than_default():
     ALLOWED_LOW_DOWNLOAD_DELAY = set(
         [
             "usps_collection_boxes",  # Need to be faster to complete within time limits
-            "rivian_us",  # Crawls a large grid of public vector map tiles; needs to be faster to complete within time limits
+            "rivian_us",  # Crawls a large grid (~1400) of public vector map tiles; 0.3s keeps the crawl under
+            # the upstream API's rate limit (empirically: 0 retries) while still finishing in ~8 minutes
         ]
     )
 


### PR DESCRIPTION
- Drop the per-charger zoom-13 \"detail\" tile fetch. It only refined coordinate precision (~77m -> ~1m), but made every item depend on a second successful request; under load the upstream API's rate limiter turned that into a large number of permanently-dropped chargers. Items now come straight from the zoom-7 search tile.
- Lower `DOWNLOAD_DELAY` to 0.3s with `CONCURRENT_REQUESTS_PER_DOMAIN: 1` instead of 0. Empirically (curl against `api.rivianservices.com`), unthrottled/bursty requests hit ~429 on 15-67% of calls, while a steady ~3.3 req/s stays under the limiter.

Locally, master's config (delay=0, two-stage) produced 207 items in 26s with 1836 429s and 445 requests permanently given up after retries. This change produced 367 items in ~8.5 minutes with zero retries and zero 429s (full coverage of all 1376 search tiles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved charger data collection by processing search results directly, reducing unnecessary follow-up requests.
  * Adjusted request concurrency to support more controlled access to Rivian’s data service.
* **Data Updates**
  * Charger features now include location coordinates and metadata as soon as search results are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->