### PR TITLE
[cash_converters_fr] Add Spider (21 locations)

### DIFF
--- a/locations/spiders/cash_converters_fr.py
+++ b/locations/spiders/cash_converters_fr.py
@@ -1,0 +1,25 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class CashConvertersFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "cash_converters_fr"
+    item_attributes = {
+        "brand": "Cash Converters",
+        "brand_wikidata": "Q124606631",
+    }
+    sitemap_urls = ["https://magasins.cashconverters.fr/sitemap.xml"]
+    sitemap_rules = [
+        (r"-[0-9]+", "parse_sd"),
+    ]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        
+        apply_category(Categories.SHOP_PAWNBROKER, item)
+        name = item.pop("name", "")
+        if "carrefour" not in name.lower():
+            item["branch"] = name.removeprefix("Cash Converters ")
+            item["website"] = (item.get("website") or "").replace("//www.", "//magasins.")
+            yield item

--- a/locations/spiders/cash_converters_fr.py
+++ b/locations/spiders/cash_converters_fr.py
@@ -1,7 +1,7 @@
 from scrapy.spiders import SitemapSpider
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class CashConvertersFRSpider(SitemapSpider, StructuredDataSpider):
@@ -16,7 +16,7 @@ class CashConvertersFRSpider(SitemapSpider, StructuredDataSpider):
     ]
 
     def post_process_item(self, item, response, ld_data, **kwargs):
-        
+
         apply_category(Categories.SHOP_PAWNBROKER, item)
         name = item.pop("name", "")
         if "carrefour" not in name.lower():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for French Cash Converters locations.
  - French store listings now include normalized branch and website information.
  - Locations are categorized as pawnbrokers for improved discovery and filtering.
  - Carrefour locations are excluded from imported results.
  - Source labels are omitted from these listings for a cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->