### PR TITLE
[japan_post_jp] Update spider to include new postboxes (201034 locations)

### DIFF
--- a/locations/geo.py
+++ b/locations/geo.py
@@ -15,6 +15,8 @@ from locations.searchable_points import get_searchable_points_path, open_searcha
 EARTH_RADIUS = 6378.1
 # Kilometers per mile
 MILES_TO_KILOMETERS = 1.60934
+# Kilometers per degree of latitude, derived from the Earth's radius
+KILOMETERS_PER_DEGREE_LATITUDE = EARTH_RADIUS * math.pi / 180
 
 
 def vincenty_distance(lat: float, lon: float, distance_km: float, bearing_deg: float) -> tuple[float, float]:

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -1,4 +1,5 @@
 import csv
+import math
 from io import StringIO
 from urllib.parse import urlencode
 
@@ -18,7 +19,7 @@ MAP_ID = "search"
 class JapanPostJPSpider(Spider):
     name = "japan_post_jp"
 
-    def make_request(self, lat, lon, radius, offset=1, count=900, tempo_count=0, post_count=0):
+    def make_request(self, lat, lon, radius, offset=1, count=900, tempo_count=0, post_count=0, source=""):
         params = {
             "cid": MAP_ID,
             "postcid": "searchPO",
@@ -54,17 +55,18 @@ class JapanPostJPSpider(Spider):
                 "count": count,
                 "tempo_count": tempo_count,
                 "post_count": post_count,
+                "source": source,
             },
         )
 
     async def start(self):
         radius_m = RADIUS_KM * 1000
         for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):
-            yield self.make_request(lat, lon, radius_m)
+            yield self.make_request(lat, lon, radius_m, source="grid-24")
         for city in city_locations("JP", 200000):
-            yield self.make_request(city["latitude"], city["longitude"], 5500)
+            yield self.make_request(city["latitude"], city["longitude"], 5500, source="city-5.5")
 
-    def parse(self, response, lat, lon, radius, offset, count=900, tempo_count=0, post_count=0):
+    def parse(self, response, lat, lon, radius, offset, count=900, tempo_count=0, post_count=0, source=""):
         # response is an EUC-encoded JS file that looks like
         #   ZdcEmapHttpResult[1] = '...';
         # where the string body is a TSV
@@ -83,14 +85,19 @@ class JapanPostJPSpider(Spider):
 
         page = (offset - 1) // count + 1
         self.logger.info(
-            f"Query (lat={lat}, lon={lon}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
+            f"Query (source={source}, lat={lat}, lon={lon}, radius={radius}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
         )
         if tempo_total >= MAX_ITEMS or post_total >= MAX_ITEMS:
-            self.logger.warning("Maximum number of items returned in one query, consider lowering the radius")
+            self.logger.warning(
+                f"Maximum number of items returned in one query, consider lowering the radius  (source={source})"
+            )
+            if source == "city-5.5":
+                yield from self._subdivide(lat, lon, radius, source)
+            return
 
         if offset + rec_count < hit_count:
             yield self.make_request(
-                lat, lon, radius, offset + rec_count, tempo_count=tempo_total, post_count=post_total
+                lat, lon, radius, offset + rec_count, tempo_count=tempo_total, post_count=post_total, source=source
             )
 
         for row in rows:

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -9,7 +9,8 @@ from locations.categories import Categories, apply_category
 from locations.geo import city_locations, country_iseadgg_centroids
 from locations.items import Feature
 
-MAX_ITEMS = 1640  # determined experimentally
+# determined experimentally. per-type cap (TEMPO/POST). a type reaching this is truncated
+MAX_ITEMS = 1640
 RADIUS_KM = 24
 MAP_ID = "search"
 
@@ -21,16 +22,23 @@ class JapanPostJPSpider(Spider):
         params = {
             "cid": MAP_ID,
             "postcid": "searchPO",
+            # include TEMPO (post offices + ATMs + kanpo insurance)
             "search_tempo": "1",
+            # include POST (postboxes)
             "search_post": "1",
             "opt": "search",
+            # starting row (1-based). increased by rec_count to paginate
             "pos": offset,
+            # page size (rows per response). does not limit the total
             "cnt": count,
             "enc": "EUC",
             "lat": lat,
             "lon": lon,
+            # cap on TEMPO rows for this whole query
             "knsu": MAX_ITEMS,
+            # cap on POST rows for this whole query
             "postknsu": MAX_ITEMS,
+            # search radius in metres
             "rad": radius,
             "hour": 1,
         }
@@ -42,7 +50,13 @@ class JapanPostJPSpider(Spider):
                 "X-Requested-With": "XMLHttpRequest",
                 "Referer": "https://map.japanpost.jp/p/search/nmap.htm",
             },
