### PR TITLE
[Romano's Macaroni Grill] Add spider

### DIFF
--- a/locations/spiders/macaroni_grill_us.py
+++ b/locations/spiders/macaroni_grill_us.py
@@ -1,0 +1,20 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class MacaroniGrillUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "macaroni_grill_us"
+    item_attributes = {"brand": "Romano's Macaroni Grill", "brand_wikidata": "Q7362714"}
+    allowed_domains = ["macaronigrill.com"]
+    sitemap_urls = ["https://www.macaronigrill.com/sitemap.xml"]
+    sitemap_rules = [(r"/locations/[-\w]+-[a-z]{2}$", "parse_sd")]
+    wanted_types = ["Restaurant"]
+    drop_attributes = {"email"}
+
+    def post_process_item(self, item: Feature, response, ld_data, **kwargs):
+        apply_category(Categories.RESTAURANT, item)
+        item["extras"]["cuisine"] = "italian"
+        yield item


### PR DESCRIPTION
Adds a spider for Romano's Macaroni Grill, a small US Italian restaurant chain (16 locations remaining after bankruptcy downsizing). Store locations are enumerated via the site's sitemap.xml, and each location detail page (e.g. macaronigrill.com/locations/cerritos-ca) publishes clean Restaurant JSON-LD with address, phone, geo coordinates and opening hours, so this uses SitemapSpider + StructuredDataSpider. Brand Wikidata (Q7362714) and brand string were verified against Wikidata and NSI respectively, and a shared corporate PR-contact email present in every page's JSON-LD is dropped via drop_attributes.

Verified locally: 16 items scraped, all with unique phone numbers, unique refs, coordinates within the continental US, and parsed opening hours. NSI matched all 16 items perfectly (amenity=restaurant, cuisine=italian).

closes #988