### PR TITLE
nespresso: drop placeholder phone numbers

### DIFF
--- a/locations/spiders/nespresso.py
+++ b/locations/spiders/nespresso.py
@@ -1,3 +1,4 @@
+import re
 from typing import AsyncIterator
 
 from scrapy import Spider
@@ -12,7 +13,13 @@ class NespressoSpider(Spider):
     allowed_domains = ["nespresso.com"]
     item_attributes = {"brand": "Nespresso", "brand_wikidata": "Q301301"}
 
+    @staticmethod
+    def is_placeholder_phone(phone: str) -> bool:
+        # Nespresso's API returns the same placeholder for every French store
+        return len(re.sub(r"\D", "", phone).rstrip("0")) <= 3
+
     async def start(self) -> AsyncIterator[Request]:
+
         countries = [
             "AD",
             "AE",
@@ -98,7 +105,9 @@ class NespressoSpider(Spider):
                 "postcode": store["point_of_interest"]["address"]["postal_code"],
                 "lat": store["position"]["latitude"],
                 "lon": store["position"]["longitude"],
-                "phone": store["point_of_interest"]["phone"],
             }
+
+            if (phone := store["point_of_interest"].get("phone")) and not self.is_placeholder_phone(phone):
+                properties["phone"] = phone
 
             yield Feature(**properties)


### PR DESCRIPTION
Fixes #18173.

Nespresso's store locator API returns the same placeholder number,
`+33 6 00 00 00 00`, for every French location. Verified against all 12
stores returned for Paris, including the flagship boutiques, every one
had the identical value.

This can't be handled by `PhoneCleanUpPipeline`: `phonenumbers` treats
the number as structurally valid and reformats it rather than flagging
it, so no `atp/field/phone/invalid` is recorded. Filtering it in the
spider treats it as source-specific junk data instead.

After the change, the same run reports `atp/field/phone/missing: 12`
with `item_scraped_count` unchanged at 12; the placeholder is dropped
without losing any locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store contact information quality by excluding missing or placeholder phone numbers from Nespresso store listings.
  * Valid phone numbers continue to be included when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->