### PR TITLE
[du_pareil_au_meme] Add Spider (127 locations)

### DIFF
--- a/locations/spiders/du_pareil_au_meme.py
+++ b/locations/spiders/du_pareil_au_meme.py
@@ -6,18 +6,13 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class DuPareilAuMemeSpider(SitemapSpider, StructuredDataSpider):
     name = "du_pareil_au_meme"
-    item_attributes = {
-        "brand": "Du Pareil au Même",
-        "brand_wikidata": "Q3040318",
-    }
+    item_attributes = {"brand": "Du Pareil au Même", "brand_wikidata": "Q3040318"}
     sitemap_urls = ["https://boutiques.dpam.com/sitemap_pois.xml"]
     wanted_types = ["ClothingStore"]
-    sitemap_rules = [
-        (r"/en/", "parse_sd"),
-    ]
+    sitemap_rules = [(r"/en/\w+-\w\w/(\d+)/du-pareil-au-meme-[^/]+/details$", "parse_sd")]
     drop_attributes = ["image", "facebook"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        apply_category(Categories.SHOP_CLOTHES, item)
         item["branch"] = item.pop("name", "").removeprefix("Du Pareil au même ")
+        apply_category(Categories.SHOP_CLOTHES, item)
         yield item

--- a/locations/spiders/du_pareil_au_meme.py
+++ b/locations/spiders/du_pareil_au_meme.py
@@ -1,4 +1,3 @@
-
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category

--- a/locations/spiders/du_pareil_au_meme.py
+++ b/locations/spiders/du_pareil_au_meme.py
@@ -1,0 +1,23 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+import json
+
+class DuPareilAuMemeSpider(SitemapSpider, StructuredDataSpider):
+    name = "du_pareil_au_meme"
+    item_attributes = {
+        "brand": "Du Pareil au Même",
+        "brand_wikidata": "Q3040318",
+    }
+    sitemap_urls = ["https://boutiques.dpam.com/sitemap_pois.xml"]
+    wanted_types = ["ClothingStore"]
+    sitemap_rules = [
+        (r"", "parse_sd"),
+    ]
+    drop_attributes = ["image", "facebook"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_CLOTHES, item)
+        item["branch"] = item.pop("name", "").removeprefix("Du Pareil au même ")
+        yield item

--- a/locations/spiders/du_pareil_au_meme.py
+++ b/locations/spiders/du_pareil_au_meme.py
@@ -1,8 +1,9 @@
+
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
-import json
+from locations.structured_data_spider import StructuredDataSpider
+
 
 class DuPareilAuMemeSpider(SitemapSpider, StructuredDataSpider):
     name = "du_pareil_au_meme"

--- a/locations/spiders/du_pareil_au_meme.py
+++ b/locations/spiders/du_pareil_au_meme.py
@@ -13,7 +13,7 @@ class DuPareilAuMemeSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://boutiques.dpam.com/sitemap_pois.xml"]
     wanted_types = ["ClothingStore"]
     sitemap_rules = [
-        (r"", "parse_sd"),
+        (r"/en/", "parse_sd"),
     ]
     drop_attributes = ["image", "facebook"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and importing Du Pareil Au Même store locations.
  * Store listings now include standardized clothing-store categories, normalized branch names, and brand information.
  * Unavailable image and Facebook details are excluded from imported listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->