### PR TITLE
[Sigma IT] Fix spider

### DIFF
--- a/locations/spiders/sigma_it.py
+++ b/locations/spiders/sigma_it.py
@@ -1,29 +1,54 @@
-import re
 from typing import AsyncIterator, Iterable
 
-from scrapy.http import FormRequest, Request, Response
+from scrapy.http import Request, Response, TextResponse
+from scrapy_camoufox.page import PageMethod
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.hours import CLOSED_IT, DAYS_IT, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class SigmaITSpider(JSONBlobSpider):
+class SigmaITSpider(JSONBlobSpider, CamoufoxSpider):
     name = "sigma_it"
     item_attributes = {"brand": "Sigma", "brand_wikidata": "Q3977979"}
     allowed_domains = ["www.supersigma.com"]
-    start_urls = ["https://www.supersigma.com/wp-admin/admin-ajax.php"]
-    locations_key = ["map_args", "locations"]
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ["document", "fetch"],
+        "CAMOUFOX_MAX_CONTEXTS": 1,
+        "CAMOUFOX_MAX_PAGES_PER_CONTEXT": 1,
+    }
 
-    async def start(self) -> AsyncIterator[FormRequest]:
-        formdata = {
-            "action": "gmw_form_ajax_submission",
-            "submitted": "true",
-            "form_id": "2",
-            "form_values": "address%5B%5D=Napoli&distance=100000&units=metric&post%5B%5D=store&page=1&per_page=10000&lat=40.85177&lng=14.26812&swlatlng=&nelatlng=&form=2&action=fs",
-        }
-        yield FormRequest(url=self.start_urls[0], formdata=formdata)
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
+            url="https://www.supersigma.com/punti-vendita/",
+            meta={
+                "camoufox_page_methods": [
+                    PageMethod(
+                        "evaluate",
+                        """async () => {
+                            const response = await fetch("/wp-admin/admin-ajax.php", {
+                                method: "POST",
+                                body: new URLSearchParams({
+                                    action: "gmw_form_ajax_submission",
+                                    submitted: "true",
+                                    form_id: "2",
+                                    form_values: "address%5B%5D=Napoli&distance=100000&units=metric&post%5B%5D=store&page=1&per_page=10000&lat=40.85177&lng=14.26812&swlatlng=&nelatlng=&form=2&action=fs",
+                                }),
+                            });
+                            if (!response.ok) throw new Error("store search returned HTTP " + response.status);
+                            return await response.json();
+                        }""",
+                    )
+                ]
+            },
+            callback=self.parse,
+        )
+
+    def extract_json(self, response: TextResponse) -> list[dict]:
+        return response.meta["camoufox_page_methods"][0].result["map_args"]["locations"]
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Request]:
         item["ref"] = feature["location_id"]
@@ -37,20 +62,21 @@ class SigmaITSpider(JSONBlobSpider):
         item["branch"] = branch_name
         item.pop("name", None)
         item["street_address"] = item.pop("street")
-        item["website"] = "https://www.supersigma.com/?p=" + feature["object_id"]
         apply_category(Categories.SHOP_SUPERMARKET, item)
