### PR TITLE
[tollens] Add spider (302 locations)

### DIFF
--- a/locations/spiders/tollens.py
+++ b/locations/spiders/tollens.py
@@ -11,10 +11,11 @@ TOLLENS = {"brand": "Tollens", "brand_wikidata": "Q127515008"}
 ZOLPAN = {"brand": "Zolpan", "brand_wikidata": "Q126875048"}
 
 
-class TollensFRSpider(SitemapSpider, StructuredDataSpider):
-    name = "tollens_fr"
+class TollensSpider(SitemapSpider, StructuredDataSpider):
+    name = "tollens"
     # tollens.com lists the whole Cromology retail network: Tollens and Zolpan
-    # branded stores, plus some co-branded "Tollens Zolpan" ones.
+    # branded stores (plus co-branded "Tollens Zolpan" ones), mostly in France
+    # but also in Poland, Luxembourg, Monaco and the French overseas departments.
     item_attributes = TOLLENS
     sitemap_urls = ["https://www.tollens.com/sitemap.xml"]
     sitemap_rules = [(r"/nos-magasins/[^/]+/[^/]+$", "parse_sd")]
@@ -23,7 +24,11 @@ class TollensFRSpider(SitemapSpider, StructuredDataSpider):
     search_for_facebook = False
 
     def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        name = item.pop("name").removeprefix("Magasin de Peinture ")
+        name = item.pop("name", None)
+        if not isinstance(name, str) or not name.strip():
+            return
+        name = name.removeprefix("Magasin de Peinture ")
+
         lowered = name.lower()
         if "zolpan" in lowered and "tollens" not in lowered:
             item.update(ZOLPAN)

--- a/locations/spiders/tollens_fr.py
+++ b/locations/spiders/tollens_fr.py
@@ -1,0 +1,37 @@
+from typing import Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+TOLLENS = {"brand": "Tollens", "brand_wikidata": "Q127515008"}
+ZOLPAN = {"brand": "Zolpan", "brand_wikidata": "Q126875048"}
+
+
+class TollensFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "tollens_fr"
+    # tollens.com lists the whole Cromology retail network: Tollens and Zolpan
+    # branded stores, plus some co-branded "Tollens Zolpan" ones.
+    item_attributes = TOLLENS
+    sitemap_urls = ["https://www.tollens.com/sitemap.xml"]
+    sitemap_rules = [(r"/nos-magasins/[^/]+/[^/]+$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    # Every store page footer links the same brand-wide page, misattributed on Zolpan stores.
+    search_for_facebook = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        name = item.pop("name").removeprefix("Magasin de Peinture ")
+        lowered = name.lower()
+        if "zolpan" in lowered and "tollens" not in lowered:
+            item.update(ZOLPAN)
+
+        branch = name
+        for prefix in ("Tollens", "Zolpan"):
+            branch = branch.removeprefix(prefix + " ").removeprefix(prefix.upper() + " ")
+        item["branch"] = branch
+
+        apply_category(Categories.SHOP_PAINT, item)
+        yield item


### PR DESCRIPTION
Fixes #18263

Adds `tollens`, covering the Cromology retail network listed on tollens.com (`/nos-magasins`): ~177 Tollens-branded stores and ~125 Zolpan-branded ones, plus co-branded "Tollens Zolpan" locations.

- `SitemapSpider` + `StructuredDataSpider`; store pages carry a clean `LocalBusiness` JSON-LD (address, coordinates, phone, opening hours with split shifts).
- `brand` / `brand:wikidata` are set per store from the store name — Tollens `Q127515008` (default) or Zolpan `Q126875048`; co-branded stores stay Tollens. Cromology is merging the two brands under Tollens.
- No country suffix: most stores are in France, but the same network also lists locations in Poland, Luxembourg, Monaco and the French overseas departments (Réunion, Mayotte), so per `docs/SPIDER_NAMING.md` the spider is left unqualified.
- `search_for_facebook` disabled: every store page footer links the same brand-wide page, misattributed on Zolpan stores.
- `shop=paint` applied.

302 locations scraped, all with address, coordinates, phone and `opening_hours`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Tollens store locations from the company’s website.
  * Added automatic classification of eligible stores as paint shops.
  * Added recognition and branding for Zolpan locations listed within the same network.
  * Excluded store entries without valid names and cleaned branch names for clearer listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->