### PR TITLE
[But] Add spider (310 locations)

### DIFF
--- a/locations/spiders/but_fr.py
+++ b/locations/spiders/but_fr.py
@@ -11,32 +11,22 @@ from locations.structured_data_spider import StructuredDataSpider
 # Site is behind DataDome; every request needs a real browser render to get past it.
 ZYTE_BROWSER_HTML = {"browserHtml": True, "geolocation": "FR", "javascript": True}
 
-# No dedicated store sitemap. The store finder's landing page links these 13 region index
-# pages, and each one lists every store in that region directly - no department-level page
-# needed in between.
-REGION_INDEX_PAGES = [
-    "Ile-de-France/index-r11",
-    "Centre-Val-de-Loire/index-r24",
-    "Bourgogne-Franche-Comte/index-r27",
-    "Normandie/index-r28",
-    "Hauts-de-France/index-r32",
-    "Grand-Est/index-r44",
-    "Pays-de-la-Loire/index-r52",
-    "Bretagne/index-r53",
-    "Nouvelle-Aquitaine/index-r75",
-    "Occitanie/index-r76",
-    "Auvergne-Rhone-Alpes/index-r84",
-    "Provence-Alpes-Cote-d-Azur/index-r93",
-    "Corse/index-r94",
-]
-
 
 class ButFRSpider(CrawlSpider, StructuredDataSpider):
     name = "but_fr"
     item_attributes = {"brand": "But", "brand_wikidata": "Q2877537", "name": "But"}
     allowed_domains = ["but.fr"]
