### PR TITLE
[ERIK'S Bike Board & Ski] Add spider

### DIFF
--- a/locations/spiders/eriks_bike_shop_us.py
+++ b/locations/spiders/eriks_bike_shop_us.py
@@ -1,0 +1,42 @@
+import json
+from typing import Any, Iterable
+
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class EriksBikeShopUSSpider(StructuredDataSpider):
+    name = "eriks_bike_shop_us"
+    item_attributes = {"brand": "ERIK'S Bike Board & Ski", "name": "ERIK'S Bike Board & Ski"}
+    allowed_domains = ["www.eriksbikeshop.com"]
+    start_urls = ["https://www.eriksbikeshop.com/pages/our-stores"]
+    wanted_types = ["BikeStore"]
+    time_format = "%I:%M%p"
+    # Site-wide contact details picked up by StructuredDataSpider's generic
+    # email/social discovery, not specific to any one branch.
+    drop_attributes = {"email", "facebook"}
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
+        # The store list/map is rendered client side from a GeoJSON blob
+        # embedded in the page rather than from real <a> links, so the
+        # per-store detail page URLs must be pulled out of this JSON.
+        blob = response.css("store-locator script[type='application/json']::text").get()
+        data = json.loads(blob)
+        for feature in data["locations"]["features"]:
+            properties = feature["properties"]
+            yield response.follow(
+                properties["detailsUrl"],
+                callback=self.parse_sd,
+                meta={"branch": properties.get("name")},
+            )
+
+    def post_process_item(self, item, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Any]:
+        # The JSON-LD "name" is a generic SEO string (e.g. "Bike, Ski and
+        # Snowboard Shop in Bayshore, WI"), not a real location name.
+        item["name"] = None
+        item["branch"] = response.meta.get("branch")
+        apply_category(Categories.SHOP_BICYCLE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for ERIK'S Bike Board & Ski (formerly "Erik's Bike Shop"), a US bike/ski/snowboard retail chain.

The site has moved off vTex (referenced in the original issue) to Shopify since 2017. The store list page (`/pages/our-stores`) embeds a GeoJSON blob of all 35 locations client-side, which is used to enumerate the per-store detail page URLs (`/pages/locations/<slug>`). Each detail page carries standard schema.org `BikeStore` JSON-LD (address, geo, phone, opening hours, payment methods, image), parsed with `StructuredDataSpider`.

Notes:
- Opening hours use 12-hour `am`/`pm` format, handled via `time_format = "%I:%M%p"`.
- The JSON-LD `name` field is a generic SEO string (e.g. "Bike, Ski and Snowboard Shop in Bayshore, WI"), not a real per-location name, so it's replaced with a static brand name plus a `branch` derived from the store list entry (e.g. "Bayshore, WI").
- `email` (`help@eriksbikeshop.com`) and `facebook` are identical across every location (brand-wide contact info, not branch-specific), so they're dropped via `drop_attributes`.
- No Wikidata entity was found for this brand (checked both "Erik's Bike Shop" and "ERIK'S Bike Board & Ski"), and it isn't present in NSI, so `brand_wikidata` is omitted.

Verified locally: 35 items scraped, all with coordinates, addresses, phone numbers, and opening hours populated.

closes #785