### PR TITLE
Also trigger add-spider workflow when new-spider label is added after issue creation

### DIFF
--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -2,7 +2,7 @@ name: Add spider from issue
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   contents: write
@@ -12,7 +12,9 @@ permissions:
 
 jobs:
   add-spider:
-    if: contains(github.event.issue.labels.*.name, 'new-spider')
+    if: |
+      contains(github.event.issue.labels.*.name, 'new-spider') &&
+      (github.event.action == 'opened' || github.event.label.name == 'new-spider')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## Summary
- The \`new-spider\` label didn't exist in the repo, so the "New Spider" issue template's \`labels: new-spider\` field was silently failing to apply it on every past issue (GitHub drops template labels that don't exist rather than erroring) — created the label separately to fix that going forward
- Widens the add-spider workflow's trigger to \`[opened, labeled]\` so an issue that gets labeled \`new-spider\` after the fact (like already-open issues, or a manually-labeled one) also fires the workflow, not just brand-new issues that already carry the label at creation