### PR TITLE
[Elkjop NO] Fix spider

### DIFF
--- a/locations/spiders/elkjop_no.py
+++ b/locations/spiders/elkjop_no.py
@@ -1,23 +1,44 @@
-from typing import Any, Iterable
+from typing import Any, AsyncIterator, Iterable
 from urllib.parse import urljoin
 
-from scrapy import Spider
+from scrapy import Request
 from scrapy.http import TextResponse
+from scrapy_camoufox.page import PageMethod
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.items import Feature
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
 
 
-class ElkjopNOSpider(Spider):
+class ElkjopNOSpider(CamoufoxSpider):
     name = "elkjop_no"
     item_attributes = {"name": "Elkjøp", "brand": "Elkjøp", "brand_wikidata": "Q1771628"}
     start_urls = ["https://www.elkjop.no/api/stores"]
-    custom_settings = {"ROBOTSTXT_OBEY": False}
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type != "document"
+        and not request.url.startswith("https://www.elkjop.no/.well-known/vercel/security/"),
+    }
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
+            self.start_urls[0],
+            meta={
+                "dont_retry": True,
+                "handle_httpstatus_list": [429],
+                "camoufox_page_methods": [
+                    # The Vercel security checkpoint answers the first request with an
+                    # HTTP 429 challenge page, which reloads the real response once its
+                    # proof-of-work solves.
+                    PageMethod("wait_for_selector", "body > pre", timeout=90000),
+                    PageMethod("evaluate", "() => JSON.parse(document.body.textContent)"),
+                ],
+            },
+        )
 
     def parse(self, response: TextResponse, **kwargs: Any) -> Iterable[Feature]:
-        res = response.json().get("data", {})
-        for store in res.get("stores", []):
+        for store in response.meta["camoufox_page_methods"][1].result.get("data", {}).get("stores", []):
             item = DictParser.parse(store)
 
             item["branch"] = item.pop("name").removeprefix("Elkjøp ")


### PR DESCRIPTION
Spider is producing data after this fix in the local.

```
{'atp/brand/Elkjøp': 131,
 'atp/brand_wikidata/Q1771628': 131,
 'atp/category/shop/electronics': 131,
 'atp/country/NO': 131,
 'atp/field/country/from_spider_name': 131,
 'atp/field/email/missing': 131,
 'atp/field/opening_hours/missing': 131,
 'atp/field/operator/missing': 131,
 'atp/field/operator_wikidata/missing': 131,
 'atp/field/phone/missing': 131,
 'atp/field/state/missing': 131,
 'atp/field/street_address/missing': 131,
 'atp/field/twitter/missing': 131,
 'atp/field/unit/missing': 131,
 'atp/item_scraped_host_count/www.elkjop.no': 131,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 131,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 5,
 'camoufox/request_count/method/GET': 4,
 'camoufox/request_count/method/POST': 1,
 'camoufox/request_count/navigation': 2,
 'camoufox/request_count/resource_type/document': 2,
 'camoufox/request_count/resource_type/fetch': 2,
 'camoufox/request_count/resource_type/script': 1,
 'camoufox/response_count': 5,
 'camoufox/response_count/method/GET': 4,
 'camoufox/response_count/method/POST': 1,
 'camoufox/response_count/resource_type/document': 2,
 'camoufox/response_count/resource_type/fetch': 2,
 'camoufox/response_count/resource_type/script': 1,
 'downloader/request_bytes': 337,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 176728,
 'downloader/response_count': 1,
 'downloader/response_status_count/429': 1,
 'elapsed_time_seconds': 81.10899999999947,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 9, 17, 8, 425463, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 131,
 'items_per_minute': 97.03703703703702,
 'log_count/DEBUG': 144,
 'log_count/INFO': 8,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.7407407407407407,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 2, 9, 15, 47, 306234, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated store data retrieval to use a browser-based flow for improved compatibility with the source site.
  * Added support for handling temporary rate-limit responses while waiting for store information to become available.
  * Reduced unnecessary network requests during data collection, helping retrieval complete more efficiently.
  * Improved the reliability of store listings when the source site delivers data dynamically or requires browser-mediated access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->