### PR TITLE
[Westpac NZ] Fix Spider

### DIFF
--- a/locations/spiders/westpac_nz.py
+++ b/locations/spiders/westpac_nz.py
@@ -3,18 +3,19 @@ from typing import Any
 
 from scrapy.http import Response
 
-from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 from locations.hours import DAYS_FULL, OpeningHours
-from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class WestpacNZSpider(CamoufoxSpider):
+class WestpacNZSpider(PlaywrightSpider):
     name = "westpac_nz"
     item_attributes = {"brand": "Westpac", "brand_wikidata": "Q2031726"}
     start_urls = ["https://www.westpac.co.nz/contact-us/branch-finder/"]
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     def parse(self, response: Response, **kwargs: Any) -> Any:
         for location in json.loads(response.xpath('//div[@class="js-branch-finder-map container"]/@data-props').get())[


### PR DESCRIPTION
```python
{'atp/brand/Westpac': 364,
 'atp/brand_wikidata/Q2031726': 364,
 'atp/category/amenity/atm': 247,
 'atp/category/amenity/bank': 117,
 'atp/clean_strings/addr_full': 1,
 'atp/clean_strings/branch': 19,
 'atp/clean_strings/ref': 19,
 'atp/country/NZ': 364,
 'atp/field/city/missing': 364,
 'atp/field/country/from_spider_name': 364,
 'atp/field/email/missing': 364,
 'atp/field/housenumber/missing': 364,
 'atp/field/name/missing': 247,
 'atp/field/opening_hours/missing': 38,
 'atp/field/operator/missing': 117,
 'atp/field/operator_wikidata/missing': 117,
 'atp/field/phone/missing': 364,
 'atp/field/postcode/missing': 364,
 'atp/field/state/missing': 364,
 'atp/field/street/missing': 364,
 'atp/field/street_address/missing': 364,
 'atp/field/twitter/missing': 364,
 'atp/field/unit/missing': 364,
 'atp/item_scraped_host_count/www.westpac.co.nz': 364,
 'atp/lineage': 'S_?',
 'atp/located_in/New World': 10,
 'atp/located_in/Pak n Save': 6,
 'atp/located_in/Woolworths': 41,
 'atp/nsi/match_perfect': 364,
 'atp/operator/Westpac': 247,
 'atp/operator_wikidata/Q2031726': 247,
 'downloader/request_bytes': 1051,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 1687909,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 2,
 'elapsed_time_seconds': 26.031000000002678,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 10, 50, 46, 574159, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 364,
 'items_per_minute': 840.0,
 'log_count/DEBUG': 421,
 'log_count/INFO': 7,
 'playwright/browser_count': 1,
 'playwright/context_count': 1,
 'playwright/context_count/max_concurrent': 1,
 'playwright/context_count/persistent/False': 1,
 'playwright/context_count/remote/False': 1,
 'playwright/page_count': 2,
 'playwright/page_count/closed': 2,
 'playwright/page_count/max_concurrent': 1,
 'playwright/request_count': 26,
 'playwright/request_count/aborted': 24,
 'playwright/request_count/method/GET': 26,
 'playwright/request_count/navigation': 2,
 'playwright/request_count/resource_type/document': 2,
 'playwright/request_count/resource_type/font': 2,
 'playwright/request_count/resource_type/image': 11,
 'playwright/request_count/resource_type/script': 9,
 'playwright/request_count/resource_type/stylesheet': 2,
 'playwright/response_count': 2,
 'playwright/response_count/method/GET': 2,
 'playwright/response_count/resource_type/document': 2,
 'response_received_count': 2,
 'responses_per_minute': 4.615384615384615,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 2, 10, 50, 20, 551760, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Westpac New Zealand location data integration to use the Playwright browser engine.
  * Applied the standard browser configuration and user-agent settings for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->