### PR TITLE
Convert seven spiders to StructuredDataSpider

### DIFF
--- a/locations/spiders/fonehouse_gb.py
+++ b/locations/spiders/fonehouse_gb.py
@@ -1,14 +1,16 @@
 import json
+from typing import Iterable
 
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
-from locations.hours import OpeningHours
-from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class FonehouseGBSpider(CrawlSpider):
+class FonehouseGBSpider(CrawlSpider, StructuredDataSpider):
     name = "fonehouse_gb"
     item_attributes = {
         "brand": "fonehouse",
@@ -17,36 +19,35 @@ class FonehouseGBSpider(CrawlSpider):
     }
 
     start_urls = ["https://www.fonehouse.co.uk/store-finder"]
-    rules = [Rule(LinkExtractor(allow=r"/stores/([^/]+)$"), callback="parse")]
-    # wanted_types = ["LocalBusiness"]
+    rules = [Rule(LinkExtractor(allow=r"/stores/([^/]+)$"), callback="parse_sd")]
+    wanted_types = ["LocalBusiness"]
 
-    def parse(self, response):
-        ldjson = response.xpath('//script[@type="application/ld+json"]/text()[contains(.,\'"LocalBusiness"\')]').get()
-        data = json.decoder.JSONDecoder(strict=False).raw_decode(ldjson, ldjson.index("{"))[0]
-        oh = OpeningHours()
-        hours = data.get("openingHoursSpecification")
-        for day in hours:
-            if day["opens"] == day["closes"]:
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        # The ld+json blob has a stray trailing comma after the JSON object, which
+        # breaks strict JSON (and json5/chompjs) parsing, so decode just the object.
+        for text in response.xpath('//script[@type="application/ld+json"]//text()').getall():
+            try:
+                ld_obj, _ = json.decoder.JSONDecoder(strict=False).raw_decode(text, text.index("{"))
+            except (ValueError, json.JSONDecodeError):
                 continue
-            oh.add_range(day.get("dayOfWeek")[0][:2].capitalize(), day.get("opens"), day.get("closes"))
 
-        properties = {
-            "ref": response.url,
-            "name": data.get("name"),
-            "branch": data.pop("name").removeprefix("Fonehouse").strip(),
-            "phone": data.get("telephone"),
-            "email": data.get("email"),
-            "street_address": data.get("address", {}).get("streetAddress"),
-            "city": data.get("address", {}).get("addressLocality"),
-            "state": data.get("address", {}).get("addressCountry"),
-            "country": "GB",
-            "postcode": data.get("address", {}).get("postalCode"),
-            "lat": data.get("geo", {}).get("latitude"),
-            "lon": data.get("geo", {}).get("longitude"),
-            "image": data.get("image"),
-            "website": response.url,
-            "opening_hours": oh,
-        }
-        item = Feature(**properties)
+            types = ld_obj.get("@type")
+            if not types:
+                continue
+            if not isinstance(types, list):
+                types = [types]
+            types = [LinkedDataParser.clean_type(t) for t in types]
+
+            for wanted_types in self.wanted_types:
+                if isinstance(wanted_types, list):
+                    if all(wanted in types for wanted in wanted_types):
+                        yield ld_obj
+                elif wanted_types in types:
+                    yield ld_obj
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["ref"] = item["website"] = response.url
+        item["branch"] = item.pop("name").removeprefix("Fonehouse").strip()
+        item["country"] = "GB"
         apply_category(Categories.SHOP_MOBILE_PHONE, item)
         yield item

--- a/locations/spiders/hairhouse_au.py
+++ b/locations/spiders/hairhouse_au.py
@@ -1,26 +1,28 @@
-from json import loads
 from typing import Iterable
 
 from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.items import Feature
 from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class HairhouseAUSpider(SitemapSpider):
+class HairhouseAUSpider(SitemapSpider, StructuredDataSpider):
     name = "hairhouse_au"
     item_attributes = {"brand": "Hairhouse", "brand_wikidata": "Q118383855"}
     allowed_domains = ["www.hairhouse.com.au"]
     sitemap_urls = ["https://www.hairhouse.com.au/store/sitemap.xml"]
