### PR TITLE
Set category on spiders missing one

### DIFF
--- a/locations/spiders/fujiservice_jp.py
+++ b/locations/spiders/fujiservice_jp.py
@@ -4,6 +4,7 @@ from typing import Any
 from scrapy import Spider
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
@@ -20,7 +21,7 @@ class FujiserviceJPSpider(Spider):
 
             item = DictParser.parse(store)
             item["ref"] = re.search(r"^\S-\d{4}", str(store["title"])).group()
-            item["extras"]["amenity"] = "luggage_locker"
+            apply_category(Categories.LUGGAGE_LOCKER, item)
             item["operator"] = "フジサービス"
             item["extras"]["operator:en"] = "Fuji Service"
             item["image"] = store["pic"]

--- a/locations/spiders/jptca.py
+++ b/locations/spiders/jptca.py
@@ -2,6 +2,7 @@ import re
 
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 
@@ -31,5 +32,5 @@ class JptcaSpider(SitemapSpider):
             if item["ref"] in img.group(1):
                 item["image"] = "https://jptca.org" + img.group(1)
 
-        item["extras"]["tourism"] = "artwork"
+        apply_category(Categories.TOURISM_ARTWORK, item)
         yield item

--- a/locations/spiders/lagenovesa.py
+++ b/locations/spiders/lagenovesa.py
@@ -3,6 +3,7 @@ import re
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 
 DAY_MAPPING = {"Lunes": "Mo", "Sábados": "Sa", "Domingos": "Su"}
@@ -108,4 +109,6 @@ class LagenovesaSpider(scrapy.Spider):
             if hours:
                 properties["opening_hours"] = hours
 
-            yield Feature(**properties)
+            item = Feature(**properties)
+            apply_category(Categories.SHOP_SUPERMARKET, item)
+            yield item

--- a/locations/spiders/mariner_finance.py
+++ b/locations/spiders/mariner_finance.py
@@ -3,6 +3,7 @@ import re
 
 import scrapy
 
+from locations.categories import Categories, apply_category
 from locations.items import Feature
 from locations.user_agents import BROWSER_DEFAULT
 
@@ -84,4 +85,6 @@ class MarinerFinanceSpider(scrapy.Spider):
         properties["lat"] = lat
         properties["lon"] = lon
 
-        yield Feature(**properties)
+        item = Feature(**properties)
+        apply_category(Categories.SHOP_MONEY_LENDER, item)
+        yield item

--- a/locations/spiders/spacer_jp.py
+++ b/locations/spiders/spacer_jp.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 from scrapy.http import Response
 
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
@@ -23,7 +24,7 @@ class SpacerJPSpider(JSONBlobSpider):
 
         item["branch"] = item.pop("name", None)
         item["country"] = "JP"
-        item["extras"]["amenity"] = "left_luggage"
+        apply_category(Categories.LEFT_LUGGAGE, item)
 
         oh = OpeningHours()
         open_time = feature.get("open")

--- a/locations/spiders/stasher.py
+++ b/locations/spiders/stasher.py
@@ -2,6 +2,7 @@ import pycountry
 from scrapy import Spider
 from scrapy.http import JsonRequest
 
+from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
@@ -46,7 +47,7 @@ class StasherSpider(Spider):
                     oh.add_range(day=day, open_time=rule["open"], close_time=rule["close"], time_format="%H:%M:%S")
             item["opening_hours"] = oh
 
-            item["extras"]["amenity"] = "left_luggage"
+            apply_category(Categories.LEFT_LUGGAGE, item)
             yield item
 
         page = data.get("page", 1)


### PR DESCRIPTION
Part of #18308.

`locations/pipelines/count_categories.py` tracks items with no OSM top-level category tag (`atp/category/missing`), and `locations/pipelines/apply_nsi_categories.py` can backfill a category from NSI when a spider sets `brand_wikidata`/`operator_wikidata`, but a handful of spiders set neither and have no way to get a category at all.

A static scan for spiders referencing none of `apply_category`, `Categories.`, `brand_wikidata`, or `operator_wikidata` anywhere in their file/inheritance chain (including base classes in `locations/storefinders/`, shared `item_attributes` dicts imported from sibling spiders, and shared helper functions) turned up only a small number of genuine gaps once inheritance and NSI-fallback paths were accounted for. Most of the several hundred spiders that looked suspicious under a naive grep already have a working NSI fallback via an inherited `brand_wikidata`.

This PR fixes the following:
- `lagenovesa` (La Genovesa, AR supermarket) — now sets `Categories.SHOP_SUPERMARKET`
- `mariner_finance` (US consumer loan branches) — now sets `Categories.SHOP_MONEY_LENDER`
- `fujiservice_jp`, `spacer_jp`, `stasher` (luggage locker / left-luggage services) — were setting `item["extras"]["amenity"]` directly instead of using `apply_category()`; converted to `Categories.LUGGAGE_LOCKER` / `Categories.LEFT_LUGGAGE`
- `jptca` (Japan Traffic Culture Association public art) — was setting `item["extras"]["tourism"]` directly; converted to `apply_category(Categories.TOURISM_ARTWORK, ...)`

Spiders intentionally left alone during this pass:
- `naptan_gb` — UK transit stop/station data, tagged with `public_transport`/`highway`/`railway` schemes rather than the shop/amenity POI categories in `locations/categories.py`
- `tomtom` — ingests a heterogeneous open POI dataset with no single applicable category
- `university_maryland_medical_system`, `ups_freight_service_centers` — mixed facility types with no single obviously-correct category; risk of mistagging outweighs leaving them uncategorized
- `carrefour_ar`/`carrefour_it`/`carrefour_ro` — looked uncategorized under a naive scan but already call `apply_category()` via a shared helper imported from `carrefour_fr.py`

This is a small slice of a large ongoing backlog (#18308), not a complete fix.