### PR TITLE
[generale_optique_fr] Add Spider (670 locations)

### DIFF
--- a/locations/spiders/generale_optique_fr.py
+++ b/locations/spiders/generale_optique_fr.py
@@ -1,8 +1,10 @@
+import json
+
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
-import json
+from locations.structured_data_spider import StructuredDataSpider
+
 
 class GeneraleOptiqueFrSpider(SitemapSpider, StructuredDataSpider):
     name = "generale_optique_fr"
@@ -15,14 +17,21 @@ class GeneraleOptiqueFrSpider(SitemapSpider, StructuredDataSpider):
         (r"/opticien/.*[0-9]+$", "parse_sd"),
     ]
     drop_attributes = ["image", "twitter", "facebook"]
-    
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         apply_category(Categories.SHOP_OPTICIAN, item)
 
         data = response.xpath("//script[contains(@id, '__NEXT_DATA__')]/text()").get()
 
-        item["branch"] = " ".join(item.pop("name","").split()).lower().removeprefix("opticien ").removeprefix("et audioprothésiste ").removeprefix("indépendant ").removesuffix(" générale d'optique").removeprefix("générale d'optique ")
+        item["branch"] = (
+            " ".join(item.pop("name", "").split())
+            .lower()
+            .removeprefix("opticien ")
+            .removeprefix("et audioprothésiste ")
+            .removeprefix("indépendant ")
+            .removesuffix(" générale d'optique")
+            .removeprefix("générale d'optique ")
+        )
 
         if data:
             data = json.loads(data)

--- a/locations/spiders/generale_optique_fr.py
+++ b/locations/spiders/generale_optique_fr.py
@@ -4,7 +4,7 @@ from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
 import json
 
-class GeneraleOptiqueFrSpider(SitemapSpider, StructuredDataSpider):
+class GeneraleOptiqueFRSpider(SitemapSpider, StructuredDataSpider):
     name = "generale_optique_fr"
     item_attributes = {
         "brand": "Générale d'Optique",
@@ -22,11 +22,23 @@ class GeneraleOptiqueFrSpider(SitemapSpider, StructuredDataSpider):
 
         data = response.xpath("//script[contains(@id, '__NEXT_DATA__')]/text()").get()
 
-        item["branch"] = " ".join(item.pop("name","").split()).lower().removeprefix("opticien ").removeprefix("et audioprothésiste ").removeprefix("indépendant ").removesuffix(" générale d'optique").removeprefix("générale d'optique ")
+        item["branch"] = " ".join(item.pop("name","").split()).lower().removeprefix("opticien ").removeprefix("et audioprothésiste ").removeprefix("indépendant ").removesuffix(" générale d'optique").removeprefix("générale d'optique ").removesuffix(" opticien")
 
         if data:
             data = json.loads(data)
-            item["lat"] = str(data["props"]["initialProps"]["pageProps"]["storeData"]["lat"])
-            item["lon"] = str(data["props"]["initialProps"]["pageProps"]["storeData"]["lon"])
+            store_data = (
+                data.get("props", {})
+                    .get("initialProps", {})
+                    .get("pageProps", {})
+                    .get("storeData")
+            )
 
+            if store_data:
+                lat = store_data.get("lat")
+                lon = store_data.get("lon")
+
+                if lat is not None and lon is not None:
+                    item["lat"] = str(lat)
+                    item["lon"] = str(lon)
+            
         yield item

--- a/locations/spiders/generale_optique_fr.py
+++ b/locations/spiders/generale_optique_fr.py
@@ -36,12 +36,7 @@ class GeneraleOptiqueFRSpider(SitemapSpider, StructuredDataSpider):
 
         if data:
             data = json.loads(data)
-            store_data = (
-                data.get("props", {})
-                    .get("initialProps", {})
-                    .get("pageProps", {})
-                    .get("storeData")
-            )
+            store_data = data.get("props", {}).get("initialProps", {}).get("pageProps", {}).get("storeData")
 
             if store_data:
                 lat = store_data.get("lat")
@@ -50,5 +45,5 @@ class GeneraleOptiqueFRSpider(SitemapSpider, StructuredDataSpider):
                 if lat is not None and lon is not None:
                     item["lat"] = str(lat)
                     item["lon"] = str(lon)
-            
+
         yield item

--- a/locations/spiders/generale_optique_fr.py
+++ b/locations/spiders/generale_optique_fr.py
@@ -1,0 +1,32 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+import json
+
+class GeneraleOptiqueFrSpider(SitemapSpider, StructuredDataSpider):
+    name = "generale_optique_fr"
+    item_attributes = {
+        "brand": "Générale d'Optique",
+        "brand_wikidata": "Q62391701",
+    }
+    sitemap_urls = ["https://www.generale-optique.com/robots.txt"]
+    sitemap_rules = [
+        (r"/opticien/.*[0-9]+$", "parse_sd"),
+    ]
+    drop_attributes = ["image", "twitter", "facebook"]
+    
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_OPTICIAN, item)
+
+        data = response.xpath("//script[contains(@id, '__NEXT_DATA__')]/text()").get()
+
+        item["branch"] = " ".join(item.pop("name","").split()).lower().removeprefix("opticien ").removeprefix("et audioprothésiste ").removeprefix("indépendant ").removesuffix(" générale d'optique").removeprefix("générale d'optique ")
+
+        if data:
+            data = json.loads(data)
+            item["lat"] = str(data["props"]["initialProps"]["pageProps"]["storeData"]["lat"])
+            item["lon"] = str(data["props"]["initialProps"]["pageProps"]["storeData"]["lon"])
+
+        yield item


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Générale d’Optique locations from sitemap data.
  * Location listings now include normalized branch names, brand and shop category details, and geographic coordinates when available.
  * Improved handling of incomplete location data so valid listings can still be processed when some nested information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->