### PR TITLE
[Seventeen Ice JP] update to resolve timeout issue

### DIFF
--- a/locations/spiders/seventeen_ice_jp.py
+++ b/locations/spiders/seventeen_ice_jp.py
@@ -66,6 +66,7 @@ class SeventeenIceJPSpider(Spider):
     custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,
         "COOKIES_ENABLED": True,
+        "CONCURRENT_REQUESTS": 1,
     }
 
     async def start(self) -> AsyncIterator[Request]:


### PR DESCRIPTION
resolves #18488 

limited concurrent requests to 1. it worked fine locally but i don't know how it will work in the cloud.

{'atp/brand/セブンティーンアイス': 19098,
 'atp/brand_wikidata/Q11314427': 19098,
 'atp/category/amenity/vending_machine': 19098,
 'atp/clean_strings/addr_full': 8,
 'atp/clean_strings/branch': 19,
 'atp/clean_strings/city': 1,
 'atp/country/JP': 19098,
 'atp/field/country/from_spider_name': 19098,
 'atp/field/email/missing': 19098,
 'atp/field/housenumber/missing': 19098,
 'atp/field/opening_hours/missing': 19098,
 'atp/field/operator/missing': 19098,
 'atp/field/operator_wikidata/missing': 19098,
 'atp/field/phone/invalid': 59,
 'atp/field/phone/missing': 2513,
 'atp/field/state/missing': 19098,
 'atp/field/street/missing': 19098,
 'atp/field/street_address/missing': 19098,
 'atp/field/twitter/missing': 19098,
 'atp/field/unit/missing': 19098,
 'atp/item_scraped_host_count/seventeenice-map.glico.com': 19098,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 19098,
 'downloader/request_bytes': 52870,
 'downloader/request_count': 52,
 'downloader/request_method_count/GET': 52,
 'downloader/response_bytes': 45587432,
 'downloader/response_count': 52,
 'downloader/response_status_count/200': 49,
 'downloader/response_status_count/302': 1,
 'downloader/response_status_count/303': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 86.28199999999924,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 6, 2, 24, 19, 375830, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 19098,
 'items_per_minute': 13324.186046511628,
 'log_count/DEBUG': 19173,
 'log_count/INFO': 4,
 'request_depth_max': 1,
 'response_received_count': 50,
 'responses_per_minute': 34.883720930232556,
 'robotstxt/request_count': 2,
 'robotstxt/response_count': 2,
 'robotstxt/response_status_count/200': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 50,
 'scheduler/dequeued/memory': 50,
 'scheduler/enqueued': 50,
 'scheduler/enqueued/memory': 50,
 'start_time': datetime.datetime(2026, 9, 6, 2, 22, 53, 100169, tzinfo=datetime.timezone.utc)}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Limited concurrent requests to one to support more controlled data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->