-            cb_kwargs={"lat": lat, "lon": lon, "offset": offset},
+            cb_kwargs={
+                "lat": lat,
+                "lon": lon,
+                "offset": offset,
+                "tempo_count": tempo_count,
+                "post_count": post_count,
+            },
         )
 
     async def start(self):

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -81,13 +81,12 @@ class JapanPostJPSpider(Spider):
         tempo_total = tempo_count + sum(1 for r in rows if r[0] == "TEMPO")
         post_total = post_count + sum(1 for r in rows if r[0] == "POST")
 
+        page = (offset - 1) // count + 1
+        self.logger.info(
+            f"Query (lat={lat}, lon={lon}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
+        )
         if tempo_total >= MAX_ITEMS or post_total >= MAX_ITEMS:
-            f"Maximum number of items returned in one query, consider lowering the radius to avoid locations (lat={lat}, lon={lon}, tempo={tempo_total}, post={post_total})"
-        else:
-            page = (offset - 1) // count + 1
-            self.logger.info(
-                f"Query OK (lat={lat}, lon={lon}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
-            )
+            self.logger.warning("Maximum number of items returned in one query, consider lowering the radius")
 
         if offset + rec_count < hit_count:
             yield self.make_request(

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -1,8 +1,9 @@
 import csv
 from io import StringIO
+from urllib.parse import urlencode
 
 from chompjs import parse_js_object
-from scrapy import Request, Spider
+from scrapy import FormRequest, Spider
 
 from locations.categories import Categories, apply_category
 from locations.geo import city_locations, country_iseadgg_centroids
@@ -16,9 +17,31 @@ MAP_ID = "search"
 class JapanPostJPSpider(Spider):
     name = "japan_post_jp"
 
-    def make_request(self, lat, lon, distance, offset=1, count=900):
-        return Request(
-            f"https://map.japanpost.jp/p/{MAP_ID}/zdcemaphttp.cgi?target=http%3A%2F%2F127.0.0.1%2Fcgi%2Fnkyoten.cgi%3F%26cid%3D{MAP_ID}%26pos%3D{offset}%26lat%3D{lat}%26lon%3D{lon}%26knsu%3D{MAX_ITEMS}%26cnt%3D{count}%26hour%3D1%26rad%3D{distance}&zdccnt=1",
+    def make_request(self, lat, lon, radius, offset=1, count=900):
+        params = {
+            "cid": MAP_ID,
+            "postcid": "searchPO",
+            "search_tempo": "1",
+            "search_post": "1",
+            "opt": "search",
+            "pos": offset,
+            "cnt": count,
+            "enc": "EUC",
+            "lat": lat,
+            "lon": lon,
+            "knsu": MAX_ITEMS,
+            "postknsu": MAX_ITEMS,
+            "rad": radius,
+            "hour": 1,
+        }
+        target = f"http://127.0.0.1/cgi/nkyoten.cgi?{urlencode(params)}"
+        return FormRequest(
+            f"https://map.japanpost.jp/p/{MAP_ID}/zdcemaphttp.cgi?zdccnt=1&enc=EUC",
+            formdata={"target": target},
+            headers={
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": "https://map.japanpost.jp/p/search/nmap.htm",
+            },
             cb_kwargs={"lat": lat, "lon": lon, "offset": offset},
         )
 
@@ -47,20 +70,45 @@ class JapanPostJPSpider(Spider):
         if rec_count >= hit_count:
             yield self.make_request(lat, lon, offset + rec_count)
         for row in reader:
+            if row[0] == "POST":
+                item = Feature()
+                item["ref"] = row[1]
+                item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{row[1]}/?post=1"
+                item["lat"] = row[2]
+                item["lon"] = row[3]
+                item["postcode"] = row[21]
+                item["addr_full"] = row[7]
+                apply_category(Categories.POST_BOX, item)
+                item["name"] = "ポスト"
+                yield item
+                continue
+
+            if row[4] == "99":
+                continue
+
             item = Feature()
-            item["ref"] = row[0]
-            item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{row[0]}/"
-            item["lat"] = row[1]
-            item["lon"] = row[2]
-            item["postcode"] = row[12]
-            item["addr_full"] = row[13]
-            if "郵便局" in row[6]:
+            item["ref"] = row[1]
+            item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{row[1]}/"
+            item["lat"] = row[2]
+            item["lon"] = row[3]
+            item["postcode"] = row[13]
+            item["addr_full"] = row[14]
+            # col [4] is an icon_id (marker image) that selects the category:
+            #   01, 02          = post office
+            #   03,04,06,07,08  = ATM
+            #   05              = Japan Post Insurance
+            #   99              = search-center pin, not a real location
+            if row[4] in ("01", "02"):
                 apply_category(Categories.POST_OFFICE, item)
                 item.update({"brand": "日本郵便", "brand_wikidata": "Q11509260"})
-                item["name"] = row[6]
+                item["name"] = row[7]
+            elif row[4] == "05":
+                apply_category(Categories.OFFICE_INSURANCE, item)
+                item.update({"brand": "かんぽ生命保険", "brand_wikidata": "Q6157781"})
+                item["name"] = row[7]
             else:
                 apply_category(Categories.ATM, item)
                 item.update({"brand": "ゆうちょ銀行", "brand_wikidata": "Q907103"})
-                item["branch"] = row[6].removesuffix("出張所")
+                item["branch"] = row[7].removesuffix("出張所")
 
             yield item

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -18,7 +18,7 @@ MAP_ID = "search"
 class JapanPostJPSpider(Spider):
     name = "japan_post_jp"
 
-    def make_request(self, lat, lon, radius, offset=1, count=900):
+    def make_request(self, lat, lon, radius, offset=1, count=900, tempo_count=0, post_count=0):
         params = {
             "cid": MAP_ID,
             "postcid": "searchPO",
@@ -54,6 +54,7 @@ class JapanPostJPSpider(Spider):
                 "lat": lat,
                 "lon": lon,
                 "offset": offset,
+                "count": count,
                 "tempo_count": tempo_count,
                 "post_count": post_count,
             },
@@ -66,7 +67,7 @@ class JapanPostJPSpider(Spider):
         for city in city_locations("JP", 200000):
             yield self.make_request(city["latitude"], city["longitude"], 5500)
 
-    def parse(self, response, lat, lon, offset):
+    def parse(self, response, lat, lon, offset, count=900, tempo_count=0, post_count=0):
         # response is an EUC-encoded JS file that looks like
         #   ZdcEmapHttpResult[1] = '...';
         # where the string body is a TSV
@@ -79,11 +80,22 @@ class JapanPostJPSpider(Spider):
         reader = csv.reader(StringIO(tsv_str), delimiter="\t")
         ret_code, rec_count, hit_count = map(int, next(reader))
         assert rec_count <= hit_count, (rec_count, hit_count)
-        if hit_count >= MAX_ITEMS:
-            self.logger.warning("Maximum number of items returned in one query, consider lowering the radius")
-        if rec_count >= hit_count:
-            yield self.make_request(lat, lon, offset + rec_count)
-        for row in reader:
+        rows = list(reader)
+        tempo_total = tempo_count + sum(1 for r in rows if r[0] == "TEMPO")
+        post_total = post_count + sum(1 for r in rows if r[0] == "POST")
+
+        if tempo_total >= MAX_ITEMS or post_total >= MAX_ITEMS:
+            f"Maximum number of items returned in one query, consider lowering the radius to avoid locations (lat={lat}, lon={lon}, tempo={tempo_total}, post={post_total})"
+        else:
+            page = (offset - 1) // count + 1
+            self.logger.info(
+                f"Query OK (lat={lat}, lon={lon}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
+            )
+
+        if offset + rec_count < hit_count:
+            yield self.make_request(lat, lon, offset + rec_count, tempo_count=tempo_total, post_count=post_total)
+
+        for row in rows:
             if row[0] == "POST":
                 item = Feature()
                 item["ref"] = row[1]

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -49,6 +49,7 @@ class JapanPostJPSpider(Spider):
             cb_kwargs={
                 "lat": lat,
                 "lon": lon,
+                "radius": radius,
                 "offset": offset,
                 "count": count,
                 "tempo_count": tempo_count,
@@ -63,7 +64,7 @@ class JapanPostJPSpider(Spider):
         for city in city_locations("JP", 200000):
             yield self.make_request(city["latitude"], city["longitude"], 5500)
 
-    def parse(self, response, lat, lon, offset, count=900, tempo_count=0, post_count=0):
+    def parse(self, response, lat, lon, radius, offset, count=900, tempo_count=0, post_count=0):
         # response is an EUC-encoded JS file that looks like
         #   ZdcEmapHttpResult[1] = '...';
         # where the string body is a TSV
@@ -89,7 +90,9 @@ class JapanPostJPSpider(Spider):
             )
 
         if offset + rec_count < hit_count:
-            yield self.make_request(lat, lon, offset + rec_count, tempo_count=tempo_total, post_count=post_total)
+            yield self.make_request(
+                lat, lon, radius, offset + rec_count, tempo_count=tempo_total, post_count=post_total
+            )
 
         for row in rows:
             if row[0] == "POST":

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -13,6 +13,7 @@ from locations.items import Feature
 # determined experimentally. per-type cap (TEMPO/POST). a type reaching this is truncated
 MAX_ITEMS = 1640
 RADIUS_KM = 24
+MIN_RADIUS_M = 1000
 MAP_ID = "search"
 
 
@@ -58,6 +59,42 @@ class JapanPostJPSpider(Spider):
                 "source": source,
             },
         )
