### PR TITLE
[adopt_parfums] Add Spider (639 locations)

### DIFF
--- a/locations/spiders/adopt.py
+++ b/locations/spiders/adopt.py
@@ -1,8 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
-
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class AdoptSpider(SitemapSpider, StructuredDataSpider):

--- a/locations/spiders/adopt.py
+++ b/locations/spiders/adopt.py
@@ -1,0 +1,27 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+
+class AdoptSpider(SitemapSpider, StructuredDataSpider):
+    name = "adopt"
+    item_attributes = {
+        "brand": "Adopt'",
+        "brand_wikidata": "Q104649177",
+    }
+    sitemap_urls = ["https://www.adopt.com/en/sitemap/sitemap.xml"]
+    sitemap_rules = [
+        (r"/store-locator/", "parse_sd"),
+    ]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = ["facebook"]
+    time_format = "%I:%M %p"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_PERFUMERY, item)
+
+        item["branch"] = item.pop("name", "").removeprefix("Adopt Parfums ")
+
+        yield item

--- a/locations/spiders/adopt_parfums.py
+++ b/locations/spiders/adopt_parfums.py
@@ -5,10 +5,10 @@ from locations.categories import Categories, apply_category
 
 
 
-class AdoptSpider(SitemapSpider, StructuredDataSpider):
-    name = "adopt"
+class AdoptParfumsSpider(SitemapSpider, StructuredDataSpider):
+    name = "adopt_parfums"
     item_attributes = {
-        "brand": "Adopt'",
+        "brand": "Adopt Parfums",
         "brand_wikidata": "Q104649177",
     }
     sitemap_urls = ["https://www.adopt.com/en/sitemap/sitemap.xml"]

--- a/locations/spiders/adopt_parfums.py
+++ b/locations/spiders/adopt_parfums.py
@@ -1,26 +1,24 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class AdoptParfumsSpider(SitemapSpider, StructuredDataSpider):
     name = "adopt_parfums"
-    item_attributes = {
-        "brand": "Adopt Parfums",
-        "brand_wikidata": "Q104649177",
-    }
+    item_attributes = {"brand": "Adopt'", "brand_wikidata": "Q104649177"}
     sitemap_urls = ["https://www.adopt.com/en/sitemap/sitemap.xml"]
-    sitemap_rules = [
-        (r"/store-locator/", "parse_sd"),
-    ]
+    sitemap_rules = [("/store-locator/", "parse_sd")]
     wanted_types = ["LocalBusiness"]
     drop_attributes = ["facebook"]
     time_format = "%I:%M %p"
 
-    def post_process_item(self, item, response, ld_data, **kwargs):
-        apply_category(Categories.SHOP_PERFUMERY, item)
-
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name", "").removeprefix("Adopt Parfums ")
 
+        apply_category(Categories.SHOP_PERFUMERY, item)
         yield item


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for collecting Adopt Parfums store locations.
  - Store listings now include business details, perfumery categorization, brand information, branch names, and formatted opening hours.
  - Unneeded social media details are excluded from store data.

- **Bug Fixes**
  - Corrected the displayed brand name to “Adopt’”.
  - Improved store categorization and branch-name handling for more consistent listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->