### PR TITLE
[ICICI Bank IN] Fix spider

### DIFF
--- a/locations/spiders/icici_bank_in.py
+++ b/locations/spiders/icici_bank_in.py
@@ -27,6 +27,7 @@ class IciciBankINSpider(Spider):
         for branch in json.loads(response.text)["branch"]:
             item = DictParser.parse(branch)
             item["street_address"] = item.pop("addr_full", None)
+            item.pop("phone", None)
             item["branch"] = branch.get("branchName")
             item["name"] = None
             item["ref"] = branch.get("ifsc")

--- a/locations/spiders/icici_bank_in.py
+++ b/locations/spiders/icici_bank_in.py
@@ -17,23 +17,30 @@ class IciciBankINSpider(Spider):
     start_urls = ["https://maps.icicibank.com/content/icicibank/in/en.microsite.json"]
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
+    @staticmethod
+    def parse_time_range(hours: str) -> tuple[str, str] | None:
+        if m := re.search(r"(\d+:\d+(?:AM|PM))-(\d+:\d+(?:AM|PM))", hours.replace(".", ":").replace(" ", "")):
+            return m.group(1), m.group(2)
+        return None
+
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for branch in json.loads(response.text)["branch"]:
             item = DictParser.parse(branch)
-            item["street_address"] = item.pop("addr_full")
-            item["branch"] = branch["branchName"]
+            item["street_address"] = item.pop("addr_full", None)
+            item["branch"] = branch.get("branchName")
             item["name"] = None
-            item["ref"] = branch["ifsc"]
-            item["postcode"] = branch["pincode"]
-            item["website"] = f'https://www.icicibank.com{branch["knowMoreUrl"]}'
+            item["ref"] = branch.get("ifsc")
+            item["postcode"] = branch.get("pincode")
+            if url := branch.get("knowMoreUrl"):
+                item["website"] = f"https://www.icicibank.com{url}"
             try:
-                if hours := branch.get("mondayToSaturdayBranchWorking", ""):
-                    if m := re.search(
-                        r"(\d+:\d+(?:AM|PM))-(\d+:\d+(?:AM|PM))",
-                        hours.replace(".", ":").replace(" ", ""),
-                    ):
-                        item["opening_hours"] = OpeningHours()
-                        item["opening_hours"].add_days_range(DAYS[0:6], m.group(1), m.group(2), "%I:%M%p")
+                oh = OpeningHours()
+                if weekday := self.parse_time_range(branch.get("mondayToFridayWorkingHrs") or ""):
+                    oh.add_days_range(DAYS[0:5], *weekday, "%I:%M%p")
+                if saturday := self.parse_time_range(branch.get("saturdayWorkingHrs") or ""):
+                    oh.add_range("Sa", *saturday, "%I:%M%p")
+                if oh.day_hours:
+                    item["opening_hours"] = oh
             except Exception as e:
                 self.crawler.stats.inc_value(f"atp/{self.name}/hours/failed")
                 self.logger.warning(f"Failed to parse hours for {item['ref']}, {e}")
@@ -44,14 +51,18 @@ class IciciBankINSpider(Spider):
 
         for atm in json.loads(response.text)["atm"]:
             item = DictParser.parse(atm)
-            item["street_address"] = item.pop("addr_full")
-            item["branch"] = item.pop("name").replace("ICICI Bank ATM in ", "").strip()
-            item["ref"] = atm["siteId"]
-            item["postcode"] = atm["pinCode"]
-            item["website"] = f'https://www.icicibank.com{atm["knowMoreUrl"]}'.replace("/en/", "/")
+            item["street_address"] = item.pop("addr_full", None)
+            if name := item.pop("name", None):
+                item["branch"] = name.replace("ICICI Bank ATM in ", "").strip()
+            item["ref"] = atm.get("siteId")
+            item["postcode"] = atm.get("pinCode")
+            if url := atm.get("knowMoreUrl"):
+                item["website"] = f"https://www.icicibank.com{url}".replace("/en/", "/")
+            if atm.get("atm") == "24X7":
+                item["opening_hours"] = "24/7"
 
             apply_category(Categories.ATM, item)
-            if "N/A" in item.get("lat"):
+            if item.get("lat") and "N/A" in item["lat"]:
                 item["lat"] = None
                 item["lon"] = None
             yield item


### PR DESCRIPTION
The feed intermittently contains records with a missing field, and the spider indexed six keys unguarded, so a single malformed record raised and lost every ATM after it in the iteration — recent runs each died at a different record, one losing 5,216 of 8,893 ATMs. The `"N/A" in item.get("lat")` check also raised when a record had no latitude at all. Absent fields are now tolerated and records are still yielded.

Branch hours previously applied the single Mo-Sa string to all six days, but the feed provides separate weekday and Saturday fields which differ on 5,230 of 7,614 branches; both are now parsed. ATM records uniformly declare "24X7", now emitted as 24/7 opening hours — ATMs previously had no hours at all.

16,688 features (7,614 banks with corrected hours, 9,074 ATMs), up from 16,487 at the last healthy run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when bank and ATM listings contain missing or incomplete information.
  - Correctly handles separate weekday and Saturday opening hours.
  - Supports 24/7 ATM availability.
  - Prevents errors when location coordinates are unavailable.
  - Normalizes website addresses when applicable.
  - Removed phone details from bank listings for more consistent information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->