+
+    def _subdivide(self, lat, lon, radius, source):
+        # Replace a truncated circle (center lat/lon, radius m) with 4 smaller
+        # circles whose union covers the original. Only used for the city-5.5 pass
+        # and only ONE level: children keep source "city-5.5-sub-<quadrant>", which
+        # never matches the "city-5.5" trigger, so they are not subdivided again.
+        #
+        # source is always hyphen-delimited, e.g. grid-24, city-5.5, city-5.5-sub-NW,
+        # so it splits cleanly for later analysis.
+        #
+        # Covering math: the parent disk (radius R) sits inside its bounding square
+        # of side 2R. Put one child at each quadrant centre, i.e. offset by R/2 in
+        # latitude and R/2 in longitude. The farthest corner of a quadrant from its
+        # centre is the half-diagonal sqrt((R/2)^2+(R/2)^2) = R*sqrt(2)/2, so a child
+        # of that radius covers its whole quadrant exactly. The 4 quadrants tile the
+        # bounding square, therefore union(4 children) = bounding square, which fully
+        # contains the parent circle. No point is missed.
+        #
+        # metre offsets -> degrees: 1 deg latitude ~ 111320 m, and a degree of
+        # longitude shrinks by cos(lat), so the R/2 offset in each axis is:
+        #   dlat = (R/2) / 111320              (degrees of latitude)
+        #   dlon = (R/2) / (111320 * cos(lat)) (degrees of longitude)
+        # sub_radius = R*sqrt(2)/2             (child radius, still in metres)
+        if radius <= MIN_RADIUS_M:
+            self.logger.warning(f"cannot subdivide below {MIN_RADIUS_M}m at {lat},{lon}")
+            return
+        dlat = (radius / 2) / 111320.0
+        dlon = (radius / 2) / (111320.0 * math.cos(math.radians(lat)))
+        sub_radius = radius * math.sqrt(2) / 2
+        for quadrant, d1, d2 in (
+            ("NW", dlat, dlon),
+            ("NE", dlat, -dlon),
+            ("SW", -dlat, dlon),
+            ("SE", -dlat, -dlon),
+        ):
+            yield self.make_request(lat + d1, lon + d2, sub_radius, source=f"{source}-sub-{quadrant}")
 
     async def start(self):
         radius_m = RADIUS_KM * 1000

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -101,45 +101,58 @@ class JapanPostJPSpider(Spider):
             )
 
         for row in rows:
