### PR TITLE
[McKesson CA] Skip records with an unknown banner

### DIFF
--- a/locations/spiders/mckesson_ca.py
+++ b/locations/spiders/mckesson_ca.py
@@ -3,6 +3,7 @@ from typing import AsyncIterator
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, DAYS_FR, OpeningHours
 
@@ -32,6 +33,8 @@ class MckessonCASpider(Spider):
 
     def parse(self, response):
         for location in response.json()["pharmacies"]:
+            if location["banner"] not in self.brands:
+                continue
             item = DictParser.parse(location)
             item.update(self.brands[location["banner"]])
             if location["banner"] in ["G", "I", "R"]:
@@ -50,4 +53,5 @@ class MckessonCASpider(Spider):
                     item["opening_hours"].add_range(
                         DAYS_FR[day_hours["day"]], day_hours["startTime"], day_hours["endTime"], "%H:%M:%S"
                     )
+            apply_category(Categories.PHARMACY, item)
             yield item


### PR DESCRIPTION
The pharmacies feed now contains a handful of records whose `banner` is an empty string. The unguarded `self.brands[location["banner"]]` lookup raises `KeyError` on the first one, which kills the generator for that response — every record after it is silently lost while the crawl still finishes cleanly. Recent runs show 681 items with `spider_exceptions/KeyError: 1`.

Records whose banner has no brand mapping are now skipped, and `amenity=pharmacy` is applied, which was not being set.

Per-banner impact, from a census of the live feed:

| banner | in source | currently emitted |
|--------|----------:|------------------:|
| Guardian    | 495 | 69 |
| I.D.A.      | 677 | 195 |
| Remedy'sRx  | 298 | 117 |
| Uniprix     | 300 | 300 |
| (no banner) | 8   | 0 |

Expected ~1,769 items, up from 681.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pharmacy listing accuracy by excluding records with unrecognized banners.
  * Classified recognized pharmacy listings under the appropriate pharmacy category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->