### PR TITLE
[BELFOR] Add spider

### DIFF
--- a/locations/spiders/belfor_us.py
+++ b/locations/spiders/belfor_us.py
@@ -1,0 +1,48 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Selector, Spider
+from scrapy.http import FormRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+
+
+class BelforUSSpider(Spider):
+    name = "belfor_us"
+    item_attributes = {"brand": "Belfor", "brand_wikidata": "Q4882373"}
+    allowed_domains = ["belfor.com"]
+
+    async def start(self) -> AsyncIterator[FormRequest]:
+        yield FormRequest(
+            url="https://www.belfor.com/us/wp-admin/admin-ajax.php",
+            formdata={"action": "get_markers", "type": "all"},
+        )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        markers = {str(marker["pid"]): marker for marker in response.json()["data"]["markers"]}
+
+        for card in Selector(text=response.json()["data"]["html"]).css("li.location-card"):
+            ref = card.attrib.get("data-id")
+            marker = markers.get(ref, {})
+
+            lat, lon = marker.get("lat"), marker.get("lng")
+            if isinstance(lat, str) and "," in lat:
+                # A handful of locations have their lat/lng values duplicated and
+                # concatenated into a single "lat, lng, lat, lng" string in both fields.
+                lat, lon = (value.strip() for value in lat.split(",")[:2])
+
+            item = DictParser.parse(
+                {
+                    "ref": ref,
+                    "name": card.css(".card-content__title::text").get(default="").strip(),
+                    "address": card.css(".-address .info::text").get(default="").strip().removesuffix(" US"),
+                    "phone": card.css(".-phone a::text").get(),
+                    "lat": lat,
+                    "lon": lon,
+                }
+            )
+            item["website"] = card.css(".card-actions a::attr(href)").get()
+
+            apply_category(Categories.OFFICE_COMPANY, item)
+
+            yield item


### PR DESCRIPTION
BELFOR's original 2019 offices URL now redirects to https://www.belfor.com/us/en/locations/, a WordPress site running the "ds-locations" plugin. Rather than scraping the rendered page, the spider POSTs directly to the plugin's `admin-ajax.php` endpoint (`action=get_markers&type=all`), which returns a single JSON response containing both a `markers` array (id/lat/lng per office) and an `html` fragment with each office's name, full address, phone number, and detail-page URL. The spider merges the two by the shared location ID.

Verified locally with a full run (single request, no crawling needed): 123 US office locations, all with valid coordinates, addresses, phone numbers, and links to per-office pages. One location had a source-data glitch where lat/lng were both populated with a duplicated "lat, lng, lat, lng" string instead of separate values — the spider detects and splits this case rather than dropping the coordinate. Category is `office=company` (matching precedent from `right_at_home_gb.py`, another franchise-office network) since these are corporate/franchise restoration offices, not retail storefronts. Wikidata QID Q4882373 was verified directly against wikidata.org (label "Belfor", description "multinational corporation that focuses on insurance restoration after natural disasters") — BELFOR is not present in NSI.

closes #1006