### PR TITLE
[Soletrader GB] Fix spider

### DIFF
--- a/locations/spiders/soletrader_gb.py
+++ b/locations/spiders/soletrader_gb.py
@@ -1,44 +1,46 @@
-import json
-import re
 from typing import Any
 
+import chompjs
 from scrapy.http import Response
-from scrapy.spiders import Spider
 
-from locations.categories import Categories
+from locations.camoufox_spider import CamoufoxSpider
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_EN, DAYS_FULL, OpeningHours
-from locations.items import Feature
+from locations.react_server_components import parse_rsc
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class SoletraderGBSpider(Spider):
+class SoletraderGBSpider(CamoufoxSpider):
     name = "soletrader_gb"
-    item_attributes = {"brand": "Soletrader", "brand_wikidata": "Q25101942", "extras": Categories.SHOP_SHOES.value}
+    item_attributes = {"brand": "Soletrader", "brand_wikidata": "Q25101942"}
     start_urls = ["https://www.soletrader.co.uk/store-locator"]
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
-        data = response.xpath('//script[contains(text(),"postalCode")]/text()').get()
-        data = re.sub(r'\\"', '"', data)
-        data = re.sub(r'^.*locations":', "", data)
-        data = re.sub(r'\}\]\\n"\]\)$', "", data)
-        for location in json.loads(data):
-            item = Feature()
+        scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()
+        payload = "".join(s for _, s in map(chompjs.parse_js_object, scripts) if isinstance(s, str))
+
+        for location in DictParser.get_nested_key(dict(parse_rsc(payload.encode())), "locations"):
+            if not location["code"].isdigit():
+                continue  # Fulfilment regions, not shops.
+
             address = location["address"]
             item = DictParser.parse(address)
+            item["ref"] = location["code"]
+            item["branch"] = (
+                location["label"].removeprefix("SOLETRADER OUTLET ").removeprefix("SOLETRADER ").removeprefix("SOLE ")
+            )
             item["street_address"] = address["address2"]
-            item["name"] = address["address1"]
-            item["ref"] = location["entityId"]
 
-            oh = OpeningHours()
+            item["opening_hours"] = OpeningHours()
             for day in DAYS_FULL:
-                open_time = location["operatingHours"][day.lower()]["opening"]
-                close_time = location["operatingHours"][day.lower()]["closing"]
-                oh.add_range(
-                    day=DAYS_EN[day],
-                    open_time=open_time,
-                    close_time=close_time,
-                )
+                hours = location["operatingHours"][day.lower()]
+                if not hours["open"]:
+                    item["opening_hours"].set_closed(DAYS_EN[day])
+                    continue
+                item["opening_hours"].add_range(DAYS_EN[day], hours["opening"], hours["closing"])
 
-            item["opening_hours"] = oh
+            apply_category(Categories.SHOP_SHOES, item)
 
             yield item

--- a/locations/spiders/soletrader_gb.py
+++ b/locations/spiders/soletrader_gb.py
@@ -1,7 +1,9 @@
-from typing import Any
+from typing import Any, AsyncIterator
 
 import chompjs
+from scrapy import Request
 from scrapy.http import Response
+from scrapy_camoufox.page import PageMethod
 
 from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
@@ -15,7 +17,26 @@ class SoletraderGBSpider(CamoufoxSpider):
     name = "soletrader_gb"
     item_attributes = {"brand": "Soletrader", "brand_wikidata": "Q25101942"}
     start_urls = ["https://www.soletrader.co.uk/store-locator"]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+    # Datacenter IPs get a Vercel security checkpoint: a 429 whose inline JS challenge
+    # reloads the real page, so the challenge needs script/fetch traffic and time to run.
+    handle_httpstatus_list = [429]
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type
+        not in ["document", "script", "xhr", "fetch", "other"],
+        "DOWNLOAD_TIMEOUT": 90,
+    }
+
+    async def start(self) -> AsyncIterator[Request]:
+        for url in self.start_urls:
+            yield Request(
+                url,
+                meta={
+                    "dont_retry": True,
+                    "camoufox_page_methods": [
+                        PageMethod("wait_for_selector", 'input[name="location"]', state="attached", timeout=60000)
+                    ],
+                },
+            )
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         scripts = response.xpath("//script[starts-with(text(), 'self.__next_f.push')]/text()").getall()


### PR DESCRIPTION
```
{'atp/brand/Soletrader': 9,
 'atp/brand_wikidata/Q25101942': 9,
 'atp/category/shop/shoes': 9,
 'atp/country/GB': 9,
 'atp/field/housenumber/missing': 9,
 'atp/field/name/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/state/missing': 9,
 'atp/field/street/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/unit/missing': 9,
 'atp/item_scraped_host_count/www.soletrader.co.uk': 9,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 9,
 'atp/nsi/match_failed': 9,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 69,
 'camoufox/request_count/aborted': 68,
 'camoufox/request_count/method/GET': 69,
 'camoufox/request_count/navigation': 1,
 'camoufox/request_count/resource_type/document': 1,
 'camoufox/request_count/resource_type/font': 5,
 'camoufox/request_count/resource_type/image': 13,
 'camoufox/request_count/resource_type/script': 36,
 'camoufox/request_count/resource_type/stylesheet': 14,
 'camoufox/response_count': 1,
 'camoufox/response_count/method/GET': 1,
 'camoufox/response_count/resource_type/document': 1,
 'downloader/request_bytes': 347,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 202224,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 70.64099999999985,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 26, 5, 40, 3, 21559, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9,
 'items_per_minute': 7.7142857142857135,
 'log_count/DEBUG': 150,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.8571428571428571,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 8, 26, 5, 38, 52, 381795, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving Soletrader store locations, including during access challenges or temporary rate limits.
  * Store listings now provide accurate branch names, shop codes, addresses, opening hours, and shoe-shop categorization.
  * Invalid or incomplete store entries are filtered out.
* **Improvements**
  * Store opening hours are presented more consistently, including clearly identifying closed days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->