### PR TITLE
[yaoko_jp] Add spider (205 locations)

### DIFF
--- a/locations/spiders/yaoko_jp.py
+++ b/locations/spiders/yaoko_jp.py
@@ -1,0 +1,60 @@
+import re
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.items import Feature
+
+
+class YaokoJPSpider(Spider):
+    """Extract Yaoko (JP) store details from the official main website.
+
+    ``start_requests`` fetches the single store-list page, extracts every store
+    detail URL, and issues one request per store. A single ``parse`` then fills
+    the whole item from each detail page (which carries all available data).
+    """
+
+    name = "yaoko_jp"
+    item_attributes = {
+        "brand": "ヤオコー",
+        "brand_wikidata": "Q11344967",
+    }
+
+    list_url = "https://www.yaoko-net.com/store/"
+
+    async def start(self):
+        yield Request(self.list_url, callback=self.parse_list)
+
+    def parse_list(self, response: Response):
+        seen: set[str] = set()
+        for url in response.xpath("//a[contains(@href, '/store/store')]/@href").getall():
+            url = response.urljoin(url)
+            if url in seen:
+                continue
+            seen.add(url)
+            yield Request(url, callback=self.parse)
+
+    def parse(self, response: Response):
+        rows = response.xpath("//table[contains(@class, 'store_info_table')]//tr")
+        info = {
+            label: value
+            for tr in rows
+            if (label := tr.xpath("./th/text()").get(""))
+            for value in [tr.xpath("string(./td)").get("")]
+        }
+
+        item = Feature()
+        item["ref"] = response.url.rstrip("/").split("/")[-1].replace(".html", "")
+        item["name"] = re.sub(r"（.*?）$", "", response.xpath("//h1/text()").get("")).strip()
+        item["website"] = response.url
+        item["country"] = "JP"
+
+        addr_lines = [line.strip() for line in info.get("住所", "").split("\n") if line.strip()]
+        item["addr_full"] = "\n".join(addr_lines)
+        postcode = re.search(r"〒\s*([0-9\-]+)", info.get("住所", ""))
+        if postcode:
+            item["postcode"] = postcode.group(1)
+        item["phone"] = info.get("電話番号", "").strip()
+        item["opening_hours"] = info.get("営業時間", "").strip()
+
+        yield item

--- a/locations/spiders/yaoko_jp.py
+++ b/locations/spiders/yaoko_jp.py
@@ -29,9 +29,11 @@ class YaokoJPSpider(Spider):
     start_urls = ["https://yaoko-job.net/jobfind-pc/area/All"]
     store_list_url = "https://www.yaoko-net.com/store/"
 
-    branch_to_coords_map: dict[str, tuple[float, float]] = {}
-    seen_job_stores: set[str] = set()
-    phase2_started = False
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.branch_to_coords_map: dict[str, tuple[float, float]] = {}
+        self.seen_job_stores: set[str] = set()
+        self.phase2_started = False
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):

--- a/locations/spiders/yaoko_jp.py
+++ b/locations/spiders/yaoko_jp.py
@@ -95,6 +95,7 @@ class YaokoJPSpider(Spider):
         }
 
         item = Feature()
+        item["name"] = "ヤオコー"
         item["ref"] = response.url.rstrip("/").split("/")[-1].replace(".html", "")
         item["branch"] = re.sub(r"（.*?）$", "", response.xpath("//h1/text()").get("")).strip()
         item["website"] = response.url

--- a/locations/spiders/yaoko_jp.py
+++ b/locations/spiders/yaoko_jp.py
@@ -1,17 +1,23 @@
 import re
 
-from scrapy import Spider
+import chompjs
+from scrapy import Spider, signals
+from scrapy.exceptions import DontCloseSpider
 from scrapy.http import Request, Response
 
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
 
 class YaokoJPSpider(Spider):
     """Extract Yaoko (JP) store details from the official main website.
 
-    ``start_requests`` fetches the single store-list page, extracts every store
-    detail URL, and issues one request per store. A single ``parse`` then fills
-    the whole item from each detail page (which carries all available data).
+    Coords are not present on the main site, so the job board is crawled first
+    to build a ``branch -> (lat, lon)`` map, then the main site's store list is
+    crawled and each store is enriched with coordinates by matching branch name.
+
+    One caveat is job board doesn't always return all sotres and changes time by time. So we only fill the coords with stores which publish at least one job posting as best effort.
     """
 
     name = "yaoko_jp"
@@ -20,21 +26,64 @@ class YaokoJPSpider(Spider):
         "brand_wikidata": "Q11344967",
     }
 
-    list_url = "https://www.yaoko-net.com/store/"
+    start_urls = ["https://yaoko-job.net/jobfind-pc/area/All"]
+    store_list_url = "https://www.yaoko-net.com/store/"
 
-    async def start(self):
-        yield Request(self.list_url, callback=self.parse_list)
+    branch_to_coords_map: dict[str, tuple[float, float]] = {}
+    seen_job_stores: set[str] = set()
+    phase2_started = False
 
