### PR TITLE
[Ecocuisine] Add spider (97 locations)

### DIFF
--- a/locations/spiders/ecocuisine.py
+++ b/locations/spiders/ecocuisine.py
@@ -44,9 +44,7 @@ class AmbianceEtStylesFRSpider(SitemapSpider, StructuredDataSpider):
     def parse_hours(self, response: TextResponse) -> OpeningHours:
         oh = OpeningHours()
 
-        rows = response.xpath(
-            '//*[contains(text(),"Horaires d\'ouverture")]/following-sibling::ul[1]/li'
-        )
+        rows = response.xpath('//*[contains(text(),"Horaires d\'ouverture")]/following-sibling::ul[1]/li')
 
         for row in rows:
             text = " ".join(row.xpath(".//text()").getall())

--- a/locations/spiders/ecocuisine.py
+++ b/locations/spiders/ecocuisine.py
@@ -1,0 +1,82 @@
+import re
+from typing import Iterable
+
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.hours import OpeningHours
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+TIME_RANGE_RE = re.compile(r"(\d{1,2}[:h]\d{2})\s*-\s*(\d{1,2}[:h]\d{2})")
+
+
+class AmbianceEtStylesFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "ecocuisine"
+    item_attributes = {"brand": "Ecocuisine", "brand_wikidata": "Q141349333"}
+    sitemap_urls = ["https://www.ecocuisine.fr/sitemap.xml"]
+    sitemap_rules = [(r"https://www.ecocuisine.fr/magasins/\d.*", "parse_sd")]
+    wanted_types = ["HomeAndConstructionBusiness"]
+    drop_attributes = {"image"}
+
+    DAYS_FR = {
+        "lundi": "Mo",
+        "mardi": "Tu",
+        "mercredi": "We",
+        "jeudi": "Th",
+        "vendredi": "Fr",
+        "samedi": "Sa",
+        "dimanche": "Su",
+    }
+    DAY_ORDER = list(DAYS_FR.keys())
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item.get("facebook") == "https://www.facebook.com/ecocuisine.officiel":
+            item["facebook"] = None
+        item["branch"] = item.pop("name").removeprefix("ECOCUISINE ")
+
+        item["opening_hours"] = self.parse_hours(response)
+
+        apply_category(Categories.SHOP_KITCHEN, item)
+        yield item
+
+    def parse_hours(self, response: TextResponse) -> OpeningHours:
+        oh = OpeningHours()
+
+        rows = response.xpath(
+            '//*[contains(text(),"Horaires d\'ouverture")]/following-sibling::ul[1]/li'
+        )
+
+        for row in rows:
+            text = " ".join(row.xpath(".//text()").getall())
+            text = text.replace("\xa0", " ").strip()
+            if ":" not in text and "h" not in text.lower():
+                continue
+
+            day_part, _, hours_part = text.partition(":")
+            day_part = day_part.strip().lower()
+            hours_part = hours_part.strip()
+
+            if "fermé" in hours_part.lower():
+                continue
+
+            if "-" in day_part:
+                start_day, end_day = [d.strip() for d in day_part.split("-")]
+                try:
+                    start_idx = self.DAY_ORDER.index(start_day)
+                    end_idx = self.DAY_ORDER.index(end_day)
+                except ValueError:
+                    continue
+                days = self.DAY_ORDER[start_idx : end_idx + 1]
+            else:
+                days = [day_part]
+
+            for open_time, close_time in TIME_RANGE_RE.findall(hours_part):
+                open_time = open_time.replace("h", ":")
+                close_time = close_time.replace("h", ":")
+                for day in days:
+                    if osm_day := self.DAYS_FR.get(day):
+                        oh.add_range(osm_day, open_time, close_time, time_format="%H:%M")
+
+        return oh


### PR DESCRIPTION
Add a spider for the french kitchen shop Ecocuisine. Most of the POIs are in France, except 2 in Portugal and Morocco.

```
{'atp/brand/Ecocuisine': 97,
 'atp/brand_wikidata/Q141349333': 97,
 'atp/category/shop/kitchen': 97,
 'atp/country/FR': 97,
 'atp/field/email/missing': 97,
 'atp/field/housenumber/missing': 97,
 'atp/field/name/missing': 97,
 'atp/field/opening_hours/missing': 1,
 'atp/field/operator/missing': 97,
 'atp/field/operator_wikidata/missing': 97,
 'atp/field/phone/invalid': 1,
 'atp/field/street/missing': 97,
 'atp/field/twitter/missing': 97,
 'atp/field/unit/missing': 97,
 'atp/item_scraped_host_count/www.ecocuisine.fr': 97,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 97,
 'atp/nsi/match_failed': 97,
 'downloader/request_bytes': 42673,
 'downloader/request_count': 104,
 'downloader/request_method_count/GET': 104,
 'downloader/response_bytes': 1451171,
 'downloader/response_count': 104,
 'downloader/response_status_count/200': 100,
 'downloader/response_status_count/302': 4,
 'dupefilter/filtered': 3,
 'elapsed_time_seconds': 123.91721362434328,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 7, 18, 6, 50, 108202, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7145261,
 'httpcompression/response_count': 100,
 'item_scraped_count': 97,
 'items_per_minute': 47.31707317073171,
 'log_count/DEBUG': 202,
 'log_count/INFO': 5,
 'memusage/max': 382894080,
 'memusage/startup': 180502528,
 'request_depth_max': 1,
 'response_received_count': 100,
 'responses_per_minute': 48.78048780487805,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 103,
 'scheduler/dequeued/memory': 103,
 'scheduler/enqueued': 103,
 'scheduler/enqueued/memory': 103,
 'start_time': datetime.datetime(2026, 9, 7, 18, 4, 46, 189568, tzinfo=datetime.timezone.utc)}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Ecocuisine store listings.
  * Store pages now include branch names, kitchen-related categorization, and parsed opening hours.
  * French opening hours, including day ranges and closed periods, are normalized for display.
  * Store information now includes standardized location details and available Facebook links.
  * Listings provide more consistent business details across Ecocuisine locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->