### PR TITLE
[Mazda CL] Fix Spider

### DIFF
--- a/locations/spiders/mazda_cl.py
+++ b/locations/spiders/mazda_cl.py
@@ -1,97 +1,49 @@
-from typing import AsyncIterator, Iterable, Optional
+from typing import Iterable
 
 import scrapy
-from scrapy.http import Request, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.dict_parser import DictParser
-from locations.hours import DAYS, OpeningHours
+from locations.hours import DAYS_ES, OpeningHours
 from locations.items import Feature
 from locations.spiders.mazda_jp import MAZDA_SHARED_ATTRIBUTES
-
-# Derco is Mazda's importer/dealer network operator in Chile. Every
-# "Derco Center" dealership sells Mazda alongside other brands Derco
-# imports, so the full subsidiaries list corresponds to Mazda's own
-# "concesionarios" network published on mazda.cl.
-DAY_RANGES = {
-    "de lunes a viernes": ["Mo", "Tu", "We", "Th", "Fr"],
-    "de lunes a jueves": ["Mo", "Tu", "We", "Th"],
-    "de lunes a sábado": ["Mo", "Tu", "We", "Th", "Fr", "Sa"],
-    "de sábado a domingo": ["Sa", "Su"],
-    "todos los días": DAYS,
-    "domingo": ["Su"],
-    "sábado": ["Sa"],
-    "viernes": ["Fr"],
-}
 
 
 class MazdaCLSpider(scrapy.Spider):
     name = "mazda_cl"
     item_attributes = MAZDA_SHARED_ATTRIBUTES
-    allowed_domains = ["middleware.dercocenter.cl"]
-    start_urls = ["https://middleware.dercocenter.cl/api/v4/subsidiaries"]
 
-    async def start(self) -> AsyncIterator[Request]:
-        for url in self.start_urls:
-            # A compressed response (the default for Scrapy requests) hits a
-            # stale CloudFront-cached empty response ("[]"); requesting an
-            # uncompressed response avoids that cache entry.
-            yield Request(url, headers={"Accept-Encoding": "identity"})
+    start_urls = ["https://www.mazda.cl/concesionarios/"]
 
     def parse(self, response: Response) -> Iterable[Feature]:
-        for region in response.json()["regions"]:
-            for subsidiary in region["subsidiaries"]:
-                item = DictParser.parse(subsidiary)
-                item["ref"] = str(subsidiary["id"])
-                item["city"] = (subsidiary.get("commune") or {}).get("name")
-                item["state"] = region.get("name")
-                item["country"] = "CL"
-                if item.get("website") and not item["website"].startswith(("http://", "https://")):
-                    item["website"] = "https://" + item["website"]
-                item["phone"] = self.service_phone(subsidiary, "venta")
-                item["opening_hours"] = self.parse_hours(subsidiary, ["venta"])
-                apply_category(Categories.SHOP_CAR, item)
-                yield item
+        for dealer in response.xpath('//*[@class="dealers-block-list"]//*[@class="dealer-card"]'):
+            item = Feature()
+            item["name"] = item["ref"] = dealer.xpath('.//*[@class="dealer-info-name"]/text()').get()
+            item["street_address"] = dealer.xpath('.//*[@class="dealer-info-address"]/text()').get()
+            item["phone"] = dealer.xpath('.//*[@class="dealer-info-phone-number"]/text()').get()
 
-                if self.find_service(subsidiary, "servicio-tecnico"):
-                    service_item = item.deepcopy()
-                    service_item["ref"] = f"{item['ref']}-SERVICE"
-                    service_item["phone"] = self.service_phone(subsidiary, "servicio-tecnico")
-                    service_item["opening_hours"] = self.parse_hours(subsidiary, ["servicio-tecnico"])
-                    apply_category(Categories.SHOP_CAR_REPAIR, service_item)
-                    yield service_item
+            for section in dealer.xpath('.//*[@class="dealer-shift-sets"]/div'):
+                service_name = (
+                    section.xpath('.//*[@class="dealer-info-shift-set-title"]/text()').get(default="").strip()
+                )
 
