### PR TITLE
[Thiriet FR] Fix the spider

### DIFF
--- a/locations/spiders/thiriet_fr.py
+++ b/locations/spiders/thiriet_fr.py
@@ -12,7 +12,9 @@ class ThirietFRSpider(StructuredDataSpider):
             yield response.follow(url, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = item["ref"] = response.url # The parameters are important as they base64-encode the ID for the shop
+        item["website"] = item["ref"] = (
+            response.url
+        )  # The parameters are important as they base64-encode the ID for the shop
         item["name"] = None
         apply_category(Categories.SHOP_FROZEN_FOOD, item)
         yield item

--- a/locations/spiders/thiriet_fr.py
+++ b/locations/spiders/thiriet_fr.py
@@ -12,7 +12,7 @@ class ThirietFRSpider(StructuredDataSpider):
             yield response.follow(url, callback=self.parse_sd)
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        item["website"] = item["ref"] = response.url.split("?", 1)[0]
+        item["website"] = item["ref"] = response.url # The parameters are important as they base64-encode the ID for the shop
         item["name"] = None
         apply_category(Categories.SHOP_FROZEN_FOOD, item)
         yield item


### PR DESCRIPTION
The thiriet website, while having different URLs that seem to be for the different shops (`magasins/magasin-de-cormontreuil,13,1158.html`, `magasins/magasin-de-vesoul-monnet,13,1158.html`) will all display information for the Epinal shop if the parameters in the URL are removed.

The parameters are a base-64 encoded string (for ex. `Y29tcF9pZD0xNzUmYWN0aW9uPWZpY2hlJmlkPTMyNiZ8`), that decode to: `comp_id=175&action=fiche&id=326&|`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal URL assignment code without changing application behavior or user-visible functionality.
  * No user-facing bug fixes or feature changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->