### PR TITLE
[Bitstop PR US CA] Fix spider

### DIFF
--- a/locations/spiders/bitstop_pr_us_ca.py
+++ b/locations/spiders/bitstop_pr_us_ca.py
@@ -1,115 +1,75 @@
-import re
-from typing import Iterable
+from typing import AsyncIterator, Iterable
 
-from scrapy.http import Response
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
+from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
 
 class BitstopPRUSCASpider(JSONBlobSpider):
     name = "bitstop_pr_us_ca"
-    allowed_domains = ["static.plutonial.net"]
-    start_urls = ["https://static.plutonial.net/clients/loc/bitstop/current_p.json"]
-    operators = {
-        "ATM Ops Inc": {
-            "operator": "ATM Ops Inc",
-            "operator_wikidata": "Q135316538",
-            "brand": "Bitstop",
-            "brand_wikidata": "Q135316538",
-        },
-        "CoinGenie": {
-            "operator": "CoinGenie",
-            "operator_wikidata": "Q135317411",
-            "brand": "CoinGenie",
-            "brand_wikidata": "Q135317411",
-        },
-        "Dynamic Exchange": {"operator": "Dynamic Exchange", "brand": "Dynamic Exchange"},
-        "Express BTM": {
-            "operator": "Express BTM",
-            "operator_wikidata": "Q135316892",
-            "brand": "Express BTM",
-            "brand_wikidata": "Q135316892",
-        },
-        "PAI": {"operator": "PAI", "brand": "PAI"},
+    allowed_domains = ["account.bitstop.co"]
+    start_urls = ["https://account.bitstop.co/api/a/v2/map/locations"]
+    locations_key = "data"
+    item_attributes = {"brand": "Bitstop", "brand_wikidata": "Q135316538"}
+    country_codes = {"USA": "US", "Canada": "CA"}
+    operator_wikidata = {
+        "ATM OPS, Inc.": "Q135316538",
+        "Express BTM, LLC.": "Q135316892",
     }
 
-    def extract_json(self, response: Response) -> list[dict]:
-        # Keys of feature properties are remapped to codes to reduce the size
-        # of the source JSON file. The original JSON file needs to be rebuilt.
-        json_data = response.json()
-        key_map = {code: key_name for key_name, code in json_data["data"]["keys"].items()}
-        source_features = json_data["data"]["features"]["features"]
-        rebuilt_features = []
-        for source_feature in source_features:
-            rebuilt_feature = {}
-            rebuilt_feature["geometry"] = source_feature["geometry"]
-            for property_code, property_value in source_feature["properties"].items():
-                rebuilt_feature[key_map[property_code]] = property_value
-            rebuilt_features.append(rebuilt_feature)
-        return rebuilt_features
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(
+            url=self.start_urls[0],
+            method="POST",
+            data={"lat": 0, "lng": 0, "page": 1, "page_size": 5000, "filter": ""},
+        )
+
+    def pre_process_data(self, feature: dict) -> None:
+        if country := feature.get("country"):
+            feature["country"] = self.country_codes.get(country, country)
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        if feature.get("closing_date") or not feature.get("visible"):
-            return
-
-        item["ref"] = feature["atm_id"]
         item.pop("name", None)
-        item["addr_full"] = item["addr_full"].removeprefix("Bitstop Bitcoin ATM, ")
-        item["street_address"] = feature["address_line_1_2"]
-        item["state"] = feature["administrative_area"]
-        item["country"] = feature["country_region"]
         item.pop("phone", None)
 
-        if located_in := feature.get("enclosing_location"):
+        if located_in := feature.get("location_name"):
             item["located_in"] = located_in
 
-        if operator_name := feature.get("operator"):
-            if operator_name in self.operators.keys():
-                item["operator"] = self.operators[operator_name]["operator"]
-                if operator_wikidata := self.operators[operator_name].get("operator_wikidata"):
-                    item["operator_wikidata"] = operator_wikidata
-                item["brand"] = self.operators[operator_name]["brand"]
-                if brand_wikidata := self.operators[operator_name].get("brand_wikidata"):
-                    item["brand_wikidata"] = brand_wikidata
-            else:
-                self.logger.warning(
-                    "Unknown partner brand/operator '{}'. Feature still extracted but the spider needs updating with awareness of this partner brand/operator.".format(
-                        operator_name
-                    )
-                )
+        if operator_name := feature.get("operated_by"):
+            item["operator"] = operator_name
+            if wikidata := self.operator_wikidata.get(operator_name):
+                item["operator_wikidata"] = wikidata
 
-        if photo_list := feature.get("other_photos"):
-            photo_urls = photo_list.split(", ")
-            for photo_url in photo_urls:
-                if photo_url != "https://media.bitstop.co/media/bitstop-locations.jpg":
-                    item["image"] = photo_url
-                    break
+        if images := feature.get("images"):
+            item["image"] = images[0]
 
-        if hours_array := feature.get("working_hours_24"):
-            item["opening_hours"] = OpeningHours()
-            for day_hours in hours_array:
-                for interval in day_hours[1]:
-                    # Fix broken intervals
-                    interval = interval.replace("060:00", "06:00").replace("00:00-01:00-", "")
-                    # Merge split intervals that occur across midnight
-                    interval = re.sub(r"^00:00-((?:0[0-9]|11):\d{2})-(\d{2}:\d{2})-24:00$", r"\2-\1", interval)
-                    if interval.startswith("00:00-01:00-") and interval.endswith("-24:00"):
-                        interval = interval.removeprefix("00:00-01:00-")
-                    item["opening_hours"].add_range(
-                        day_hours[0].replace("_hours", ""), *interval.split("-", 1), "%H:%M"
-                    )
+        if hours_array := feature.get("hours"):
+            # Placeholder value seen when a location's actual hours are unconfirmed
+            if set(hours_array) != {"12:00 AM - 1:00 AM, 12:00 PM - 1:00 PM"}:
+                item["opening_hours"] = OpeningHours()
+                for day, hours in zip(DAYS, hours_array):
+                    if hours == "-":
+                        item["opening_hours"].set_closed(day)
+                    elif hours == "24/7":
+                        item["opening_hours"].add_range(day, "00:00", "24:00")
+                    else:
+                        open_time, close_time = hours.split(" - ")
+                        item["opening_hours"].add_range(day, open_time, close_time, "%I:%M %p")
 
         apply_category(Categories.ATM, item)
         item["extras"]["currency:XBT"] = "yes"
-        item["extras"]["currency:USD"] = "yes"
+        match item.get("country"):
+            case "CA":
+                item["extras"]["currency:CAD"] = "yes"
+            case "US" | "PR":
+                item["extras"]["currency:USD"] = "yes"
         item["extras"]["cash_in"] = "yes"
         item["extras"]["cash_out"] = "no"
 
-        item["extras"]["ref:google:place_id"] = feature["place_id"]
-        if start_date := feature.get("location_opening_date"):
-            item["extras"]["start_date"] = start_date
+        if place_id := feature.get("place_id"):
+            item["extras"]["ref:google:place_id"] = place_id
 
         yield item


### PR DESCRIPTION
The spider read a third-party mirror (static.plutonial.net) of Bitstop's locations, which no longer responds — every request times out, so recent runs returned nothing.

Bitstop's own site now serves its locator from a first-party API that returns the whole estate in one request, with a new data model: all units are presented as Bitstop with the network operator alongside (the per-operator consumer brands in the old feed no longer exist), host venues are a dedicated field (now mapped to `located_in`), hours are per-day arrays with closed and 24/7 markers, and per-location photos are included. Country values are normalised (USA/Canada variants) and the cash currency extra now follows the country instead of being hardcoded USD.

2,806 features (2,559 US, 240 CA, 7 PR), up from ~2,714 — the Canadian network is actively growing. All with coordinates and host venues; hours on 2,760 (the remainder publish a placeholder).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bitstop location data retrieval for more reliable and current results.
  - Corrected country, operator, currency, image, and business-hours information.
  - Added handling for placeholder or incomplete hours data.
  - Updated location processing to support the latest source data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->