### PR TITLE
Make add-spider workflow act autonomously instead of waiting for confirmation

### DIFF
--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           prompt: |
             Follow the instructions in .claude/agents/add-spider.md exactly to research and
             build a new spider for issue #${{ github.event.issue.number }} in this repository.
@@ -35,3 +36,4 @@ jobs:
           claude_args: |
             --max-turns 100
             --allowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,TodoWrite"
+            --append-system-prompt "You are running fully unattended in a GitHub Actions job. There is no human present to ask for confirmation or approval at any point. Do not pause, ask a clarifying question, or describe what you would do instead of doing it — carry out the entire task yourself, including running shell commands, editing files, committing, pushing branches, and opening the pull request, exactly as instructed in the prompt and in .claude/agents/add-spider.md."


### PR DESCRIPTION
## Summary
- The first real run (issue #18295) finished in 2 turns and 8 seconds without touching any tools or opening a PR. Automation mode uses the same default Claude Code system prompt as interactive sessions, including guidance to check with the user before risky actions - but an unattended run has no user to check with. Adds an appended system prompt making explicit that this run is unattended and should act through the whole task rather than pause or describe what it would do.
- Also sets show_full_output to true so future runs show what Claude did in the workflow log. It was hidden by default, which is why the first run showed no output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Automation**
  * Improved automated issue processing with more detailed action output.
  * Added instructions for unattended execution without requiring confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->