### PR TITLE
Ignore columbus_cafe_fr in NSI brand-string test

### DIFF
--- a/tests/test_item_attributes.py
+++ b/tests/test_item_attributes.py
@@ -44,6 +44,7 @@ def test_item_attributes_brand_strings_match_nsi():
     """
     ignored_spiders = [
         "sparkasse_de",  # Overcomplicated in NSI
+        "columbus_cafe_fr",  # Brand dropped "& Co" but NSI hasn't caught up yet
     ]
 
     fails = []


### PR DESCRIPTION
#18212 dropped "& Co" from the columbus_cafe_fr brand string to match current real-world branding (confirmed on columbuscafe.com), but NSI's Q2984582 entry still lists "Columbus Café & Co", so `test_item_attributes_brand_strings_match_nsi` now fails on master. Adding the spider to `ignored_spiders`, same pattern already used for sparkasse_de.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated brand-string validation to exclude the Columbus Cafe France spider from the NSI matching check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->