### PR TITLE
Stop duplicating structured address fields into addr_full in more spiders

### DIFF
--- a/locations/spiders/bipa_hr.py
+++ b/locations/spiders/bipa_hr.py
@@ -6,7 +6,6 @@ from scrapy.http import Response
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_SR, OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class BipaHRSpider(Spider):
@@ -21,7 +20,8 @@ class BipaHRSpider(Spider):
             item["lat"] = store.xpath("@data-lat").get()
             item["lon"] = store.xpath("@data-lng").get()
             item["street_address"] = store.xpath("./article/address/text()[1]").get()
-            item["addr_full"] = merge_address_lines(store.xpath("./article/address/text()").getall())
+            if postcode_city := store.xpath("./article/address/text()[2]").get():
+                item["postcode"], _, item["city"] = postcode_city.strip().partition(" ")
             item["ref"] = store.xpath("./article/@class").get().split(" ", 1)[0]
 
             oh = OpeningHours()

--- a/locations/spiders/calvin_klein_au.py
+++ b/locations/spiders/calvin_klein_au.py
@@ -6,7 +6,6 @@ from scrapy.http import Response
 
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 from locations.spiders.calvin_klein import CalvinKleinSpider
 
 
@@ -22,7 +21,6 @@ class CalvinKleinAUSpider(Spider):
             item["lat"] = location["l"]
             item["lon"] = location["g"]
             item["branch"] = location["n"].split(" | ", 1)[1].removeprefix("Calvin Klein ")
-            item["addr_full"] = merge_address_lines(location.get("a"))
             item["street_address"] = location["a"][0]
             item["city"] = location["a"][1]
             item["state"] = location["a"][2]

--- a/locations/spiders/cooplands_doncaster_gb.py
+++ b/locations/spiders/cooplands_doncaster_gb.py
@@ -19,7 +19,7 @@ class CooplandsDoncasterGBSpider(scrapy.Spider):
 
         for index, store in enumerate(stores):
             data = store.xpath("ul/li/text()").extract()
