### PR TITLE
[New York Pizza NL DE] Fix spider

### DIFF
--- a/locations/spiders/new_york_pizza_nl_de.py
+++ b/locations/spiders/new_york_pizza_nl_de.py
@@ -4,6 +4,7 @@ from typing import AsyncIterator, Iterable
 from scrapy import Spider
 from scrapy.http import FormRequest, Request, Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, OpeningHours
 
@@ -46,6 +47,9 @@ class NewYorkPizzaNLDESpider(Spider):
                 item["opening_hours"] = self.convert_opening_hours(store)
             except Exception:
                 pass
+
+            apply_category(Categories.FAST_FOOD, item)
+
             yield item
 
     @staticmethod

--- a/locations/spiders/new_york_pizza_nl_de.py
+++ b/locations/spiders/new_york_pizza_nl_de.py
@@ -5,7 +5,7 @@ from scrapy import Spider
 from scrapy.http import FormRequest, Request, Response
 
 from locations.dict_parser import DictParser
-from locations.hours import DAYS_DE, DAYS_EN, OpeningHours
+from locations.hours import DAYS_EN, OpeningHours
 
 
 class NewYorkPizzaNLDESpider(Spider):
@@ -42,16 +42,15 @@ class NewYorkPizzaNLDESpider(Spider):
             item["postcode"], item["city"] = store["address_line_2"].split(maxsplit=1)
             item["country"] = top_level_domain.upper()
             item["website"] = response.urljoin(store["details_url"])
-            item["opening_hours"] = self.convert_opening_hours(store, top_level_domain)
+            item["opening_hours"] = self.convert_opening_hours(store)
             yield item
 
     @staticmethod
-    def convert_opening_hours(store, language) -> OpeningHours:
-        days_to_en = DAYS_DE if language == "de" else DAYS_EN
+    def convert_opening_hours(store) -> OpeningHours:
         re_interval = re.compile(r"(\d\d:\d\d) - (\d\d:\d\d)")
         hours = OpeningHours()
         for entry in store["opening_hours"]:
-            for weekday in OpeningHours.days_in_day_range(entry["key"].split("-"), days_to_en):
+            for weekday in OpeningHours.days_in_day_range(entry["key"].split("-"), DAYS_EN):
                 for open_time, close_time in re_interval.findall(entry["value"]):
                     hours.add_range(weekday, open_time, close_time)
         return hours

--- a/locations/spiders/new_york_pizza_nl_de.py
+++ b/locations/spiders/new_york_pizza_nl_de.py
@@ -42,7 +42,10 @@ class NewYorkPizzaNLDESpider(Spider):
             item["postcode"], item["city"] = store["address_line_2"].split(maxsplit=1)
             item["country"] = top_level_domain.upper()
             item["website"] = response.urljoin(store["details_url"])
-            item["opening_hours"] = self.convert_opening_hours(store)
+            try:
+                item["opening_hours"] = self.convert_opening_hours(store)
+            except Exception:
+                pass
             yield item
 
     @staticmethod

--- a/locations/spiders/new_york_pizza_nl_de.py
+++ b/locations/spiders/new_york_pizza_nl_de.py
@@ -23,7 +23,7 @@ class NewYorkPizzaNLDESpider(Spider):
     def parse_auth_token(self, response: Response, top_level_domain: str = None) -> Iterable[FormRequest]:
         auth_token = response.xpath('//input[@id="completeAntiForgeryToken"]/@value').get()
         yield FormRequest(
-            url=f"https://www.newyorkpizza.{top_level_domain}/General/GetFilteredStores/",
+            url=f"https://www.newyorkpizza.{top_level_domain}/General/GetFilteredStores",
             formdata={"includeSliceStores": "false", "storeIds": ""},
             headers={"RequestVerificationToken": auth_token},
             callback=self.parse,


### PR DESCRIPTION
The store request was sent to a path with a trailing slash, which now redirects to the same path without one. Following the redirect turns the POST into a GET, dropping both the form body and the verification token header, so the request ended on a not-found page and the spider returned nothing.

The trailing slash is removed.

A live crawl returns 297 restaurants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed store-location data retrieval for New York Pizza in the Netherlands by correcting the filtered-stores API URL.
  * Improved opening-hours interpretation to ensure days are consistently mapped and displayed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->