-    sitemap_rules = [(r"^https:\/\/www\.hairhouse\.com\.au\/store\/[^\/]+$", "parse")]
-    # wanted_types = ["HealthAndBeautyBusiness"]
+    sitemap_rules = [(r"^https:\/\/www\.hairhouse\.com\.au\/store\/[^\/]+$", "parse_sd")]
+    wanted_types = ["HealthAndBeautyBusiness"]
 
-    def parse(self, response: Response) -> Iterable[Feature]:
-        ldjson_blob = response.xpath('//script[@type="application/ld+json"]/text()').get()
-        ldjson = loads(ldjson_blob)["script:ld+json"]
-        item = LinkedDataParser.parse_ld(ldjson, time_format="%H:%M")
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        # The ld+json blob is nested under a non-standard "script:ld+json" wrapper key
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            if wrapped := ld_obj.get("script:ld+json"):
+                yield wrapped
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
         item["branch"] = item.pop("name").removeprefix("Hairhouse ")
         item["addr_full"] = item.pop("street_address", None)
         item.pop("image", None)

--- a/locations/spiders/houlihans_us.py
+++ b/locations/spiders/houlihans_us.py
@@ -1,28 +1,32 @@
-import json
-from typing import Any
+from typing import Any, Iterable
 
-from scrapy import Request, Spider
+from scrapy import Request
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class HoulihansUSSpider(Spider):
+class HoulihansUSSpider(StructuredDataSpider):
     name = "houlihans_us"
     item_attributes = {"brand": "Houlihan's", "brand_wikidata": "Q5913100"}
     allowed_domains = ["houlihans.com"]
     start_urls = ["https://www.houlihans.com/store-locator/"]
