### PR TITLE
Split add-spider-from-issue into a dispatcher and an agent workflow

### DIFF
--- a/.github/workflows/add-spider-agent.yml
+++ b/.github/workflows/add-spider-agent.yml
@@ -1,0 +1,87 @@
+name: Add spider agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to build a spider for
+        required: true
+      branch:
+        description: Checkpoint branch with the draft PR already open
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  add-spider:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: astral-sh/setup-uv@v7
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          prompt: |
+            Follow the instructions in .claude/agents/add-spider.md exactly to research and
+            build a new spider for issue #${{ inputs.issue_number }} in this repository.
+            This checkout is exclusively yours for this run, so the worktree step in that file
+            is unnecessary here — work directly in the checked-out repo.
+
+            Do this yourself, in this single session — do NOT use the Agent/Task tool to
+            delegate any part of it to a subagent. There is no process left running to receive
+            a "task complete" notification once this job's turn ends, so a backgrounded
+            subagent's work is silently lost when the job finishes. Read the file's contents
+            and carry out its steps directly with your own Bash/Read/Write/Edit tool calls.
+
+            The workflow already created your branch (`${{ inputs.branch }}`, currently
+            checked out) and opened a draft PR for it before invoking you — don't create
+            either yourself, and don't check out a different branch.
+
+            Commit locally, at each meaningful checkpoint, as you go — this protects your work
+            even if you run out of turns. But don't push after every commit: every push
+            re-triggers CI on the open PR, which is noisy and wasteful for WIP commits that
+            aren't finished yet. Push only once, near the end, after your local commits already
+            reflect the finished, verified spider.
+
+            When you're done and have pushed your final commit: update the PR's title and body
+            with the real summary (data source, pattern, verified item count,
+            `closes #${{ inputs.issue_number }}`) via `gh pr edit`, then take it out of
+            draft with `gh pr ready`.
+
+            If no clean data source exists, don't force a broken spider — say so clearly in the
+            workflow log, and close the draft PR with `gh pr close --comment "<why>"` rather than
+            leaving an empty, unexplained draft open.
+
+            As a safety net, the workflow itself will push whatever is committed locally right
+            after you finish, in case you run out of turns before pushing yourself — but don't
+            rely on that as your plan; push your own final commit yourself once verification
+            passes.
+          claude_args: |
+            --max-turns 100
+            --allowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,TodoWrite"
+            --disallowedTools "Agent,Task"
+            --append-system-prompt "You are running fully unattended in a GitHub Actions job, in a single non-interactive session with no event loop after this turn ends. There is no human present to ask for confirmation or approval. Do not pause, ask a clarifying question, or describe what you would do instead of doing it. Do not delegate any part of the task to a subagent (Agent/Task tool) — a backgrounded subagent never gets its result back to you or anyone else once this run ends, so its work is wasted. Carry out the entire task yourself with your own tool calls, including running shell commands, editing files, committing, and opening or finalizing the pull request, exactly as instructed in the prompt and in .claude/agents/add-spider.md. A branch and draft PR already exist for you — commit locally throughout the run to protect your work, but push only once near the end; pushing after every commit spams CI on the open PR. A workflow step pushes a safety-net commit after you finish in case you don't push in time yourself, but treat that as a last resort, not your plan."
+
+      - name: Push safety-net checkpoint
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Automated checkpoint: workflow safety net"
+          fi
+          git push origin "HEAD:${{ inputs.branch }}"

--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -29,12 +29,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            exit 0
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
+            git push origin "$BRANCH"
           fi
 
-          git checkout -b "$BRANCH"
-          git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
-          git push origin "$BRANCH"
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            exit 0
+          fi
 
           gh pr create --draft \
             --title "[WIP] Add spider for #${{ github.event.issue.number }}" \
@@ -60,11 +65,14 @@ jobs:
       - name: Dispatch add-spider agent
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          APPROVER: ${{ github.actor }}
         run: |
           set -euo pipefail
-          BRANCH="add-spider-issue-${{ github.event.issue.number }}"
+          BRANCH="add-spider-issue-${ISSUE_NUMBER}"
           gh workflow run add-spider-agent.yml \
             --ref master \
-            -f issue_number="${{ github.event.issue.number }}" \
+            -f issue_number="$ISSUE_NUMBER" \
             -f branch="$BRANCH"
-          gh issue comment "${{ github.event.issue.number }}" --body "🤖 Approved by @${{ github.actor }} — starting the add-spider agent."
+          gh issue comment "$ISSUE_NUMBER" --body "🤖 Approved by @${APPROVER} — starting the add-spider agent."

