### PR TITLE
[Shoprite Holdings] Fix spider

### DIFF
--- a/locations/spiders/shoprite_holdings.py
+++ b/locations/spiders/shoprite_holdings.py
@@ -1,56 +1,56 @@
-from json.decoder import JSONDecodeError
-from typing import AsyncIterator
+from typing import AsyncIterator, Iterable
 
 from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import JsonRequest, Response
 
-from locations.categories import Categories, Extras, apply_yes_no
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import OpeningHours
+from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 SHOPRITE_BRANDS = {
-    "Checkers": {"brand": "Checkers", "brand_wikidata": "Q5089126", "extras": Categories.SHOP_SUPERMARKET.value},
+    "Checkers": {"brand": "Checkers", "brand_wikidata": "Q5089126", "category": Categories.SHOP_SUPERMARKET},
     "Checkers Hyper": {
         "brand": "Checkers Hyper",
         "brand_wikidata": "Q116518886",
-        "extras": Categories.SHOP_SUPERMARKET.value,
+        "category": Categories.SHOP_SUPERMARKET,
     },
     "Checkers LiquorShop": {
         "brand": "Checkers",
         "brand_wikidata": "Q5089126",
-        "extras": Categories.SHOP_ALCOHOL.value,
+        "category": Categories.SHOP_ALCOHOL,
     },
     "MediRite": {
         "brand": "MediRite",
         "brand_wikidata": "Q115696233",
         "located_in": "Checkers",
         "located_in_wikidata": "Q5089126",
-        "extras": Categories.PHARMACY.value,
+        "category": Categories.PHARMACY,
     },
-    "MediRite Plus": {"brand": "MediRite Plus", "brand_wikidata": "Q115696233", "extras": Categories.PHARMACY.value},
-    "Shoprite": {"brand": "Shoprite", "brand_wikidata": "Q1857639", "extras": Categories.SHOP_SUPERMARKET.value},
+    "MediRite Plus": {"brand": "MediRite Plus", "brand_wikidata": "Q115696233", "category": Categories.PHARMACY},
+    "Shoprite": {"brand": "Shoprite", "brand_wikidata": "Q1857639", "category": Categories.SHOP_SUPERMARKET},
     "Shoprite Hyper": {
         "brand": "Shoprite Hyper",
         "brand_wikidata": "Q1857639",
-        "extras": Categories.SHOP_SUPERMARKET.value,
+        "category": Categories.SHOP_SUPERMARKET,
     },
     "Shoprite LiquorShop": {
         "brand": "LiquorShop Shoprite",
         "brand_wikidata": "Q1857639",
-        "extras": Categories.SHOP_ALCOHOL.value,
+        "category": Categories.SHOP_ALCOHOL,
     },
     "Shoprite Mini": {
         "brand": "Shoprite Mini",
         "brand_wikidata": "Q1857639",
-        "extras": Categories.SHOP_CONVENIENCE.value,
+        "category": Categories.SHOP_CONVENIENCE,
     },
     "Super Usave": {
         "brand": "Super Usave",
         "brand_wikidata": "Q115696368",
-        "extras": Categories.SHOP_SUPERMARKET.value,
+        "category": Categories.SHOP_SUPERMARKET,
     },
-    "Usave": {"brand": "Usave", "brand_wikidata": "Q115696368", "extras": Categories.SHOP_SUPERMARKET.value},
+    "Usave": {"brand": "Usave", "brand_wikidata": "Q115696368", "category": Categories.SHOP_SUPERMARKET},
 }
 
 COUNTRY_IDS = {
@@ -66,6 +66,8 @@ COUNTRY_IDS = {
     "239": "ZM",
 }
 
+STORES_API = "https://www.medirite.co.za/bin/commons/stores.json"
+
 
 class ShopriteHoldingsSpider(Spider):
     name = "shoprite_holdings"
@@ -75,40 +77,33 @@ class ShopriteHoldingsSpider(Spider):
     ]
 
     start_urls = [
-        f"https://www.shopriteholdings.co.za/bin/stores.json?national=yes&brand={brand}&country={country}"
+        f"{STORES_API}?national=yes&brand={brand}&country={country}"
         for brand in brand_filters
         for country in COUNTRY_IDS
     ]
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         for url in self.start_urls:
-            yield JsonRequest(url=url, callback=self.parse_store_list, encoding="ISO-8859-1")
+            yield JsonRequest(url=url, callback=self.parse_store_list)
 
