### PR TITLE
[arken_zoo_se] Add spider

### DIFF
--- a/locations/spiders/arken_zoo_se.py
+++ b/locations/spiders/arken_zoo_se.py
@@ -1,0 +1,56 @@
+import re
+from urllib.parse import urljoin
+
+from chompjs import parse_js_object
+from scrapy import Selector
+from scrapy.http import Response, TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
+
+# The generic national customer-service line/email, present on almost every
+# store page's structured data instead of a branch-specific contact.
+NATIONAL_HOTLINE_DIGITS = "104906255"
+NATIONAL_EMAIL = "kundtjanst@arkenzoo.se"
+
+
+class ArkenZooSESpider(StructuredDataSpider):
+    name = "arken_zoo_se"
+    item_attributes = {"brand": "Arken Zoo", "brand_wikidata": "Q16497087"}
+    start_urls = ["https://www.arkenzoo.se/info/vara-butiker"]
+    wanted_types = ["LocalBusiness"]
+
+    def parse(self, response: TextResponse, **kwargs):
+        # The store locator page embeds a JS array of stores (link, lat, lon, street)
+        # used to plot a Mapbox map. This is the only place coordinates are published.
+        blob = re.search(r"var locations\s*=\s*(\[.*?\]);", response.text, re.S)
+        if not blob:
+            return
+        for store in parse_js_object(blob.group(1)):
+            if not store:
+                continue
+            link_html, lat, lon = store[0], store[1], store[2]
+            if href := Selector(text=link_html).xpath("//a/@href").get():
+                # hrefs are relative to the site root, not this /info/ page
+                url = urljoin("https://www.arkenzoo.se/", href)
+                yield response.follow(url, callback=self.parse_sd, meta={"lat": lat, "lon": lon})
+
+    def iter_linked_data(self, response: Response):
+        # Store pages nest the LocalBusiness under a WebPage's mainEntity, which the
+        # default linked data lookup does not descend into.
+        for ld_obj in LinkedDataParser.iter_linked_data(response, self.json_parser):
+            if ld_obj.get("@type") == "WebPage" and isinstance(ld_obj.get("mainEntity"), dict):
+                yield ld_obj["mainEntity"]
+
+    def post_process_item(self, item, response: Response, ld_item: dict, **kwargs):
+        item["lat"] = response.meta.get("lat")
+        item["lon"] = response.meta.get("lon")
+        item["branch"] = item["name"].removeprefix("Arken Zoo").strip()
+        if re.sub(r"\D", "", item.get("phone") or "").endswith(NATIONAL_HOTLINE_DIGITS):
+            item["phone"] = None
+        if item.get("email") == NATIONAL_EMAIL:
+            item["email"] = None
+        item["image"] = None  # same generic brand logo used on every store page
+        apply_category(Categories.SHOP_PET, item)
+        yield item

--- a/locations/spiders/arken_zoo_se.py
+++ b/locations/spiders/arken_zoo_se.py
@@ -46,7 +46,7 @@ class ArkenZooSESpider(StructuredDataSpider):
     def post_process_item(self, item, response: Response, ld_item: dict, **kwargs):
         item["lat"] = response.meta.get("lat")
         item["lon"] = response.meta.get("lon")
-        item["branch"] = item["name"].removeprefix("Arken Zoo").strip()
+        item["branch"] = item.pop("name").removeprefix("Arken Zoo").strip()
         if re.sub(r"\D", "", item.get("phone") or "").endswith(NATIONAL_HOTLINE_DIGITS):
             item["phone"] = None
         if item.get("email") == NATIONAL_EMAIL:


### PR DESCRIPTION
Adds a spider for Arken Zoo (Swedish pet store chain, brand:wikidata Q16497087, confirmed against NSI `brands/shop/pet` entry `arkenzoo-8a75dc`).

The store locator page (`/info/vara-butiker`) embeds a JS array (`var locations=[...]`) used to plot a Mapbox map, giving each store's URL slug, latitude and longitude, and street — this is the only place coordinates are published. Each store's own page then carries JSON-LD nested under a `WebPage`'s `mainEntity` (not caught by the default linked-data lookup, so `iter_linked_data` is overridden) with name, address, phone, and opening hours.

Nulled out a shared national customer-service phone number (`010 - 490 62 55`, present on 144/148 stores) and shared customer-service email (`kundtjanst@arkenzoo.se`, 147/148) rather than treating them as branch-specific, while preserving the small number of stores with genuinely distinct contact details. Also dropped the `image` field since every store page links the same generic brand logo.

Verified locally: 148 items, all with unique refs, coordinates, and opening hours, and a perfect NSI match on every item.

closes #7665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for collecting Arken Zoo store locations across Sweden.
  - Store listings now include branch names, contact details, addresses, map coordinates, pet shop categorization, and brand information.
  - Store detail pages are processed to remove generic national contact information and branding imagery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->