### PR TITLE
[Lindt] Fix Spider

### DIFF
--- a/locations/spiders/lindt.py
+++ b/locations/spiders/lindt.py
@@ -12,7 +12,24 @@ class LindtSpider(JSONBlobSpider):
         "brand": "Lindt",
         "brand_wikidata": "Q152822",
     }
-    start_urls = ["https://www.lindt-spruengli.com/stores/"]
+    start_urls = [
+        "https://www.lindt.com.au/stores/",
+        "https://www.lindt.bg/stores/",
+        "https://www.lindt.ca/en/stores/",
+        "https://www.lindt.cz/stores/",
+        "https://www.lindt.dk/dk/stores/",
+        "https://www.lindt.de/shops/",
+        "https://www.lindt.es/tiendas-lindt/",
+        "https://www.lindt.hu/stores/",
+        "https://www.lindt.com.nl/nl/stores/",
+        "https://www.lindt.no/no/stores/",
+        "https://www.lindt.at/stores/",
+        "https://www.lindt.pl/stores/",
+        "https://www.lindt.ch/de/shops/",
+        "https://www.lindt.sk/stores/",
+        "https://www.lindt.fi/fi/stores/",
+        "https://www.lindtusa.com/stores/",
+    ]
 
     def extract_json(self, response):
         return DictParser.get_nested_key(


### PR DESCRIPTION
```python
{'atp/brand/Lindt': 304,
 'atp/brand_wikidata/Q152822': 304,
 'atp/category/shop/chocolate': 304,
 'atp/clean_strings/city': 1,
 'atp/clean_strings/name': 7,
 'atp/clean_strings/phone': 3,
 'atp/clean_strings/postcode': 14,
 'atp/clean_strings/street_address': 6,
 'atp/country/AT': 9,
 'atp/country/AU': 18,
 'atp/country/BE': 5,
 'atp/country/BG': 4,
 'atp/country/CA': 54,
 'atp/country/CH': 17,
 'atp/country/CZ': 12,
 'atp/country/DE': 65,
 'atp/country/DK': 3,
 'atp/country/ES': 28,
 'atp/country/FI': 4,
 'atp/country/GL': 1,
 'atp/country/HU': 10,
 'atp/country/LI': 1,
 'atp/country/NL': 6,
 'atp/country/NO': 2,
 'atp/country/PL': 22,
 'atp/country/PT': 5,
 'atp/country/SK': 3,
 'atp/country/US': 35,
 'atp/field/branch/missing': 304,
 'atp/field/country/from_reverse_geocoding': 81,
 'atp/field/country/from_website_url': 10,
 'atp/field/email/missing': 283,
 'atp/field/housenumber/missing': 304,
 'atp/field/opening_hours/missing': 36,
 'atp/field/operator/missing': 304,
 'atp/field/operator_wikidata/missing': 304,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 19,
 'atp/field/postcode/missing': 1,
 'atp/field/state/from_reverse_geocoding': 8,
 'atp/field/state/missing': 34,
 'atp/field/street/missing': 304,
 'atp/field/twitter/missing': 304,
 'atp/field/unit/missing': 304,
 'atp/geometry/null_island': 9,
 'atp/item_scraped_host_count/www.lindt.at': 9,
 'atp/item_scraped_host_count/www.lindt.bg': 4,
 'atp/item_scraped_host_count/www.lindt.ca': 54,
 'atp/item_scraped_host_count/www.lindt.ch': 18,
 'atp/item_scraped_host_count/www.lindt.com.au': 18,
 'atp/item_scraped_host_count/www.lindt.com.nl': 11,
 'atp/item_scraped_host_count/www.lindt.cz': 12,
 'atp/item_scraped_host_count/www.lindt.de': 65,
 'atp/item_scraped_host_count/www.lindt.dk': 3,
 'atp/item_scraped_host_count/www.lindt.es': 33,
 'atp/item_scraped_host_count/www.lindt.fi': 4,
 'atp/item_scraped_host_count/www.lindt.hu': 10,
 'atp/item_scraped_host_count/www.lindt.no': 2,
 'atp/item_scraped_host_count/www.lindt.pl': 23,
 'atp/item_scraped_host_count/www.lindt.sk': 3,
 'atp/item_scraped_host_count/www.lindtusa.com': 35,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 304,
 'downloader/request_bytes': 14101,
 'downloader/request_count': 38,
 'downloader/request_method_count/GET': 38,
 'downloader/response_bytes': 2953850,
 'downloader/response_count': 38,
 'downloader/response_status_count/200': 32,
 'downloader/response_status_count/301': 2,
 'downloader/response_status_count/302': 4,
 'elapsed_time_seconds': 8.484000000000037,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 6, 20, 25, 492001, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7821438,
 'httpcompression/response_count': 32,
 'item_scraped_count': 304,
 'items_per_minute': 2280.0,
 'log_count/DEBUG': 342,
 'log_count/INFO': 3,
 'response_received_count': 32,
 'responses_per_minute': 240.0,
 'robotstxt/request_count': 16,
 'robotstxt/response_count': 16,
 'robotstxt/response_status_count/200': 16,
 'scheduler/dequeued': 16,
 'scheduler/dequeued/memory': 16,
 'scheduler/enqueued': 16,
 'scheduler/enqueued/memory': 16,
 'start_time': datetime.datetime(2026, 9, 2, 6, 20, 17, 14927, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded store locator coverage to include country-specific locations across Australia, Bulgaria, Canada, Czech Republic, Denmark, Germany, Spain, Hungary, the Netherlands, Norway, Austria, Poland, Switzerland, Slovakia, Finland, and the United States.
  * Store information can now be collected from dedicated regional store locator pages instead of a single global page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->