### PR TITLE
[Piggly Wiggly US] Fix spider

### DIFF
--- a/locations/spiders/piggly_wiggly_us.py
+++ b/locations/spiders/piggly_wiggly_us.py
@@ -1,25 +1,34 @@
 import json
 import re
+from typing import Any
 
-from scrapy.spiders import SitemapSpider
+from scrapy.http import Response
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
+from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
 
 
-class PigglyWigglyUSSpider(SitemapSpider):
+class PigglyWigglyUSSpider(CrawlSpider):
     name = "piggly_wiggly_us"
     item_attributes = {"brand": "Piggly Wiggly", "brand_wikidata": "Q3388303"}
-    sitemap_urls = ["https://www.pigglywiggly.com/wp-sitemap-posts-page-1.xml"]
-    sitemap_rules = [(r"/store-locations/.+/", "parse")]
+    start_urls = ["https://www.pigglywiggly.com/store-locations/"]
+    rules = [
+        Rule(
+            LinkExtractor(allow=r"^https://www\.pigglywiggly\.com/store-locations/[^/]+/$"),
+            callback="parse_state",
+        )
+    ]
 
-    def parse(self, response, **kwargs):
+    def parse_state(self, response: Response, **kwargs: Any) -> Any:
         locations = json.loads(re.search(r"locations = (\[?{.+}\]?);", response.text).group(1))
         if isinstance(locations, dict):
             locations = locations.values()
 
         for location in locations:
             item = DictParser.parse(location)
-            item["ref"] = location["storeNumber"]
-            item["website"] = item.pop("email")
             item["name"] = None
+            item.pop("email")
+            apply_category(Categories.SHOP_SUPERMARKET, item)
             yield item


### PR DESCRIPTION
The WordPress sitemap the spider crawled from now returns 404, so recent runs produced no items.

Rewrote the spider as a `CrawlSpider` over the 17 per-state store-location pages, parsing the embedded locations blob each page carries. `ref` now uses the source's unique `storeID` rather than `storeNumber`, which collides on several values and previously suppressed stores from the output. The source's `email` field, which holds a regional franchise-group URL shared across many stores, is no longer emitted as a per-store `website`. Applies an explicit supermarket category. 488 stores, up from 474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection of Piggly Wiggly store locations by following state-specific location pages.
  * Updated supermarket listings with the appropriate supermarket category.
  * Refined captured store details by excluding unsupported reference and website values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->