### PR TITLE
[GBFS] Add default category

### DIFF
--- a/locations/spiders/gbfs.py
+++ b/locations/spiders/gbfs.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, AsyncGenerator, Iterable, Iterator
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
@@ -416,6 +417,17 @@ class GbfsSpider(CSVFeedSpider):
             vehicle_types_categories[vehicle_type["vehicle_type_id"]] = cat
         return vehicle_types_categories
 
+    def get_system_fallback_category(self, vehicle_types_categories: dict[Any, dict[str, str]]) -> dict[str, str]:
+        """Determine the category to fall back on for stations whose own feed
+        data doesn't resolve to one. If every vehicle type declared by the
+        system shares a single amenity (e.g. a car sharing system only offers
+        cars), that amenity applies to the whole system. Otherwise assume a
+        bicycle rental, which is by far the most common kind of GBFS system."""
+        amenities = {cat["amenity"] for cat in vehicle_types_categories.values() if cat.get("amenity")}
+        if len(amenities) == 1:
+            return {"amenity": amenities.pop()}
+        return Categories.BICYCLE_RENTAL.value
+
     def get_station_status_categories(
         self, station_status: Any, vehicle_types_categories: dict[Any, dict[str, str]]
     ) -> dict[Any, list[dict[str, str]]]:
@@ -483,10 +495,17 @@ class GbfsSpider(CSVFeedSpider):
             else self.get_station_status_categories(station_status, vehicle_types_categories)
         )
 
+        fallback_category = self.get_system_fallback_category(vehicle_types_categories)
+
         # Now scrape the stations.
         for station in DictParser.get_nested_key(station_information, "stations") or []:
             yield self.parse_station(
-                station, shared_attributes, vehicle_types_categories, station_status_categories, **kwargs
+                station,
+                shared_attributes,
+                vehicle_types_categories,
+                station_status_categories,
+                fallback_category,
+                **kwargs,
             )
 
     def parse_station(
@@ -495,10 +514,11 @@ class GbfsSpider(CSVFeedSpider):
         shared_attributes: dict[str, Any],
         vehicle_types_categories: dict[Any, dict[str, str]],
         station_status_categories: dict[Any, list[dict[str, str]]],
+        fallback_category: dict[str, str],
         **kwargs,
     ) -> Feature:
         """Process an individual GBFS station."""
-        item = Feature(**shared_attributes)
+        item = Feature(**copy.deepcopy(shared_attributes))
         item["ref"] = item["extras"]["ref:gbfs"] = f"{kwargs['System ID']}:{station['station_id']}"
         item["extras"][f"ref:gbfs:{kwargs['System ID']}"] = str(station["station_id"])
         item["lat"] = station["lat"]
@@ -557,6 +577,6 @@ class GbfsSpider(CSVFeedSpider):
 
         # If neither the vehicle type nor a brand preset were available, set a fallback category.
         if "amenity" not in item["extras"] and not item.get("brand_wikidata"):
-            apply_category(Categories.BICYCLE_RENTAL, item)
+            apply_category(fallback_category, item)
 
         return item


### PR DESCRIPTION
## `extras` was shared between all stations of a GBFS system

`get_shared_attributes_from_row()` builds one attribute dict per system (gbfs.py:380), and every station's Feature was created from it with `Feature(**shared_attributes)`. `**` unpacks only one level, so the `extras` dict was the *same object* for every station — `item["extras"] is shared_attributes["extras"]`.

Every `item["extras"][...] = ...` write therefore mutated one system-wide dict, causing:

