### PR TITLE
[Specsavers] Missing name

### DIFF
--- a/locations/spiders/specsavers.py
+++ b/locations/spiders/specsavers.py
@@ -169,4 +169,6 @@ fragment sectionalNotification on StoreSectionalNotification {
                 elif store_type == "audiology":
                     apply_category(Categories.SHOP_HEARING_AIDS, item)
                     item["extras"]["healthcare"] = "audiologist"
+                if not item["name"]:
+                    item["name"] = "Specsavers"
                 yield item


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback store name of “Specsavers” when a location’s name is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->