### PR TITLE
[Chevron US] Fix spider

### DIFF
--- a/locations/spiders/chevron_us.py
+++ b/locations/spiders/chevron_us.py
@@ -60,7 +60,7 @@ def slugify(s):
 class ChevronUSSpider(JSONBlobSpider):
     name = "chevron_us"
     start_urls = [
-        "https://apis.chevron.com/api/StationFinder/alongtheway?clientid=A67B7471&geoLoc=((90%2C-180)%2C(-90%2C-180))&oLat=1&oLng=1"
+        "https://apis.chevron.com/api/StationFinder/nearby?clientid=A67B7471&geoLoc=((90%2C-180)%2C(-90%2C-180))&oLat=1&oLng=1"
     ]
     locations_key = "stations"
 


### PR DESCRIPTION
The station finder route `/api/StationFinder/alongtheway` now returns HTTP 500 with an empty body for any query, so the spider has returned no locations in recent runs.

The sibling route `/api/StationFinder/nearby` on the same host serves the same payload — same `stations` key, same per-station fields — and returns the whole estate in a single request.

16,991 features (13,727 Chevron, 3,153 Texaco, 111 ExtraMile).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Chevron station searches to use the nearby-stations endpoint, improving the accuracy and relevance of returned locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->