### PR TITLE
[conforama_fr] Add spider (171 locations)

### DIFF
--- a/locations/spiders/conforama_fr.py
+++ b/locations/spiders/conforama_fr.py
@@ -1,0 +1,25 @@
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class ConforamaFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "conforama_fr"
+    item_attributes = {"brand": "Conforama", "brand_wikidata": "Q541134"}
+    allowed_domains = ["www.conforama.fr"]
+    sitemap_urls = ["https://www.conforama.fr/sitemap-magasins.xml"]
+    sitemap_rules = [(r"/magasins-conforama/[\w-]+/[\w-]+$", "parse_sd")]
+    # robots.txt disallows all UAs except a named crawler allowlist
+    custom_settings = {"ROBOTSTXT_OBEY": False}
+    # Cloudflare blocks cloud/datacenter ASNs regardless of User-Agent
+    requires_proxy = True
+    # National call centre number shared by almost every store, not a per-branch line.
+    generic_phone = "+33 892 010 808"
+
+    def post_process_item(self, item, response, ld_data):
+        item.pop("image", None)  # Same generic brand image on every store page.
+        if ld_data.get("telephone") == self.generic_phone:
+            item["phone"] = None
+        apply_category(Categories.SHOP_FURNITURE, item)
+        yield item


### PR DESCRIPTION
Adds a spider for Conforama (French furniture/homeware retail chain), closes #18017. Retry of #18023, closed for a Cloudflare/CI-proxy limitation that turned out not to require the architecture fix it was blocked on (see below).

Uses the sitemap at `sitemap-magasins.xml` (171 stores) plus embedded schema.org structured data. conforama.fr sits behind a Cloudflare managed challenge that blocks requests from cloud/datacenter ASNs even with a convincing browser User-Agent — confirmed by direct testing from AWS `us-east-1` (the same network CI's `alltheplaces-fetch` job runs on), which was rejected outright while the identical request succeeded from a non-cloud IP. No browser rendering is needed to read the data itself (it's plain server-rendered JSON-LD), so rather than `CamoufoxSpider` this uses `requires_proxy = True` to route around the ASN block via Zyte instead.

Verified at real scale (`sitemap-magasins.xml`, 171 stores): 171/171 items scraped (100%), perfect NSI match (Q541134) on every item, 0 duplicates. 136/171 (79.5%) have coordinates; the remaining 35 have an empty `geo` object (`{"@type": "GeoCoordinates"}`, no `latitude`/`longitude`) in their own JSON-LD — confirmed this is a gap in Conforama's own data, not an extraction issue (no alternate coordinate source found on the page). ~18% of requests hit a transient Cloudflare ban on first attempt; Zyte's automap retried these transparently, for a 100% final success rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and processing Conforama France store locations.
  * Store listings now include Conforama-specific metadata, furniture categorization, structured location details, and cleaned contact and image information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->