### PR TITLE
Construct store website URLs for VPZ GB spider

### DIFF
--- a/locations/spiders/vpz_gb.py
+++ b/locations/spiders/vpz_gb.py
@@ -1,3 +1,5 @@
+import re
+
 from typing import Iterable
 
 from scrapy.http import Response
@@ -15,5 +17,6 @@ class VpzGBSpider(UberallSpider):
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
         item["image"] = None
         item["ref"] = location.get("id")
+        item["website"] = "https://www.vpz.co.uk/stores/l/{0}/{1}/{2}".format(re.sub("[-., '/]+","-",location.get("city").lower()),re.sub("[-., '/]+","-",location.get("streetAndNumber").lower()),location.get("id"))
         apply_category(Categories.SHOP_E_CIGARETTE, item)
         yield item

--- a/locations/spiders/vpz_gb.py
+++ b/locations/spiders/vpz_gb.py
@@ -1,5 +1,4 @@
 import re
-
 from typing import Iterable
 
 from scrapy.http import Response
@@ -17,6 +16,10 @@ class VpzGBSpider(UberallSpider):
     def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
         item["image"] = None
         item["ref"] = location.get("id")
-        item["website"] = "https://www.vpz.co.uk/stores/l/{0}/{1}/{2}".format(re.sub("[-., '/]+","-",location.get("city").lower()),re.sub("[-., '/]+","-",location.get("streetAndNumber").lower()),location.get("id"))
+        item["website"] = "https://www.vpz.co.uk/stores/l/{0}/{1}/{2}".format(
+            re.sub("[-., '/]+", "-", location.get("city").lower()),
+            re.sub("[-., '/]+", "-", location.get("streetAndNumber").lower()),
+            location.get("id"),
+        )
         apply_category(Categories.SHOP_E_CIGARETTE, item)
         yield item


### PR DESCRIPTION
The store URLs appear to be made by kebab-casing the `city` and `streetAndNumber` fields in the data and then appending the store `ref`. I've checked what the [VPZ storefinder](https://www.vpz.co.uk/stores) returns for a number of branches where there are special characters in the address fields to see how they're transformed. I think I've got the transformation rules right. Various characters are changed to "-", and certainly " - " is reduced to a single "-".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store listings now include accurate VPZ website links based on each location’s city, street address, and location ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->