### PR TITLE
[maisons_clair_logis_fr] Add Spider (14 locations)

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -61,6 +61,7 @@ class Categories(Enum):
 
     CLUB_SCOUT = {"club": "scout"}
 
+    CRAFT_BUILDER = {"craft": "builder"}
     CRAFT_CAR_PAINTER = {"craft": "car_painter"}
     CRAFT_CARPENTER = {"craft": "carpenter"}
     CRAFT_CATERER = {"craft": "caterer"}

--- a/locations/spiders/maisons_clair_logis_fr.py
+++ b/locations/spiders/maisons_clair_logis_fr.py
@@ -16,12 +16,7 @@ class MaisonsClairLogisFRSpider(SitemapSpider, StructuredDataSpider):
     ]
     drop_attributes = ["facebook", "image"]
 
-
-    # wanted_types = ["GroceryStore"]
-
     def post_process_item(self, item, response, ld_data, **kwargs):
         apply_category(Categories.CRAFT_BUILDER, item)
         item["branch"] = item.pop("name", "").removeprefix("Maisons Clair Logis ")
-
-         
         yield item

--- a/locations/spiders/maisons_clair_logis_fr.py
+++ b/locations/spiders/maisons_clair_logis_fr.py
@@ -1,0 +1,27 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class MaisonsClairLogisFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "maisons_clair_logis_fr"
+    item_attributes = {
+        "brand": "Maisons Clair Logis",
+        "brand_wikidata": "Q141175303",
+    }
+    sitemap_urls = ["https://www.maisonsclairlogis.fr/agence-sitemap.xml"]
+    sitemap_rules = [
+        (r"", "parse_sd"),
+    ]
+    drop_attributes = ["facebook", "image"]
+
+
+    # wanted_types = ["GroceryStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.CRAFT_BUILDER, item)
+        item["branch"] = item.pop("name", "").removeprefix("Maisons Clair Logis ")
+
+         
+        yield item

--- a/locations/spiders/maisons_clair_logis_fr.py
+++ b/locations/spiders/maisons_clair_logis_fr.py
@@ -8,7 +8,6 @@ class MaisonsClairLogisFRSpider(SitemapSpider, StructuredDataSpider):
     name = "maisons_clair_logis_fr"
     item_attributes = {
         "brand": "Maisons Clair Logis",
-        "brand_wikidata": "Q141175303",
     }
     sitemap_urls = ["https://www.maisonsclairlogis.fr/agence-sitemap.xml"]
     sitemap_rules = [

--- a/locations/spiders/maisons_clair_logis_fr.py
+++ b/locations/spiders/maisons_clair_logis_fr.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class MaisonsClairLogisFRSpider(SitemapSpider, StructuredDataSpider):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Maisons Clair Logis branch locations from the agency’s sitemap.
  * Extracted and incorporated structured location information for more complete listings.
  * Classified collected locations under the craft builder category.
  * Standardized branch names for more consistent listings.
  * Improved location data quality by removing selected unnecessary attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->