### PR TITLE
[vandb_fr] Add V and B spider

### DIFF
--- a/locations/spiders/vandb_fr.py
+++ b/locations/spiders/vandb_fr.py
@@ -52,7 +52,9 @@ class VandbFRSpider(SitemapSpider, StructuredDataSpider):
                     item["opening_hours"].set_closed(day)
                     continue
                 times = [t.strip().replace("h", ":") for t in hours.split(" - ")]
-                for open_time, close_time in zip(times[0::2], times[1::2]):
+                if len(times) % 2 != 0:
+                    continue  # malformed hours text (odd token count) - skip rather than guess
+                for open_time, close_time in zip(times[0::2], times[1::2], strict=True):
                     item["opening_hours"].add_range(day, open_time, close_time)
 
         yield item

--- a/locations/spiders/vandb_fr.py
+++ b/locations/spiders/vandb_fr.py
@@ -1,0 +1,58 @@
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS_FR, OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+# Source JSON-LD hardcodes addressCountry to "FR" for every branch, but a handful are
+# actually elsewhere: 2 in Réunion (ISO country RE, not FR) and 1 in Northampton, UK -
+# whose page also carries a bogus postcode copy-pasted from the FR head office's.
+COUNTRY_OVERRIDES = {
+    "v-and-b-st-denis": "RE",
+    "v-and-b-st-pierre": "RE",
+    "v-and-b-northampton": "GB",
+}
+
+
+class VandbFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "vandb_fr"
+    item_attributes = {"brand": "V and B", "brand_wikidata": "Q100706329"}
+    sitemap_urls = ["https://www.vandb.fr/sitemap.xml"]
+    # "centrale" (head office) has no "v-and-b-" slug, so it's excluded here already.
+    sitemap_rules = [(r"/nos-magasins/(v-and-b-[a-z0-9-]+)$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name", "").removeprefix("V and B ")
+        apply_category(Categories.SHOP_ALCOHOL, item)
+
+        if country := COUNTRY_OVERRIDES.get(item["ref"]):
+            item["country"] = country
+            if item["ref"] == "v-and-b-northampton":
+                item["postcode"] = None
+
+        # Opening hours aren't in the JSON-LD; scrape the HTML hours grid instead.
+        # A handful of listed stores show "Fermé" on all 7 days with no exceptional-closure
+        # note - that's an unfilled-in listing, not a real weekly closure, so leave hours unset.
+        hour_rows = []
+        for row in response.xpath('//h2[contains(text(), "Horaires")]/following-sibling::div[1]/div'):
+            day = row.xpath("./span[1]/text()").get("").strip()
+            hours = row.xpath("./span[2]/text()").get("").strip()
+            if day in DAYS_FR:
+                hour_rows.append((DAYS_FR[day], hours))
+
+        if hour_rows and not all("ferm" in hours.lower() for _, hours in hour_rows):
+            item["opening_hours"] = OpeningHours()
+            for day, hours in hour_rows:
+                if "ferm" in hours.lower():
+                    item["opening_hours"].set_closed(day)
+                    continue
+                times = [t.strip().replace("h", ":") for t in hours.split(" - ")]
+                for open_time, close_time in zip(times[0::2], times[1::2]):
+                    item["opening_hours"].add_range(day, open_time, close_time)
+
+        yield item


### PR DESCRIPTION
Adds a spider for V and B (French alcohol shop chain, Wikidata Q100706329, NSI `vandb-f2c698`), scraping the 295 stores listed on vandb.fr's own sitemap under `/nos-magasins/v-and-b-*` (the site's head office page, `/nos-magasins/centrale`, has no such slug and is excluded by the same pattern). Each store page carries a clean `LocalBusiness` JSON-LD block for name/address/geo/phone/email, but opening hours aren't in it - they're scraped from a plain HTML day-by-day grid instead.

A few source-data quirks worth flagging: `addressCountry` is hardcoded to "FR" on every single page, but 3 stores are genuinely elsewhere - 2 in Réunion (ISO country RE) and 1 in Northampton, UK (whose page also carries a bogus postcode copy-pasted from the FR head office's own) - handled with a small per-ref country override rather than trusting the source. 2 stores have `0,0` coordinates in the JSON-LD itself and are correctly left without geometry. 6 stores show "Fermé" on all 7 days with no exceptional-closure note, which reads as an unfilled-in listing rather than a real weekly closure, so `opening_hours` is left unset for those instead of asserting a false closure. Category (`shop=alcohol`) is applied explicitly via `apply_category` rather than relying solely on NSI, since NSI's `vandb-f2c698` locationSet only covers France/Réunion and would otherwise leave the Northampton store uncategorised.

Verified locally with a full uncapped run: 295/295 pages 200 OK, 295/295 items scraped and tagged `shop=alcohol`, 292/295 exact NSI brand matches (the 3 country-overridden items match on brand/wikidata alone, as expected).

closes #7046

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for V and B location listings.
  * Extracts location categories, standardized branch names, country details, and weekly opening hours.
  * Excludes locations marked as permanently closed.
  * Corrects regional country assignments and invalid postcode data for affected listings.
  * Improves reliability when processing opening-hour information, avoiding incomplete or malformed schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->