### PR TITLE
[Sun & Ski Sports] Add spider

### DIFF
--- a/locations/spiders/sun_and_ski_sports_us.py
+++ b/locations/spiders/sun_and_ski_sports_us.py
@@ -1,0 +1,16 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SunAndSkiSportsUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "sun_and_ski_sports_us"
+    item_attributes = {"brand": "Sun & Ski Sports", "brand_wikidata": "Q7638173"}
+    sitemap_urls = ["https://www.sunandski.com/sitemap.xml"]
+    sitemap_rules = [(r"/stores/[^/]+$", "parse_sd")]
+    wanted_types = ["SportingGoodsStore"]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        apply_category(Categories.SHOP_SPORTS, item)
+        yield item


### PR DESCRIPTION
Sun & Ski Sports is a US outdoor/sporting-goods retail chain (Wikidata Q7638173). Each store page (https://www.sunandski.com/stores/<slug>) embeds `SportingGoodsStore` JSON-LD with full address, geo coordinates, phone, per-store email, and structured opening hours, so this uses `SitemapSpider` + `StructuredDataSpider` against the site's sitemap.xml, filtered to bare `/stores/<slug>` URLs (excluding the per-store `bike-shop-services`/`ski-shop-services`/etc. sub-pages also present in the sitemap).

Verified locally with a full run (small brand): 30 items, matching the 30 store slugs in the sitemap. Spot-checked several records — unique phone numbers, unique per-store images, real per-store emails, correctly split address fields, and correctly parsed opening hours across multiple stores.

closes #1002