- **Leaked attributes** — a station inherited the previous station's `ref:gbfs`, payment tags, `parking` and `amenity`.
- **`capacity:<vehicle_type>` summed across the whole system** instead of per station (gbfs.py:571-572).
- **A dead category guard** — `if "amenity" not in item["extras"]` (gbfs.py:579) tested the shared dict, so after the first station of a system resolved an amenity, no later station could apply its own or reach the fallback.
- **Last-write-wins on export** — `CONCURRENT_ITEMS` defaults to 100, so items sit in the pipeline while later stations mutate the same dict. Whatever `extras` held at serialization time was written to *every* feature in the system. This is why whole systems came out mis-categorised rather than individual stations.
```
{
 "atp/brand/2EM Car Sharing": 1743,
 "atp/brand/7 Vall\u00e9es V\u00e9lo": 4,
 "atp/brand/AAR Bike": 118,
 "atp/brand/AB mit Lara": 17,
 "atp/brand/ALF - das Affst\u00e4tter Lastenfahrrad": 1,
 "atp/brand/AMBici": 237,
 "atp/brand/AQTA": 12,
 "atp/brand/AW-bike": 22,
 "atp/brand/Acc\u00e8s V\u00e9lo": 21,
 "atp/brand/Alba Iulia Velocity": 18,
 "atp/brand/Altervelo Libre-service": 36,
 "atp/brand/Arriva Bike": 23,
 "atp/brand/Auch Velo'C": 10,
 "atp/brand/Auto-en-Velay": 9,
 "atp/brand/BA Ecobici": 394,
 "atp/brand/BCycle": 614,
 "atp/brand/BIKE SHARE LANTERNA(Croatia)": 10,
 "atp/brand/BIKER Bia\u0142ystok": 64,
 "atp/brand/BIKETOWN": 299,
 "atp/brand/BL bike": 5,
 "atp/brand/BYCOR": 2,
 "atp/brand/Bajs Zagreb (Croatia)": 196,
 "atp/brand/Bergen Bysykkel": 98,
 "atp/brand/Bergisches e-Bike": 57,
 "atp/brand/Beryl": 2111,
 "atp/brand/Beryl - Bradford": 34,
 "atp/brand/Beryl - Canterbury": 27,
 "atp/brand/Beryl - Eastleigh": 13,
 "atp/brand/Beryl - Guildford": 56,
 "atp/brand/Beryl - Stevenage": 47,
 "atp/brand/Beryl - Weymouth": 32,
 "atp/brand/Beryl - Worcester": 56,
 "atp/brand/Beryl Belfast": 65,
 "atp/brand/BiciMAD": 679,
 "atp/brand/BiciMislata": 21,
 "atp/brand/BiciPalma": 100,
 "atp/brand/Bicicoru\u00f1a": 84,
 "atp/brand/BicikeLJ": 88,
 "atp/brand/BicinRivas": 42,
 "atp/brand/Bicing": 544,
 "atp/brand/Bike Brasilia": 68,
 "atp/brand/Bike Chattanooga": 43,
 "atp/brand/Bike Est\u00e1cio": 50,
 "atp/brand/Bike Ita\u00fa - Pernambuco": 90,
 "atp/brand/Bike Ita\u00fa - Rio": 403,
 "atp/brand/Bike Ita\u00fa - Salvador": 76,
 "atp/brand/Bike Ita\u00fa - Sampa": 240,
 "atp/brand/Bike Ita\u00fa - Santiago": 202,
 "atp/brand/Bike Nordelta": 21,
 "atp/brand/Bike Porto Alegre": 90,
 "atp/brand/Bike Share Toronto": 1069,
 "atp/brand/Bike Sharing Alimos": 6,
 "atp/brand/Bike Sharing Elliniko \u2013 Argyroupoli": 8,
 "atp/brand/Bike Sharing Glyfada": 8,
 "atp/brand/Bike Sharing Palaio Faliro": 7,
 "atp/brand/BikeCity Campia Turzii": 9,
 "atp/brand/BikeKIA": 39,
 "atp/brand/BikeLNK": 21,
 "atp/brand/Bikesharing Amprion": 5,
 "atp/brand/Biki": 237,
 "atp/brand/Bilbao Bizi": 67,
 "atp/brand/Bird Adeje": 199,
 "atp/brand/Bird Ajaccio": 36,
 "atp/brand/Bird Barcelona": 3590,
 "atp/brand/Bird Blois": 78,
 "atp/brand/Bird Bordeaux": 3152,
 "atp/brand/Bird Cascais": 157,
 "atp/brand/Bird Draguignan": 63,
 "atp/brand/Bird Gap": 50,
 "atp/brand/Bird Halifax": 708,
 "atp/brand/Bird Larochesuryon": 69,
 "atp/brand/Bird Laval": 83,
 "atp/brand/Bird Lisbon": 1756,
 "atp/brand/Bird Marseille": 803,
 "atp/brand/Bird Matosinhos": 187,
 "atp/brand/Bird Millau": 76,
 "atp/brand/Bird Montlucon": 63,
 "atp/brand/Bird Ottawa": 565,
 "atp/brand/Bird Porto": 199,
 "atp/brand/Bird Sarreguemines": 65,
 "atp/brand/Bird Schaffhausen": 88,
 "atp/brand/Bird Vaughan": 496,
 "atp/brand/Bird Vichy": 50,
 "atp/brand/Bixi": 1112,
 "atp/brand/Bizi": 276,
 "atp/brand/Blue-bike": 319,
 "atp/brand/Bluebikes": 619,
 "atp/brand/Bogot\u00e1": 252,
 "atp/brand/Bolt Liverpool": 1505,
 "atp/brand/Bolt Technology O\u00dc": 3037,
 "atp/brand/Bora": 39,
 "atp/brand/Bre.Bike": 119,
 "atp/brand/BreizhGo": 16,
 "atp/brand/Brennus \u00e0 V\u00e9lo (Sens)": 18,
 "atp/brand/Bubi 3.0": 219,
 "atp/brand/Bublr Bikes": 165,
 "atp/brand/Buzau VeloCity": 47,
 "atp/brand/Bysykkel": 6,
 "atp/brand/C-V\u00e9lo": 82,
 "atp/brand/CHATELLERAULT": 13,
 "atp/brand/CaliV\u00e9lo": 73,
 "atp/brand/Call a Bike": 1621,
 "atp/brand/Campus Berlin-Buch": 16,
 "atp/brand/CapCotentin": 52,
 "atp/brand/CapMetro": 86,
 "atp/brand/Capital Bikeshare": 866,
 "atp/brand/Car-ship": 21,
 "atp/brand/CarSharing Renningen": 33,
 "atp/brand/Careem BIKE": 216,
 "atp/brand/Carsharing in Wertheim": 2,
 "atp/brand/Che\u0142mski Rower": 17,
 "atp/brand/Choletbus 2 Roues": 16,
 "atp/brand/Citi Bike": 2507,
 "atp/brand/Citiz": 1439,
 "atp/brand/Citiz M\u00e9tropole Lyon": 200,
 "atp/brand/City Bikes Helsinki": 456,
 "atp/brand/Cit\u00e9 Cycle": 3,
 "atp/brand/Cit\u00e9dia Services": 2,
 "atp/brand/Clem": 377,
 "atp/brand/Clemson BikeShare": 11,
 "atp/brand/Compte Mobilit\u00e9": 26,
 "atp/brand/Conficars": 26,
 "atp/brand/Cycl'AM": 36,
 "atp/brand/CyclOcity": 25,
 "atp/brand/Cyclocity": 36,
 "atp/brand/Cyclolibre": 11,
 "atp/brand/Cyclovis": 31,
 "atp/brand/Cykl": 14,
 "atp/brand/Dbizi": 70,
 "atp/brand/Deer": 558,
 "atp/brand/Dej Velo City": 16,
 "atp/brand/Die Gr\u00fcne Flotte": 295,
 "atp/brand/Divvy": 2053,
 "atp/brand/Docomo Bike Share": 1906,
 "atp/brand/Donkey EPFL - Lausanne": 6,
 "atp/brand/Donkey Ergolding": 2,
 "atp/brand/Donkey Kelheim": 13,
 "atp/brand/Donkey KielRegion+Smile24": 199,
 "atp/brand/Donkey Neutraubling": 5,
 "atp/brand/Donkey Obertraubling": 6,
 "atp/brand/Donkey Ochtrup": 6,
 "atp/brand/Donkey Prignitz": 25,
 "atp/brand/Donkey Regensburg": 132,
 "atp/brand/Donkey Republic": 8419,
 "atp/brand/Donkey Republic Augsburg": 13,
 "atp/brand/Donkey Republic Barcelona": 1517,
 "atp/brand/Donkey Republic Bayern Komplett": 174,
 "atp/brand/Donkey Republic Hannover": 421,
 "atp/brand/Donkey Republic Katwijk": 393,
 "atp/brand/Donkey Republic Qbuzz": 202,
 "atp/brand/Donkey Republic Rivierenland": 3,
 "atp/brand/Donkey Republic Rotterdam/Den Haag": 3,
 "atp/brand/Donkey Republic Valenciennes": 40,
 "atp/brand/Donkey RepublicHelsinki": 304,
 "atp/brand/Dott Aachen": 22,
 "atp/brand/Dott Abu Dhabi": 1433,
 "atp/brand/Dott Athens": 10,
 "atp/brand/Dott Baden bei Wien": 47,
 "atp/brand/Dott Basel": 44,
 "atp/brand/Dott Bath": 226,
 "atp/brand/Dott Berlin": 557,
 "atp/brand/Dott Bordeaux": 3460,
 "atp/brand/Dott Bourgoin Jallieu": 69,
 "atp/brand/Dott Bregenz": 98,
 "atp/brand/Dott Bristol": 1259,
 "atp/brand/Dott Brussels": 2458,
 "atp/brand/Dott Brzeg": 7,
 "atp/brand/Dott Brzeg Dolny": 8,
 "atp/brand/Dott Bytom": 2,
 "atp/brand/Dott Charleroi": 1078,
 "atp/brand/Dott Chrzan\u00f3w": 3,
 "atp/brand/Dott Colchester": 546,
 "atp/brand/Dott Cologne": 207,
 "atp/brand/Dott Copenhagen": 7756,
 "atp/brand/Dott Cz\u0119stochowa": 25,
 "atp/brand/Dott Dornbirn": 3,
 "atp/brand/Dott Dortmund": 27,
 "atp/brand/Dott Dubai": 351,
 "atp/brand/Dott Dubai Hills": 7,
 "atp/brand/Dott Duisburg": 18,
 "atp/brand/Dott Dusseldorf": 354,
 "atp/brand/Dott Erlangen": 9,
 "atp/brand/Dott Essen": 57,
 "atp/brand/Dott Flensburg": 30,
 "atp/brand/Dott Frederikssund": 44,
 "atp/brand/Dott Friedrichshafen": 35,
 "atp/brand/Dott Gdansk": 469,
 "atp/brand/Dott Gera": 24,
 "atp/brand/Dott Ghent": 3591,
 "atp/brand/Dott Gladbeck": 10,
 "atp/brand/Dott Goleniow": 19,
 "atp/brand/Dott Hamburg": 44,
 "atp/brand/Dott Hamm": 1,
 "atp/brand/Dott Hannover": 33,
 "atp/brand/Dott Heidelberg": 29,
 "atp/brand/Dott Heilbronn": 34,
 "atp/brand/Dott Herford": 3,
 "atp/brand/Dott Herne": 6,
 "atp/brand/Dott Herten": 2,
 "atp/brand/Dott Hilden": 23,
 "atp/brand/Dott Hildesheim": 4,
 "atp/brand/Dott Ingolstadt": 16,
 "atp/brand/Dott Innsbruck": 56,
 "atp/brand/Dott Jeddah": 33,
 "atp/brand/Dott Jelenia G\u00f3ra": 14,
 "atp/brand/Dott Kaiserslautern": 30,
 "atp/brand/Dott Karlsruhe": 32,
 "atp/brand/Dott Kassel": 1346,
 "atp/brand/Dott Katowice": 103,
 "atp/brand/Dott Kiel": 17,
 "atp/brand/Dott Klagenfurt": 48,
 "atp/brand/Dott Ko\u0142obrzeg": 88,
 "atp/brand/Dott Krakow": 394,
 "atp/brand/Dott Langenfeld": 8,
 "atp/brand/Dott Leipzig": 137,
 "atp/brand/Dott Leoben": 47,
 "atp/brand/Dott Liege": 932,
 "atp/brand/Dott Lindau": 35,
 "atp/brand/Dott Linz": 153,
 "atp/brand/Dott Lubliniec": 2,
 "atp/brand/Dott Ludwigsburg": 18,
 "atp/brand/Dott Lyon": 1396,
 "atp/brand/Dott L\u00fcbeck": 33,
 "atp/brand/Dott Malbork": 10,
 "atp/brand/Dott Malvik": 7,
 "atp/brand/Dott Mannheim": 195,
 "atp/brand/Dott Melhus": 10,
 "atp/brand/Dott Milton Keynes": 1848,
 "atp/brand/Dott Minden": 3,
 "atp/brand/Dott Mi\u0119dzyzdroje": 25,
 "atp/brand/Dott Monchengladbach": 3,
 "atp/brand/Dott Monheim am Rhein": 3,
 "atp/brand/Dott Mons": 127,
 "atp/brand/Dott Mulheim an der Ruhr": 70,
 "atp/brand/Dott Munich": 422,
 "atp/brand/Dott M\u00f6dling": 69,
 "atp/brand/Dott M\u00fcnster": 404,
 "atp/brand/Dott Neuss": 12,
 "atp/brand/Dott Nottingham": 387,
 "atp/brand/Dott Nowogard": 27,
 "atp/brand/Dott Nowy Dw\u00f3r Mazowiecki": 10,
 "atp/brand/Dott Nowy-Targ": 17,
 "atp/brand/Dott Nuremberg": 352,
 "atp/brand/Dott Ol-Vallee": 8,
 "atp/brand/Dott Ole\u015bnica": 71,
 "atp/brand/Dott Orkanger": 4,
 "atp/brand/Dott Osnabr\u00fcck": 2,
 "atp/brand/Dott O\u015bwi\u0119cim": 18,
 "atp/brand/Dott Paderborn": 26,
 "atp/brand/Dott Paris": 13207,
 "atp/brand/Dott Potsdam": 8,
 "atp/brand/Dott Poznan": 272,
 "atp/brand/Dott Prawobrze\u017ce": 30,
 "atp/brand/Dott P\u0142ock": 1,
 "atp/brand/Dott Ras Al Khaimah": 31,
 "atp/brand/Dott Recklinghausen": 13,
 "atp/brand/Dott Regensburg": 40,
 "atp/brand/Dott Region Hovedstaden": 1190,
 "atp/brand/Dott Reutlingen": 12,
 "atp/brand/Dott Rewal": 20,
 "atp/brand/Dott Rheda-Wiedenbr\u00fcck": 3,
 "atp/brand/Dott Riyadh": 32,
 "atp/brand/Dott Romanshorn": 214,
 "atp/brand/Dott Rorschach": 137,
 "atp/brand/Dott Roskilde": 82,
 "atp/brand/Dott Rostock": 51,
 "atp/brand/Dott R\u00fcsselsheim": 72,
 "atp/brand/Dott SBF": 26,
 "atp/brand/Dott SIEMU": 117,
 "atp/brand/Dott Saarbr\u00fccken": 33,
 "atp/brand/Dott Saint Anton am Arlberg": 14,
 "atp/brand/Dott Sankt Augustin": 40,
 "atp/brand/Dott Sharjah": 42,
 "atp/brand/Dott Skaun": 5,
 "atp/brand/Dott Skawina": 34,
 "atp/brand/Dott Solingen": 6,
 "atp/brand/Dott Sosnowiec": 64,
 "atp/brand/Dott St. Gallen": 135,
 "atp/brand/Dott Stj\u00f8rdal": 30,
 "atp/brand/Dott Stuttgart": 63,
 "atp/brand/Dott Swidnica": 21,
 "atp/brand/Dott Szczecin": 110,
 "atp/brand/Dott Tarnowskie G\u00f3ry": 15,
 "atp/brand/Dott Tczew": 23,
 "atp/brand/Dott Tel-Aviv": 1672,
 "atp/brand/Dott Thessaloniki": 125,
 "atp/brand/Dott Tignes": 8,
 "atp/brand/Dott Troisdorf": 2,
 "atp/brand/Dott Trondheim": 137,
 "atp/brand/Dott T\u00fcbingen": 10,
 "atp/brand/Dott Ulm": 30,
 "atp/brand/Dott Velden-Am-Worthersee": 15,
 "atp/brand/Dott Versailles Grand-Parc": 79,
 "atp/brand/Dott Warsaw": 39,
 "atp/brand/Dott Wels": 47,
 "atp/brand/Dott Wiener-Neustadt": 58,
 "atp/brand/Dott Wiesbaden": 61,
 "atp/brand/Dott Wolfsburg": 30,
 "atp/brand/Dott Wroc\u0142aw": 1202,
 "atp/brand/Dott Zurich": 104,
 "atp/brand/Dott brunel-university": 8,
 "atp/brand/Dott \u00dcberlingen": 12,
 "atp/brand/Dott \u015awinouj\u015bcie": 1,
 "atp/brand/Dublinbikes": 116,
 "atp/brand/EDEKA Gr\u00fcnheide": 16,
 "atp/brand/EVENTbike - Austria": 21,
 "atp/brand/Ecobici": 677,
 "atp/brand/Eifel e-Bike": 55,
 "atp/brand/Einfach Unterwegs": 28,
 "atp/brand/EinfachMobil": 91,
 "atp/brand/Estr\u00e9es Saint Denis": 6,
 "atp/brand/Explore Bike Share": 30,
 "atp/brand/Fa.Mo.Se": 25,
 "atp/brand/FaRe - das Bananologen Lastenrad": 1,
 "atp/brand/Farte Bysykkel": 55,
 "atp/brand/Flamingo Auckland": 128,
 "atp/brand/Flamingo Christchurch": 25,
 "atp/brand/Flamingo Dunedin": 37,
 "atp/brand/Flamingo Palmerston North": 53,
 "atp/brand/Flamingo Porirua": 24,
 "atp/brand/Flamingo Tauranga": 13,
 "atp/brand/Flamingo Waimakariri": 6,
 "atp/brand/Flamingo Wellington": 61,
 "atp/brand/Flinkster": 84,
 "atp/brand/Ford Carsharing (Autohaus Albert)": 4,
 "atp/brand/Ford Carsharing (Autohaus Baur)": 35,
 "atp/brand/Ford Carsharing (Autohaus B\u00f6lz)": 5,
 "atp/brand/Ford Carsharing (Autohaus Kauderer)": 1,
 "atp/brand/Frelo": 177,
 "atp/brand/GREENbike": 72,
 "atp/brand/GRM Grodzisk Poland": 23,
 "atp/brand/Ganxeta": 24,
 "atp/brand/GoAbout": 44,
 "atp/brand/Gothenburg Cargo": 3,
 "atp/brand/Graben - ready4green": 2,
 "atp/brand/G\u00e9vaudan": 2,
 "atp/brand/G\u00fclf - das G\u00fcltsteiner Lastenrad": 1,
 "atp/brand/HELLO CYCLING": 14964,
 "atp/brand/HERTLEIN Carsharing": 5,
 "atp/brand/HIBike": 22,
 "atp/brand/HelBi (Kreis Soest)": 81,
 "atp/brand/Hertz Bildeling": 26,
 "atp/brand/Hunedoara": 13,
 "atp/brand/Hvar (Croatia)": 2,
 "atp/brand/IDEcycle (Pau)": 40,
 "atp/brand/Impulsyon": 31,
 "atp/brand/Indego": 319,
 "atp/brand/Indiana Pacers Bikeshare": 56,
 "atp/brand/Inter Bike": 7,
 "atp/brand/JOLT Hutt Valley": 83,
 "atp/brand/JOLT New Plymouth": 72,
 "atp/brand/JOLT Selwyn": 19,
 "atp/brand/Jackson County": 1,
 "atp/brand/KVB Rad": 292,
 "atp/brand/KVV.nextbike": 119,
 "atp/brand/Karu'V\u00e9lo": 17,
 "atp/brand/Koni\u0144ski Rower Miejski Poland": 13,
 "atp/brand/Koszali\u0144ski Rower Miejski Poland": 20,
 "atp/brand/Ko\u0142obrzeski Rower Nextbike": 20,
 "atp/brand/LE v\u00e9lo STAR": 57,
 "atp/brand/LIEmobil Liechtenstein": 36,
 "atp/brand/LOVELO Libre-service": 126,
 "atp/brand/LVR Bike": 4,
 "atp/brand/La Baule": 14,
 "atp/brand/LaRa to go": 17,
 "atp/brand/Landkreis Nordsachsen": 18,
 "atp/brand/LastenVelo Freiburg": 46,
 "atp/brand/Le Marcel": 29,
 "atp/brand/Le V\u00e9lo par TBM": 231,
 "atp/brand/Les Petites Reines": 17,
 "atp/brand/Li Bia Velo": 27,
 "atp/brand/LiBike": 3,
 "atp/brand/Lib\u00e9lo": 68,
 "atp/brand/Lime Arlington": 1,
 "atp/brand/Lime Atlanta": 1,
 "atp/brand/Lime Baltimore": 1,
 "atp/brand/Lime Brussels": 1,
 "atp/brand/Lime Calgary": 1,
 "atp/brand/Lime Chicago": 1,
 "atp/brand/Lime Cleveland": 1,
 "atp/brand/Lime Colorado Springs": 1,
 "atp/brand/Lime Detroit": 1,
 "atp/brand/Lime Dresden": 1,
 "atp/brand/Lime Edmonton": 1,
 "atp/brand/Lime Frankfurt": 1,
 "atp/brand/Lime Grand Rapids": 1,
 "atp/brand/Lime Kelowna": 1,
 "atp/brand/Lime Kortrijk": 1,
 "atp/brand/Lime Les Lilas": 1,
 "atp/brand/Lime Lille": 1,
 "atp/brand/Lime Lincoln": 1,
 "atp/brand/Lime Louisville": 1,
 "atp/brand/Lime Marseille": 1,
 "atp/brand/Lime Mexico City": 1,
 "atp/brand/Lime Mississauga": 1,
 "atp/brand/Lime New York": 1,
 "atp/brand/Lime Nice": 1,
 "atp/brand/Lime Nogent-sur-Marne": 1,
 "atp/brand/Lime Oakland": 1,
 "atp/brand/Lime Oberhausen": 1,
 "atp/brand/Lime Opfikon": 1,
 "atp/brand/Lime Ottawa": 1,
 "atp/brand/Lime Paris": 1,
 "atp/brand/Lime San Francisco": 1,
 "atp/brand/Lime San Jose": 1,
 "atp/brand/Lime Seattle": 1,
 "atp/brand/Lime Sophia Antipolis": 1,
 "atp/brand/Lime Tel Aviv": 1,
 "atp/brand/Lime Uppsala": 1,
 "atp/brand/Lime Vancouver": 247,
 "atp/brand/Lime Wuppertal": 1,
 "atp/brand/Lime Zug": 1,
 "atp/brand/Lovesharing (Canary Islands)": 15,
 "atp/brand/Lundahoj": 23,
 "atp/brand/Lyft": 119,
 "atp/brand/Lyft Bike": 636,
 "atp/brand/MBajk": 42,
 "atp/brand/MOBIbike": 550,
 "atp/brand/Marguerite - V\u00e9hicule en libre-service \u00e0 Nantes": 87,
 "atp/brand/Mein konrad": 37,
 "atp/brand/Metro Bike Share": 223,
 "atp/brand/Metrorower": 942,
 "atp/brand/Mevo": 862,
 "atp/brand/Mi Bici Tu Bici": 101,
 "atp/brand/Mibici Guadalajara": 468,
 "atp/brand/Mikar": 200,
 "atp/brand/Milan Bikemi": 320,
 "atp/brand/Mobi Bike Share": 264,
 "atp/brand/Mobility": 1774,
 "atp/brand/Mogo Detroit": 81,
 "atp/brand/Moinesti": 8,
 "atp/brand/MonaBike": 58,
 "atp/brand/MontenV\u00e9lo": 23,
 "atp/brand/MyBuxi": 2117,
 "atp/brand/MyRadl": 803,
 "atp/brand/M\u0142awskie Rowery Miejskie": 10,
 "atp/brand/NEW M\u00f6Bus nextbike": 55,
 "atp/brand/NS OV Fiets": 284,
 "atp/brand/Naolib": 119,
 "atp/brand/Naolib Micromob'": 17,
 "atp/brand/Naturenergie sharing": 337,
 "atp/brand/NemoV\u00e9lo": 52,
 "atp/brand/Nextbike": 7059,
 "atp/brand/Nike Biketown": 26,
 "atp/brand/Nomago Bikes -  LJUBLJANA in MEDVODE": 50,
 "atp/brand/Nomago Bikes - GO2GO": 21,
 "atp/brand/Nomago Bikes - GO2GO Gorizia": 3,
 "atp/brand/Nomago Bikes - KOLESCE": 82,
 "atp/brand/Nomago Bikes - ZANAPREJ": 7,
 "atp/brand/OLORON": 2,
 "atp/brand/OberSchwabenMobil CarSharing": 11,
 "atp/brand/Optymo Belfort": 32,
 "atp/brand/Optymo Belfort Auto libre-service": 53,
 "atp/brand/Oslo Bysykkel": 268,
 "atp/brand/Otto": 7,
 "atp/brand/Otwocki Rower Miejski": 10,
 "atp/brand/PAYS D'OPALE": 4,
 "atp/brand/PAYS DE L'ARBRESLE - VEL'PAR": 4,
 "atp/brand/PAYS DU COQUELICOT": 1,
 "atp/brand/PBSC HQ": 9,
 "atp/brand/Piaseczy\u0144ski Rower Miejski": 7,
 "atp/brand/PickeBike Aubonne": 14,
 "atp/brand/PickeBike Basel": 80,
 "atp/brand/PickeBike Fribourg": 31,
 "atp/brand/Pogoh": 60,
 "atp/brand/Pony Angers": 1456,
 "atp/brand/Pony Basque Country": 541,
 "atp/brand/Pony Beauvais": 219,
 "atp/brand/Pony Bordeaux": 3056,
 "atp/brand/Pony Bourges": 376,
 "atp/brand/Pony Evry": 214,
 "atp/brand/Pony Herouville": 209,
 "atp/brand/Pony Limoges": 301,
 "atp/brand/Pony Lorient": 202,
 "atp/brand/Pony Nice": 484,
 "atp/brand/Pony Perpignan": 1042,
 "atp/brand/Pony Poitiers": 409,
 "atp/brand/Porec bike share (Croatia)": 6,
 "atp/brand/Porte de Vassivi\u00e8re": 1,
 "atp/brand/Potsdam Rad": 154,
 "atp/brand/Prishtina bike (Kosovo)": 10,
 "atp/brand/Pruszkowski Rower Miejski": 16,
 "atp/brand/P\u00e9riv\u00e9lo": 3,
 "atp/brand/QuickRent": 86,
 "atp/brand/RLV'Lib": 15,
 "atp/brand/RTC Bike Share": 38,
 "atp/brand/Red Bike": 79,
 "atp/brand/Redding Bikeshare": 22,
 "atp/brand/RegioRad Stuttgart": 233,
 "atp/brand/Rhoule": 2,
 "atp/brand/Rivi Bike": 7,
 "atp/brand/Roche - Bike": 12,
 "atp/brand/Rower Powiatowy Soko\u0142\u00f3w Podlaski": 6,
 "atp/brand/Rubis'Velo": 46,
 "atp/brand/Ryde Oslo": 376,
 "atp/brand/Ryde Sandefjord": 11,
 "atp/brand/Ryde Skien": 2,
 "atp/brand/Ryde Stavanger": 32,
 "atp/brand/Ryde Troms\u00f8": 3,
 "atp/brand/Ryde Trondheim": 113,
 "atp/brand/Ryde T\u00f8nsberg": 4,
 "atp/brand/Ryde \u00c5lesund": 6,
 "atp/brand/SAP Walldorf": 16,
 "atp/brand/SBU Wolf Ride Bike Share": 14,
 "atp/brand/SEEFAHRER E-Carsharing": 11,
 "atp/brand/SRM Jask\u00f3\u0142ka": 30,
 "atp/brand/Semo V\u00e9lo": 40,
 "atp/brand/Senica bajk": 26,
 "atp/brand/Sevici": 243,
 "atp/brand/Share Birrer": 22,
 "atp/brand/Sibiu BikeCity": 57,
 "atp/brand/Slatina Velo City": 5,
 "atp/brand/Slobozia Bike City": 26,
 "atp/brand/StadtRad Greifswald": 25,
 "atp/brand/Stadtmobil Karlsruhe": 600,
 "atp/brand/Stadtmobil Rhein-Neckar": 471,
 "atp/brand/Stadtmobil Stuttgart": 355,
 "atp/brand/Stadtrad Innsbruck Austria": 55,
 "atp/brand/Stadtwerk Tauberfranken": 13,
 "atp/brand/Styr & St\u00e4ll (Sweden, G\u00f6teborg)": 143,
 "atp/brand/Swansea University Cycles": 8,
 "atp/brand/System Roweru Gminnego": 2,
 "atp/brand/System Rower\u00f3w Miejskich w Pszczynie": 9,
 "atp/brand/TLP Mobilites": 19,
 "atp/brand/TORRENTBICI": 20,
 "atp/brand/TUeBICI": 42,
 "atp/brand/Targu Mures": 5,
 "atp/brand/Tarnowski Rower Miejski": 18,
 "atp/brand/TeilAuto Biberach": 10,
 "atp/brand/TeilAuto Neckar-Alb": 196,
 "atp/brand/TeilAuto Schw\u00e4bisch Hall": 15,
 "atp/brand/Tempovelo": 16,
 "atp/brand/Ti V\u00e9lo": 14,
 "atp/brand/Topoloveni Bike": 4,
 "atp/brand/Toru\u0144ski Rower Miejski": 62,
 "atp/brand/Trinity Metro Bikes": 57,
 "atp/brand/Trondheim Bysykkel": 74,
 "atp/brand/TubaBike (Barcelos)": 41,
 "atp/brand/Tugo": 41,
 "atp/brand/Twisto V\u00e9lolib": 76,
 "atp/brand/Tychowski Rower Miejski": 2,
 "atp/brand/UsedomRad": 97,
 "atp/brand/V'lille": 268,
 "atp/brand/VAG_Rad": 125,
 "atp/brand/VALLEE D'OSSAU": 3,
 "atp/brand/VELO VEZERE LASCAUX": 5,
 "atp/brand/VETURILO 3.0": 349,
 "atp/brand/VMOBIL Rad": 20,
 "atp/brand/VOI Antwerp": 5630,
 "atp/brand/VRNnextbike": 387,
 "atp/brand/VVT REGIORAD Tirol": 23,
 "atp/brand/Valenbisi": 276,
 "atp/brand/Valentine Bike Share": 1,
 "atp/brand/Vel'OH!": 147,
 "atp/brand/Velam": 45,
 "atp/brand/Velect'in": 9,
 "atp/brand/Velo": 322,
 "atp/brand/Velo S\u00e2ntana": 8,
 "atp/brand/Veloleo": 189,
 "atp/brand/Velospot": 1675,
 "atp/brand/Vel\u2019in": 80,
 "atp/brand/Vernou V\u00e9lo": 1,
 "atp/brand/Verona Bike": 40,
 "atp/brand/Vertuose": 39,
 "atp/brand/Viav\u00e9lo": 23,
 "atp/brand/Villo": 360,
 "atp/brand/Vilvolt": 106,
 "atp/brand/Viv\u00e9lo": 8,
 "atp/brand/Voi": 348,
 "atp/brand/Voi Arendal": 85,
 "atp/brand/Voi Baerum": 526,
 "atp/brand/Voi Fredrikstad": 53,
 "atp/brand/Voi Grand Paris Seine et Oise": 355,
 "atp/brand/Voi Grenoble": 708,
 "atp/brand/Voi Kristiansand": 135,
 "atp/brand/Voi Le Havre": 482,
 "atp/brand/Voi Lillestrom": 66,
 "atp/brand/Voi Marseille": 1265,
 "atp/brand/Voi Moss": 64,
 "atp/brand/Voi Oslo": 3055,
 "atp/brand/Voi Paris": 13065,
 "atp/brand/Voi Saint-Quentin-en-Yvelines": 386,
 "atp/brand/Voi Stavanger": 623,
 "atp/brand/Voi Switzerland": 1533,
 "atp/brand/Voi Trondheim": 831,
 "atp/brand/Voi V'L\u00f4nes": 77,
 "atp/brand/V\u00e9lO2": 93,
 "atp/brand/V\u00e9lOstan'lib": 38,
 "atp/brand/V\u00e9lYc\u00e9o": 5,
 "atp/brand/V\u00e9lhop - Strasbourg": 40,
 "atp/brand/V\u00e9lib' Metropole": 1519,
 "atp/brand/V\u00e9lib\u00e9o": 26,
 "atp/brand/V\u00e9livert": 104,
 "atp/brand/V\u00e9lo Fluo Grand-Est": 52,
 "atp/brand/V\u00e9lo Modalis Angoul\u00eame": 57,
 "atp/brand/V\u00e9lo Modalis Grand Cognac": 14,
 "atp/brand/V\u00e9lo Modalis Royan": 10,
 "atp/brand/V\u00e9lo Modalis Saintes": 10,
 "atp/brand/V\u00e9lo Tanlib": 58,
 "atp/brand/V\u00e9lo d'Aqui": 6,
 "atp/brand/V\u00e9lo'Baie": 12,
 "atp/brand/V\u00e9lo'Cit\u00e9": 19,
 "atp/brand/V\u00e9lo'v": 465,
 "atp/brand/V\u00e9loCit\u00e9": 33,
 "atp/brand/V\u00e9loCit\u00e9 Mulhouse": 62,
 "atp/brand/V\u00e9loMoove": 28,
 "atp/brand/V\u00e9loZef": 47,
 "atp/brand/V\u00e9lomagg": 52,
 "atp/brand/V\u00e9lonecy": 79,
 "atp/brand/V\u00e9lopop": 29,
 "atp/brand/V\u00e9l\u00d4Toulouse": 466,
 "atp/brand/WE-cycle": 101,
 "atp/brand/WESTcargo powered by nextbike": 4,
 "atp/brand/WRM nextbike Poland": 273,
 "atp/brand/WienMobil Rad": 262,
 "atp/brand/WinsenRad": 21,
 "atp/brand/Wolszty\u0144ski Rower Miejski": 4,
 "atp/brand/W\u0142ower - W\u0142oc\u0142awski Rower Miejski": 46,
 "atp/brand/Yoio G\u00f6ttingen": 1,
 "atp/brand/Zebullo": 65,
 "atp/brand/Zenica": 15,
 "atp/brand/Zielonog\u00f3rski Rower Miejski": 40,
 "atp/brand/bibo": 39,
 "atp/brand/biciArteixo": 15,
 "atp/brand/bizkaibizi (Spain)": 107,
 "atp/brand/bizkaibizi 4.0": 1,
 "atp/brand/carvelo eCargo-Bike Sharing": 317,
 "atp/brand/city bike Linz": 55,
 "atp/brand/docomo bike share service": 5823,
 "atp/brand/edrive carsharing": 81,
 "atp/brand/euregiobike": 70,
 "atp/brand/flux Bikesharing": 17,
 "atp/brand/invia BikeShare": 59,
 "atp/brand/lev\u00e9lo - Marseille": 228,
 "atp/brand/meinSiggi": 65,
 "atp/brand/mobic": 165,
 "atp/brand/moin mobil Achim": 35,
 "atp/brand/movemix_bike": 90,
 "atp/brand/moxsi (Las Palmas de Gran Canaria)": 65,
 "atp/brand/nextbike BE Vlaamse Rand": 68,
 "atp/brand/nextbike BiciLOG": 35,
 "atp/brand/nextbike Bratislava": 446,
 "atp/brand/nextbike Hannover": 122,
 "atp/brand/nextbike Kol\u00edn": 47,
 "atp/brand/nextbike Krnov": 56,
 "atp/brand/nextbike Kyjov": 11,
 "atp/brand/nextbike Lipn\u00edk nad Be\u010dvou": 11,
 "atp/brand/nextbike Litovel": 14,
 "atp/brand/nextbike Lovosice": 17,
 "atp/brand/nextbike Neratovice": 17,
 "atp/brand/nextbike Otrokovice": 17,
 "atp/brand/nextbike Roudnice nad Labem": 17,
 "atp/brand/nextbike Ruhrgebiet": 17,
 "atp/brand/nextbike Vala\u0161sko": 98,
 "atp/brand/nextbike \u010cesk\u00fd Brod": 12,
 "atp/brand/nextbike \u0160umperk": 21,
 "atp/brand/nextbike \u017dd\u00e1r nad S\u00e1zavou": 46,
 "atp/brand/sharedmobility.ch": 13172,
 "atp/brand/stadtRad - das stadtnavi Lastenrad": 1,
 "atp/brand/swabi - augsburg": 527,
 "atp/brand/welo": 299,
 "atp/brand/westBike": 20,
 "atp/brand/wupsiRad Leverkusen": 120,
 "atp/brand/zeo Carsharing": 62,
 "atp/brand/\u00e0V\u00e9lo": 226,
 "atp/brand/\u0141oKeR - \u0141om\u017ca": 15,
 "atp/brand/\u017byrardowski Rower Miejski": 7,
 "atp/brand_wikidata/Q100272303": 101,
 "atp/brand_wikidata/Q1034635": 866,
 "atp/brand_wikidata/Q104727968": 38,
 "atp/brand_wikidata/Q1060525": 1621,
 "atp/brand_wikidata/Q106575365": 2111,
 "atp/brand_wikidata/Q108789295": 165,
 "atp/brand_wikidata/Q109288835": 98,
 "atp/brand_wikidata/Q109557888": 56,
 "atp/brand_wikidata/Q111760142": 104,
 "atp/brand_wikidata/Q111794110": 262,
 "atp/brand_wikidata/Q1120762": 1519,
 "atp/brand_wikidata/Q119107871": 30,
 "atp/brand_wikidata/Q123507620": 942,
 "atp/brand_wikidata/Q17018523": 1069,
 "atp/brand_wikidata/Q17077936": 119,
 "atp/brand_wikidata/Q17332642": 319,
 "atp/brand_wikidata/Q17402113": 679,
 "atp/brand_wikidata/Q1833385": 544,
 "atp/brand_wikidata/Q18393750": 79,
 "atp/brand_wikidata/Q18419538": 394,
 "atp/brand_wikidata/Q19876452": 319,
 "atp/brand_wikidata/Q2351279": 7059,
 "atp/brand_wikidata/Q2413118": 322,
 "atp/brand_wikidata/Q3080530": 1439,
 "atp/brand_wikidata/Q3142157": 619,
 "atp/brand_wikidata/Q4833723": 614,
 "atp/brand_wikidata/Q4919302": 1112,
 "atp/brand_wikidata/Q55533296": 1906,
 "atp/brand_wikidata/Q56314221": 1675,
 "atp/brand_wikidata/Q57274085": 233,
 "atp/brand_wikidata/Q5817067": 677,
 "atp/brand_wikidata/Q60860236": 862,
 "atp/brand_wikidata/Q63753939": 8419,
 "atp/brand_wikidata/Q7107010": 268,
 "atp/brand_wikidata/Q86706492": 30,
 "atp/brand_wikidata/Q91231927": 14964,
 "atp/brand_wikidata/Q98337927": 133,
 "atp/category/amenity/bicycle_rental": 194309,
 "atp/category/amenity/car_sharing": 11223,
 "atp/category/amenity/charging_station": 59,
 "atp/category/amenity/kick-scooter_rental": 6447,
 "atp/category/missing": 8640,
 "atp/cdn/cloudflare/response_count": 884,
 "atp/cdn/cloudflare/response_status_count/200": 877,
 "atp/cdn/cloudflare/response_status_count/404": 7,
 "atp/clean_strings/name": 1567,
 "atp/clean_strings/operator": 23,
 "atp/clean_strings/postcode": 63,
 "atp/clean_strings/ref": 3,
 "atp/clean_strings/street_address": 1855,
 "atp/closed_check": 1,
 "atp/country/AE": 2080,
 "atp/country/AR": 516,
 "atp/country/AT": 1396,
 "atp/country/BA": 63,
 "atp/country/BE": 19081,
 "atp/country/BR": 1024,
 "atp/country/CA": 4722,
 "atp/country/CH": 24726,
 "atp/country/CL": 202,
 "atp/country/CO": 252,
 "atp/country/CY": 311,
 "atp/country/CZ": 4177,
 "atp/country/DE": 19107,
 "atp/country/DK": 12701,
 "atp/country/ES": 8463,
 "atp/country/FI": 1256,
 "atp/country/FR": 55762,
 "atp/country/GB": 8212,
 "atp/country/GR": 164,
 "atp/country/HR": 459,
 "atp/country/HU": 316,
 "atp/country/IE": 181,
 "atp/country/IL": 1673,
 "atp/country/IS": 1,
 "atp/country/IT": 460,
 "atp/country/JP": 22718,
 "atp/country/LI": 43,
 "atp/country/LT": 36,
 "atp/country/LU": 147,
 "atp/country/LV": 44,
 "atp/country/MC": 58,
 "atp/country/MX": 1146,
 "atp/country/NL": 2228,
 "atp/country/NO": 6712,
 "atp/country/NZ": 521,
 "atp/country/PL": 6011,
 "atp/country/PT": 2379,
 "atp/country/RO": 216,
 "atp/country/SA": 91,
 "atp/country/SE": 362,
 "atp/country/SI": 293,
 "atp/country/SK": 534,
 "atp/country/TR": 118,
 "atp/country/US": 9706,
 "atp/country/XK": 10,
 "atp/duplicate_count": 6,
 "atp/field/branch/missing": 220678,
 "atp/field/brand_wikidata/missing": 168911,
 "atp/field/city/missing": 220678,
 "atp/field/email/missing": 220678,
 "atp/field/geometry/invalid": 2,
 "atp/field/housenumber/missing": 220678,
 "atp/field/name/missing": 59448,
 "atp/field/opening_hours/missing": 220591,
 "atp/field/operator/missing": 144879,
 "atp/field/operator_wikidata/missing": 198703,
 "atp/field/phone/missing": 205707,
 "atp/field/postcode/missing": 211306,
 "atp/field/state/from_reverse_geocoding": 12364,
 "atp/field/state/missing": 208324,
 "atp/field/street/missing": 220678,
 "atp/field/street_address/missing": 163764,
 "atp/field/twitter/missing": 220678,
 "atp/field/unit/missing": 220678,
 "atp/geometry/null_island": 16,
 "atp/item_scraped_host_count/abmitlara.de": 17,
 "atp/item_scraped_host_count/acoruna.publicbikesystem.net": 84,
 "atp/item_scraped_host_count/api-public.odpt.org": 22698,
 "atp/item_scraped_host_count/api.cyclocity.fr": 2626,
 "atp/item_scraped_host_count/api.delijn.be": 319,
 "atp/item_scraped_host_count/api.entur.io": 6415,
 "atp/item_scraped_host_count/api.gbfs.v3.0.ecovelo.mobi": 882,
 "atp/item_scraped_host_count/api.mobidata-bw.de": 15167,
 "atp/item_scraped_host_count/api.saint-etienne-metropole.fr": 104,
 "atp/item_scraped_host_count/api.voiapp.io": 21968,
 "atp/item_scraped_host_count/app.car-ship.jetzt": 21,
 "atp/item_scraped_host_count/app.linkalock.com": 118,
 "atp/item_scraped_host_count/aspen.publicbikesystem.net": 101,
 "atp/item_scraped_host_count/austin.publicbikesystem.net": 86,
 "atp/item_scraped_host_count/backend.citiz.fr": 1625,
 "atp/item_scraped_host_count/barcelona.publicbikesystem.net": 544,
 "atp/item_scraped_host_count/bdx.mecatran.com": 231,
 "atp/item_scraped_host_count/beryl-gbfs-production.web.app": 2133,
 "atp/item_scraped_host_count/bilbao.publicbikesystem.net": 67,
 "atp/item_scraped_host_count/bogota.publicbikesystem.net": 252,
 "atp/item_scraped_host_count/brasilia.publicbikesystem.net": 68,
 "atp/item_scraped_host_count/buenosaires.publicbikesystem.net": 394,
 "atp/item_scraped_host_count/careem.publicbikesystem.net": 216,
 "atp/item_scraped_host_count/chattanooga.publicbikesystem.net": 43,
 "atp/item_scraped_host_count/clermontferrand.publicbikesystem.net": 82,
 "atp/item_scraped_host_count/curitiba.publicbikesystem.net": 50,
 "atp/item_scraped_host_count/data.lime.bike": 285,
 "atp/item_scraped_host_count/data.optymo.fr": 85,
 "atp/item_scraped_host_count/data.rideflamingo.com": 347,
 "atp/item_scraped_host_count/dej.publicbikesystem.net": 16,
 "atp/item_scraped_host_count/detroit.publicbikesystem.net": 81,
 "atp/item_scraped_host_count/eu.ftp.opendatasoft.com": 57,
 "atp/item_scraped_host_count/fortworth.publicbikesystem.net": 57,
 "atp/item_scraped_host_count/gbfs.api.ridedott.com": 53443,
 "atp/item_scraped_host_count/gbfs.bcycle.com": 1652,
 "atp/item_scraped_host_count/gbfs.beryl.cc": 308,
 "atp/item_scraped_host_count/gbfs.biketownpdx.com": 299,
 "atp/item_scraped_host_count/gbfs.bluebikes.com": 619,
 "atp/item_scraped_host_count/gbfs.capitalbikeshare.com": 866,
 "atp/item_scraped_host_count/gbfs.citibikenyc.com": 2507,
 "atp/item_scraped_host_count/gbfs.clem.mobi": 377,
 "atp/item_scraped_host_count/gbfs.divvybikes.com": 2053,
 "atp/item_scraped_host_count/gbfs.ganxeta.cat": 24,
 "atp/item_scraped_host_count/gbfs.goabout.com": 44,
 "atp/item_scraped_host_count/gbfs.kappa.fifteen.eu": 264,
 "atp/item_scraped_host_count/gbfs.lyft.com": 119,
 "atp/item_scraped_host_count/gbfs.lyftbikes.com": 636,
 "atp/item_scraped_host_count/gbfs.mex.lyftbikes.com": 677,
 "atp/item_scraped_host_count/gbfs.nextbike.net": 16729,
 "atp/item_scraped_host_count/gbfs.omega.fifteen.eu": 228,
 "atp/item_scraped_host_count/gbfs.openov.nl": 284,
 "atp/item_scraped_host_count/gbfs.partners.fifteen.eu": 1162,
 "atp/item_scraped_host_count/gbfs.primelayer.pt": 39,
 "atp/item_scraped_host_count/gbfs.smartbike.com": 322,
 "atp/item_scraped_host_count/gbfs.theta.fifteen.eu": 508,
 "atp/item_scraped_host_count/gbfs.urbansharing.com": 1665,
 "atp/item_scraped_host_count/gbfs.velobixi.com": 1112,
 "atp/item_scraped_host_count/guadalajara.publicbikesystem.net": 468,
 "atp/item_scraped_host_count/honolulu.publicbikesystem.net": 133,
 "atp/item_scraped_host_count/hunedoara.publicbikesystem.net": 13,
 "atp/item_scraped_host_count/kona.publicbikesystem.net": 22,
 "atp/item_scraped_host_count/madrid.publicbikesystem.net": 679,
 "atp/item_scraped_host_count/mds.bird.co": 12533,
 "atp/item_scraped_host_count/mds.bolt.eu": 4403,
 "atp/item_scraped_host_count/media.ilevia.fr": 268,
 "atp/item_scraped_host_count/miamiunderline.publicbikesystem.net": 7,
 "atp/item_scraped_host_count/moinesti.publicbikesystem.net": 8,
 "atp/item_scraped_host_count/monaco.publicbikesystem.net": 58,
 "atp/item_scraped_host_count/nike.publicbikesystem.net": 26,
 "atp/item_scraped_host_count/nordelta.publicbikesystem.net": 21,
 "atp/item_scraped_host_count/pbsn.publicbikesystem.net": 9,
 "atp/item_scraped_host_count/pittsburgh.publicbikesystem.net": 60,
 "atp/item_scraped_host_count/portoalegre.publicbikesystem.net": 90,
 "atp/item_scraped_host_count/prod-api.joltscooters.co.nz": 174,
 "atp/item_scraped_host_count/proxy.transport.data.gouv.fr": 8509,
 "atp/item_scraped_host_count/quebec.publicbikesystem.net": 226,
 "atp/item_scraped_host_count/quickrent.ch": 86,
 "atp/item_scraped_host_count/recife.publicbikesystem.net": 90,
 "atp/item_scraped_host_count/riodejaneiro.publicbikesystem.net": 403,
 "atp/item_scraped_host_count/rivas.publicbikesystem.net": 42,
 "atp/item_scraped_host_count/riviera.publicbikesystem.net": 7,
 "atp/item_scraped_host_count/saguenay.publicbikesystem.net": 21,
 "atp/item_scraped_host_count/salvador.publicbikesystem.net": 76,
 "atp/item_scraped_host_count/sansebastian.publicbikesystem.net": 70,
 "atp/item_scraped_host_count/santana.publicbikesystem.net": 8,
 "atp/item_scraped_host_count/santiago.publicbikesystem.net": 202,
 "atp/item_scraped_host_count/saopaulo.publicbikesystem.net": 240,
 "atp/item_scraped_host_count/sibiu.publicbikesystem.net": 57,
 "atp/item_scraped_host_count/stables.donkey.bike": 11883,
 "atp/item_scraped_host_count/stce.transdev-hdf.fr": 80,
 "atp/item_scraped_host_count/stonybrook.publicbikesystem.net": 14,
 "atp/item_scraped_host_count/targumures.publicbikesystem.net": 5,
 "atp/item_scraped_host_count/toronto.publicbikesystem.net": 1069,
 "atp/item_scraped_host_count/tucson.publicbikesystem.net": 41,
 "atp/item_scraped_host_count/valence.publicbikesystem.net": 68,
 "atp/item_scraped_host_count/valladolid.publicbikesystem.net": 104,
 "atp/item_scraped_host_count/velib-metropole-opendata.smovengo.cloud": 1519,
 "atp/item_scraped_host_count/www.cykl.nl": 14,
 "atp/item_scraped_host_count/www.imarguerite.com": 87,
 "atp/item_scraped_host_count/www.mibicitubici.gob.ar": 101,
 "atp/item_scraped_host_count/www.mobility-parc.net": 43,
 "atp/item_scraped_host_count/www.share-birrer.ch": 22,
 "atp/item_scraped_host_count/www.sharedmobility.ch": 13172,
 "atp/item_scraped_host_count/yoio.rideatom.com": 1,
 "atp/item_scraped_host_count/zaragoza.publicbikesystem.net": 276,
 "atp/lineage": "S_?",
 "atp/nsi/brand_or_operator_missing": 168911,
 "atp/nsi/brand_unknown": 1112,
 "atp/nsi/category_missing": 11516,
 "atp/nsi/category_unknown": 2053,
 "atp/nsi/location_unknown": 23725,
 "atp/nsi/match_failed": 197707,
 "atp/nsi/match_imperfect": 2876,
 "atp/nsi/match_perfect": 20095,
 "atp/nsi/multiple_matches": 1906,
 "atp/operator/-": 942,
 "atp/operator/205, The Frames, 1 Phipp St, London EC2A 4PS": 2441,
 "atp/operator/AMCO S.A. Area Pyrgos, Korinthos, PO 20100, Greece": 29,
 "atp/operator/ARRIVA Slovakia a.s. Sturova 72 949 44 Nitra": 88,
 "atp/operator/Avenida Alcalde Jos\u00e9 Ramirez Betancourt 33, Las Palmas de Gran Canaria, Las Palmas. 35004 Spain": 65,
 "atp/operator/BCycle": 749,
 "atp/operator/BKT": 677,
 "atp/operator/Bicycle Transit Systems": 344,
 "atp/operator/Bike to Bike": 101,
 "atp/operator/Biki": 133,
 "atp/operator/Bird Rides, Inc.": 12533,
 "atp/operator/Blue-Mobility": 319,
 "atp/operator/Bublr Bikes": 165,
 "atp/operator/C/Many\u00e0 24, Parque Empresarial T\u00e1ctica \u2013 46980 Paterna, Valencia (Espa\u00f1a)": 20,
 "atp/operator/CCBP": 28,
 "atp/operator/CITYBIKE Normandie - groupe INURBA Mobility": 126,
 "atp/operator/Car-ship e.G. i.Gr.": 21,
 "atp/operator/City Bike Linz Rental Service GmbH, Wischerstra\u00dfe 2, 4040 Linz, \u00d6sterreich": 55,
 "atp/operator/Clear Channel Belgium Velo Antwerpen, Mediaplein 7, 2018 Antwerpen, Belgien": 322,
 "atp/operator/Communaut\u00e9 d\u2019Agglom\u00e9ration d\u2019\u00c9pinal": 106,
 "atp/operator/Cykl": 14,
 "atp/operator/Deutsche Bahn Connect": 1621,
 "atp/operator/Directorate for the Administration of Streets and Public Lighting, Dr\u0103g\u0103ne\u0219ti Street, 25A, 230019 Slatina": 5,
 "atp/operator/Explore Bike Share": 30,
 "atp/operator/Exterior Plus, Ctra. del Cortijo Nr. 35, Km 26006 Logro\u00f1o": 35,
 "atp/operator/Fifteen": 244,
 "atp/operator/IGPDecaux S.p.A.": 360,
 "atp/operator/Inurba": 1537,
 "atp/operator/JOLT Scooters": 174,
 "atp/operator/LU.102 1 Filament Walk Wandsworth SW19 4GQ London": 8,
 "atp/operator/Leonbici nextbike GmbH y autobuses urbanos de Le\u00f3n SA UTE, Poligono Industrial Vilecha Oeste s/n, 24192 Le\u00f3n": 51,
 "atp/operator/Lyft": 4747,
 "atp/operator/Minho Bus - Transportes do Minho Soc. Unip. Lda Pra\u00e7a da Esta\u00e7\u00e3o Rodovi\u00e1ria, 4700 - 377 Braga": 41,
 "atp/operator/Mobil'\u00e9co": 97,
 "atp/operator/Movilidad Urbana Sostenible S.L MOVUS": 39,
 "atp/operator/Movilidad Urbana Sostenible, S.L., c/ Manyo 24, Parque Empresarial T\u00e1ctica, 46980, Patenta - Valencia, Spain": 21,
 "atp/operator/NS": 284,
 "atp/operator/Nave de SUMARTE, r\u00faa Laxobre, 19. Lugar de Laxobre, Arteixo, 15142 Arteixo": 15,
 "atp/operator/Nextbike Polska S.A. ul. Przasnyska 6B, 01-756 Warszawa": 68,
 "atp/operator/Nextbike Polska S.A. ul. Przasnyska 6B, 01-756 Warszawa KRS 0000362899 NIP: 895-198-10-07 REGON: 021336152": 43,
 "atp/operator/Nextbike Polska S.A. ul. Przasnyska 6B, 01-756 Warszawa KRS 0000646950 NIP: 895-198-10-07 REGON: 021336152": 2,
 "atp/operator/Nextbike Polska S.A. ul. Staniewicka 5, 03-310 Warszawa": 409,
 "atp/operator/Nextbike Polska S.A. ul. Staniewicka 5, 03-310 Warszawa KRS 0000362899 NIP: 895-198-10-07 REGON: 021336152": 40,
 "atp/operator/Nomago d.o.o., Vo\u0161njakova 3, 1000 Ljubljana, Slovenia": 163,
 "atp/operator/OpenStreet Corp.": 14964,
 "atp/operator/Prisavlje 2, 10000 Zagreb": 12,
 "atp/operator/PubliBike": 944,
 "atp/operator/RTTB": 32,
 "atp/operator/Radland GmbH, Werkst\u00e4ttenstra\u00dfe 13, 3100 St. P\u00f6lten": 251,
 "atp/operator/SC NEXT BIKE SRL, Aleea Poarta Alba nr. 1-3, Bucharest, ROMANIA": 78,
 "atp/operator/SHA Prishtina Parking, Zyra Qendrore, Rr. Luan Haradinaj, objekti i ish ASK, Pristhtine 10000, Kosovo": 10,
 "atp/operator/STAR": 57,
 "atp/operator/SWA": 527,
 "atp/operator/Saint-Brieuc Armor Agglom\u00e9ration": 12,
 "atp/operator/Societat Municipal d\u2019Aparcaments i Projectes, S.A., Ctra. de Manacor, 70, 07007 Palma, Illes Balears, Spain": 100,
 "atp/operator/Staniewicka 5, 03-310 Warszawa": 72,
 "atp/operator/Strasbourg Mobilit\u00e9s V\u00e9lo, 55 rue du March\u00e9 Gare, 67000 Strasbourg": 40,
 "atp/operator/Sustav javnih bicikala d.o.o., Prisavlje 2, 10000 Zagreb": 196,
 "atp/operator/Swiss Federal Office of Energy": 13172,
 "atp/operator/TIER Mobility SE Filiale Italiana, Corso Massimo d'Azeglio 57, 10126 Torino, Italia": 25,
 "atp/operator/TIER Mobility SE, Karl-Heine-Str. 46, 04229 Leipzig, Germany": 237,
 "atp/operator/TIER Operations Limited c/o We Work, 1 Mark Square London, EC2a 4EG": 4,
 "atp/operator/TaM": 52,
 "atp/operator/Toronto Parking Authority": 1069,
 "atp/operator/Transdev": 80,
 "atp/operator/Trg srpskih vladara 1, 78000 Banja luka, Bosna i Hercegovina": 5,
 "atp/operator/UIP Bauer Media Outdoor Norge AS": 98,
 "atp/operator/UIP Oslo Bysykkel AS": 268,
 "atp/operator/UTE BICIS SANTANDER C. Pe\u00f1a Sagra, 4,39011 Santander, Cantabria, Spain": 42,
 "atp/operator/UTE Bizkaiabizi LEIOA, C/ P.A.E. IBARRABARRI, PAB. 13 E,48940 LEIOA - BIZKAIA": 107,
 "atp/operator/Ul. Staniewicka 5, 03-310, Warszawa": 64,
 "atp/operator/UsedomRad GmbH, Hauptstra\u00dfe 8, 17459 \u00dcckeritz": 122,
 "atp/operator/VAG Verkehrs-Aktiengesellschaft, S\u00fcdliche F\u00fcrther Stra\u00dfe 5, 90429 N\u00fcrnberg": 125,
 "atp/operator/Vancouver Bike Share": 264,
 "atp/operator/Veloc'Ouest": 12,
 "atp/operator/Ville de Landerneau": 14,
 "atp/operator/V\u00e9logik": 76,
 "atp/operator/Zmaja od Bosne 47A, 71000 Sarajevo": 15,
 "atp/operator/fifteen": 14,
 "atp/operator/lev\u00e9lo": 228,
 "atp/operator/lovesharing, Av. Rafael Cabrera 24, Portal 22b, Oficina 10, Las Palmas, Spain": 15,
 "atp/operator/nextbike AT GmbH, Karl-Heine-Str. 46, 04229 Leipzig, Germany": 51,
 "atp/operator/nextbike Belgium": 68,
 "atp/operator/nextbike Czech Republic, Libusina 526/101, 779 00 Olomouc": 4623,
 "atp/operator/nextbike France, 17 Avenue de Strasbourg, 68350 Brunstatt-Didenheim": 110,
 "atp/operator/nextbike GmbH": 5,
 "atp/operator/nextbike GmbH, Karl-Heine-Str. 46, 04229 Leipzig": 7639,
 "atp/operator/nextbike GmbH, Lievelingsweg 104 A (Im Hinterhof), 53119 Bonn": 299,
 "atp/operator/nextbike Sverige AB, Fl\u00f6jelbergsgatan 7 B, 431 37 M\u00f6lndal": 146,
 "atp/operator/nextbike by TIER - Karl-Heine-Str. 46 - D-04229 Leipzig": 59,
 "atp/operator/transdev": 8,
 "atp/operator/velogik et fifteen": 29,
 "atp/operator/v\u00e9logik": 47,
 "atp/operator_wikidata/Q104005517": 344,
 "atp/operator_wikidata/Q108789295": 165,
 "atp/operator_wikidata/Q1152100": 1621,
 "atp/operator_wikidata/Q17077936": 1604,
 "atp/operator_wikidata/Q2413118": 322,
 "atp/operator_wikidata/Q3555363": 944,
 "atp/operator_wikidata/Q43593262": 14964,
 "atp/operator_wikidata/Q4833723": 749,
 "atp/operator_wikidata/Q60860205": 30,
 "atp/operator_wikidata/Q7826466": 1069,
 "atp/operator_wikidata/Q86706492": 30,
 "atp/operator_wikidata/Q98337927": 133,
 "downloader/exception_count": 12,
 "downloader/exception_type_count/scrapy.exceptions.CannotResolveHostError": 12,
 "downloader/request_bytes": 3083453,
 "downloader/request_count": 6149,
 "downloader/request_method_count/GET": 6149,
 "downloader/response_bytes": 41015118,
 "downloader/response_count": 6137,
 "downloader/response_status_count/200": 5873,
 "downloader/response_status_count/302": 5,
 "downloader/response_status_count/307": 3,
 "downloader/response_status_count/400": 4,
 "downloader/response_status_count/403": 12,
 "downloader/response_status_count/404": 178,
 "downloader/response_status_count/410": 7,
 "downloader/response_status_count/421": 1,
 "downloader/response_status_count/429": 30,
 "downloader/response_status_count/500": 9,
 "downloader/response_status_count/502": 12,
 "downloader/response_status_count/503": 3,
 "elapsed_time_seconds": 3387.65699999989,
 "finish_reason": "finished",
 "finish_time": "2026-09-11T19:18:39.350734+00:00",
 "httpcache/firsthand": 6059,
 "httpcache/hit": 78,
 "httpcache/miss": 6071,
 "httpcache/store": 6059,
 "httpcompression/response_bytes": 192435983,
 "httpcompression/response_count": 4247,
 "httperror/response_ignored_count": 217,
 "httperror/response_ignored_status_count/400": 3,
 "httperror/response_ignored_status_count/403": 12,
 "httperror/response_ignored_status_count/404": 178,
 "httperror/response_ignored_status_count/410": 7,
 "httperror/response_ignored_status_count/421": 1,
 "httperror/response_ignored_status_count/429": 9,
 "httperror/response_ignored_status_count/500": 2,
 "httperror/response_ignored_status_count/502": 4,
 "httperror/response_ignored_status_count/503": 1,
 "item_dropped_count": 6,
 "item_dropped_reasons_count/DropItem": 6,
 "item_scraped_count": 220678,
 "items_per_minute": 3909.2648361381753,
 "log_count/ERROR": 27,
 "log_count/INFO": 637,
 "log_count/WARNING": 2,
 "request_depth_max": 1,
 "response_received_count": 6093,
 "responses_per_minute": 107.93622674933569,
 "retry/count": 44,
 "retry/max_reached": 22,
 "retry/reason_count/429 Unknown Status": 20,
 "retry/reason_count/500 Internal Server Error": 6,
 "retry/reason_count/502 Bad Gateway": 8,
 "retry/reason_count/503 Service Unavailable": 2,
 "retry/reason_count/scrapy.exceptions.CannotResolveHostError": 8,
 "scheduler/dequeued": 1577,
 "scheduler/dequeued/memory": 1577,
 "scheduler/enqueued": 1577,
 "scheduler/enqueued/memory": 1577,
 "start_time": "2026-09-11T18:22:11.692065+00:00"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GBFS station categorization by deriving fallback categories from the vehicle types provided in the feed.
  * Preserved station-specific attributes when processing multiple stations.
  * Retained bicycle rental as the fallback when no shared vehicle category is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->