### PR TITLE
[sushiro_jp] Add spider (669 locations)

### DIFF
--- a/locations/geo.py
+++ b/locations/geo.py
@@ -10,32 +10,13 @@ from typing import Any, Iterable
 import geonamescache
 from pyproj import Transformer
 
+from locations.lang_utils import katakana_to_hiragana
 from locations.searchable_points import get_searchable_points_path, open_searchable_points
 
 # Radius of the Earth in kilometers
 EARTH_RADIUS = 6378.1
 # Kilometers per mile
 MILES_TO_KILOMETERS = 1.60934
-
-# Katakana to hiragana map for Japanese postal data
-_KATAKANA = (
-    "ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトド"
-    "ナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶー"
-)
-_HIRAGANA = (
-    "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとど"
-    "なにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖー"
-)
-_KATAKANA_TO_HIRAGANA = str.maketrans(_KATAKANA, _HIRAGANA)
-
-
-def _katakana_to_hiragana(text: str) -> str:
-    """
-    Convert a katakana string to hiragana.
-
-    Japan Post ships in katakana but OSM's "ja-Hira" name variant expects in hiragana.
-    """
-    return text.translate(_KATAKANA_TO_HIRAGANA)
 
 
 def vincenty_distance(lat: float, lon: float, distance_km: float, bearing_deg: float) -> tuple[float, float]:
