### PR TITLE
[Rapid Pare-Brise] Add spider (198 locations)

### DIFF
--- a/locations/spiders/rapid_pare_brise_fr.py
+++ b/locations/spiders/rapid_pare_brise_fr.py
@@ -1,0 +1,25 @@
+from typing import Iterable
+from scrapy.http import TextResponse
+from scrapy.spiders import SitemapSpider
+
+from locations.categories import Categories, apply_category
+from locations.items import Feature
+from locations.structured_data_spider import StructuredDataSpider
+
+
+class RapidPareBriseFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "rapid_pare_brise_fr"
+    item_attributes = {"brand": "Rapid Pare-Brise", "brand_wikidata": "Q112064766"}
+    sitemap_urls = ["https://www.rapidparebrise.fr/sitemap.xml"]
+    sitemap_rules = [(r"^https://www\.rapidparebrise\.fr/.*-\d+$", "parse_sd")]
+    wanted_types = ["LocalBusiness"]
+    drop_attributes = {"image"}
+
+    def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
+        if item.get("facebook") == "https://www.facebook.com/rapidparebrisefrance":
+        	item["facebook"] = None
+        
+        item["branch"] = item.pop("name").removeprefix("Rapid Pare-Brise ")
+        
+        apply_category(Categories.SHOP_CAR_REPAIR, item)
+        yield item

--- a/locations/spiders/rapid_pare_brise_fr.py
+++ b/locations/spiders/rapid_pare_brise_fr.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+
 from scrapy.http import TextResponse
 from scrapy.spiders import SitemapSpider
 
@@ -17,9 +18,9 @@ class RapidPareBriseFRSpider(SitemapSpider, StructuredDataSpider):
 
     def post_process_item(self, item: Feature, response: TextResponse, ld_data: dict, **kwargs) -> Iterable[Feature]:
         if item.get("facebook") == "https://www.facebook.com/rapidparebrisefrance":
-        	item["facebook"] = None
-        
+            item["facebook"] = None
+
         item["branch"] = item.pop("name").removeprefix("Rapid Pare-Brise ")
-        
+
         apply_category(Categories.SHOP_CAR_REPAIR, item)
         yield item


### PR DESCRIPTION
Adds a spider for the french winshield replacement chain "Rapid Pare-Brise".

```
{'atp/brand/Rapid Pare-Brise': 198,
 'atp/brand_wikidata/Q112064766': 198,
 'atp/category/shop/car_repair': 198,
 'atp/country/FR': 198,
 'atp/field/email/missing': 198,
 'atp/field/housenumber/missing': 198,
 'atp/field/operator/missing': 198,
 'atp/field/operator_wikidata/missing': 198,
 'atp/field/street/missing': 198,
 'atp/field/twitter/missing': 198,
 'atp/field/unit/missing': 198,
 'atp/item_scraped_host_count/www.rapidparebrise.fr': 198,
 'atp/lineage': 'S_?',
 'atp/nsi/match_perfect': 198,
 'downloader/request_bytes': 92779,
 'downloader/request_count': 200,
 'downloader/request_method_count/GET': 200,
 'downloader/response_bytes': 2264556,
 'downloader/response_count': 200,
 'downloader/response_status_count/200': 200,
 'elapsed_time_seconds': 245.76704404130578,
 'feedexport/success_count/FileFeedStorage': 1,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2026, 9, 11, 0, 37, 54, 968390, tzinfo=datetime.timezone.utc),
 'httpcompression/response_bytes': 7176983,
 'httpcompression/response_count': 200,
 'item_scraped_count': 198,
 'items_per_minute': 48.48979591836735,
 'log_count/DEBUG': 398,
 'log_count/INFO': 7,
 'memusage/max': 416563200,
 'memusage/startup': 180649984,
 'request_depth_max': 1,
 'response_received_count': 200,
 'responses_per_minute': 48.9795918367347,
 'robotstxt/request_count': 1,
 'robotstxt/response_count': 1,
 'robotstxt/response_status_count/200': 1,
 'scheduler/dequeued': 199,
 'scheduler/dequeued/memory': 199,
 'scheduler/enqueued': 199,
 'scheduler/enqueued/memory': 199,
 'start_time': datetime.datetime(2026, 9, 11, 0, 33, 49, 221700, tzinfo=datetime.timezone.utc)}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coverage for Rapid Pare-Brise France locations.
  - Location listings now include branch names, brand details, and car-repair categorization.
  - Unwanted image and known social media data are excluded from resulting listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->