### PR TITLE
[Brown University] Add spider

### DIFF
--- a/locations/spiders/brown_university_us.py
+++ b/locations/spiders/brown_university_us.py
@@ -1,0 +1,32 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.arcgis_feature_server import ArcGISFeatureServerSpider
+
+
+class BrownUniversityUSSpider(ArcGISFeatureServerSpider):
+    name = "brown_university_us"
+    item_attributes = {"operator": "Brown University", "operator_wikidata": "Q49114", "state": "RI"}
+    host = "services1.arcgis.com"
+    context_path = "HMLBxPKXzqtpFXfq/ArcGIS"
+    service_id = "Active_Buildings_2_view"
+    layer_id = "0"
+    # Excludes a lone parking structure sharing this layer, and a handful of
+    # "Pre-active" records (sheds/dugouts/press boxes tied to sports fields
+    # that aren't yet in active use) that aren't distinct mappable buildings.
+    where_query = "Property_Type = 'Building' AND Property_Status = 'Active'"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item.pop("geometry", None)
+        item["lat"] = feature["lat"]
+        item["lon"] = feature["lon"]
+        item["ref"] = feature["Property_Code"]
+        item["name"] = feature["Property_Name"]
+        item["street_address"] = feature["Address_Line_1"]
+        item["city"] = "Providence"
+        item["postcode"] = feature["ZIP_code"]
+        apply_category(Categories.UNIVERSITY, item)
+        yield item


### PR DESCRIPTION
Brown's old JS-driven campus map (linked from the issue) now redirects to an ArcGIS Experience Builder app (https://experience.arcgis.com/experience/dc278deab79e4fcaa875a81a1732e13e), which loads its "Buildings" layer from a public ArcGIS FeatureServer (`Active_Buildings_2_view`) hosted by Brown's facilities GIS. This layer exposes rich per-building attributes (name, address, ZIP, explicit lat/lon fields) directly as GeoJSON, so this uses the existing `ArcGISFeatureServerSpider` storefinder base class rather than any custom scraping.

The `where_query` filters to `Property_Type = 'Building' AND Property_Status = 'Active'`, which excludes a single parking-structure record sharing the layer and ~21 "Pre-active" records (sheds/dugouts/press boxes tied to sports fields that aren't distinct mappable buildings). Verified locally with a full uncapped run: 241 items, all with coordinates, names, street addresses and postcodes populated, and coordinates falling within Providence, RI as expected. Wikidata QID Q49114 was verified directly against wikidata.org (label/description confirm "Brown University, private university in Providence, Rhode Island").

closes #1190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Brown University building locations to the location directory.
  * Includes active building records while excluding inactive and non-building properties.
  * Classified imported locations under the university category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->