### PR TITLE
[benita_bg] Add spider

### DIFF
--- a/locations/spiders/benita_bg.py
+++ b/locations/spiders/benita_bg.py
@@ -1,0 +1,44 @@
+import re
+from typing import Any
+
+from scrapy import Spider
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, Fuel, apply_category, apply_yes_no
+from locations.items import Feature
+
+
+class BenitaBGSpider(Spider):
+    name = "benita_bg"
+    item_attributes = {"brand": "Бенита", "brand_wikidata": "Q111762601", "name": "Бенита", "country": "BG"}
+    start_urls = ["https://benita.bg/бензиностанции"]
+
+    def parse(self, response: Response, **kwargs: Any) -> Any:
+        for location in response.css("div.object_item"):
+            item = Feature()
+            item["lat"] = location.attrib.get("data-lat")
+            item["lon"] = location.attrib.get("data-lng")
+            item["website"] = location.css("a.pull-left::attr(href)").get()
+            item["ref"] = item["website"].rstrip("/").rsplit("/", 1)[-1]
+
+            name = location.css("a.pull-left h2::text").get("").strip()
+            item["branch"] = re.sub(r"(?i)^benita\s*", "", name).strip(" –-")
+
+            item["addr_full"] = location.css("span.short_description::text").get("").strip()
+            item["phone"] = location.css('a.link[href^="tel:"]::attr(href)').get("").removeprefix("tel:")
+            item["email"] = location.css('a.link[href^="mailto:"]::attr(href)').get("").removeprefix("mailto:")
+
+            filters = [f.upper() for f in location.css("div.object_filter::text").getall()]
+
+            apply_yes_no(Fuel.DIESEL, item, any("DIESEL" in f for f in filters))
+            apply_yes_no(Fuel.OCTANE_95, item, any("A95" in f for f in filters))
+            apply_yes_no(Fuel.OCTANE_100, item, any("A100" in f for f in filters))
+            apply_yes_no(Fuel.LPG, item, any("LPG" in f for f in filters))
+            apply_yes_no(Fuel.PROPANE, item, any("БИТОВА ГАЗ" in f for f in filters))
+            apply_yes_no(Fuel.CNG, item, any("CNG" in f for f in filters))
+            apply_yes_no(Fuel.ADBLUE, item, any("ADBLUE" in f for f in filters))
+            apply_yes_no(Extras.CAR_WASH, item, any("АВТОМИВКА" in f for f in filters))
+
+            apply_category(Categories.FUEL_STATION, item)
+
+            yield item


### PR DESCRIPTION
Adds a spider for Benita (Бенита), a Bulgarian petrol station chain (Wikidata Q111762601, confirmed against benita.bg).

All 29 station locations are listed on a single HTML page (https://benita.bg/бензиностанции) with per-station lat/lng, address, phone, email, and fuel-type filter tags embedded as data attributes/divs — no pagination or JS API needed. Fuel filter labels are mapped to `fuel:*` tags per the issue's guidance (LPG-branded fuel -> `fuel:lpg`, "Битова газ" -> `fuel:propane`), plus diesel, octane 95/100, CNG, and AdBlue where present. Car wash presence is also captured.

Per-station telephone numbers and JSON-LD `openingHours`/company-wide phone on the detail pages turned out to be generic/boilerplate, so the spider uses the listing page's distinct per-branch phone numbers instead (verified all 29 are unique) and does not set opening_hours.

Verified locally: 29/29 items scraped, `atp/nsi/match_perfect` for all, brand string matches NSI exactly.

closes #5479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Benita fuel station locations in Bulgaria.
  * Captures station names, addresses, contact details, website links, and geographic coordinates.
  * Records available fuel types and services, including car washes, LPG, CNG, propane, and AdBlue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->