### PR TITLE
[Sephora ME] Try with proxy

### DIFF
--- a/locations/spiders/sephora_me.py
+++ b/locations/spiders/sephora_me.py
@@ -25,6 +25,7 @@ class SephoraMESpider(Spider):
     name = "sephora_me"
     item_attributes = {"brand": "Sephora", "brand_wikidata": "Q2408041"}
     custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    requires_proxy = "AE"
 
     async def start(self) -> AsyncIterator[Request]:
         for cc, coords in COUNTRIES.items():


### PR DESCRIPTION
Spider is working fine in my local. Trying with proxy enabled.

```
{'atp/brand/Sephora': 92,
 'atp/brand_wikidata/Q2408041': 92,
 'atp/category/shop/cosmetics': 92,
 'atp/clean_strings/phone': 1,
 'atp/country/AE': 26,
 'atp/country/BH': 4,
 'atp/country/KW': 10,
 'atp/country/OM': 1,
 'atp/country/QA': 6,
 'atp/country/SA': 45,
 'atp/field/housenumber/missing': 92,
 'atp/field/operator/missing': 92,
 'atp/field/operator_wikidata/missing': 92,
 'atp/field/postcode/missing': 92,
 'atp/field/state/missing': 92,
 'atp/field/street/missing': 92,
 'atp/field/twitter/missing': 92,
 'atp/field/unit/missing': 92,
 'atp/item_scraped_host_count/www.sephora.me': 92,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 92,
 'downloader/request_bytes': 12848,
 'downloader/request_count': 7,
 'downloader/request_method_count/GET': 7,
 'downloader/response_bytes': 49700,
 'downloader/response_count': 7,
 'downloader/response_status_count/200': 7,
 'elapsed_time_seconds': 8.765000000130385,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 3, 12, 57, 36, 84199, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 560680,
 'httpcompression/response_count': 7,
 'item_scraped_count': 92,
 'items_per_minute': 690.0,
 'log_count/DEBUG': 99,
 'log_count/INFO': 3,
 'response_received_count': 7,
 'responses_per_minute': 52.5,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 6,
 'scheduler/dequeued/memory': 6,
 'scheduler/enqueued': 6,
 'scheduler/enqueued/memory': 6,
 'start_time': datetime.datetime(2026, 9, 3, 12, 57, 27, 320377, tzinfo=datetime.timezone.utc)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated United Arab Emirates location requests to use a proxy, improving access reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->