### PR TITLE
[MGEN FR] Add Spider

### DIFF
--- a/locations/spiders/mgen_fr.py
+++ b/locations/spiders/mgen_fr.py
@@ -1,17 +1,21 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
-from locations.categories import Categories
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
 class MGENFRSpider(SitemapSpider, StructuredDataSpider):
     name = "mgen_fr"
-    item_attributes = {
-        "brand": "MGEN",
-        "brand_wikidata": "Q3331039",
-        "extras": Categories.OFFICE_INSURANCE.value,
-    }
+    item_attributes = {"brand": "MGEN", "brand_wikidata": "Q3331039"}
     sitemap_urls = ["https://proximite.mgen.fr/locationsitemap1.xml"]
     sitemap_rules = [(r"https://proximite\.mgen\.fr/.+", "parse_sd")]
     wanted_types = ["LocalBusiness"]
     drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.OFFICE_INSURANCE, item)
+        yield item

--- a/locations/spiders/mgen_fr.py
+++ b/locations/spiders/mgen_fr.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MGENFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "mgen_fr"
+    item_attributes = {
+        "brand": "MGEN",
+        "brand_wikidata": "Q3331039",
+        "extras": Categories.OFFICE_INSURANCE.value,
+    }
+    sitemap_urls = ["https://proximite.mgen.fr/locationsitemap1.xml"]
+    sitemap_rules = [(r"https://proximite\.mgen\.fr/.+", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image"}

--- a/locations/spiders/mgen_fr.py
+++ b/locations/spiders/mgen_fr.py
@@ -8,7 +8,7 @@ from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class MGENFRSpider(SitemapSpider, StructuredDataSpider):
+class MgenFRSpider(SitemapSpider, StructuredDataSpider):
     name = "mgen_fr"
     item_attributes = {"brand": "MGEN", "brand_wikidata": "Q3331039"}
     sitemap_urls = ["https://proximite.mgen.fr/locationsitemap1.xml"]


### PR DESCRIPTION
Adds a spider for the french mutual insurance MGEN.

```
{'atp/brand/MGEN': 168,
 'atp/brand_wikidata/Q3331039': 168,
 'atp/category/office/insurance': 168,
 'atp/cdn/cloudflare/response_count': 170,
 'atp/cdn/cloudflare/response_status_count/200': 170,
 'atp/clean_strings/name': 28,
 'atp/clean_strings/street_address': 14,
 'atp/country/FR': 159,
 'atp/country/GF': 1,
 'atp/country/GP': 1,
 'atp/country/MQ': 1,
 'atp/country/PF': 2,
 'atp/country/PM': 1,
 'atp/country/RE': 2,
 'atp/country/YT': 1,
 'atp/field/branch/missing': 168,
 'atp/field/email/missing': 165,
 'atp/field/housenumber/missing': 168,
 'atp/field/opening_hours/missing': 22,
 'atp/field/operator/missing': 168,
 'atp/field/operator_wikidata/missing': 168,
 'atp/field/phone/invalid': 124,
 'atp/field/phone/missing': 21,
 'atp/field/state/missing': 168,
 'atp/field/street/missing': 168,
 'atp/field/twitter/missing': 165,
 'atp/field/unit/missing': 168,
 'atp/item_scraped_host_count/proximite.mgen.fr': 168,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 168,
 'atp/nsi/match_failed': 168,
 'downloader/request_bytes': 92627,
 'downloader/request_count': 170,
 'downloader/request_method_count/GET': 170,
 'downloader/response_bytes': 3484215,
 'downloader/response_count': 170,
 'downloader/response_status_count/200': 170,
 'elapsed_time_seconds': 202.89532458409667,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 8, 28, 8, 47, 42, 216212, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 22632837,
 'httpcompression/response_count': 170,
 'item_scraped_count': 168,
 'items_per_minute': 49.9009900990099,
 'log_count/DEBUG': 338,
 'log_count/INFO': 6,
 'memusage/max': 398606336,
 'memusage/startup': 180256768,
 'request_depth_max': 1,
 'response_received_count': 170,
 'responses_per_minute': 50.495049504950494,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 169,
 'scheduler/dequeued/memory': 169,
 'scheduler/enqueued': 169,
 'scheduler/enqueued/memory': 169,
 'start_time': datetime.datetime(2026, 8, 28, 8, 44, 19, 321066, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering MGEN insurance locations in France.
  * Extracts business details from MGEN location listings for improved directory coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->