### PR TITLE
[YWCA] Add spider

### DIFF
--- a/locations/spiders/ywca_us.py
+++ b/locations/spiders/ywca_us.py
@@ -1,0 +1,36 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.elfsight import ElfsightSpider
+
+
+class YwcaUSSpider(ElfsightSpider):
+    name = "ywca_us"
+    item_attributes = {"brand": "YWCA", "brand_wikidata": "Q17022739"}
+    host = "core.service.elfsight.com"
+    api_key = "9a21c171-1a02-4a3e-bbc8-e5fb34782244"
+
+    def pre_process_data(self, feature: dict) -> None:
+        # Coordinates are "lat lon" (space separated), not the "lat, lon" the base
+        # class expects.
+        if coordinates := feature.get("coordinates"):
+            feature["coordinates"] = coordinates.replace(" ", ", ", 1)
+        super().pre_process_data(feature)
+
+    def post_process_item(self, item: Feature, response: Response, location: dict) -> Iterable[Feature]:
+        # Addresses are published as a single free-text line with inconsistent
+        # formatting (missing commas, zip codes without leading zeros, PO boxes),
+        # so it isn't reliably splittable into street/city/state/postcode. DictParser
+        # already maps the "addr" key (set by the base class) to addr_full.
+        if site := location.get("infoSite"):
+            if not site.startswith(("http://", "https://")):
+                site = f"https://{site}"
+            if "facebook.com" in site:
+                item["facebook"] = site
+            else:
+                item["website"] = site
+        apply_category(Categories.COMMUNITY_CENTRE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for YWCA USA, sourced from the "Find Your YWCA" map on https://www.ywca.org/what-we-do/in-your-community/find-your-ywca, which is an Elfsight-hosted widget (`core.service.elfsight.com`, API key `9a21c171-1a02-4a3e-bbc8-e5fb34782244`) publishing all 204 local YWCA associations directly from YWCA USA's own site. Uses the existing `ElfsightSpider` storefinder base class.

Addresses are a single free-text line with inconsistent formatting (missing commas, zip codes without leading zeros, PO boxes) so they're kept as `addr_full` rather than force-split into street/city/postcode. Category applied is `amenity=community_centre` (no NSI brand entry exists for YWCA to match against; precedent for treating a federation of independently-run local associations as one OSM brand is the existing `ymca.py` spider, `brand=YMCA`). `brand_wikidata` is `Q17022739` ("YWCA USA"), verified against Wikidata to be the correct national entity, distinct from World YWCA (Q643370).

Verified locally: 204 items, all with coordinates, address, and phone; per-branch websites/Facebook pages normalized to include a URL scheme.

One item from the "Childcare chains" checklist in #183 (a multi-brand batch issue; the other two items are being handled separately).