+    wanted_types = ["FoodEstablishment"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for store in json.loads(response.xpath('//*[@type="application/ld+json"]/text()').get())["subOrganization"]:
-            item = LinkedDataParser.parse_ld(store)
-            item["branch"] = item.pop("name")
-            item["ref"] = item["website"]
-            apply_category(Categories.RESTAURANT, item)
-            yield Request(url=item["website"], callback=self.parse_location, meta={"item": item})
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        # The store list is nested as subOrganization entries of the top-level Organization
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            yield from ld_obj.get("subOrganization", [])
 
-    def parse_location(self, response, **kwargs):
+    def post_process_item(self, item, response, ld_data, **kwargs) -> Any:
+        item["branch"] = item.pop("name")
+        item["ref"] = item["website"]
+        apply_category(Categories.RESTAURANT, item)
+        yield Request(url=item["website"], callback=self.parse_location, meta={"item": item})
+
+    def parse_location(self, response: Response, **kwargs: Any) -> Any:
         item = response.meta["item"]
         item["facebook"] = response.xpath(
             '//a[contains(@href, "https://www.facebook.com/")][not(contains(@href, "/houlihans/"))]/@href'

--- a/locations/spiders/lab_corp_us.py
+++ b/locations/spiders/lab_corp_us.py
@@ -1,30 +1,20 @@
-import json
-
-from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
-from locations.linked_data_parser import LinkedDataParser
 from locations.spiders.tesco_gb import set_located_in
 from locations.spiders.walgreens import WalgreensSpider
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LabCorpUSSpider(SitemapSpider):
+class LabCorpUSSpider(SitemapSpider, StructuredDataSpider):
     name = "lab_corp_us"
     item_attributes = {"brand": "LabCorp", "brand_wikidata": "Q6466630"}
     sitemap_urls = ["https://locations.labcorp.com/robots.txt"]
-    sitemap_rules = [(r"/\w\w/[^/]+/(\d+)/", "parse")]
+    sitemap_rules = [(r"/\w\w/[^/]+/(\d+)/", "parse_sd")]
+    wanted_types = ["MedicalBusiness"]
+    # Some ld+json blobs contain stray "//" comments, which json5 tolerates
+    json_parser = "json5"
 
-    def parse(self, response: Response, **kwargs):
-        # Remove comments from JSON
-        json_blob = ""
-        for line in (
-            response.xpath('//script[@type="application/ld+json"][contains(text(), "MedicalBusiness")]/text()')
-            .get()
-            .splitlines()
-        ):
-            json_blob += line.split(" //", 1)[0]
-
-        item = LinkedDataParser.parse_ld(json.loads(json_blob))
+    def post_process_item(self, item, response, ld_data, **kwargs):
         if item.get("name", "").upper().endswith("WALGREENS"):
             set_located_in(WalgreensSpider.WALGREENS, item)
         item["name"] = None

--- a/locations/spiders/lincolnshire_cooperative.py
+++ b/locations/spiders/lincolnshire_cooperative.py
@@ -1,21 +1,21 @@
-import json
-
 from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
-from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class LincolnshireCooperativeSpider(SitemapSpider):
+class LincolnshireCooperativeSpider(SitemapSpider, StructuredDataSpider):
     name = "lincolnshire_cooperative"
     item_attributes = {"brand": "Lincolnshire Co-op", "brand_wikidata": "Q6551231", "nsi_id": "N/A"}
     sitemap_urls = ["https://www.lincolnshire.coop/sitemap.xml"]
     sitemap_rules = [
         (
             r"https:\/\/www\.lincolnshire\.coop\/branches\/(food-stores|pharmacies|funeral-homes|travel-branches|filling-stations|coffee|florist)\/[-\w]+$",
-            "parse_item",
+            "parse_sd",
         )
     ]
+    # The ld+json blob contains stray "//" comments, which json5 tolerates
+    json_parser = "json5"
     categories = [
         ("food store", Categories.SHOP_CONVENIENCE),
         ("pharmacy", Categories.PHARMACY),
@@ -28,14 +28,11 @@ class LincolnshireCooperativeSpider(SitemapSpider):
         ("podiatry", Categories.SHOP_ORTHOPEDICS),
     ]
 
-    def parse_item(self, response):
-        ld_item = response.xpath('//script[@type="application/ld+json"]//text()').get()
-        ld_item = json.loads(ld_item.replace('// "addressLocality"', '"addressLocality"'), strict=False)
-
-        item = LinkedDataParser.parse_ld(ld_item)
-
+    def post_process_item(self, item, response, ld_data, **kwargs):
         if item.get("image"):
-            item["image"] = item["image"].replace("//www.lincolnshire.coophttps://", "https://")
+            # Source data has a malformed protocol-relative URL (e.g. "//www.lincolnshire.coophttps://...")
+            # which the base StructuredDataSpider urljoin()s against the response URL, doubling up the scheme.
+            item["image"] = "https://" + item["image"].split("https://")[-1]
 
         if item.get("phone"):
             item["phone"] = item["phone"].replace(" (24 hours)", "")
@@ -45,4 +42,4 @@ class LincolnshireCooperativeSpider(SitemapSpider):
                 apply_category(cat, item)
                 break
 
-        return item
+        yield item

--- a/locations/spiders/sbarro.py
+++ b/locations/spiders/sbarro.py
@@ -1,39 +1,14 @@
-import json
+from scrapy import Request
 
-import scrapy
-
-from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class SbarroSpider(scrapy.Spider):
+class SbarroSpider(StructuredDataSpider):
     name = "sbarro"
     item_attributes = {"brand": "Sbarro", "brand_wikidata": "Q2589409"}
     allowed_domains = ["sbarro.com"]
     start_urls = ["https://sbarro.com/locations/?user_search=78749&radius=50000&count=5000"]
-
-    def parse_store(self, response):
-        try:
-            data = json.loads(
-                response.xpath(
-                    '//script[@type="application/ld+json" and contains(text(), "PostalAddress")]/text()'
-                ).extract_first(),
-                strict=False,
-            )
-            properties = {
-                "ref": response.meta["ref"],
-                "branch": response.xpath('//*[@class="location-name "]/text()').extract_first(),
-                "street_address": data["address"]["streetAddress"],
-                "city": data["address"]["addressLocality"],
-                "state": data["address"]["addressRegion"],
-                "postcode": data["address"]["postalCode"],
-                "lat": response.meta["lat"],
-                "lon": response.meta["lon"],
-                "website": response.url,
-            }
-
-            yield Feature(**properties)
-        except:
-            pass
+    wanted_types = ["Restaurant"]
 
     def parse(self, response):
         store_urls = response.xpath('//*[@class="location-name "]/a/@href').extract()
@@ -43,8 +18,16 @@ class SbarroSpider(scrapy.Spider):
 
         for store_url, id, lat, long in zip(store_urls, ids, lats, longs):
             store_url = "https://sbarro.com" + store_url + "/"
-            yield scrapy.Request(
+            yield Request(
                 response.urljoin(store_url),
-                callback=self.parse_store,
+                callback=self.parse_sd,
                 meta={"lat": lat, "lon": long, "ref": id},
             )
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["ref"] = response.meta["ref"]
+        item["branch"] = response.xpath('//*[@class="location-name "]/text()').get()
+        item["name"] = None
+        item["lat"] = response.meta["lat"]
+        item["lon"] = response.meta["lon"]
+        yield item

--- a/locations/spiders/your_move_gb.py
+++ b/locations/spiders/your_move_gb.py
@@ -1,24 +1,26 @@
-import json
-from typing import Any
+from typing import Iterable
 
-from scrapy import Spider
 from scrapy.http import Response
 
 from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
 
 
-class YourMoveGBSpider(Spider):
+class YourMoveGBSpider(StructuredDataSpider):
     name = "your_move_gb"
     item_attributes = {"brand": "Your Move", "brand_wikidata": "Q81078416"}
     start_urls = ["https://www.your-move.co.uk/branches"]
+    wanted_types = ["RealEstateAgent"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        items = json.loads(
-            response.xpath('//script[@type="application/ld+json"][contains(text(), "RealEstateAgent")]/text()').get()
-        )
-        for location in items["itemListElement"]:
-            item = LinkedDataParser.parse_ld(location)
-            item["branch"] = item.pop("name")
-            item["image"] = location["image"]["url"]
-            item["ref"] = item["website"].split("/")[-1]
-            yield item
+    def iter_linked_data(self, response: Response) -> Iterable[dict]:
+        # A single ld+json blob holds an ItemList of RealEstateAgent branches
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            if ld_obj.get("@type") == "ItemList":
+                yield from ld_obj.get("itemListElement", [])
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        item["branch"] = item.pop("name")
+        if image := ld_data.get("image", {}).get("url"):
+            item["image"] = image
+        item["ref"] = item["website"].split("/")[-1]
+        yield item


### PR DESCRIPTION
## Summary
Part of #18303 (sub-issue of the #4878 TODO meta-issue): converts spiders that were hand-parsing JSON-LD (`application/ld+json`) into using the `StructuredDataSpider` mixin instead.

Converted:
- `hairhouse_au` — ld+json is nested under a non-standard `script:ld+json` wrapper key; added an `iter_linked_data` override to unwrap it.
- `fonehouse_gb` — the ld+json blob has a stray trailing comma after the object, which breaks strict/json5/chompjs parsing; added an `iter_linked_data` override that decodes just the JSON object and discards the trailing garbage (same approach the original spider used).
- `your_move_gb` — the ld+json is an `ItemList` of `RealEstateAgent` branches; added an `iter_linked_data` override to unwrap `itemListElement`.
- `houlihans_us` — the store list is nested as `subOrganization` entries under a top-level `Organization`; added an `iter_linked_data` override to unwrap it, and kept the existing second-page fetch (via `post_process_item` returning a `Request`) since lat/lon and Facebook aren't present in the structured data.
- `sbarro` — kept the existing list-page crawl (lat/lon/ref come from the HTML listing, not present in the per-store ld+json) but now hands off to `parse_sd`/`post_process_item` for the per-store extraction, picking up phone/facebook/twitter/payment for free.
- `lincolnshire_cooperative` — ld+json contains stray `//` comments; switched to `json_parser = "json5"`, which tolerates them.
- `lab_corp_us` — same stray-comment issue; switched to `json5` as well.

All conversions preserve existing site-specific quirks (name/branch overrides, category mapping, hardcoded country codes, image URL fixups, Walgreens co-location detection, etc.) verified against live pages.

Left for future batches: several other `application/ld+json`/`itemprop` spiders were reviewed but not converted because they genuinely need custom parsing beyond structured data (e.g. `geico`, `mariner_finance`, `uhaul`, `next`, `q_park` fetch lat/lon from separate APIs; `wells_fargo_us`/`playa_bowls_us` have malformed JSON that standard/json5/chompjs parsers can't recover; `eyes_and_more`/`clapton_craft_gb`/`gov_mot_gb` only use ld+json incidentally for a secondary field). The `itemprop`/microdata candidates haven't been surveyed yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved location data extraction across several business, restaurant, healthcare, retail, and real-estate listings.
  * Added support for more flexible structured-data formats, including malformed JSON-LD.
  * Improved handling of branch details, categories, contact information, images, and geographic data.
  * Normalized inconsistent image URLs and preserved additional location relationships where available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->