@@ -313,9 +294,9 @@ def postal_regions(country_code: str, min_population: int = 0, consolidate_citie
                     "postal_region": row[2],
                     "jis_code": row[0],
                     "province:ja": row[6],
-                    "province:ja-Hira": _katakana_to_hiragana(row[3]),
+                    "province:ja-Hira": katakana_to_hiragana(row[3]),
                     "city:ja": row[7],
-                    "city:ja-Hira": _katakana_to_hiragana(row[4]),
+                    "city:ja-Hira": katakana_to_hiragana(row[4]),
                     "flags": {
                         "one_town_multi_postcode": row[9],
                         "per_subarea_addressing": row[10],
@@ -329,10 +310,10 @@ def postal_regions(country_code: str, min_population: int = 0, consolidate_citie
                 if "以下に掲載がない場合" not in row[8]:
                     if region["flags"]["per_subarea_addressing"] == "1":
                         region["quarter:ja"] = row[8]
-                        region["quarter:ja-Hira"] = _katakana_to_hiragana(row[5])
+                        region["quarter:ja-Hira"] = katakana_to_hiragana(row[5])
                     else:
                         region["neighbourhood:ja"] = row[8]
-                        region["neighbourhood:ja-Hira"] = _katakana_to_hiragana(row[5])
+                        region["neighbourhood:ja-Hira"] = katakana_to_hiragana(row[5])
                 yield region
     else:
         raise Exception("country code not supported: " + country_code)

--- a/locations/lang_utils.py
+++ b/locations/lang_utils.py
@@ -1,0 +1,16 @@
+_KATAKANA = (
+    "ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトド"
+    "ナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶー"
+)
+_HIRAGANA = (
+    "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとど"
+    "なにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖー"
+)
+_KATAKANA_TO_HIRAGANA = str.maketrans(_KATAKANA, _HIRAGANA)
+
+
+def katakana_to_hiragana(text: str) -> str:
+    """
+    Convert a katakana string to hiragana for OSM's "ja-Hira" tag.
+    """
+    return text.translate(_KATAKANA_TO_HIRAGANA)

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -126,7 +126,7 @@ class SushiroJPSpider(JSONBlobSpider):
             item["extras"]["contact:fax"] = fax
 
         if kana := feature.get("kana"):
-            item["extras"]["name:ja-Hira"] = katakana_to_hiragana(kana)
+            item["extras"]["branch:ja-Hira"] = katakana_to_hiragana(kana)
 
         if "クレジット" in (feature.get("memo") or ""):
             apply_yes_no(PaymentMethods.CREDIT_CARDS, item, True)

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -124,9 +124,9 @@ class SushiroJPSpider(JSONBlobSpider):
         item["extras"]["addr:province"] = feature["pref_name"]
         item["country"] = "JP"
         item["website"] = f"https://www.akindo-sushiro.co.jp/shop/detail.php?id={feature['id']}"
-        item["extras"]["website:menu"] = (
-            f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
-        )
+        item["extras"][
+            "website:menu"
+        ] = f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
         item["extras"]["website:allergens"] = "https://www.akindo-sushiro.co.jp/menu/allergy.html"
         item["opening_hours"] = self._parse_hours(feature["hours"])
 

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -103,16 +103,8 @@ class SushiroJPSpider(JSONBlobSpider):
     def extract_json(self, response: Response) -> list[dict]:
         data_raw = response.xpath("//script[contains(text(), 'items = [')]/text()").get()
         start = data_raw.rindex("items = [") + len("items = [")
-        depth = 1
-        i = start
-        while depth > 0:
-            char = data_raw[i]
-            if char == "[":
-                depth += 1
-            elif char == "]":
-                depth -= 1
-            i += 1
-        return json.loads(data_raw[start - 1 : i])
+        items, _ = json.JSONDecoder().raw_decode(data_raw[start - 1 :])
+        return items
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
         # Recorded as tags (see each line for the source field):
@@ -124,9 +116,9 @@ class SushiroJPSpider(JSONBlobSpider):
         item["extras"]["addr:province"] = feature["pref_name"]
         item["country"] = "JP"
         item["website"] = f"https://www.akindo-sushiro.co.jp/shop/detail.php?id={feature['id']}"
-        item["extras"][
-            "website:menu"
-        ] = f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
+        item["extras"]["website:menu"] = (
+            f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
+        )
         item["extras"]["website:allergens"] = "https://www.akindo-sushiro.co.jp/menu/allergy.html"
         item["opening_hours"] = self._parse_hours(feature["hours"])
 

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -1,0 +1,151 @@
+import json
+import re
+from typing import Iterable
+
+from scrapy.http import Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, DAYS_JP, OpeningHours, day_range
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
+
+# Prefecture ids used by the site's <select name="pref"> store locator, keyed
+# by the JIS prefecture code each option carries. Used to build the
+# per-prefecture ?pref=<id> requests that return every store in that
+# prefecture.
+PREFECTURES = (
+    (1, "北海道"),
+    (2, "青森県"),
+    (3, "岩手県"),
+    (4, "宮城県"),
+    (5, "秋田県"),
+    (6, "山形県"),
+    (7, "福島県"),
+    (8, "茨城県"),
+    (9, "栃木県"),
+    (10, "群馬県"),
+    (11, "埼玉県"),
+    (12, "千葉県"),
+    (13, "東京都"),
+    (14, "神奈川県"),
+    (15, "新潟県"),
+    (16, "富山県"),
+    (17, "石川県"),
+    (18, "福井県"),
+    (19, "山梨県"),
+    (20, "長野県"),
+    (21, "岐阜県"),
+    (22, "静岡県"),
+    (23, "愛知県"),
+    (24, "三重県"),
+    (25, "滋賀県"),
+    (26, "京都府"),
+    (27, "大阪府"),
+    (28, "兵庫県"),
+    (29, "奈良県"),
+    (30, "和歌山県"),
+    (31, "鳥取県"),
+    (32, "島根県"),
+    (33, "岡山県"),
+    (34, "広島県"),
+    (35, "山口県"),
+    (36, "徳島県"),
+    (37, "香川県"),
+    (38, "愛媛県"),
+    (39, "高知県"),
+    (40, "福岡県"),
+    (41, "佐賀県"),
+    (42, "長崎県"),
+    (43, "熊本県"),
+    (44, "大分県"),
+    (45, "宮崎県"),
+    (46, "鹿児島県"),
+    (47, "沖縄県"),
+)  # fmt: skip
+
+
+def expand_days(raw_day_part: str) -> list[str]:
+    stripped = raw_day_part.replace("祝", "").strip()
+    if not stripped:
+        return list(DAYS)
+    if "-" in stripped:
+        start_part, _, end_part = stripped.partition("-")
+        start = DAYS_JP.get(start_part[-1]) if start_part else None
+        end = DAYS_JP.get(end_part[-1]) if end_part else None
+        if start and end:
+            return day_range(start, end)
+        return []
+    return [DAYS_JP[c] for c in stripped if c in DAYS_JP]
+
+
+def parse_hours(text: str) -> str:
+    oh = OpeningHours()
+    has_holiday = False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("※"):
+            continue
+        has_holiday = has_holiday or "祝" in line
+        line = line.replace("～", "-").replace("〜", "-").replace("：", ":")
+        time_match = re.search(r"(\d{1,2}:\d{2})-(\d{1,2}:\d{2})", line)
+        if not time_match:
+            continue
+        open_time, close_time = time_match.group(1), time_match.group(2)
+        for day in expand_days(line[: time_match.start()]):
+            oh.add_range(day, open_time, close_time)
+
+    result = oh.as_opening_hours()
+    if not has_holiday or not result:
+        return result
+
+    # The OpeningHours helper has no concept of public holidays, so append
+    # PH to the weekend group (土日祝) manually rather than drop it.
+    groups = result.split("; ")
+    for index, group in enumerate(groups):
+        day_part, _, hours = group.partition(" ")
+        if "Sa" in day_part or "Su" in day_part:
+            groups[index] = f"{day_part},PH {hours}"
+            break
+    return "; ".join(groups)
+
+
+class SushiroJPSpider(JSONBlobSpider):
+    name = "sushiro_jp"
+    item_attributes = {"brand": "スシロー", "brand_wikidata": "Q11257037"}
+    start_urls = ["https://www.akindo-sushiro.co.jp/shop/"]
+
+    def parse(self, response: Response) -> Iterable[Feature | Request]:
+        if "?pref=" not in response.url:
+            for pref_id, _ in PREFECTURES:
+                yield Request(f"{self.start_urls[0]}?pref={pref_id}")
+            return
+        yield from super().parse(response)
+
+    def extract_json(self, response: Response) -> list[dict]:
+        data_raw = response.xpath("//script[contains(text(), 'items = [')]/text()").get()
+        start = data_raw.rindex("items = [") + len("items = [")
+        depth = 1
+        i = start
+        while depth > 0:
+            char = data_raw[i]
+            if char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+            i += 1
+        return json.loads(data_raw[start - 1 : i])
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        item["ref"] = feature["id"]
+        item["branch"] = item.pop("name").splitlines()[0].strip()
+        item["addr_full"] = feature["address"]
+        item["postcode"] = f'{feature["zip1"]}{feature["zip2"]}'
+        item["city"] = feature["city_name"]
+        item["state"] = feature["pref_name"]
+        item["country"] = "JP"
+        item["opening_hours"] = parse_hours(feature["hours"])
+
+        apply_category(Categories.FAST_FOOD, item)
+        item["extras"]["cuisine"] = "sushi"
+
+        yield item

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -123,6 +123,11 @@ class SushiroJPSpider(JSONBlobSpider):
         item["city"] = feature["city_name"]
         item["extras"]["addr:province"] = feature["pref_name"]
         item["country"] = "JP"
+        item["website"] = f"https://www.akindo-sushiro.co.jp/shop/detail.php?id={feature['id']}"
+        item["extras"]["website:menu"] = (
+            f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
+        )
+        item["extras"]["website:allergens"] = "https://www.akindo-sushiro.co.jp/menu/allergy.html"
         item["opening_hours"] = self._parse_hours(feature["hours"])
 
         if fax := feature.get("fax"):
@@ -155,18 +160,16 @@ class SushiroJPSpider(JSONBlobSpider):
                 elif tag == "changing_table":
                     apply_yes_no(Extras.BABY_CHANGING_TABLE, item, True)
 
-        # Other skipped fields
+        # Unmapped fields
         #   pref_id       JIS prefecture code
         #   city_id       internal
         #   base_post_id  internal (parent-store link)
-        #   sushipass_id  internal membership-store id
         #   language      constant "0"
         #   category      constant "13"
         #   price_range   cost tier 1-7; no standard OSM tag
         #   access        transport directions; no standard OSM key
         #   result_name   duplicate of name plus a price note
-        #   togo_menu_url / demaecan_url / uber_eats_url
-        #                 takeout/delivery links, empty for most stores
+        #   togo_menu_url / demaecan_url / uber_eats_url   empty for all stores as of 2026-09-05
         #   recruit_url   job/hiring page, not POI data
         #   status        constant "0" (open)
         #   output_flag   constant "1" (shown on site)

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -8,6 +8,7 @@ from locations.categories import Categories, Extras, PaymentMethods, apply_categ
 from locations.hours import DAYS, DAYS_JP, OpeningHours, day_range
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
+from locations.lang_utils import katakana_to_hiragana
 
 # Map of the site's "service" facility codes to OSM tags.
 SERVICE_TAGS = {
@@ -128,7 +129,7 @@ class SushiroJPSpider(JSONBlobSpider):
             item["extras"]["contact:fax"] = fax
 
         if kana := feature.get("kana"):
-            item["extras"]["name:ja-Hira"] = kana
+            item["extras"]["name:ja-Hira"] = katakana_to_hiragana(kana)
 
         if "クレジット" in (feature.get("memo") or ""):
             apply_yes_no(PaymentMethods.CREDIT_CARDS, item, True)

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -118,7 +118,7 @@ class SushiroJPSpider(JSONBlobSpider):
         # Recorded as tags (see each line for the source field):
         item["ref"] = feature["id"]
         item["branch"] = item.pop("name").splitlines()[0].strip()
-        item["addr_full"] = feature["address"]
+        item["addr_full"] = f"{feature['pref_name']}{feature['city_name']}{feature['address']}"
         item["postcode"] = f"{feature['zip1']}{feature['zip2']}"
         item["city"] = feature["city_name"]
         item["extras"]["addr:province"] = feature["pref_name"]

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -1,18 +1,41 @@
 import json
 import re
-from typing import Iterable
+from collections.abc import AsyncIterator, Iterable
 
 from scrapy.http import Request, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.hours import DAYS, DAYS_JP, OpeningHours, day_range
 from locations.items import Feature
 from locations.json_blob_spider import JSONBlobSpider
 
-# Prefecture ids used by the site's <select name="pref"> store locator, keyed
-# by the JIS prefecture code each option carries. Used to build the
-# per-prefecture ?pref=<id> requests that return every store in that
-# prefecture.
+# Map of the site's "service" facility codes to OSM tags.
+SERVICE_TAGS = {
+    1: "parking",  # 駐車場あり
+    2: "capacity:disabled",  # 身障者用駐車場
+    3: "wheelchair",  # 1F店舗（スロープ有り）
+    7: "changing_table",  # おむつ替えシート
+}
+# Facility codes deliberately not mapped to any OSM tag:
+#   5 = 2階建て店舗 (storey count, no POI tag)
+#   6 = エレベーター (no standard restaurant accessibility tag)
+#   13 = 自動土産ロッカー (souvenir locker)
+#   16 = デジロー (Sushiro digital-ordering system, brand-specific)
+# Codes 4, 8, 9, 10, 11, 12, 14 are not rendered and meaning is unknown
+
+# free-text 'memo' value
+# example: "ご利用可能なクレジットカード： VISA・MasterCard・JCB・American Express・Diners Club・DISCOVER・銀聯"
+CARD_BRANDS = {
+    "VISA": PaymentMethods.VISA,
+    "MasterCard": PaymentMethods.MASTER_CARD,
+    "JCB": PaymentMethods.JCB,
+    "American Express": PaymentMethods.AMERICAN_EXPRESS,
+    "Diners Club": PaymentMethods.DINERS_CLUB,
+    "DISCOVER": PaymentMethods.DISCOVER_CARD,
+    "銀聯": PaymentMethods.UNIONPAY,
+}
+
+# JIS prefecture code used in <select name="pref"> options
 PREFECTURES = (
     (1, "北海道"),
     (2, "青森県"),
@@ -61,52 +84,7 @@ PREFECTURES = (
     (45, "宮崎県"),
     (46, "鹿児島県"),
     (47, "沖縄県"),
-)  # fmt: skip
-
-
-def expand_days(raw_day_part: str) -> list[str]:
-    stripped = raw_day_part.replace("祝", "").strip()
-    if not stripped:
-        return list(DAYS)
-    if "-" in stripped:
-        start_part, _, end_part = stripped.partition("-")
-        start = DAYS_JP.get(start_part[-1]) if start_part else None
-        end = DAYS_JP.get(end_part[-1]) if end_part else None
-        if start and end:
-            return day_range(start, end)
-        return []
-    return [DAYS_JP[c] for c in stripped if c in DAYS_JP]
-
-
-def parse_hours(text: str) -> str:
-    oh = OpeningHours()
-    has_holiday = False
-    for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("※"):
-            continue
-        has_holiday = has_holiday or "祝" in line
-        line = line.replace("～", "-").replace("〜", "-").replace("：", ":")
-        time_match = re.search(r"(\d{1,2}:\d{2})-(\d{1,2}:\d{2})", line)
-        if not time_match:
-            continue
-        open_time, close_time = time_match.group(1), time_match.group(2)
-        for day in expand_days(line[: time_match.start()]):
-            oh.add_range(day, open_time, close_time)
-
-    result = oh.as_opening_hours()
-    if not has_holiday or not result:
-        return result
-
-    # The OpeningHours helper has no concept of public holidays, so append
-    # PH to the weekend group (土日祝) manually rather than drop it.
-    groups = result.split("; ")
-    for index, group in enumerate(groups):
-        day_part, _, hours = group.partition(" ")
-        if "Sa" in day_part or "Su" in day_part:
-            groups[index] = f"{day_part},PH {hours}"
-            break
-    return "; ".join(groups)
+)
 
 
 class SushiroJPSpider(JSONBlobSpider):
@@ -114,12 +92,12 @@ class SushiroJPSpider(JSONBlobSpider):
     item_attributes = {"brand": "スシロー", "brand_wikidata": "Q11257037"}
     start_urls = ["https://www.akindo-sushiro.co.jp/shop/"]
 
-    def parse(self, response: Response) -> Iterable[Feature | Request]:
-        if "?pref=" not in response.url:
-            for pref_id, _ in PREFECTURES:
-                yield Request(f"{self.start_urls[0]}?pref={pref_id}")
-            return
-        yield from super().parse(response)
+    async def start(self) -> AsyncIterator[Request]:
+        # The store list is loaded per-prefecture via a ?pref=<id> query on the
+        # same URL, and the prefecture ids are already hardcoded in PREFECTURES
+        # (no need to scrape the start page's <select name="pref"> first).
+        for pref_id, _ in PREFECTURES:
+            yield Request(f"{self.start_urls[0]}?pref={pref_id}")
 
     def extract_json(self, response: Response) -> list[dict]:
         data_raw = response.xpath("//script[contains(text(), 'items = [')]/text()").get()
@@ -136,16 +114,113 @@ class SushiroJPSpider(JSONBlobSpider):
         return json.loads(data_raw[start - 1 : i])
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # Recorded as tags (see each line for the source field):
         item["ref"] = feature["id"]
         item["branch"] = item.pop("name").splitlines()[0].strip()
         item["addr_full"] = feature["address"]
-        item["postcode"] = f'{feature["zip1"]}{feature["zip2"]}'
+        item["postcode"] = f"{feature['zip1']}{feature['zip2']}"
         item["city"] = feature["city_name"]
-        item["state"] = feature["pref_name"]
+        item["extras"]["addr:province"] = feature["pref_name"]
         item["country"] = "JP"
-        item["opening_hours"] = parse_hours(feature["hours"])
+        item["opening_hours"] = self._parse_hours(feature["hours"])
+
+        if fax := feature.get("fax"):
+            item["extras"]["contact:fax"] = fax
+
+        if kana := feature.get("kana"):
+            item["extras"]["name:ja-Hira"] = kana
+
+        if "クレジット" in (feature.get("memo") or ""):
+            apply_yes_no(PaymentMethods.CREDIT_CARDS, item, True)
+            for brand, tag in CARD_BRANDS.items():
+                if brand in feature["memo"]:
+                    apply_yes_no(tag, item, True)
+
+        if line := feature.get("line_url"):
+            item["extras"]["contact:line"] = line
+
+        if line_mini := feature.get("line_mini_url"):
+            apply_yes_no("reservation", item, True)
+            item["extras"]["website:booking"] = line_mini
+
+        for code, tag in SERVICE_TAGS.items():
+            if any(int(s["service"]) == code for s in feature["service"]):
+                if tag == "parking":
+                    item["extras"]["parking"] = "yes"
+                elif tag == "capacity:disabled":
+                    apply_yes_no(Extras.PARKING_WHEELCHAIR, item, True)
+                elif tag == "wheelchair":
+                    apply_yes_no(Extras.WHEELCHAIR, item, True)
+                elif tag == "changing_table":
+                    apply_yes_no(Extras.BABY_CHANGING_TABLE, item, True)
+
+        # Other skipped fields
+        #   pref_id       JIS prefecture code
+        #   city_id       internal
+        #   base_post_id  internal (parent-store link)
+        #   sushipass_id  internal membership-store id
+        #   language      constant "0"
+        #   category      constant "13"
+        #   price_range   cost tier 1-7; no standard OSM tag
+        #   access        transport directions; no standard OSM key
+        #   result_name   duplicate of name plus a price note
+        #   togo_menu_url / demaecan_url / uber_eats_url
+        #                 takeout/delivery links, empty for most stores
+        #   recruit_url   job/hiring page, not POI data
+        #   status        constant "0" (open)
+        #   output_flag   constant "1" (shown on site)
+        #   created / modified / start_datetime / end_datetime / open_datetime / close_datetime
+        #   / renewal_start_datetime / renewalend_datetime
+        #                 CMS / schedule metadata; closure windows are not
+        #                 reliably populated and are surfaced instead in the
+        #                 name/hours text of affected stores
 
         apply_category(Categories.FAST_FOOD, item)
         item["extras"]["cuisine"] = "sushi"
 
         yield item
+
+    @staticmethod
+    def _expand_days(raw_day_part: str) -> list[str]:
+        stripped = raw_day_part.replace("祝", "").strip()
+        if not stripped:
+            return list(DAYS)
+        if "-" in stripped:
+            start_part, _, end_part = stripped.partition("-")
+            start = DAYS_JP.get(start_part[-1]) if start_part else None
+            end = DAYS_JP.get(end_part[-1]) if end_part else None
+            if start and end:
+                return day_range(start, end)
+            return []
+        return [DAYS_JP[c] for c in stripped if c in DAYS_JP]
+
+    @staticmethod
+    def _parse_hours(text: str) -> str:
+        oh = OpeningHours()
+        has_holiday = False
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("※"):
+                continue
+            has_holiday = has_holiday or "祝" in line
+            line = line.replace("～", "-").replace("〜", "-").replace("：", ":")
+            time_match = re.search(r"(\d{1,2}:\d{2})-(\d{1,2}:\d{2})", line)
+            if not time_match:
+                continue
+            open_time, close_time = time_match.group(1), time_match.group(2)
+            for day in SushiroJPSpider._expand_days(line[: time_match.start()]):
+                oh.add_range(day, open_time, close_time)
+
+        result = oh.as_opening_hours()
+        if not has_holiday or not result:
+            return result
+
+        # The OpeningHours helper has no concept of public holidays, so append
+        # PH to the weekend group (土日祝) manually rather than drop it.
+        groups = result.split("; ")
+        for index, group in enumerate(groups):
+            day_part, _, hours = group.partition(" ")
+            if "Sa" in day_part or "Su" in day_part:
+                groups[index] = f"{day_part},PH {hours}"
+                break
+        return "; ".join(groups)

--- a/locations/spiders/sushiro_jp.py
+++ b/locations/spiders/sushiro_jp.py
@@ -116,9 +116,9 @@ class SushiroJPSpider(JSONBlobSpider):
         item["extras"]["addr:province"] = feature["pref_name"]
         item["country"] = "JP"
         item["website"] = f"https://www.akindo-sushiro.co.jp/shop/detail.php?id={feature['id']}"
-        item["extras"]["website:menu"] = (
-            f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
-        )
+        item["extras"][
+            "website:menu"
+        ] = f"https://www.akindo-sushiro.co.jp/menu/menu_detail/?s_id={feature['sushipass_id']}"
         item["extras"]["website:allergens"] = "https://www.akindo-sushiro.co.jp/menu/allergy.html"
         item["opening_hours"] = self._parse_hours(feature["hours"])
 


### PR DESCRIPTION
close #18478 

This adds Sushiro, a popular conveyor belt sushi restaurants in Japan (I'll add other sushi brands later 🍣 ). Each store list page per prefecture has an embedded JSON data which includes all store information (store detail page jsut render the same data per store so no need to fetch detail page).

Note for refactoring ab9a976fc03d9acf8a2f12f7ececcc9e5cc5f57d: To better organize the codebase, I moved the Japanese language-specific helper (added by #18405) from `locations/geo.py` to `locations/lang_utils.py` and made it public API. This spider requires that same helper, and it will likely be used for future spiders as well. If more language-specific helpers are implemented, we can organize them into language-specific submodules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for Sushiro restaurant locations across Japan.
  * Sushiro listings include full addresses, contact details, opening hours, menus, payment options, booking links, and accessibility information.
  * Restaurant entries identify Sushiro as a fast-food venue serving sushi.
  * Japanese postal-region names now provide consistent hiragana values for prefectures, cities, quarters, and neighbourhoods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->