### PR TITLE
Fix blank item count in PR CI summary when spider run has no stats file

### DIFF
--- a/ci/run_pr_spiders.sh
+++ b/ci/run_pr_spiders.sh
@@ -338,9 +338,20 @@ do
             fi
             continue
         else
+            # A missing stats file usually means the spider was force-killed
+            # (e.g. a closespider_timeout that didn't leave enough time for a
+            # Playwright/Camoufox browser to shut down cleanly) before the
+            # LOGSTATS_FILE extension could write it on spider close. The
+            # geojson output is left truncated in that case too, but each
+            # line of the ndgeojson output is still valid on its own, so
+            # count those lines to avoid reporting a blank item count for a
+            # run that actually produced items.
             (>&2 echo "${spider} has no stats file")
             STATS_WARNINGS=""
             STATS_ERRORS=""
+            if [ -f "${NDGEOJSON}" ]; then
+                FEATURE_COUNT=$(wc -l < "${NDGEOJSON}" | tr -d ' ')
+            fi
         fi
 
         PR_COMMENT_BODY="${PR_COMMENT_BODY}|[\`$spider\`](https://github.com/alltheplaces/alltheplaces/blob/${GITHUB_SHA}/${spider})|[${FEATURE_COUNT} items](${OUTFILE_URL}) ([Map](https://alltheplaces.xyz/preview.html?show=${OUTFILE_URL}))|Resulted in a \`${FAILURE_REASON}\` ([Log](${LOGFILE_URL}))|\\n"


### PR DESCRIPTION
PR #17881 (motel6) hit a `closespider_timeout` and its raw log clearly showed `scraped 5 items`, but the scraper-bot's summary table showed a blank item count instead of 5.

Root cause: motel6 is a Playwright spider. When `CLOSESPIDER_TIMEOUT` (120s) fires but the browser doesn't finish shutting down within the remaining buffer before the outer shell `timeout` (150s) sends SIGTERM/SIGKILL, the process is force-killed before the `LOGSTATS_FILE` extension can write `stats.json` on spider close. `output.geojson` is left truncated (missing its closing brackets) too, but each line of `output.ndgeojson` is still valid on its own since it's written incrementally.

`ci/run_pr_spiders.sh`'s "no stats file" fallback branch left `FEATURE_COUNT` unset, producing a blank `[ items]` cell in the summary table even though items were actually scraped. This falls back to counting lines in `output.ndgeojson` in that case, so the summary reflects the real item count instead of nothing.
