### PR TITLE
[Under Armour] Fix spider

### DIFF
--- a/locations/spiders/under_armour.py
+++ b/locations/spiders/under_armour.py
@@ -7,6 +7,7 @@ from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.user_agents import BOT_USER_AGENT_REQUESTS
 
 
 class UnderArmourSpider(Spider):
@@ -15,7 +16,10 @@ class UnderArmourSpider(Spider):
     allowed_domains = ["store-locator.underarmour.com"]
 
     async def start(self) -> AsyncIterator[Any]:
-        yield JsonRequest(url="https://store-locator.underarmour.com/api/stores/nearby/?lat=0&lng=0&radius=50000")
+        yield JsonRequest(
+            url="https://store-locator.underarmour.com/api/stores/nearby/?lat=0&lng=0&radius=50000",
+            headers={"User-Agent": BOT_USER_AGENT_REQUESTS},
+        )
 
     def parse(self, response: Response, **kwargs: Any):
         for store in response.json()["stores"]:


### PR DESCRIPTION
The store API rejects browser user agents, answering 418 with an empty body, which is what the spider was sending. It returned nothing.

The request now identifies itself as the project's bot, which the API accepts.

A live crawl returns 698 stores across 75 countries with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Under Armour store-locator requests to ensure store data can be retrieved more reliably.
  * Store details and opening-hours information remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->