### PR TITLE
[Au Vide Grenier] Add spider

### DIFF
--- a/locations/spiders/au_vide_grenier_fr.py
+++ b/locations/spiders/au_vide_grenier_fr.py
@@ -1,16 +1,21 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class AuVideGrenierFRSpider(SitemapSpider, StructuredDataSpider):
     name = "au_vide_grenier_fr"
-    item_attributes = {
-        "brand": "Au Vide Grenier",
-        "brand_wikidata": "Q141175815",
-        "extras": Categories.SHOP_SECOND_HAND.value,
-    }
+    item_attributes = {"brand": "Au Vide Grenier", "brand_wikidata": "Q141175815"}
     sitemap_urls = ["https://auvidegrenier.fr/sitemap/shops.xml"]
     sitemap_rules = [(r"https:\/\/auvidegrenier\.fr\/magasins\/", "parse_sd")]
     drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Au Vide Grenier ")
+        apply_category(Categories.SHOP_SECOND_HAND, item)
+        yield item

--- a/locations/spiders/au_vide_grenier_fr.py
+++ b/locations/spiders/au_vide_grenier_fr.py
@@ -1,0 +1,16 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class AuVideGrenierFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "au_vide_grenier_fr"
+    item_attributes = {
+        "brand": "Au Vide Grenier",
+        "brand_wikidata": "Q141175815",
+        "extras": Categories.SHOP_SECOND_HAND.value,
+    }
+    sitemap_urls = ["https://auvidegrenier.fr/sitemap/shops.xml"]
+    sitemap_rules = [(r"https:\/\/auvidegrenier\.fr\/magasins\/", "parse_sd")]
+    drop_attributes = {"image"}


### PR DESCRIPTION
Adds a spider for the french second hand brand Au Vide Grenier.

```
{'atp/brand/Au Vide Grenier': 44,
 'atp/brand_wikidata/Q141175815': 44,
 'atp/category/shop/second_hand': 44,
 'atp/cdn/cloudfront/response_count': 44,
 'atp/cdn/cloudfront/response_status_count/200': 44,
 'atp/country/FR': 44,
 'atp/field/branch/missing': 44,
 'atp/field/country/from_spider_name': 1,
 'atp/field/housenumber/missing': 44,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 44,
 'atp/field/operator_wikidata/missing': 44,
 'atp/field/phone/missing': 2,
 'atp/field/state/missing': 44,
 'atp/field/street/missing': 44,
 'atp/field/twitter/missing': 44,
 'atp/field/unit/missing': 44,
 'atp/item_scraped_host_count/auvidegrenier.fr': 44,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 44,
 'atp/nsi/match_failed': 44,
 'downloader/request_bytes': 18107,
 'downloader/request_count': 46,
 'downloader/request_method_count/GET': 46,
 'downloader/response_bytes': 1359882,
 'downloader/response_count': 46,
 'downloader/response_status_count/200': 46,
 'elapsed_time_seconds': 55.82273137383163,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 25, 14, 23, 52, 516593, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5177762,
 'httpcompression/response_count': 45,
 'item_scraped_count': 44,
 'items_per_minute': 48.0,
 'log_count/DEBUG': 90,
 'log_count/INFO': 3,
 'memusage/max': 181764096,
 'memusage/startup': 181764096,
 'request_depth_max': 1,
 'response_received_count': 46,
 'responses_per_minute': 50.18181818181819,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 45,
 'scheduler/dequeued/memory': 45,
 'scheduler/enqueued': 45,
 'scheduler/enqueued/memory': 45,
 'start_time': datetime.datetime(2026, 8, 25, 14, 22, 56, 694220, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Au Vide Grenier store listings now include standardized second-hand shop classification.
  * Store listings now provide a simplified branch name for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->