### PR TITLE
Accor: localize hotel website URL to hotel's country language

### DIFF
--- a/locations/spiders/accor.py
+++ b/locations/spiders/accor.py
@@ -1,4 +1,5 @@
 from locations.categories import Categories, apply_category
+from locations.country_utils import get_locale
 from locations.storefinders.woosmap import WoosmapSpider
 
 
@@ -6,6 +7,32 @@ class AccorSpider(WoosmapSpider):
     name = "accor"
     key = "accor-prod-woos"
     origin = "https://accor.com"
+
+    # Languages that https://all.accor.com/ hotel pages are published in
+    # (i.e. valid "index.<lang>.shtml" suffixes). A country whose language
+    # is not in this set falls back to English.
+    SUPPORTED_WEBSITE_LANGUAGES = {
+        "ar",
+        "de",
+        "en",
+        "es",
+        "fr",
+        "id",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "pt-br",
+        "ru",
+        "th",
+        "tr",
+        "zh",
+    }
+    # Countries where the language code returned by country_utils.get_locale()
+    # does not match the locale code used by all.accor.com.
+    WEBSITE_LANGUAGE_OVERRIDES = {"BR": "pt-br"}
 
     brand_mapping = {
         "SUI": {"brand": "Novotel", "brand_wikidata": "Q420545"},
@@ -78,6 +105,15 @@ class AccorSpider(WoosmapSpider):
         else:
             self.crawler.stats.inc_value(f"atp/accor/unknown_brand/{brand_id}")
         item["addr_full"] = item.pop("street_address")
-        item["website"] = f"https://all.accor.com/hotel/{item['ref']}/index.en.shtml"
+        item["website"] = (
+            f"https://all.accor.com/hotel/{item['ref']}/index.{self.website_language(item['country'])}.shtml"
+        )
         apply_category(Categories.HOTEL, item)
         yield item
+
+    def website_language(self, country: str | None) -> str:
+        language = self.WEBSITE_LANGUAGE_OVERRIDES.get(country)
+        if not language and country:
+            locale = get_locale(country)
+            language = locale.split("-")[0] if locale else None
+        return language if language in self.SUPPORTED_WEBSITE_LANGUAGES else "en"

--- a/locations/spiders/accor.py
+++ b/locations/spiders/accor.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from locations.categories import Categories, apply_category
 from locations.country_utils import get_locale
 from locations.storefinders.woosmap import WoosmapSpider
@@ -11,7 +13,7 @@ class AccorSpider(WoosmapSpider):
     # Languages that https://all.accor.com/ hotel pages are published in
     # (i.e. valid "index.<lang>.shtml" suffixes). A country whose language
     # is not in this set falls back to English.
-    SUPPORTED_WEBSITE_LANGUAGES = {
+    SUPPORTED_WEBSITE_LANGUAGES: ClassVar[set[str]] = {
         "ar",
         "de",
         "en",
@@ -32,9 +34,9 @@ class AccorSpider(WoosmapSpider):
     }
     # Countries where the language code returned by country_utils.get_locale()
     # does not match the locale code used by all.accor.com.
-    WEBSITE_LANGUAGE_OVERRIDES = {"BR": "pt-br"}
+    WEBSITE_LANGUAGE_OVERRIDES: ClassVar[dict[str, str]] = {"BR": "pt-br"}
 
-    brand_mapping = {
+    brand_mapping: ClassVar[dict[str, dict[str, str] | None]] = {
         "SUI": {"brand": "Novotel", "brand_wikidata": "Q420545"},
         "NOV": {"brand": "Novotel", "brand_wikidata": "Q420545"},
         "NOL": {"brand": "Novotel", "brand_wikidata": "Q420545"},


### PR DESCRIPTION
Fixes #18429.

`AccorSpider` hardcoded `index.en.shtml` in the generated `website` URL for
every hotel, regardless of where it is located, so e.g. a hotel in France
got `https://all.accor.com/hotel/6342/index.en.shtml` instead of
`https://all.accor.com/hotel/6342/index.fr.shtml`.

## Fix

Derive the locale segment from the item's `country` (already populated by
`WoosmapSpider`/`DictParser`) using the existing `country_utils.get_locale()`
helper (same pattern as `volkswagen.py`/`mitsubishi.py`), restricted to the
set of languages `all.accor.com` actually publishes hotel pages in — taken
from the page's own `hreflang` alternates (`ar`, `de`, `en`, `es`, `fr`,
`id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `pt-br`, `ru`, `th`, `tr`, `zh`).
Anything unmapped or unsupported (e.g. India → `hi`) falls back to `en`,
same as today. Brazil is special-cased to `pt-br` since Accor separates it
from `pt` (Portugal).

## Verification

Checked against the live site that all mapped language suffixes resolve
(HTTP 200), e.g.:
- `index.fr.shtml`, `index.de.shtml`, `index.it.shtml`, `index.ar.shtml` → 200
- `index.shtml` (no language) → 404, confirming a language suffix is required

Ran `black`/`isort`/`flake8` on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Hotel website links now use the appropriate language for each country when available.
  - Brazilian hotel links now use Portuguese-language websites.
  - Links fall back to English when a country’s language is unavailable or unsupported.
  - This provides more localized and consistent website destinations across supported hotel locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->