-            if row[0] == "POST":
+            row_type = row[0]
+            ref = row[1]
+            lat = row[2]
+            lon = row[3]
+
+            if row_type == "POST":
+                postcode = row[21]
+                addr_full = row[7]
                 item = Feature()
-                item["ref"] = row[1]
-                item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{row[1]}/?post=1"
-                item["lat"] = row[2]
-                item["lon"] = row[3]
-                item["postcode"] = row[21]
-                item["addr_full"] = row[7]
+                item["ref"] = ref
+                # post detail page is not accessible without `?post=1`
+                item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{ref}/?post=1"
+                item["lat"] = lat
+                item["lon"] = lon
+                item["postcode"] = postcode
+                item["addr_full"] = addr_full
                 apply_category(Categories.POST_BOX, item)
                 item["name"] = "ポスト"
                 yield item
                 continue
 
-            if row[4] == "99":
-                continue
-
-            item = Feature()
-            item["ref"] = row[1]
-            item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{row[1]}/"
-            item["lat"] = row[2]
-            item["lon"] = row[3]
-            item["postcode"] = row[13]
-            item["addr_full"] = row[14]
-            # col [4] is an icon_id (marker image) that selects the category:
+            # col [icon] is an icon_id (marker image) that selects the category:
             #   01, 02          = post office
             #   03,04,06,07,08  = ATM
-            #   05              = Japan Post Insurance
+            #   05              = Japan Post kanpo Insurance
             #   99              = search-center pin, not a real location
-            if row[4] in ("01", "02"):
+            icon = row[4]
+            if icon == "99":
+                continue
+
+            name = row[7]
+            postcode = row[13]
+            addr_full = row[14]
+
+            item = Feature()
+            item["ref"] = ref
+            item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{ref}/"
+            item["lat"] = lat
+            item["lon"] = lon
+            item["postcode"] = postcode
+            item["addr_full"] = addr_full
+            if icon in ("01", "02"):
                 apply_category(Categories.POST_OFFICE, item)
                 item.update({"brand": "日本郵便", "brand_wikidata": "Q11509260"})
-                item["name"] = row[7]
-            elif row[4] == "05":
+                item["name"] = name
+            elif icon == "05":
                 apply_category(Categories.OFFICE_INSURANCE, item)
                 item.update({"brand": "かんぽ生命保険", "brand_wikidata": "Q6157781"})
