### PR TITLE
[Kuroneko Yamato JP] update to stop crawling convenience stores and parcel lockers, convert Tokyo Datum coordinates to WGS84

### DIFF
--- a/locations/spiders/kuroneko_jp.py
+++ b/locations/spiders/kuroneko_jp.py
@@ -61,7 +61,7 @@ class KuronekoJPSpider(Spider):
         if rec_count >= hit_count:
             yield self.make_request(lat, lon, offset + rec_count)
         for row in reader:
-            if row[3] in ("001", "002"):  # skip FamilyMart, 7-11
+            if row[3] in ("001", "002", "101", "171", "418", "436"):  # skip convenience stores
                 continue
             item = Feature()
             item["ref"] = row[0]

--- a/locations/spiders/kuroneko_jp.py
+++ b/locations/spiders/kuroneko_jp.py
@@ -3,6 +3,7 @@ import re
 from io import StringIO
 
 from chompjs import parse_js_object
+from pyproj import Transformer
 from scrapy import Request, Spider
 
 from locations.categories import Categories, apply_category
@@ -19,6 +20,7 @@ BRANDS = {
     "YTC": ("ヤマト運輸", "Q6584353"),
 }
 MAX_ITEMS = 1640  # determined experimentally
+TOKYO_TO_WGS84 = Transformer.from_pipeline("EPSG:15484")
 RADIUS_KM = 24
 MAP_ID = "yamato01"  # for storefinder
 
@@ -59,13 +61,16 @@ class KuronekoJPSpider(Spider):
         if rec_count >= hit_count:
             yield self.make_request(lat, lon, offset + rec_count)
         for row in reader:
-            if row[3] == "001":  # skip FamilyMart
+            if row[3] in ("001", "002"):  # skip FamilyMart, 7-11
                 continue
             item = Feature()
             item["ref"] = row[0]
             item["website"] = f"https://www.e-map.ne.jp/p/{MAP_ID}/dtl/{row[0]}/"
-            item["lat"] = row[1]
-            item["lon"] = row[2]
+            lat = float(row[1])
+            lon = float(row[2])
+            wgs84_lat, wgs84_lon = TOKYO_TO_WGS84.transform(lat, lon)
+            item["lat"] = wgs84_lat
+            item["lon"] = wgs84_lon
             if row[3] == "YTC":
                 apply_category(Categories.POST_OFFICE, item)
                 item["branch"] = row[6]


### PR DESCRIPTION
There is now a PR #18610 for Seven-Eleven JP, so this doesn't need to scrape those anymore. Other convenience store chains previously scraped by this spider are also able to be scraped with their own storefinders. Also, same fix as other Area Marker spiders with converting Tokyo Datum to WGS84.

also stops parcel lockers, those are covered by pudo_jp

Todo:

- [x] remove all convenience stores.
- [x] skip Tsuruha Drug stores.
- [x] figure out if there's a way to request only the data we want
- [x] remove extra scraping steps

{'atp/brand/ヤマト運輸': 4477,
 'atp/brand_wikidata/Q6584353': 4477,
 'atp/category/amenity/post_office': 4477,
 'atp/category/amenity/yes': 677,
 'atp/country/JP': 5154,
 'atp/duplicate_count': 13455,
 'atp/field/branch/missing': 677,
 'atp/field/brand/missing': 677,
 'atp/field/brand_wikidata/missing': 677,
 'atp/field/city/missing': 5154,
 'atp/field/country/from_spider_name': 5154,
 'atp/field/email/missing': 5154,
 'atp/field/housenumber/missing': 5154,
 'atp/field/opening_hours/missing': 4885,
 'atp/field/operator/missing': 5154,
 'atp/field/operator_wikidata/missing': 5154,
 'atp/field/phone/invalid': 2,
 'atp/field/postcode/missing': 5154,
 'atp/field/state/missing': 5154,
 'atp/field/street/missing': 5154,
 'atp/field/street_address/missing': 5154,
 'atp/field/twitter/missing': 5154,
 'atp/field/unit/missing': 5154,
 'atp/item_scraped_host_count/[www.e-map.ne.jp](http://www.e-map.ne.jp/)': 18609,
 'atp/lineage': 'S_?',
 'atp/nsi/brand_or_operator_missing': 677,
 'atp/nsi/category_unknown': 4477,
 'atp/nsi/match_failed': 5154,
 'downloader/request_bytes': 4977139,
 'downloader/request_count': 3074,
 'downloader/request_method_count/GET': 3074,
 'downloader/response_bytes': 7987054,
 'downloader/response_count': 3074,
 'downloader/response_status_count/200': 3074,
 'dupefilter/filtered': 1045,
 'elapsed_time_seconds': 3753.9210000000003,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 14, 10, 29, 23, 168646, tzinfo=datetime.timezone.utc),
 'item_dropped_count': 13455,
 'item_dropped_reasons_count/DropItem': 13455,
 'item_scraped_count': 5154,
 'items_per_minute': 82.39808153477219,
 'log_count/DEBUG': 21684,
 'log_count/INFO': 65,
 'request_depth_max': 4,
 'response_received_count': 3074,
 'responses_per_minute': 49.144684252597926,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 3073,
 'scheduler/dequeued/memory': 3073,
 'scheduler/enqueued': 3073,
 'scheduler/enqueued/memory': 3073,
 'start_time': datetime.datetime(2026, 9, 14, 9, 26, 49, 244429, tzinfo=datetime.timezone.utc)}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Japan location coordinates by converting source data to WGS84.
  * Updated location filtering to exclude Tsuruha Drug entries and other excluded records.
  * Refined location processing by excluding parcel lockers and unsupported store-location records.
  * Improved brand labeling for Yamato Transport post offices and other postal partners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->