### PR TITLE
[Williams Sonoma CA] Fix spider

### DIFF
--- a/locations/spiders/williams_sonoma_us.py
+++ b/locations/spiders/williams_sonoma_us.py
@@ -2,15 +2,16 @@ from typing import Iterable
 
 from scrapy.http import Response
 
-from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
-from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class WilliamsSonomaUSSpider(JSONBlobSpider, CamoufoxSpider):
+class WilliamsSonomaUSSpider(JSONBlobSpider, PlaywrightSpider):
     name = "williams_sonoma_us"
     allowed_domains = ["www.williams-sonoma.com"]
     start_urls = [
@@ -20,10 +21,11 @@ class WilliamsSonomaUSSpider(JSONBlobSpider, CamoufoxSpider):
         "WS": {"brand": "Williams-Sonoma", "brand_wikidata": "Q2581220"},
         "PB": {"brand": "Pottery Barn", "brand_wikidata": "Q3400126"},
     }
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
     locations_key = ["storeListResponse", "stores"]
 
     def extract_json(self, response: Response) -> dict | list[dict]:
+        print(response.text)
         return super().extract_json(response.replace(body=response.xpath("string(//body)").get()))
 
     def pre_process_data(self, feature: dict) -> None:


### PR DESCRIPTION
```python
{'atp/brand/Pottery Barn': 5,
 'atp/brand/Williams-Sonoma': 4,
 'atp/brand_wikidata/Q2581220': 4,
 'atp/brand_wikidata/Q3400126': 5,
 'atp/category/shop/furniture': 5,
 'atp/category/shop/houseware': 4,
 'atp/country/CA': 9,
 'atp/field/branch/missing': 9,
 'atp/field/email/missing': 9,
 'atp/field/housenumber/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/street/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/unit/missing': 9,
 'atp/item_scraped_host_count/www.williams-sonoma.ca': 9,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 5,
 'atp/nsi/match_perfect': 4,
 'atp/nsi/multiple_matches': 5,
 'downloader/request_bytes': 645,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14187,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.938000000000102,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 9, 50, 38, 833329, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9,
 'items_per_minute': 180.0,
 'log_count/DEBUG': 18,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 2, 9, 50, 34, 895741, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Williams Sonoma page retrieval to use the current browser automation configuration, improving compatibility and consistency when loading location data.
  - Standardized browser identification during retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->