-    @staticmethod
-    def find_service(subsidiary: dict, slug: str) -> Optional[dict]:
-        for service in subsidiary.get("services", []):
-            if service.get("slug") == slug:
-                return service
-        return None
+                oh = OpeningHours()
 
-    @staticmethod
-    def service_phone(subsidiary: dict, slug: str) -> Optional[str]:
-        if service := MazdaCLSpider.find_service(subsidiary, slug):
-            if numbers := service.get("contactNumber"):
-                # A handful of source entries concatenate two phone numbers
-                # into a single string separated by " - "; keep only the
-                # first number in that case.
-                return numbers[0].split(" - ")[0].strip()
-        return None
+                for hours_text in section.xpath('.//*[@class="dealer-shift"]').xpath("normalize-space()").getall():
+                    oh.add_ranges_from_string(
+                        hours_text.replace(" a ", "-"),
+                        DAYS_ES,
+                    )
 
-    @staticmethod
-    def parse_hours(subsidiary: dict, slugs: list[str]) -> OpeningHours:
-        oh = OpeningHours()
-        for service in subsidiary.get("services", []):
-            if service.get("slug") not in slugs:
-                continue
-            for entry in service.get("openingHours", []):
-                days = DAY_RANGES.get((entry.get("name") or "").strip().lower())
-                time_range = entry.get("value") or ""
-                if not days or " - " not in time_range:
-                    continue
-                open_time, close_time = time_range.split(" - ", 1)
-                open_time = ":".join(open_time.strip().split(":")[:2])
-                close_time = ":".join(close_time.strip().split(":")[:2])
-                for day in days:
-                    oh.add_range(day, open_time, close_time)
-        return oh
+                if service_name == "Venta":
+                    item = item.deepcopy()
+                    apply_category(Categories.SHOP_CAR, item)
+                    item["opening_hours"] = oh
+                    yield item
+
+                elif service_name == "Servicios":
+                    item = item.deepcopy()
+                    item["ref"] = f"{item['ref']}-SERVICE"
+                    apply_category(Categories.SHOP_CAR_REPAIR, item)
+                    item["opening_hours"] = oh
+                    yield item


### PR DESCRIPTION
```python
{'atp/brand/Mazda': 128,
 'atp/brand_wikidata/Q35996': 128,
 'atp/category/shop/car': 69,
 'atp/category/shop/car_repair': 59,
 'atp/clean_strings/name': 128,
 'atp/clean_strings/ref': 128,
 'atp/clean_strings/street_address': 128,
 'atp/country/CL': 128,
 'atp/duplicate_count': 4,
 'atp/field/branch/missing': 128,
 'atp/field/city/missing': 128,
 'atp/field/country/from_spider_name': 128,
 'atp/field/email/missing': 128,
 'atp/field/geometry/missing': 128,
 'atp/field/housenumber/missing': 128,
 'atp/field/operator/missing': 128,
 'atp/field/operator_wikidata/missing': 128,
 'atp/field/phone/invalid': 3,
 'atp/field/postcode/missing': 128,
 'atp/field/state/missing': 128,
 'atp/field/street/missing': 128,
 'atp/field/twitter/missing': 128,
 'atp/field/unit/missing': 128,
 'atp/item_scraped_host_count/www.mazda.cl': 132,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 128,
 'downloader/request_bytes': 812,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 27952,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 4.063000000001921,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 1, 10, 21, 13, 927488, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 828351,
 'httpcompression/response_count': 2,
 'item_dropped_count': 4,
 'item_dropped_reasons_count/DropItem': 4,
 'item_scraped_count': 128,
 'items_per_minute': 1920.0,
 'log_count/DEBUG': 134,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 30.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 1, 10, 21, 9, 865932, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Quality Improvements**
  * Dealer information is now collected directly from Mazda Chile’s official dealership directory.
  * Dealer names, addresses, and phone numbers are captured from the directory listings.
  * Separate sales and service records are generated with corresponding categories.
  * Opening hours now include Spanish day ranges and dealership-specific schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->