### PR TITLE
[Cabinet Bedin] Add spider (62 locations)

### DIFF
--- a/locations/spiders/cabinet_bedin_fr.py
+++ b/locations/spiders/cabinet_bedin_fr.py
@@ -1,0 +1,22 @@
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class CabinetBedinFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "cabinet_bedin_fr"
+    item_attributes = {"brand": "Cabinet Bedin", "brand_wikidata": "Q141309660"}
+    sitemap_urls = ["https://www.cabinet-bedin.com/sitemap.xml"]
+    sitemap_rules = [(r"https://www.cabinet-bedin.com/agence-immobiliere/.*", "parse_sd")]
+    wanted_types = ["RealEstateAgent"]
+    drop_attributes = {"image", "email"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Cabinet Bedin Immobilier ")
+    
+        apply_category(Categories.OFFICE_ESTATE_AGENT, item)
+        yield item

--- a/locations/spiders/cabinet_bedin_fr.py
+++ b/locations/spiders/cabinet_bedin_fr.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
@@ -17,6 +18,6 @@ class CabinetBedinFRSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         item["branch"] = item.pop("name").removeprefix("Cabinet Bedin Immobilier ")
-    
+
         apply_category(Categories.OFFICE_ESTATE_AGENT, item)
         yield item


### PR DESCRIPTION
Adds a spider for the french real estate agent chain "Cabinet Bedin"

```
{'atp/brand/Cabinet Bedin': 62,
 'atp/brand_wikidata/Q141309660': 62,
 'atp/category/office/estate_agent': 62,
 'atp/country/FR': 62,
 'atp/field/email/missing': 62,
 'atp/field/housenumber/missing': 62,
 'atp/field/name/missing': 62,
 'atp/field/operator/missing': 62,
 'atp/field/operator_wikidata/missing': 62,
 'atp/field/state/missing': 62,
 'atp/field/street/missing': 62,
 'atp/field/twitter/missing': 62,
 'atp/field/unit/missing': 62,
 'atp/item_scraped_host_count/www.cabinet-bedin.com': 62,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 62,
 'atp/nsi/match_failed': 62,
 'downloader/request_bytes': 28316,
 'downloader/request_count': 64,
 'downloader/request_method_count/GET': 64,
 'downloader/response_bytes': 3515847,
 'downloader/response_count': 64,
 'downloader/response_status_count/200': 64,
 'elapsed_time_seconds': 79.38463433273137,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 5, 17, 8, 1, 905465, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 20137644,
 'httpcompression/response_count': 64,
 'item_scraped_count': 62,
 'items_per_minute': 47.08860759493671,
 'log_count/DEBUG': 126,
 'log_count/INFO': 4,
 'memusage/max': 331022336,
 'memusage/startup': 175570944,
 'request_depth_max': 1,
 'response_received_count': 64,
 'responses_per_minute': 48.607594936708864,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 63,
 'scheduler/dequeued/memory': 63,
 'scheduler/enqueued': 63,
 'scheduler/enqueued/memory': 63,
 'start_time': datetime.datetime(2026, 9, 5, 17, 6, 42, 520845, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location data coverage for Cabinet Bedin real estate agency branches in France.
  * Branch listings are categorized as real estate agent offices and include normalized branch names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->