### PR TITLE
feat: support hour notation over 24:00

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -1065,6 +1065,28 @@ def sanitise_day(day: str, days: dict[str, str] = DAYS_EN) -> str | None:
     return days.get(day)
 
 
+def _normalise_hour_over_24(value: str) -> tuple[str, bool]:
+    """
+    Reduce the hour of a time string by 24 when it is 24 or later.
+
+    A value like 24:00, 25:00 or 26:30 denotes a time after midnight on the
+    following day and is reduced to 00:00, 01:00 or 02:30.
+
+    :param value: time string in a ``%H``-based format.
+    :returns: the normalised time string and whether the hour was 24 or later.
+    """
+    hour, sep, rest = value.partition(":")
+    if not sep:
+        return value, False
+    try:
+        hour_int = int(hour)
+    except ValueError:
+        return value, False
+    if hour_int < 24:
+        return value, False
+    return f"{hour_int - 24:02d}{sep}{rest}", True
+
+
 class OpeningHours:
     def __init__(self):
         self.day_hours = defaultdict(set)
@@ -1148,10 +1170,24 @@ class OpeningHours:
                 # Invalid range supplied. Probably the source data uses this
                 # notation for closed days.
                 return
+
+        # A time of 24:00 or later denotes a time after midnight. A close of
+        # exactly 24:00 means "until midnight" and becomes 23:59. Any other
+        # time of 24:00 or later (e.g. an open of 24:00, or 25:00/26:30) is
+        # reduced by 24 hours so it fits %H. An opening time past 24:00 places
+        # the whole range on the following day.
+        open_after_midnight = False
+        if isinstance(open_time, str):
+            open_time, open_after_midnight = _normalise_hour_over_24(open_time)
+        if isinstance(close_time, str):
             if close_time in ("24:00", "00:00", "0:00"):
                 close_time = "23:59"
-            if close_time in ("24:00:00", "00:00:00"):
+            elif close_time in ("24:00:00", "00:00:00"):
                 close_time = "23:59:00"
+            else:
+                close_time, _ = _normalise_hour_over_24(close_time)
+        if open_after_midnight:
+            day = DAYS[(DAYS.index(day) + 1) % len(DAYS)]
         if not isinstance(open_time, time.struct_time):
             open_time = time.strptime(open_time, time_format)
         if not isinstance(close_time, time.struct_time):

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -18,6 +18,7 @@ from locations.hours import (
     NAMED_TIMES_IT,
     NAMED_TIMES_RU,
     OpeningHours,
+    _normalise_hour_over_24,
     day_range,
     sanitise_day,
 )
@@ -165,6 +166,32 @@ def test_over_midnight():
     assert (
         o.as_opening_hours() == "Mo 00:00-03:00,07:00-24:00; Tu-Sa 00:00-02:00,07:00-24:00; Su 00:00-02:00,05:00-24:00"
     )
+
+
+def test_over_24_close_hour():
+    o = OpeningHours()
+    o.add_range("Mo", "09:00", "25:00")
+    assert o.as_opening_hours() == "Mo 09:00-24:00; Tu 00:00-01:00"
+
+
+def test_over_24_open_next_day():
+    o = OpeningHours()
+    o.add_range("Mo", "25:00", "27:00")
+    assert o.as_opening_hours() == "Tu 01:00-03:00"
+
+
+def test_over_24_open_close_under_24():
+    o = OpeningHours()
+    o.add_range("Mo", "25:00", "6:00")
+    assert o.as_opening_hours() == "Tu 01:00-06:00"
+
+
+def test_normalise_hour_over_24_without_separator():
+    assert _normalise_hour_over_24("25") == ("25", False)
+
+
+def test_normalise_hour_over_24_non_numeric_hour():
+    assert _normalise_hour_over_24("ab:00") == ("ab:00", False)
 
 
 def test_till_midnight():

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -1,5 +1,7 @@
 import time
 
+import pytest
+
 from locations.hours import (
     CLOSED_IT,
     DAYS,
@@ -186,12 +188,28 @@ def test_over_24_open_close_under_24():
     assert o.as_opening_hours() == "Tu 01:00-06:00"
 
 
-def test_normalise_hour_over_24_without_separator():
-    assert _normalise_hour_over_24("25") == ("25", False)
+def test_normalise_hour_over_24_under_24():
+    assert _normalise_hour_over_24("09:00") == ("09:00", False)
 
 
-def test_normalise_hour_over_24_non_numeric_hour():
-    assert _normalise_hour_over_24("ab:00") == ("ab:00", False)
+def test_normalise_hour_over_24_exact_24():
+    assert _normalise_hour_over_24("24:00") == ("00:00", True)
+
+
+def test_normalise_hour_over_24_over_24():
+    assert _normalise_hour_over_24("26:30") == ("02:30", True)
+
+
+def test_add_range_time_without_separator_raises():
+    o = OpeningHours()
+    with pytest.raises(ValueError):
+        o.add_range("Mo", "25", "26")
+
+
+def test_add_range_time_with_non_numeric_hour_raises():
+    o = OpeningHours()
+    with pytest.raises(ValueError):
+        o.add_range("Mo", "ab:00", "10:00")
 
 
 def test_till_midnight():


### PR DESCRIPTION
This PR adds support for hour notations that exceed 24:00. For example, "Mon 22:00-26:00" will be interpreted as "Mon 22:00-24:00" + "Tue 00:00-02:00", and "Mon 25:00-6:00" as "Tue 1:00-6:00".

In Japan, it is common for businesses such as restaurants to use this notation to denote late-night hours. Adding this functionality allows the utility to handle such data easily without manual conversion.

I encounter this in #18501 and I also found similar patterns in existing spiders that can benefit from this:
https://github.com/alltheplaces/alltheplaces/blob/d7897ea64645cc2eb881c5b96adcb8712b6972dd/locations/spiders/zensho_jp.py#L50-L54
→ similar normalise function

https://github.com/alltheplaces/alltheplaces/blob/1d14024b385d47ad5b838f1f0ad884f76e6b423e/locations/spiders/starbucks_jp.py#L78-L79
→ hardcoded conversion 25:00 -> 1:00 (only works for exact 25:00)

However, I'm not sure how common this notation is outside of Japan. Does this make sense to include in this utility?
