### PR TITLE
[Dor Alon IL] Add spider

### DIFF
--- a/locations/spiders/dor_alon_il.py
+++ b/locations/spiders/dor_alon_il.py
@@ -65,6 +65,6 @@ class DorAlonILSpider(Spider):
                         oh.set_closed(day)
                     elif hours := re.match(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$", value):
                         oh.add_range(day, hours.group(1), hours.group(2))
-                except ValueError:
+                except (TypeError, ValueError):  # non-string or unparseable value
                     self.crawler.stats.inc_value("atp/{}/hours/failed".format(self.name))
         return oh

--- a/locations/spiders/dor_alon_il.py
+++ b/locations/spiders/dor_alon_il.py
@@ -13,9 +13,10 @@ from locations.items import Feature
 
 class DorAlonILSpider(Spider):
     name = "dor_alon_il"
-    item_attributes = {"brand": "Dor Alon", "brand_wikidata": "Q16130352"}
+    item_attributes = {"brand": "דור אלון", "brand_wikidata": "Q16130352"}
     allowed_domains = ["www.doralon.co.il"]
     start_urls = ["https://www.doralon.co.il/station/"]
+    requires_proxy = True  # doralon.co.il is unreachable from the crawl datacenter without an Israel exit
 
     # station flag (value "1") -> tag
     SERVICES = {

--- a/locations/spiders/dor_alon_il.py
+++ b/locations/spiders/dor_alon_il.py
@@ -34,7 +34,10 @@ class DorAlonILSpider(Spider):
     }
 
     def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        for station in chompjs.parse_js_object(response.text[response.text.find("var stations =") :]):
+        if (start := response.text.find("var stations =")) == -1:
+            self.logger.error("Dor Alon: station data not found")
+            return
+        for station in chompjs.parse_js_object(response.text[start:]):
             item = DictParser.parse(station)  # id -> ref, title -> name, lat/lng, address -> addr_full
             item["ref"] = str(item["ref"])
             item["branch"] = item.pop("name", None)  # the brand name comes from NSI
@@ -50,18 +53,18 @@ class DorAlonILSpider(Spider):
 
     def parse_hours(self, station: dict) -> OpeningHours:
         oh = OpeningHours()
-        try:
-            for field, days in self.HOURS.items():
-                value = station.get(field)
-                if not value or value == "None":
-                    continue
-                for day in days:
+        for field, days in self.HOURS.items():
+            value = station.get(field)
+            if not value or value == "None":
+                continue
+            for day in days:
+                try:
                     if value == "24":
                         oh.add_range(day, "00:00", "24:00")
                     elif value == "סגור":  # closed
                         oh.set_closed(day)
                     elif hours := re.match(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$", value):
                         oh.add_range(day, hours.group(1), hours.group(2))
-        except Exception:
-            self.crawler.stats.inc_value("atp/{}/hours/failed".format(self.name))
+                except ValueError:
+                    self.crawler.stats.inc_value("atp/{}/hours/failed".format(self.name))
         return oh

--- a/locations/spiders/dor_alon_il.py
+++ b/locations/spiders/dor_alon_il.py
@@ -1,0 +1,66 @@
+import re
+from typing import Any, Iterable
+
+from chompjs import chompjs
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+
+class DorAlonILSpider(Spider):
+    name = "dor_alon_il"
+    item_attributes = {"brand": "Dor Alon", "brand_wikidata": "Q16130352"}
+    allowed_domains = ["www.doralon.co.il"]
+    start_urls = ["https://www.doralon.co.il/station/"]
+
+    # station flag (value "1") -> tag
+    SERVICES = {
+        "gaz98": Fuel.OCTANE_98,  # בנזין 98
+        "gaz_station": Fuel.LPG,  # גז (autogas)
+        "masheva_oreaa": Fuel.ADBLUE,  # משאבת אוריאה (AdBlue pump)
+        "electric_cars": Fuel.ELECTRIC,
+        "car_wash": Extras.CAR_WASH,
+    }
+    # Israeli opening-hours fields: the working week is Sunday-Thursday, then Friday and Saturday.
+    HOURS = {
+        "station_hours_week": ["Su", "Mo", "Tu", "We", "Th"],
+        "station_hours_friday": ["Fr"],
+        "station_hours_saturday": ["Sa"],
+    }
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        for station in chompjs.parse_js_object(response.text[response.text.find("var stations =") :]):
+            item = DictParser.parse(station)  # id -> ref, title -> name, lat/lng, address -> addr_full
+            item["ref"] = str(item["ref"])
+            item["branch"] = item.pop("name", None)  # the brand name comes from NSI
+            item["street_address"] = item.pop("addr_full", None)
+            item["phone"] = station.get("station_phone")
+            item["opening_hours"] = self.parse_hours(station)
+            apply_category(Categories.FUEL_STATION, item)
+
+            for field, tag in self.SERVICES.items():
+                apply_yes_no(tag, item, str(station.get(field)) == "1")
+
+            yield item
+
+    def parse_hours(self, station: dict) -> OpeningHours:
+        oh = OpeningHours()
+        try:
+            for field, days in self.HOURS.items():
+                value = station.get(field)
+                if not value or value == "None":
+                    continue
+                for day in days:
+                    if value == "24":
+                        oh.add_range(day, "00:00", "24:00")
+                    elif value == "סגור":  # closed
+                        oh.set_closed(day)
+                    elif hours := re.match(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$", value):
+                        oh.add_range(day, hours.group(1), hours.group(2))
+        except Exception:
+            self.crawler.stats.inc_value("atp/{}/hours/failed".format(self.name))
+        return oh


### PR DESCRIPTION
Adds a spider for Dor Alon (דור אלון, Q16130352), an Israeli fuel-station chain (~240 stations). 
Data comes from the var stations JSON embedded in doralon.co.il/station/ , the site publishes its own coordinates (no Google/Waze links), plus name, address, phone, opening hours, and service flags. 
All 241 match NSI perfectly. Fuel/services tagged from the source flags: gaz98→octane 98, gaz_station→LPG, masheva_oreaa→AdBlue, electric_cars→EV, car_wash. Base petrol/diesel aren't flagged in the source (assumed at every station), so they're not tagged.

Opening hours are parsed from the source's station_hours_week/_friday/_saturday fields (Israeli week = Sun–Thu, then Fri, Sat), handling 24 (all-day), HH:MM-HH:MM ranges, and סגור (closed), so Shabbat closures are captured correctly.

Stats:
{
  "atp/brand/Dor Alon": 241,
  "atp/brand_wikidata/Q16130352": 241,
  "atp/category/amenity/fuel": 241,
  "atp/country/IL": 241,
  "atp/field/country/from_spider_name": 241,
  "atp/nsi/match_perfect": 241,
  "item_scraped_count": 241
}

Attribute counts: opening_hours 240, phone ~172, fuel:adblue 146, fuel:electricity 68, fuel:octane_98 63, fuel:lpg 41, car_wash 40.

Samples:
```
[
  {
    "type": "Feature",
    "properties": {
      "ref": "50501",
      "amenity": "fuel",
      "fuel:octane_98": "yes",
      "fuel:lpg": "yes",
      "fuel:adblue": "yes",
      "name": "דור אלון",
      "branch": "אור יהודה",
      "name:en": "Dor Alon",
      "name:he": "דור אלון",
      "addr:street_address": "החרושת 17 אור יהודה",
      "addr:country": "IL",
      "phone": "+972 54-543-8784",
      "opening_hours": "Mo-Th 06:00-22:00; Fr 06:00-15:00; Sa closed; Su 06:00-22:00",
      "brand": "Dor Alon",
      "brand:wikidata": "Q16130352",
      "nsi_id": "doralon-bb4acb"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [
        34.86487627,
        32.02173979
      ]
    }
  },
  {
    "type": "Feature",
    "properties": {
      "ref": "50675",
      "amenity": "fuel",
      "fuel:adblue": "yes",
      "fuel:electricity": "yes",
      "name": "דור אלון",
      "branch": "אורים",
      "name:en": "Dor Alon",
      "name:he": "דור אלון",
      "addr:street_address": "כביש 471, צומת אורים צאלים",
      "addr:country": "IL",
      "opening_hours": "Mo-Su 00:00-24:00",
      "brand": "Dor Alon",
      "brand:wikidata": "Q16130352",
      "nsi_id": "doralon-bb4acb"
    },
    "geometry": {
      "type": "Point",
      "coordinates": [
        34.5255356,
        31.31695123
      ]
    }
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Dor Alon fuel stations in Israel.
  * Station listings include names, addresses, coordinates, phone numbers, opening hours, and fuel-station categorization.
  * Service availability is provided for LPG, AdBlue, electric charging, car wash, and 98-octane fuel.
  * Opening hours are parsed and presented for easier planning.

* **Bug Fixes**
  * Improved handling of unavailable or malformed station data so valid listings and opening hours continue to be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->