### PR TITLE
Add boulangerie_louise_fr spider (119 locations)

### DIFF
--- a/locations/spiders/boulangerie_louise_fr.py
+++ b/locations/spiders/boulangerie_louise_fr.py
@@ -1,0 +1,73 @@
+import re
+from typing import Any, Iterable
+
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import CLOSED_FR, DAYS_FR, OpeningHours, sanitise_day
+from locations.items import Feature
+
+# The single-location map widget embeds a small JS object per page with the
+# post's numeric ID and its lat/lng, e.g.:
+#   "locations":[{"ID":"3190",...,"lat":"49.011482","lng":"1.169983",...}]
+LOCATION_JS_RE = re.compile(r'"locations":\[\{"ID":"(\d+)".*?"lat":"([\-\d.]+)","lng":"([\-\d.]+)"')
+
+
+class BoulangerieLouiseFRSpider(SitemapSpider):
+    name = "boulangerie_louise_fr"
+    item_attributes = {"brand": "Boulangerie Louise", "brand_wikidata": "Q127591514"}
+    sitemap_urls = ["https://www.boulangerielouise.com/boulangerie-sitemap.xml"]
+    sitemap_rules = [(r"/boulangerie/[^/]+/$", "parse")]
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        item = Feature()
+        item["ref"] = item["website"] = response.url
+
+        if m := LOCATION_JS_RE.search(response.xpath('//script[contains(text(), "gmwMapObjects")]/text()').get("")):
+            item["ref"], item["lat"], item["lon"] = m.groups()
+
+        item["branch"] = (
+            response.xpath('//div[@class="section-title"]/div[@class="h3"]/text()')
+            .get("")
+            .strip()
+            .removeprefix("Boulangerie Louise")
+            .strip()
+        )
+
+        # Free text with an inconsistent format across branches (comma-separated or not,
+        # postcode/country present or not) - not safe to split into street/city/postcode.
+        # See SPECS.md for the range of formats seen.
+        if addr_full := response.xpath(
+            '//div[@class="section-title"]/i[contains(@class, "fa-map-marker")]/following-sibling::text()[1]'
+        ).get():
+            item["addr_full"] = addr_full.strip()
+
+        item["phone"] = response.xpath(
+            '//div[@class="section-title"]/i[contains(@class, "fa-phone")]/following-sibling::text()[1]'
+        ).get()
+        item["email"] = response.xpath(
+            '//div[@class="section-title"]/i[contains(@class, "fa-envelope")]/following-sibling::text()[1]'
+        ).get()
+
+        item["opening_hours"] = OpeningHours()
+        for row in response.xpath('//table[contains(@class, "table-striped")]//tr'):
+            day, hours = row.xpath("./td//text()").getall()[:2]
+            if not (day := sanitise_day(day.strip(), DAYS_FR)):
+                continue
+            hours = hours.strip()
+            if hours.lower() in CLOSED_FR:
+                item["opening_hours"].add_range(day, hours, hours, closed=CLOSED_FR)
+                continue
+            if "-" not in hours:
+                continue
+            # Round hours are sometimes written without minutes, e.g. "8h - 20h".
+            open_time, close_time = (re.sub(r"(?<=h)$", "00", t.strip()) for t in hours.split("-", 1))
+            try:
+                item["opening_hours"].add_range(day, open_time, close_time, time_format="%Hh%M")
+            except ValueError:
+                continue
+
+        apply_category(Categories.SHOP_BAKERY, item)
+
+        yield item

--- a/locations/spiders/boulangerie_louise_fr.py
+++ b/locations/spiders/boulangerie_louise_fr.py
@@ -52,7 +52,11 @@ class BoulangerieLouiseFRSpider(SitemapSpider):
 
         item["opening_hours"] = OpeningHours()
         for row in response.xpath('//table[contains(@class, "table-striped")]//tr'):
-            day, hours = row.xpath("./td//text()").getall()[:2]
+            cells = row.xpath("./td")
+            if len(cells) < 2:
+                continue
+            day = " ".join(cells[0].xpath(".//text()").getall())
+            hours = " ".join(cells[1].xpath(".//text()").getall())
             if not (day := sanitise_day(day.strip(), DAYS_FR)):
                 continue
             hours = hours.strip()


### PR DESCRIPTION
Adds a spider for Boulangerie Louise (Wikidata Q127591514), a French artisanal bakery chain.

Closes #18271

## Approach

- Dedicated Yoast SEO sitemap (`boulangerie-sitemap.xml`) drives a `SitemapSpider`.
- No anti-bot/bot protection on the site — plain sitemap + per-page scrape, no Zyte required.
- Coordinates come from an inline `gmwMapObjects` JS blob (Geo my WP plugin), parsed with a regex.
- Name, address, phone, email, and opening hours are scraped from the theme's own per-branch
  content block (icon-prefixed text), not the plugin's own widget, which has a generic
  (non-branch-specific) email and a messier address format.
- `addr_full` is used rather than structured street/city/postcode fields: the source addresses
  are free text and genuinely inconsistent in format from branch to branch (sometimes
  comma-separated, sometimes not, postcode sometimes present/sometimes absent) — splitting them
  would guess wrong as often as right.
- NSI already has a single FR entry for this brand (`shop=bakery`), so `apply_category` plus
  `item_attributes` is sufficient.

## Validation

Full crawl: 119/119 locations scraped, 0 duplicates, unique refs/coordinates, `opening_hours` on
every item, perfect NSI match on all 119. `pre-commit`, `ty check`, and the full `pytest` suite
(314 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location data collection for Boulangerie Louise branches in France.
  * Captures branch names, addresses, contact details, geographic coordinates, opening hours, and bakery categorization.
  * Supports French opening-day labels, closed days, and round-hour formats.
  * Handles incomplete opening-hours entries while retaining valid schedule information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->