### PR TITLE
[NTT Le Perc JP, Mister Donut JP, Mapion Storefinder] implement fixes from review

### DIFF
--- a/locations/spiders/mister_donut_jp.py
+++ b/locations/spiders/mister_donut_jp.py
@@ -1,13 +1,12 @@
-import json
 import re
 from typing import Iterable
 
-from scrapy import Spider
-from scrapy.http import Request, Response
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
+from locations.storefinders.mapion import MapionSpider
 
 # The store list is served from a single wide "tile" (x=63&y=18) which
 # encompasses the whole of Japan, rather than needing to be paginated
@@ -15,34 +14,18 @@ from locations.items import Feature
 LIST_URL = "https://md.mapion.co.jp/b/misterdonut/attr/?t=attr_con&x=63&y=18&start={}"
 
 
-class MisterDonutJPSpider(Spider):
+class MisterDonutJPSpider(MapionSpider):
     name = "mister_donut_jp"
     item_attributes = {"brand": "ミスタードーナツ", "brand_wikidata": "Q1065819"}
     allowed_domains = ["md.mapion.co.jp"]
-    start_urls = [LIST_URL.format(1)]
+    list_url = LIST_URL
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        if m := re.search(r'pager-num">\d+/(\d+)', response.text):
-            if response.url == self.start_urls[0]:
-                for page in range(2, int(m.group(1)) + 1):
-                    yield Request(LIST_URL.format(page), callback=self.parse)
-
-        for href in response.xpath('//li[@class="list-item"]//a[h2]/@href').getall():
-            yield response.follow(href, callback=self.parse_store)
-
-    def parse_store(self, response: Response) -> Iterable[Feature]:
-        m = re.search(r"window\.infoJSON\s*=\s*(\{.*?\});", response.text)
-        if not m:
-            return
-        data = json.loads(m.group(1))
-
-        item = Feature()
+    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
         item["ref"] = data.get("id")
         item["name"] = self.item_attributes["brand"]
         item["branch"] = data.get("map_name")
         item["addr_full"] = data.get("full_address")
         item["postcode"] = data.get("zip_code")
-        item["website"] = response.url
 
         if tel := data.get("tel"):
             item["phone"] = "+81 " + tel
@@ -66,7 +49,7 @@ class MisterDonutJPSpider(Spider):
             if close_match := re.match(r"\d{1,2}:\d{2}", close_time):
                 oh = OpeningHours()
                 oh.add_days_range(DAYS, open_time, close_match.group())
-                item["opening_hours"] = oh.as_opening_hours()
+                item["opening_hours"] = oh
 
         apply_category(Categories.FAST_FOOD, item)
         item["extras"]["cuisine"] = "donut"

--- a/locations/spiders/mister_donut_jp.py
+++ b/locations/spiders/mister_donut_jp.py
@@ -16,6 +16,7 @@ class MisterDonutJPSpider(MapionSpider):
     feature_url_template = "https://md.mapion.co.jp/b/misterdonut/attr/?t=attr_con&start={}"
 
     def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
+        item["name"] = None
         item["branch"] = data.get("map_name")
 
         if (open_time := data.get("open_time")) and (close_time := data.get("close_time")):

--- a/locations/spiders/mister_donut_jp.py
+++ b/locations/spiders/mister_donut_jp.py
@@ -8,6 +8,7 @@ from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.storefinders.mapion import MapionSpider
 
+
 class MisterDonutJPSpider(MapionSpider):
     name = "mister_donut_jp"
     item_attributes = {"brand": "ミスタードーナツ", "brand_wikidata": "Q1065819"}

--- a/locations/spiders/mister_donut_jp.py
+++ b/locations/spiders/mister_donut_jp.py
@@ -8,38 +8,14 @@ from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.storefinders.mapion import MapionSpider
 
-# The store list is served from a single wide "tile" (x=63&y=18) which
-# encompasses the whole of Japan, rather than needing to be paginated
-# through many individual map tiles like some other Mapion based sites.
-LIST_URL = "https://md.mapion.co.jp/b/misterdonut/attr/?t=attr_con&x=63&y=18&start={}"
-
-
 class MisterDonutJPSpider(MapionSpider):
     name = "mister_donut_jp"
     item_attributes = {"brand": "ミスタードーナツ", "brand_wikidata": "Q1065819"}
     allowed_domains = ["md.mapion.co.jp"]
