### PR TITLE
[docomo_shop_jp] use the shop list API instead of the sitemap

### DIFF
--- a/locations/spiders/docomo_shop_jp.py
+++ b/locations/spiders/docomo_shop_jp.py
@@ -113,7 +113,9 @@ class DocomoShopJPSpider(Spider):
         if len(hhmm) != 4 or not hhmm.isascii() or not hhmm.isdigit():
             return None
         hours, minutes = int(hhmm[:2]), int(hhmm[2:])
-        return f"{hours:02d}:{minutes:02d}" if hours <= 24 and minutes < 60 else None
+        if minutes > 59 or hours > 24 or (hours == 24 and minutes):
+            return None
+        return f"{hours:02d}:{minutes:02d}"
 
     @staticmethod
     def weekly_closures(holiday_code: Any) -> Iterable[str]:

--- a/locations/spiders/docomo_shop_jp.py
+++ b/locations/spiders/docomo_shop_jp.py
@@ -1,137 +1,135 @@
 import re
-from typing import Any, Iterable
+from typing import Any, AsyncIterator, Iterable
 
-from scrapy.http import Response
-from scrapy.spiders import SitemapSpider
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS, OpeningHours
+from locations.hours import DAYS, DAYS_JP, OpeningHours
 from locations.items import Feature
 
-DAY_CHARS = {"月": "Mo", "火": "Tu", "水": "We", "木": "Th", "金": "Fr", "土": "Sa", "日": "Su"}
-FULLWIDTH_DIGITS = str.maketrans("０１２３４５６７８９", "0123456789")
+API_URL = "https://shop.smt.docomo.ne.jp/api/shopsearch/shoplist"
+PAGE_SIZE = 30
 
-HOURS_RE = re.compile(r"(午前|午後)(\d{1,2})時(?:(\d{1,2})分)?[~〜～-](午前|午後)(\d{1,2})時(?:(\d{1,2})分)?")
+# Weekday names inside shophour_modify2. "祝日" (public holidays) also appears there and is
+# skipped, since OpeningHours has no day for it.
+ALTERNATE_DAY_RE = re.compile(r"毎週([月火水木金土日])曜")
+
+WEEKLY_ORDINAL = 6
 
 
-class DocomoShopJPSpider(SitemapSpider):
+class DocomoShopJPSpider(Spider):
     name = "docomo_shop_jp"
     item_attributes = {"brand": "NTT docomo", "brand_wikidata": "Q853958"}
-    sitemap_urls = ["https://shop.smt.docomo.ne.jp/sitemap.xml"]
-    # The sitemap also lists info/service pages and secondary per-shop pages
-    # (e.g. "0300304163300/02.html"); only the shop's primary page is wanted.
-    sitemap_rules = [(r"/shop_detail/\d+/$", "parse")]
 
-    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
-        body = response.css("body")
-        shop_name = body.attrib.get("data-shopname")
-        if not shop_name:
-            # A handful of sitemap entries 404 (stale listing for a closed shop).
-            return
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(url=API_URL)
 
-        ref_match = re.search(r"/shop_detail/(\d+)/", response.url)
-        if not ref_match:
-            return
+    def parse(self, response: Response, page: int = 1, **kwargs: Any) -> Iterable[Any]:
+        payload = response.json()
 
+        shops = payload.get("list") or []
+
+        # Counted here rather than read back from the response, and stopped on a page that
+        # returned nothing, so neither the page size nor an echoed page number is trusted.
+        if shops:
+            yield JsonRequest(url=f"{API_URL}?page={page + 1}", cb_kwargs={"page": page + 1})
+
+        for shop in shops:
+            yield self.parse_shop(shop)
+
+    def parse_shop(self, shop: dict) -> Feature:
         item = Feature()
-        item["ref"] = ref_match.group(1)
+
+        # The detail page is addressed by the two codes concatenated.
+        shop_name = str(shop.get("shop_name") or "")
+        item["ref"] = f"{shop['shop_code']}{shop['add_shop_code']}"
+        item["website"] = f"https://shop.smt.docomo.ne.jp/shop_detail/{item['ref']}/"
+
         item["name"] = shop_name
         item["branch"] = shop_name.removeprefix("ドコモショップ").strip()
