### PR TITLE
Add la_taverne_table_de_caractere_fr spider (27 locations)

### DIFF
--- a/locations/spiders/la_taverne_table_de_caractere_fr.py
+++ b/locations/spiders/la_taverne_table_de_caractere_fr.py
@@ -1,0 +1,36 @@
+from scrapy import Spider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+
+
+class LaTaverneTableDeCaractereFRSpider(Spider):
+    name = "la_taverne_table_de_caractere_fr"
+    item_attributes = {"brand": "La Taverne - Table de Caractère", "brand_wikidata": "Q141215923"}
+    start_urls = ["https://www.lestavernes.com/nos-restaurants-la-taverne-table-de-caracteres/"]
+
+    def parse(self, response, **kwargs):
+        for li in response.xpath('//ul[contains(@class, "wpv-loop")]/li'):
+            marker = li.xpath('preceding-sibling::div[contains(@class, "js-wpv-addon-maps-marker")][1]')
+            website = li.xpath(".//a/@href").get()
+
+            item = Feature()
+            item["ref"] = website.strip("/").rsplit("/", 1)[-1]
+            item["website"] = website
+            item["branch"] = li.xpath('.//div[@class="nom-restaurant"]/text()').get("").strip()
+            item["street_address"] = li.xpath('.//div[@class="adresse-restaurant"]/text()').get("").strip()
+            item["postcode"] = li.xpath('.//div[@class="code_postal-restaurant"]/text()').get("").strip()
+            item["city"] = (
+                li.xpath('.//div[@class="code_postal-restaurant"]/following-sibling::div/text()').get("").strip()
+            )
+            item["phone"] = li.xpath('.//div[@class="tel-restaurant"]/text()').get()
+            item["email"] = li.xpath('.//div[@class="mail-restaurant"]//a/@href').get("").replace("mailto:", "")
+            item["lat"] = marker.xpath("@data-markerlat").get()
+            item["lon"] = marker.xpath("@data-markerlon").get()
+
+            # A couple of locations have the postcode merged into the city field on the source page.
+            if item["city"][:5].isdigit():
+                item["postcode"], item["city"] = item["city"][:5], item["city"][5:].strip()
+
+            apply_category(Categories.RESTAURANT, item)
+            yield item

--- a/locations/spiders/la_taverne_table_de_caractere_fr.py
+++ b/locations/spiders/la_taverne_table_de_caractere_fr.py
@@ -1,12 +1,14 @@
 from scrapy import Spider
 
 from locations.categories import Categories, apply_category
+from locations.hours import CLOSED_FR, DAYS_FR, OpeningHours
 from locations.items import Feature
 
 
 class LaTaverneTableDeCaractereFRSpider(Spider):
     name = "la_taverne_table_de_caractere_fr"
     item_attributes = {"brand": "La Taverne - Table de Caractère", "brand_wikidata": "Q141215923"}
+    allowed_domains = ["lestavernes.com"]
     start_urls = ["https://www.lestavernes.com/nos-restaurants-la-taverne-table-de-caracteres/"]
 
     def parse(self, response, **kwargs):
@@ -33,4 +35,45 @@ class LaTaverneTableDeCaractereFRSpider(Spider):
                 item["postcode"], item["city"] = item["city"][:5], item["city"][5:].strip()
 
             apply_category(Categories.RESTAURANT, item)
-            yield item
+
+            yield response.follow(website, callback=self.parse_hours, cb_kwargs={"item": item})
+
+    def parse_hours(self, response, item):
+        # Opening hours live on the restaurant page as a column of Elementor heading widgets (day names)
+        # each followed by two "shortcode" widgets holding either a "HHhMM - HHhMM" range, a bare "HHhMM"
+        # time (a single continuous range split into an open and a close value), or "Fermé".
+        oh = OpeningHours()
+        for heading in response.xpath('//h5[contains(@class, "elementor-heading-title")]'):
+            day = heading.xpath("normalize-space(.)").get()
+            if day not in DAYS_FR:
+                continue
+            day = DAYS_FR[day]
+
+            slots = heading.xpath(
+                'ancestor::div[contains(@class, "elementor-widget-heading")]'
+                '/following-sibling::div[contains(@class, "elementor-widget-shortcode")][position() <= 2]'
+                '//div[contains(@class, "elementor-shortcode")]/text()'
+            ).getall()
+            slots = [slot.strip() for slot in slots if slot.strip()]
+            if slots and all(slot.lower() in CLOSED_FR for slot in slots):
+                oh.set_closed(day)
+                continue
+
+            bare = []
+            for slot in slots:
+                if slot.lower() in CLOSED_FR:
+                    continue
+                if "-" in slot:
+                    start, end = slot.split("-", 1)
+                    oh.add_range(day, self.clean_time(start), self.clean_time(end), closed=CLOSED_FR)
+                else:
+                    bare.append(self.clean_time(slot))
+            if len(bare) == 2:
+                oh.add_range(day, bare[0], bare[1], closed=CLOSED_FR)
+
+        item["opening_hours"] = oh
+        yield item
+
+    @staticmethod
+    def clean_time(value):
+        return value.strip().lower().replace("h", ":")


### PR DESCRIPTION
Adds a spider for the French restaurant chain **La Taverne - Table de Caractère** ([Q141215923](https://www.wikidata.org/wiki/Q141215923)).

- Source: https://www.lestavernes.com/nos-restaurants-la-taverne-table-de-caracteres/
- The listing page renders all 27 restaurants server-side with coordinates (map marker attributes) and structured address/phone/email fields, so it is parsed in a single request.
- No usable schema.org / microdata / Open Graph on the site (Yoast graph only exposes `WebPage`/`Organization`), so `StructuredDataSpider` is not applicable.
- Each restaurant page is then fetched to extract opening hours (Elementor day/time widgets; handles split lunch/dinner services and `Fermé` days).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting La Taverne – Table de Caractère restaurant listings in France.
  * Captures restaurant details, locations, contact information, categories, and opening hours.
  * Handles closed days and multiple opening-time formats in French listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->