-    list_url = LIST_URL
+    feature_url_template = "https://md.mapion.co.jp/b/misterdonut/attr/?t=attr_con&start={}"
 
-    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
-        item["ref"] = data.get("id")
-        item["name"] = self.item_attributes["brand"]
+    def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
         item["branch"] = data.get("map_name")
-        item["addr_full"] = data.get("full_address")
-        item["postcode"] = data.get("zip_code")
-
-        if tel := data.get("tel"):
-            item["phone"] = "+81 " + tel
-
-        # Despite the "Tky" suffix the site applies to these fields in its
-        # schema.org markup (latitudeTky/longitudeTky), window.infoJSON's
-        # plain latitude/longitude values are already correct WGS84 and
-        # match real store addresses/landmarks closely. The page's
-        # schema.org/GeoCoordinates microdata is the one that's wrong: it
-        # applies a spurious Tokyo Datum correction to already-WGS84 data,
-        # landing stores ~300-400m away (verified against several stores'
-        # real-world addresses), so it must not be used.
-        item["lat"] = data.get("latitude")
-        item["lon"] = data.get("longitude")
 
         if (open_time := data.get("open_time")) and (close_time := data.get("close_time")):
             # close_time occasionally has a trailing free-text exception note

--- a/locations/spiders/ntt_le_perc_jp.py
+++ b/locations/spiders/ntt_le_perc_jp.py
@@ -1,0 +1,44 @@
+from typing import Iterable
+
+from scrapy.http import Response
+
+from locations.categories import Categories, apply_category
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.storefinders.mapion import MapionSpider
+
+
+class NttLePercJPSpider(MapionSpider):
+    name = "ntt_le_perc_jp"
+    item_attributes = {"brand": "NTTル・パルク", "brand_wikidata": "Q11236111"}
+    allowed_domains = ["sasp.mapion.co.jp"]
+    list_url = "https://sasp.mapion.co.jp/b/leperc/attr/?t=attr_con&start={}"
+
+    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
+        item["ref"] = data.get("id")
+        item["name"] = data.get("name")
+        item["addr_full"] = data.get("full_address")
+        item["country"] = "JP"
+        item["lat"] = data.get("latitude")
+        item["lon"] = data.get("longitude")
+
+        if kencode := data.get("kencode"):
+            item["state"] = f"JP-{kencode}"
+
+        # tel is a single national maintenance hotline ("保守連絡先", i.e.
+        # "maintenance contact") repeated identically across every location,
+        # not a branch-specific number, so it is deliberately not extracted.
+
+        # These are unattended coin-operated parking lots, so accessible
+        # 24/7; the per-lot data only varies by-time-of-day pricing tier,
+        # not by opening/closing hours.
+        oh = OpeningHours()
+        oh.add_days_range(DAYS, "00:00", "23:59")
+        item["opening_hours"] = oh
+
+        apply_category(Categories.PARKING, item)
+        item["extras"]["fee"] = "yes"
+        if car_count := data.get("car_count"):
+            item["extras"]["capacity"] = car_count
+
+        yield item

--- a/locations/spiders/ntt_le_perc_jp.py
+++ b/locations/spiders/ntt_le_perc_jp.py
@@ -16,6 +16,7 @@ class NttLePercJPSpider(MapionSpider):
     def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
         apply_category(Categories.PARKING, item)
         item["extras"]["fee"] = "yes"
+        item["phone"] = None
         if car_count := data.get("car_count"):
             item["extras"]["capacity"] = car_count
 

--- a/locations/spiders/ntt_le_perc_jp.py
+++ b/locations/spiders/ntt_le_perc_jp.py
@@ -14,10 +14,12 @@ class NttLePercJPSpider(MapionSpider):
     feature_url_template = "https://sasp.mapion.co.jp/b/leperc/attr/?t=attr_con&start={}"
 
     def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
-        apply_category(Categories.PARKING, item)
-        item["extras"]["fee"] = "yes"
         item["phone"] = None
