### PR TITLE
[Isuzu JP] update to use Mapion storefinder, convert locations to WGS84

### DIFF
--- a/locations/spiders/isuzu_jp.py
+++ b/locations/spiders/isuzu_jp.py
@@ -10,6 +10,7 @@ from locations.storefinders.mapion import MapionSpider
 ISUZU_SHARED_ATTRIBUTES = {"brand": "Isuzu", "brand_wikidata": "Q29803"}
 TOKYO_TO_WGS84 = Transformer.from_pipeline("EPSG:15484")
 
+
 class IsuzuJPSpider(MapionSpider):
     name = "isuzu_jp"
     item_attributes = ISUZU_SHARED_ATTRIBUTES

--- a/locations/spiders/isuzu_jp.py
+++ b/locations/spiders/isuzu_jp.py
@@ -1,55 +1,35 @@
-import re
 from typing import Iterable
 
-from scrapy.http import Request, Response
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-from unidecode import unidecode
+from pyproj import Transformer
+from scrapy.http import Response
 
 from locations.categories import Categories, apply_category
 from locations.items import Feature
+from locations.storefinders.mapion import MapionSpider
 
 ISUZU_SHARED_ATTRIBUTES = {"brand": "Isuzu", "brand_wikidata": "Q29803"}
+TOKYO_TO_WGS84 = Transformer.from_pipeline("EPSG:15484")
 
-
-class IsuzuJPSpider(CrawlSpider):
+class IsuzuJPSpider(MapionSpider):
     name = "isuzu_jp"
     item_attributes = ISUZU_SHARED_ATTRIBUTES
     allowed_domains = ["sasp.mapion.co.jp"]
-    start_urls = ["https://sasp.mapion.co.jp/b/isuzu_shop/attr/?t=attr_con&x=63&y=18"]
-    rules = [
-        Rule(
-            LinkExtractor(allow=r"\/b\/isuzu_shop\/attr\/\?start=\d+", restrict_xpaths='//a[@id="m_nextpage_link"]'),
-            callback="parse",
-            follow=True,
-        )
-    ]
+    feature_url_template = "https://sasp.mapion.co.jp/b/isuzu_shop/attr/?t=attr_con&start={}"
 
-    def parse(self, response: Response) -> Iterable[Request]:
-        for dealer in response.xpath('//tr[@class="MapiInfoGenre"]'):
-            properties = {
-                "ref": dealer.xpath("./td[2]/a/@href").get().split("/")[-2],
-                "name": dealer.xpath("./td[2]/a/text()").get(),
-                "lat": dealer.xpath("./td[1]/a/@href").get().split("/isuzu_shop/", 1)[1].split("_", 1)[0],
-                "lon": dealer.xpath("./td[1]/a/@href")
-                .get()
-                .split("/isuzu_shop/", 1)[1]
-                .split("_", 1)[1]
-                .split("_", 1)[0],
-                "addr_full": dealer.xpath("./td[3]/text()").get(),
-                "website": "https://" + self.allowed_domains[0] + dealer.xpath("./td[2]/a/@href").get(),
-            }
-            apply_category(Categories.SHOP_TRUCK, properties)
-            yield Request(url=properties["website"], meta={"properties": properties}, callback=self.parse_phone_number)
+    def post_process_item(self, item: Feature, data: dict, response: Response) -> Iterable[Feature]:
+        lat = data.get("latitude")
+        lon = data.get("longitude")
+        wgs84_lat, wgs84_lon = TOKYO_TO_WGS84.transform(lat, lon)
+        item["lat"] = wgs84_lat
+        item["lon"] = wgs84_lon
+        item["name"] = None
+        if branch := data.get("name"):
+            item["branch"] = branch
+        if phone := data.get("office_tel"):
+            item["phone"] = phone
+        if fax := data.get("office_fax"):
+            item["extras"]["fax"] = fax
 
-    def parse_phone_number(self, response: Response) -> Iterable[Feature]:
-        properties = response.meta["properties"]
+        apply_category(Categories.SHOP_TRUCK, item)
 
-        # The first phone number like number listed should be the location's
-        # primary phone number and not it's fax number, or separate number for
-        # a service department adjoining the primary sales department.
-        extra_data = unidecode(" ".join(response.xpath('//ul[@class="MapiInfoShopData"]/li/text()').getall()))
-        if m := re.search(r"\W(\d{2,4}-\d{2,4}-\d{2,4})\W", extra_data):
-            properties["phone"] = m.group(1)
-
-        yield Feature(**properties)
+        yield item


### PR DESCRIPTION
This converts to use the Mapion storefinder, and the locations were wrong in the original spider so this update re-projects them from Tokyo Datum.

{'atp/brand/Isuzu': 280,
 'atp/brand_wikidata/Q29803': 280,
 'atp/category/shop/truck': 280,
 'atp/country/JP': 280,
 'atp/field/country/from_spider_name': 280,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 277,
 'atp/field/housenumber/missing': 280,
 'atp/field/name/missing': 280,
 'atp/field/opening_hours/missing': 280,
 'atp/field/operator/missing': 280,
 'atp/field/operator_wikidata/missing': 280,
 'atp/field/phone/invalid': 1,
 'atp/field/phone/missing': 13,
 'atp/field/state/missing': 280,
 'atp/field/street/missing': 280,
 'atp/field/street_address/missing': 280,
 'atp/field/twitter/missing': 280,
 'atp/field/unit/missing': 280,
 'atp/item_scraped_host_count/sasp.mapion.co.jp': 280,
 'atp/lineage': 'S_?',
 'atp/nsi/category_unknown': 280,
 'atp/nsi/match_failed': 280,
 'downloader/request_bytes': 126102,
 'downloader/request_count': 292,
 'downloader/request_method_count/GET': 292,
 'downloader/response_bytes': 4984814,
 'downloader/response_count': 292,
 'downloader/response_status_count/200': 290,
 'downloader/response_status_count/404': 2,
 'elapsed_time_seconds': 355.67199999999957,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 9, 12, 3, 23, 871498, tzinfo=datetime.timezone.utc),
 'httperror/response_ignored_count': 1,
 'httperror/response_ignored_status_count/404': 1,
 'item_scraped_count': 280,
 'items_per_minute': 47.32394366197183,
 'log_count/DEBUG': 572,
 'log_count/INFO': 9,
 'request_depth_max': 10,
 'response_received_count': 292,
 'responses_per_minute': 49.352112676056336,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/404': 1,
 'scheduler/dequeued': 291,
 'scheduler/dequeued/memory': 291,
 'scheduler/enqueued': 291,
 'scheduler/enqueued/memory': 291,
 'start_time': datetime.datetime(2026, 9, 9, 11, 57, 28, 213690, tzinfo=datetime.timezone.utc)}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Isuzu Japan locations now use Mapion-supplied data for improved location processing.
  * Location coordinates are converted for accurate map positioning.
  * Branch, phone, and fax details are processed and displayed consistently.
  * Isuzu locations are categorized as truck shops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->