### PR TITLE
[groupama_fr] Add spider (1835 locations)

### DIFF
--- a/locations/spiders/groupama_fr.py
+++ b/locations/spiders/groupama_fr.py
@@ -31,7 +31,9 @@ class GroupamaFRSpider(StructuredDataSpider):
             yield response.follow(url, self.parse_sd)
 
     def post_process_item(self, item, response: Response, ld_data: dict, **kwargs):
-        item["ref"] = ld_data["@id"].rpartition("location-")[2]
-        item["branch"] = item.pop("name").removeprefix("Agence Groupama").removeprefix(" De ").strip(" -")
+        if isinstance(ld_data.get("@id"), str) and "location-" in ld_data["@id"]:
+            item["ref"] = ld_data["@id"].rpartition("location-")[2]
+        branch = (item.pop("name", None) or "").removeprefix("Agence Groupama").removeprefix(" De ").strip(" -")
+        item["branch"] = branch or None
         apply_category(Categories.OFFICE_INSURANCE, item)
         yield item

--- a/locations/spiders/groupama_fr.py
+++ b/locations/spiders/groupama_fr.py
@@ -1,0 +1,37 @@
+import re
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+POI_URL_RE = re.compile(r"\"webreseau\":\"(https://agences\.groupama\.fr/[^\"?]+-id[A-Z0-9]+)")
+DEPARTMENT_URL_RE = re.compile(r"/agences-[-\w]+-r[0-9AB]+$")
+
+
+class GroupamaFRSpider(StructuredDataSpider):
+    name = "groupama_fr"
+    item_attributes = {"brand": "Groupama", "brand_wikidata": "Q3083531"}
+    allowed_domains = ["agences.groupama.fr"]
+    start_urls = ["https://agences.groupama.fr/assurance/sitemap_agence_geo.xml"]
+    wanted_types = ["InsuranceAgency"]
+    drop_attributes = {"image"}
+    # The pages only expose region-level (not agency-level) social accounts.
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def parse(self, response: Response, **kwargs):
+        response.selector.remove_namespaces()
+        for url in response.xpath("//loc/text()").getall():
+            if DEPARTMENT_URL_RE.search(url):
+                yield response.follow(url, self.parse_department)
+
+    def parse_department(self, response: Response):
+        for url in set(POI_URL_RE.findall(response.text)):
+            yield response.follow(url, self.parse_sd)
+
+    def post_process_item(self, item, response: Response, ld_data: dict, **kwargs):
+        item["ref"] = ld_data["@id"].rpartition("location-")[2]
+        item["branch"] = item.pop("name").removeprefix("Agence Groupama").removeprefix(" De ").strip(" -")
+        apply_category(Categories.OFFICE_INSURANCE, item)
+        yield item

--- a/locations/spiders/groupama_fr.py
+++ b/locations/spiders/groupama_fr.py
@@ -1,38 +1,36 @@
 import re
 
 from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
 
 from locations.categories import Categories, apply_category
 from locations.structured_data_spider import StructuredDataSpider
 
 POI_URL_RE = re.compile(r"\"webreseau\":\"(https://agences\.groupama\.fr/[^\"?]+-id[A-Z0-9]+)")
-DEPARTMENT_URL_RE = re.compile(r"/agences-[-\w]+-r[0-9AB]+$")
 
 
-class GroupamaFRSpider(StructuredDataSpider):
+class GroupamaFRSpider(SitemapSpider, StructuredDataSpider):
     name = "groupama_fr"
     item_attributes = {"brand": "Groupama", "brand_wikidata": "Q3083531"}
     allowed_domains = ["agences.groupama.fr"]
-    start_urls = ["https://agences.groupama.fr/assurance/sitemap_agence_geo.xml"]
+    sitemap_urls = ["https://agences.groupama.fr/assurance/sitemap_agence_geo.xml"]
+    # The geo sitemap only lists region/department/city SEO pages. The per-agency
+    # pages are linked (as "webreseau") from the department listings, so match
+    # those and harvest the agency URLs from each.
+    sitemap_rules = [(r"/agences-[-\w]+-r[0-9AB]+$", "parse_department")]
     wanted_types = ["InsuranceAgency"]
     drop_attributes = {"image"}
     # The pages only expose region-level (not agency-level) social accounts.
     search_for_twitter = False
     search_for_facebook = False
 
-    def parse(self, response: Response, **kwargs):
-        response.selector.remove_namespaces()
-        for url in response.xpath("//loc/text()").getall():
-            if DEPARTMENT_URL_RE.search(url):
-                yield response.follow(url, self.parse_department)
-
     def parse_department(self, response: Response):
         for url in set(POI_URL_RE.findall(response.text)):
             yield response.follow(url, self.parse_sd)
 
     def post_process_item(self, item, response: Response, ld_data: dict, **kwargs):
-        if isinstance(ld_data.get("@id"), str) and "location-" in ld_data["@id"]:
-            item["ref"] = ld_data["@id"].rpartition("location-")[2]
+        if isinstance(ld_data.get("@id"), str) and (ref := ld_data["@id"].rpartition("location-")[2]):
+            item["ref"] = ref
         branch = (item.pop("name", None) or "").removeprefix("Agence Groupama").removeprefix(" De ").strip(" -")
         item["branch"] = branch or None
         apply_category(Categories.OFFICE_INSURANCE, item)

--- a/locations/spiders/groupama_fr.py
+++ b/locations/spiders/groupama_fr.py
@@ -29,8 +29,10 @@ class GroupamaFRSpider(SitemapSpider, StructuredDataSpider):
             yield response.follow(url, self.parse_sd)
 
     def post_process_item(self, item, response: Response, ld_data: dict, **kwargs):
-        if isinstance(ld_data.get("@id"), str) and (ref := ld_data["@id"].rpartition("location-")[2]):
-            item["ref"] = ref
+        if isinstance(ld_id := ld_data.get("@id"), str):
+            _, marker, ref = ld_id.rpartition("location-")
+            if marker and ref:
+                item["ref"] = ref
         branch = (item.pop("name", None) or "").removeprefix("Agence Groupama").removeprefix(" De ").strip(" -")
         item["branch"] = branch or None
         apply_category(Categories.OFFICE_INSURANCE, item)


### PR DESCRIPTION
Fixes #18375

Groupama insurance agencies in France (incl. overseas départements).

Enumerates ~108 department pages from the geo sitemap, extracts each agency's detail-page URL from the embedded `AddPoi(...)` blobs, and parses the schema.org `InsuranceAgency` JSON-LD on each (address, geo, phone, opening hours).

Local run: ~1835 agencies, opening hours on 99.9%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved discovery and collection of eligible Groupama agency pages across France through sitemap-based crawling.
  * Agency listings continue to include standardized office-insurance categorization and location references where available.

* **Bug Fixes**
  * Improved location reference handling to preserve reliable identifiers when agency pages lack a usable location marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->