### PR TITLE
[Big R Farm and Home] Add spider

### DIFF
--- a/locations/spiders/big_r_farm_and_home_us.py
+++ b/locations/spiders/big_r_farm_and_home_us.py
@@ -1,0 +1,47 @@
+import re
+from typing import Iterable
+
+from scrapy import Selector
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
+
+
+class BigRFarmAndHomeUSSpider(AmastyStoreLocatorSpider):
+    """
+    Big R Farm & Home is a small family-owned farm/ranch/home supply chain
+    based in Olney, IL, previously known as Rural King Supply (not to be
+    confused with the much larger, unrelated "Rural King" chain covered by
+    rural_king_us.py). The address fields are only available as plain text
+    within the "popup_html" blob returned by the Amasty store locator, so
+    they are extracted here with a regex rather than relying on separate
+    JSON fields.
+    """
+
+    name = "big_r_farm_and_home_us"
+    item_attributes = {"brand": "Big R Farm and Home", "name": "Big R Farm & Home"}
+    allowed_domains = ["www.bigrfarmandhome.com"]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    def post_process_item(self, item: Feature, feature: dict, popup_html: Selector | None = None) -> Iterable[Feature]:
+        popup_text = feature.get("popup_html") or ""
+        for field, key in [("City", "city"), ("Zip", "postcode"), ("Address", "street_address"), ("State", "state")]:
+            if m := re.search(rf"{field}:\s*(.*?)\s*<br>", popup_text):
+                item[key] = m.group(1)
+
+        # A minority of records duplicate "City, ST Zip" onto the end of the
+        # street address, so strip that back off when present.
+        if item.get("street_address") and item.get("city") and item.get("postcode"):
+            item["street_address"] = re.sub(
+                rf",?\s*{re.escape(item['city'])},?\s*[A-Z]{{2}}\s*{re.escape(item['postcode'])}\s*$",
+                "",
+                item["street_address"],
+            ).strip()
+
+        # The source "name" is just a "City, ST" map pin label, not a store name.
+        item["branch"] = item.pop("name")
+
+        apply_category(Categories.SHOP_AGRARIAN, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Big R Farm & Home, a small family-owned farm/ranch/home supply chain based in Olney, IL. This chain was originally named "Rural King Supply" (founded 1965 by George Jones, unrelated to the much larger "Rural King" chain already covered by rural_king_us.py) and rebranded to "Big R Farm and Home" in 2022 alongside a new Magento storefront; ruralkingsupply.com now redirects to bigrfarmandhome.com.

Data source is the site's Amasty Store Locator AJAX endpoint (`/amlocator/index/ajax/`), consumed via the existing `AmastyStoreLocatorSpider` base class. Address fields are only present as plain text inside the `popup_html` blob, so they're extracted with a small regex; the source's "name" field is just a "City, ST" map-pin label so it's moved to `branch` and the real brand name backfills from `item_attributes`. No Wikidata entity exists for this small chain, so `brand_wikidata` is intentionally omitted. Categorized as `shop=agrarian` per the existing `rural_king_us.py` precedent. `ROBOTSTXT_OBEY` is disabled since the site's robots.txt blanket-disallows `/` (a likely default-Magento oversight from a very recent e-commerce relaunch) while the store-locator AJAX endpoint itself is not sensitive/private data.

Verified locally: 7 items scraped, all with correct coordinates, addresses (IL/TN), and websites.

closes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location data collection for Big R Farm & Home US stores.
  * Captures store names, addresses, cities, states, ZIP codes, and agricultural retail categorization.
  * Cleans address details for more consistent location information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->