### PR TITLE
[Würth FR] Add spider (249 locations)

### DIFF
--- a/locations/spiders/wurth_fr.py
+++ b/locations/spiders/wurth_fr.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 

--- a/locations/spiders/wurth_fr.py
+++ b/locations/spiders/wurth_fr.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class WurthFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "wurth_fr"
+    item_attributes = {"brand": "Würth", "brand_wikidata": "Q679750"}
+    sitemap_urls = ["https://magasins.wurth.fr/locationsitemap1.xml"]
+    sitemap_rules = [(r"https://magasins.wurth.fr/.*", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image", "facebook", "twitter"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        item["branch"] = item.pop("name").removeprefix("Würth ")
+        apply_category(Categories.SHOP_HARDWARE, item)
+        yield item


### PR DESCRIPTION
```
{'atp/brand/Würth': 249,
 'atp/brand_wikidata/Q679750': 249,
 'atp/category/shop/hardware': 249,
 'atp/cdn/cloudflare/response_count': 251,
 'atp/cdn/cloudflare/response_status_count/200': 251,
 'atp/country/FR': 249,
 'atp/field/email/missing': 249,
 'atp/field/housenumber/missing': 249,
 'atp/field/operator/missing': 249,
 'atp/field/operator_wikidata/missing': 249,
 'atp/field/state/missing': 249,
 'atp/field/street/missing': 249,
 'atp/field/twitter/missing': 249,
 'atp/field/unit/missing': 249,
 'atp/item_scraped_host_count/magasins.wurth.fr': 249,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 249,
 'downloader/request_bytes': 136637,
 'downloader/request_count': 251,
 'downloader/request_method_count/GET': 251,
 'downloader/response_bytes': 11271814,
 'downloader/response_count': 251,
 'downloader/response_status_count/200': 251,
 'elapsed_time_seconds': 301.7905121240765,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 9, 19, 16, 57, 612665, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 77691437,
 'httpcompression/response_count': 251,
 'item_scraped_count': 249,
 'items_per_minute': 49.63455149501661,
 'log_count/DEBUG': 500,
 'log_count/INFO': 8,
 'memusage/max': 424673280,
 'memusage/startup': 181108736,
 'request_depth_max': 1,
 'response_received_count': 251,
 'responses_per_minute': 50.033222591362126,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 250,
 'scheduler/dequeued/memory': 250,
 'scheduler/enqueued': 250,
 'scheduler/enqueued/memory': 250,
 'start_time': datetime.datetime(2026, 9, 9, 19, 11, 55, 797108, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Würth France branch locations.
  * Branch listings now include standardized business details, branch names, and hardware-shop categorization.
  * Location data is sourced from Würth France’s structured sitemap information.
  * Improved consistency of Würth France location records for browsing and discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->