### PR TITLE
[aeon_cinema_jp] Add spider (99 locations)

### DIFF
--- a/locations/spiders/aeon_cinema_jp.py
+++ b/locations/spiders/aeon_cinema_jp.py
@@ -1,0 +1,64 @@
+from typing import Any, AsyncIterator
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, Response
+
+from locations.categories import Categories, apply_category, apply_yes_no
+from locations.dict_parser import DictParser
+
+
+class AeonCinemaJPSpider(Spider):
+    name = "aeon_cinema_jp"
+    item_attributes = {
+        "brand": "イオンシネマ",
+        "brand_wikidata": "Q11285965",
+        "extras": {"brand:en": "AEON Cinema", "brand:ja": "イオンシネマ"},
+    }
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield JsonRequest(url="https://www.aeoncinema.com/json/_theaters.json")
+
+    def parse(self, response: Response) -> Any:
+        data = response.json()  # ty: ignore[unresolved-attribute]
+        for _, prefectures in data.items():
+            for prefecture, theaters in prefectures.items():
+                for theater in theaters:
+                    item = DictParser.parse(theater)
+                    item["branch"] = item.pop("name")
+                    item["name"] = "イオンシネマ"
+                    item["ref"] = theater["theater_id"]
+                    item["website"] = theater["schedule"]
+                    if twitter := theater.get("x"):
+                        item["twitter"] = twitter
+
+                    item["state"] = self.add_prefecture_suffix(prefecture)
+
+                    apply_yes_no("cinema:3D", item, theater["3-D"], False)
+                    apply_yes_no("cinema:4DX", item, theater["4DX"], False)
+                    apply_yes_no("cinema:dbox", item, theater["D-BOX"], False)
+                    apply_yes_no("cinema:dolby_atmos", item, theater["Dolby Atmos"], False)
+                    apply_yes_no("cinema:IMAX", item, theater["IMAX"], False)
+                    apply_yes_no("cinema:MX4D", item, theater["MX4D"], False)
+                    apply_yes_no("cinema:THX", item, theater["THX"], False)
+
+                    apply_category(Categories.CINEMA, item)
+
+                    yield item
+
+    @staticmethod
+    def add_prefecture_suffix(prefecture: str) -> str:
+        """
+        Appends appropriate Japanese administrative suffixes (県, 府, 都, 道)
+        to a given Japanese prefecture name without duplicating suffixes.
+        """
+        name = prefecture.strip()
+        if not name or name.endswith(("都", "道", "府", "県")):
+            return name
+
+        special_cases = {
+            "東京": "東京都",
+            "京都": "京都府",
+            "大阪": "大阪府",
+        }
+
+        return special_cases.get(name, f"{name}県")


### PR DESCRIPTION
resolve #18618

- All data is from static JSON file.
- It doesn't include the number of screens, which can be enriched by crawing each cinema page, but I leave it as a optential future enhancement.
- The prefecture name had to be fixed by adding suffix (都道府県) so I created a helper function, which can be a shared helper function if encountered more. (I saw a similar prefecture name issue in `pycountry` library's localization data.)
- Also added several `cinema:*` tags, though it is still quite minor except 3D and IMAX (ref. https://taginfo.openstreetmap.org/search?q=cinema:)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting AEON Cinema locations across Japan.
  * Captures theater details, websites, social media references, and available screening features such as IMAX, 4DX, Dolby Atmos, and 3D.
  * Includes Japanese prefecture names with appropriate administrative suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->