### PR TITLE
[softbank_jp] add spider

### DIFF
--- a/locations/spiders/softbank_jp.py
+++ b/locations/spiders/softbank_jp.py
@@ -1,0 +1,66 @@
+from typing import Any, AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category
+from locations.geo import country_iseadgg_centroids
+from locations.hours import OpeningHours, sanitise_day
+from locations.items import Feature
+
+# The API clamps its radius to about 38 km whatever `dist` asks for, so cells wider than that
+# leave gaps: 48 km centroids return 966 shops against 2157 from the 24 km set.
+SEARCH_RADIUS_KM = 24
+
+
+class SoftbankJPSpider(Spider):
+    name = "softbank_jp"
+    item_attributes = {"brand": "SoftBank", "brand_wikidata": "Q2214105"}
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        for latitude, longitude in country_iseadgg_centroids(["JP"], SEARCH_RADIUS_KM):
+            yield JsonRequest(
+                url="https://www.softbank.jp/shop/d/system/v1/api/shop-search/"
+                f"?type=current&sort=0&results=10000&lat={latitude}&lon={longitude}&dist=50"
+            )
+
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # Cells overlap, so the same shop arrives from several centroids. The pipeline
+        # deduplicates on ref.
+        for shop in response.json().get("item") or []:
+            yield self.parse_shop(shop)
+
+    def parse_shop(self, shop: dict) -> Feature:
+        item = Feature()
+
+        item["ref"] = shop["shop_id"]
+        item["website"] = f"https://www.softbank.jp/shop/search/detail/{item['ref']}/"
+        item["branch"] = (shop.get("shop_name") or {}).get("name")
+
+        item["country"] = "JP"
+        item["addr_full"] = shop.get("address")
+        item["phone"] = shop.get("tel")
+
+        geo = shop.get("geo") or {}
+        item["lat"] = geo.get("lat")
+        item["lon"] = geo.get("lon")
+
+        item["opening_hours"] = self.parse_hours(shop.get("hours") or {})
+
+        apply_category(Categories.SHOP_MOBILE_PHONE, item)
+
+        return item
+
+    @staticmethod
+    def parse_hours(hours: dict) -> OpeningHours:
+        opening_hours = OpeningHours()
+        for day, times in hours.items():
+            # The weekdays are joined by a "holiday" entry for public holidays, which
+            # sanitise_day returns None for because OpeningHours has no day to put it on.
+            if not (weekday := sanitise_day(day)):
+                continue
+            # `reception_time` beside it is a 受付時間 desk cut-off, not the shop's own hours.
+            opening, _, closing = str((times or {}).get("business_hours") or "").partition("～")
+            if opening and closing:
+                opening_hours.add_range(weekday, opening.strip(), closing.strip())
+        return opening_hours


### PR DESCRIPTION
Closes #18407.

2157 shops.

## Which centroid radius

The issue suggests trying 48 km later to cut requests. I ran both:

```
48 km centroids   159 requests    966 unique shops
24 km centroids   469 requests   2157 unique shops
```

24 km is a strict superset. 48 km misses 1191 of the 2157 and finds nothing the other set does not, so the cheaper grid would run clean and return a plausible number while dropping half of Japan.

`dist` is clamped server side at roughly 38 km whatever you pass, so 50, 100 and 200 return the same set, and cells wider than that leave gaps. No result-count cap: the densest cell returns 240 and a hand-placed Tokyo query returns 279, all of which the sweep already had.

## Hours

`hours` gives per-weekday `business_hours`, all 33 distinct values in `HH:MM～HH:MM`. 187 shops differ between days, so each day is read separately.

Not read: `reception_time`, a `受付時間` desk cut-off rather than opening hours, and the `holiday` key beside the weekdays, which is for public holidays and which `sanitise_day` returns `None` for.

The record's top-level `holiday` is a closing-day note in forms `OpeningHours` cannot express: `不定休` and `月一不定休` (369 shops) and `第二水曜日` Nth-weekday closures (307 shops). Encoding those weekly would overstate them, so they are left off.

## Other fields

`shop_id` is the ref and addresses the detail page, so `H205` gives `/shop/search/detail/H205/`. `TD44` from the issue resolves the same way. `address` is one Japanese string with no separate prefecture field, so it goes to `addr_full`. `geo` is already decimal degrees.

## Validation

```
scrapy crawl softbank_jp
item_scraped_count: 2157
```

2157 unique refs, with `branch`, `phone`, `website`, `opening_hours` and geometry on every one. That matches the independent sweep above exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SoftBank Japan shop listings to location search results.
  * Included shop details with mobile-phone-shop categorization and SoftBank branding.
  * Added normalized opening hours, excluding holiday-only schedules and reception cut-off times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->