### PR TITLE
[Avis] Fix spider

### DIFF
--- a/locations/spiders/avis.py
+++ b/locations/spiders/avis.py
@@ -9,12 +9,14 @@ class AvisSpider(SitemapSpider, StructuredDataSpider):
     name = "avis"
     item_attributes = {"brand": "Avis", "brand_wikidata": "Q791136"}
     sitemap_urls = ["https://www.avis.com/sitemap.xml"]
-    sitemap_rules = [(r"https://www.avis.com/en/locations/[^/]+/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    sitemap_rules = [(r"https://www.avis.com/en/locations/[^/]+/[^/]+/[^/]+/[^/]+(?:/[^/]+)?$", "parse_sd")]
     wanted_types = ["AutoRental"]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
         if item.get("name"):
             item["branch"] = item.pop("name").removeprefix("Avis ")
+        item.pop("facebook", None)
+        item.pop("twitter", None)
         oh = OpeningHours()
         for day_time in ld_data["openingHours"]:
             if "24 hrs" in day_time:

--- a/locations/spiders/avis.py
+++ b/locations/spiders/avis.py
@@ -17,6 +17,7 @@ class AvisSpider(SitemapSpider, StructuredDataSpider):
             item["branch"] = item.pop("name").removeprefix("Avis ")
         item.pop("facebook", None)
         item.pop("twitter", None)
+        item.pop("image", None)
         oh = OpeningHours()
         for day_time in ld_data["openingHours"]:
             if "24 hrs" in day_time:


### PR DESCRIPTION
Avis restructured its location URLs, adding a region tier (nam/lat/pac/af/as/me). Countries with a state segment (US, AU, CA, …) now have five path segments under `/en/locations/`, but the sitemap rule matched exactly four, so those store pages were silently skipped — recent runs halved from ~3,300 to ~1,265 features with no errors.

The rule now matches four or five segments. City directory pages and the six-segment marketing articles ("road-trip-from-…") remain excluded, and pages without AutoRental structured data are filtered by `wanted_types` as before.

New-format pages also inject Avis's global Twitter/Facebook accounts into every location's structured data; these are dropped, as they were in #10882 when the same values appeared previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location discovery to include URLs with optional sub-location paths.
  * Removed unsupported social media and image fields from location results for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->