--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -8,9 +8,10 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  issues: write
 
 jobs:
-  add-spider:
+  queue:
     if: |
       contains(github.event.issue.labels.*.name, 'new-spider') &&
       (github.event.action == 'opened' || github.event.label.name == 'new-spider')
@@ -18,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Create checkpoint branch, draft PR, and dispatch agent
+      - name: Create checkpoint branch and draft PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -28,28 +29,42 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-          else
-            git checkout -b "$BRANCH"
-            git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
-            git push origin "$BRANCH"
+            exit 0
           fi
 
-          if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
-            gh pr create --draft \
-              --title "[WIP] Add spider for #${{ github.event.issue.number }}" \
-              --body "Automated add-spider run in progress for #${{ github.event.issue.number }}. A bot will push commits and finalize this PR — or close it — as work completes." \
-              --head "$BRANCH" --base master
-          fi
+          git checkout -b "$BRANCH"
+          git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
+          git push origin "$BRANCH"
 
-          # Dispatched separately (rather than running the agent inline here) because this
-          # job's actor is whoever opened/labeled the issue. anthropics/claude-code-action
-          # requires write access from that actor and 401s otherwise — which silently stalls
-          # this workflow for issues filed by contributors without write access (e.g. #18419).
-          # workflow_dispatch runs are exempt from that actor check, since GitHub itself
-          # requires write access to dispatch a workflow.
+          gh pr create --draft \
+            --title "[WIP] Add spider for #${{ github.event.issue.number }}" \
+            --body "Automated add-spider run queued for #${{ github.event.issue.number }}. Waiting on maintainer approval before the agent starts — see the issue for details." \
+            --head "$BRANCH" --base master
+
+          # anthropics/claude-code-action requires the triggering actor to have repo write
+          # access, and 401s otherwise — silently stalling this flow for issues filed by
+          # contributors without write access (e.g. #18419). Rather than dispatching the
+          # agent here, wait for a maintainer to opt in explicitly: GitHub itself only lets
+          # Triage+ users add a label to someone else's issue, so the 'new-spider-approved'
+          # label event below is a trustworthy approval signal regardless of who filed the
+          # issue.
+          gh issue comment "${{ github.event.issue.number }}" --body "🤖 Queued an automated add-spider attempt for this issue (draft PR opened). A maintainer needs to add the \`new-spider-approved\` label to start the agent."
+
+  dispatch:
+    if: |
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'new-spider-approved' &&
+      contains(github.event.issue.labels.*.name, 'new-spider')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch add-spider agent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="add-spider-issue-${{ github.event.issue.number }}"
           gh workflow run add-spider-agent.yml \
             --ref master \
             -f issue_number="${{ github.event.issue.number }}" \
             -f branch="$BRANCH"
+          gh issue comment "${{ github.event.issue.number }}" --body "🤖 Approved by @${{ github.actor }} — starting the add-spider agent."

--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -7,8 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
-  id-token: write
+  actions: write
 
 jobs:
   add-spider:
@@ -16,14 +15,10 @@ jobs:
       contains(github.event.issue.labels.*.name, 'new-spider') &&
       (github.event.action == 'opened' || github.event.label.name == 'new-spider')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Create checkpoint branch and draft PR
