### PR TITLE
Convert apina_jp, pls_us, and GoReview spiders to CrawlSpider

### DIFF
--- a/locations/spiders/apina_jp.py
+++ b/locations/spiders/apina_jp.py
@@ -1,8 +1,9 @@
 import re
 from typing import Any, Iterable
 
-from scrapy import Spider
 from scrapy.http import Request, Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.google_url import url_to_coords
@@ -14,7 +15,7 @@ DAY_CHARS = {"月": "Mo", "火": "Tu", "水": "We", "木": "Th", "金": "Fr", "�
 DAY_RANGE = re.compile(r"([月火水木金土日])-([月火水木金土日])")
 
 
-class ApinaJPSpider(Spider):
+class ApinaJPSpider(CrawlSpider):
     name = "apina_jp"
     item_attributes = {"brand": "アピナ", "brand_wikidata": "Q55385192"}
     allowed_domains = ["www.kyowa-corp.co.jp"]
@@ -22,13 +23,10 @@ class ApinaJPSpider(Spider):
     # Apina locations are pure bowling alleys or batting centres with no
     # amusement arcade on site, and those are out of scope for this spider.
     start_urls = ["https://www.kyowa-corp.co.jp/am/shop/?s=&howcat%5B%5D=amusement"]
-
-    def parse(self, response: Response, **kwargs: Any) -> Iterable[Request]:
-        for href in response.css("div.cont-lst a.item::attr(href)").getall():
-            yield response.follow(href, callback=self.parse_store)
-
-        if next_page := response.css("a.nextpostslink::attr(href)").get():
-            yield response.follow(next_page, callback=self.parse)
+    rules = [
+        Rule(LinkExtractor(restrict_css="div.cont-lst a.item"), callback="parse_store"),
+        Rule(LinkExtractor(restrict_css="a.nextpostslink"), follow=True),
+    ]
 
     def parse_store(self, response: Response, **kwargs: Any) -> Iterable[Feature | Request]:
         name = response.css("h2.cont-ttl span::text").get()

--- a/locations/spiders/colcacchio.py
+++ b/locations/spiders/colcacchio.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy.http import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.storefinders.go_review import GoReviewSpider
 
 
@@ -11,16 +6,6 @@ class ColcacchioSpider(GoReviewSpider):
     item_attributes = {"brand": "Col'Cacchio Pizzeria", "brand_wikidata": "Q25613087"}
     start_urls = ["https://colcacchio.goreview.co.za/"]
     skip_auto_cc_domain = True
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)
 
     def post_process_item(self, item, response):
         item["branch"] = item["branch"].replace("Col'Cacchio ", "")

--- a/locations/spiders/hudsons_za.py
+++ b/locations/spiders/hudsons_za.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.categories import Categories
 from locations.storefinders.go_review import GoReviewSpider
 
@@ -15,16 +10,6 @@ class HudsonsZASpider(GoReviewSpider):
         "extras": Categories.RESTAURANT.value,
     }
     start_urls = ["https://hudsons.goreview.co.za/"]
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)
 
     def post_process_item(self, item, response):
         item["branch"] = item["branch"].replace("Hudsons ", "")

--- a/locations/spiders/kauai_za.py
+++ b/locations/spiders/kauai_za.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.storefinders.go_review import GoReviewSpider
 
 
@@ -10,16 +5,6 @@ class KauaiZASpider(GoReviewSpider):
     name = "kauai_za"
     item_attributes = {"brand": "Kauai", "brand_wikidata": "Q116498799"}
     start_urls = ["https://kauai.goreview.co.za/store-locator"]
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)
 
     def post_process_item(self, item, response):
         item["branch"] = item["branch"].replace("KAUAI ", "")

--- a/locations/spiders/moo_moo_za.py
+++ b/locations/spiders/moo_moo_za.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy.http import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.storefinders.go_review import GoReviewSpider
 
 
@@ -10,16 +5,6 @@ class MooMooZASpider(GoReviewSpider):
     name = "moo_moo_za"
     item_attributes = {"brand": "Moo Moo Meet & Whine", "brand_wikidata": "Q130378128"}
     start_urls = ["https://moomoo.goreview.co.za/"]
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)
 
     def post_process_item(self, item, response):
         item["branch"] = item["branch"].replace("Moo Moo ", "")

--- a/locations/spiders/nu_za.py
+++ b/locations/spiders/nu_za.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy.http import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.storefinders.go_review import GoReviewSpider
 
 
@@ -10,16 +5,6 @@ class NuZASpider(GoReviewSpider):
     name = "nu_za"
     item_attributes = {"brand": "Nü Health Food", "brand_wikidata": "Q130400175"}
     start_urls = ["https://nu.goreview.co.za/store-locator/"]
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)
 
     def post_process_item(self, item, response):
         item["branch"] = item["branch"].replace("Nü Health Food ", "")

--- a/locations/spiders/ocean_basket_1.py
+++ b/locations/spiders/ocean_basket_1.py
@@ -1,8 +1,3 @@
-from typing import AsyncIterator
-
-from scrapy.http import Request
-from scrapy.linkextractors import LinkExtractor
-
 from locations.storefinders.go_review import GoReviewSpider
 
 OCEAN_BASKET_SHARED_ATTRIBUTES = {"brand": "Ocean Basket", "brand_wikidata": "Q62075311"}
