### PR TITLE
Add boulanger_fr spider (232 locations)

### DIFF
--- a/locations/spiders/boulanger_fr.py
+++ b/locations/spiders/boulanger_fr.py
@@ -1,0 +1,82 @@
+import json
+import random
+from typing import Iterable
+
+from scrapy.downloadermiddlewares.retry import get_retry_request
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from locations.dict_parser import DictParser
+from locations.hours import OpeningHours
+from locations.items import Feature, set_closed
+from locations.pipelines.address_clean_up import merge_address_lines
+
+
+class BoulangerFRSpider(SitemapSpider):
+    name = "boulanger_fr"
+    item_attributes = {"brand": "Boulanger", "brand_wikidata": "Q2921695"}
+    sitemap_urls = ["https://www.boulanger.com/sitemap_magasins.xml"]
+    # Sitemap also lists brand shop-in-shops ("espaces") and news posts ("actualites");
+    # only the 4-segment region/department/city/address paths are actual store pages.
+    sitemap_rules = [(r"/magasins/(?!espaces/|actualites/)[^/]+/[^/]+/[^/]+/[^/]+$", "parse")]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+
+    async def start(self):
+        # Akamai-protected, so even the initial sitemap fetch needs Zyte. httpResponseHeaders is
+        # required alongside httpResponseBody, or scrapy-zyte-api returns an unparseable binary Response.
+        async for request in super().start():
+            request.meta["zyte_api"] = {"httpResponseBody": True, "httpResponseHeaders": True}
+            yield request
+
+    def _parse_sitemap(self, response):
+        for request in super()._parse_sitemap(response):
+            request.meta["zyte_api"] = {"httpResponseBody": True, "httpResponseHeaders": True}
+            yield request
+
+    def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
+        # No JSON-LD; this Yext Pages template embeds the full location profile here instead.
+        raw = response.css("#js-map-config-dir-map::text").get()
+        entities = json.loads(raw).get("entities") if raw else None
+        if not entities:
+            # Zyte occasionally hands back a genuine 200 with a truncated render; retry rather
+            # than silently losing the store.
+            if response.request is not None:
+                if retry := get_retry_request(
+                    response.request,
+                    spider=self,
+                    reason="no map-config JSON found",
+                    priority_adjust=random.randint(-20, -1),
+                ):
+                    yield retry
+            return
+        profile = entities[0]["profile"]
+
+        item = DictParser.parse(profile)
+        item["ref"] = profile["meta"]["id"]
+        item["website"] = response.url  # profile's own websiteUrl can point at a stale domain
+        item.pop("phone")  # same national hotline (09 69 32 32 23) on every store, not per-branch
+        item["state"] = None  # a French département name, not a real addr:state value
+        item["branch"] = " ".join(item.pop("name", "").removeprefix("Boulanger").strip(" -").split())
+
+        address = profile.get("address") or {}
+        item["street_address"] = merge_address_lines([address.get("line1"), address.get("line2"), address.get("line3")])
+
+        item["opening_hours"] = self.parse_hours(profile.get("hours", {}).get("normalHours", []))
+
+        if profile.get("closed") is True:
+            set_closed(item)
+
+        yield item
+
+    @staticmethod
+    def parse_hours(normal_hours: list) -> OpeningHours:
+        oh = OpeningHours()
+        for day in normal_hours:
+            if day.get("isClosed"):
+                oh.set_closed(day["day"])
+                continue
+            for interval in day.get("intervals", []):
+                start = f"{interval['start'] // 100:02d}:{interval['start'] % 100:02d}"
+                end = f"{interval['end'] // 100:02d}:{interval['end'] % 100:02d}"
+                oh.add_range(day["day"], start, end)
+        return oh

--- a/locations/spiders/boulanger_fr.py
+++ b/locations/spiders/boulanger_fr.py
@@ -36,7 +36,12 @@ class BoulangerFRSpider(SitemapSpider):
     def parse(self, response: Response, **kwargs) -> Iterable[Feature]:
         # No JSON-LD; this Yext Pages template embeds the full location profile here instead.
         raw = response.css("#js-map-config-dir-map::text").get()
-        entities = json.loads(raw).get("entities") if raw else None
+        try:
+            entities = json.loads(raw).get("entities") if raw else None
+        except json.JSONDecodeError:
+            # A truncated render can leave `raw` non-empty but syntactically invalid JSON;
+            # treat it the same as a missing blob so it hits the retry path below.
+            entities = None
         if not entities:
             # Zyte occasionally hands back a genuine 200 with a truncated render; retry rather
             # than silently losing the store.


### PR DESCRIPTION
Adds a spider for Boulanger (Wikidata Q2921695), a French electronics/appliance retailer.

Closes #18043

## Approach

- `SitemapSpider` on `sitemap_magasins.xml`, but the sitemap is mixed (shop-in-shop "espaces"
  and news "actualites" entries alongside real store pages) — `sitemap_rules` is anchored on
  the real 4-segment `/magasins/{region}/{department}/{city}/{address}` path and excludes the
  other two prefixes explicitly.
- Site is behind Akamai Bot Manager (plain requests get a deceptive `400`, direct browser
  fetches hang waiting on a JS challenge) — every request, including the sitemap fetch itself,
  goes through Zyte `httpResponseBody` (`httpResponseHeaders` is required alongside it, or
  scrapy-zyte-api can't see `Content-Type` and hands back an unparseable binary `Response`).
- No JSON-LD. Store pages are a Yext Pages template with the full location profile embedded in
  a `<script id="js-map-config-dir-map">` JSON blob — parsed by hand rather than via
  `YextAnswersSpider`/`YextSearchSpider`, since there's no public Yext API host for this brand
  and the hours format differs (`HHMM` integers, not `"HH:MM"` strings).
- `website` comes from `response.url`, not the profile's own `websiteUrl` — one store had a
  stale value pointing at a dead legacy subdomain.
- Phone is dropped: the same national call-center number appears on every store sampled, not a
  per-branch line.
- `state` is left unset — the sitemap/profile value is a French région name, not a real
  `addr:state`.
- Address is built from `line1`/`line2`/`line3` via `merge_address_lines` rather than blind
  concatenation — `line2` is inconsistent (sometimes a mall name, sometimes a duplicate of the
  city).
- `parse()` retries via `get_retry_request` when the JSON blob is missing from an otherwise-200
  response — Zyte occasionally hands back a genuine 200 with a truncated render even with
  `httpResponseBody` (no JS execution), and a plain retry fetch gets the full page.
- No `apply_category` needed — NSI already has an exact `brand:wikidata=Q2921695` match
  (`shop=electronics`, France) that resolves automatically.

## Validation

Full crawl: 242 store URLs matched by `sitemap_rules` — 232 status-200 (→ 232 items, 0
duplicates), 9 genuine 404s (stale sitemap entries, not a spider bug), 1 fatal `RequestError`
after Zyte's own retries (Limoges, `520 Website Ban`) not blocking. The 233rd `200` in the raw
Zyte/downloader stats is the sitemap fetch itself, not a store page. `scrapy-zyte-api/success_ratio`
99.6%. `pre-commit` and `pytest tests/test_item_attributes.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Boulanger France store locations from the store directory.
  * Store details now include normalized addresses, location metadata, opening hours, and closed-store status.
  * Improved handling of temporary or incomplete store information so available location data can be collected reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->