### PR TITLE
[Caffè Nero] Fix spider

### DIFF
--- a/locations/spiders/caffe_nero.py
+++ b/locations/spiders/caffe_nero.py
@@ -55,11 +55,12 @@ class CaffeNeroSpider(Spider):
 
             item["opening_hours"] = OpeningHours()
             for day_name, day_hours in location["properties"]["hoursRegular"].items():
-                if day_hours["open"] == "closed" or day_hours["close"] == "closed":
-                    item["opening_hours"].set_closed(day_name)
                 if day_name == "holiday":
                     continue
-                item["opening_hours"].add_range(day_name, day_hours["open"], day_hours["close"])
+                if day_hours["open"] == "closed" or day_hours["close"] == "closed":
+                    item["opening_hours"].set_closed(day_name)
+                else:
+                    item["opening_hours"].add_range(day_name, day_hours["open"][:5], day_hours["close"][:5])
 
             apply_yes_no(Extras.TAKEAWAY, item, location["properties"]["status"]["takeaway"], False)
             apply_yes_no(Extras.DELIVERY, item, location["properties"]["status"]["delivery"], False)


### PR DESCRIPTION
The GB stores feed changed its time values from HH:MM to HH:MM:SS, so hours parsing raised ValueError on the first GB store and the whole GB response was lost — recent runs dropped from 982 to 348 features. Times are now truncated to HH:MM, which accepts both formats (other country feeds still use HH:MM).

Separately, days marked "closed" called `set_closed()` and then fell through to `add_range(day, "closed", "closed")`, which also raised. Closed days are now recorded properly — previously they were never captured at all, since this path always raised. The `holiday` pseudo-day is skipped before either branch.

982 features, matching the last healthy run exactly (GB restored at 634).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening-hours handling for holiday and closed days.
  * Standardized displayed opening and closing times to the HH:MM format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->