### PR TITLE
[new_york_state_department_of_motor_vehicles_us] Add spider

### DIFF
--- a/locations/spiders/new_york_state_department_of_motor_vehicles_us.py
+++ b/locations/spiders/new_york_state_department_of_motor_vehicles_us.py
@@ -1,0 +1,46 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.storefinders.socrata import SocrataSpider
+
+
+class NewYorkStateDepartmentOfMotorVehiclesUSSpider(SocrataSpider):
+    name = "new_york_state_department_of_motor_vehicles_us"
+    item_attributes = {
+        "name": "Department of Motor Vehicles",
+        "operator": "New York State Department of Motor Vehicles",
+        "operator_wikidata": "Q17109616",
+        "state": "NY",
+        "country": "US",
+    }
+    host = "data.ny.gov"
+    resource_id = "9upz-c7xg"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature.get("office_name")
+        item["branch"] = feature.get("office_name")
+
+        street_address = feature.get("street_address_line_1") or ""
+        if line_2 := feature.get("street_address_line_2"):
+            street_address = f"{street_address}, {line_2}"
+        item["street_address"] = street_address
+
+        item["phone"] = feature.get("public_phone_number")
+
+        oh = OpeningHours()
+        for day, field_prefix in zip(DAYS, ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]):
+            open_time = feature.get(f"{field_prefix}_beginning_hours")
+            close_time = feature.get(f"{field_prefix}_ending_hours")
+            oh.add_range(day, open_time, close_time, time_format="%I:%M %p")
+        # The dataset has no Sunday columns at all; DMV offices are never open Sundays.
+        oh.add_range("Su", "CLOSED", "CLOSED")
+        item["opening_hours"] = oh
+
+        apply_category({"office": "government"}, item)
+        item.set_tag("government", "vehicle_registration")
+
+        yield item


### PR DESCRIPTION
Adds a spider for New York State DMV office locations, sourced from NY's Socrata open-data portal (`https://data.ny.gov/resource/9upz-c7xg.json`, dataset "Department of Motor Vehicle (DMV) Office Locations"). Uses the existing `SocrataSpider` storefinder base class.

This is a scoped, single-state alternative to the stale issue #159, which targeted the unreliable third-party aggregator dmv.org (ruled out by prior research due to stale sitemaps and generic duplicate emails). The Socrata dataset instead gives 141 official NY DMV offices with structured addresses, per-day opening hours, and coordinates (140/141 populated).

Verified locally: 141 items scraped, one item missing coordinates (matches the source data), `opening_hours` correctly built from the per-weekday begin/end columns, phone numbers normalized by the phone pipeline, and a perfect NSI brand match (`newyorkstatedepartmentofmotorvehicles-b00967`) for all items.

Tagged `office=government` + `government=vehicle_registration`, following the precedent in `locations/spiders/government/npr_pp_tjenester_no.py`.

Reviewer note: about 10 of the 141 records are "AAA ISSUING OFFICE" type — membership-limited offices operated by AAA clubs under contract to issue registrations, included in NY's own official DMV office directory. The spider currently tags these the same as state-run offices (`operator` = NY State DMV); a reviewer may want to special-case these if a more precise operator/category is preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for New York State Department of Motor Vehicles office locations.
  * Included office names, addresses, phone numbers, opening hours, and vehicle registration categorization.
  * Sunday closures and Monday–Saturday operating hours are now reflected in location details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->