### PR TITLE
[Bleuforêt FR] Add spider (38 locations)

### DIFF
--- a/locations/spiders/bleuforet_fr.py
+++ b/locations/spiders/bleuforet_fr.py
@@ -6,7 +6,7 @@ from scrapy.http import TextResponse
 from scrapy.spiders import Spider
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS, OpeningHours
+from locations.hours import OpeningHours
 from locations.items import Feature
 
 DAY_FR = {
@@ -61,9 +61,7 @@ class BleuforetFRSpider(Spider):
 
         item["phone"] = self.get_detail(response, "Téléphone")
 
-        email_encoded = response.xpath(
-            '//tr[normalize-space(td[1])="Email"]//@data-cfemail'
-        ).get()
+        email_encoded = response.xpath('//tr[normalize-space(td[1])="Email"]//@data-cfemail').get()
         if email_encoded:
             item["email"] = self.decode_cf_email(email_encoded)
 
@@ -82,14 +80,12 @@ class BleuforetFRSpider(Spider):
 
     @staticmethod
     def get_detail(response: TextResponse, label: str) -> str:
-        return response.xpath(
-            f'normalize-space(//table//tr[normalize-space(td[1])="{label}"]/td[2])'
-        ).get("")
+        return response.xpath(f'normalize-space(//table//tr[normalize-space(td[1])="{label}"]/td[2])').get("")
 
     @staticmethod
     def decode_cf_email(encoded: str) -> str:
         r = int(encoded[:2], 16)
-        return "".join(chr(int(encoded[i:i + 2], 16) ^ r) for i in range(2, len(encoded), 2))
+        return "".join(chr(int(encoded[i : i + 2], 16) ^ r) for i in range(2, len(encoded), 2))
 
     def parse_hours(self, response: TextResponse) -> OpeningHours:
         oh = OpeningHours()

--- a/locations/spiders/bleuforet_fr.py
+++ b/locations/spiders/bleuforet_fr.py
@@ -1,0 +1,124 @@
+import re
+from typing import Iterable
+
+from scrapy import Request
+from scrapy.http import TextResponse
+from scrapy.spiders import Spider
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+DAY_FR = {
+    "lundi": "Mo",
+    "mardi": "Tu",
+    "mercredi": "We",
+    "jeudi": "Th",
+    "vendredi": "Fr",
+    "samedi": "Sa",
+    "dimanche": "Su",
+}
+
+LAT_RE = re.compile(r'defaultLat\s*=\s*parseFloat\("(-?\d+\.\d+)"\)')
+LON_RE = re.compile(r'defaultLong\s*=\s*parseFloat\("(-?\d+\.\d+)"\)')
+
+
+class BleuforetFRSpider(Spider):
+    name = "bleuforet_fr"
+    item_attributes = {"brand": "Bleuforêt", "brand_wikidata": "Q2906440"}
+    allowed_domains = ["bleuforet.fr"]
+    start_urls = ["https://www.bleuforet.fr/fr/magasins"]
+
+    def parse(self, response: TextResponse) -> Iterable[Request]:
+        for href in response.css('a[href*="/fr/magasins/"]::attr(href)').getall():
+            if re.search(r"/fr/magasins/\d+-", href):
+                yield response.follow(href, callback=self.parse_store)
+
+    def parse_store(self, response: TextResponse) -> Iterable[Feature]:
+        name = (response.css("h1::text").get() or "").strip()
+        if not name:
+            return
+
+        item = Feature()
+        item["ref"] = response.url.rstrip("/").rsplit("/", 1)[-1].split("-", 1)[0]
+        item["name"] = name
+        item["website"] = response.url
+        item["country"] = "FR"
+
+        if "bleuforêt" not in name.lower() and "bleuforet" not in name.lower():
+            item["brand"] = None
+            item["brand_wikidata"] = None
+
+        addr = self.get_detail(response, "Adresse")
+        if addr:
+            m = re.match(r"(?P<street>.+?)(?P<postcode>\d{5})\s*(?P<city>.+)", addr)
+            if m:
+                item["street_address"] = m.group("street").strip()
+                item["postcode"] = m.group("postcode")
+                item["city"] = m.group("city").strip()
+            else:
+                item["addr_full"] = addr
+
+        item["phone"] = self.get_detail(response, "Téléphone")
+
+        email_encoded = response.xpath(
+            '//tr[normalize-space(td[1])="Email"]//@data-cfemail'
+        ).get()
+        if email_encoded:
+            item["email"] = self.decode_cf_email(email_encoded)
+
+        item["opening_hours"] = self.parse_hours(response)
+
+        lat, lon = self.extract_latlon(response)
+        if lat and lon:
+            item["lat"] = lat
+            item["lon"] = lon
+        else:
+            self.crawler.stats.inc_value("atp/bleuforet_fr/no_geometry")
+
+        apply_category(Categories.SHOP_CLOTHES, item)
+
+        yield item
+
+    @staticmethod
+    def get_detail(response: TextResponse, label: str) -> str:
+        return response.xpath(
+            f'normalize-space(//table//tr[normalize-space(td[1])="{label}"]/td[2])'
+        ).get("")
+
+    @staticmethod
+    def decode_cf_email(encoded: str) -> str:
+        r = int(encoded[:2], 16)
+        return "".join(chr(int(encoded[i:i + 2], 16) ^ r) for i in range(2, len(encoded), 2))
+
+    def parse_hours(self, response: TextResponse) -> OpeningHours:
+        oh = OpeningHours()
+
+        for row in response.xpath("//table//tr"):
+            cells = [c.strip() for c in row.xpath(".//text()").getall() if c.strip()]
+            if len(cells) < 2:
+                continue
+
+            day_fr = cells[0].rstrip(":").lower()
+            if day_fr not in DAY_FR:
+                continue
+
+            hours_str = " ".join(cells[1:])
+            if "fermé" in hours_str.lower():
+                continue
+
+            times = [f"{int(h):02d}:{m or '00':0>2}" for h, m in re.findall(r"(\d{1,2})h(\d{0,2})", hours_str)]
+
+            for i in range(0, len(times), 2):
+                if i + 1 < len(times):
+                    oh.add_range(DAY_FR[day_fr], times[i], times[i + 1], time_format="%H:%M")
+
+        return oh
+
+    @staticmethod
+    def extract_latlon(response: TextResponse):
+        lat = LAT_RE.search(response.text)
+        lon = LON_RE.search(response.text)
+        if lat and lon:
+            return lat.group(1), lon.group(1)
+        return None, None

--- a/locations/spiders/bleuforet_fr.py
+++ b/locations/spiders/bleuforet_fr.py
@@ -28,6 +28,7 @@ class BleuforetFRSpider(Spider):
     item_attributes = {"brand": "Bleuforêt", "brand_wikidata": "Q2906440"}
     allowed_domains = ["bleuforet.fr"]
     start_urls = ["https://www.bleuforet.fr/fr/magasins"]
+    requires_proxy = "FR"
 
     def parse(self, response: TextResponse) -> Iterable[Request]:
         for href in response.css('a[href*="/fr/magasins/"]::attr(href)').getall():


### PR DESCRIPTION
Adds a spider for the french socks/underwear chain Bleuforêt. This code was made by Claude.

```
{'atp/brand/Bleuforêt': 38,
 'atp/brand_wikidata/Q2906440': 38,
 'atp/category/shop/clothes': 38,
 'atp/cdn/cloudflare/response_count': 40,
 'atp/cdn/cloudflare/response_status_count/200': 40,
 'atp/clean_strings/city': 2,
 'atp/clean_strings/street_address': 1,
 'atp/country/FR': 38,
 'atp/field/branch/missing': 38,
 'atp/field/city/missing': 1,
 'atp/field/email/missing': 18,
 'atp/field/housenumber/missing': 38,
 'atp/field/opening_hours/missing': 2,
 'atp/field/operator/missing': 38,
 'atp/field/operator_wikidata/missing': 38,
 'atp/field/phone/missing': 6,
 'atp/field/postcode/missing': 1,
 'atp/field/state/missing': 38,
 'atp/field/street/missing': 38,
 'atp/field/street_address/missing': 1,
 'atp/field/twitter/missing': 38,
 'atp/field/unit/missing': 38,
 'atp/item_scraped_host_count/www.bleuforet.fr': 38,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 38,
 'atp/nsi/match_failed': 38,
 'downloader/request_bytes': 34919,
 'downloader/request_count': 40,
 'downloader/request_method_count/GET': 40,
 'downloader/response_bytes': 916154,
 'downloader/response_count': 40,
 'downloader/response_status_count/200': 40,
 'dupefilter/filtered': 38,
 'elapsed_time_seconds': 47.64477095939219,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 3, 21, 8, 53, 287949, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 5292048,
 'httpcompression/response_count': 40,
 'item_scraped_count': 38,
 'items_per_minute': 48.51063829787234,
 'log_count/DEBUG': 79,
 'log_count/INFO': 3,
 'memusage/max': 181993472,
 'memusage/startup': 181993472,
 'request_depth_max': 1,
 'response_received_count': 40,
 'responses_per_minute': 51.06382978723404,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 39,
 'scheduler/dequeued/memory': 39,
 'scheduler/enqueued': 39,
 'scheduler/enqueued/memory': 39,
 'start_time': datetime.datetime(2026, 9, 3, 21, 8, 5, 644367, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Bleuforêt France store locations.
  * Store listings now include addresses, contact details, opening hours, and map coordinates when available.
  * French opening-hour formats and protected email addresses are handled automatically.
  * Store information is linked to individual store pages for more complete location details.
  * Locations without available map coordinates remain accessible with their other store information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->