### PR TITLE
[Kennards Storage AU NZ] Fix spiders

### DIFF
--- a/locations/spiders/kennards_self_storage_au.py
+++ b/locations/spiders/kennards_self_storage_au.py
@@ -1,5 +1,10 @@
+from typing import Any, Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -7,4 +12,19 @@ class KennardsSelfStorageAUSpider(SitemapSpider, StructuredDataSpider):
     name = "kennards_self_storage_au"
     item_attributes = {"brand": "Kennards Storage", "brand_wikidata": "Q115565997"}
     sitemap_urls = ["https://www.kss.com.au/sitemap.xml"]
-    sitemap_rules = [("locations/(.*)$", "parse_sd")]
+    sitemap_rules = [(r"/locations/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    wanted_types = ["SelfStorage"]
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def pre_process_data(self, ld_data: dict, **kwargs: Any) -> None:
+        # A described specification covers 24 hour customer access, not office hours
+        if isinstance(rules := ld_data.get("openingHoursSpecification"), list):
+            ld_data["openingHoursSpecification"] = [rule for rule in rules if not rule.get("description")]
+
+    def post_process_item(
+        self, item: Feature, response: TextResponse, ld_data: dict, **kwargs: Any
+    ) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        apply_category(Categories.SHOP_STORAGE_RENTAL, item)
+        yield item

--- a/locations/spiders/kennards_self_storage_nz.py
+++ b/locations/spiders/kennards_self_storage_nz.py
@@ -1,5 +1,10 @@
+from typing import Any, Iterable
+
+from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
+from locations.categories import Categories, apply_category
+from locations.items import Feature
 from locations.structured_data_spider import StructuredDataSpider
 
 
@@ -7,4 +12,21 @@ class KennardsSelfStorageNZSpider(SitemapSpider, StructuredDataSpider):
     name = "kennards_self_storage_nz"
     item_attributes = {"brand": "Kennards Storage", "brand_wikidata": "Q115565997"}
     sitemap_urls = ["https://www.kennards.co.nz/sitemap.xml"]
-    sitemap_rules = [("locations/(.*)$", "parse_sd")]
+    sitemap_rules = [(r"/locations/[^/]+/[^/]+/[^/]+$", "parse_sd")]
+    wanted_types = ["SelfStorage"]
+    search_for_twitter = False
+    search_for_facebook = False
+
+    def pre_process_data(self, ld_data: dict, **kwargs: Any) -> None:
+        # A described specification covers 24 hour customer access, not office hours
+        if isinstance(rules := ld_data.get("openingHoursSpecification"), list):
+            ld_data["openingHoursSpecification"] = [rule for rule in rules if not rule.get("description")]
+
+    def post_process_item(
+        self, item: Feature, response: TextResponse, ld_data: dict, **kwargs: Any
+    ) -> Iterable[Feature]:
+        item["branch"] = item.pop("name")
+        # Every location incorrectly states an Australian addressCountry
+        item["country"] = "NZ"
+        apply_category(Categories.SHOP_STORAGE_RENTAL, item)
+        yield item


### PR DESCRIPTION
Kennards replatformed both kss.com.au and kennards.co.nz; during the cutover both sites served a robots.txt that blocked their sitemaps, so recent runs produced no items. The block has since been lifted, but the rebuilt pages broke the spiders in three ways: every page now carries both a `SelfStorage` and a `LocalBusiness` ld+json block (double-yielding each location), a new always-on 24-hour-access `openingHoursSpecification` polluted office hours, and the NZ site stamps `addressCountry: AU` on every store.

Set `wanted_types` to the single `SelfStorage` type, filter the described 24-hour-access specification out of opening hours, override the incorrect country on the NZ spider, derive `branch` from the per-store name, apply an explicit storage-rental category, and stop collecting the brand-level (and malformed) Twitter/Facebook accounts. AU: 113 locations (the source sitemap now lists 113, down from 115). NZ: 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved discovery and processing of Kennards Self Storage locations in Australia and New Zealand.
  - Location listings are now more accurately classified as storage-rental facilities.
  - Listings use clearer branch naming and improved opening-hours information.
  - New Zealand listings consistently display the correct country.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->