### PR TITLE
Add scheduled workflow to refresh pinned browser user agents

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,6 @@
     select = B,C,E,F,W,T4,B9,T20,N801,N802,N803,N806,N816
     per-file-ignores =
         ci/restore_history.py: T20
+        ci/update_user_agents.py: T20
         locations/commands/*: T20
         locations/__init__.py: T201

--- a/.github/workflows/update-user-agents.yml
+++ b/.github/workflows/update-user-agents.yml
@@ -1,0 +1,38 @@
+name: Update browser user agents
+
+on:
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-user-agents:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Update user agent constants
+        id: update
+        run: |
+          output=$(uv run python ci/update_user_agents.py)
+          echo "$output"
+          echo "output<<EOF" >> $GITHUB_ENV
+          echo "$output" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Open PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "[Core] Update browser user agents"
+          title: "[Core] Update browser user agents"
+          branch: action/update-user-agents
+          body: |
+            Refreshes the pinned browser user agent strings in `locations/user_agents.py` from https://www.useragents.me/.
+
+            ${{ env.output }}

--- a/.github/workflows/update-user-agents.yml
+++ b/.github/workflows/update-user-agents.yml
@@ -33,6 +33,6 @@ jobs:
           title: "[Core] Update browser user agents"
           branch: action/update-user-agents
           body: |
-            Refreshes the pinned browser user agent strings in `locations/user_agents.py` from https://www.useragents.me/.
+            Refreshes the pinned browser user agent strings in `locations/user_agents.py` from Mozilla's (https://product-details.mozilla.org/1.0/firefox_versions.json) and Google's (https://versionhistory.googleapis.com) official version APIs.
 
             ${{ env.output }}

--- a/ci/update_user_agents.py
+++ b/ci/update_user_agents.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 Refresh the pinned browser user agent strings in locations/user_agents.py
-using real-world data from https://www.useragents.me/.
+using official version data from Mozilla and Google.
 
-Only ever moves a pinned version forward (never downgrades it), since the
-source site's snapshot can lag behind what is already pinned.
+Only ever moves a pinned version forward (never downgrades it), since these
+services occasionally serve a staged/rolled-back version.
 """
 
 import re
@@ -12,88 +12,45 @@ import sys
 from pathlib import Path
 
 import requests
-from parsel import Selector
 
 USER_AGENTS_PATH = Path(__file__).parent.parent / "locations" / "user_agents.py"
-SOURCE_URL = "https://www.useragents.me/"
 
-# The "Latest Linux Desktop Useragents" table lists browsers by OS in the same
-# style (X11; Linux x86_64) already pinned in user_agents.py. Firefox usually
-# appears at two distinct versions there: the current stable release, and a
-# noticeably older one that lines up with the current Firefox ESR release.
-LINUX_TABLE_HEADING_ID = "latest-linux-desktop-useragents"
-
-LABEL_RE = re.compile(r"^(Chrome|Firefox)\s+(\d+)")
-
-# The existing pinned strings are a plain, distro-less 64-bit Linux UA. The
-# source site lists several Linux flavours (generic, Ubuntu, Fedora, i686)
-# per version; prefer a matching plain "X11; Linux x86_64" string, falling
-# back to any 64-bit variant, so we don't end up pinning a 32-bit UA.
-GENERIC_LINUX_X64_RE = re.compile(r"\(X11; Linux x86_64[;)]")
-X64_RE = re.compile(r"x86_64")
-
-
-def _linux_variant_rank(ua: str) -> int:
-    if GENERIC_LINUX_X64_RE.search(ua):
-        return 0
-    if X64_RE.search(ua):
-        return 1
-    return 2
-
+FIREFOX_VERSIONS_URL = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+CHROME_VERSIONS_URL = (
+    "https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases"
+    "?filter=endtime=none"
+)
 
 FETCH_USER_AGENT = (
     "AllThePlacesBot (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) python-requests"
 )
 
+FIREFOX_UA_TEMPLATE = "Mozilla/5.0 (X11; Linux x86_64; rv:{major}.0) Gecko/20100101 Firefox/{major}.0"
+CHROME_UA_TEMPLATE = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{major}.0.0.0 Safari/537.36"
+)
 
-def fetch_linux_user_agents() -> dict[str, list[tuple[int, str]]]:
-    resp = requests.get(SOURCE_URL, headers={"User-Agent": FETCH_USER_AGENT}, timeout=30)
+
+def major_version(version: str) -> int:
+    return int(re.match(r"\d+", version).group())
+
+
+def fetch_firefox_majors() -> tuple[int, int]:
+    """Returns (latest, esr) major versions."""
+    resp = requests.get(FIREFOX_VERSIONS_URL, headers={"User-Agent": FETCH_USER_AGENT}, timeout=30)
     resp.raise_for_status()
-
-    selector = Selector(text=resp.text)
-    rows = selector.xpath(
-        f'//h2[@id="{LINUX_TABLE_HEADING_ID}"]'
-        '/following-sibling::div[contains(@class, "table-responsive")][1]'
-        "//tbody/tr"
-    )
-    if not rows:
-        raise RuntimeError(f"Could not find any rows under #{LINUX_TABLE_HEADING_ID} on {SOURCE_URL}")
-
-    candidates: dict[tuple[str, int], list[str]] = {}
-    for row in rows:
-        label = " ".join(row.xpath("./td[1]//text()").getall()).strip()
-        ua = row.xpath(".//textarea/text()").get()
-        if not label or not ua:
-            continue
-        match = LABEL_RE.match(label)
-        if not match:
-            continue
-        browser, major = match.group(1), int(match.group(2))
-        candidates.setdefault((browser, major), []).append(ua.strip())
-
-    by_browser: dict[str, list[tuple[int, str]]] = {"Chrome": [], "Firefox": []}
-    for (browser, major), uas in candidates.items():
-        best = min(uas, key=_linux_variant_rank)
-        by_browser[browser].append((major, best))
-
-    return by_browser
+    data = resp.json()
+    return major_version(data["LATEST_FIREFOX_VERSION"]), major_version(data["FIREFOX_ESR"])
 
 
-def pick_latest_and_esr(
-    firefox_versions: list[tuple[int, str]],
-) -> tuple[tuple[int, str] | None, tuple[int, str] | None]:
-    distinct = sorted(set(firefox_versions), key=lambda v: v[0], reverse=True)
-    if not distinct:
-        return None, None
-    latest = distinct[0]
-    esr = None
-    for major, ua in distinct[1:]:
-        # ESR tracks lag well behind stable; a handful of versions apart is
-        # the expected gap, not noise from two nearby point releases.
-        if latest[0] - major >= 3:
-            esr = (major, ua)
-            break
-    return latest, esr
+def fetch_chrome_major() -> int:
+    resp = requests.get(CHROME_VERSIONS_URL, headers={"User-Agent": FETCH_USER_AGENT}, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    releases = data.get("releases", [])
+    if not releases:
+        raise RuntimeError(f"No Chrome releases returned from {CHROME_VERSIONS_URL}")
+    return major_version(releases[0]["version"])
 
 
 def current_pinned_version(content: str, constant_prefix: str) -> int | None:
@@ -117,30 +74,29 @@ def replace_constant_block(
 
 
 def main() -> int:
-    by_browser = fetch_linux_user_agents()
-
-    chrome_latest = max(by_browser["Chrome"], key=lambda v: v[0], default=None)
-    firefox_latest, firefox_esr = pick_latest_and_esr(by_browser["Firefox"])
+    firefox_latest, firefox_esr = fetch_firefox_majors()
+    chrome_latest = fetch_chrome_major()
 
     content = USER_AGENTS_PATH.read_text()
     changes = []
 
-    if chrome_latest:
-        content, changed = replace_constant_block(content, "CHROME", "CHROME_LATEST", *chrome_latest)
-        if changed:
-            changes.append(f"Chrome -> {chrome_latest[0]}")
+    content, changed = replace_constant_block(
+        content, "CHROME", "CHROME_LATEST", chrome_latest, CHROME_UA_TEMPLATE.format(major=chrome_latest)
+    )
+    if changed:
+        changes.append(f"Chrome -> {chrome_latest}")
 
-    if firefox_latest:
-        content, changed = replace_constant_block(content, "FIREFOX", "FIREFOX_LATEST", *firefox_latest)
-        if changed:
-            changes.append(f"Firefox -> {firefox_latest[0]}")
+    content, changed = replace_constant_block(
+        content, "FIREFOX", "FIREFOX_LATEST", firefox_latest, FIREFOX_UA_TEMPLATE.format(major=firefox_latest)
+    )
+    if changed:
+        changes.append(f"Firefox -> {firefox_latest}")
 
-    if firefox_esr:
-        content, changed = replace_constant_block(content, "FIREFOX_ESR", "FIREFOX_ESR_LATEST", *firefox_esr)
-        if changed:
-            changes.append(f"Firefox ESR -> {firefox_esr[0]}")
-    else:
-        print("Could not identify a distinct Firefox ESR version this run; leaving FIREFOX_ESR_LATEST untouched.")
+    content, changed = replace_constant_block(
+        content, "FIREFOX_ESR", "FIREFOX_ESR_LATEST", firefox_esr, FIREFOX_UA_TEMPLATE.format(major=firefox_esr)
+    )
+    if changed:
+        changes.append(f"Firefox ESR -> {firefox_esr}")
 
     if not changes:
         print("No user agent constants needed updating.")

--- a/ci/update_user_agents.py
+++ b/ci/update_user_agents.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Refresh the pinned browser user agent strings in locations/user_agents.py
+using real-world data from https://www.useragents.me/.
+
+Only ever moves a pinned version forward (never downgrades it), since the
+source site's snapshot can lag behind what is already pinned.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import requests
+from parsel import Selector
+
+USER_AGENTS_PATH = Path(__file__).parent.parent / "locations" / "user_agents.py"
+SOURCE_URL = "https://www.useragents.me/"
+
+# The "Latest Linux Desktop Useragents" table lists browsers by OS in the same
+# style (X11; Linux x86_64) already pinned in user_agents.py. Firefox usually
+# appears at two distinct versions there: the current stable release, and a
+# noticeably older one that lines up with the current Firefox ESR release.
+LINUX_TABLE_HEADING_ID = "latest-linux-desktop-useragents"
+
+LABEL_RE = re.compile(r"^(Chrome|Firefox)\s+(\d+)")
+
+# The existing pinned strings are a plain, distro-less 64-bit Linux UA. The
+# source site lists several Linux flavours (generic, Ubuntu, Fedora, i686)
+# per version; prefer a matching plain "X11; Linux x86_64" string, falling
+# back to any 64-bit variant, so we don't end up pinning a 32-bit UA.
+GENERIC_LINUX_X64_RE = re.compile(r"\(X11; Linux x86_64[;)]")
+X64_RE = re.compile(r"x86_64")
+
+
+def _linux_variant_rank(ua: str) -> int:
+    if GENERIC_LINUX_X64_RE.search(ua):
+        return 0
+    if X64_RE.search(ua):
+        return 1
+    return 2
+
+
+FETCH_USER_AGENT = (
+    "AllThePlacesBot (+https://github.com/alltheplaces/alltheplaces; +https://alltheplaces.xyz/) python-requests"
+)
+
+
+def fetch_linux_user_agents() -> dict[str, list[tuple[int, str]]]:
+    resp = requests.get(SOURCE_URL, headers={"User-Agent": FETCH_USER_AGENT}, timeout=30)
+    resp.raise_for_status()
+
+    selector = Selector(text=resp.text)
+    rows = selector.xpath(
+        f'//h2[@id="{LINUX_TABLE_HEADING_ID}"]'
+        '/following-sibling::div[contains(@class, "table-responsive")][1]'
+        "//tbody/tr"
+    )
+    if not rows:
+        raise RuntimeError(f"Could not find any rows under #{LINUX_TABLE_HEADING_ID} on {SOURCE_URL}")
+
+    candidates: dict[tuple[str, int], list[str]] = {}
+    for row in rows:
+        label = " ".join(row.xpath("./td[1]//text()").getall()).strip()
+        ua = row.xpath(".//textarea/text()").get()
+        if not label or not ua:
+            continue
+        match = LABEL_RE.match(label)
+        if not match:
+            continue
+        browser, major = match.group(1), int(match.group(2))
+        candidates.setdefault((browser, major), []).append(ua.strip())
+
+    by_browser: dict[str, list[tuple[int, str]]] = {"Chrome": [], "Firefox": []}
+    for (browser, major), uas in candidates.items():
+        best = min(uas, key=_linux_variant_rank)
+        by_browser[browser].append((major, best))
+
+    return by_browser
+
+
+def pick_latest_and_esr(
+    firefox_versions: list[tuple[int, str]],
+) -> tuple[tuple[int, str] | None, tuple[int, str] | None]:
+    distinct = sorted(set(firefox_versions), key=lambda v: v[0], reverse=True)
+    if not distinct:
+        return None, None
+    latest = distinct[0]
+    esr = None
+    for major, ua in distinct[1:]:
+        # ESR tracks lag well behind stable; a handful of versions apart is
+        # the expected gap, not noise from two nearby point releases.
+        if latest[0] - major >= 3:
+            esr = (major, ua)
+            break
+    return latest, esr
+
+
+def current_pinned_version(content: str, constant_prefix: str) -> int | None:
+    match = re.search(rf'{constant_prefix}_(\d+) = "', content)
+    return int(match.group(1)) if match else None
+
+
+def replace_constant_block(
+    content: str, constant_prefix: str, alias_name: str, new_major: int, new_ua: str
+) -> tuple[str, bool]:
+    old_major = current_pinned_version(content, constant_prefix)
+    if old_major is not None and new_major <= old_major:
+        return content, False
+
+    pattern = re.compile(rf'{constant_prefix}_\d+ = "[^"]*"\n{alias_name} = {constant_prefix}_\d+')
+    new_block = f'{constant_prefix}_{new_major} = "{new_ua}"\n{alias_name} = {constant_prefix}_{new_major}'
+    new_content, count = pattern.subn(new_block, content)
+    if count != 1:
+        raise RuntimeError(f"Expected exactly one {alias_name} block in {USER_AGENTS_PATH}, found {count}")
+    return new_content, True
+
+
+def main() -> int:
+    by_browser = fetch_linux_user_agents()
+
+    chrome_latest = max(by_browser["Chrome"], key=lambda v: v[0], default=None)
+    firefox_latest, firefox_esr = pick_latest_and_esr(by_browser["Firefox"])
+
+    content = USER_AGENTS_PATH.read_text()
+    changes = []
+
+    if chrome_latest:
+        content, changed = replace_constant_block(content, "CHROME", "CHROME_LATEST", *chrome_latest)
+        if changed:
+            changes.append(f"Chrome -> {chrome_latest[0]}")
+
+    if firefox_latest:
+        content, changed = replace_constant_block(content, "FIREFOX", "FIREFOX_LATEST", *firefox_latest)
+        if changed:
+            changes.append(f"Firefox -> {firefox_latest[0]}")
+
+    if firefox_esr:
+        content, changed = replace_constant_block(content, "FIREFOX_ESR", "FIREFOX_ESR_LATEST", *firefox_esr)
+        if changed:
+            changes.append(f"Firefox ESR -> {firefox_esr[0]}")
+    else:
+        print("Could not identify a distinct Firefox ESR version this run; leaving FIREFOX_ESR_LATEST untouched.")
+
+    if not changes:
+        print("No user agent constants needed updating.")
+        return 0
+
+    USER_AGENTS_PATH.write_text(content)
+    print("Updated: " + ", ".join(changes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/locations/user_agents.py
+++ b/locations/user_agents.py
@@ -7,11 +7,11 @@ from locations.settings import BOT_NAME
 FIREFOX_ESR_140 = "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0"
 FIREFOX_ESR_LATEST = FIREFOX_ESR_140
 
-FIREFOX_152 = "Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0"
-FIREFOX_LATEST = FIREFOX_152
+FIREFOX_154 = "Mozilla/5.0 (X11; Linux x86_64; rv:154.0) Gecko/20100101 Firefox/154.0"
+FIREFOX_LATEST = FIREFOX_154
 
-CHROME_151 = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
-CHROME_LATEST = CHROME_151
+CHROME_152 = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"
+CHROME_LATEST = CHROME_152
 
 BROWSER_DEFAULT = FIREFOX_ESR_LATEST
 


### PR DESCRIPTION
Related to #18307. Adds a weekly scheduled workflow (`.github/workflows/update-user-agents.yml`, plus `workflow_dispatch` for manual runs) that refreshes the pinned Firefox/Firefox ESR/Chrome user agent strings in `locations/user_agents.py` (used by `BROWSER_DEFAULT`).

**Data source:** originally scraped useragents.me, but that site's own footer says "Last Updated: 26 March, 2025" — it's an abandoned/stale snapshot, not live data. Switched to two official, actively-maintained APIs instead:
- Mozilla's `product-details.mozilla.org/1.0/firefox_versions.json` for `LATEST_FIREFOX_VERSION` and `FIREFOX_ESR` (no more guessing which version is the ESR release — Mozilla publishes it directly).
- Google's `versionhistory.googleapis.com` Chrome version history API for the current stable Linux release.

`ci/update_user_agents.py`:
- Fetches both APIs, extracts the major version number from each.
- Only ever moves a pinned constant *forward* — if the fetched version isn't newer than what's already pinned, that constant is left untouched, so a rollback/staged rollout on either service can't regress anything here.
- Rewrites the matching `FIREFOX_<ver>`/`FIREFOX_ESR_<ver>`/`CHROME_<ver>` constant + its `_LATEST` alias in `locations/user_agents.py`, following the existing naming convention.

Also included in this PR: running the script against the real APIs found `FIREFOX_LATEST` was pinned to a fabricated "152" (actual current release is 154), so that's corrected as part of this change, along with `CHROME_LATEST` (151 -> 152). `FIREFOX_ESR_LATEST` (140) was already correct and is left alone.

Mirrors the existing `vendor-nsi.yaml` workflow pattern: the script does the update and prints a summary, `peter-evans/create-pull-request` opens a PR from the diff (no PR is opened if nothing changed).

Also added `ci/update_user_agents.py: T20` to `.flake8`'s per-file-ignores (matching the existing `ci/restore_history.py` entry) since the script prints its summary for the workflow to pick up.