@@ -28,13 +23,3 @@ class OceanBasket1Spider(GoReviewSpider):
         "https://obqa.goreview.co.za/store-locator",
         "https://obmt.goreview.co.za/store-locator/goreview/default",
     ]
-
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            yield Request(url=url, callback=self.fetch_store)
-
-    def fetch_store(self, response):
-        links = LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$").extract_links(response)
-        for link in links:
-            store_page_url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
-            yield Request(url=store_page_url, callback=self.parse)

--- a/locations/spiders/pls_us.py
+++ b/locations/spiders/pls_us.py
@@ -1,10 +1,13 @@
 from urllib.parse import urlparse
 
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
 from locations.categories import Categories
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class PlsUSSpider(StructuredDataSpider):
+class PlsUSSpider(CrawlSpider, StructuredDataSpider):
     name = "pls_us"
     allowed_domains = ["pls247.com"]
     item_attributes = {
@@ -16,6 +19,10 @@ class PlsUSSpider(StructuredDataSpider):
         f"https://pls247.com/{state}/elements/content_boxes/stores_ajax.html"
         for state in ["az", "ca", "il", "in", "ky", "ma", "ny", "nc", "oh", "ok", "tx", "wi"]
     ]
+    rules = [
+        Rule(LinkExtractor(restrict_xpaths="//a[@class='row-i']"), callback="parse_sd"),
+        Rule(LinkExtractor(restrict_xpaths="//span[text()='Next']/.."), follow=True),
+    ]
     search_for_facebook = False
     search_for_image = False
     time_format = "%I:%M %p"
@@ -23,13 +30,6 @@ class PlsUSSpider(StructuredDataSpider):
     def pre_process_data(self, ld_data):
         for i, hr in enumerate(ld_data.get("openingHours", [])):
             ld_data["openingHours"][i] = hr.replace("—", "-")
-
-    def parse(self, response):
-        for link in response.xpath("//a[@class='row-i']/@href").getall():
-            yield response.follow(link, callback=self.parse_sd)
-
-        if next_url := response.xpath("//span[text()='Next']/../@href").get():
-            yield response.follow(next_url)
 
     def post_process_item(self, item, response, ld_data):
         item["state"] = urlparse(response.url).path.split("/")[1].upper()

--- a/locations/storefinders/go_review.py
+++ b/locations/storefinders/go_review.py
@@ -27,15 +27,26 @@ class GoReviewSpider(CrawlSpider):
         Rule(
             LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/store-information.+$"),
             callback="parse",
-        )
+        ),
+        # Some sites only link to the "goreview/default" landing page for a
+        # store rather than directly to "store-information"; rewrite those
+        # links to the store-information URL before following them.
+        Rule(
+            LinkExtractor(allow=r"^https:\/\/.+\.goreview\.co\.za\/goreview\/default$"),
+            process_links="process_goreview_default_links",
+            callback="parse",
+        ),
     ]
     days: dict = DAYS_EN
 
     async def start(self) -> AsyncIterator[Request]:
-        if len(self.start_urls) != 1:
-            raise ValueError("Specify one URL in the start_urls list attribute.")
-            return
-        yield Request(url=self.start_urls[0])
+        for url in self.start_urls:
+            yield Request(url=url)
+
+    def process_goreview_default_links(self, links: list) -> list:
+        for link in links:
+            link.url = link.url.replace("goreview.co.za/goreview/default", "goreview.co.za/store-information")
+        return links
 
     def parse(self, response: TextResponse) -> Iterable[Feature]:
         item = Feature()


### PR DESCRIPTION
Part of #18305.

Converts a handful of spiders that manually re-implement CrawlSpider's link-following to use `CrawlSpider`/`Rule`/`LinkExtractor` instead:

- `apina_jp` and `pls_us`: classic two-level list-page-with-pagination -> detail-page pattern, now expressed as two `Rule`s each (matching the existing idiom used by `allsaints.py`/`ann_summers_gb.py`).
- `locations/storefinders/go_review.py` (the shared `GoReviewSpider` base used by 8 spiders): six subclasses (`colcacchio`, `hudsons_za`, `kauai_za`, `moo_moo_za`, `nu_za`, `ocean_basket_1`) each duplicated an identical manual `start()`/`fetch_store()` override to work around store-locator pages linking to a `goreview/default` landing page instead of directly to `store-information`. Added a second default `Rule` to the base class (using `process_links` to rewrite the URL) so the base class's own `CrawlSpider` rules handle this case, and removed the now-redundant per-spider overrides.

Verified locally with capped crawls (`CLOSESPIDER_ITEMCOUNT`) for `apina_jp`, `pls_us`, `kauai_za`, and `ocean_basket_1` (which covers the multi-country/edge-case start URL) — items parse correctly with the same shape as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved location discovery across multiple starting pages.
  * Added more reliable handling of store-directory links and pagination.
  * Expanded support for automatically finding and processing store information pages.

* **Bug Fixes**
  * Improved branch-name cleanup for several South African listings by removing unnecessary brand prefixes.
  * Increased consistency when collecting locations from supported store finders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->