### PR TITLE
[Austin Community College] Add spider

### DIFF
--- a/locations/spiders/austin_community_college_us.py
+++ b/locations/spiders/austin_community_college_us.py
@@ -1,0 +1,82 @@
+import re
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+
+# "City, TX 78701" or "City, Texas 78701" - the site is inconsistent about
+# abbreviating the state, so match both and just hardcode "TX" ourselves
+# below since every campus is in Central Texas.
+CITY_STATE_ZIP = re.compile(r"^(?P<city>[A-Za-z .]+),\s*(?:TX|Texas)\s+(?P<postcode>\d{5})$")
+
+
+class AustinCommunityCollegeUSSpider(Spider):
+    name = "austin_community_college_us"
+    item_attributes = {
+        "brand": "Austin Community College District",
+        "brand_wikidata": "Q3629946",
+        "state": "TX",
+    }
+    start_urls = [
+        "https://www.austincc.edu/campuses/cypress-creek/",
+        "https://www.austincc.edu/campuses/eastview-campus/",
+        "https://www.austincc.edu/campuses/elgin-campus/",
+        "https://www.austincc.edu/campuses/hays-campus/",
+        "https://www.austincc.edu/campuses/highland-campus/",
+        "https://www.austincc.edu/campuses/acc-lockhart/",
+        "https://www.austincc.edu/campuses/northridge-campus/",
+        "https://www.austincc.edu/campuses/rio-grande-campus/",
+        "https://www.austincc.edu/campuses/riverside-campus/",
+        "https://www.austincc.edu/campuses/round-rock-campus/",
+        "https://www.austincc.edu/campuses/san-gabriel-campus/",
+        "https://www.austincc.edu/campuses/south-austin-campus/",
+    ]
+
+    def parse(self, response: Response):
+        item = Feature()
+        item["ref"] = response.url
+        item["website"] = response.url
+        item["branch"] = " ".join(response.xpath("//h1//text()").getall()).strip()
+
+        contact_lines = [
+            line.strip()
+            for line in response.xpath(
+                '//h3[normalize-space(text())="Contact"]/parent::div/following-sibling::p[1]//text()'
+            ).getall()
+            if line.strip() and line.strip() != "Map"
+        ]
+        if not contact_lines:
+            # Page doesn't follow the usual template; skip rather than yield a broken item.
+            return
+
+        item["phone"] = contact_lines[-1]
+        addr_lines = contact_lines[:-1]
+
+        if len(addr_lines) == 2 and (city_state_zip := CITY_STATE_ZIP.match(addr_lines[1])):
+            item["street_address"] = addr_lines[0]
+            item["city"] = city_state_zip.group("city")
+            item["postcode"] = city_state_zip.group("postcode")
+        else:
+            # e.g. the Lockhart Center's address doesn't split cleanly into a
+            # single street line and a "City, TX ZIP" line, so fall back to
+            # an unsplit address rather than forcing an incorrect split.
+            item["addr_full"] = ", ".join(addr_lines)
+            if postcode := re.search(r"(\d{5})$", addr_lines[-1]):
+                item["postcode"] = postcode.group(1)
+
+        hours_lines = response.xpath(
+            '//h3[normalize-space(text())="Hours"]/parent::div/following-sibling::p[1]//text()'
+        ).getall()
+        hours_text = re.sub(r"\s+", " ", " ".join(line.strip() for line in hours_lines)).strip()
+        if hours_text and "class" not in hours_text.lower():
+            # "Noon" isn't recognised by OpeningHours' named times, but "Midday" is.
+            oh = OpeningHours()
+            oh.add_ranges_from_string(hours_text.replace("Noon", "Midday"))
+            item["opening_hours"] = oh
+
+        apply_category(Categories.COLLEGE, item)
+
+        yield item


### PR DESCRIPTION
Adds a spider for Austin Community College District (12 campuses across Central Texas), verified against the current live site (the issue's linked page from 2019 now redirects to https://www.austincc.edu/campuses/, which still lists the same set of campuses plus a Lockhart extension center).

Each campus page has no structured data (JSON-LD is present but only on an unrelated `VideoObject` block that happens to embed the contact info as plain transcript text, not a typed `LocalBusiness`/`EducationalOrganization`), so the spider scrapes the "Contact" and "Hours" blocks directly from the rendered HTML of the 12 known campus pages. Address, phone, and opening hours parse cleanly for 11 of the 12 campuses; the Lockhart Center (co-located with a high school) has a differently-shaped address line and no real operating hours, so it falls back to `addr_full` and skips `opening_hours` rather than forcing an incorrect split. No coordinates are available: the only map links on these pages are `maps.app.goo.gl` short links to a Google Maps place, which per repo convention are geocode results and not safe to extract coordinates from, so `lat`/`lon` are left unset.

Verified locally with a full run (`uv run scrapy runspider locations/spiders/austin_community_college_us.py`) — all 12 items scraped successfully with `amenity=college`, brand/brand_wikidata (`Q3629946`), address, phone, and opening hours (where available).

closes #1023