### PR TITLE
[PFG FR] Add spider (942 locations)

### DIFF
--- a/locations/spiders/pfg_fr.py
+++ b/locations/spiders/pfg_fr.py
@@ -35,6 +35,7 @@ class PfgFRSpider(SitemapSpider, StructuredDataSpider):
 
         # address.addressLocality/addressRegion are lowercase, unaccented slugs; the breadcrumb has clean names.
         item.pop("state", None)
+        item.pop("city", None)
         if breadcrumbs := LinkedDataParser.find_linked_data(response, "BreadcrumbList"):
             for crumb in breadcrumbs.get("itemListElement", []):
                 if crumb.get("position") == 3:

--- a/locations/spiders/pfg_fr.py
+++ b/locations/spiders/pfg_fr.py
@@ -1,0 +1,51 @@
+import re
+
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.linked_data_parser import LinkedDataParser
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class PfgFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "pfg_fr"
+    item_attributes = {"brand": "PFG", "brand_wikidata": "Q3396087", "name": "PFG"}
+    sitemap_urls = ["https://www.pfg.fr/sitemap/agency.xml"]
+    # Sitemap also lists department/city listing pages; this keeps only individual agency pages.
+    sitemap_rules = [(r"/agence-pompes-funebres-pfg-[\w-]+-(\d+)$", "parse")]
+    # robots.txt is DataDome-blocked and fetched before spider code can attach zyte_api meta.
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    # twitter:site is the brand's own handle, identical on every page, not a per-location value.
+    search_for_twitter = False
+
+    def _parse_sitemap(self, response):
+        # httpResponseHeaders is required too, or scrapy-zyte-api returns a binary response with no .selector.
+        for request in super()._parse_sitemap(response):
+            request.meta["zyte_api"] = {"httpResponseBody": True, "httpResponseHeaders": True, "geolocation": "FR"}
+            yield request
+
+    async def start(self):
+        async for request in super().start():
+            request.meta["zyte_api"] = {"httpResponseBody": True, "httpResponseHeaders": True, "geolocation": "FR"}
+            yield request
+
+    def post_process_item(self, item: Feature, response, ld_data: dict, **kwargs):
+        apply_category(Categories.SHOP_FUNERAL_DIRECTORS, item)
+
+        # address.addressLocality/addressRegion are lowercase, unaccented slugs; the breadcrumb has clean names.
+        item.pop("state", None)
+        if breadcrumbs := LinkedDataParser.find_linked_data(response, "BreadcrumbList"):
+            for crumb in breadcrumbs.get("itemListElement", []):
+                if crumb.get("position") == 3:
+                    item["state"] = re.sub(r"\s*\(\d+\)$", "", crumb["name"])
+                elif crumb.get("position") == 4:
+                    item["city"] = item["branch"] = crumb["name"]
+
+        # JSON-LD "name" format is inconsistent across pages; branch (above) is the reliable one.
+        item["name"] = None
+
+        if item.get("street_address"):
+            item["street_address"] = " ".join(item["street_address"].split())
+
+        yield item


### PR DESCRIPTION
Adds a spider for PFG (Pompes Funèbres Générales, brand of OGF), a French funeral services
chain — closes #17951.

pfg.fr sits fully behind DataDome (confirmed on robots.txt, the store finder, and individual
agency pages). Zyte's httpResponseBody automap gets through cleanly with no browserHtml or
requires_proxy needed, so the spider crawls sitemap/agency.xml via SitemapSpider and parses
each agency's schema.org/Store JSON-LD via StructuredDataSpider. The sitemap mixes 942
individual agency pages with ~4000 department/city listing pages sharing a similar URL shape;
sitemap_rules filters to only the former.

Each page carries name, address, phone, coordinates, and opening hours directly in JSON-LD.
addr:city/addr:state/branch come from the page's breadcrumb rather than the JSON-LD address
block, since the latter's addressLocality/addressRegion are lowercase, unaccented slugs.
Verified locally on a ~160-location sample (cache-backed dev run): 100% Zyte success rate, 0
duplicate refs, correct category (shop=funeral_directors) and brand (Q3396087) via a perfect
NSI match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage for PFG funeral-home agency locations in France.
  * Agency details are collected from official PFG location listings, including standardized addresses, cities, regions, and branch information.
  * Listings are categorized as funeral directors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->