### PR TITLE
Push add-spider PR checkpoints instead of losing work on timeout

### DIFF
--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -22,6 +22,34 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      - name: Create checkpoint branch and draft PR
+        id: checkpoint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="add-spider-issue-${{ github.event.issue.number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
+            git push origin "$BRANCH"
+          fi
+
+          if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
+            gh pr create --draft \
+              --title "[WIP] Add spider for #${{ github.event.issue.number }}" \
+              --body "Automated add-spider run in progress for #${{ github.event.issue.number }}. A bot will push commits and finalize this PR — or close it — as work completes." \
+              --head "$BRANCH" --base master
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -38,10 +66,47 @@ jobs:
             subagent's work is silently lost when the job finishes. Read the file's contents
             and carry out its steps directly with your own Bash/Read/Write/Edit tool calls.
 
-            Open a pull request when you're done. If no clean data source exists, say so clearly
-            in the workflow log instead of forcing a broken spider.
+            The workflow already created your branch (`${{ steps.checkpoint.outputs.branch }}`,
+            currently checked out) and opened a draft PR for it before invoking you — don't
+            create either yourself, and don't check out a different branch.
+
+            Commit locally, at each meaningful checkpoint, as you go — this protects your work
+            even if you run out of turns. But don't push after every commit: every push
+            re-triggers CI on the open PR, which is noisy and wasteful for WIP commits that
+            aren't finished yet. Push only once, near the end, after your local commits already
+            reflect the finished, verified spider.
+
+            When you're done and have pushed your final commit: update the PR's title and body
+            with the real summary (data source, pattern, verified item count,
+            `closes #${{ github.event.issue.number }}`) via `gh pr edit`, then take it out of
+            draft with `gh pr ready`.
+
+            If no clean data source exists, don't force a broken spider — say so clearly in the
+            workflow log, and close the draft PR with `gh pr close --comment "<why>"` rather than
+            leaving an empty, unexplained draft open.
+
+            As a safety net, the workflow itself will push whatever is committed locally right
+            after you finish, in case you run out of turns before pushing yourself — but don't
+            rely on that as your plan; push your own final commit yourself once verification
+            passes.
           claude_args: |
             --max-turns 100
             --allowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,TodoWrite"
             --disallowedTools "Agent,Task"
-            --append-system-prompt "You are running fully unattended in a GitHub Actions job, in a single non-interactive session with no event loop after this turn ends. There is no human present to ask for confirmation or approval. Do not pause, ask a clarifying question, or describe what you would do instead of doing it. Do not delegate any part of the task to a subagent (Agent/Task tool) — a backgrounded subagent never gets its result back to you or anyone else once this run ends, so its work is wasted. Carry out the entire task yourself with your own tool calls, including running shell commands, editing files, committing, pushing branches, and opening the pull request, exactly as instructed in the prompt and in .claude/agents/add-spider.md."
+            --append-system-prompt "You are running fully unattended in a GitHub Actions job, in a single non-interactive session with no event loop after this turn ends. There is no human present to ask for confirmation or approval. Do not pause, ask a clarifying question, or describe what you would do instead of doing it. Do not delegate any part of the task to a subagent (Agent/Task tool) — a backgrounded subagent never gets its result back to you or anyone else once this run ends, so its work is wasted. Carry out the entire task yourself with your own tool calls, including running shell commands, editing files, committing, and opening or finalizing the pull request, exactly as instructed in the prompt and in .claude/agents/add-spider.md. A branch and draft PR already exist for you — commit locally throughout the run to protect your work, but push only once near the end; pushing after every commit spams CI on the open PR. A workflow step pushes a safety-net commit after you finish in case you don't push in time yourself, but treat that as a last resort, not your plan."
+
+      - name: Push safety-net checkpoint
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ steps.checkpoint.outputs.branch }}"
+          if [ -z "$BRANCH" ]; then
+            exit 0
+          fi
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Automated checkpoint: workflow safety net"
+          fi
+          git push origin "HEAD:$BRANCH"


### PR DESCRIPTION
The add-spider workflow only committed/pushed/opened a PR at the very end of the run. If the agent hit the 100-turn cap before reaching that point, all research and code was lost with nothing for a human to pick up.

Now:
- A workflow step creates the branch and opens a draft PR (with an empty starter commit) before invoking Claude.
- Claude is told to commit locally at each checkpoint but push only once near the end, since every push re-triggers CI on the open PR and pushing after every WIP commit would be noisy.
- A final workflow step (`if: always()`) commits any leftover uncommitted changes and pushes the branch as a safety net in case Claude runs out of turns before pushing itself.