### PR TITLE
Accor: add stars, amenity extras, phone and email

### DIFF
--- a/locations/spiders/accor.py
+++ b/locations/spiders/accor.py
@@ -172,7 +172,12 @@ class AccorSpider(WoosmapSpider):
                 item["phone"] = phone
             if email := LinkedDataParser.get_case_insensitive(ld, "email"):
                 item["email"] = email
-            amenities = {a.get("name") for a in ld.get("amenityFeature") or [] if str(a.get("value")).lower() == "true"}
+            amenity_features = ld.get("amenityFeature") or []
+            if isinstance(amenity_features, dict):
+                # schema.org allows a single-valued multi-value property to
+                # be serialised as a lone object instead of a one-item list.
+                amenity_features = [amenity_features]
+            amenities = {a.get("name") for a in amenity_features if str(a.get("value")).lower() == "true"}
             for name, extra in self.AMENITY_EXTRAS.items():
                 apply_yes_no(extra, item, name in amenities)
         yield item

--- a/locations/spiders/accor.py
+++ b/locations/spiders/accor.py
@@ -1,7 +1,12 @@
 from typing import ClassVar
 
-from locations.categories import Categories, apply_category
+from scrapy import Request
+from scrapy.http import Response
+
+from locations.categories import Categories, Extras, apply_category, apply_yes_no
 from locations.country_utils import get_locale
+from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
 from locations.storefinders.woosmap import WoosmapSpider
 
 
@@ -98,6 +103,25 @@ class AccorSpider(WoosmapSpider):
         # "TST": 6,
     }
 
+    # Woosmap "tags" that map cleanly onto an OSM extras tag. Absence of a
+    # tag is not treated as a "no" since Woosmap's tagging is not known to
+    # be exhaustive (apply_yes_no's default apply_positive_only=True skips
+    # the negative case for us).
+    TAG_EXTRAS: ClassVar[dict[str, Extras]] = {
+        "wifi": Extras.WIFI,
+        "air_conditioning": Extras.AIR_CONDITIONING,
+        "parking": Extras.PARKING,
+        "wheelchair_access": Extras.WHEELCHAIR,
+        "pool": Extras.SWIMMING_POOL,
+        "pet": Extras.PETS_ALLOWED,
+    }
+    # Named entries in a hotel page's schema.org amenityFeature list that map
+    # onto an OSM extras tag.
+    AMENITY_EXTRAS: ClassVar[dict[str, Extras]] = {
+        "Bar": Extras.BAR,
+        "Breakfast": Extras.BREAKFAST,
+    }
+
     def parse_item(self, item, feature, **kwargs):
         if "COMING SOON" in item["name"].upper():
             return
@@ -110,8 +134,30 @@ class AccorSpider(WoosmapSpider):
         item["website"] = (
             f"https://all.accor.com/hotel/{item['ref']}/index.{self.website_language(item['country'])}.shtml"
         )
+
+        if stars := feature["properties"]["user_properties"].get("localRating"):
+            item["extras"]["stars"] = str(stars).removesuffix(".0")
+
+        tags = feature["properties"].get("tags", [])
+        for tag, extra in self.TAG_EXTRAS.items():
+            apply_yes_no(extra, item, tag in tags)
+        if "non_smoking" in tags:
+            # Explicitly asserted by the source, unlike the tags above whose
+            # absence doesn't tell us anything either way.
+            apply_yes_no(Extras.SMOKING, item, False, apply_positive_only=False)
+
         apply_category(Categories.HOTEL, item)
-        yield item
+
+        # Phone, email and a couple of amenities are only available on the
+        # hotel's own page, not in the Woosmap feed, so fetch it too. Always
+        # use the English page for this regardless of item["website"]'s
+        # language: phone/email don't vary by language, but the amenity
+        # names we match on (self.AMENITY_EXTRAS) are translated on other
+        # locales, e.g. "Breakfast" becomes "Petit-déjeuner" on the French
+        # page. Fall back to yielding what we already have if the request
+        # fails.
+        detail_url = f"https://all.accor.com/hotel/{item['ref']}/index.en.shtml"
+        yield Request(detail_url, callback=self.parse_hotel_page, cb_kwargs={"item": item}, errback=self.failed)
 
     def website_language(self, country: str | None) -> str:
         language = self.WEBSITE_LANGUAGE_OVERRIDES.get(country)
@@ -119,3 +165,17 @@ class AccorSpider(WoosmapSpider):
             locale = get_locale(country)
             language = locale.split("-")[0] if locale else None
         return language if language in self.SUPPORTED_WEBSITE_LANGUAGES else "en"
+
+    def parse_hotel_page(self, response: Response, item: Feature):
+        if ld := LinkedDataParser.find_linked_data(response, "Hotel"):
+            if phone := LinkedDataParser.get_case_insensitive(ld, "telephone"):
+                item["phone"] = phone
+            if email := LinkedDataParser.get_case_insensitive(ld, "email"):
+                item["email"] = email
+            amenities = {a.get("name") for a in ld.get("amenityFeature") or [] if str(a.get("value")).lower() == "true"}
+            for name, extra in self.AMENITY_EXTRAS.items():
+                apply_yes_no(extra, item, name in amenities)
+        yield item
+
+    def failed(self, failure):
+        yield failure.request.cb_kwargs["item"]


### PR DESCRIPTION
Addresses #18514.

Most of the requested attributes were already present in the Woosmap feed but
unused: `stars` (`user_properties.localRating`) and several amenities
(`tags[]`: wifi, air_conditioning, parking, wheelchair_access, pool, pet,
non_smoking) — these are free, no extra requests needed.

Phone, email, bar and breakfast are only available in the schema.org `Hotel`
JSON-LD block on each hotel's own page, so this fetches it too, falling back
to yielding what we already have if that request fails.

## A gotcha found via a live crawl test

The detail-page fetch always uses `index.en.shtml`, regardless of the hotel's
localized `item["website"]` (from #18504/#18429): the JSON-LD
`amenityFeature` names are translated per page locale (e.g. "Breakfast"
becomes "Petit-déjeuner" on the French page), which would otherwise make the
English-keyed amenity matching silently fail for every non-English-language
hotel. Phone/email don't vary by language, so this doesn't cost us anything.

## Verification

- Checked the Woosmap `/stores` feed directly across all ~6000 hotels to
  confirm which fields are populated vs. always empty (`contact`, `bar` are
  always `{}` — genuinely unavailable from Woosmap, not a pagination/field-
  selection limitation).
- Confirmed via the site's own JSON-LD (`https://all.accor.com/hotel/0912/index.en.shtml`)
  that `telephone`/`email`/`starRating`/`amenityFeature` are present and
  reliable.
- Ran a real crawl of a sample of hotels end-to-end: stars, wifi, air
  conditioning, parking, wheelchair, swimming pool, pets, smoking, bar,
  breakfast, phone and email all populate correctly in the output, including
  for non-English-language hotels (FR, BR, ES, KR, MX, CI samples checked).
- `black`/`isort`/`flake8`/`ruff` all pass; full `pytest` suite (314 tests)
  passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lu8UwoSzeh6hTCN6Dug97x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hotel listings now include phone numbers, email addresses, amenities, and star ratings when available.
  * Hotel tags and amenities are mapped to more detailed listing attributes.
  * Non-smoking properties are explicitly identified.

* **Bug Fixes**
  * Listings are still provided when a hotel’s detail page cannot be reached.
  * Hotel listings are now processed correctly when amenity information contains a single entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->