-        item["website"] = response.url
+
         item["country"] = "JP"
-        item["lat"] = body.attrib.get("data-lat")
-        item["lon"] = body.attrib.get("data-lng")
+        item["state"] = shop.get("prefecture")
+        item["city"] = shop.get("municipality")
+        item["street_address"] = " ".join(
+            part for part in (shop.get("address"), shop.get("address_building"), shop.get("address_floor")) if part
+        )
+        post_code = str(shop.get("post_code") or "")
+        if len(post_code) == 7 and post_code.isascii() and post_code.isdigit():
+            item["postcode"] = f"{post_code[:3]}-{post_code[3:]}"
 
-        hours_text = None
-        holiday_text = None
+        item["lat"] = self.decimal_degrees(
+            shop["north_latitude"], shop["north_latitude_min"], shop["north_latitude_sec"]
+        )
+        item["lon"] = self.decimal_degrees(
+            shop["east_longitude"], shop["east_longitude_min"], shop["east_longitude_sec"]
+        )
 
-        for column in response.css(".store-basic-information-0002-column"):
-            title = column.css(".store-basic-information-0002-title::text").get("").strip()
-            if title == "住所":
-                self._parse_address(item, column)
-            elif title == "営業時間":
-                hours_text = " ".join(
-                    t.strip() for t in column.css(".store-basic-information-0002__text-area ::text").getall()
-                )
-            elif title == "定休日":
-                holiday_text = " ".join(
-                    t.strip() for t in column.css(".store-basic-information-0002__text-area ::text").getall()
-                )
+        # free_tel is a regional 0120 number shared between shops, so it is not a per-location value.
+        item["phone"] = shop.get("customer_tel")
 
-        if hours_text and (oh := self._parse_hours(hours_text, holiday_text)):
-            item["opening_hours"] = oh
+        item["opening_hours"] = self.parse_hours(shop)
 
         apply_category(Categories.SHOP_MOBILE_PHONE, item)
 
-        yield item
+        return item
 
     @staticmethod
-    def _parse_address(item: Feature, column) -> None:
-        addr_html = column.css("p.store-basic-information-0002_margin.sm-txt").get()
-        if not addr_html:
-            return
-        lines = [re.sub(r"<[^>]+>", "", part).strip() for part in re.split(r"<br\s*/?>", addr_html)]
-        lines = [line for line in lines if line]
-        if lines:
-            item["addr_full"] = " ".join(lines)
-
-        # The first tel: link is a shared regional free-dial (0120) number
-        # reused across multiple shops; the second is the shop's own direct
-        # line, which is what's wanted here.
-        tel_hrefs = column.css("a[href^='tel:']::attr(href)").getall()
-        local_numbers = [h.removeprefix("tel:") for h in tel_hrefs if not h.removeprefix("tel:").startswith("0120")]
-        if local_numbers:
-            item["phone"] = local_numbers[-1]
-        elif tel_hrefs:
-            item["phone"] = tel_hrefs[-1].removeprefix("tel:")
-
-    @staticmethod
-    def _to_24h(marker: str, hour: str, minute: str | None) -> str:
-        h = int(hour)
-        m = int(minute) if minute else 0
-        if marker == "午後" and h != 12:
-            h += 12
-        if marker == "午前" and h == 12:
-            h = 0
-        return f"{h:02d}:{m:02d}"
-
-    def _parse_hours(self, hours_text: str, holiday_text: str | None) -> OpeningHours | None:
-        matches = list(HOURS_RE.finditer(hours_text))
-        if not matches:
+    def decimal_degrees(degrees: Any, minutes: Any, seconds: Any) -> float | None:
+        """Coordinates arrive as degrees, minutes, and thousandths of a second."""
+        try:
+            return int(degrees) + int(minutes) / 60 + int(seconds) / 1000 / 3600
+        except (TypeError, ValueError):
             return None
 
