### PR TITLE
[France Travail] Switch to the DILA open data API

### DIFF
--- a/locations/spiders/france_travail_fr.py
+++ b/locations/spiders/france_travail_fr.py
@@ -14,7 +14,7 @@ from locations.licenses import Licenses
 # The export endpoint returns every matching record in one response, so there
 # is no pagination to walk (the records endpoint caps out at 10000 anyway).
 DATASET_URL = (
-    "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets"
+    "https://api-lannuaire.service-public.gouv.fr/api/explore/v2.1/catalog/datasets"
     "/api-lannuaire-administration/exports/json?where=pivot%20like%20%22france_travail%22"
     "&select=id,nom,pivot,adresse,plage_ouverture,siret"
 )
@@ -23,7 +23,7 @@ DATASET_URL = (
 class FranceTravailFRSpider(Spider):
     name = "france_travail_fr"
     item_attributes = {"brand": "France Travail", "brand_wikidata": "Q8901192"}
-    allowed_domains = ["api-lannuaire.service-public.fr"]
+    allowed_domains = ["api-lannuaire.service-public.gouv.fr"]
     # The portal's robots.txt is the stock Opendatasoft template and blocks
     # /api/ from indexing. data.gouv.fr publishes this API as the dataset's
     # official access channel, under the Etalab 2.0 licence.

--- a/locations/spiders/france_travail_fr.py
+++ b/locations/spiders/france_travail_fr.py
@@ -1,58 +1,92 @@
+import json
 import re
+from typing import Any, AsyncIterator, Iterable
 
-import scrapy
+from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.hours import DAYS, DAYS_FR, OpeningHours, sanitise_day
 from locations.items import Feature
-from locations.linked_data_parser import LinkedDataParser
-from locations.structured_data_spider import StructuredDataSpider
+from locations.licenses import Licenses
+
+# https://www.data.gouv.fr/datasets/service-public-gouv-fr-annuaire-de-ladministration-base-de-donnees-locales
+# The export endpoint returns every matching record in one response, so there
+# is no pagination to walk (the records endpoint caps out at 10000 anyway).
+DATASET_URL = (
+    "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets"
+    "/api-lannuaire-administration/exports/json?where=pivot%20like%20%22france_travail%22"
+    "&select=id,nom,pivot,adresse,plage_ouverture,siret"
+)
 
 
-class FranceTravailFRSpider(StructuredDataSpider):
+class FranceTravailFRSpider(Spider):
     name = "france_travail_fr"
     item_attributes = {"brand": "France Travail", "brand_wikidata": "Q8901192"}
-    # The national government directory offers a "nearby offices" search which, when
-    # paginated to exhaustion from any single starting point, enumerates every France
-    # Travail office in the country (including overseas territories).
-    start_urls = ["https://lannuaire.service-public.gouv.fr/navigation/france_travail?page=1"]
-    wanted_types = ["GovernmentOffice"]
-    time_format = "%Hh%M"
-    # The only "telephone" present is the generic national hotline (3949), shared by
-    # every office, not a branch specific number; and the twitter/facebook links found
-    # on the page are generic site-wide social links, not specific to the office.
-    search_for_twitter = False
-    search_for_facebook = False
-    # The site aggressively rate limits (HTTP 429) with a low request budget, even at
-    # a conservative one request per second, well before all ~900 offices can be
-    # fetched in a single crawl.
-    requires_proxy = True
+    allowed_domains = ["api-lannuaire.service-public.fr"]
+    # The portal's robots.txt is the stock Opendatasoft template and blocks
+    # /api/ from indexing. data.gouv.fr publishes this API as the dataset's
+    # official access channel, under the Etalab 2.0 licence.
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    dataset_attributes = Licenses.ETALAB2.value | {
+        "source": "api",
+        "attribution:name": "Direction de l'information légale et administrative (DILA)",
+        "attribution:website": "https://lannuaire.service-public.gouv.fr/",
+    }
 
-    def parse(self, response, **kwargs):
-        urls = response.css('a[data-test="href-link-annuaireGeo"]::attr(href)').getall()
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(url=DATASET_URL)
 
-        for url in urls:
-            yield scrapy.Request(response.urljoin(url), callback=self.parse_sd)
+    def parse(self, response: Response) -> Iterable[Any]:
+        for location in response.json():
+            # Several fields are JSON documents embedded in strings.
+            pivots = json.loads(location["pivot"] or "[]")
+            if not any(pivot["type_service_local"] == "france_travail" for pivot in pivots):
+                continue
 
-        # A full page of 20 results implies there may be more pages to fetch.
-        if len(urls) >= 20:
-            page = int(re.search(r"page=(\d+)", response.url).group(1))
-            next_url = re.sub(r"page=\d+", f"page={page + 1}", response.url)
-            yield scrapy.Request(next_url, callback=self.parse)
+            # "Adresse postale" entries are PO boxes and carry no coordinates.
+            addresses = [a for a in json.loads(location["adresse"] or "[]") if a["type_adresse"] == "Adresse"]
+            if not addresses or not addresses[0].get("latitude"):
+                self.crawler.stats.inc_value("atp/france_travail_fr/no_coordinates")
+                continue
+            address = addresses[0]
 
-    def post_process_item(self, item: Feature, response, ld_data, **kwargs):
-        item["country"] = "FR"
-        # The generic national hotline number (3949), not a branch specific number.
-        item["phone"] = None
+            item = Feature()
+            item["ref"] = location["id"]
+            item["branch"] = re.sub(r"^(Agence|Relai)\b.*?France Travail\s*", "", location["nom"])
+            item["street_address"] = ", ".join(
+                filter(None, [address["complement1"], address["complement2"], address["numero_voie"]])
+            )
+            item["postcode"] = address["code_postal"]
+            item["city"] = address["nom_commune"]
+            item["country"] = "FR"
+            item["lat"] = address["latitude"]
+            item["lon"] = address["longitude"]
+            # The only telephone and website given are the national hotline
+            # (3949) and francetravail.fr, shared by every office.
+            item["extras"]["ref:FR:SIRET"] = location["siret"]
 
-        # The structured data nests the postal address under "location", which
-        # LinkedDataParser.parse_ld does not look inside for address fields (it only
-        # looks there for "geo"), so extract it here instead.
-        if location := LinkedDataParser.get_case_insensitive(ld_data, "location"):
-            if address := LinkedDataParser.get_case_insensitive(location, "address"):
-                item["street_address"] = LinkedDataParser.get_case_insensitive(address, "streetAddress")
-                item["city"] = LinkedDataParser.get_case_insensitive(address, "addressLocality")
-                item["postcode"] = LinkedDataParser.get_case_insensitive(address, "postalCode")
+            apply_category(Categories.OFFICE_EMPLOYMENT_AGENCY, item)
+            item["opening_hours"] = self.parse_opening_hours(json.loads(location["plage_ouverture"] or "[]"))
 
-        apply_category(Categories.OFFICE_EMPLOYMENT_AGENCY, item)
+            yield item
 
-        yield item
+    def parse_opening_hours(self, ranges: list[dict]) -> OpeningHours:
+        oh = OpeningHours()
+        for day_range in ranges:
+            start = sanitise_day(day_range["nom_jour_debut"], DAYS_FR)
+            # A handful of records leave the end of the range empty.
+            end = sanitise_day(day_range["nom_jour_fin"], DAYS_FR) or start
+            if not start:
+                self.crawler.stats.inc_value("atp/france_travail_fr/unparsed_days")
+                continue
+            first, last = DAYS.index(start), DAYS.index(end)
+            days = DAYS[first : last + 1] if first <= last else DAYS[first:] + DAYS[: last + 1]
+            for slot in ("1", "2"):
+                oh.add_days_range(
+                    days,
+                    day_range[f"valeur_heure_debut_{slot}"],
+                    day_range[f"valeur_heure_fin_{slot}"],
+                    time_format="%H:%M:%S",
+                )
+        return oh


### PR DESCRIPTION
An open data source is provided for public administration in France that allows us to not consume proxy requests and guarantee the data stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Updates**
  * France Travail location data is now sourced from the current public government directory export.
  * Location records are retrieved from a centralized data service, improving consistency in published location information.
  * The dataset continues to include records corresponding to France Travail locations only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->