### PR TITLE
[TUI FR] Add spider (230 locations)

### DIFF
--- a/locations/spiders/tui_fr.py
+++ b/locations/spiders/tui_fr.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
@@ -18,7 +19,15 @@ class TuiFRSpider(SitemapSpider, StructuredDataSpider):
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         if item.get("facebook") == "https://www.facebook.com/TUIFrance/":
             item["facebook"] = None
-        item["branch"] = item.pop("name").removeprefix("Agence de voyage TUI Store ").removeprefix("TUI STORE ").removeprefix("TUI STORE ").removeprefix("Agence adhérente TUI ").removeprefix("TUI Store ").removeprefix("Agence de voyage TUI STORE ")
-        
+        item["branch"] = (
+            item.pop("name")
+            .removeprefix("Agence de voyage TUI Store ")
+            .removeprefix("TUI STORE ")
+            .removeprefix("TUI STORE ")
+            .removeprefix("Agence adhérente TUI ")
+            .removeprefix("TUI Store ")
+            .removeprefix("Agence de voyage TUI STORE ")
+        )
+
         apply_category(Categories.SHOP_TRAVEL_AGENCY, item)
         yield item

--- a/locations/spiders/tui_fr.py
+++ b/locations/spiders/tui_fr.py
@@ -1,0 +1,24 @@
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class TuiFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "tui_fr"
+    item_attributes = {"brand": "TUI", "brand_wikidata": "Q573103"}
+    sitemap_urls = ["https://agences-de-voyages.tui.fr/sitemap.xml"]
+    sitemap_rules = [(r"https://agences-de-voyages.tui.fr/.*\d$", "parse_sd")]
+    wanted_types = ["TravelAgency"]
+    drop_attributes = {"image", "twitter"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item.get("facebook") == "https://www.facebook.com/TUIFrance/":
+            item["facebook"] = None
+        item["branch"] = item.pop("name").removeprefix("Agence de voyage TUI Store ").removeprefix("TUI STORE ").removeprefix("TUI STORE ").removeprefix("Agence adhérente TUI ").removeprefix("TUI Store ").removeprefix("Agence de voyage TUI STORE ")
+        
+        apply_category(Categories.SHOP_TRAVEL_AGENCY, item)
+        yield item


### PR DESCRIPTION
Adds a spider for the stores of TUI in France.
An email is available on their website but is hidden in the code, I couldn't retrieve it.

```
{'atp/brand/TUI': 230,
 'atp/brand_wikidata/Q573103': 230,
 'atp/category/shop/travel_agency': 230,
 'atp/country/FR': 230,
 'atp/field/email/missing': 220,
 'atp/field/housenumber/missing': 230,
 'atp/field/opening_hours/missing': 3,
 'atp/field/operator/missing': 230,
 'atp/field/operator_wikidata/missing': 230,
 'atp/field/state/missing': 230,
 'atp/field/street/missing': 230,
 'atp/field/twitter/missing': 230,
 'atp/field/unit/missing': 230,
 'atp/item_scraped_host_count/agences-de-voyages.tui.fr': 230,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 230,
 'downloader/request_bytes': 101924,
 'downloader/request_count': 232,
 'downloader/request_method_count/GET': 232,
 'downloader/response_bytes': 6572533,
 'downloader/response_count': 232,
 'downloader/response_status_count/200': 232,
 'elapsed_time_seconds': 278.7102262508124,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 8, 22, 34, 14, 384918, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 39483043,
 'httpcompression/response_count': 232,
 'item_scraped_count': 230,
 'items_per_minute': 49.640287769784166,
 'log_count/DEBUG': 462,
 'log_count/INFO': 7,
 'memusage/max': 431783936,
 'memusage/startup': 180764672,
 'request_depth_max': 1,
 'response_received_count': 232,
 'responses_per_minute': 50.07194244604316,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 231,
 'scheduler/dequeued/memory': 231,
 'scheduler/enqueued': 231,
 'scheduler/enqueued/memory': 231,
 'start_time': datetime.datetime(2026, 9, 8, 22, 29, 35, 671283, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for collecting TUI France travel agency locations from tui.fr.
  - Agency listings now include standardized agency and branch names, normalized Facebook information, and the appropriate travel agency category.
  - This expands available location data for TUI France agencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->