### PR TITLE
[Radisson Hotels] Fix Spider

### DIFF
--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -29,6 +29,7 @@ class RadissonHotelsSpider(Spider):
         "USER_AGENT": BROWSER_DEFAULT,
         "ROBOTSTXT_OBEY": False,
     }
+    requires_proxy = True
 
     async def start(self) -> AsyncIterator[JsonRequest]:
         yield JsonRequest(

--- a/locations/spiders/radisson_hotels.py
+++ b/locations/spiders/radisson_hotels.py
@@ -1,15 +1,14 @@
 from typing import Any, AsyncIterator
 
+from scrapy import Spider
 from scrapy.http import JsonRequest, Response
 
 from locations.categories import Categories, apply_category
 from locations.dict_parser import DictParser
-from locations.playwright_spider import PlaywrightSpider
-from locations.settings import DEFAULT_PLAYWRIGHT_SETTINGS
 from locations.user_agents import BROWSER_DEFAULT
 
 
-class RadissonHotelsSpider(PlaywrightSpider):
+class RadissonHotelsSpider(Spider):
     name = "radisson_hotels"
     allowed_domains = ["www.radissonhotels.com"]
     brand_mapping = {
@@ -26,10 +25,9 @@ class RadissonHotelsSpider(PlaywrightSpider):
         "ri": ["Radisson Individuals", None],
         "pis": ["Park Inn & Suites by Radisson", None],
     }
-    custom_settings = DEFAULT_PLAYWRIGHT_SETTINGS | {
+    custom_settings = {
         "USER_AGENT": BROWSER_DEFAULT,
         "ROBOTSTXT_OBEY": False,
-        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 300 * 1000,
     }
 
     async def start(self) -> AsyncIterator[JsonRequest]:


### PR DESCRIPTION
```python
{'atp/brand/Art’otel': 7,
 'atp/brand/Country Inn & Suites by Radisson': 9,
 'atp/brand/Park Inn': 94,
 'atp/brand/Park Inn & Suites by Radisson': 4,
 'atp/brand/Park Plaza': 38,
 'atp/brand/Prizeotel': 20,
 'atp/brand/Radisson': 148,
 'atp/brand/Radisson Blu': 333,
 'atp/brand/Radisson Collection': 46,
 'atp/brand/Radisson Individuals': 106,
 'atp/brand/Radisson RED': 34,
 'atp/brand_wikidata/Q14516231': 7,
 'atp/brand_wikidata/Q1751979': 148,
 'atp/brand_wikidata/Q2052550': 38,
 'atp/brand_wikidata/Q28233721': 34,
 'atp/brand_wikidata/Q5177332': 9,
 'atp/brand_wikidata/Q60711675': 94,
 'atp/brand_wikidata/Q60716706': 46,
 'atp/brand_wikidata/Q7281341': 333,
 'atp/category/tourism/hotel': 860,
 'atp/clean_strings/email': 26,
 'atp/clean_strings/phone': 28,
 'atp/clean_strings/postcode': 29,
 'atp/clean_strings/street_address': 25,
 'atp/country/AE': 16,
 'atp/country/AL': 1,
 'atp/country/AM': 2,
 'atp/country/AT': 12,
 'atp/country/AU': 2,
 'atp/country/AZ': 1,
 'atp/country/BD': 2,
 'atp/country/BE': 16,
 'atp/country/BG': 2,
 'atp/country/BH': 2,
 'atp/country/BN': 1,
 'atp/country/CG': 1,
 'atp/country/CH': 9,
 'atp/country/CI': 1,
 'atp/country/CN': 58,
 'atp/country/CY': 2,
 'atp/country/CZ': 1,
 'atp/country/DE': 59,
 'atp/country/DK': 8,
 'atp/country/EE': 5,
 'atp/country/EG': 4,
 'atp/country/ES': 12,
 'atp/country/ET': 1,
 'atp/country/FI': 9,
 'atp/country/FJ': 1,
 'atp/country/FR': 25,
 'atp/country/GA': 2,
 'atp/country/GB': 66,
 'atp/country/GE': 6,
 'atp/country/GN': 1,
 'atp/country/GR': 8,
 'atp/country/HR': 7,
 'atp/country/HU': 8,
 'atp/country/ID': 3,
 'atp/country/IE': 8,
 'atp/country/IN': 144,
 'atp/country/IQ': 2,
 'atp/country/IS': 3,
 'atp/country/IT': 17,
 'atp/country/JO': 1,
 'atp/country/KE': 3,
 'atp/country/KW': 2,
 'atp/country/KZ': 4,
 'atp/country/LA': 1,
 'atp/country/LB': 2,
 'atp/country/LK': 5,
 'atp/country/LT': 4,
 'atp/country/LU': 1,
 'atp/country/LV': 7,
 'atp/country/LY': 1,
 'atp/country/MA': 10,
 'atp/country/MD': 1,
 'atp/country/ME': 1,
 'atp/country/MG': 3,
 'atp/country/ML': 2,
 'atp/country/MT': 3,
 'atp/country/MU': 3,
 'atp/country/MV': 1,
 'atp/country/MY': 2,
 'atp/country/MZ': 1,
 'atp/country/NE': 1,
 'atp/country/NG': 4,
 'atp/country/NL': 11,
 'atp/country/NO': 24,
 'atp/country/NP': 1,
 'atp/country/NZ': 1,
 'atp/country/OM': 7,
 'atp/country/PH': 8,
 'atp/country/PK': 2,
 'atp/country/PL': 20,
 'atp/country/PT': 2,
 'atp/country/QA': 1,
 'atp/country/RE': 1,
 'atp/country/RO': 8,
 'atp/country/RS': 4,
 'atp/country/RU': 38,
 'atp/country/RW': 2,
 'atp/country/SA': 33,
 'atp/country/SE': 10,
 'atp/country/SI': 1,
 'atp/country/SK': 2,
 'atp/country/SL': 1,
 'atp/country/SN': 2,
 'atp/country/SS': 1,
 'atp/country/TD': 1,
 'atp/country/TH': 12,
 'atp/country/TN': 4,
 'atp/country/TR': 41,
 'atp/country/UA': 5,
 'atp/country/UZ': 2,
 'atp/country/VN': 8,
 'atp/country/ZA': 14,
 'atp/country/ZM': 2,
 'atp/field/branch/missing': 860,
 'atp/field/brand/missing': 21,
 'atp/field/brand_wikidata/missing': 151,
 'atp/field/email/invalid': 1,
 'atp/field/email/missing': 5,
 'atp/field/housenumber/missing': 860,
 'atp/field/opening_hours/missing': 860,
 'atp/field/operator/missing': 860,
 'atp/field/operator_wikidata/missing': 860,
 'atp/field/phone/invalid': 2,
 'atp/field/phone/missing': 7,
 'atp/field/postcode/missing': 48,
 'atp/field/state/missing': 857,
 'atp/field/street/missing': 860,
 'atp/field/twitter/missing': 860,
 'atp/field/unit/missing': 860,
 'atp/item_scraped_host_count/www.radissonhotels.com': 860,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 151,
 'atp/nsi/location_unknown': 2,
 'atp/nsi/match_failed': 153,
 'atp/nsi/match_perfect': 707,
 'atp/radisson_hotels/unknown_brand/Golden Tulip': 2,
 'atp/radisson_hotels/unknown_brand/J.': 1,
 'atp/radisson_hotels/unknown_brand/Jin Jiang': 15,
 'atp/radisson_hotels/unknown_brand/Kunlun': 3,
 'downloader/request_bytes': 313,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 438795,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 3.7029999999999745,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 10, 5, 8, 47, 805886, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 3162936,
 'httpcompression/response_count': 1,
 'item_scraped_count': 860,
 'items_per_minute': 17200.0,
 'log_count/DEBUG': 861,
 'log_count/INFO': 3,
 'log_count/WARNING': 1,
 'response_received_count': 1,
 'responses_per_minute': 20.0,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2026, 9, 10, 5, 8, 44, 108538, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the Radisson Hotels data collection process to use a standard crawling workflow.
  * Removed browser-based navigation configuration and related timeout settings.
  * Configured the collection process to use a proxy when accessing Radisson Hotels content, supporting more consistent data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->