### PR TITLE
[Coinhub US] Fix located_in

### DIFF
--- a/locations/spiders/coinhub_us.py
+++ b/locations/spiders/coinhub_us.py
@@ -12,8 +12,8 @@ class CoinhubUSSpider(StorepointSpider):
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
         item["ref"] = str(item["ref"])
-        if " inside: " in item["name"]:
-            item["located_in"] = item["name"].split(" inside: ", 1)[1]
+        if " - Inside " in item["name"]:
+            item["located_in"] = item["name"].split(" - Inside ", 1)[1]
         item.pop("name", None)
         item.pop("phone", None)
         item.pop("email", None)


### PR DESCRIPTION
Every Coinhub ATM is hosted inside another business and the feed encodes the host venue in the name, e.g. "Coinhub Bitcoin ATM - Inside 101 Liquor and Wine". The spider matched ` inside: ` — a pattern that does not occur in the data — so `located_in` was never populated on any feature.

Match the pattern the feed actually uses. `located_in` is now set on every feature (e.g. "101 Liquor and Wine").

Separately, the source API is currently serving a reduced 25-location set (down from ~1,850 in July); that is an upstream account/data issue, not addressed here — this fix applies to however many locations the API returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location extraction for Coinhub listings using the updated item-name format.
  * Ensured listings correctly identify where they are located when names include “- Inside.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->