### PR TITLE
[Cellarbrations AU] Fix spider

### DIFF
--- a/locations/spiders/cellarbrations_au.py
+++ b/locations/spiders/cellarbrations_au.py
@@ -5,7 +5,7 @@ class CellarbrationsAUSpider(StorefrontgatewaySpider):
     name = "cellarbrations_au"
     item_attributes = {"brand": "Cellarbrations", "brand_wikidata": "Q109807592"}
     allowed_domains = ["storefrontgateway.cellarbrations.com.au"]
-    requires_proxy = "AU"
+    requires_proxy = True
     start_urls = [
         "https://storefrontgateway.cellarbrations.com.au/api/near/-33.867778/151.21/20000/20000/stores",
     ]


### PR DESCRIPTION
The proxy was pinned to Australia, and the site bans the proxy's Australian addresses, so every run failed with a "Website Ban" and the spider returned nothing.

The pin is dropped. The proxy is still used, and a live crawl through it returns all 522 stores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to Cellarbrations Australia location data by ensuring requests use the required proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->