### PR TITLE
[Braum's] Add spider

### DIFF
--- a/locations/spiders/braums_us.py
+++ b/locations/spiders/braums_us.py
@@ -1,0 +1,25 @@
+from locations.categories import apply_category
+from locations.hours import DAYS_EN
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class BraumsUSSpider(WPStoreLocatorSpider):
+    name = "braums_us"
+    item_attributes = {"brand": "Braum's", "brand_wikidata": "Q4958263"}
+    allowed_domains = ["www.braums.com"]
+    # Braum's operates only in a handful of states, and the OKC metro area
+    # is dense enough that a country-wide grid at this radius would risk
+    # truncation there, so restrict the grid to the states it operates in.
+    searchable_points_files = ["us_centroids_50mile_radius_state.csv"]
+    area_field_filter = ["OK", "KS", "TX", "MO", "AR"]
+    search_radius = 50
+    max_results = 200
+    days = DAYS_EN
+
+    def post_process_item(self, item: Feature, response, feature: dict):
+        item["branch"] = item.pop("name")
+        apply_category(
+            {"amenity": "fast_food", "shop": "dairy", "cuisine": "ice_cream;burger", "takeaway": "yes"}, item
+        )
+        yield item


### PR DESCRIPTION
Adds a spider for Braum's, a WPStoreLocator-based regional ice cream/dairy/fast-food chain in Oklahoma, Kansas, Texas, Missouri, and Arkansas, using the existing `WPStoreLocatorSpider` base class.

The site's `store_search` AJAX endpoint truncates at `max_results` per query (confirmed via testing — the OKC metro area alone returns 59-69 stores within a 25-50 mile radius), so the spider uses a geographic grid restricted to the five states Braum's operates in (`us_centroids_50mile_radius_state.csv` filtered to OK/KS/TX/MO/AR) rather than a full-country search. This keeps the crawl to ~160 requests instead of searching the whole US.

Verified locally: 331 unique locations scraped (matches the site's "over 300 locations" claim), all matching NSI perfectly (`brand`/`brand:wikidata` verified against Wikidata Q4958263 and NSI's `braums-4d2ff4` entry), addresses/phones/hours all correctly parsed and non-duplicated, no truncation (max single-query result was 67, well under `max_results=200`).

closes #1034