### PR TITLE
[JD Sports IE] Fix spider

### DIFF
--- a/locations/spiders/jd_sports_ie.py
+++ b/locations/spiders/jd_sports_ie.py
@@ -1,12 +1,25 @@
+from typing import Any, Iterable
+
+from scrapy.http import Response
 from scrapy.linkextractors import LinkExtractor
 from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.playwright_spider import PlaywrightSpider
+from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.structured_data_spider import StructuredDataSpider
 
 
-class JdSportsIESpider(CrawlSpider, StructuredDataSpider):
+class JdSportsIESpider(CrawlSpider, StructuredDataSpider, PlaywrightSpider):
     name = "jd_sports_ie"
     item_attributes = {"brand": "JD Sports", "brand_wikidata": "Q6108019"}
     start_urls = ["https://www.jdsports.ie/store-locator/all-stores/"]
     rules = [Rule(LinkExtractor(allow="store-locator/", deny="-soon"), callback="parse_sd")]
-    requires_proxy = True
+    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS
+    search_for_facebook = False
+
+    def post_process_item(self, item: Feature, response: Response, ld_data: dict, **kwargs: Any) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        apply_category(Categories.SHOP_CLOTHES, item)
+        yield item


### PR DESCRIPTION
jdsports.ie now blocks the proxy transport the spider used (every request returned a ban error), so recent runs produced almost no items.

Switched the spider to the Playwright transport its other-country siblings already use, and removed the `requires_proxy` flag, which is inoperative under the Playwright settings. Also derives `branch` from the per-store name, applies an explicit clothes-shop category, and stops collecting the site-wide footer Facebook account that previously appeared on every store. 32 stores, matching the last healthy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - JD Sports Ireland store listings now support more reliable collection of dynamically rendered location information.
  - Store records use clearer branch naming and are categorized under clothing, improving consistency across listings.
  - Location data processing has been standardized to provide more complete and usable store details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->