### PR TITLE
docs: fix broken links in Issue template for new spider request

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.yaml
+++ b/.github/ISSUE_TEMPLATE/request.yaml
@@ -35,7 +35,7 @@ body:
     id: difficulty
     attributes:
       label: Difficulty?
-      description: How similar to existing code is this spider? See [API SPIDER](../../docs/API_SPIDER.md) and [HARD WORK SPIDER](../../docs/HARD_WORK_SPIDER.md)
+      description: How similar to existing code is this spider? See [API SPIDER](../blob/master/docs/API_SPIDER.md) and [HARD WORK SPIDER](../blob/master/docs/HARD_WORK_SPIDER.md)
       options:
         - Easy - existing storefinders and no customisation
         - Medium - some customisation or data cleansing
@@ -56,7 +56,7 @@ body:
     id: behaviour
     attributes:
       label: Behaviours
-      description: How does the storefinder appear to work? See [API SPIDER](../../docs/API_SPIDER.md) and [HARD WORK SPIDER](../../docs/HARD_WORK_SPIDER.md)
+      description: How does the storefinder appear to work? See [API SPIDER](../blob/master/docs/API_SPIDER.md) and [HARD WORK SPIDER](../blob/master/docs/HARD_WORK_SPIDER.md)
       options:
         - label: Has coordinates?
         - label: Has opening hours?


### PR DESCRIPTION
<img width="834" height="516" alt="Screenshot of new spider request form page, red squares high lighting broken links" src="https://github.com/user-attachments/assets/f5ba4a43-e65d-4382-9a47-35216181832b" />

This fixes four broken links in the issue template for the new spider request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated spider documentation links in the issue template to point to the correct repository documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->