### PR TITLE
[V and B] Add spider (296 locations)

### DIFF
--- a/locations/spiders/v_and_b_fr.py
+++ b/locations/spiders/v_and_b_fr.py
@@ -1,0 +1,61 @@
+import re
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+DAY_FR = {
+    "Lundi": "Mo",
+    "Mardi": "Tu",
+    "Mercredi": "We",
+    "Jeudi": "Th",
+    "Vendredi": "Fr",
+    "Samedi": "Sa",
+    "Dimanche": "Su",
+}
+
+HOURS_RE = re.compile(
+    rf"({'|'.join(DAY_FR)})\s*((?:\d{{1,2}}h\d{{2}}\s*-\s*)*\d{{1,2}}h\d{{2}}|Ferm[ée])",
+    re.IGNORECASE,
+)
+
+
+class VAndBFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "v_and_b_fr"
+    item_attributes = {"brand": "V and B", "brand_wikidata": "Q100706329"}
+    sitemap_urls = ["https://www.vandb.fr/sitemap.xml"]
+    sitemap_rules = [(r"https\:\/\/www\.vandb\.fr\/nos-magasins\/.+$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        apply_category(Categories.SHOP_ALCOHOL, item)
+        item["opening_hours"] = self.parse_opening_hours(response)
+        yield item
+
+    def parse_opening_hours(self, response: TextResponse) -> OpeningHours:
+        oh = OpeningHours()
+
+        text = " ".join(response.xpath("//text()").getall()).replace("\xa0", " ")
+        text = re.sub(r"[–—]", "-", text)
+        text = re.sub(r"\s+", " ", text)
+
+        if not (matches := HOURS_RE.findall(text)):
+            self.crawler.stats.inc_value("atp/v_and_b_fr/no_hours_found")
+            return oh
+
+        for day_fr, hours_str in matches:
+            if hours_str.lower().startswith("ferm"):
+                continue
+
+            times = [t.replace("h", ":") for t in re.findall(r"\d{1,2}h\d{2}", hours_str)]
+            for i in range(0, len(times), 2):
+                if i + 1 < len(times):
+                    oh.add_range(DAY_FR[day_fr.capitalize()], times[i], times[i + 1], time_format="%H:%M")
+
+        return oh


### PR DESCRIPTION
Adds a spider for the french alcohol seller V and B.

```
{'atp/brand/V and B': 296,
 'atp/brand_wikidata/Q100706329': 296,
 'atp/category/shop/alcohol': 296,
 'atp/clean_strings/phone': 2,
 'atp/country/FR': 296,
 'atp/field/branch/missing': 296,
 'atp/field/email/missing': 1,
 'atp/field/geometry/missing': 3,
 'atp/field/housenumber/missing': 296,
 'atp/field/opening_hours/missing': 7,
 'atp/field/operator/missing': 296,
 'atp/field/operator_wikidata/missing': 296,
 'atp/field/phone/invalid': 3,
 'atp/field/phone/missing': 6,
 'atp/field/state/missing': 296,
 'atp/field/street/missing': 296,
 'atp/field/twitter/missing': 296,
 'atp/field/unit/missing': 296,
 'atp/item_scraped_host_count/www.vandb.fr': 296,
 'atp/lineage': 'S_?',
 'atp/nsi/location_unknown': 296,
 'atp/nsi/match_failed': 296,
 'atp/v_and_b_fr/no_hours_found': 1,
 'downloader/request_bytes': 117371,
 'downloader/request_count': 298,
 'downloader/request_method_count/GET': 298,
 'downloader/response_bytes': 13695292,
 'downloader/response_count': 298,
 'downloader/response_status_count/200': 298,
 'elapsed_time_seconds': 359.1997239999473,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 2, 16, 6, 33, 311750, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 59300631,
 'httpcompression/response_count': 298,
 'item_scraped_count': 296,
 'items_per_minute': 49.47075208913649,
 'log_count/DEBUG': 594,
 'log_count/INFO': 8,
 'memusage/max': 417841152,
 'memusage/startup': 179814400,
 'request_depth_max': 1,
 'response_received_count': 298,
 'responses_per_minute': 49.8050139275766,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 297,
 'scheduler/dequeued/memory': 297,
 'scheduler/enqueued': 297,
 'scheduler/enqueued/memory': 297,
 'start_time': datetime.datetime(2026, 9, 2, 16, 0, 34, 107685, tzinfo=datetime.timezone.utc)}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting V and B France store locations.
  * Store listings now include business details, alcohol-shop categorization, and opening hours.
  * Opening hours are interpreted from French weekday and time-range information, excluding closed days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->