### PR TITLE
[Chemist Discount Centre AU] Add spider (63 locations)

### DIFF
--- a/locations/spiders/chemist_discount_centre_au.py
+++ b/locations/spiders/chemist_discount_centre_au.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+from locations.pipelines.address_clean_up import clean_address
+
+AU_STATES = {
+    "ACT": "ACT",
+    "NSW": "NSW",
+    "NT": "NT",
+    "QLD": "QLD",
+    "QUEENSLAND": "QLD",
+    "SA": "SA",
+    "TAS": "TAS",
+    "TASMANIA": "TAS",
+    "VIC": "VIC",
+    "VICTORIA": "VIC",
+    "WA": "WA",
+}
+
+
+class ChemistDiscountCentreAUSpider(JSONBlobSpider):
+    name = "chemist_discount_centre_au"
+    item_attributes = {"brand": "Chemist Discount Centre", "brand_wikidata": "Q141233470"}
+    allowed_domains = ["www.chemistdiscountcentre.com.au"]
+    start_urls = ["https://www.chemistdiscountcentre.com.au/breeze/frontend/Shops"]
+
+    def extract_json(self, response: Response) -> list[dict]:
+        return [
+            shop
+            for shop in response.json()
+            if isinstance(shop, dict) and shop.get("Visible") and shop.get("Name") != "Chemist Discount Centre Online"
+        ]
+
+    def pre_process_data(self, feature: dict) -> None:
+        feature["ref"] = str(feature.pop("Id"))
+        feature["street_address"] = clean_address([feature.pop("StreerNumber", None), feature.pop("Address", None)])
+        feature["phone"] = feature.pop("ContactNumber1", None)
+
+        # "Suburb" is usually "<suburb> <state>", but is sometimes just the
+        # suburb or, for a few records, only the state.
+        parts = (feature.pop("Suburb", None) or "").split()
+        if parts and parts[-1].upper() in AU_STATES:
+            feature["state"] = AU_STATES[parts.pop().upper()]
+        feature["city"] = " ".join(parts)
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Any:
+        item["branch"] = item.pop("name").removeprefix("Chemist Discount Centre ")
+        apply_category(Categories.PHARMACY, item)
+        yield item

--- a/locations/spiders/chemist_discount_centre_au.py
+++ b/locations/spiders/chemist_discount_centre_au.py
@@ -7,20 +7,6 @@ from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 from locations.pipelines.address_clean_up import clean_address
 
-AU_STATES = {
-    "ACT": "ACT",
-    "NSW": "NSW",
-    "NT": "NT",
-    "QLD": "QLD",
-    "QUEENSLAND": "QLD",
-    "SA": "SA",
-    "TAS": "TAS",
-    "TASMANIA": "TAS",
-    "VIC": "VIC",
-    "VICTORIA": "VIC",
-    "WA": "WA",
-}
-
 
 class ChemistDiscountCentreAUSpider(JSONBlobSpider):
     name = "chemist_discount_centre_au"
@@ -35,19 +21,10 @@ class ChemistDiscountCentreAUSpider(JSONBlobSpider):
             if isinstance(shop, dict) and shop.get("Visible") and shop.get("Name") != "Chemist Discount Centre Online"
         ]
 
-    def pre_process_data(self, feature: dict) -> None:
-        feature["ref"] = str(feature.pop("Id"))
-        feature["street_address"] = clean_address([feature.pop("StreerNumber", None), feature.pop("Address", None)])
-        feature["phone"] = feature.pop("ContactNumber1", None)
-
-        # "Suburb" is usually "<suburb> <state>", but is sometimes just the
-        # suburb or, for a few records, only the state.
-        parts = (feature.pop("Suburb", None) or "").split()
-        if parts and parts[-1].upper() in AU_STATES:
-            feature["state"] = AU_STATES[parts.pop().upper()]
-        feature["city"] = " ".join(parts)
-
     def post_process_item(self, item: Feature, response: Response, feature: dict, **kwargs: Any) -> Any:
         item["branch"] = item.pop("name").removeprefix("Chemist Discount Centre ")
+        item["street_address"] = clean_address([feature.get("StreerNumber"), feature.get("Address")])
+        item["addr_full"] = clean_address([item["street_address"], item.pop("city", None), item.get("postcode")])
+        item["phone"] = feature.get("ContactNumber1")
         apply_category(Categories.PHARMACY, item)
         yield item


### PR DESCRIPTION
Closes #18368

Chemist Discount Centre (AU) publishes all shops as a single JSON array at `/breeze/frontend/Shops`, so this is a `JSONBlobSpider`.

- Filters out non-visible records and the `Chemist Discount Centre Online` entry (which has no coordinates).
- `Id` is used as `ref` (`StoreId` is `0` for several stores).
- `Suburb` mixes `"<suburb> <state>"`, bare suburb, and occasionally just the state, so the trailing state token is split out into `addr:state` when present.
- The store finder exposes no opening hours (all `TradingHours*` / `ShopsHours` fields are null), so none are set.

63 locations, all with coordinates, phone, email and address. `black`/`isort`/`flake8`/`check_spider_naming_consistency` clean and `uv run pytest` passes (314).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for Chemist Discount Centre Australia locations.
  * Displays visible physical pharmacies while excluding online-only stores.
  * Includes pharmacy names, branch details, full street addresses, states, phone numbers, and reference information.
  * Improved the presentation and consistency of address and contact details for listed pharmacies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->