### PR TITLE
[DiBella's Subs] Add spider

### DIFF
--- a/locations/spiders/dibellas_subs_us.py
+++ b/locations/spiders/dibellas_subs_us.py
@@ -1,0 +1,33 @@
+import scrapy
+
+from locations.categories import Categories, apply_category
+from locations.dict_parser import DictParser
+from locations.hours import DAYS_EN, OpeningHours
+
+
+class DibellasSubsUSSpider(scrapy.Spider):
+    name = "dibellas_subs_us"
+    item_attributes = {"brand": "DiBella's Subs", "brand_wikidata": "Q5269976"}
+    start_urls = ["https://dibellas.com/api/v2/locations"]
+
+    def parse(self, response):
+        for location in response.json()["locations"]:
+            item = DictParser.parse(location)
+            item["branch"] = item.pop("name")
+            item["website"] = f"https://dibellas.com/locations/{location['path']}/"
+            item["opening_hours"] = self.parse_hours(location.get("hours", []))
+
+            apply_category(Categories.FAST_FOOD, item)
+
+            yield item
+
+    @staticmethod
+    def parse_hours(hours) -> OpeningHours:
+        oh = OpeningHours()
+        for rule in hours:
+            day = DAYS_EN.get(rule.get("day", "").capitalize())
+            open_time = rule.get("open")
+            close_time = rule.get("close")
+            if day and open_time and close_time:
+                oh.add_range(day, open_time, close_time)
+        return oh


### PR DESCRIPTION
Adds a spider for DiBella's Subs, a Rochester NY-based sandwich shop chain (closes #3525).

Despite the "Cloudflare" label on the issue, the store finder (`order.dibellas.com/locations`, which redirects to `dibellas.com/locations/`) is a plain Nuxt.js site with no bot protection. The location list is populated client-side from an unauthenticated JSON API at `https://dibellas.com/api/v2/locations`, which returns all 38 current locations (NY, MI, PA, OH, CT) in a single request with name, address, coordinates, per-location phone, and structured day-by-day opening hours. No proxy or browser rendering is needed.

Verified locally: 38/38 items scraped from a single request, all matching NSI perfectly (brand_wikidata Q5269976, confirmed against Wikidata's label/description), unique per-branch phone numbers, and correctly parsed opening hours (e.g. `Mo-Sa 10:00-21:00; Su 11:00-19:00`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location data collection for DiBella’s Subs restaurants across the United States.
  * Included branch names, website links, addresses, opening hours, and fast-food categorization for each location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->