### PR TITLE
[UniCredit SI] Add spider

### DIFF
--- a/locations/spiders/unicredit_bank_si.py
+++ b/locations/spiders/unicredit_bank_si.py
@@ -1,0 +1,147 @@
+import re
+from typing import Any, AsyncIterator
+from urllib.parse import urlencode
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+
+# Titles that are just the generic word for "ATM" rather than anything location-specific, so
+# keeping them as name would add no information beyond the category tag already applied.
+GENERIC_TITLES = {"atm"}
+
+# An internal reference/branch code sometimes prepended as its own address line (e.g. "KR01",
+# "BA00057N"), duplicating the record's own branchCode field where that is set.
+CODE_LINE = re.compile(r"^[A-Za-z]{2}\d+[A-Za-z]?$")
+
+DAY_CODES = {"MO": "Mo", "TU": "Tu", "WE": "We", "TH": "Th", "FR": "Fr", "SA": "Sa", "SU": "Su"}
+
+
+class UnicreditBankSISpider(Spider):
+    name = "unicredit_bank_si"
+    item_attributes = {"brand": "UniCredit", "brand_wikidata": "Q45568"}
+
+    # Shared UniCredit group locator (also used by the unicreditbank.si branch finder iframe).
+    # getMarkersFiltered returns branches and ATMs inside a map bounding box, but the server
+    # collapses dense areas to at most ~99 markers. We therefore walk the country as a quadtree:
+    # a cell that comes back at/above SPLIT_THRESHOLD is subdivided until every leaf is complete.
+    API = "https://group.unicreditbanking.net/branch/markerService/getMarkersFiltered"
+    COUNTRY_BBOX = (45.3, 13.3, 46.9, 16.7)  # (sw_lat, sw_lng, ne_lat, ne_lng) covering Slovenia
+    SPLIT_THRESHOLD = 90  # complete responses observed up to ~95; truncation plateaus at ~99
+    MIN_SPAN = 0.02  # stop subdividing below this span (degrees) to guarantee termination
+
+    async def start(self) -> AsyncIterator[Any]:
+        yield self._cell_request(self.COUNTRY_BBOX)
+
+    def _cell_request(self, bbox: tuple[float, float, float, float]) -> JsonRequest:
+        sw_lat, sw_lng, ne_lat, ne_lng = bbox
+        params = {
+            "country": "SI",
+            "lang": "en",
+            "mandant": "si",
+            "globalFilter": 3,  # default filter: returns both branches and ATMs
+            "localFilter": "",
+            "showGroupLocations": "false",  # Slovenian locations only, no cross-border group POIs
+            "swLat": sw_lat,
+            "swLng": sw_lng,
+            "neLat": ne_lat,
+            "neLng": ne_lng,
+            "zoomLevel": 13,
+        }
+        return JsonRequest(
+            url="{}?{}".format(self.API, urlencode(params)),
+            headers={"Referer": "https://www.unicreditbank.si/"},
+            cb_kwargs={"bbox": bbox},
+        )
+
+    def parse(self, response: Response, bbox: tuple[float, float, float, float], **kwargs: Any) -> Any:
+        locations = response.json()
+        sw_lat, sw_lng, ne_lat, ne_lng = bbox
+
+        if (
+            len(locations) >= self.SPLIT_THRESHOLD
+            and (ne_lat - sw_lat) > self.MIN_SPAN
+            and (ne_lng - sw_lng) > self.MIN_SPAN
+        ):
+            mid_lat, mid_lng = (sw_lat + ne_lat) / 2, (sw_lng + ne_lng) / 2
+            for sub_bbox in (
+                (sw_lat, sw_lng, mid_lat, mid_lng),
+                (sw_lat, mid_lng, mid_lat, ne_lng),
+                (mid_lat, sw_lng, ne_lat, mid_lng),
+                (mid_lat, mid_lng, ne_lat, ne_lng),
+            ):
+                yield self._cell_request(sub_bbox)
+            return
+
+        if len(locations) >= self.SPLIT_THRESHOLD:
+            self.logger.warning("Cell {} hit the marker cap at minimum span; results may be truncated".format(bbox))
+
+        for location in locations:
+            if item := self.parse_location(location):
+                yield item
+
+    def parse_location(self, location: dict) -> Any:
+        item = DictParser.parse(location)
+        item["ref"] = str(location["id"])
+        item["lat"] = location.get("locLat")
+        item["lon"] = location.get("locLng")
+        item["phone"] = location.get("phoneNo")
+
+        if (item.get("name") or "").strip().lower() in GENERIC_TITLES:
+            item.pop("name", None)
+
+        # faxNo is identical to phoneNo on every branch record observed; it is not a genuine
+        # separate fax line, so it is not worth surfacing as an extra.
+
+        self.parse_address(item, location.get("address"))
+        if opening_hours := self.parse_hours(location.get("workinghours")):
+            item["opening_hours"] = opening_hours
+
+        if location.get("type") == "branch":
+            item["branch"] = item.pop("name", None)
+            apply_yes_no(Extras.ATM, item, location.get("bankomat") is True)
+            apply_category(Categories.BANK, item)
+        elif location.get("type") == "atm":
+            apply_category(Categories.ATM, item)
+        else:
+            self.logger.error("Unexpected location type: {}".format(location.get("type")))
+            return None
+
+        return item
+
+    def parse_address(self, item: dict, address: str | None) -> None:
+        item.pop("addr_full", None)  # HTML blob; parsed into components below
+        if not address:
+            return
+        lines = [line.strip() for line in re.split(r"<br\s*/?>", address) if line.strip()]
+        if lines and CODE_LINE.match(lines[0]):
+            lines = lines[1:]
+        if not lines:
+            return
+        # Last line is usually "<postcode> <city>" (sometimes "SI-<postcode> <city>"), but some
+        # records omit the postcode and give just the city.
+        last = lines[-1]
+        if match := re.match(r"^(?:SI-)?(\d{3,8})\s+(.+?)\.?$", last):
+            item["postcode"], item["city"] = match.group(1), match.group(2)
+        else:
+            item["city"] = last.rstrip(".")
+        lines = lines[:-1]
+        if lines:
+            item["street_address"] = lines[0]
+
+    def parse_hours(self, workinghours: list | None) -> OpeningHours | None:
+        if not isinstance(workinghours, list) or not workinghours:
+            return None
+        opening_hours = OpeningHours()
+        # Flat list in groups of five per day: [day_code, open, close, open2, close2].
+        for i in range(0, len(workinghours) - 4, 5):
+            if not (day := DAY_CODES.get(workinghours[i])):
+                continue
+            if workinghours[i + 1] and workinghours[i + 2]:
+                opening_hours.add_range(day, workinghours[i + 1], workinghours[i + 2])
+            if workinghours[i + 3] and workinghours[i + 4]:
+                opening_hours.add_range(day, workinghours[i + 3], workinghours[i + 4])
+        return opening_hours or None


### PR DESCRIPTION
Adds a spider for UniCredit's Slovenia branches and ATMs (unicreditbank.si), using the shared UniCredit group locator API (`group.unicreditbanking.net/branch/markerService/getMarkersFiltered`) with quadtree bounding-box subdivision, following the same pattern established for the CZ/RS/HU UniCredit spiders.

Data source is JSON from the group locator. Slovenian addresses have an extra leading line carrying an internal reference/branch code (e.g. "KR01", "BA00057N") duplicating the record's own `branchCode` field where set; this is stripped before parsing street/postcode/city. Most ATM titles here are genuinely informative (host store, mall or petrol-station names), so they're kept as name; the single literal placeholder title ("atm") is dropped. `faxNo` is identical to `phoneNo` on every observed record, so it's dropped rather than surfaced as an extra. No shared/hotline phone pattern was found in this country's data (phones are unique per record).

Verified locally: 43 items scraped (matches full crawl count), types and coordinates check out, addresses/hours parse correctly, brand resolves to the existing NSI UniCredit entry.

One of several countries tracked in #4494 (Slovenia row).