### PR TITLE
[daiso_sangyo_jp] Add spider (4885 locations)

### DIFF
--- a/locations/spiders/daiso_sangyo_jp.py
+++ b/locations/spiders/daiso_sangyo_jp.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator, Iterable
 from scrapy import Spider
 from scrapy.http import JsonRequest, Request, Response
 
-from locations.categories import Categories, apply_category
+from locations.categories import Categories, Extras, PaymentMethods, apply_category, apply_yes_no
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 
@@ -30,6 +30,25 @@ class DaisoSangyoJPSpider(Spider):
         "threeppy": "THREEPPY ",
         "sp": "Standard Products ",
         "coucou": "CouCou ",
+    }
+
+    # Maps each service listed on the shop detail page
+    # to the OSM tag.
+    # "eクーポン" (e-coupon) has no OSM tag and is intentionally left unmapped.
+    SERVICE_TAGS = {
+        "各種クレジットカード": PaymentMethods.CREDIT_CARDS,
+        "イオンクレジット": PaymentMethods.CREDIT_CARDS,
+        "各種電子マネー": PaymentMethods.ICSF,
+        "PayPay": PaymentMethods.PAYPAY,
+        "auPay": PaymentMethods.AU_PAY,
+        "メルペイ": PaymentMethods.MERPAY,
+        "楽天ペイ": PaymentMethods.RAKUTEN_PAY,
+        "アリペイ": PaymentMethods.ALIPAY,
+        "WeChatペイ": PaymentMethods.WECHAT,
+        "d払い": PaymentMethods.D_BARAI,
+        "WAON": PaymentMethods.WAON,
+        "5円コピー": Extras.COPYING,
+        "写真プリント": Extras.PHOTO_PRINTING,
     }
 
     async def start(self) -> AsyncIterator[JsonRequest]:
@@ -63,9 +82,21 @@ class DaisoSangyoJPSpider(Spider):
 
         item["opening_hours"] = self.parse_hours(shop["hours"])
 
+        self.apply_service_tags(item, response)
+
         apply_category(Categories.SHOP_VARIETY_STORE, item)
 
         yield item
+
+    @classmethod
+    def apply_service_tags(cls, item: Feature, response: Response) -> None:
+        for li in response.xpath('//div[contains(@class,"shopSingle-service")]//ul/li'):
+            text = "".join(li.xpath(".//text()").getall()).strip()
+            if not text:
+                continue
+            for part in text.split("、"):
+                if tag := cls.SERVICE_TAGS.get(part):
+                    apply_yes_no(tag, item, True)
 
     @staticmethod
     def parse_hours(value: str) -> OpeningHours:

--- a/locations/spiders/daiso_sangyo_jp.py
+++ b/locations/spiders/daiso_sangyo_jp.py
@@ -1,0 +1,75 @@
+from typing import AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Request, Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+
+API_URL = "https://daisosangyo.locationsmart.org/map/g2?n=90&s=0&w=0&e=179&z=99"
+DETAIL_URL_TEMPLATE = "https://www.daiso-sangyo.co.jp/shop/detail/{shop_id}"
+
+
+class DaisoSangyoJPSpider(Spider):
+    name = "daiso_sangyo_jp"
+    allowed_domains = ["daisosangyo.locationsmart.org", "www.daiso-sangyo.co.jp"]
+
+    # brand_id -> (brand name, wikidata id). CouCou has no wikidata item.
+    BRANDS = {
+        "daiso": ("ダイソー", "Q866991"),
+        "threeppy": ("THREEPPY", "Q137916752"),
+        "sp": ("Standard Products", "Q137916628"),
+        "coucou": ("CouCou", None),
+    }
+
+    # Store names start with the brand prefix, the rest is the branch name,
+    # e.g. "DAISO マルナカ三田店" -> branch "マルナカ三田店".
+    BRAND_PREFIXES = {
+        "daiso": "DAISO ",
+        "threeppy": "THREEPPY ",
+        "sp": "Standard Products ",
+        "coucou": "CouCou ",
+    }
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(url=API_URL)
+
+    def parse(self, response: Response) -> Iterable[Request]:
+        for shop in response.json()["shops"]:  # ty: ignore[unresolved-attribute]
+            yield Request(
+                url=DETAIL_URL_TEMPLATE.format(shop_id=shop["id"]), callback=self.parse_store, cb_kwargs={"shop": shop}
+            )
+
+    def parse_store(self, response: Response, shop: dict) -> Iterable[Feature]:
+        item = Feature()
+        item["ref"] = shop["id"]
+        item["branch"] = shop["name"].removeprefix(self.BRAND_PREFIXES[shop["brand_id"]])
+        item["lat"] = shop["lat"]
+        item["lon"] = shop["lon"]
+        item["website"] = DETAIL_URL_TEMPLATE.format(shop_id=shop["id"])
+
+        address = "".join(response.xpath('//dt[text()="住所"]/following-sibling::dd[1]//text()').getall()).strip()
+        if address:
+            item["addr_full"] = address
+
+        brand_name, wikidata = self.BRANDS[shop["brand_id"]]
+        item["brand"] = brand_name
+        if wikidata:
+            item["brand_wikidata"] = wikidata
+        if shop["brand_id"] != "daiso":
+            # daiso is in NSI which supplies its name
+            item["name"] = brand_name
+
+        item["opening_hours"] = self.parse_hours(shop["hours"])
+
+        apply_category(Categories.SHOP_VARIETY_STORE, item)
+
+        yield item
+
+    @staticmethod
+    def parse_hours(value: str) -> OpeningHours:
+        opening_hours = OpeningHours()
+        open_time, close_time = value.split("-", 1)
+        opening_hours.add_days_range(DAYS, open_time, close_time)
+        return opening_hours


### PR DESCRIPTION
resolve #18425 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location data for Japanese Daiso Sangyo stores.
  * Store listings now include addresses, coordinates, websites, opening hours, brand information, categories, and available services.
  * Supported payment methods and other services are included as store tags.
  * Handles incomplete store details and varying service information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->