### PR TITLE
[Superdry] Drop generic email address

### DIFF
--- a/locations/spiders/superdry.py
+++ b/locations/spiders/superdry.py
@@ -13,7 +13,10 @@ class SuperdrySpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Superdry", "brand_wikidata": "Q1684445"}
     sitemap_urls = ["https://stores.superdry.com/sitemap.xml"]
     wanted_types = ["ClothingStore"]
-    drop_attributes = {"image", "email"}
+    search_for_email = False
+    search_for_facebook = False
+    search_for_twitter = False
+    drop_attributes = {"image"}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("Superdry").strip().removeprefix("™").strip()

--- a/locations/spiders/superdry.py
+++ b/locations/spiders/superdry.py
@@ -13,7 +13,7 @@ class SuperdrySpider(SitemapSpider, StructuredDataSpider):
     item_attributes = {"brand": "Superdry", "brand_wikidata": "Q1684445"}
     sitemap_urls = ["https://stores.superdry.com/sitemap.xml"]
     wanted_types = ["ClothingStore"]
-    drop_attributes = {"image"}
+    drop_attributes = {"image", "email"}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("Superdry").strip().removeprefix("™").strip()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Superdry location data processing to retain email information in listings while continuing to exclude images.
  * Disabled automatic discovery of email, Facebook, and Twitter details for Superdry locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->