### PR TITLE
[Sdek] Fix spider

### DIFF
--- a/locations/spiders/sdek.py
+++ b/locations/spiders/sdek.py
@@ -1,34 +1,66 @@
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Iterable
 
-from scrapy import Spider
-from scrapy.http import JsonRequest, Response
+from scrapy import Request
+from scrapy.http import Response
+from scrapy_camoufox.page import PageMethod
 
+from locations.camoufox_spider import CamoufoxSpider
 from locations.categories import Categories, apply_category, apply_yes_no
 from locations.dict_parser import DictParser
 from locations.hours import DAYS, OpeningHours
 from locations.items import Feature
-from locations.user_agents import BROWSER_DEFAULT
+from locations.settings import DEFAULT_CAMOUFOX_SETTINGS
+
+ALLOWED_RESOURCE_TYPES = ["document", "script", "fetch"]
 
 
-class SdekSpider(Spider):
+class SdekSpider(CamoufoxSpider):
     name = "sdek"
     allowed_domains = ["www.cdek.ru"]
     item_attributes = {"brand": "СДЭК", "brand_wikidata": "Q28665980"}
-    custom_settings = {"USER_AGENT": BROWSER_DEFAULT}
+    custom_settings = DEFAULT_CAMOUFOX_SETTINGS | {
+        "CAMOUFOX_ABORT_REQUEST": lambda request: request.resource_type not in ALLOWED_RESOURCE_TYPES
+    }
 
-    # Because of bot detection after certain no. of requests querying GraphQL API https://www.cdek.ru/api-site/v1/graphql/ for individual POI details is no longer feasible.
-    def make_request(self, page: int, limit: int = 100) -> JsonRequest:
-        return JsonRequest(
-            url=f"https://www.cdek.ru/api-site/website/office/?locale=ru&coords[startLat]=-90&coords[startLong]=-180&coords[endLat]=90&coords[endLong]=180&limit={limit}&page={page}",
-            meta={"page": page},
-            dont_filter=True,
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(
+            url="https://www.cdek.ru/ru/offices/",
+            meta={
+                "camoufox_page_methods": [
+                    # Navigation returns while the challenge is still running, and
+                    # fetching before it has reloaded the page gets an HTTP 418.
+                    PageMethod("wait_for_selector", "js-challenge-loader", state="detached", timeout=60000),
+                    PageMethod(
+                        "evaluate",
+                        """async () => {
+                            // The API silently falls back to a page size of 25 for any limit above 100.
+                            const PAGE_SIZE = 100;
+                            const url = (page) => "/api-site/website/office/?locale=ru"
+                                + "&coords[startLat]=-90&coords[startLong]=-180&coords[endLat]=90&coords[endLong]=180"
+                                + "&limit=" + PAGE_SIZE + "&page=" + page;
+                            const fetchPage = async (page) => {
+                                const response = await fetch(url(page), {headers: {"Accept": "application/json"}});
+                                if (!response.ok) throw new Error(url(page) + " returned HTTP " + response.status);
+                                return (await response.json()).data;
+                            };
+
+                            const firstPage = await fetchPage(1);
+                            const offices = [...firstPage.data];
+                            const pages = Math.ceil(firstPage.amount / PAGE_SIZE);
+                            for (let page = 2; page <= pages; page++) {
+                                await new Promise((resolve) => setTimeout(resolve, 1000));
+                                offices.push(...(await fetchPage(page)).data);
+                            }
+                            return offices;
+                        }""",
+                    ),
+                ]
+            },
         )
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield self.make_request(1)
-
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for poi in response.json().get("data", {}).get("data", []):
+    def parse(self, response: Response, **kwargs: Any) -> Iterable[Feature]:
+        # Index 1 is the fetch loop, index 0 is the challenge wait above.
+        for poi in response.meta["camoufox_page_methods"][1].result:
             item = DictParser.parse(poi)
             item["street_address"] = item.pop("addr_full")
             item["ref"] = poi.get("code")
@@ -47,10 +79,7 @@ class SdekSpider(Spider):
             item["extras"]["brand:en"] = "SDEK"
             yield item
 
-        if response.json()["data"]["count"] == 100:
-            yield self.make_request(response.meta["page"] + 1)
-
-    def parse_hours(self, item: Feature, poi: dict) -> Any:
+    def parse_hours(self, item: Feature, poi: dict) -> None:
         if hours := poi.get("worktimes"):
             try:
                 oh = OpeningHours()


### PR DESCRIPTION
Spider is working fine after this fix in the local environment.

```
{'atp/brand/СДЭК': 10491,
 'atp/brand_wikidata/Q28665980': 10491,
 'atp/category/amenity/parcel_locker': 607,
 'atp/category/amenity/post_office': 9884,
 'atp/clean_strings/street_address': 17,
 'atp/country/RU': 10491,
 'atp/field/branch/missing': 10491,
 'atp/field/city/missing': 10491,
 'atp/field/country/from_website_url': 10491,
 'atp/field/email/missing': 10491,
 'atp/field/housenumber/missing': 10491,
 'atp/field/name/missing': 607,
 'atp/field/operator/missing': 10491,
 'atp/field/operator_wikidata/missing': 10491,
 'atp/field/phone/missing': 10491,
 'atp/field/postcode/missing': 10491,
 'atp/field/state/missing': 10491,
 'atp/field/street/missing': 10491,
 'atp/field/twitter/missing': 10491,
 'atp/field/unit/missing': 10491,
 'atp/item_scraped_host_count/www.cdek.ru': 10491,
 'atp/lineage': 'S_?',
 'atp/nsi/category_unknown': 607,
 'atp/nsi/match_failed': 607,
 'atp/nsi/match_perfect': 9884,
 'camoufox/browser_count': 1,
 'camoufox/context_count': 1,
 'camoufox/context_count/max_concurrent': 1,
 'camoufox/context_count/persistent/False': 1,
 'camoufox/page_count': 1,
 'camoufox/page_count/closed': 1,
 'camoufox/page_count/max_concurrent': 1,
 'camoufox/request_count': 293,
 'camoufox/request_count/aborted': 48,
 'camoufox/request_count/method/GET': 292,
 'camoufox/request_count/method/POST': 1,
 'camoufox/request_count/navigation': 6,
 'camoufox/request_count/resource_type/document': 6,
 'camoufox/request_count/resource_type/fetch': 110,
 'camoufox/request_count/resource_type/image': 36,
 'camoufox/request_count/resource_type/script': 129,
 'camoufox/request_count/resource_type/stylesheet': 6,
 'camoufox/request_count/resource_type/xhr': 6,
 'camoufox/response_count': 245,
 'camoufox/response_count/method/GET': 245,
 'camoufox/response_count/resource_type/document': 6,
 'camoufox/response_count/resource_type/fetch': 110,
 'camoufox/response_count/resource_type/script': 129,
 'downloader/request_bytes': 336,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 373767,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 358.0630000000001,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 7, 6, 38, 49, 486842, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 10491,
 'items_per_minute': 1758.2681564245809,
 'log_count/DEBUG': 11080,
 'log_count/INFO': 12,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 0.16759776536312848,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 7, 6, 32, 51, 429256, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDEK office data collection to work more reliably when anti-bot checks are present.
  * Updated pagination handling to collect office locations across all available pages.
  * Reduced unnecessary resource loading during data collection.
* **Refactor**
  * Migrated the SDEK location importer to browser-based processing for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->