-                item["name"] = row[7]
+                item["name"] = name
             else:
                 apply_category(Categories.ATM, item)
                 item.update({"brand": "ゆうちょ銀行", "brand_wikidata": "Q907103"})
-                item["branch"] = row[7].removesuffix("出張所")
+                item["branch"] = name.removesuffix("出張所")
 
             yield item

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -3,7 +3,7 @@ from io import StringIO
 from urllib.parse import urlencode
 
 from chompjs import parse_js_object
-from scrapy import FormRequest, Spider
+from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
 from locations.geo import city_locations, country_iseadgg_centroids
@@ -42,14 +42,10 @@ class JapanPostJPSpider(Spider):
             "rad": radius,
             "hour": 1,
         }
-        target = f"http://127.0.0.1/cgi/nkyoten.cgi?{urlencode(params)}"
-        return FormRequest(
-            f"https://map.japanpost.jp/p/{MAP_ID}/zdcemaphttp.cgi?zdccnt=1&enc=EUC",
-            formdata={"target": target},
-            headers={
-                "X-Requested-With": "XMLHttpRequest",
-                "Referer": "https://map.japanpost.jp/p/search/nmap.htm",
-            },
+        target = urlencode({"target": f"http://127.0.0.1/cgi/nkyoten.cgi?{urlencode(params)}"})
+        url = f"https://map.japanpost.jp/p/{MAP_ID}/zdcemaphttp.cgi?{target}&zdccnt=1&enc=EUC"
+        return Request(
+            url,
             cb_kwargs={
                 "lat": lat,
                 "lon": lon,

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -108,8 +108,8 @@ class JapanPostJPSpider(Spider):
 
     async def start(self):
         radius_m = RADIUS_KM * 1000
-        for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):
-            yield self.make_request(lat, lon, radius_m, source="grid")
+        for i, (lat, lon) in enumerate(country_iseadgg_centroids("JP", RADIUS_KM)):
+            yield self.make_request(lat, lon, radius_m, source=f"grid-{i}")
 
     def parse(
         self,

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -225,7 +225,7 @@ class JapanPostJPSpider(Spider):
         groups = {
             "Mo-Fr": row[42:62],
             "Sa": row[62:82],
-            "Su": row[82:102],
+            "Su,PH": row[82:102],
         }
         parts = []
         for day, times in groups.items():

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -133,7 +133,7 @@ class JapanPostJPSpider(Spider):
         js_ls = f"[{js_str}]"
         (tsv_str,) = parse_js_object(js_ls)
         reader = csv.reader(StringIO(tsv_str), delimiter="\t")
-        ret_code, rec_count, hit_count = map(int, next(reader))
+        _, rec_count, hit_count = map(int, next(reader))
         assert rec_count <= hit_count, (rec_count, hit_count)
         rows = list(reader)
         tempo_total = tempo_count + sum(1 for r in rows if r[0] == "TEMPO")

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -4,6 +4,7 @@ from io import StringIO
 from urllib.parse import urlencode
 
 from chompjs import parse_js_object
+from pyproj import Transformer
 from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
@@ -12,6 +13,9 @@ from locations.items import Feature
 
 # determined experimentally. per-type cap (TEMPO/POST). a type reaching this is truncated
 MAX_ITEMS = 1640
+
+# Tokyo (EPSG:4301) -> WGS 84 (EPSG:4326) via EPSG:15484 (Tokyo to WGS 84 (108)).
+TOKYO_TO_WGS84 = Transformer.from_pipeline("EPSG:15484")
 RADIUS_KM = 24
 MIN_RADIUS_M = 1000
 MAP_ID = "search"
@@ -142,6 +146,8 @@ class JapanPostJPSpider(Spider):
             ref = row[1]
             lat = row[2]
             lon = row[3]
+            # raw lat/lon are Tokyo datum (EPSG:4301). convert to WGS 84 (EPSG:4326)
+            wgs84_lat, wgs84_lon = TOKYO_TO_WGS84.transform(float(lat), float(lon))
 
             if row_type == "POST":
                 postcode = row[21]
@@ -150,8 +156,8 @@ class JapanPostJPSpider(Spider):
                 item["ref"] = ref
                 # post detail page is not accessible without `?post=1`
                 item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{ref}/?post=1"
-                item["lat"] = lat
-                item["lon"] = lon
+                item["lat"] = wgs84_lat
+                item["lon"] = wgs84_lon
                 item["postcode"] = postcode
                 item["addr_full"] = addr_full
                 apply_category(Categories.POST_BOX, item)
@@ -174,8 +180,8 @@ class JapanPostJPSpider(Spider):
             item = Feature()
             item["ref"] = ref
             item["website"] = f"https://map.japanpost.jp/p/{MAP_ID}/dtl/{ref}/"
-            item["lat"] = lat
-            item["lon"] = lon
+            item["lat"] = wgs84_lat
+            item["lon"] = wgs84_lon
             item["postcode"] = postcode
             item["addr_full"] = addr_full
             if icon in ("01", "02"):

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -174,6 +174,7 @@ class JapanPostJPSpider(Spider):
                 item["lon"] = wgs84_lon
                 item["postcode"] = postcode
                 item["addr_full"] = addr_full
+                item["extras"]["post_box:design"] = f"郵便差出箱{row[14]}"
 
                 apply_category(Categories.POST_BOX, item)
                 item["operator_wikidata"] = "Q11509260"

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -155,7 +155,6 @@ class JapanPostJPSpider(Spider):
                 item["postcode"] = postcode
                 item["addr_full"] = addr_full
                 apply_category(Categories.POST_BOX, item)
-                item["name"] = "ポスト"
                 yield item
                 continue
 

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -182,6 +182,7 @@ class JapanPostJPSpider(Spider):
                 item["addr_full"] = addr_full
 
                 apply_category(Categories.POST_BOX, item)
+                item["operator_wikidata"] = "Q11509260"
                 yield item
                 continue
 

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -9,7 +9,7 @@ from scrapy import Request, Spider
 from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.geo import KILOMETERS_PER_DEGREE_LATITUDE, city_locations, country_iseadgg_centroids
+from locations.geo import KILOMETERS_PER_DEGREE_LATITUDE, country_iseadgg_centroids
 from locations.items import Feature
 
 # determined experimentally. per-type cap (TEMPO/POST). a type reaching this is truncated
@@ -96,25 +96,20 @@ class JapanPostJPSpider(Spider):
         ]
 
     def _subdivide(self, lat_parent: float, lon_parent: float, radius_parent: float, source: str):
-        # Request layer: split a truncated circle into 4 children and issue their
-        # queries. Only used for the city-5.5 pass and only ONE level: children keep
-        # source "city-5.5-sub-<quadrant>", which never matches the "city-5.5" trigger,
-        # so they are not subdivided again. source is always hyphen-delimited, so it
-        # splits cleanly for later analysis.
+        # Split a truncated circle into 4 children and issue their queries.
+        # Children keep source "<parent>-<quadrant>" and are recursively subdivided until no child is truncated.
         if radius_parent <= MIN_RADIUS_M:
             self.logger.warning(f"cannot subdivide below {MIN_RADIUS_M}m at {lat_parent},{lon_parent}")
             return
         for center_child_lat, center_child_lon, radius_child, quadrant in self._child_circles(
             lat_parent, lon_parent, radius_parent
         ):
-            yield self.make_request(center_child_lat, center_child_lon, radius_child, source=f"{source}-sub-{quadrant}")
+            yield self.make_request(center_child_lat, center_child_lon, radius_child, source=f"{source}-{quadrant}")
 
     async def start(self):
         radius_m = RADIUS_KM * 1000
         for lat, lon in country_iseadgg_centroids("JP", RADIUS_KM):
-            yield self.make_request(lat, lon, radius_m, source="grid-24")
-        for city in city_locations("JP", 200000):
-            yield self.make_request(city["latitude"], city["longitude"], 5500, source="city-5.5")
+            yield self.make_request(lat, lon, radius_m, source="grid")
 
     def parse(
         self,
@@ -149,11 +144,10 @@ class JapanPostJPSpider(Spider):
             f"Query (source={source}, lat={lat}, lon={lon}, radius={radius}, page={page}, offset={offset}, rec={rec_count}, hit={hit_count}, tempo={tempo_total}, post={post_total})"
         )
         if tempo_total >= MAX_ITEMS or post_total >= MAX_ITEMS:
-            self.logger.warning(
-                f"Maximum number of items returned in one query, consider lowering the radius  (source={source})"
+            self.logger.info(
+                f"Maximum number of items {MAX_ITEMS} returned in one query, subdividing into small circles (source={source})"
             )
-            if source == "city-5.5":
-                yield from self._subdivide(lat, lon, radius, source)
+            yield from self._subdivide(lat, lon, radius, source)
             return
 
         if offset + rec_count < hit_count:

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -6,9 +6,10 @@ from urllib.parse import urlencode
 from chompjs import parse_js_object
 from pyproj import Transformer
 from scrapy import Request, Spider
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
-from locations.geo import city_locations, country_iseadgg_centroids
+from locations.geo import KILOMETERS_PER_DEGREE_LATITUDE, city_locations, country_iseadgg_centroids
 from locations.items import Feature
 
 # determined experimentally. per-type cap (TEMPO/POST). a type reaching this is truncated
@@ -24,7 +25,17 @@ MAP_ID = "search"
 class JapanPostJPSpider(Spider):
     name = "japan_post_jp"
 
-    def make_request(self, lat, lon, radius, offset=1, count=900, tempo_count=0, post_count=0, source=""):
+    def make_request(
+        self,
+        lat: float,
+        lon: float,
+        radius: float,
+        offset: int = 1,
+        count: int = 900,
+        tempo_count: int = 0,
+        post_count: int = 0,
+        source: str = "",
+    ):
         params = {
             "cid": MAP_ID,
             "postcid": "searchPO",
@@ -64,41 +75,39 @@ class JapanPostJPSpider(Spider):
             },
         )
 
-    def _subdivide(self, lat, lon, radius, source):
-        # Replace a truncated circle (center lat/lon, radius m) with 4 smaller
-        # circles whose union covers the original. Only used for the city-5.5 pass
-        # and only ONE level: children keep source "city-5.5-sub-<quadrant>", which
-        # never matches the "city-5.5" trigger, so they are not subdivided again.
-        #
-        # source is always hyphen-delimited, e.g. grid-24, city-5.5, city-5.5-sub-NW,
-        # so it splits cleanly for later analysis.
-        #
-        # Covering math: the parent disk (radius R) sits inside its bounding square
-        # of side 2R. Put one child at each quadrant centre, i.e. offset by R/2 in
-        # latitude and R/2 in longitude. The farthest corner of a quadrant from its
-        # centre is the half-diagonal sqrt((R/2)^2+(R/2)^2) = R*sqrt(2)/2, so a child
-        # of that radius covers its whole quadrant exactly. The 4 quadrants tile the
-        # bounding square, therefore union(4 children) = bounding square, which fully
-        # contains the parent circle. No point is missed.
-        #
-        # metre offsets -> degrees: 1 deg latitude ~ 111320 m, and a degree of
-        # longitude shrinks by cos(lat), so the R/2 offset in each axis is:
-        #   dlat = (R/2) / 111320              (degrees of latitude)
-        #   dlon = (R/2) / (111320 * cos(lat)) (degrees of longitude)
-        # sub_radius = R*sqrt(2)/2             (child radius, still in metres)
-        if radius <= MIN_RADIUS_M:
-            self.logger.warning(f"cannot subdivide below {MIN_RADIUS_M}m at {lat},{lon}")
+    def _child_circles(
+        self, lat_parent: float, lon_parent: float, radius_parent: float
+    ) -> list[tuple[float, float, float, str]]:
+        """
+        Return the 4 child circles to fully cover a parent circle of the given radius.
+
+        Each child is offset from the parent center by half the parent radius in latitude and in
+        longitude, and its radius is the distance to the half-diagonal. The four quadrants tile the
+        square around the parent circle, so the children cover it completely.
+        """
+        lat_child = (radius_parent / 2 / 1000) / KILOMETERS_PER_DEGREE_LATITUDE
+        lon_child = (radius_parent / 2 / 1000) / (KILOMETERS_PER_DEGREE_LATITUDE * math.cos(math.radians(lat_parent)))
+        radius_child = radius_parent * math.sqrt(2) / 2
+        return [
+            (lat_parent + lat_child, lon_parent + lon_child, radius_child, "NW"),
+            (lat_parent + lat_child, lon_parent - lon_child, radius_child, "NE"),
+            (lat_parent - lat_child, lon_parent + lon_child, radius_child, "SW"),
+            (lat_parent - lat_child, lon_parent - lon_child, radius_child, "SE"),
+        ]
+
+    def _subdivide(self, lat_parent: float, lon_parent: float, radius_parent: float, source: str):
+        # Request layer: split a truncated circle into 4 children and issue their
+        # queries. Only used for the city-5.5 pass and only ONE level: children keep
+        # source "city-5.5-sub-<quadrant>", which never matches the "city-5.5" trigger,
+        # so they are not subdivided again. source is always hyphen-delimited, so it
+        # splits cleanly for later analysis.
+        if radius_parent <= MIN_RADIUS_M:
+            self.logger.warning(f"cannot subdivide below {MIN_RADIUS_M}m at {lat_parent},{lon_parent}")
             return
-        dlat = (radius / 2) / 111320.0
-        dlon = (radius / 2) / (111320.0 * math.cos(math.radians(lat)))
-        sub_radius = radius * math.sqrt(2) / 2
-        for quadrant, d1, d2 in (
-            ("NW", dlat, dlon),
-            ("NE", dlat, -dlon),
-            ("SW", -dlat, dlon),
-            ("SE", -dlat, -dlon),
+        for center_child_lat, center_child_lon, radius_child, quadrant in self._child_circles(
+            lat_parent, lon_parent, radius_parent
         ):
-            yield self.make_request(lat + d1, lon + d2, sub_radius, source=f"{source}-sub-{quadrant}")
+            yield self.make_request(center_child_lat, center_child_lon, radius_child, source=f"{source}-sub-{quadrant}")
 
     async def start(self):
         radius_m = RADIUS_KM * 1000
@@ -107,7 +116,18 @@ class JapanPostJPSpider(Spider):
         for city in city_locations("JP", 200000):
             yield self.make_request(city["latitude"], city["longitude"], 5500, source="city-5.5")
 
-    def parse(self, response, lat, lon, radius, offset, count=900, tempo_count=0, post_count=0, source=""):
+    def parse(
+        self,
+        response: Response,
+        lat: float,
+        lon: float,
+        radius: float,
+        offset: int,
+        count=900,
+        tempo_count=0,
+        post_count=0,
+        source="",
+    ):
         # response is an EUC-encoded JS file that looks like
         #   ZdcEmapHttpResult[1] = '...';
         # where the string body is a TSV
@@ -144,10 +164,10 @@ class JapanPostJPSpider(Spider):
         for row in rows:
             row_type = row[0]
             ref = row[1]
-            lat = row[2]
-            lon = row[3]
+            lat = float(row[2])
+            lon = float(row[3])
             # raw lat/lon are Tokyo datum (EPSG:4301). convert to WGS 84 (EPSG:4326)
-            wgs84_lat, wgs84_lon = TOKYO_TO_WGS84.transform(float(lat), float(lon))
+            wgs84_lat, wgs84_lon = TOKYO_TO_WGS84.transform(lat, lon)
 
             if row_type == "POST":
                 postcode = row[21]
@@ -160,6 +180,7 @@ class JapanPostJPSpider(Spider):
                 item["lon"] = wgs84_lon
                 item["postcode"] = postcode
                 item["addr_full"] = addr_full
+
                 apply_category(Categories.POST_BOX, item)
                 yield item
                 continue

--- a/locations/spiders/japan_post_jp.py
+++ b/locations/spiders/japan_post_jp.py
@@ -1,6 +1,7 @@
 import csv
 import math
 from io import StringIO
+from typing import List
 from urllib.parse import urlencode
 
 from chompjs import parse_js_object
@@ -174,6 +175,8 @@ class JapanPostJPSpider(Spider):
                 item["lon"] = wgs84_lon
                 item["postcode"] = postcode
                 item["addr_full"] = addr_full
+                if collection_times := self.get_collection_times(row):
+                    item["extras"]["collection_times"] = collection_times
                 item["extras"]["post_box:design"] = f"郵便差出箱{row[14]}"
 
                 apply_category(Categories.POST_BOX, item)
@@ -215,3 +218,18 @@ class JapanPostJPSpider(Spider):
                 item["branch"] = name.removesuffix("出張所")
 
             yield item
+
+    def get_collection_times(self, row: List[str]) -> str:
+        # POST rows have collection times in three fixed 20-slot groups:
+        #   cols 42-61 weekday (平日), 62-81 Saturday (土曜), 82-101 Sunday/holiday (日曜・休日)
+        groups = {
+            "Mo-Fr": row[42:62],
+            "Sa": row[62:82],
+            "Su": row[82:102],
+        }
+        parts = []
+        for day, times in groups.items():
+            times = [t for t in times if t]
+            if times:
+                parts.append(f"{day} {','.join(times)}")
+        return "; ".join(parts)


### PR DESCRIPTION
resolve #17076 

The left 4 small circle is the intended process in `_subdivide()`. Since there's much more postboxes exist in a dense city area, the API still truncates additional locations when the limit in the current 5.5km city circle exceeds. So when truncates happens, this calls additonal 4 API calls with small circle areas which covers the original 5.5km circle.

<img width="1740" height="860" alt="two diagrams. right is green pixel green single circle checking if the city-5.5 circle is covered by 4 sub circles. left is five circles. large city circle and four small circles, union of them covering entire city circle" src="https://github.com/user-attachments/assets/5d14874d-f661-43ee-9c2a-6ae4a4bc78b3" />

I'm still checking logs but this is the visualization of the API call results, each circle is correnponding a single API call.

<img width="1320" height="1320" alt="circles_map, japan map with many small circles with three types" src="https://github.com/user-attachments/assets/16ba6fdb-8742-4439-b88a-f6d08006bd64" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved Japan Post location accuracy by converting source coordinates to WGS 84.
  - Expanded coverage in areas reaching search result limits through automatic subdivision into smaller search regions.
  - Improved handling of paginated search results for more complete location coverage.
  - Added collection schedules and postbox design details to applicable location records.
  - Improved operator information with linked Wikidata identifiers where available.
  - Added clearer query labels and search statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->