### PR TITLE
[Delek IL] Add spider

### DIFF
--- a/locations/spiders/delek_il.py
+++ b/locations/spiders/delek_il.py
@@ -1,0 +1,61 @@
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import FormRequest, Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class DelekILSpider(Spider):
+    name = "delek_il"
+    item_attributes = {"brand": "Delek", "brand_wikidata": "Q1184087"}
+    allowed_domains = ["delek.co.il"]
+    start_urls = ["https://delek.co.il/איתור-תחנה/"]
+
+    # station flag (value "כן" = yes) -> tag
+    SERVICES = {
+        "gas": Fuel.LPG,  # תדלוק בגז (autogas)
+        "orea": Fuel.ADBLUE,  # אוריאה
+        "energy": Fuel.ELECTRIC,  # טעינה חשמלית
+        "wash": Extras.CAR_WASH,  # שטיפה
+        "atm": Extras.ATM,
+        "disabled": Extras.WHEELCHAIR,  # מונגשת
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # The station finder loads its data from a nonce-protected admin-ajax action.
+        if not (nonce := re.search(r"'nonce',\s*'([0-9a-f]+)'", response.text)):
+            self.logger.error("Delek stations nonce not found")
+            return
+        yield self.stations_request(nonce.group(1), 1)
+
+    def stations_request(self, nonce: str, page: int) -> FormRequest:
+        return FormRequest(
+            url="https://delek.co.il/wp-admin/admin-ajax.php",
+            formdata={"action": "sq_get_stations", "page": str(page), "nonce": nonce},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+            callback=self.parse_stations,
+            cb_kwargs={"nonce": nonce},
+        )
+
+    def parse_stations(self, response: Response, nonce: str, **kwargs: Any) -> Any:
+        data = response.json()["data"]
+        for station in data["stations"]:
+            item = DictParser.parse(station)  # id -> ref, name, lat, address -> addr_full, city
+            item["ref"] = str(item["ref"])
+            item["lon"] = station.get("lang")  # the source misspells "lng" as "lang"
+            item["branch"] = item.pop("name", None)  # the brand name comes from NSI
+            item["street_address"] = item.pop("addr_full", None)
+            if station.get("hours") == "24/7":
+                item["opening_hours"] = "24/7"
+            apply_category(Categories.FUEL_STATION, item)
+
+            for field, tag in self.SERVICES.items():
+                apply_yes_no(tag, item, station.get(field) == "כן")
+
+            yield item
+
+        if next_page := data.get("next"):
+            yield self.stations_request(nonce, next_page)


### PR DESCRIPTION
Delek (דלק, Q1184087), one of Israel's largest fuel brands (~240 stations). 
Data comes from the delek.co.il station finder, which loads stations from a nonce-protected admin-ajax action (sq_get_stations, paginated).
The spider scrapes a fresh nonce from the locator page, then pages through it. 
The source doesn't flag base petrol/diesel (assumed at every station), so only the explicit extra services are tagged: LPG (autogas), AdBlue, EV charging, and wheelchair accessibility. 
Opening hours: only mapped where the source gives a clean 24/7 (158 stations). The rest of the hours field is unreliable free-text: a mix of non-hours notes (ללא חנות ג'ו "no Joe store", זמנית התחנה סגורה "temporarily closed"), day-less time ranges (assuming a 7-day week would be a guess, and many Israeli stations close on Shabbat), and non-standard values (24/5, 24/6), so it's intentionally skipped rather than risk incorrect hours.

Samples :
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "10083",
      "amenity": "fuel",
      "fuel:lpg": "yes",
      "fuel:adblue": "yes",
      "fuel:electricity": "yes",
      "wheelchair": "yes",
      "name": "Delek",
      "branch": "מסמיה",
      "name:en": "Delek",
      "name:he": "דלק",
      "name:ru": "Делек",
      "addr:street_address": "כביש ראשי מסמיה",
      "addr:city": "יואב",
      "addr:country": "IL",
      "opening_hours": "24/7",
      "brand": "Delek",
      "brand:wikidata": "Q1184087",
      "nsi_id": "delek-bb4acb"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [34.783683, 31.758357]
    }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "10081",
      "amenity": "fuel",
      "wheelchair": "yes",
      "name": "Delek",
      "branch": "צומת אורה",
      "name:en": "Delek",
      "name:he": "דלק",
      "name:ru": "Делек",
      "addr:street_address": "צומת אורה, ירושלים",
      "addr:city": "ירושלים",
      "addr:country": "IL",
      "opening_hours": "24/7",
      "brand": "Delek",
      "brand:wikidata": "Q1184087",
      "nsi_id": "delek-bb4acb"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [35.159889, 31.755963]
    }
  }
]
```
Stats:
```
{
  "atp/brand/Delek": 241,
  "atp/brand_wikidata/Q1184087": 241,
  "atp/category/amenity/fuel": 241,
  "atp/country/IL": 241,
  "atp/field/country/from_spider_name": 241,
  "atp/nsi/match_perfect": 241,
  "item_scraped_count": 241
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Delek Israel station locations.
  * Captures station details, including addresses, coordinates, fuel offerings, and available services.
  * Supports retrieving station data across multiple result pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->