### PR TITLE
[gold_union_fr] Add Spider (132 locations)

### DIFF
--- a/locations/spiders/gold_union_fr.py
+++ b/locations/spiders/gold_union_fr.py
@@ -1,0 +1,14 @@
+from typing import Iterable
+
+from locations.items import Feature
+from locations.storefinders.stockist import StockistSpider
+
+
+class GoldUnionFR(StockistSpider):
+    name = "gold_union_fr"
+    item_attributes = {"brand": "Gold Union", "brand_wikidata": ""}
+    key = "u20465"
+
+    def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        yield item

--- a/locations/spiders/gold_union_fr.py
+++ b/locations/spiders/gold_union_fr.py
@@ -1,9 +1,8 @@
 from typing import Iterable
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.storefinders.stockist import StockistSpider
-from locations.categories import Categories, apply_category
-
 
 
 class GoldUnionFRSpider(StockistSpider):

--- a/locations/spiders/gold_union_fr.py
+++ b/locations/spiders/gold_union_fr.py
@@ -2,13 +2,16 @@ from typing import Iterable
 
 from locations.items import Feature
 from locations.storefinders.stockist import StockistSpider
+from locations.categories import Categories, apply_category
 
 
-class GoldUnionFR(StockistSpider):
+
+class GoldUnionFRSpider(StockistSpider):
     name = "gold_union_fr"
     item_attributes = {"brand": "Gold Union", "brand_wikidata": ""}
     key = "u20465"
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:
         item["branch"] = item.pop("name")
+        apply_category(Categories.SHOP_GOLD_BUYER, item)
         yield item

--- a/locations/spiders/gold_union_fr.py
+++ b/locations/spiders/gold_union_fr.py
@@ -8,7 +8,7 @@ from locations.categories import Categories, apply_category
 
 class GoldUnionFRSpider(StockistSpider):
     name = "gold_union_fr"
-    item_attributes = {"brand": "Gold Union", "brand_wikidata": ""}
+    item_attributes = {"brand": "Gold Union", "brand_wikidata": "Q131622916"}
     key = "u20465"
 
     def parse_item(self, item: Feature, location: dict) -> Iterable[Feature]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for finding Gold Union stockist locations in France.
  * Gold Union branch information is displayed in the standard location format.
  * Gold Union locations are categorized as gold buyers for more consistent discovery and filtering.
  * Gold Union locations are now linked to the correct brand identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->