-        yield Request(url=item["website"], meta={"item": item}, callback=self.parse_store_page)
+        yield Request(
+            url="https://www.supersigma.com/?p=" + feature["object_id"],
+            meta={"item": item},
+            callback=self.parse_store_page,
+        )
 
     def parse_store_page(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
-        item["website"] = response.url  # Capture redirect destination
-        if m := re.findall(
-            r"\b\d{10}\b", " ".join(response.xpath('//span[contains(@class, "littleaddress")]/span[3]/text()').getall())
-        ):
-            item["phone"] = "; ".join(m)
-        item["email"] = response.xpath('//span[contains(@class, "littleaddress")]/span[4]/text()').get()
+        item["website"] = response.url  # The store's own slug, after the ?p= redirect
+        item["phone"] = response.xpath('//div[img[contains(@src, "icon-phone.svg")]]/span/i/text()').get()
+        item["email"] = response.xpath('//div[img[contains(@src, "icon-email.svg")]]/span/i/text()').get()
         item["opening_hours"] = OpeningHours()
-        if hours_text := " ".join(response.xpath('//span[contains(@class, "bkg_orari")]/span/span//text()').getall()):
-            item["opening_hours"] = OpeningHours()
-            item["opening_hours"].add_ranges_from_string(hours_text, days=DAYS_IT, closed=CLOSED_IT)
+        for day_row in response.xpath('//p[contains(@class, "timetable-row")]'):
+            day = day_row.xpath('./span[contains(@class, "timetable-day")]/text()').get()
+            times = day_row.xpath('./span[contains(@class, "timetable-hour")]/text()').get()
+            item["opening_hours"].add_ranges_from_string(f"{day}: {times}", days=DAYS_IT, closed=CLOSED_IT)
         yield item

--- a/locations/spiders/sigma_it.py
+++ b/locations/spiders/sigma_it.py
@@ -15,6 +15,7 @@ class SigmaITSpider(JSONBlobSpider, CamoufoxSpider):
     name = "sigma_it"
     item_attributes = {"brand": "Sigma", "brand_wikidata": "Q3977979"}
     allowed_domains = ["www.supersigma.com"]
+    requires_proxy = True
     custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {
         "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ["document", "fetch"],
         "CAMOUFOX_MAX_CONTEXTS": 1,


### PR DESCRIPTION
Spider produced below stats when ran on US network after the fix.

```
{'atp/brand/Sigma': 389,
 'atp/brand_wikidata/Q3977979': 389,
 'atp/category/shop/supermarket': 389,
 'atp/clean_strings/phone': 2,
 'atp/clean_strings/postcode': 2,
 'atp/clean_strings/street_address': 1,
 'atp/country/IT': 389,
 'atp/field/city/missing': 2,
 'atp/field/country/from_spider_name': 337,
 'atp/field/email/missing': 109,
 'atp/field/housenumber/missing': 338,
 'atp/field/opening_hours/missing': 17,
 'atp/field/operator/missing': 389,
 'atp/field/operator_wikidata/missing': 389,
 'atp/field/phone/invalid': 15,
 'atp/field/phone/missing': 38,
 'atp/field/postcode/missing': 3,
 'atp/field/street/missing': 389,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 389,
 'atp/field/unit/missing': 389,
 'atp/item_scraped_host_count/www.supersigma.com': 389,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 389,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 390,
 'camoufox/page_count/closed': 390,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 27844,
 'camoufox/request_count/aborted': 27044,
 'camoufox/request_count/method/GET': 27843,
 'camoufox/request_count/method/POST': 1,
 'camoufox/request_count/navigation': 780,
 'camoufox/request_count/resource_type/document': 780,
 'camoufox/request_count/resource_type/fetch': 1,
 'camoufox/request_count/resource_type/font': 1,
 'camoufox/request_count/resource_type/image': 20905,
 'camoufox/request_count/resource_type/script': 3264,
 'camoufox/request_count/resource_type/stylesheet': 2893,
 'camoufox/response_count': 781,
 'camoufox/response_count/method/GET': 780,
 'camoufox/response_count/method/POST': 1,
 'camoufox/response_count/resource_type/document': 780,
 'camoufox/response_count/resource_type/fetch': 1,
 'downloader/request_bytes': 152934,
 'downloader/request_count': 390,
 'downloader/request_method_count/GET': 390,
 'downloader/response_bytes': 21284310,
 'downloader/response_count': 390,
 'downloader/response_status_count/200': 390,
 'elapsed_time_seconds': 2130.031000000001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 26, 8, 51, 59, 590030, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 389,
 'items_per_minute': 10.95774647887324,
 'log_count/DEBUG': 56839,
 'log_count/INFO': 42,
 'log_count/WARNING': 1,
 'request_depth_max': 1,
 'response_received_count': 390,
 'responses_per_minute': 10.985915492957746,
 'scheduler/dequeued': 390,
 'scheduler/dequeued/memory': 390,
 'scheduler/enqueued': 390,
 'scheduler/enqueued/memory': 390,
 'start_time': datetime.datetime(2026, 8, 26, 8, 16, 29, 568028, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store search reliability by using a browser-based request flow.
  * Updated location details extraction to accurately capture phone numbers, email addresses, and opening hours from the latest store page layout.
  * Improved handling of search responses to ensure store locations are discovered consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->