### PR TITLE
[Northside Hospital US] Fix Spider

### DIFF
--- a/locations/spiders/northside_hospital_us.py
+++ b/locations/spiders/northside_hospital_us.py
@@ -1,15 +1,18 @@
-from scrapy import Spider
 from scrapy.http import JsonRequest
 
 from locations.categories import Categories, HealthcareSpecialities, apply_category, apply_healthcare_specialities
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
+from locations.user_agents import BROWSER_DEFAULT
 
 
-class NorthsideHospitalUSSpider(Spider):
+class NorthsideHospitalUSSpider(PlaywrightSpider):
     name = "northside_hospital_us"
     item_attributes = {"brand": "Northside Hospital", "brand_wikidata": "Q7059745"}
     start_urls = ["https://locations-api-prod.northside.com/api/LocationsSearch?&Page=1&PageSize=10"]
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {"USER_AGENT": BROWSER_DEFAULT}
 
     _category_map = {
         "Cancer Services": (Categories.HOSPITAL, [HealthcareSpecialities.ONCOLOGY]),

--- a/locations/spiders/northside_hospital_us.py
+++ b/locations/spiders/northside_hospital_us.py
@@ -1,19 +1,18 @@
+from scrapy import Spider
 from scrapy.http import JsonRequest
 
-from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, HealthcareSpecialities, apply_category, apply_healthcare_specialities
 from locations.dict_parser import DictParser
 from locations.pipelines.address_clean_up import merge_address_lines
-from locations.settings import DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
 
 
-class NorthsideHospitalUSSpider(CamoufoxSpider):
+class NorthsideHospitalUSSpider(Spider):
     name = "northside_hospital_us"
     item_attributes = {"brand": "Northside Hospital", "brand_wikidata": "Q7059745"}
     start_urls = ["https://locations-api-prod.northside.com/api/LocationsSearch?&Page=1&PageSize=10"]
-    captcha_type = "cloudflare_turnstile"
-    captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
-    custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
+    # captcha_type = "cloudflare_turnstile"
+    # captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
+    # custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
     handle_httpstatus_list = [403]
 
     _category_map = {

--- a/locations/spiders/northside_hospital_us.py
+++ b/locations/spiders/northside_hospital_us.py
@@ -10,10 +10,6 @@ class NorthsideHospitalUSSpider(Spider):
     name = "northside_hospital_us"
     item_attributes = {"brand": "Northside Hospital", "brand_wikidata": "Q7059745"}
     start_urls = ["https://locations-api-prod.northside.com/api/LocationsSearch?&Page=1&PageSize=10"]
-    # captcha_type = "cloudflare_turnstile"
-    # captcha_selector_indicating_success = '//link[@href="resource://content-accessible/plaintext.css"]'
-    # custom_settings = DEFAULT_CAMOUFOX_SETTINGS_FOR_CLOUDFLARE_TURNSTILE
-    handle_httpstatus_list = [403]
 
     _category_map = {
         "Cancer Services": (Categories.HOSPITAL, [HealthcareSpecialities.ONCOLOGY]),


### PR DESCRIPTION
```python
{'atp/brand/Northside Hospital': 635,
 'atp/brand_wikidata/Q7059745': 635,
 'atp/category/amenity/clinic': 407,
 'atp/category/amenity/doctors': 39,
 'atp/category/amenity/hospital': 122,
 'atp/category/healthcare/medical_imaging': 67,
 'atp/cdn/cloudflare/response_count': 65,
 'atp/cdn/cloudflare/response_status_count/200': 64,
 'atp/cdn/cloudflare/response_status_count/404': 1,
 'atp/clean_strings/city': 6,
 'atp/country/US': 635,
 'atp/field/branch/missing': 635,
 'atp/field/country/from_spider_name': 635,
 'atp/field/email/missing': 635,
 'atp/field/housenumber/missing': 635,
 'atp/field/opening_hours/missing': 635,
 'atp/field/operator/missing': 635,
 'atp/field/operator_wikidata/missing': 635,
 'atp/field/phone/missing': 11,
 'atp/field/state/from_reverse_geocoding': 3,
 'atp/field/street/missing': 635,
 'atp/field/twitter/missing': 635,
 'atp/field/unit/missing': 635,
 'atp/geometry/null_island': 5,
 'atp/item_scraped_host_count/locations-api-prod.northside.com': 635,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 635,
 'atp/nsi/match_failed': 635,
 'downloader/request_bytes': 57753,
 'downloader/request_count': 65,
 'downloader/request_method_count/GET': 65,
 'downloader/response_bytes': 296244,
 'downloader/response_count': 65,
 'downloader/response_status_count/200': 64,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 93.82800000000134,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 3, 9, 24, 38, 627592, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 1027010,
 'httpcompression/response_count': 64,
 'item_scraped_count': 635,
 'items_per_minute': 409.6774193548387,
 'log_count/DEBUG': 700,
 'log_count/INFO': 4,
 'log_count/WARNING': 45,
 'request_depth_max': 63,
 'response_received_count': 65,
 'responses_per_minute': 41.935483870967744,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 64,
 'scheduler/dequeued/memory': 64,
 'scheduler/enqueued': 64,
 'scheduler/enqueued/memory': 64,
 'start_time': datetime.datetime(2026, 9, 3, 9, 23, 4, 800930, tzinfo=datetime.timezone.utc)}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Northside Hospital location retrieval to use browser-based browsing behavior.
  * Standardized the source’s browser settings and user-agent configuration for more consistent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->