-        open_time = self._to_24h(matches[0].group(1), matches[0].group(2), matches[0].group(3))
-        close_time = self._to_24h(matches[0].group(4), matches[0].group(5), matches[0].group(6))
+    def parse_hours(self, shop: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
 
-        oh = OpeningHours()
+        alternate_days = []
+        if self.clock_time(shop["shophour_start2"]) and self.clock_time(shop["shophour_end2"]):
+            alternate_days = [DAYS_JP[day] for day in ALTERNATE_DAY_RE.findall(shop["shophour_modify2"] or "")]
+        if alternate_days:
+            opening_hours.add_days_range(
+                alternate_days, self.clock_time(shop["shophour_start2"]), self.clock_time(shop["shophour_end2"])
+            )
 
-        # A second time range usually describes a narrower internal "受付時間"
-        # (reception/sign-up desk cut-off) rather than the shop's own hours,
-        # and is intentionally ignored - except when the text between the two
-        # ranges explicitly says weekends have their own hours, which is a
-        # genuine difference in when the shop itself opens/closes.
-        if (
-            len(matches) > 1
-            and "毎週土曜" in hours_text[matches[0].end() : matches[1].start()]
-            and "毎週日曜" in hours_text[matches[0].end() : matches[1].start()]
-        ):
-            weekend_open = self._to_24h(matches[1].group(1), matches[1].group(2), matches[1].group(3))
-            weekend_close = self._to_24h(matches[1].group(4), matches[1].group(5), matches[1].group(6))
-            oh.add_days_range(["Mo", "Tu", "We", "Th", "Fr"], open_time, close_time)
-            oh.add_days_range(["Sa", "Su"], weekend_open, weekend_close)
-        else:
-            oh.add_days_range(DAYS, open_time, close_time)
+        # shophour_start4 is a 受付時間 reception cut-off rather than the hours the shop is open.
+        base_open = self.clock_time(shop["shophour_start1"])
+        base_close = self.clock_time(shop["shophour_end1"])
+        if base_open and base_close:
+            opening_hours.add_days_range([day for day in DAYS if day not in alternate_days], base_open, base_close)
 
-        # "定休日" (regular closing day) is usually either "無休" (no closure)
-        # or a specific weekday closed every week ("毎週火曜"). A third form,
-        # closure on the Nth occurrence of a weekday each month (e.g.
-        # "第２木曜"), can't be expressed by the weekly-only OpeningHours
-        # helper here, so it's deliberately left unencoded rather than
-        # mis-stated as a full weekly closure.
-        if holiday_text:
-            normalised = holiday_text.translate(FULLWIDTH_DIGITS)
-            if normalised.startswith("毎週"):
-                if day_match := re.search(r"([月火水木金土日])曜", normalised):
-                    oh.set_closed(DAY_CHARS[day_match.group(1)])
+        for day in self.weekly_closures(shop["shop_holiday_code"]):
+            opening_hours.set_closed(day)
 
-        return oh
+        return opening_hours
+
+    @staticmethod
+    def clock_time(hhmm: Any) -> str | None:
+        """HHMM to HH:MM, or None. Validated, not just counted: a four-digit string is not
+        necessarily a time, and an invalid one raises out of OpeningHours rather than here."""
+        hhmm = str(hhmm or "")
+        if len(hhmm) != 4 or not hhmm.isascii() or not hhmm.isdigit():
+            return None
+        hours, minutes = int(hhmm[:2]), int(hhmm[2:])
+        return f"{hours:02d}:{minutes:02d}" if hours <= 24 and minutes < 60 else None
+
+    @staticmethod
+    def weekly_closures(holiday_code: Any) -> Iterable[str]:
+        """The weekdays a shop closes every week, per shop_holiday_code.
+
+        Three four-character groups then a "never closes" flag. Per group the last character is
+        the weekday and the leading three are the ordinals, zero padded: "6003" is every
+        Wednesday, "2303" the second and third. Only the every-week form can be expressed by
+        weekly OpeningHours, so an Nth-weekday closure is left off rather than overstated.
+        """
+        holiday_code = str(holiday_code or "")
+        for start in (0, 4, 8):
+            group = holiday_code[start : start + 4]
+            if len(group) < 4 or not (group.isascii() and group.isdigit()) or group == "0000":
+                continue
+            ordinals = [int(character) for character in group[:3] if character != "0"]
+            weekday = int(group[3])
+            if ordinals == [WEEKLY_ORDINAL] and 1 <= weekday <= len(DAYS):
+                yield DAYS[weekday - 1]


### PR DESCRIPTION
Closes #18463.

The spider crawled `sitemap.xml`, which lists 517 shop pages and yields 456 items. The site's own shop list API reports 2064.

```
before   456 features
after   2064 features
```

Every one of the 456 refs the sitemap version produced is still present. `shop_code + add_shop_code` is the id the detail page is addressed by, so refs are unchanged and nothing churns.

## What changed beyond the count

Comparing the two runs across the 456 shared shops:

| field | differences |
|---|---|
| name, branch, phone, website | 0 |
| coordinates | 0 (largest delta 4.5e-12 degrees, float representation only) |
| opening_hours | 24 |

All 24 are corrections.

22 are shops whose weekly closing day the HTML parser missed entirely. The site states it as `毎週火曜`, and those shops were being published as open seven days:

```
0134108700900   before  Mo-Su 09:00-18:00
                after   Mo 09:00-18:00; Tu closed; We-Su 09:00-18:00
```

The other 2 are the weekend-hours heuristic getting it wrong rather than missing it. The old code applied alternate hours only when the text named Saturday and Sunday together:

```
0400501214800   site says 毎週金曜・毎週土曜・毎週日曜 10:00-21:00
                before  Mo-Fr 10:00-20:00; Sa-Su 10:00-21:00     (Friday dropped)
                after   Mo-Th 10:00-20:00; Fr-Su 10:00-21:00

0601600348100   site says 毎週日曜 11:00-20:30
                before  Mo-Su 11:00-21:00                        (Sunday lost)
                after   Mo-Sa 11:00-21:00; Su 11:00-20:30
```

The API separates the fields the HTML page ran together, which is what removes the guessing:

- `shophour_start1`/`end1` are the shop's hours; `shophour_start2`/`end2` with `shophour_modify2` are genuine alternate hours for named days (65 shops).
- `shophour_name4` is a `受付時間` reception cut-off rather than the hours the shop is open (306 shops). The old spider ignored it by heuristic; it is now ignored by name.
- `shop_holiday_code` is three four-character groups: last character the weekday, the leading three the ordinals it applies to. `6003` is every Wednesday, `2303` the second and third.

I decoded that field and checked it back against the site's own `定休日` text for all 2064 records, and it reconstructs exactly, so the reading is not a guess from a handful of samples.

Only the every-week form is emitted. 1159 shops close on something like the second Wednesday, which `OpeningHours` cannot express, and encoding it would overstate it as every Wednesday. Those keep full hours, as before.

`祝日` (public holidays) appears in the alternate-hours field and is also left unencoded, since there is no day for it.

## Coordinates

Latitude and longitude arrive as degrees, minutes, and thousandths of a second. The conversion agrees with the `data-lat`/`data-lng` the detail page carries:

```
page  43.15565 / 141.39756111111
api   43.15565 / 141.397561
```

## Notes

`DictParser` is not used here. On this payload it returns three fields and one is wrong: it maps `address` onto `addr_full`, but that field holds only the street number (`5-1-10`), with the prefecture and municipality in separate keys.

`phone` is `customer_tel` only. `free_tel` is a regional 0120 number shared between shops, so it is not a per-location value. Four shops publish no `customer_tel` and now carry no phone; all four are among the newly reachable shops, so nothing that exists today loses a number.

Three of the 2064 are not ドコモショップ: two iPhone repair corners and one ハーティプラザ, marked by `shop_category` 3 and 4. They are docomo-operated and the sitemap crawl included them, so I have left them in. Happy to filter on `shop_category == 1` if you would rather they were out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection of Docomo shop information using structured shop-search data.
  * Improved shop location accuracy by converting coordinates to decimal format.
  * Improved opening-hours and regular-closing-day information.
  * Added support for retrieving shop listings across multiple result pages.
  * Corrected handling of invalid late-night time values to prevent inaccurate opening-hour displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->