### PR TITLE
Stop duplicating structured address fields into addr_full in a few spiders

### DIFF
--- a/locations/spiders/crew_carwash_us.py
+++ b/locations/spiders/crew_carwash_us.py
@@ -54,16 +54,6 @@ class CrewCarwashUSSpider(scrapy.Spider):
             lat = acf.get("latitude") or acf.get("lat") or acf.get("latitude")
             lon = acf.get("longitude") or acf.get("lng") or acf.get("longitude")
 
-            addr_parts = []
-            if acf.get("street_address"):
-                addr_parts.append(acf.get("street_address"))
-            if acf.get("city"):
-                addr_parts.append(acf.get("city"))
-            if acf.get("state"):
-                addr_parts.append(acf.get("state"))
-            if acf.get("zip_code"):
-                addr_parts.append(acf.get("zip_code"))
-
             opening_hours = self.parse_hours(acf.get("hours") or "")
 
             properties = {
@@ -72,7 +62,10 @@ class CrewCarwashUSSpider(scrapy.Spider):
                 "lon": lon,
                 "website": row.get("link") or acf.get("location_link"),
                 "name": row.get("title", {}).get("rendered"),
-                "addr_full": ", ".join(addr_parts) if addr_parts else None,
+                "street_address": acf.get("street_address"),
+                "city": acf.get("city"),
+                "state": acf.get("state"),
+                "postcode": acf.get("zip_code"),
                 "phone": acf.get("phone_number") or acf.get("phone"),
                 "opening_hours": opening_hours,
             }

--- a/locations/spiders/easy_point_tr.py
+++ b/locations/spiders/easy_point_tr.py
@@ -51,7 +51,6 @@ class EasyPointTRSpider(Spider):
             d["state"] = item["city"]  # province/il in Turkish
             d["city"] = item["district"]  # district/ilçe in Turkish
             d["street_address"] = item["muhaberatAddress1"]
-            d["addr_full"] = f"{item['muhaberatAddress1']} {item['district']} {item['city']}"
             d["extras"]["addr:neighborhood"] = item["region"]  # mahalle in Turkish
             d["extras"]["addr:desc"] = item["pointAddressDefinition"]
 

--- a/locations/spiders/pudo_tr.py
+++ b/locations/spiders/pudo_tr.py
@@ -16,15 +16,12 @@ class PudoTRSpider(scrapy.Spider):
             d["name"] = f"{self.item_attributes['brand']} {item['name']}"
             d["state"] = item["city"]  # this is province / il in Turkish
             d["city"] = item["county"]  # this is district / ilçe in Turkish
+            d["street_address"] = item["addressText"]
             neighborhood = item["district"]
             addr_desc = item["addressDescription"]
 
-            # if no neighborhood, address text only contains ilçe and il
             if neighborhood:
-                d["addr_full"] = f"{item['addressText']} {item['county']} {item['city']}"
                 d.set_tag("addr:neighborhood", neighborhood)  # mahalle in Turkish
-            else:
-                d["addr_full"] = item["addressText"]
 
             if addr_desc and addr_desc != neighborhood:
                 d.set_tag("addr:desc", addr_desc)

--- a/locations/spiders/rural_king_us.py
+++ b/locations/spiders/rural_king_us.py
@@ -94,7 +94,7 @@ class RuralKingUSSpider(Spider):
         properties = {
             "ref": store.get("uniqueID"),
             "name": "Rural King",
-            "addr_full": " ".join(store.get("addressLine", [])),
+            "street_address": " ".join(store.get("addressLine", [])),
             "city": store.get("city"),
             "state": store.get("stateOrProvinceName"),
             "postcode": store.get("postalCode", "").strip(),

--- a/locations/spiders/sok_tr.py
+++ b/locations/spiders/sok_tr.py
@@ -6,7 +6,7 @@ from scrapy.http import Request
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import clean_address, merge_address_lines
+from locations.pipelines.address_clean_up import clean_address
 
 PROVINCES_URL = "https://kurumsal.sokmarket.com.tr/ajax/servis/sehirler"
 DISTRICTS_URL = "https://kurumsal.sokmarket.com.tr/ajax/servis/ilceler?city={province}"
@@ -49,8 +49,7 @@ class SokTRSpider(Spider):
             item["city"] = response.meta["district"]
             item["country"] = "TR"
             item["phone"] = store.get("phone")
-            item["street_address"] = clean_address(store["address"])
-            item["addr_full"] = merge_address_lines([item["street_address"], item["city"], item["state"]])
+            item["street_address"] = clean_address(item.pop("addr_full", store["address"]))
             apply_category(Categories.SHOP_SUPERMARKET, item)
 
             yield item

--- a/locations/spiders/youngs_gb.py
+++ b/locations/spiders/youngs_gb.py
@@ -5,7 +5,6 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class YoungsGBSpider(scrapy.Spider):
@@ -25,7 +24,6 @@ class YoungsGBSpider(scrapy.Spider):
                 data.get("pubExternalUrl").replace("https://https://", "https://").replace("http://", "https://")
             )
             item["branch"] = data.get("venueName")
-            item["addr_full"] = merge_address_lines([item["city"], item["postcode"]])
             lon = item.get("lon", "")
             if isinstance(lon, str):
                 lon_clean = lon.replace(",", "").replace(" ", "")


### PR DESCRIPTION
## Summary

Part of #18306 (a sub-issue of #4878): several old spiders parse a source that already exposes clearly-separate address components (street/city/state/postcode as distinct API or dict keys) but then also build a redundant `addr_full` string from those same components, or dump the street-only text into `addr_full` instead of `street_address`. This fixes six of the clearest, lowest-risk cases, verified against live crawls:

- `crew_carwash_us`: the ACF payload has distinct `street_address`/`city`/`state`/`zip_code` keys that were being joined into `addr_full` instead of populated individually.
- `sok_tr`: `street_address`/`city`/`state` were already set explicitly, then re-joined into a fully redundant `addr_full`.
- `easy_point_tr`: same pattern — `street_address`/`city`/`state` already set, `addr_full` was a pure redundant rebuild of the same three fields.
- `pudo_tr`: the street-only `addressText` field was going into `addr_full` (concatenated with the already-separately-set city/state) instead of `street_address`.
- `youngs_gb`: `addr_full` duplicated the already-set `city`+`postcode` fields with no additional information (the source has no separate street field at all).
- `rural_king_us`: `addressLine` is the API's street-only field (city/state/postcode are already separate keys); it was being put in `addr_full` instead of `street_address`.

Each change was verified with a live `scrapy crawl <spider> -s CLOSESPIDER_ITEMCOUNT=N` run before and after, confirming no address information is lost and the output now uses `street_address`/`city`/`state`/`postcode` instead of a duplicate/redundant `addr_full`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved location data consistency by providing street address, city, state, and postcode as separate fields.
  * Updated address extraction across multiple location sources for more accurate street-level details.
  * Removed redundant combined address formatting where structured address components are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->