### PR TITLE
Convert potbelly_sandwich_shop and sdi_broker_bg to SitemapSpider

### DIFF
--- a/locations/spiders/potbelly_sandwich_shop.py
+++ b/locations/spiders/potbelly_sandwich_shop.py
@@ -1,27 +1,30 @@
 import re
 
 import scrapy
-from scrapy.spiders import Spider
+from scrapy.spiders import SitemapSpider
+from scrapy.spiders.sitemap import iterloc
+from scrapy.utils.sitemap import Sitemap
 
 from locations.hours import OpeningHours
 from locations.items import Feature
 
 
-class PotbellySandwichShopSpider(Spider):
+class PotbellySandwichShopSpider(SitemapSpider):
     name = "potbelly_sandwich_shop"
     item_attributes = {"brand": "Potbelly", "brand_wikidata": "Q7234777"}
     allowed_domains = ["www.potbelly.com", "api.prod.potbelly.com"]
-    start_urls = [
+    sitemap_urls = [
         "https://www.potbelly.com/sitemap_locations.xml",
     ]
 
-    def parse(self, response):
-        response.selector.remove_namespaces()
-        for url in response.xpath("//loc/text()").extract():
+    def _parse_sitemap(self, response):
+        # Location pages are never fetched: the API can be queried directly using a
+        # slug parsed out of each sitemap URL, so bypass the default per-URL requests.
+        for url in iterloc(Sitemap(self._get_sitemap_body(response))):
             if m := re.search("/locations/[^/]+/([^/]+)", url):
                 slug = m[1]
-                url = f"https://api.prod.potbelly.com/v1/restaurants/byslug/{slug}?includeHours=true"
-                yield scrapy.Request(url, callback=self.parse_store)
+                api_url = f"https://api.prod.potbelly.com/v1/restaurants/byslug/{slug}?includeHours=true"
+                yield scrapy.Request(api_url, callback=self.parse_store)
 
     def parse_store(self, response):
         store = response.json()

--- a/locations/spiders/sdi_broker_bg.py
+++ b/locations/spiders/sdi_broker_bg.py
@@ -2,27 +2,23 @@ import json
 import re
 from typing import Any, Iterable
 
-from scrapy import Spider
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.hours import OpeningHours
 from locations.items import Feature
 
 
-class SdiBrokerBGSpider(Spider):
+class SdiBrokerBGSpider(SitemapSpider):
     """Spider for SDI Broker (Bulgaria) insurance offices.
     Closes #5915
     """
 
     name = "sdi_broker_bg"
     item_attributes = {"brand": "SDI Broker", "brand_wikidata": "Q65224484"}
-    start_urls = ["https://www.sdi.bg/sitemap.xml"]
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for url in response.xpath("//url/loc/text() | //*[local-name()='loc']/text()").getall():
-            if re.match(r"https://www\.sdi\.bg/offices/[a-z].*\.html$", url):
-                yield response.follow(url, callback=self.parse_city)
+    sitemap_urls = ["https://www.sdi.bg/sitemap.xml"]
+    sitemap_rules = [(r"https://www\.sdi\.bg/offices/[a-z].*\.html$", "parse_city")]
 
     def parse_city(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
         m = re.search(r"var offices\s*=\s*(\[[\s\S]*?\]);", response.text)


### PR DESCRIPTION
Part of #18304.

Converts two of the three remaining spiders that manually parsed `sitemap.xml` via XPath (`/loc/text()`) to use scrapy's `SitemapSpider` instead:

- `potbelly_sandwich_shop`: uses `SitemapSpider._parse_sitemap` override (the same idiom already used by `kroger_us`) since the API is queried directly by slug and the sitemap location pages themselves are never fetched.
- `sdi_broker_bg`: uses standard `sitemap_rules` matching, since each matched sitemap URL is already fetched and parsed by `parse_city`.

`amc_theatres_us.py` is intentionally left unconverted: its "sitemap" embeds full theatre data (address, lat/lon, ref) as `<PageMap><DataObject><Attribute name="...">` elements alongside `<loc>`. Scrapy's built-in `Sitemap` parser only captures direct child elements of `<url>` by tag name, so it can't see into the nested `PageMap`/`DataObject`/`Attribute` structure, and even if it could, repeated `Attribute` tags with different `name=` attributes would collide in the resulting dict (only the last one would survive). Converting this spider to `SitemapSpider` would silently drop the theatre data it currently reads out of the sitemap. Manual XPath parsing is intentional here since this isn't really being used as a URL discovery sitemap, it's a structured per-theatre data feed shaped like one.

Verified both conversions with `scrapy parse` against the live sitemaps, comparing the request URLs and yielded items against the previous implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved collection of Potbelly Sandwich Shop location data from sitemap listings.
  * Improved collection of SDI Broker office locations by routing valid office pages directly for processing.
  * Reduced unnecessary page requests, helping location information update more efficiently and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->