### PR TITLE
[AJP Immobilier] Add spider (87 locations)

### DIFF
--- a/locations/spiders/ajp_immobilier_fr.py
+++ b/locations/spiders/ajp_immobilier_fr.py
@@ -1,0 +1,24 @@
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class AjpImmobilierFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "ajp_immobilier_fr"
+    item_attributes = {"brand": "AJP Immobilier", "brand_wikidata": "Q141301527"}
+    sitemap_urls = ["https://www.ajp-immobilier.com/sitemap.xml"]
+    sitemap_rules = [(r"https://www.ajp-immobilier.com/agence-immobiliere/.*", "parse_sd")]
+    wanted_types = ["RealEstateAgent"]
+    drop_attributes = {"image", "twitter"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item.get("facebook") == "https://www.facebook.com/ajpimmobilierfrance":
+            item["facebook"] = None
+        item["branch"] = item.pop("name").removeprefix("AJP Immobilier ")
+    
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+        yield item

--- a/locations/spiders/ajp_immobilier_fr.py
+++ b/locations/spiders/ajp_immobilier_fr.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
@@ -19,6 +20,6 @@ class AjpImmobilierFRSpider(SitemapSpider, StructuredDataSpider):
         if item.get("facebook") == "https://www.facebook.com/ajpimmobilierfrance":
             item["facebook"] = None
         item["branch"] = item.pop("name").removeprefix("AJP Immobilier ")
-    
+
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item


### PR DESCRIPTION
Adds a spider for the french estate agent chain "AJP Immobilier".

```
{'atp/brand/AJP Immobilier': 87,
 'atp/brand_wikidata/Q141301527': 87,
 'atp/category/office/estate_agent': 87,
 'atp/clean_strings/branch': 2,
 'atp/clean_strings/street_address': 7,
 'atp/country/FR': 87,
 'atp/field/geometry/missing': 1,
 'atp/field/housenumber/missing': 87,
 'atp/field/name/missing': 87,
 'atp/field/operator/missing': 87,
 'atp/field/operator_wikidata/missing': 87,
 'atp/field/state/missing': 87,
 'atp/field/street/missing': 87,
 'atp/field/twitter/missing': 87,
 'atp/field/unit/missing': 87,
 'atp/item_scraped_host_count/www.ajp-immobilier.com': 87,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 87,
 'atp/nsi/match_failed': 87,
 'downloader/request_bytes': 86426,
 'downloader/request_count': 89,
 'downloader/request_method_count/GET': 89,
 'downloader/response_bytes': 1656708,
 'downloader/response_count': 89,
 'downloader/response_status_count/200': 89,
 'elapsed_time_seconds': 109.70593770779669,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 5, 11, 40, 0, 950075, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 11411268,
 'httpcompression/response_count': 88,
 'item_scraped_count': 87,
 'items_per_minute': 47.88990825688074,
 'log_count/DEBUG': 176,
 'log_count/INFO': 4,
 'memusage/max': 315768832,
 'memusage/startup': 158400512,
 'request_depth_max': 1,
 'response_received_count': 89,
 'responses_per_minute': 48.99082568807339,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 88,
 'scheduler/dequeued/memory': 88,
 'scheduler/enqueued': 88,
 'scheduler/enqueued/memory': 88,
 'start_time': datetime.datetime(2026, 9, 5, 11, 38, 11, 243657, tzinfo=datetime.timezone.utc)}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting office locations from French AJP Immobilier.
  * Listings now include normalized Facebook links, branch names, and the appropriate real estate office classification.
  * AJP Immobilier locations are now available alongside other supported real estate offices for more complete directory coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->