### PR TITLE
Handle invalid hour-24 close times in OpeningHours.add_range

### DIFF
--- a/locations/hours.py
+++ b/locations/hours.py
@@ -1152,6 +1152,14 @@ class OpeningHours:
                 close_time = "23:59"
             if close_time in ("24:00:00", "00:00:00"):
                 close_time = "23:59:00"
+            if re.match(r"^24:(?!00(:00)?$)\d{2}(:\d{2})?$", close_time):
+                # Hour 24 is only a valid representation of midnight at
+                # exactly "24:00" (rewritten above to "23:59"). Anything
+                # else with hour 24 (e.g. "24:30") isn't a real time and
+                # isn't representable as a same-day close time - treat it
+                # as invalid source data rather than crashing in
+                # time.strptime() below.
+                return
         if not isinstance(open_time, time.struct_time):
             open_time = time.strptime(open_time, time_format)
         if not isinstance(close_time, time.struct_time):

--- a/tests/test_opening_hours.py
+++ b/tests/test_opening_hours.py
@@ -211,6 +211,22 @@ def test_till_midnight_formatted_in_other_unusual_formats():
     assert o.as_opening_hours() == "Mo 11:00-24:00"
 
 
+def test_invalid_hour_24_close_time_is_ignored_not_raised():
+    # "24:00" is a valid way of expressing midnight (handled above), but
+    # anything else with hour 24 (e.g. "24:30") isn't a real time and
+    # previously raised out of time.strptime() instead of being treated as
+    # invalid source data.
+    o = OpeningHours()
+    o.add_range("Mo", "10:00", "24:30")
+
+    assert o.as_opening_hours() == ""
+
+    o = OpeningHours()
+    o.add_range("Tu", "10:00:00", "24:30:00", time_format="%H:%M:%S")
+
+    assert o.as_opening_hours() == ""
+
+
 def test_sanitise_days():
     assert sanitise_day("Mo") == "Mo"
     assert sanitise_day("Mon") == "Mo"


### PR DESCRIPTION
add_range already special-cases the literal string "24:00" (rewriting it to "23:59"), but anything else with hour 24 and nonzero minutes/seconds (e.g. "24:30") fell through to time.strptime() and raised ValueError, crashing the whole spider run. This surfaced in #18484 (docomo_shop_jp), which worked around it with a spider-local hour==24-check — this generalizes that fix into the shared library so every spider benefits, not just ones that happen to validate it themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid same-day closing times such as `24:30` are now safely ignored instead of causing an error.
  - Valid `24:00` closing times continue to be handled correctly across supported time formats.

- **Tests**
  - Added coverage for invalid hour-24 closing times in standard and seconds-inclusive formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->