### PR TITLE
[ca_dmv_us] Add spider

### DIFF
--- a/locations/categories.py
+++ b/locations/categories.py
@@ -269,6 +269,7 @@ class Categories(Enum):
     OFFICE_ESTATE_AGENT = {"office": "estate_agent"}
     OFFICE_FINANCIAL = {"office": "financial"}
     OFFICE_FINANCIAL_ADVISOR = {"office": "financial_advisor"}
+    OFFICE_GOVERNMENT = {"office": "government"}
     OFFICE_HEALTHCARE = {"office": "healthcare"}
     OFFICE_INSURANCE = {"office": "insurance"}
     OFFICE_IT = {"office": "it"}

--- a/locations/spiders/ca_dmv_us.py
+++ b/locations/spiders/ca_dmv_us.py
@@ -1,0 +1,32 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
+
+
+class CaDmvUSSpider(ArcGISFeatureServerSpider):
+    name = "ca_dmv_us"
+    item_attributes = {
+        "operator": "California Department of Motor Vehicles",
+        "operator_wikidata": "Q5020431",
+        "name": "California DMV",
+        "state": "CA",
+        "country": "US",
+    }
+    host = "services6.arcgis.com"
+    context_path = "8zbIxywG5xu2vq8a/arcgis"
+    service_id = "Department_of_Motor_Vehicles_Office_Locations"
+    layer_id = "0"
+
+    def pre_process_data(self, feature: dict) -> None:
+        if address := feature.get("Address"):
+            feature["Address"] = address.replace("\n", ", ")
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["FAC_ID"]
+        item["branch"] = item.pop("name")
+        apply_category(Categories.OFFICE_GOVERNMENT, item)
+        yield item


### PR DESCRIPTION
Adds a spider for the 208 California DMV (Department of Motor Vehicles) field offices, using the ArcGIS Feature Server behind the state's GIS Geoportal dataset "Department of Motor Vehicles Office Locations" (services6.arcgis.com/8zbIxywG5xu2vq8a/.../Department_of_Motor_Vehicles_Office_Locations/FeatureServer/0). No auth or bot protection required.

This is a scoped, single-state alternative to the stale issue #159, which targeted the unreliable third-party aggregator dmv.org (ruled out in prior research due to stale sitemaps and generic duplicate contact info). This dataset is the DMV's own authoritative GIS data instead.

Verified locally: 208 items, all with unique refs (FAC_ID) and valid WGS84 coordinates (note: the raw feature properties also contain a `longitude`/`latitude` pair in a non-WGS84 projected CRS — these are ignored in favor of the GeoJSON `geometry`, which the ArcGIS query reprojects to EPSG:4326). Added a new `Categories.OFFICE_GOVERNMENT` (`office=government`) entry, none existed previously; NSI matches this brand/operator (Q5020431) perfectly and backfills `government=transportation` and `operator:short` automatically. No phone/hours fields exist in this source, so those are left blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added California DMV office locations sourced from the California DMV.
  * Government offices can now be categorized using a dedicated government office category.
  * Improved address formatting for DMV location details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->