### PR TITLE
[Skiset] Add spider (551 locations)

### DIFF
--- a/locations/spiders/skiset.py
+++ b/locations/spiders/skiset.py
@@ -1,0 +1,36 @@
+import json
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class SkisetSpider(SitemapSpider, StructuredDataSpider):
+    name = "skiset"
+    item_attributes = {"brand": "Skiset", "brand_wikidata": "Q48747223"}
+    sitemap_urls = ["https://www.skiset.com/sitemap.xml"]
+    sitemap_rules = [(r"https://www\.skiset\.com/.*/magasins/.*", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item.get("facebook") == "https://www.facebook.com/skiset.france/":
+            item["facebook"] = None
+        item["branch"] = item.pop("name").removeprefix("Skiset ")
+        
+        if (idx := response.text.find("window.appConfig=")) != -1:
+            start = idx + len("window.appConfig=")
+            try:
+                config, _ = json.JSONDecoder().raw_decode(response.text[start:])
+                geo = config.get("shop", {}).get("map", {})
+                if geo.get("lat") is not None and geo.get("lng") is not None:
+                    item["lat"] = geo["lat"]
+                    item["lon"] = geo["lng"]
+            except (json.JSONDecodeError, AttributeError):
+                pass
+        
+        apply_category(Categories.SHOP_SPORTS, item)
+        yield item

--- a/locations/spiders/skiset.py
+++ b/locations/spiders/skiset.py
@@ -1,5 +1,6 @@
 import json
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
@@ -20,7 +21,7 @@ class SkisetSpider(SitemapSpider, StructuredDataSpider):
         if item.get("facebook") == "https://www.facebook.com/skiset.france/":
             item["facebook"] = None
         item["branch"] = item.pop("name").removeprefix("Skiset ")
-        
+
         if (idx := response.text.find("window.appConfig=")) != -1:
             start = idx + len("window.appConfig=")
             try:
@@ -31,6 +32,6 @@ class SkisetSpider(SitemapSpider, StructuredDataSpider):
                     item["lon"] = geo["lng"]
             except (json.JSONDecodeError, AttributeError):
                 pass
-        
+
         apply_category(Categories.SHOP_SPORTS, item)
         yield item

--- a/locations/spiders/skiset.py
+++ b/locations/spiders/skiset.py
@@ -15,11 +15,9 @@ class SkisetSpider(SitemapSpider, StructuredDataSpider):
     sitemap_urls = ["https://www.skiset.com/sitemap.xml"]
     sitemap_rules = [(r"https://www\.skiset\.com/.*/magasins/.*", "parse_sd")]
     wanted_types = ["LocalBusiness"]
-    drop_attributes = {"image"}
+    drop_attributes = {"image", "facebook"}
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
-        if item.get("facebook") == "https://www.facebook.com/skiset.france/":
-            item["facebook"] = None
         item["branch"] = item.pop("name").removeprefix("Skiset ")
 
         if (idx := response.text.find("window.appConfig=")) != -1:


### PR DESCRIPTION
Adds a spider for the ski rental company Skiset.

```
{'atp/brand/Skiset': 551,
 'atp/brand_wikidata/Q48747223': 551,
 'atp/category/shop/sports': 551,
 'atp/country/AD': 11,
 'atp/country/AT': 92,
 'atp/country/BG': 3,
 'atp/country/CH': 30,
 'atp/country/DE': 4,
 'atp/country/ES': 27,
 'atp/country/FR': 293,
 'atp/country/IT': 83,
 'atp/country/SI': 1,
 'atp/country/XK': 1,
 'atp/field/city/missing': 1,
 'atp/field/country/from_reverse_geocoding': 545,
 'atp/field/country/missing': 6,
 'atp/field/email/missing': 550,
 'atp/field/geometry/missing': 6,
 'atp/field/housenumber/missing': 551,
 'atp/field/name/missing': 551,
 'atp/field/operator/missing': 551,
 'atp/field/operator_wikidata/missing': 551,
 'atp/field/postcode/missing': 13,
 'atp/field/state/missing': 6,
 'atp/field/street/missing': 551,
 'atp/field/street_address/missing': 5,
 'atp/field/twitter/missing': 551,
 'atp/field/unit/missing': 551,
 'atp/item_scraped_host_count/www.skiset.com': 551,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_unknown': 551,
 'atp/nsi/country_missing': 7,
 'atp/nsi/match_failed': 551,
 'downloader/exception_count': 3,
 'downloader/exception_type_count/scrapy.exceptions.DownloadTimeoutError': 3,
 'downloader/request_bytes': 258466,
 'downloader/request_count': 556,
 'downloader/request_method_count/GET': 556,
 'downloader/response_bytes': 6961007,
 'downloader/response_count': 553,
 'downloader/response_status_count/200': 553,
 'elapsed_time_seconds': 688.6881497520953,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 9, 18, 26, 39, 985354, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 24924279,
 'httpcompression/response_count': 552,
 'item_scraped_count': 551,
 'items_per_minute': 48.05232558139535,
 'log_count/DEBUG': 1107,
 'log_count/INFO': 14,
 'memusage/max': 465502208,
 'memusage/startup': 182173696,
 'request_depth_max': 1,
 'response_received_count': 553,
 'responses_per_minute': 48.22674418604651,
 'retry/count': 3,
 'retry/reason_count/scrapy.exceptions.DownloadTimeoutError': 3,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 555,
 'scheduler/dequeued/memory': 555,
 'scheduler/enqueued': 555,
 'scheduler/enqueued/memory': 555,
 'start_time': datetime.datetime(2026, 9, 9, 18, 15, 11, 292135, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Skiset shop locations to the available location data.
  - Listings include Skiset branding, sports-shop categorization, branch names, and geographic coordinates.
  - Shop details are sourced from Skiset location pages and standardized for consistent display.
  - Location records now provide more complete branch information, helping users identify and distinguish individual Skiset shops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->