### PR TITLE
[Allianz DE] Use brand name and apply category

### DIFF
--- a/locations/spiders/allianz_de.py
+++ b/locations/spiders/allianz_de.py
@@ -1,5 +1,10 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
@@ -15,6 +20,8 @@ class AllianzDESpider(SitemapSpider, StructuredDataSpider, PlaywrightSpider):
     sitemap_rules = [("", "parse_sd")]
     custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
-    def post_process_item(self, item, response, ld_data):
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["name"] = None
         item["phone"] = ld_data.get("telePhone", None)
+        apply_category(Categories.OFFICE_INSURANCE, item)
         yield item


### PR DESCRIPTION
Each agency page's structured data names the individual agent running it, so every feature was emitting a person's name as the POI name — for example "Allianz Versicherung Anna Schmitt GENERALVERTRETUNG". In the most recent run that was 2,732 distinct names across 2,736 features, none of which was the brand name. It also stopped NSI matching cleanly.

The scraped name is now dropped so the brand name is used instead. `branch` is left unset, since the only per-office label available is the agent's name — matching `state_farm_us` and `erie_insurance_us`, which handle the same situation the same way.

The spider applied no category; it now applies `office=insurance`, matching the other insurance spiders.

NSI matching goes from imperfect to perfect on every feature as a result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of Allianz Germany location data.
  * Corrected telephone details and applied the appropriate office-insurance category.
  * Ensured location names are cleared and processed entries are returned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->