+        item["name"] = None
         if car_count := data.get("car_count"):
             item["extras"]["capacity"] = car_count
+
+        apply_category(Categories.PARKING, item)
+        item["extras"]["fee"] = "yes"
 
         yield item

--- a/locations/spiders/ntt_le_perc_jp.py
+++ b/locations/spiders/ntt_le_perc_jp.py
@@ -12,30 +12,9 @@ class NttLePercJPSpider(MapionSpider):
     name = "ntt_le_perc_jp"
     item_attributes = {"brand": "NTTル・パルク", "brand_wikidata": "Q11236111"}
     allowed_domains = ["sasp.mapion.co.jp"]
-    list_url = "https://sasp.mapion.co.jp/b/leperc/attr/?t=attr_con&start={}"
+    feature_url_template = "https://sasp.mapion.co.jp/b/leperc/attr/?t=attr_con&start={}"
 
-    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
-        item["ref"] = data.get("id")
-        item["name"] = data.get("name")
-        item["addr_full"] = data.get("full_address")
-        item["country"] = "JP"
-        item["lat"] = data.get("latitude")
-        item["lon"] = data.get("longitude")
-
-        if kencode := data.get("kencode"):
-            item["state"] = f"JP-{kencode}"
-
-        # tel is a single national maintenance hotline ("保守連絡先", i.e.
-        # "maintenance contact") repeated identically across every location,
-        # not a branch-specific number, so it is deliberately not extracted.
-
-        # These are unattended coin-operated parking lots, so accessible
-        # 24/7; the per-lot data only varies by-time-of-day pricing tier,
-        # not by opening/closing hours.
-        oh = OpeningHours()
-        oh.add_days_range(DAYS, "00:00", "23:59")
-        item["opening_hours"] = oh
-
+    def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
         apply_category(Categories.PARKING, item)
         item["extras"]["fee"] = "yes"
         if car_count := data.get("car_count"):

--- a/locations/spiders/ntt_le_perc_jp.py
+++ b/locations/spiders/ntt_le_perc_jp.py
@@ -3,7 +3,6 @@ from typing import Iterable
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
 from locations.storefinders.mapion import MapionSpider
 

--- a/locations/storefinders/mapion.py
+++ b/locations/storefinders/mapion.py
@@ -1,0 +1,49 @@
+import json
+import re
+from typing import AsyncIterator, Iterable
+
+from scrapy import Spider
+from scrapy.http import Request, Response
+
+from locations.items import Feature
+
+
+class MapionSpider(Spider):
+    """
+    Storefinder platform used by several Japanese chains' store locator
+    pages, hosted on mapion.co.jp subdomains/paths (e.g. Mister Donut,
+    NTT Le Perc). Listing pages are paginated with a "start" query
+    parameter and stop once a page has no more detail links; detail pages
+    embed the location's own data as a `window.infoJSON = {...};` blob.
+
+    To use, set `list_url` to a str.format() template for a listing page
+    taking the page number, and implement `parse_item`.
+    """
+
+    list_url = ""
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(self.list_url.format(1), meta={"page": 1}, callback=self.parse_list)
+
+    def parse_list(self, response: Response) -> Iterable[Request]:
+        hrefs = set(response.xpath('//a[contains(@href, "/info/")]/@href').getall())
+        if not hrefs:
+            return
+
+        for href in hrefs:
+            yield response.follow(href, callback=self.parse_detail)
+
+        page = response.meta["page"] + 1
+        yield Request(self.list_url.format(page), meta={"page": page}, callback=self.parse_list)
+
+    def parse_detail(self, response: Response) -> Iterable[Feature]:
+        if not (m := re.search(r"window\.infoJSON\s*=\s*(\{.*?\});", response.text)):
+            return
+        data = json.loads(m.group(1))
+
+        item = Feature()
+        item["website"] = response.url
+        yield from self.parse_item(item, data, response) or []
+
+    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
+        raise NotImplementedError

--- a/locations/storefinders/mapion.py
+++ b/locations/storefinders/mapion.py
@@ -5,8 +5,8 @@ from typing import AsyncIterator, Iterable
 from scrapy import Spider
 from scrapy.http import Request, Response
 