-        id: checkpoint
+      - name: Create checkpoint branch, draft PR, and dispatch agent
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -48,65 +43,13 @@ jobs:
               --head "$BRANCH" --base master
           fi
 
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true
-          prompt: |
-            Follow the instructions in .claude/agents/add-spider.md exactly to research and
-            build a new spider for issue #${{ github.event.issue.number }} in this repository.
-            This checkout is exclusively yours for this run, so the worktree step in that file
-            is unnecessary here — work directly in the checked-out repo.
-
-            Do this yourself, in this single session — do NOT use the Agent/Task tool to
-            delegate any part of it to a subagent. There is no process left running to receive
-            a "task complete" notification once this job's turn ends, so a backgrounded
-            subagent's work is silently lost when the job finishes. Read the file's contents
-            and carry out its steps directly with your own Bash/Read/Write/Edit tool calls.
-
-            The workflow already created your branch (`${{ steps.checkpoint.outputs.branch }}`,
-            currently checked out) and opened a draft PR for it before invoking you — don't
-            create either yourself, and don't check out a different branch.
-
-            Commit locally, at each meaningful checkpoint, as you go — this protects your work
-            even if you run out of turns. But don't push after every commit: every push
-            re-triggers CI on the open PR, which is noisy and wasteful for WIP commits that
-            aren't finished yet. Push only once, near the end, after your local commits already
-            reflect the finished, verified spider.
-
-            When you're done and have pushed your final commit: update the PR's title and body
-            with the real summary (data source, pattern, verified item count,
-            `closes #${{ github.event.issue.number }}`) via `gh pr edit`, then take it out of
-            draft with `gh pr ready`.
-
-            If no clean data source exists, don't force a broken spider — say so clearly in the
-            workflow log, and close the draft PR with `gh pr close --comment "<why>"` rather than
-            leaving an empty, unexplained draft open.
-
-            As a safety net, the workflow itself will push whatever is committed locally right
-            after you finish, in case you run out of turns before pushing yourself — but don't
-            rely on that as your plan; push your own final commit yourself once verification
-            passes.
-          claude_args: |
-            --max-turns 100
-            --allowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,TodoWrite"
-            --disallowedTools "Agent,Task"
-            --append-system-prompt "You are running fully unattended in a GitHub Actions job, in a single non-interactive session with no event loop after this turn ends. There is no human present to ask for confirmation or approval. Do not pause, ask a clarifying question, or describe what you would do instead of doing it. Do not delegate any part of the task to a subagent (Agent/Task tool) — a backgrounded subagent never gets its result back to you or anyone else once this run ends, so its work is wasted. Carry out the entire task yourself with your own tool calls, including running shell commands, editing files, committing, and opening or finalizing the pull request, exactly as instructed in the prompt and in .claude/agents/add-spider.md. A branch and draft PR already exist for you — commit locally throughout the run to protect your work, but push only once near the end; pushing after every commit spams CI on the open PR. A workflow step pushes a safety-net commit after you finish in case you don't push in time yourself, but treat that as a last resort, not your plan."
-
-      - name: Push safety-net checkpoint
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          BRANCH="${{ steps.checkpoint.outputs.branch }}"
-          if [ -z "$BRANCH" ]; then
-            exit 0
-          fi
-          git add -A
-          if ! git diff --cached --quiet; then
-            git commit -m "Automated checkpoint: workflow safety net"
-          fi
-          git push origin "HEAD:$BRANCH"
+          # Dispatched separately (rather than running the agent inline here) because this
+          # job's actor is whoever opened/labeled the issue. anthropics/claude-code-action
+          # requires write access from that actor and 401s otherwise — which silently stalls
+          # this workflow for issues filed by contributors without write access (e.g. #18419).
+          # workflow_dispatch runs are exempt from that actor check, since GitHub itself
+          # requires write access to dispatch a workflow.
+          gh workflow run add-spider-agent.yml \
+            --ref master \
+            -f issue_number="${{ github.event.issue.number }}" \
+            -f branch="$BRANCH"


### PR DESCRIPTION
## Summary

PR #18419 (issue #18418, filed by a contributor without write access) got stuck as an empty `[WIP]` draft: the workflow's actor for `issues: opened/labeled` is whoever opened/labeled the issue, and `anthropics/claude-code-action` requires that actor to have repo write access, 401ing during OIDC token exchange otherwise (`App token exchange failed: 401 Unauthorized - User does not have write access on this repository`). This silently stalls the flow for anyone without write access.

Split the single workflow into two:
- `add-spider-from-issue.yml` — triggers on `issues: opened/labeled`. A `queue` job always creates the checkpoint branch + draft PR with plain git/gh (no Claude auth involved) and comments on the issue that it's waiting for approval. A separate `dispatch` job only fires when someone adds the new `new-spider-approved` label, and calls `gh workflow run` to kick off the agent.
- `add-spider-agent.yml` (new) — triggers only on `workflow_dispatch`, runs the actual `claude-code-action` step (moved as-is) plus the safety-net push.

This intentionally does **not** just remove the write-access check — running the agent (which has `Bash`/`Write`/`Edit` and a write-scoped token) against arbitrary issue content is a real prompt-injection surface, so the agent should only run once someone with at least Triage access has looked at the issue and opted in. GitHub itself only lets Triage+ users add a label to someone else's issue, so requiring the `new-spider-approved` label before dispatch is a trustworthy approval gate — no need to separately verify permissions via the API. `workflow_dispatch` events are also exempt from claude-code-action's actor-write-access check ("GitHub itself requires write access to dispatch a workflow"), which is what actually fixes the 401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an approval-based workflow for creating spiders from reported issues.
  * Automatically prepares a draft pull request and requests maintainer approval before processing.
  * Added a manually triggered process to build and finalize approved spider submissions.

* **Improvements**
  * Improved handling for existing branches and pull requests.
  * Added clearer outcomes for successful or unsuccessful submissions, including preserving changes and closing pull requests when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->