### PR TITLE
[Machine Shed] Add spider

### DIFF
--- a/locations/spiders/machine_shed_us.py
+++ b/locations/spiders/machine_shed_us.py
@@ -1,0 +1,28 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MachineShedUSSpider(StructuredDataSpider):
+    name = "machine_shed_us"
+    item_attributes = {"name": "Machine Shed"}
+    start_urls = [
+        "https://machineshed.com/appleton/",
+        "https://machineshed.com/davenport/",
+        "https://machineshed.com/pewaukee/",
+        "https://machineshed.com/rockford/",
+        "https://machineshed.com/urbandale/",
+    ]
+    wanted_types = ["Restaurant"]
+    drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name", "").removeprefix("Machine Shed Restaurant ")
+
+        apply_category(Categories.RESTAURANT, item)
+
+        yield item


### PR DESCRIPTION
The Machine Shed is a small Midwest US restaurant chain (Iowa, Illinois, Wisconsin) with 5 locations, each on its own page at machineshed.com with clean JSON-LD structured data including full address and coordinates. Parses via `StructuredDataSpider` against the 5 known location pages (confirmed complete via the site's `/locations/` page and sitemap). Dropped the shared brand logo `image` field since it's identical across all locations; branch names derived from the JSON-LD `name` field.

No Wikidata entity exists for this brand, so `brand_wikidata` is omitted.

Verified locally: 5 items scraped, all with distinct addresses, coordinates, phone numbers, and opening hours.

closes #794