### PR TITLE
[Quicklee's] Add spider

### DIFF
--- a/locations/spiders/quicklees_us.py
+++ b/locations/spiders/quicklees_us.py
@@ -1,0 +1,22 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class QuickleesUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "quicklees_us"
+    item_attributes = {"name": "Quicklee's", "brand": "Quicklee's"}
+    sitemap_urls = ["https://quicklees.com/sitemap.xml"]
+    sitemap_rules = [(r"/locations/[^/]+$", "parse_sd")]
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        item["ref"] = ld_data.get("@id") or response.url
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+        apply_category(Categories.FUEL_STATION, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Quicklee's, an Indiana... actually a Rochester/upstate New York-based convenience store and gas station chain (closes #3467).

Data source: each of the 14 store pages listed in the site's `store_location_sitemap.xml` publishes a schema.org `LocalBusiness` JSON-LD block with name, address, phone, geo coordinates, and structured `openingHoursSpecification` — no bot protection or JS rendering needed. Used `SitemapSpider` + `StructuredDataSpider`. The site's own `name` field is the store's local identifier (e.g. "Gates", "Avon Travel Center") rather than the brand, so it's moved to `branch` and the brand name is set statically via `item_attributes`. `ref` uses the source's Google Place ID from the JSON-LD `@id` field, falling back to the page URL for the one location missing it. No Wikidata entity or NSI brand entry exists for this brand, so `brand_wikidata` is omitted.

Verified locally: all 14 locations crawled successfully with correct addresses, phone numbers, coordinates, and per-location opening hours (which genuinely vary store to store, including a couple of 24-hour travel-center locations). Postcode isn't published by the source for any location, so it's left blank rather than guessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location data collection for Quicklee’s U.S. stores.
  * Captures store names, page references, and classifies locations as convenience stores and fuel stations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->