### PR TITLE
[BellStores] Add spider

### DIFF
--- a/locations/spiders/bellstores_us.py
+++ b/locations/spiders/bellstores_us.py
@@ -1,0 +1,73 @@
+import json
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.items import Feature, set_closed
+
+
+class BellstoresUSSpider(Spider):
+    name = "bellstores_us"
+    item_attributes = {"brand": "BellStores", "brand_wikidata": "Q111698204", "name": "BellStores"}
+    start_urls = ["https://bellstores.com/home/locations"]
+
+    # Grades are only labelled ("Regular"/"Midgrade"/"Premium"/etc.), not given explicit octane numbers.
+    unleaded_fuel_keys = (
+        "HasFuelTypeRegular",
+        "HasFuelTypeMidgrade",
+        "HasFuelTypePremium",
+        "HasFuelTypeMid1",
+        "HasFuelTypeSuper2",
+        "HasFuelTypeRec89",
+        "HasFuelTypeRec90",
+    )
+    fast_food_keys = (
+        "HasSubway",
+        "HasDairyQueen",
+        "HasDominosPizza",
+        "HasHuntBrothersPizza",
+        "HasChampsChicken",
+        "HasChampsBreakfast",
+    )
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        # The store finder renders a Google Map from a JS array embedded in the page; there is no separate API.
+        locations_blob = re.search(r"var locations = (\[.*\]);", response.text)
+        for location in json.loads(locations_blob.group(1)):
+            if location["StandAloneStore"]:
+                # These are standalone Subway/Dairy Queen restaurants with no BellStores fuel or convenience
+                # store on site, not BellStores locations themselves.
+                continue
+
+            item = Feature()
+            item["ref"] = item["branch"] = location["Name"]
+            item["street_address"] = location["Address1"]
+            item["city"] = location["City"]
+            item["state"] = location["State"]
+            item["postcode"] = location["Zip"]
+            item["lat"] = location["Latitude"]
+            item["lon"] = location["Longitude"]
+            item["phone"] = location["PhoneNumber"]
+
+            if location["isTemporarilyClosed"]:
+                set_closed(item)
+
+            apply_category(Categories.SHOP_CONVENIENCE, item)
+
+            has_unleaded = any(location[key] for key in self.unleaded_fuel_keys)
+            if has_unleaded or location["HasFuelTypeDiesel"] or location["HasFuelTypeKerosene"]:
+                apply_category(Categories.FUEL_STATION, item)
+
+            apply_yes_no(Fuel.GASOLINE, item, has_unleaded, False)
+            apply_yes_no(Fuel.DIESEL, item, location["HasFuelTypeDiesel"], False)
+            apply_yes_no(Fuel.KEROSENE, item, location["HasFuelTypeKerosene"], False)
+            apply_yes_no(Fuel.ELECTRIC, item, location["HasEvCharging"], False)
+
+            apply_yes_no(Extras.CAR_WASH, item, location["HasCarwash"], False)
+            apply_yes_no(Extras.DRIVE_THROUGH, item, location["HasDriveThru"], False)
+            apply_yes_no(Extras.FAST_FOOD, item, any(location[key] for key in self.fast_food_keys), False)
+
+            yield item


### PR DESCRIPTION
Adds a spider for BellStores, an Ohio convenience store/gas station chain.

Data source is a JS array (`var locations = [...]`) embedded directly in the HTML of https://bellstores.com/home/locations that backs the Google Map on the page, matching the "JavaScript blob" label on the original issue. The array is valid JSON, so it's extracted with a regex and parsed directly.

The locator also includes 11 standalone Subway/Dairy Queen restaurants with no BellStores fuel or convenience store on site (flagged `StandAloneStore: true`, no fuel fields set); these are excluded since they're sibling franchise businesses, not BellStores locations. The remaining 80 combo gas/convenience locations are tagged `shop=convenience` plus `amenity=fuel` when the location has any fuel type, with `fuel:diesel`/`fuel:kerosene`/`fuel:electricity` set from explicit flags and a generic `fuel:gasoline=yes` for unleaded grades (the source only labels grades as "Regular"/"Midgrade"/"Premium"/etc. with no explicit octane numbers, so no octane grade is guessed). One temporarily-closed location is tagged with `set_closed()`.

Verified locally with a full crawl (single page, 80 items): addresses, phone numbers, and coordinates all check out for the Ohio bounding box, and `brand`/`brand:wikidata` match NSI's BellStores entry (`bellstores-147d98`) exactly.

closes #1037