### PR TITLE
[Blue-bike BE] Fix spider

### DIFF
--- a/locations/spiders/blue_bike_be.py
+++ b/locations/spiders/blue_bike_be.py
@@ -1,28 +1,35 @@
-from typing import Any
+from typing import Any, Iterable
 
-from scrapy import Spider
-from scrapy.http import Response
+from scrapy.http import TextResponse
 
-from locations.dict_parser import DictParser
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.json_blob_spider import JSONBlobSpider
 
 
-class BlueBikeBESpider(Spider):
+class BlueBikeBESpider(JSONBlobSpider):
     name = "blue_bike_be"
     item_attributes = {"brand_wikidata": "Q17332642"}
-    start_urls = ["https://www.blue-bike.be/wp-json/v1/location"]
+    start_urls = ["https://blue-bike.be/wp-json/bb/v1/locations"]
 
-    def parse(self, response: Response, **kwargs: Any) -> Any:
-        for location in response.json():
-            if location.pop("state") != 1:
-                continue
-            item = DictParser.parse(location)
-            # TODO: location["type"]
-            item["extras"]["capacity"] = str(location["bikes_available"])
-            item["website"] = item["extras"]["website:nl"] = "https://www.blue-bike.be/location-details/{}".format(
-                location["slug"]
-            )
+    def post_process_item(self, item: Feature, response: TextResponse, location: dict[str, Any]) -> Iterable[Feature]:
+        item.pop("state", None)
+        if location["state"] != 1:
+            return
 
-            item["extras"]["website:en"] = "https://www.blue-bike.be/en/location-details/{}".format(location["slug"])
-            item["extras"]["website:fr"] = "https://www.blue-bike.be/fr/location-details/{}".format(location["slug"])
+        item["branch"] = item.pop("name")
+        item["extras"]["capacity"] = str(location["capaciteit"])
 
-            yield item
+        apply_category(
+            Categories.BICYCLE_RENTAL_CARGO if location["soort"] == "bakfiets" else Categories.BICYCLE_RENTAL, item
+        )
+        if location["ebike"]:
+            item["extras"]["rental"] = "city_bike;ebike"
+
+        item["website"] = item["extras"]["website:nl"] = "https://blue-bike.be/locaties/#locatie={}".format(
+            location["slug"]
+        )
+        item["extras"]["website:en"] = "https://blue-bike.be/en/locations/#locatie={}".format(location["slug"])
+        item["extras"]["website:fr"] = "https://blue-bike.be/fr/emplacements/#locatie={}".format(location["slug"])
+
+        yield item


### PR DESCRIPTION
Blue-bike rebuilt its WordPress site: the locations REST route moved from `www.blue-bike.be/wp-json/v1/location` (which now redirects and then returns 404) to `blue-bike.be/wp-json/bb/v1/locations` with a renamed field schema, so recent runs produced no items.

Repointed the spider at the new endpoint and converted it to a `JSONBlobSpider`. Now also collects `branch`, the station's actual capacity (the old spider published the live bikes-available count as `capacity`), `rental=city_bike;ebike` for e-bike stations, and applies `BICYCLE_RENTAL_CARGO` to the 34 cargo-bike (`bakfiets`) stations, resolving the previous TODO for station type. Per-station `website` uses the locator's `#locatie=<slug>` deep links, as the rebuilt site no longer has per-station pages. The network has grown since the last successful runs (319 stations, was 252).

Note: the same 319 stations are also emitted by the `gbfs` spider (system `bluebike`, same `brand_wikidata`); that pre-existing overlap is unchanged by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Blue-bike location data to use the latest source, improving location coverage and accuracy.
  * Corrected location names, capacity information, and website links.
  * Excluded locations outside the supported region.
  * Improved categorization for bicycle rentals, including cargo bikes and e-bikes.
  * Added rental details for e-bike availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->