### PR TITLE
[Suburban Propane] Add spider

### DIFF
--- a/locations/spiders/suburban_propane_us.py
+++ b/locations/spiders/suburban_propane_us.py
@@ -1,0 +1,18 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, Fuel, apply_category, apply_yes_no
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SuburbanPropaneUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "suburban_propane_us"
+    item_attributes = {"brand": "Suburban Propane", "brand_wikidata": "Q120122434"}
+    sitemap_urls = ["https://www.suburbanpropane.com/locations-sitemap.xml"]
+    sitemap_rules = [(r"/locations/[^/]+/$", "parse_sd")]
+    # Times in openingHoursSpecification include seconds, e.g. "08:00:00"
+    time_format = "%H:%M:%S"
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_GAS, item)
+        apply_yes_no(Fuel.LPG, item, True)
+        yield item


### PR DESCRIPTION
Adds a spider for Suburban Propane, a US propane fuel distributor with ~770 branch/depot locations nationwide. The original 2019 issue noted a WPStoreLocator admin-ajax.php endpoint, but that endpoint now returns HTTP 400 - the site has since moved to a standard WordPress sitemap (`locations-sitemap.xml`) with LocalBusiness JSON-LD on each location page, so this uses `SitemapSpider` + `StructuredDataSpider` instead. Locations are tagged `shop=gas`/`fuel:lpg=yes` following the existing `mighty_flame.py` precedent for propane/bottled-gas retailers. `time_format` is overridden to `%H:%M:%S` since the source's `openingHoursSpecification` includes seconds.

Verified locally with a full crawl: 769 items, all in the US with valid state codes, coordinates present for all but 9 locations (which lack geo data on the source), and opening hours parsed correctly where published (about a third of locations don't publish hours). Closes #1020.