### PR TITLE
[Yancey Rents] Add spider

### DIFF
--- a/locations/spiders/yancey_rents_us.py
+++ b/locations/spiders/yancey_rents_us.py
@@ -1,0 +1,31 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS_EN
+from locations.items import Feature
+from locations.storefinders.wp_store_locator import WPStoreLocatorSpider
+
+
+class YanceyRentsUSSpider(WPStoreLocatorSpider):
+    name = "yancey_rents_us"
+    item_attributes = {"brand": "Yancey Rents", "name": "Yancey Rents"}
+    allowed_domains = ["www.yanceybros.com"]
+    days = DAYS_EN
+    requires_proxy = True
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        # The store locator covers every Yancey Bros Co division (equipment
+        # sales, hydraulics, power systems, bus sales, etc.), and a "rents"
+        # category is also applied to some non-Yancey Rents branches that
+        # merely also offer rental services, so filter on the branded name.
+        if not item["name"].startswith("Yancey Rents"):
+            return
+        item["branch"] = item["name"].rsplit("–", 1)[-1].strip()
+        item["name"] = None
+        # The "url" field is usually a Google review short link rather than
+        # the branch's own page, so use the permalink for the website field.
+        item["website"] = feature.get("permalink") or item["website"]
+        apply_category(Categories.SHOP_PLANT_HIRE, item)
+        yield item


### PR DESCRIPTION
Yancey Rents' original standalone site (yanceyrents.com) now just redirects to a dealer page on Caterpillar's "Cat Rental Store" platform. The current online presence for individual branches lives on yanceybros.com (the parent Cat dealer, Yancey Bros. Co.), which runs the WP Store Locator plugin's `admin-ajax.php?action=store_search&autoload=1` endpoint — an existing `WPStoreLocatorSpider` storefinder in this repo.

That endpoint is shared across every Yancey Bros division (equipment sales, hydraulics, power systems, bus sales, etc.), so `post_process_item` filters to only the branded "Yancey Rents" entries and tags them `shop=plant_hire`. It also swaps the `website` field to the branch's own permalink, since the source's `url` field is usually a Google review short link rather than the branch's page. No matching Wikidata entity exists for "Yancey Rents" or "Yancey Bros", so `brand_wikidata` is omitted.

Verified locally with a full run (single API call, no pagination needed): 17 items, all in Georgia, each with a distinct address/phone/opening_hours.

closes #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Yancey Rents US branch locations.
  * Listings are limited to relevant rental branches and include branch names, website links, and shop plant hire categorization.
  * Location data is gathered through the required proxy connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->