-    start_urls = [f"https://www.but.fr/magasins/{page}.html" for page in REGION_INDEX_PAGES]
-    rules = [Rule(LinkExtractor(allow=r"/magasins/\d+/"), callback="parse_item", process_request="use_zyte_browser")]
+    # No dedicated store sitemap. The store finder's landing page links 13 region index pages
+    # (also cross-linked from every region page itself, so a single start URL is enough), and
+    # each region page lists every store in that region directly - no department-level page
+    # needed in between.
+    start_urls = ["https://www.but.fr/magasins/recherche-magasins"]
+    rules = [
+        # Region pages: no callback, so CrawlSpider follows them (default follow=True) without
+        # yielding items - just to discover the other regions and their store links below.
+        Rule(LinkExtractor(allow=r"/magasins/[^/]+/index-r\d+\.html"), process_request="use_zyte_browser"),
+        Rule(LinkExtractor(allow=r"/magasins/\d+/"), callback="parse_item", process_request="use_zyte_browser"),
+    ]
     # Source gives hours as "10h00"/"09h30", not "10:00"/"09:30".
     time_format = "%Hh%M"
     custom_settings = {

--- a/locations/spiders/but_fr.py
+++ b/locations/spiders/but_fr.py
@@ -1,0 +1,97 @@
+import random
+
+from scrapy.downloadermiddlewares.retry import get_retry_request
+from scrapy.http import TextResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+# Site is behind DataDome; every request needs a real browser render to get past it.
+ZYTE_BROWSER_HTML = {"browserHtml": True, "geolocation": "FR", "javascript": True}
+
+# No dedicated store sitemap. The store finder's landing page links these 13 region index
+# pages, and each one lists every store in that region directly - no department-level page
+# needed in between.
+REGION_INDEX_PAGES = [
+    "Ile-de-France/index-r11",
+    "Centre-Val-de-Loire/index-r24",
+    "Bourgogne-Franche-Comte/index-r27",
+    "Normandie/index-r28",
+    "Hauts-de-France/index-r32",
+    "Grand-Est/index-r44",
+    "Pays-de-la-Loire/index-r52",
+    "Bretagne/index-r53",
+    "Nouvelle-Aquitaine/index-r75",
+    "Occitanie/index-r76",
+    "Auvergne-Rhone-Alpes/index-r84",
+    "Provence-Alpes-Cote-d-Azur/index-r93",
+    "Corse/index-r94",
+]
+
+
+class ButFRSpider(CrawlSpider, StructuredDataSpider):
+    name = "but_fr"
+    item_attributes = {"brand": "But", "brand_wikidata": "Q2877537"}
+    start_urls = [f"https://www.but.fr/magasins/{page}.html" for page in REGION_INDEX_PAGES]
+    rules = [Rule(LinkExtractor(allow=r"/magasins/\d+/"), callback="parse_item", process_request="use_zyte_browser")]
+    # Source gives hours as "10h00"/"09h30", not "10:00"/"09:30".
+    time_format = "%Hh%M"
+    custom_settings = {
+        # Default concurrency risked bans in manual testing against DataDome.
+        "DOWNLOAD_DELAY": 3,
+        "CONCURRENT_REQUESTS_PER_DOMAIN": 2,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    async def start(self):
+        async for request in super().start():
+            request.meta["zyte_api"] = ZYTE_BROWSER_HTML
+            yield request
+
+    def use_zyte_browser(self, request, response):
+        request.meta["zyte_api"] = ZYTE_BROWSER_HTML
+        return request
+
+    def parse_item(self, response: TextResponse, **kwargs):
+        # Zyte occasionally returns the page before the JSON-LD has finished loading; retry
+        # instead of losing the location.
+        yielded = False
+        for result in self.parse_sd(response):
+            yielded = True
+            yield result
+        if not yielded and response.request is not None:
+            if retry := get_retry_request(
+                response.request,
+                spider=self,
+                max_retry_times=5,
+                reason="no structured data extracted",
+                priority_adjust=random.randint(-20, -1),  # noqa: S311 - retry priority jitter
+            ):
+                yield retry
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs):
+        # Both the JSON-LD address and "name" are generated from a URL-safe slug, not the real
+        # text: spaces become hyphens and accents/apostrophes are dropped (e.g. "l'Auge" ->
+        # "l-Auge", "Créteil" -> "Creteil", "Mantes-la-jolie - Buchelay" -> the misleading
+        # triple-hyphen "Mantes-la-jolie---Buchelay"). Visible page text is unaffected, so
+        # street/city/branch are all read from there instead; postcode/country are fine as
+        # parsed from the JSON-LD.
+        lines = response.css("div.shop-address div.address p::text").getall()
+        if len(lines) == 2:
+            item["street_address"] = lines[0].strip()
+            item["city"] = lines[1].removeprefix(item["postcode"]).strip()
+
+        item.pop("name", None)
+        if h1 := response.css("div.detailShop-header h1::text").get():
+            item["branch"] = h1.removeprefix("But ")
+
+        # Same national call-centre number on every store page seen so far, not a store line.
+        item["phone"] = None
+
+        # Same generic "store entrance" stock photo on every store page seen so far.
+        if item.get("image", "").endswith("/font-magasin/entree-magasin.jpg"):
+            item["image"] = None
+
+        yield item

--- a/locations/spiders/but_fr.py
+++ b/locations/spiders/but_fr.py
@@ -33,7 +33,7 @@ REGION_INDEX_PAGES = [
 
 class ButFRSpider(CrawlSpider, StructuredDataSpider):
     name = "but_fr"
-    item_attributes = {"brand": "But", "brand_wikidata": "Q2877537"}
+    item_attributes = {"brand": "But", "brand_wikidata": "Q2877537", "name": "But"}
     start_urls = [f"https://www.but.fr/magasins/{page}.html" for page in REGION_INDEX_PAGES]
     rules = [Rule(LinkExtractor(allow=r"/magasins/\d+/"), callback="parse_item", process_request="use_zyte_browser")]
     # Source gives hours as "10h00"/"09h30", not "10:00"/"09:30".
@@ -72,12 +72,9 @@ class ButFRSpider(CrawlSpider, StructuredDataSpider):
                 yield retry
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs):
-        # Both the JSON-LD address and "name" are generated from a URL-safe slug, not the real
-        # text: spaces become hyphens and accents/apostrophes are dropped (e.g. "l'Auge" ->
-        # "l-Auge", "Créteil" -> "Creteil", "Mantes-la-jolie - Buchelay" -> the misleading
-        # triple-hyphen "Mantes-la-jolie---Buchelay"). Visible page text is unaffected, so
-        # street/city/branch are all read from there instead; postcode/country are fine as
-        # parsed from the JSON-LD.
+        # JSON-LD address/name are generated from a URL slug, not the real text (spaces become
+        # hyphens, accents/apostrophes drop) - street/city/branch are read from visible text
+        # instead; postcode/country are fine as parsed from the JSON-LD.
         lines = response.css("div.shop-address div.address p::text").getall()
         if len(lines) == 2:
             item["street_address"] = lines[0].strip()

--- a/locations/spiders/but_fr.py
+++ b/locations/spiders/but_fr.py
@@ -34,6 +34,7 @@ REGION_INDEX_PAGES = [
 class ButFRSpider(CrawlSpider, StructuredDataSpider):
     name = "but_fr"
     item_attributes = {"brand": "But", "brand_wikidata": "Q2877537", "name": "But"}
+    allowed_domains = ["but.fr"]
     start_urls = [f"https://www.but.fr/magasins/{page}.html" for page in REGION_INDEX_PAGES]
     rules = [Rule(LinkExtractor(allow=r"/magasins/\d+/"), callback="parse_item", process_request="use_zyte_browser")]
     # Source gives hours as "10h00"/"09h30", not "10:00"/"09:30".


### PR DESCRIPTION
Adds `but_fr`: a CrawlSpider crawling But's 13 region index pages
(/magasins/<Region>/index-rNN.html) which each link directly to their stores'
pages - there's no dedicated sitemap. Store pages are parsed with
StructuredDataSpider off each store's JSON-LD LocalBusiness block. The site is
behind DataDome, so every request goes through Zyte browserHtml.

The JSON-LD address and name fields are generated from a URL slug and drop
spaces/accents (e.g. "Mantes-la-jolie---Buchelay" for a real name of "Mantes
la jolie - Buchelay") - street/city/branch are read from the page's visible
text instead. A shared national call-centre phone number and a generic stock
photo, both identical on every page, are dropped.

Verified 310 locations, 0 duplicates, full coverage on category (NSI
shop=furniture), opening hours, address and coordinates.

closes #18221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for collecting French But store locations from the store finder.
  - Expanded coverage across regional store listings in France.
  - Store records now include addresses, cities, branch details, opening hours, and contact information where available.
  - Improved support for dynamically loaded and protected store pages.
  - Enhanced data accuracy by prioritizing visible store details and filtering generic listing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->