### PR TITLE
[Rapid Pare-Brise] Fix brand tag to match NSI

### DIFF
--- a/locations/spiders/rapid_pare_brise_fr.py
+++ b/locations/spiders/rapid_pare_brise_fr.py
@@ -10,7 +10,7 @@ from locations.structured_data_spider import StructuredDataSpider
 
 class RapidPareBriseFRSpider(SitemapSpider, StructuredDataSpider):
     name = "rapid_pare_brise_fr"
-    item_attributes = {"brand": "Rapid Pare-Brise", "brand_wikidata": "Q112064766"}
+    item_attributes = {"brand": "Rapid Pare Brise", "brand_wikidata": "Q112064766"}
     sitemap_urls = ["https://www.rapidparebrise.fr/sitemap.xml"]
     sitemap_rules = [(r"^https://www\.rapidparebrise\.fr/.*-\d+$", "parse_sd")]
     wanted_types = ["LocalBusiness"]


### PR DESCRIPTION
## Summary
- `rapid_pare_brise_fr.py` (merged in #18636) set `brand` to `"Rapid Pare-Brise"` (with hyphen), but the name suggestion index entry for `Q112064766` uses `"Rapid Pare Brise"` (no hyphen).
- This broke `test_item_attributes_brand_strings_match_nsi` on master, which in turn fails `pytest` CI for every other open PR.

## Fix
- Update the `brand` tag to match NSI: `"Rapid Pare Brise"`.

## Test plan
- [x] `uv run pytest tests/test_item_attributes.py` passes locally
- [x] Full `uv run pytest` suite passes locally (322 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUQ22jqtUjQeZbxhdpHLGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUQ22jqtUjQeZbxhdpHLGz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the brand name formatting for Rapid Pare Brise locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->