### PR TITLE
[Fresh Market US] Increase page size to prevent record truncation

### DIFF
--- a/locations/spiders/fresh_market_us.py
+++ b/locations/spiders/fresh_market_us.py
@@ -1,16 +1,22 @@
-import scrapy
+from typing import Iterable
 
-from locations.dict_parser import DictParser
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class FreshMarketUSSpider(scrapy.Spider):
+class FreshMarketUSSpider(JSONBlobSpider):
     name = "fresh_market_us"
     item_attributes = {"brand": "The Fresh Market", "brand_wikidata": "Q7735265"}
-    start_urls = ["https://api.thefreshmarket.com/v1/stores?page[number]=1&page[size]=200&Filter[radius]=100000"]
+    start_urls = ["https://api.thefreshmarket.com/v1/stores?page[number]=1&page[size]=1000&Filter[radius]=100000"]
+    locations_key = "data"
 
-    def parse(self, response):
-        for store in response.json()["data"]:
-            store.update(store.pop("attributes"))
-            item = DictParser.parse(store)
-            item["street_address"] = item.pop("addr_full")
-            yield item
+    def pre_process_data(self, feature: dict) -> None:
+        feature.update(feature.pop("attributes", {}))
+
+    def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        item["street_address"] = item.pop("addr_full", None)
+        apply_category(Categories.SHOP_SUPERMARKET, item)
+        yield item

--- a/locations/spiders/fresh_market_us.py
+++ b/locations/spiders/fresh_market_us.py
@@ -17,6 +17,8 @@ class FreshMarketUSSpider(JSONBlobSpider):
         feature.update(feature.pop("attributes", {}))
 
     def post_process_item(self, item: Feature, response: TextResponse, feature: dict) -> Iterable[Feature]:
+        if feature["store_status_name"] == "Inactive":
+            return
         item["street_address"] = item.pop("addr_full", None)
         apply_category(Categories.SHOP_SUPERMARKET, item)
         yield item


### PR DESCRIPTION
In previous [runs](https://alltheplaces-data.openaddresses.io/runs/2026-08-29-13-32-18/stats/fresh_market_us.json), records were capped to `200`. Now, `page[size]` is updated to capture all records.

```python
{'atp/brand/The Fresh Market': 230,
 'atp/brand_wikidata/Q7735265': 230,
 'atp/category/shop/supermarket': 230,
 'atp/country/US': 230,
 'atp/field/branch/missing': 230,
 'atp/field/country/from_spider_name': 230,
 'atp/field/email/missing': 230,
 'atp/field/geometry/missing': 1,
 'atp/field/housenumber/missing': 230,
 'atp/field/opening_hours/missing': 230,
 'atp/field/operator/missing': 230,
 'atp/field/operator_wikidata/missing': 230,
 'atp/field/phone/missing': 6,
 'atp/field/twitter/missing': 230,
 'atp/field/unit/missing': 230,
 'atp/item_scraped_host_count/api.thefreshmarket.com': 230,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 230,
 'downloader/request_bytes': 756,
 'downloader/request_count': 2,
 'downloader/request_method_count/GET': 2,
 'downloader/response_bytes': 101820,
 'downloader/response_count': 2,
 'downloader/response_status_count/200': 1,
 'downloader/response_status_count/403': 1,
 'elapsed_time_seconds': 3.514999999999418,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 7, 13, 44, 34, 41904, tzinfo=datetime.timezone.utc),
 'item_scraped_count': 230,
 'items_per_minute': 4600.0,
 'log_count/DEBUG': 233,
 'log_count/INFO': 3,
 'response_received_count': 2,
 'responses_per_minute': 40.0,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/403': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 7, 13, 44, 30, 525571, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Fresh Market location data now includes more complete street address information.
  - Location categories are applied consistently for improved place classification.
  - More locations can be retrieved per request.
  - Inactive store locations are excluded from the available results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->