### PR TITLE
[Fannie May] Add spider

### DIFF
--- a/locations/spiders/fannie_may_us.py
+++ b/locations/spiders/fannie_may_us.py
@@ -1,0 +1,13 @@
+from locations.categories import Categories, apply_category
+from locations.storefinders.rio_seo import RioSeoSpider
+
+
+class FannieMayUSSpider(RioSeoSpider):
+    name = "fannie_may_us"
+    item_attributes = {"brand": "Fannie May", "brand_wikidata": "Q5433964", "name": "Fannie May"}
+    end_point = "https://maps.locations.fanniemay.com"
+
+    def post_process_feature(self, feature, location):
+        feature["branch"] = feature.pop("name", None)
+        apply_category(Categories.SHOP_CHOCOLATE, feature)
+        yield feature


### PR DESCRIPTION
Adds a spider for Fannie May (US chocolate/candy shops), using the Rio SEO storefinder (`locations/storefinders/rio_seo.py`), whose `getAsyncLocations` API endpoint was identified in the issue comments.

Branch names in the source data are city/location labels (e.g. "Meacham", "Golf"), not the shop name, so `name` is set statically to "Fannie May" via `item_attributes` and the source's `location_name` is moved to `branch`, matching the pattern used by sibling Rio SEO spiders like `party_city.py`.

Verified locally: 46 items scraped, all with unique `ref`/phone, populated opening hours, and addresses across IL/IN/IA/OH. `brand`/`brand_wikidata` (Q5433964) verified against Wikidata and matches NSI's `fanniemay-0e6ae0` entry exactly (`test_item_attributes_brand_strings_match_nsi` passes).

closes #7276