-    def parse_list(self, response: Response):
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = super().from_crawler(crawler, *args, **kwargs)
+        crawler.signals.connect(spider.handle_idle, signal=signals.spider_idle)
+        return spider
+
+    def parse(self, response: Response):
+        next_page = response.xpath("//a[contains(@href, '?page=') and contains(., '次へ')]/@href").get()
+        if next_page:
+            yield response.follow(next_page, callback=self.parse)
+
+        job_postings = response.xpath("//article[contains(@class, 'multiple_standard')]//div[contains(@class,'box')]")
+        for job_posting in job_postings:
+            store_name = job_posting.xpath("normalize-space(.//h2/a/text())").get()
+            if not store_name:
+                continue
+            parts = store_name.split()
+            branch = parts[1] if len(parts) > 1 else store_name
+            key = self.branch_key(branch)
+            if key in self.seen_job_stores:
+                continue
+            self.seen_job_stores.add(key)
+
+            website = response.urljoin(job_posting.xpath(".//h2/a/@href").get())
+            yield Request(f"{website}/map", callback=self.parse_job_map, cb_kwargs={"key": key})
+
+    def handle_idle(self):
+        # Coords come from the job board (phase 1), not the main site (phase 2).
+        # Scrapy runs requests concurrently with no ordering, so without this
+        # gate the store crawl would start before ``branch_to_coords_map`` is fully
+        # built and most stores would silently get no coords. ``spider_idle`` called
+        # only once phase 1 is complete, so we start phase 2 exactly then.
+        if not self.phase2_started:
+            self.phase2_started = True
+            self.crawler.engine.crawl(Request(self.store_list_url, callback=self.parse_store_list))
+            raise DontCloseSpider
+
+    def parse_job_map(self, response: Response, key: str):
+        coords = self.extract_json(response)
+        self.branch_to_coords_map[key] = (coords["latitude"], coords["longitude"])
+
+    def parse_store_list(self, response: Response):
         seen: set[str] = set()
-        for url in response.xpath("//a[contains(@href, '/store/store')]/@href").getall():
+        for url in response.xpath("//a[contains(@href, '/store/store') and contains(@href, '.html')]/@href").getall():
             url = response.urljoin(url)
             if url in seen:
                 continue
             seen.add(url)
-            yield Request(url, callback=self.parse)
+            yield Request(url, callback=self.parse_store)
 
-    def parse(self, response: Response):
+    def parse_store(self, response: Response):
         rows = response.xpath("//table[contains(@class, 'store_info_table')]//tr")
         info = {
             label: value
@@ -45,16 +94,40 @@ class YaokoJPSpider(Spider):
 
         item = Feature()
         item["ref"] = response.url.rstrip("/").split("/")[-1].replace(".html", "")
-        item["name"] = re.sub(r"（.*?）$", "", response.xpath("//h1/text()").get("")).strip()
+        item["branch"] = re.sub(r"（.*?）$", "", response.xpath("//h1/text()").get("")).strip()
         item["website"] = response.url
         item["country"] = "JP"
 
         addr_lines = [line.strip() for line in info.get("住所", "").split("\n") if line.strip()]
-        item["addr_full"] = "\n".join(addr_lines)
+        item["addr_full"] = re.sub(r"〒\s*[0-9\-]+\s*", "", "\n".join(addr_lines)).strip()
         postcode = re.search(r"〒\s*([0-9\-]+)", info.get("住所", ""))
         if postcode:
             item["postcode"] = postcode.group(1)
         item["phone"] = info.get("電話番号", "").strip()
-        item["opening_hours"] = info.get("営業時間", "").strip()
+        item["opening_hours"] = self.parse_hours(info.get("営業時間", "").strip())
+
+        coords = self.branch_to_coords_map.get(self.branch_key(item["branch"]))
+        if coords:
+            item["lat"], item["lon"] = coords
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
 
         yield item
+
+    @staticmethod
+    def branch_key(name: str) -> str:
+        return re.sub(r"[（(][^）)]*[）)]$", "", name).strip()
+
+    @staticmethod
+    def parse_hours(text: str) -> OpeningHours:
+        oh = OpeningHours()
+        line = re.sub(r"\s", "", text.replace("：", ":").replace("～", "-").replace("〜", "-"))
+        m = re.search(r"(\d{1,2}:\d{2})-(\d{1,2}:\d{2})", line)
+        if m:
+            oh.add_days_range(DAYS, m.group(1), m.group(2))
+        return oh
+
+    def extract_json(self, response: Response) -> dict:
+        script = response.xpath("//script[contains(., 'createGoogleMaps')]/text()").get()
+        blob = re.search(r"createGoogleMaps\(\s*(\{.*?\})\s*\)", script or "", re.S).group(1)
+        return chompjs.parse_js_object(blob)


### PR DESCRIPTION
resolve #18459 

This adds Yaoko, a supermarket brand popular in Kanto region.

As noted in #18459, the main website has no coordinates. So I had to fill coordinates from another offcial job posting website. The one problem is job posting is not always open for all stores so it can fill 88% of stores (179/205) as of today and it will change time to time. As far as I know, other locaiton data is not available across official websites.

I split into two phase crawings: 1) builds the in-memory store name -> coords mapping from job posting sites, 2) fill athe vailbale coordinates to each store item in the second phase. I had to use the store name as key since the job posting seems to be developed by other compaany and they don't use the correct store ID used across official websites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added coverage for Yaoko supermarket locations in Japan.
- Store listings now include branch details such as addresses, contact information, opening hours, website links, and map coordinates.
- Yaoko locations are categorized as supermarkets for consistent discovery.
- Store and job listing information is matched to improve branch identification and coordinate accuracy.
- Yaoko locations now display the standardized name “ヤオコー” in store details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->