### PR TITLE
Use BROWSER_DEFAULT instead of hardcoded browser user agents

### DIFF
--- a/locations/spiders/allsaints.py
+++ b/locations/spiders/allsaints.py
@@ -3,6 +3,7 @@ from scrapy.spiders import CrawlSpider, Rule
 
 from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class AllsaintsSpider(CrawlSpider, StructuredDataSpider):
@@ -18,7 +19,7 @@ class AllsaintsSpider(CrawlSpider, StructuredDataSpider):
         "ROBOTSTXT_OBEY": False,
         "DEFAULT_REQUEST_HEADERS": {
             "Host": "www.allsaints.com",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0",
+            "User-Agent": BROWSER_DEFAULT,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "upgrade-insecure-requests": "1",
             "Referer": "https://www.allsaints.com/",

--- a/locations/spiders/bala_cz.py
+++ b/locations/spiders/bala_cz.py
@@ -7,13 +7,14 @@ from scrapy.http import Response
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_CZ, OpeningHours
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class BalaCZSpider(Spider):
     name = "bala_cz"
     item_attributes = {"brand": "Bala"}
     start_urls = ["https://www.mojebala.cz/mapa"]
-    custom_settings = {"USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response):
         # All store data is embedded as a JavaScript variable in the page

--- a/locations/spiders/hostelling_scotland.py
+++ b/locations/spiders/hostelling_scotland.py
@@ -5,15 +5,14 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class HostellingScotlandSpider(Spider):
     name = "hostelling_scotland"
     item_attributes = {"brand": "Hostelling Scotland", "brand_wikidata": "Q7438052", "country": "GB"}
     start_urls = ["https://www.hostellingscotland.org.uk/inspiration/view-all-hostels/"]
-    custom_settings = {
-        "USER_AGENT": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs):
         data_raw = response.xpath('//input[@id="data"]/@value').get("")

--- a/locations/spiders/kasikorn_bank_th.py
+++ b/locations/spiders/kasikorn_bank_th.py
@@ -14,6 +14,7 @@ from locations.spiders.lotuss_th import LotussTHSpider
 from locations.spiders.makro_th import MakroTHSpider
 from locations.spiders.ptt_th import PttTHSpider
 from locations.spiders.seven_eleven_au import SEVEN_ELEVEN_SHARED_ATTRIBUTES
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class KasikornBankTHSpider(PlaywrightSpider):
@@ -50,7 +51,7 @@ class KasikornBankTHSpider(PlaywrightSpider):
             headers={
                 "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
                 "referer": "https://www.kasikornbank.com/th/branch/",
-                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+                "user-agent": BROWSER_DEFAULT,
             },
         )
 

--- a/locations/spiders/sams_club_mx.py
+++ b/locations/spiders/sams_club_mx.py
@@ -5,6 +5,7 @@ from scrapy.http import JsonRequest, Response
 
 from locations.dict_parser import DictParser
 from locations.geo import city_locations
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class SamsClubMXSpider(Spider):
@@ -18,7 +19,7 @@ class SamsClubMXSpider(Spider):
                 method="POST",
                 headers={
                     "content-type": "application/json",
-                    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+                    "user-agent": BROWSER_DEFAULT,
                     "x-apollo-operation-name": "nearByNodes",
                     "x-o-bu": "SAMS-MX",
                     "x-o-gql-query": "query nearByNodes",

--- a/locations/spiders/t2_si.py
+++ b/locations/spiders/t2_si.py
@@ -8,6 +8,7 @@ from scrapy.spiders import CrawlSpider, Rule
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_SI, OpeningHours
 from locations.items import Feature
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class T2SISpider(CrawlSpider):
@@ -20,9 +21,7 @@ class T2SISpider(CrawlSpider):
             callback="parse_store",
         ),
     ]
-    custom_settings = {
-        "USER_AGENT": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
+    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse_store(self, response: Response, **kwargs: Any) -> Any:
         geo_text = response.xpath('//div[@class="geo-data"]/text()').getall()

--- a/locations/spiders/tatra_banka_sk.py
+++ b/locations/spiders/tatra_banka_sk.py
@@ -9,6 +9,7 @@ from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.playwright_spider import PlaywrightSpider
 from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class TatraBankaSKSpider(PlaywrightSpider):
@@ -36,10 +37,7 @@ class TatraBankaSKSpider(PlaywrightSpider):
                 "branchesWithCashRegister": "false",
             },
             headers={
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                ),
+                "User-Agent": BROWSER_DEFAULT,
                 "Referer": "https://www.tatrabanka.sk/sk/o-banke/pobocky-bankomaty/",
                 "Accept-Language": "sk-SK",
                 "X-Requested-With": "XMLHttpRequest",

--- a/locations/spiders/wawa.py
+++ b/locations/spiders/wawa.py
@@ -26,7 +26,7 @@ class WawaSpider(Spider):
                 },
                 headers={
                     "content-type": "application/json",
-                    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+                    "user-agent": BROWSER_DEFAULT,
                 },
                 method="POST",
             )

--- a/locations/spiders/zara.py
+++ b/locations/spiders/zara.py
@@ -6,6 +6,7 @@ from locations.categories import Categories, Clothes, apply_category, apply_clot
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.user_agents import BROWSER_DEFAULT
 
 
 class ZaraSpider(JSONBlobSpider):
@@ -63,7 +64,7 @@ class ZaraSpider(JSONBlobSpider):
     ]
     custom_settings = {
         "ROBOTSTXT_OBEY": False,
-        "USER_AGENT": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:150.0) Gecko/20100101 Firefox/150.0",
+        "USER_AGENT": BROWSER_DEFAULT,
         "DEFAULT_REQUEST_HEADERS": {
             "Host": "www.zara.com",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",


### PR DESCRIPTION
Converts 9 of the 11 spiders with hardcoded browser user-agent strings to import and use `BROWSER_DEFAULT` from `locations/user_agents.py` instead:

- allsaints
- bala_cz
- hostelling_scotland
- kasikorn_bank_th
- sams_club_mx
- t2_si
- tatra_banka_sk
- wawa (already imported `BROWSER_DEFAULT` for `custom_settings`, but a stray hardcoded UA in a per-request header was silently overriding it for the actual API request)
- zara

Verified live (via `scrapy fetch`/`scrapy parse` or direct HTTP requests replicating each spider's exact request) that each site still responds normally with `BROWSER_DEFAULT`.

Two spiders are intentionally left with their hardcoded/derived user agents, since these sites specifically block realistic browser user agents (PerimeterX) and need a generic/minimal one instead — confirmed live that swapping in `BROWSER_DEFAULT` gets blocked (403/302) while their current UA gets 200:

- `pacsun_us` uses the literal string `"Mozilla/5.0"` (see #17518)
- `talbots_ca_us` strips the `"Mozilla/5.0 (X11; Linux x86_64) "` prefix off the bot's own `USER_AGENT` (see #17509)

closes #18307