### PR TITLE
[Neoness FR] Add Spider (32 locations)

### DIFF
--- a/locations/spiders/neoness_fr.py
+++ b/locations/spiders/neoness_fr.py
@@ -1,0 +1,16 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class NeonessFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "neoness_fr"
+    item_attributes = {
+        "brand": "Neoness",
+        "brand_wikidata": "Q86668014",
+        "extras": Categories.GYM.value,
+    }
+    sitemap_urls = ["https://www.neoness.fr/sitemap.xml"]
+    sitemap_rules = [(r"/clubs/", "parse_sd")]
+    drop_attributes = {"image", "facebook"}

--- a/locations/spiders/neoness_fr.py
+++ b/locations/spiders/neoness_fr.py
@@ -1,16 +1,22 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class NeonessFRSpider(SitemapSpider, StructuredDataSpider):
     name = "neoness_fr"
-    item_attributes = {
-        "brand": "Neoness",
-        "brand_wikidata": "Q86668014",
-        "extras": Categories.GYM.value,
-    }
-    sitemap_urls = ["https://www.neoness.fr/sitemap.xml"]
-    sitemap_rules = [(r"/clubs/", "parse_sd")]
-    drop_attributes = {"image", "facebook"}
+    item_attributes = {"brand": "Neoness", "brand_wikidata": "Q86668014"}
+    sitemap_urls = ["https://www.neoness.fr/robots.txt"]
+    sitemap_rules = [("/clubs/", "parse_sd")]
+    drop_attributes = {"image"}
+    search_for_facebook = False
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Neoness ")
+        apply_category(Categories.GYM, item)
+        yield item


### PR DESCRIPTION
Adds a spider for the french fitness center chain Neoness.

```
{'atp/brand/Neoness': 32,
 'atp/brand_wikidata/Q86668014': 32,
 'atp/category/leisure/fitness_centre': 32,
 'atp/cdn/cloudflare/response_count': 34,
 'atp/cdn/cloudflare/response_status_count/200': 34,
 'atp/clean_strings/name': 1,
 'atp/clean_strings/street_address': 3,
 'atp/country/FR': 32,
 'atp/field/branch/missing': 32,
 'atp/field/email/missing': 2,
 'atp/field/housenumber/missing': 32,
 'atp/field/operator/missing': 32,
 'atp/field/operator_wikidata/missing': 32,
 'atp/field/state/missing': 32,
 'atp/field/street/missing': 32,
 'atp/field/twitter/missing': 32,
 'atp/field/unit/missing': 32,
 'atp/item_scraped_host_count/www.neoness.fr': 32,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 32,
 'atp/nsi/match_failed': 32,
 'atp/structured_data/unmapped/amenity_features': 32,
 'atp/structured_data/unmapped/payment_accepted/Carte bancaire': 32,
 'atp/structured_data/unmapped/payment_accepted/Prélèvement': 32,
 'downloader/request_bytes': 17920,
 'downloader/request_count': 34,
 'downloader/request_method_count/GET': 34,
 'downloader/response_bytes': 3926723,
 'downloader/response_count': 34,
 'downloader/response_status_count/200': 34,
 'elapsed_time_seconds': 41.967977249994874,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 26, 0, 19, 59, 977607, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 17447241,
 'httpcompression/response_count': 34,
 'item_scraped_count': 32,
 'items_per_minute': 46.829268292682926,
 'log_count/DEBUG': 162,
 'log_count/INFO': 99,
 'memusage/max': 180224000,
 'memusage/startup': 180224000,
 'request_depth_max': 1,
 'response_received_count': 34,
 'responses_per_minute': 49.75609756097561,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 33,
 'scheduler/dequeued/memory': 33,
 'scheduler/enqueued': 33,
 'scheduler/enqueued/memory': 33,
 'start_time': datetime.datetime(2026, 8, 26, 0, 19, 18, 9238, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved discovery of Neoness France gym locations.
  * Gym listings now include branch, brand, and category information.

* **Updates**
  * Location details no longer include images or Facebook attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->