### PR TITLE
[Sportsman's Warehouse] Add spider

### DIFF
--- a/locations/spiders/sportsmans_warehouse_us.py
+++ b/locations/spiders/sportsmans_warehouse_us.py
@@ -1,0 +1,28 @@
+import re
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SportsmansWarehouseUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "sportsmans_warehouse_us"
+    item_attributes = {"brand": "Sportsman's Warehouse", "brand_wikidata": "Q7579979"}
+    allowed_domains = ["stores.sportsmans.com"]
+    sitemap_urls = ["https://stores.sportsmans.com/sitemap.xml"]
+    sitemap_rules = [(r"^https://stores\.sportsmans\.com/sportsmans-warehouse/us/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    drop_attributes = {"facebook", "twitter"}  # brand's own generic social accounts, not store-specific
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["ref"] = item["website"] = response.url
+
+        # No coordinates are present in the JSON-LD, but the page's embedded
+        # Yext hydration data carries the location's own published pin.
+        if coords := re.search(
+            r'"yextDisplayCoordinate":\{"latitude":([\d.-]+),"longitude":([\d.-]+)\}', response.text
+        ):
+            item["lat"], item["lon"] = coords.groups()
+
+        apply_category(Categories.SHOP_OUTDOOR, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Sportsman's Warehouse (US outdoor/hunting/fishing retail chain, sportsmans.com), Wikidata Q7579979. The primary sportsmans.com domain is behind a Cloudflare managed challenge, but its store-locator widget links out to a separate Yext-hosted directory at stores.sportsmans.com, which is not Cloudflare-protected and exposes a clean sitemap plus per-store JSON-LD (LocalBusiness) structured data. Used SitemapSpider + StructuredDataSpider against that domain, filtering the sitemap to leaf store pages only (excluding state/city index pages and department sub-pages like /fishing-shop which carry no structured data). Coordinates aren't in the JSON-LD, so they're pulled from the page's own embedded Yext hydration data (`yextDisplayCoordinate`), the same pattern already used by the sibling `bass_pro_shops` and `cabelas_us` spiders on the same platform.

Verified locally with a 50-item capped crawl (66 items returned before the cap stopped pending requests, out of ~147 store URLs in the sitemap): all records have distinct phone numbers and distinct store-manager emails (no shared hotline), correct 2-letter state codes, and coordinates within the expected US bounding box. `brand`/`brand_wikidata` match NSI's `brands/shop/outdoor` entry exactly and `apply_category(Categories.SHOP_OUTDOOR, ...)` is used. Confirmed via Wikidata that this is a distinct entity (Q7579979, "Sportsman's Warehouse", US chain) from the existing `sportsmans_warehouse_na_za` spider's brand (Q130485344, "Sportsmans Warehouse", Southern Africa chain) — different companies, different domains, no overlap.

closes #1092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Sportsman’s Warehouse store locations.
  * Store listings now include structured business details, brand and category information, website references, and geographic coordinates.
  * Generic social media links are excluded from location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->