### PR TITLE
[coop_sapporo_jp] Add spider (113 locations)

### DIFF
--- a/locations/spiders/coop_sapporo_jp.py
+++ b/locations/spiders/coop_sapporo_jp.py
@@ -21,6 +21,9 @@ class CoopSapporoJPSpider(CanlySpider):
         item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
         item["website"] = f"https://map.sapporo.coop/store/detail/{feature.get('storeCode')}/"
 
+        if start_date := feature.get("establishmentDate"):
+            item["extras"]["start_date"] = start_date
+
         if feature.get("openStatus") != "IS_ALREADY_OPEN":
             # Temporarily closed locations (for example, closed for renovation)
             item["extras"]["disused:shop"] = "supermarket"

--- a/locations/spiders/coop_sapporo_jp.py
+++ b/locations/spiders/coop_sapporo_jp.py
@@ -16,15 +16,15 @@ class CoopSapporoJPSpider(CanlySpider):
     api_endpoint = "https://api.site.can-ly.com/v2/directories/91/shops/search"
 
     def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
-        # Skip any non-open locations
-        if feature.get("openStatus") != "IS_ALREADY_OPEN":
-            return
-
         item["name"] = feature.get("brand").get("name")
         item["branch"] = feature.get("nameKanji")
         item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
         item["website"] = f"https://map.sapporo.coop/store/detail/{feature.get('storeCode')}/"
 
-        apply_category(Categories.SHOP_SUPERMARKET, item)
+        if feature.get("openStatus") != "IS_ALREADY_OPEN":
+            # Temporarily closed locations (for example, closed for renovation)
+            item["extras"]["disused:shop"] = "supermarket"
+        else:
+            apply_category(Categories.SHOP_SUPERMARKET, item)
 
         yield item

--- a/locations/spiders/coop_sapporo_jp.py
+++ b/locations/spiders/coop_sapporo_jp.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
+from locations.hours import DAYS_FULL, OpeningHours
 from locations.items import Feature
 from locations.storefinders.canly import CanlySpider
 
@@ -29,6 +30,9 @@ class CoopSapporoJPSpider(CanlySpider):
         if feature.get("openStatus") != "IS_ALREADY_OPEN":
             # API reports these as permanently closed, but they can be closed for
             # renovation and later reopen in the same place (e.g. 砂川 -> すながわ)
-            item["extras"]["opening_hours"] = "closed"
+            closed_hours = OpeningHours()
+            for day in DAYS_FULL:
+                closed_hours.set_closed(day)
+            item["opening_hours"] = closed_hours
 
         yield item

--- a/locations/spiders/coop_sapporo_jp.py
+++ b/locations/spiders/coop_sapporo_jp.py
@@ -1,0 +1,30 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.storefinders.canly import CanlySpider
+
+
+class CoopSapporoJPSpider(CanlySpider):
+    name = "coop_sapporo_jp"
+    item_attributes = {
+        "brand": "COOP SAPPORO",
+        "brand_wikidata": "Q11574624",
+    }
+    api_endpoint = "https://api.site.can-ly.com/v2/directories/91/shops/search"
+
+    def post_process_item(self, item: Feature, response: Response, feature: dict) -> Iterable[Feature]:
+        # Skip any non-open locations
+        if feature.get("openStatus") != "IS_ALREADY_OPEN":
+            return
+
+        item["name"] = feature.get("brand").get("name")
+        item["branch"] = feature.get("nameKanji")
+        item["extras"]["branch:ja-Hira"] = feature.get("nameKana")
+        item["website"] = f"https://map.sapporo.coop/store/detail/{feature.get('storeCode')}/"
+
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
+        yield item

--- a/locations/spiders/coop_sapporo_jp.py
+++ b/locations/spiders/coop_sapporo_jp.py
@@ -24,10 +24,11 @@ class CoopSapporoJPSpider(CanlySpider):
         if start_date := feature.get("establishmentDate"):
             item["extras"]["start_date"] = start_date
 
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+
         if feature.get("openStatus") != "IS_ALREADY_OPEN":
-            # Temporarily closed locations (for example, closed for renovation)
-            item["extras"]["disused:shop"] = "supermarket"
-        else:
-            apply_category(Categories.SHOP_SUPERMARKET, item)
+            # API reports these as permanently closed, but they can be closed for
+            # renovation and later reopen in the same place (e.g. 砂川 -> すながわ)
+            item["extras"]["opening_hours"] = "closed"
 
         yield item


### PR DESCRIPTION
resolve #18494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for COOP SAPPORO store locations in Japan.
  * Store listings now include branch names, Japanese kana names, website links, supermarket categorization, and establishment dates when available.
  * Listings now indicate when a location has not yet opened, including corresponding opening-hours information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->