-    def parse_store_list(self, response):
-        try:
-            locations = response.json()["stores"]
-        except (UnicodeEncodeError, UnicodeDecodeError, JSONDecodeError):
-            locations = response.replace(body=response.text.encode("ASCII", "ignore").decode("utf-8", "ignore")).json()[
-                "stores"
-            ]
+    def parse_store_list(self, response: Response) -> Iterable[JsonRequest]:
+        store_list = response.json()
+        if not isinstance(store_list, dict):
+            # A brand/country pair with no stores returns a bare status list, e.g. [204]
+            return
 
-        for location in locations:
+        for location in store_list["stores"]:
             location["ref"] = location.pop("uid")
 
-            location = {k: v for k, v in location.items() if v != "null"}
+            location = {k: v for k, v in location.items() if v not in ("null", "")}
 
-            if "phoneInternationalCode" in location:
-                if location["phoneInternationalCode"].startswith("00"):
-                    location["phoneNumber"] = (
-                        "+"
-                        + location["phoneInternationalCode"].lstrip("00")
-                        + " "
-                        + location["phoneNumber"].lstrip("0")
-                    )
-                else:
-                    location["phoneNumber"] = (
-                        "+" + location["phoneInternationalCode"] + " " + location["phoneNumber"].lstrip("0")
-                    )
+            if location.get("phoneInternationalCode") and location.get("phoneNumber"):
+                location["phoneNumber"] = (
+                    "+"
+                    + location["phoneInternationalCode"].removeprefix("00")
+                    + " "
+                    + location["phoneNumber"].lstrip("0")
+                )
 
             location["street-address"] = clean_address(
                 [location.get("physicalAdd1"), location.get("physicalAdd2"), location.get("physicalAdd3")]
@@ -122,20 +117,20 @@ class ShopriteHoldingsSpider(Spider):
             item = DictParser.parse(location)
 
             item["branch"] = location["branch"]
-            item.update(SHOPRITE_BRANDS.get(location.get("brand")))
+            attributes = dict(SHOPRITE_BRANDS[location["brand"]])
+            apply_category(attributes.pop("category"), item)
+            item.update(attributes)
             item["website"] = self.get_website(item)
 
             yield JsonRequest(
-                url=f"https://www.shopriteholdings.co.za/bin/stores.json?uid={item['ref']}",
+                url=f"{STORES_API}?uid={item['ref']}",
                 meta={"item": item},
                 callback=self.parse_store,
             )
 
-    def parse_store(self, response):
+    def parse_store(self, response: Response) -> Iterable[Feature]:
         item = response.meta["item"]
-        response = response.replace(body=response.text.encode("ASCII", "ignore").decode("utf-8", "ignore"))
-        # Same info as main stores.json response:
-        # location = response.json()["singleStoreData"][0]
+        # response.json()["singleStoreData"][0] repeats the main stores.json record, so it is ignored
 
         services = [service["FacilityTypeName"] for service in response.json()["services"]]
         # Many other services can be listed for Checkers and LiquorShop, but not all refer to in-store facilities, some are just available nearby
@@ -152,10 +147,10 @@ class ShopriteHoldingsSpider(Spider):
             else:
                 item["opening_hours"].add_range(day_hours["TradingDay"], day_hours["StartTime"], day_hours["EndTime"])
 
-        item["extras"]["@source_uri"] = f"https://www.shopriteholdings.co.za/bin/stores.json?uid={item['ref']}"
+        item["extras"]["@source_uri"] = f"{STORES_API}?uid={item['ref']}"
         yield item
 
-    def get_website(self, item):
+    def get_website(self, item: Feature) -> str | None:
         # Checkers/Shoprite ZA redirect to fuller urls, but this seems simpler
         # e.g. https://www.shoprite.co.za/Western-Cape/Cape-Town/Durbanville/Shoprite-Durbanville/store-details/1894
         # i.e. /province/city/suburb/brand-branch/ref

--- a/locations/spiders/shoprite_holdings.py
+++ b/locations/spiders/shoprite_holdings.py
@@ -10,47 +10,25 @@ from locations.items import Feature
 from locations.pipelines.address_clean_up import clean_address
 
 SHOPRITE_BRANDS = {
-    "Checkers": {"brand": "Checkers", "brand_wikidata": "Q5089126", "category": Categories.SHOP_SUPERMARKET},
-    "Checkers Hyper": {
-        "brand": "Checkers Hyper",
-        "brand_wikidata": "Q116518886",
-        "category": Categories.SHOP_SUPERMARKET,
-    },
-    "Checkers LiquorShop": {
-        "brand": "Checkers",
-        "brand_wikidata": "Q5089126",
-        "category": Categories.SHOP_ALCOHOL,
-    },
-    "MediRite": {
-        "brand": "MediRite",
-        "brand_wikidata": "Q115696233",
-        "located_in": "Checkers",
-        "located_in_wikidata": "Q5089126",
-        "category": Categories.PHARMACY,
-    },
-    "MediRite Plus": {"brand": "MediRite Plus", "brand_wikidata": "Q115696233", "category": Categories.PHARMACY},
-    "Shoprite": {"brand": "Shoprite", "brand_wikidata": "Q1857639", "category": Categories.SHOP_SUPERMARKET},
-    "Shoprite Hyper": {
-        "brand": "Shoprite Hyper",
-        "brand_wikidata": "Q1857639",
-        "category": Categories.SHOP_SUPERMARKET,
-    },
-    "Shoprite LiquorShop": {
-        "brand": "LiquorShop Shoprite",
-        "brand_wikidata": "Q1857639",
-        "category": Categories.SHOP_ALCOHOL,
-    },
-    "Shoprite Mini": {
-        "brand": "Shoprite Mini",
-        "brand_wikidata": "Q1857639",
-        "category": Categories.SHOP_CONVENIENCE,
-    },
-    "Super Usave": {
-        "brand": "Super Usave",
-        "brand_wikidata": "Q115696368",
-        "category": Categories.SHOP_SUPERMARKET,
-    },
-    "Usave": {"brand": "Usave", "brand_wikidata": "Q115696368", "category": Categories.SHOP_SUPERMARKET},
+    "Checkers": ({"brand": "Checkers", "brand_wikidata": "Q5089126"}, Categories.SHOP_SUPERMARKET),
+    "Checkers Hyper": ({"brand": "Checkers Hyper", "brand_wikidata": "Q116518886"}, Categories.SHOP_SUPERMARKET),
+    "Checkers LiquorShop": ({"brand": "Checkers", "brand_wikidata": "Q5089126"}, Categories.SHOP_ALCOHOL),
+    "MediRite": (
+        {
+            "brand": "MediRite",
+            "brand_wikidata": "Q115696233",
+            "located_in": "Checkers",
+            "located_in_wikidata": "Q5089126",
+        },
+        Categories.PHARMACY,
+    ),
+    "MediRite Plus": ({"brand": "MediRite Plus", "brand_wikidata": "Q115696233"}, Categories.PHARMACY),
+    "Shoprite": ({"brand": "Shoprite", "brand_wikidata": "Q1857639"}, Categories.SHOP_SUPERMARKET),
+    "Shoprite Hyper": ({"brand": "Shoprite Hyper", "brand_wikidata": "Q1857639"}, Categories.SHOP_SUPERMARKET),
+    "Shoprite LiquorShop": ({"brand": "LiquorShop Shoprite", "brand_wikidata": "Q1857639"}, Categories.SHOP_ALCOHOL),
+    "Shoprite Mini": ({"brand": "Shoprite Mini", "brand_wikidata": "Q1857639"}, Categories.SHOP_CONVENIENCE),
+    "Super Usave": ({"brand": "Super Usave", "brand_wikidata": "Q115696368"}, Categories.SHOP_SUPERMARKET),
+    "Usave": ({"brand": "Usave", "brand_wikidata": "Q115696368"}, Categories.SHOP_SUPERMARKET),
 }
 
 COUNTRY_IDS = {
@@ -117,9 +95,9 @@ class ShopriteHoldingsSpider(Spider):
             item = DictParser.parse(location)
 
             item["branch"] = location["branch"]
-            attributes = dict(SHOPRITE_BRANDS[location["brand"]])
-            apply_category(attributes.pop("category"), item)
-            item.update(attributes)
+            brand, cat = SHOPRITE_BRANDS[location["brand"]]
+            apply_category(cat, item)
+            item.update(brand)
             item["website"] = self.get_website(item)
 
             yield JsonRequest(
@@ -147,7 +125,7 @@ class ShopriteHoldingsSpider(Spider):
             else:
                 item["opening_hours"].add_range(day_hours["TradingDay"], day_hours["StartTime"], day_hours["EndTime"])
 
-        item["extras"]["@source_uri"] = f"{STORES_API}?uid={item['ref']}"
+        # item["extras"]["@source_uri"] = f"{STORES_API}?uid={item['ref']}"
         yield item
 
     def get_website(self, item: Feature) -> str | None:

--- a/locations/spiders/shoprite_holdings.py
+++ b/locations/spiders/shoprite_holdings.py
@@ -124,8 +124,6 @@ class ShopriteHoldingsSpider(Spider):
                 item["opening_hours"].set_closed(day_hours["TradingDay"])
             else:
                 item["opening_hours"].add_range(day_hours["TradingDay"], day_hours["StartTime"], day_hours["EndTime"])
-
-        # item["extras"]["@source_uri"] = f"{STORES_API}?uid={item['ref']}"
         yield item
 
     def get_website(self, item: Feature) -> str | None:


### PR DESCRIPTION
```
{'atp/brand/Checkers': 706,
 'atp/brand/Checkers Hyper': 41,
 'atp/brand/LiquorShop Shoprite': 627,
 'atp/brand/MediRite': 114,
 'atp/brand/MediRite Plus': 25,
 'atp/brand/Shoprite': 738,
 'atp/brand/Shoprite Hyper': 3,
 'atp/brand/Shoprite Mini': 156,
 'atp/brand/Super Usave': 1,
 'atp/brand/Usave': 528,
 'atp/brand_wikidata/Q115696233': 139,
 'atp/brand_wikidata/Q115696368': 529,
 'atp/brand_wikidata/Q116518886': 41,
 'atp/brand_wikidata/Q1857639': 1524,
 'atp/brand_wikidata/Q5089126': 706,
 'atp/category/amenity/pharmacy': 139,
 'atp/category/multiple': 139,
 'atp/category/shop/alcohol': 991,
 'atp/category/shop/convenience': 156,
 'atp/category/shop/supermarket': 1653,
 'atp/clean_strings/branch': 27,
 'atp/clean_strings/city': 18,
 'atp/clean_strings/postcode': 157,
 'atp/clean_strings/state': 11,
 'atp/country/AO': 26,
 'atp/country/BW': 39,
 'atp/country/GH': 7,
 'atp/country/LS': 28,
 'atp/country/MZ': 15,
 'atp/country/NA': 96,
 'atp/country/SZ': 42,
 'atp/country/ZA': 2639,
 'atp/country/ZM': 47,
 'atp/field/country/from_reverse_geocoding': 42,
 'atp/field/email/missing': 2939,
 'atp/field/housenumber/missing': 2939,
 'atp/field/name/missing': 1,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 2939,
 'atp/field/operator_wikidata/missing': 2939,
 'atp/field/phone/invalid': 37,
 'atp/field/phone/missing': 35,
 'atp/field/postcode/missing': 54,
 'atp/field/street/missing': 2939,
 'atp/field/twitter/missing': 2939,
 'atp/field/unit/missing': 2939,
 'atp/item_scraped_host_count/www.medirite.co.za': 2939,
 'atp/lineage': 'S_?',
 'atp/located_in/Checkers': 114,
 'atp/located_in_wikidata/Q5089126': 114,
 'atp/nsi/location_unknown': 1,
 'atp/nsi/match_failed': 1,
 'atp/nsi/match_perfect': 2938,
 'downloader/request_bytes': 1422270,
 'downloader/request_count': 2960,
 'downloader/request_method_count/GET': 2960,
 'downloader/response_bytes': 5885905,
 'downloader/response_count': 2960,
 'downloader/response_status_count/200': 2960,
 'dupefilter/filtered': 139,
 'elapsed_time_seconds': 3625.078,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 3, 8, 0, 59, 514644, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 10050828,
 'httpcompression/response_count': 2960,
 'item_scraped_count': 2939,
 'items_per_minute': 48.64551724137931,
 'log_count/DEBUG': 5900,
 'log_count/INFO': 63,
 'request_depth_max': 1,
 'response_received_count': 2960,
 'responses_per_minute': 48.99310344827586,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 2959,
 'scheduler/dequeued/memory': 2959,
 'scheduler/enqueued': 2959,
 'scheduler/enqueued/memory': 2959,
 'start_time': datetime.datetime(2026, 9, 3, 7, 0, 34, 446490, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store data retrieval through the updated MediRite stores service.
  * Improved handling of incomplete or empty store responses.
  * Removed empty field values from store listings.
  * Improved international phone number normalization when complete information is available.
  * Updated store-detail links to use the current service endpoint.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->