-from locations.items import Feature
 from locations.dict_parser import DictParser
+from locations.items import Feature
 
 
 class MapionSpider(Spider):
@@ -49,7 +49,7 @@ class MapionSpider(Spider):
 
     def pre_process_data(self, data: dict, **kwargs) -> None:
         """Override with any pre-processing on the item."""
-    
+
     def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
         """Override with any post-processing on the item."""
         yield item

--- a/locations/storefinders/mapion.py
+++ b/locations/storefinders/mapion.py
@@ -44,6 +44,8 @@ class MapionSpider(Spider):
 
         item = DictParser.parse(data)
         item["extras"]["addr:province"] = data.get("kenname")
+        if ruby := data.get("poi_name_yomi"):
+            item["extras"]["branch:ja-Hira"] = ruby
         item["website"] = response.url
         yield from self.post_process_item(item, data, response) or []
 

--- a/locations/storefinders/mapion.py
+++ b/locations/storefinders/mapion.py
@@ -6,24 +6,24 @@ from scrapy import Spider
 from scrapy.http import Request, Response
 
 from locations.items import Feature
+from locations.dict_parser import DictParser
 
 
 class MapionSpider(Spider):
     """
     Storefinder platform used by several Japanese chains' store locator
-    pages, hosted on mapion.co.jp subdomains/paths (e.g. Mister Donut,
-    NTT Le Perc). Listing pages are paginated with a "start" query
+    pages, hosted on mapion.co.jp subdomains/paths or on the brand's domain. If the paginated list of stores ends with `attr/?t=attr_con&start=1` then it's a Mapion spider. Listing pages are paginated with a "start" query
     parameter and stop once a page has no more detail links; detail pages
     embed the location's own data as a `window.infoJSON = {...};` blob.
 
-    To use, set `list_url` to a str.format() template for a listing page
-    taking the page number, and implement `parse_item`.
+    To use, set `feature_url_template` to a str.format() template for a listing page
+    taking the page number, and optionally implement `post_process_item`.
     """
 
-    list_url = ""
+    feature_url_template: str
 
     async def start(self) -> AsyncIterator[Request]:
-        yield Request(self.list_url.format(1), meta={"page": 1}, callback=self.parse_list)
+        yield Request(self.feature_url_template.format(1), meta={"page": 1}, callback=self.parse_list)
 
     def parse_list(self, response: Response) -> Iterable[Request]:
         hrefs = set(response.xpath('//a[contains(@href, "/info/")]/@href').getall())
@@ -34,16 +34,22 @@ class MapionSpider(Spider):
             yield response.follow(href, callback=self.parse_detail)
 
         page = response.meta["page"] + 1
-        yield Request(self.list_url.format(page), meta={"page": page}, callback=self.parse_list)
+        yield Request(self.feature_url_template.format(page), meta={"page": page}, callback=self.parse_list)
 
     def parse_detail(self, response: Response) -> Iterable[Feature]:
         if not (m := re.search(r"window\.infoJSON\s*=\s*(\{.*?\});", response.text)):
             return
         data = json.loads(m.group(1))
+        self.pre_process_data(data)
 
-        item = Feature()
+        item = DictParser.parse(data)
+        item["extras"]["addr:province"] = data.get("kenname")
         item["website"] = response.url
-        yield from self.parse_item(item, data, response) or []
+        yield from self.post_process_item(item, data, response) or []
 
-    def parse_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
-        raise NotImplementedError
+    def pre_process_data(self, data: dict, **kwargs) -> None:
+        """Override with any pre-processing on the item."""
+    
+    def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
+        """Override with any post-processing on the item."""
+        yield item


### PR DESCRIPTION
This implements fixes from review of #18359.

closes #18224

TODO:

- [x] check additional values in JSON that are common across all Mapion storefinders, add to storefinder code.

poi_name_yomi: use walrus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added location data for NTT Le Parc parking facilities, including vehicle capacity and fee availability.
  - Added support for collecting Japanese store and facility listings from Mapion.

- **Improvements**
  - Updated Mister Donut Japan location data collection to use Mapion listing and detail pages.
  - Improved consistency of addresses, branch information, websites, contact details, and opening hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->