### PR TITLE
[A+Glass FR] Add Spider (467 locations)

### DIFF
--- a/locations/spiders/a_plus_glass_fr.py
+++ b/locations/spiders/a_plus_glass_fr.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class APlusGlassFRSpider(SitemapSpider, StructuredDataSpider):

--- a/locations/spiders/a_plus_glass_fr.py
+++ b/locations/spiders/a_plus_glass_fr.py
@@ -1,0 +1,23 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class APlusGlassFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "a_plus_glass_fr"
+    item_attributes = {
+        "brand": "A+Glass",
+        "brand_wikidata": "Q116688243",
+    }
+    sitemap_urls = ["https://www.aplusglass.com/service-centers-sitemap.xml"]
+    sitemap_rules = [
+        (r"", "parse_sd"),
+    ]
+    wanted_types = ["AutoRepair"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
+        item["branch"] = item.pop("name", "").removeprefix("A+GLASS ")
+
+        yield item

--- a/locations/spiders/a_plus_glass_fr.py
+++ b/locations/spiders/a_plus_glass_fr.py
@@ -6,18 +6,11 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class APlusGlassFRSpider(SitemapSpider, StructuredDataSpider):
     name = "a_plus_glass_fr"
-    item_attributes = {
-        "brand": "A+Glass",
-        "brand_wikidata": "Q116688243",
-    }
+    item_attributes = {"brand": "A+Glass", "brand_wikidata": "Q116688243"}
     sitemap_urls = ["https://www.aplusglass.com/service-centers-sitemap.xml"]
-    sitemap_rules = [
-        (r"", "parse_sd"),
-    ]
     wanted_types = ["AutoRepair"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        apply_category(Categories.SHOP_CAR_REPAIR, item)
         item["branch"] = item.pop("name", "").removeprefix("A+GLASS ")
-
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coverage for A+Glass France service-center locations.
  - Service centers are categorized as auto repair and include brand and branch information.
  - Location details are collected automatically from the provider’s sitemap and structured data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->