### PR TITLE
Require manual gh workflow run for add-spider approval

### DIFF
--- a/.github/workflows/add-spider-from-issue.yml
+++ b/.github/workflows/add-spider-from-issue.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
   issues: write
 
 jobs:
@@ -24,7 +23,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BRANCH="add-spider-issue-${{ github.event.issue.number }}"
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          BRANCH="add-spider-issue-${ISSUE_NUMBER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -33,7 +33,7 @@ jobs:
             git checkout -B "$BRANCH" "origin/$BRANCH"
           else
             git checkout -b "$BRANCH"
-            git commit --allow-empty -m "Start add-spider work for #${{ github.event.issue.number }}"
+            git commit --allow-empty -m "Start add-spider work for #${ISSUE_NUMBER}"
             git push origin "$BRANCH"
           fi
 
@@ -42,37 +42,16 @@ jobs:
           fi
 
           gh pr create --draft \
-            --title "[WIP] Add spider for #${{ github.event.issue.number }}" \
-            --body "Automated add-spider run queued for #${{ github.event.issue.number }}. Waiting on maintainer approval before the agent starts — see the issue for details." \
+            --title "[WIP] Add spider for #${ISSUE_NUMBER}" \
+            --body "Automated add-spider run queued for #${ISSUE_NUMBER}. Waiting on maintainer approval before the agent starts — see the issue for details." \
             --head "$BRANCH" --base master
 
           # anthropics/claude-code-action requires the triggering actor to have repo write
           # access, and 401s otherwise — silently stalling this flow for issues filed by
-          # contributors without write access (e.g. #18419). Rather than dispatching the
-          # agent here, wait for a maintainer to opt in explicitly: GitHub itself only lets
-          # Triage+ users add a label to someone else's issue, so the 'new-spider-approved'
-          # label event below is a trustworthy approval signal regardless of who filed the
-          # issue.
-          gh issue comment "${{ github.event.issue.number }}" --body "🤖 Queued an automated add-spider attempt for this issue (draft PR opened). A maintainer needs to add the \`new-spider-approved\` label to start the agent."
-
-  dispatch:
-    if: |
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'new-spider-approved' &&
-      contains(github.event.issue.labels.*.name, 'new-spider')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch add-spider agent
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          APPROVER: ${{ github.actor }}
-        run: |
-          set -euo pipefail
-          BRANCH="add-spider-issue-${ISSUE_NUMBER}"
-          gh workflow run add-spider-agent.yml \
-            --ref master \
-            -f issue_number="$ISSUE_NUMBER" \
-            -f branch="$BRANCH"
-          gh issue comment "$ISSUE_NUMBER" --body "🤖 Approved by @${APPROVER} — starting the add-spider agent."
+          # contributors without write access (e.g. #18419). We can't auto-dispatch the
+          # agent from here either: workflow_dispatch skips that actor-write-access check,
+          # but claude-code-action separately blocks bot actors outright, and dispatching
+          # via GITHUB_TOKEN makes the run's actor github-actions[bot]. So a maintainer
+          # needs to dispatch it themselves — that's a real user with real write access,
+          # which satisfies the check with no extra config.
+          gh issue comment "$ISSUE_NUMBER" --body "🤖 Queued an automated add-spider attempt for this issue (draft PR opened). A maintainer needs to approve by running \`gh workflow run add-spider-agent.yml -f issue_number=${ISSUE_NUMBER} -f branch=${BRANCH}\` (or via the Actions tab's *Run workflow* button) to start the agent."


### PR DESCRIPTION
## Summary

Follow-up to #18420. The label-triggered `dispatch` job doesn't actually work: `workflow_dispatch` events skip claude-code-action's actor-write-access check, but the action separately blocks bot actors outright, and dispatching via `GITHUB_TOKEN` makes the resulting run's actor `github-actions[bot]`. Tested live against issue #18418 — the run failed immediately with "Workflow initiated by non-human actor: github-actions (type: Bot)." `allowed_bots` is the documented way around that, but has open upstream issues (anthropics/claude-code-action#900, #1133) where it still 404s on a later permission check for bot actors.

Rather than fight that, drop the auto-dispatch-on-label job. The `queue` job still creates the checkpoint branch + draft PR and comments on the issue, but now tells a maintainer to run `gh workflow run add-spider-agent.yml -f issue_number=N -f branch=...` themselves (or use the Actions tab's "Run workflow" button) to approve. That's a real user dispatching a workflow, which GitHub itself already requires write access for — no bot-actor edge cases, no new secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the spider creation workflow to start the agent manually through the command line or Actions interface.
  * Improved generated pull request and issue comment details by consistently including the originating issue number.

* **Removed**
  * Removed automatic agent dispatching based on applying the `new-spider-approved` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->