### PR TITLE
[East of England CO-OP GB] Fix spider

### DIFF
--- a/locations/spiders/east_of_england_coop_gb.py
+++ b/locations/spiders/east_of_england_coop_gb.py
@@ -18,7 +18,7 @@ class EastOfEnglandCoopGBSpider(SitemapSpider):
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
-        item["branch"] = response.xpath("//h2/text()").get()
+        item["branch"] = response.xpath("//h1/text()").get()
         item["street_address"] = response.xpath('//*[@class="flex flex-col gap-1"]/span/text()').get()
         item["city"] = response.xpath('//*[@class="flex flex-col gap-1"]/span[2]/text()').get()
         item["postcode"] = response.xpath('//*[@class="flex flex-col gap-1"]/span[3]/text()').get()
@@ -45,6 +45,14 @@ class EastOfEnglandCoopGBSpider(SitemapSpider):
             item.update(self.EAST_OF_ENGLAND_COOP)
             apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
 
+        try:
+            item["opening_hours"] = self.parse_opening_hours(response)
+        except Exception:
+            pass
+
+        yield item
+
+    def parse_opening_hours(self, response: Response) -> OpeningHours:
         oh = OpeningHours()
         for rule in response.xpath('//h3[contains(text(), "Opening times")]/parent::div//li'):
             day = rule.xpath("./div/span/text()").get()
@@ -53,7 +61,5 @@ class EastOfEnglandCoopGBSpider(SitemapSpider):
                 oh.set_closed(day)
             else:
                 open_time, close_time = time.split(" – ")
-                oh.add_range(day=day, open_time=open_time, close_time=close_time)
-        item["opening_hours"] = oh
-
-        yield item
+                oh.add_range(day, open_time, close_time)
+        return oh


### PR DESCRIPTION
```python
{'atp/brand/Co-op Daily': 116,
 'atp/brand/East of England CO-OP': 78,
 'atp/brand_wikidata/Q107589681': 116,
 'atp/brand_wikidata/Q5329759': 78,
 'atp/category/amenity/post_office': 29,
 'atp/category/shop/convenience': 116,
 'atp/category/shop/funeral_directors': 49,
 'atp/category/shop/supermarket': 13,
 'atp/category/shop/travel_agency': 16,
 'atp/clean_strings/branch': 3,
 'atp/clean_strings/phone': 2,
 'atp/country/GB': 223,
 'atp/field/brand/missing': 29,
 'atp/field/brand_wikidata/missing': 29,
 'atp/field/city/missing': 1,
 'atp/field/country/from_spider_name': 223,
 'atp/field/email/missing': 223,
 'atp/field/housenumber/missing': 223,
 'atp/field/name/missing': 29,
 'atp/field/opening_hours/missing': 94,
 'atp/field/operator/missing': 94,
 'atp/field/operator_wikidata/missing': 94,
 'atp/field/phone/invalid': 49,
 'atp/field/phone/missing': 31,
 'atp/field/state/missing': 223,
 'atp/field/street/missing': 223,
 'atp/field/twitter/missing': 223,
 'atp/field/unit/missing': 223,
 'atp/item_scraped_host_count/www.eastofengland.coop': 223,
 'atp/lineage': 'S_ATP_BRANDS',
 'atp/nsi/brand_or_operator_missing': 29,
 'atp/nsi/category_unknown': 65,
 'atp/nsi/match_failed': 94,
 'atp/nsi/match_perfect': 129,
 'atp/operator/East of England Co-operative Society': 129,
 'atp/operator_wikidata/Q5329759': 129,
 'downloader/request_bytes': 94386,
 'downloader/request_count': 225,
 'downloader/request_method_count/GET': 225,
 'downloader/response_bytes': 3052730,
 'downloader/response_count': 225,
 'downloader/response_status_count/200': 225,
 'dupefilter/filtered': 1,
 'elapsed_time_seconds': 99.07521291599915,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 26, 11, 25, 37, 774432, tzinfo=datetime.timezone.utc),
 'httpcache/firsthand': 82,
 'httpcache/hit': 143,
 'httpcache/miss': 82,
 'httpcache/store': 82,
 'httpcompression/response_bytes': 17005009,
 'httpcompression/response_count': 224,
 'item_scraped_count': 223,
 'items_per_minute': 135.15151515151516,
 'log_count/INFO': 4,
 'log_count/WARNING': 1,
 'memusage/max': 499130368,
 'memusage/startup': 308215808,
 'request_depth_max': 1,
 'response_received_count': 225,
 'responses_per_minute': 136.36363636363637,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 224,
 'scheduler/dequeued/memory': 224,
 'scheduler/enqueued': 224,
 'scheduler/enqueued/memory': 224,
 'start_time': datetime.datetime(2026, 8, 26, 11, 23, 58, 699215, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch name extraction for East of England Co-op locations.
  * Improved opening-hours parsing and handling when hours cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->