### PR TITLE
[Office Depot FR] Add spider (27 locations)

### DIFF
--- a/locations/spiders/office_depot_fr.py
+++ b/locations/spiders/office_depot_fr.py
@@ -1,8 +1,8 @@
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
-from locations.structured_data_spider import StructuredDataSpider
 from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
 
 
 class OfficeDepotFRSpider(CrawlSpider, StructuredDataSpider):

--- a/locations/spiders/office_depot_fr.py
+++ b/locations/spiders/office_depot_fr.py
@@ -1,0 +1,29 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from locations.structured_data_spider import StructuredDataSpider
+from locations.categories import Categories, apply_category
+
+
+class OfficeDepotFRSpider(CrawlSpider, StructuredDataSpider):
+    name = "office_depot_fr"
+    item_attributes = {
+        "brand": "Office Depot",
+        "brand_wikidata": "Q1337797",
+    }
+    allowed_domains = ["officedepot.fr"]
+    start_urls = ["https://officedepot.fr/nos-magasins"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"/description-magasin/magasin-office-depot-"),
+            callback="parse",
+            follow=True,
+        ),
+    ]
+
+    def post_process_item(self, item, response, ld_data):
+        apply_category(Categories.SHOP_STATIONERY, item)
+        if item.get("facebook") == "https://www.facebook.com/OfficeDepot.fr":
+            item["facebook"] = None
+        item["branch"] = item.pop("name").removeprefix("Office DEPOT ")
+        yield item


### PR DESCRIPTION
Adds a spider for the french branch of the US-american stationery brand Office Depot.

```
{'atp/brand/Office Depot': 27,
 'atp/brand_wikidata/Q1337797': 27,
 'atp/category/shop/stationery': 27,
 'atp/country/FR': 27,
 'atp/field/email/missing': 27,
 'atp/field/housenumber/missing': 27,
 'atp/field/image/dropped': 27,
 'atp/field/operator/missing': 27,
 'atp/field/operator_wikidata/missing': 27,
 'atp/field/state/missing': 27,
 'atp/field/street/missing': 27,
 'atp/field/twitter/missing': 27,
 'atp/field/unit/missing': 27,
 'atp/item_scraped_host_count/officedepot.fr': 27,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 27,
 'downloader/request_bytes': 47808,
 'downloader/request_count': 31,
 'downloader/request_method_count/GET': 31,
 'downloader/response_bytes': 1325217,
 'downloader/response_count': 31,
 'downloader/response_status_count/200': 29,
 'downloader/response_status_count/302': 1,
 'downloader/response_status_count/404': 1,
 'elapsed_time_seconds': 34.81515650078654,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 8, 13, 23, 58, 992533, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 9313732,
 'httpcompression/response_count': 29,
 'item_scraped_count': 27,
 'items_per_minute': 47.64705882352941,
 'log_count/DEBUG': 58,
 'log_count/INFO': 3,
 'memusage/max': 180125696,
 'memusage/startup': 180125696,
 'request_depth_max': 1,
 'response_received_count': 30,
 'responses_per_minute': 52.94117647058824,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 30,
 'scheduler/dequeued/memory': 30,
 'scheduler/enqueued': 30,
 'scheduler/enqueued/memory': 30,
 'start_time': datetime.datetime(2026, 9, 8, 13, 23, 24, 177198, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering Office Depot France store locations.
  * Store listings include structured details, stationery categorization, and branch names derived from store information.
  * Generic brand-level Facebook links are excluded from individual store listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->