### PR TITLE
[banque_palatine_fr] Add Spider (41 locations)

### DIFF
--- a/locations/spiders/banque_palatine_fr.py
+++ b/locations/spiders/banque_palatine_fr.py
@@ -1,8 +1,8 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class BanquePalatineFRSpider(CrawlSpider, StructuredDataSpider):
@@ -23,12 +23,11 @@ class BanquePalatineFRSpider(CrawlSpider, StructuredDataSpider):
     custom_settings = {"ROBOTSTXT_OBEY": False}
     drop_attributes = ["image"]
 
-
     def post_process_item(self, item, response, ld_data):
         apply_category(Categories.BANK, item)
-        if item.get("email","") == "contact@palatine.fr":
+        if item.get("email", "") == "contact@palatine.fr":
             item.pop("email")
 
         item["branch"] = item.pop("name", "")
-        
+
         yield item

--- a/locations/spiders/banque_palatine_fr.py
+++ b/locations/spiders/banque_palatine_fr.py
@@ -1,0 +1,34 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class BanquePalatineFRSpider(CrawlSpider, StructuredDataSpider):
+    name = "banque_palatine_fr"
+    item_attributes = {
+        "brand": "Q2883429",
+        "brand_wikidata": "Q2883429",
+    }
+    allowed_domains = ["agences.palatine.fr"]
+    start_urls = ["https://agences.palatine.fr/toutes-nos-agences"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"-id[0-9]+$"),
+            callback="parse_sd",
+            follow=False,
+        ),
+    ]
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    drop_attributes = ["image"]
+
+
+    def post_process_item(self, item, response, ld_data):
+        apply_category(Categories.BANK, item)
+        if item.get("email","") == "contact@palatine.fr":
+            item.pop("email")
+
+        item["branch"] = item.pop("name", "")
+        
+        yield item

--- a/locations/spiders/banque_palatine_fr.py
+++ b/locations/spiders/banque_palatine_fr.py
@@ -8,7 +8,7 @@ from locations.structured_data_spider import StructuredDataSpider
 class BanquePalatineFRSpider(CrawlSpider, StructuredDataSpider):
     name = "banque_palatine_fr"
     item_attributes = {
-        "brand": "Q2883429",
+        "brand": "Banque Palatine",
         "brand_wikidata": "Q2883429",
     }
     allowed_domains = ["agences.palatine.fr"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting Banque Palatine France branch locations.
  * Branch details are now extracted from Banque Palatine’s location directory and categorized as bank branches.
  * Branch records use the branch name consistently.
  * Generic contact email addresses and non-useful image data are excluded from collected branch information.
  * Structured branch information is now available for eligible Banque Palatine locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->