### PR TITLE
[movix_jp] Add spider (23 locations)

### DIFF
--- a/locations/spiders/movix_jp.py
+++ b/locations/spiders/movix_jp.py
@@ -1,0 +1,60 @@
+from collections.abc import AsyncIterator
+from typing import Iterable
+
+from scrapy import Request, Spider
+
+from locations.google_url import extract_google_position
+from locations.items import Feature
+
+THEATER_LIST_URL = "https://www.smt-cinema.com/assets/module/page_theater_list_partner.html"
+
+
+class MovixJPSpider(Spider):
+    name = "movix_jp"
+    item_attributes = {"brand_wikidata": "Q11532184"}
+
+    async def start(self) -> AsyncIterator[Request]:
+        yield Request(url=THEATER_LIST_URL, callback=self.parse_theater_list)
+
+    def parse_theater_list(self, response) -> Iterable[Request]:
+        for href in response.xpath("//a[contains(@href, '/site/')]/@href").getall():
+            yield Request(
+                url=response.urljoin(href.rstrip("/") + "/access.html"),
+                callback=self.parse_theater,
+            )
+
+    def parse_theater(self, response) -> Iterable[Feature]:
+        item = Feature()
+        item["ref"] = response.url.split("/site/")[1].split("/")[0]
+
+        extract_google_position(item, response)
+
+        name = response.xpath('//meta[@property="og:site_name"]/@content').get("").split(" | ")[0].strip()
+        item["name"], item["branch"] = self.name_branch_for(name)
+        if address := self.extract_address(response):
+            item["addr_full"] = address
+
+        if phone := response.xpath(
+            '//div[contains(@class, "phone")]//a[starts-with(@href, "tel:")]/span/text()[1]'
+        ).get():
+            item["phone"] = f"+81 {phone.strip()}"
+
+        yield item
+
+    @staticmethod
+    def extract_address(response) -> str | None:
+        parts = response.xpath(
+            '//h3[contains(text(), "所在地")]/following-sibling::p[not(a)]/text()'
+            ' | //h3[contains(text(), "所在地")]/following-sibling::p[not(a)]/span/text()'
+        ).getall()
+        for part in parts:
+            part = part.strip()
+            if part and not part.startswith(("【", "（", "▶")):
+                return part
+        return None
+
+    @staticmethod
+    def name_branch_for(name: str) -> tuple[str | None, str | None]:
+        if name.startswith("MOVIX"):
+            return None, name[5:] or None
+        return name, None

--- a/locations/spiders/movix_jp.py
+++ b/locations/spiders/movix_jp.py
@@ -11,7 +11,7 @@ THEATER_LIST_URL = "https://www.smt-cinema.com/assets/module/page_theater_list_p
 
 class MovixJPSpider(Spider):
     name = "movix_jp"
-    item_attributes = {"brand_wikidata": "Q11532184"}
+    item_attributes = {"brand": "MOVIX", "brand_wikidata": "Q11532184"}
 
     async def start(self) -> AsyncIterator[Request]:
         yield Request(url=THEATER_LIST_URL, callback=self.parse_theater_list)


### PR DESCRIPTION
resolve #18626

### Notes
MOVIX Hiroshima Station uses Google Maps short URL (https://maps.app.goo.gl/Jn1PhX7NzPkynvEW9) so the coordinates cannot be extracted from URL text.

There are four theaters without "MOVIX" name in it: 東劇, 新宿ピカデリー, 丸の内ピカデリー, 熊本ピカデリー. Those are treated as special theater often used to premiere new films or used for special events.

After some research, I couldn't find clear explanation on how those theaters are structured under SMT group. For example, 新宿ピカデリー etc. seems to be used as a proper noun, not a branch of ピカデリー, so it's unclear if it should be in a separate brand or directly under the SMT gorup unlike MOVIX brand. I think we need to wait more future research and Wikidata brand QID updates. For now, I kept it the default wikidata Q11532184 and "MOVIX" and just adjust name and branch for the special theaters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting MOVIX Japan theater locations.
  * Captures theater names, branches, addresses, phone numbers, and map coordinates.
  * Formats Japanese phone numbers for international use.
  * Separates MOVIX brand names from individual branch names.
  * Identifies each location with the MOVIX brand for clearer display and discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->