-            addr_full = merge_address_lines(data[:-1])
+            addr_full = merge_address_lines(data[:-2])
 
             item = Feature(
                 ref=index,

--- a/locations/spiders/costa_coffee_cz.py
+++ b/locations/spiders/costa_coffee_cz.py
@@ -5,7 +5,6 @@ from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class CostaCoffeeCZSpider(scrapy.Spider):
@@ -24,7 +23,6 @@ class CostaCoffeeCZSpider(scrapy.Spider):
             item["street_address"] = shop.xpath(".//*[@class='address px-6']//text()").get()
             item["postcode"] = shop.xpath(".//*[@class='address px-6']//span[2]/text()").get()
             item["city"] = shop.xpath(".//*[@class='address px-6']//span[3]/text()").get()
-            item["addr_full"] = merge_address_lines(shop.xpath(".//*[@class='address px-6']//text()").getall())
 
             apply_category(Categories.COFFEE_SHOP, item)
 

--- a/locations/spiders/gifi.py
+++ b/locations/spiders/gifi.py
@@ -47,7 +47,7 @@ class GifiSpider(Spider):
             item["branch"] = item.pop("name").removeprefix("Gifi ")
             item["city"] = location["city"]["name"]
             item["street_address"] = merge_address_lines([location["street1"], location["street2"]])
-            item["addr_full"] = merge_address_lines(location["formatted_address"])
+            item["postcode"] = location["zip_code"]
             item["lat"] = location["_geoloc"]["lat"]
             item["lon"] = location["_geoloc"]["lng"]
             item["image"] = location["pictures"][0]

--- a/locations/spiders/lcbo_ca.py
+++ b/locations/spiders/lcbo_ca.py
@@ -7,7 +7,6 @@ from scrapy.http import Request, Response
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_EN, OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 from locations.storefinders.amasty_store_locator import AmastyStoreLocatorSpider
 
 
@@ -29,13 +28,9 @@ class LcboCASpider(AmastyStoreLocatorSpider):
         item["state"] = (
             popup_html.xpath('(.//div[@class="amlocator-info-popup"]/text())[2]').get("").strip(", ").split(" ", 1)[0]
         )
-        item["addr_full"] = merge_address_lines(
-            [
-                popup_html.xpath('.//span[@class="amlocator-info-address"]/text()').get(),
-                item.get("state"),
-                item.get("postcode"),
-            ]
-        )
+        # Fallback in case the follow-up request below fails to find a matching store;
+        # normally overwritten with a cleaner value from that response.
+        item["street_address"] = popup_html.xpath('.//span[@class="amlocator-info-address"]/text()').get()
         item["website"] = popup_html.xpath('.//a[@class="amlocator-link-store-details"]/@href').get()
         item["phone"] = (
             popup_html.xpath('.//a[@class="amlocator-phone-number"]/@href').get("").replace("tel:", "").strip("[]")

--- a/locations/spiders/mitsubishi_pr.py
+++ b/locations/spiders/mitsubishi_pr.py
@@ -25,9 +25,8 @@ class MitsubishiPRSpider(scrapy.Spider):
             item = DictParser.parse(address_data)
             item["ref"] = key["id"]
             item["postcode"] = address_data["postalArea"]
-            item["addr_full"] = merge_address_lines(
-                [address_data["addressLine1"], address_data["addressLine2"], address_data["addressLine3"]]
-            )
+            item["city"] = address_data["addressLine3"]
+            item["addr_full"] = merge_address_lines([address_data["addressLine2"]])
             item["phone"] = raw_data[1][f'${key["id"]}.phone']["phoneNumber"]
             item["branch"] = raw_data[1][key["id"]]["name"]
             apply_category(Categories.SHOP_CAR, item)

--- a/locations/spiders/old_chicago_us.py
+++ b/locations/spiders/old_chicago_us.py
@@ -4,7 +4,6 @@ from scrapy.http import Response
 from scrapy.spiders import SitemapSpider
 
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class OldChicagoUSSpider(SitemapSpider):
@@ -16,8 +15,14 @@ class OldChicagoUSSpider(SitemapSpider):
     def parse(self, response: Response, **kwargs: Any) -> Any:
         item = Feature()
         item["branch"] = response.xpath("//h2/text()").get()
-        item["street_address"] = response.xpath('//*[@class="location-address"]//a/text()').get()
-        item["addr_full"] = merge_address_lines(response.xpath('//*[@class="location-address"]/a//text()').getall())
+        addr_lines = response.xpath('//*[@class="location-address"]/a//text()').getall()
+        item["street_address"] = addr_lines[0].strip() if addr_lines else None
+        if len(addr_lines) > 1:
+            city, _, rest = addr_lines[1].strip().partition(",")
+            state, _, postcode = rest.strip().partition(",")
+            item["city"] = city.strip()
+            item["state"] = state.strip()
+            item["postcode"] = postcode.strip()
         item["phone"] = response.xpath('//*[contains(@href,"tel:")]/text()').get()
         item["ref"] = item["website"] = response.url
         yield item

--- a/locations/spiders/tudors_biscuit_world_us.py
+++ b/locations/spiders/tudors_biscuit_world_us.py
@@ -2,7 +2,6 @@ import scrapy
 
 from locations.hours import OpeningHours
 from locations.items import Feature
-from locations.pipelines.address_clean_up import merge_address_lines
 
 
 class TudorsBiscuitWorldUSSpider(scrapy.Spider):
@@ -23,8 +22,13 @@ class TudorsBiscuitWorldUSSpider(scrapy.Spider):
             item["lat"], item["lon"] = addr[0].xpath("@href").get().removeprefix("geo:").split(",")
             if not item["lon"].startswith("-"):
                 item["lon"] = "-" + item["lon"]
-            item["addr_full"] = merge_address_lines([a.xpath(".//text()").get() for a in addr])
             item["street_address"] = addr[0].xpath(".//text()").get()
+            if len(addr) > 1 and (city_state_zip := addr[1].xpath(".//text()").get()):
+                city, _, rest = city_state_zip.strip().partition(",")
+                state, _, postcode = rest.strip().rpartition(" ")
+                item["city"] = city.strip()
+                item["state"] = state.strip()
+                item["postcode"] = postcode.strip()
             item["phone"] = inner.xpath(".//a[starts-with(@href, 'tel:')]/@href").get().removeprefix("tel:")
 
             oh = OpeningHours()


### PR DESCRIPTION
## Summary

Part of #18306 (a sub-issue of #4878), round 2. Continuing to find spiders that already expose clearly-separate address components (street/city/state/postcode as distinct dict keys or DOM text nodes) but discard or duplicate them into `addr_full` instead of using the individual fields. Round 1 (#18314) fixed six spiders; this fixes nine more, each verified against live crawls (full or large-sample) before and after to confirm no address information is lost:

- `calvin_klein_au`: `addr_full` was an exact duplicate of the four-element `location["a"]` list that `street_address`/`city`/`state`/`postcode` were already being populated from individually.
- `costa_coffee_cz`: `addr_full` re-merged the very same DOM text nodes already split out into `street_address`/`postcode`/`city`.
- `gifi`: the source has a distinct `zip_code` field that was going unused; `postcode` is now populated from it instead of only appearing inside a redundant `addr_full`.
- `lcbo_ca`: `addr_full` was built early (street text + state + postcode) before a follow-up request later set the authoritative `street_address`/`city`, leaving a stale, redundant value. Removed, with the popup's street text kept as a fallback for the rare case (~3 of 688 stores per an existing code comment) where the follow-up request doesn't find a match.
- `bipa_hr`: the second address text node is reliably `"<postcode> <city>"`; now split into `postcode`/`city` instead of being folded into `addr_full`.
- `old_chicago_us`: the second address text node is reliably `"<city>, <state>, <zip>"`; now parsed into `city`/`state`/`postcode` instead of `addr_full`.
- `mitsubishi_pr`: `addressLine3` is consistently the town/municipality; now used for `city` instead of being buried in `addr_full` alongside the street and barrio lines.
- `tudors_biscuit_world_us`: the second address anchor text is reliably `"<city>, <state> <zip>"`; now parsed into `city`/`state`/`postcode` instead of `addr_full`.
- `cooplands_doncaster_gb`: `addr_full` included the postcode line that was already being set as `postcode` separately; trimmed to stop duplicating it.

Some other candidates found during this pass were deliberately left alone because the "extra" text couldn't be reliably split (e.g. mixed-format international addresses, or address blobs with a variable/unclear number of components), or because a live crawl showed a meaningful fraction of items are missing the structured fields that would be needed (e.g. `car_mart_us`, where ~16% of live listings only have address data in the `addr_full`-source text, not in the separate `data-lot-*` attributes).

This is still a large, ongoing backlog (`addr_full` legitimately appears in the vast majority of ~1200+ spiders where the source truly only exposes one unparsed address string) — more rounds will follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved location data accuracy by separating street addresses, cities, states, and postal codes into dedicated fields.
  * Corrected address parsing for multiple retailers and locations across Australia, Canada, Europe, Puerto Rico, and the United States.
  * Prevented postal codes and phone numbers from being included in street address values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->