### PR TITLE
[Williams Sonoma CA] Fix Spider

### DIFF
--- a/locations/spiders/williams_sonoma_ca.py
+++ b/locations/spiders/williams_sonoma_ca.py
@@ -1,3 +1,5 @@
+from scrapy.http import Response
+
 from locations.spiders.williams_sonoma_us import WilliamsSonomaUSSpider
 
 
@@ -7,3 +9,6 @@ class WilliamsSonomaCASpider(WilliamsSonomaUSSpider):
     start_urls = [
         "https://www.williams-sonoma.ca/search/stores.json?brands=WS,PB&lat=40.71304703&lng=-74.00723267&radius=100000&includeOutlets=false",
     ]
+
+    def extract_json(self, response: Response) -> dict | list[dict]:
+        return response.json().get("storeListResponse").get("stores")


### PR DESCRIPTION
```python
{'atp/brand/Pottery Barn': 5,
 'atp/brand/Williams-Sonoma': 4,
 'atp/brand_wikidata/Q2581220': 4,
 'atp/brand_wikidata/Q3400126': 5,
 'atp/category/shop/furniture': 5,
 'atp/category/shop/houseware': 4,
 'atp/country/CA': 9,
 'atp/field/branch/missing': 9,
 'atp/field/email/missing': 9,
 'atp/field/housenumber/missing': 9,
 'atp/field/operator/missing': 9,
 'atp/field/operator_wikidata/missing': 9,
 'atp/field/street/missing': 9,
 'atp/field/twitter/missing': 9,
 'atp/field/unit/missing': 9,
 'atp/item_scraped_host_count/www.williams-sonoma.ca': 9,
 'atp/lineage': 'S_?',
 'atp/nsi/match_failed': 5,
 'atp/nsi/match_perfect': 4,
 'atp/nsi/multiple_matches': 5,
 'downloader/request_bytes': 645,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 14187,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 3.938000000000102,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 9, 50, 38, 833329, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 9,
 'items_per_minute': 180.0,
 'log_count/DEBUG': 18,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 2,
 'playwright/request_count/method/GET': 2,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 2, 9, 50, 34, 895741, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store location data extraction from Williams Sonoma Canada responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->