### PR TITLE
[daily_yamazaki_jp] Add spider (1111 locations) (with areamarker storefinder)

### DIFF
--- a/locations/spiders/daily_yamazaki_jp.py
+++ b/locations/spiders/daily_yamazaki_jp.py
@@ -81,7 +81,7 @@ class DailyYamazakiJPSpider(AreamarkerSpider):
 
         if store["hours"] == "00:00-23:59":
             item["opening_hours"] = "24/7"
-        elif m := OPENING_HOURS_RE.match(store["hours"]):
+        elif store["hours"] and (m := OPENING_HOURS_RE.match(store["hours"])):
             oh = OpeningHours()
             oh.add_days_range(DAYS, m.group(1), m.group(2))
             item["opening_hours"] = oh

--- a/locations/spiders/daily_yamazaki_jp.py
+++ b/locations/spiders/daily_yamazaki_jp.py
@@ -1,0 +1,101 @@
+import re
+import unicodedata
+from typing import Iterable
+
+from scrapy.http import TextResponse
+
+from locations.categories import Categories, Extras, Sells, apply_category, apply_yes_no
+from locations.hours import DAYS, OpeningHours
+from locations.items import Feature
+from locations.storefinders.areamarker import AreamarkerSpider
+
+# descriptive label -> API column name. meanings from the map page's
+# https://www.areamarker.com/daily-yamazaki/data/filterStore.json labels.
+FIELDS = {
+    "ref": "kyo_id",  # store id
+    "name": "name",  # full store name, e.g. デイリ－ヤマザキ本八幡駅前店
+    "lat": "lat_en",  # latitude (WGS84. API also exposes lat_jp/lon_jp in the Tokyo datum)
+    "lon": "lon_en",  # longitude (WGS84)
+    "addr": "addr_1",  # full street address
+    "postcode": "zip_code",  # postal code
+    "phone": "tel_1",  # phone number
+    "hours": "b_mon",  # opening hours; every weekday shares one value, e.g. 06:00-23:00
+    "alcohol": "col_6",  # お酒 (alcohol)
+    "tobacco": "col_7",  # タバコ (tobacco)
+    "atm": "col_8",  # ATM
+    "fresh_bread": "col_9",  # 焼きたてパン (fresh-baked bread)
+    "bento": "col_10",  # 手づくり弁当 (handmade lunch boxes)
+    "fried_food": "col_11",  # FF惣菜 唐揚げ (fried food)
+    "copier": "col_12",  # マルチコピー (multi-function copier)
+    "self_checkout": "col_13",  # セルフレジ (self-checkout)
+    "rakuten_check": "col_14",  # 楽天チェック (Rakuten Check)
+    "online_pickup": "col_15",  # ネット商品受取 (online order pickup)
+}
+
+# The brand-family name is spelled with either ー (U+30FC) or － (U+FF0D) and
+# historically as デイリーヤマザキ / ニューヤマザキデイリーストア /
+# ヤマザキデイリーストア. Strip it to leave the location-specific branch name.
+DASH_RE = "[ー－]"
+BRAND_PREFIX_RE = re.compile(
+    rf"^(?:デイリ{DASH_RE}ヤマザキ|ニューヤマザキデイリ{DASH_RE}ストアー?|ヤマザキデイリ{DASH_RE}ストアー?)"
+)
+OPENING_HOURS_RE = re.compile(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$")
+
+
+class DailyYamazakiJPSpider(AreamarkerSpider):
+    name = "daily_yamazaki_jp"
+    item_attributes = {
+        "brand": "デイリーヤマザキ",
+        "brand_wikidata": "Q5209392",
+        "extras": {"brand:en": "Daily YAMAZAKI"},
+    }
+
+    api_url = "https://ss-api.areamarker.com/v1/search-by-condition"
+    corp_id = "daily-yamazaki"
+    referer = "https://www.areamarker.com/daily-yamazaki/"
+    fields = list(FIELDS.values())
+    page_size = 500
+
+    def post_process_item(self, record: dict, response: TextResponse) -> Iterable[Feature]:
+        # The API omits empty fields, so use .get() and treat a missing
+        # service column as absent rather than a failed scrape.
+        store = {label: record["fields"].get(column) for label, column in FIELDS.items()}
+
+        item = Feature()
+        item["ref"] = store["ref"]
+        item["lat"] = store["lat"]
+        item["lon"] = store["lon"]
+
+        # Normalize inconsistent store names
+        if m := BRAND_PREFIX_RE.match(store["name"]):
+            item["branch"] = store["name"][m.end() :]
+        else:
+            item["branch"] = store["name"]
+        item["phone"] = store["phone"]
+        item["website"] = f"https://www.areamarker.com/daily-yamazaki/info/{store['ref']}"
+        item["addr_full"] = unicodedata.normalize("NFKC", store["addr"])
+        item["postcode"] = store["postcode"]
+
+        if store["hours"] == "00:00-23:59":
+            item["opening_hours"] = "24/7"
+        elif m := OPENING_HOURS_RE.match(store["hours"]):
+            oh = OpeningHours()
+            oh.add_days_range(DAYS, m.group(1), m.group(2))
+            item["opening_hours"] = oh
+
+        apply_yes_no(Sells.ALCOHOL, item, store["alcohol"] == "1")
+        apply_yes_no(Sells.TOBACCO, item, store["tobacco"] == "1")
+        apply_yes_no(Extras.ATM, item, store["atm"] == "1")
+        apply_yes_no(Extras.COPYING, item, store["copier"] == "1")
+        apply_yes_no(Extras.SELF_CHECKOUT, item, store["self_checkout"] == "1")
+
+        # Skipped service flags (no established OSM tag):
+        #   store["fresh_bread"] 焼きたてパン (fresh-baked bread)
+        #   store["bento"] 手づくり弁当 (handmade lunch boxes)
+        #   store["fried_food"] FF惣菜 唐揚げ (fried food)
+        #   store["rakuten_check"] 楽天チェック (Rakuten Check - unknown Rakuten service)
+        #   store["online_pickup"] ネット商品受取 (online order pickup)
+
+        apply_category(Categories.SHOP_CONVENIENCE, item)
+
+        yield item

--- a/locations/spiders/daily_yamazaki_jp.py
+++ b/locations/spiders/daily_yamazaki_jp.py
@@ -45,9 +45,12 @@ OPENING_HOURS_RE = re.compile(r"^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$")
 class DailyYamazakiJPSpider(AreamarkerSpider):
     name = "daily_yamazaki_jp"
     item_attributes = {
-        "brand": "デイリーヤマザキ",
+        "brand": "Daily YAMAZAKI",
         "brand_wikidata": "Q5209392",
-        "extras": {"brand:en": "Daily YAMAZAKI"},
+        "extras": {
+            "brand:en": "Daily YAMAZAKI",
+            "brand:ja": "デイリーヤマザキ",
+        },
     }
 
     api_url = "https://ss-api.areamarker.com/v1/search-by-condition"

--- a/locations/spiders/seven_eleven_jp.py
+++ b/locations/spiders/seven_eleven_jp.py
@@ -1,20 +1,15 @@
 from datetime import datetime
-from typing import AsyncIterator, Iterator
+from typing import Iterable
 from zoneinfo import ZoneInfo
 
-from scrapy import Spider
-from scrapy.http import JsonRequest
+from scrapy.http import TextResponse
 
 from locations.categories import Categories, Drink, Extras, Sells, apply_category, apply_yes_no
 from locations.items import Feature
+from locations.storefinders.areamarker import AreamarkerSpider
 
 CORP = "711map"
 API_URL = "https://seven-eleven-ss-api.areamarker.com/v1/search-by-condition"
-API_HEADERS = {
-    "X-Amss-Shopsite-Corp-ID": CORP,
-    "Origin": "https://seven-eleven.areamarker.com",
-    "Referer": "https://seven-eleven.areamarker.com/711map/",
-}
 
 # descriptive label -> API column name. meanings from the map page's
 # https://seven-eleven.areamarker.com/711map/data/serviceCol.json and sample data.
@@ -63,77 +58,57 @@ SEARCH_CONDITIONS = [
     },
 ]
 
-# A nationwide query pages through all ~21K stores. Keep the page small enough
-# that a single response stays under the API's ~6MB size cap.
-PAGE_SIZE = 1000
 
-
-class SevenElevenJPSpider(Spider):
+class SevenElevenJPSpider(AreamarkerSpider):
     name = "seven_eleven_jp"
     item_attributes = {
         "brand": "7-ELEVEN",
         "brand_wikidata": "Q259340",
     }
 
-    def make_request(self, search_after=None) -> JsonRequest:
-        body = {
-            "search_conditions": SEARCH_CONDITIONS,
-            "fields": list(FIELDS.values()),
-            "paging_mode": "search_after",
-            "sort": "+pre_code,+city_code,+kyo_id",
-            "corp_id": CORP,
-            "size": PAGE_SIZE,
-        }
-        if search_after:
-            body["search_after"] = search_after
-        return JsonRequest(API_URL, data=body, headers=API_HEADERS)
+    api_url = API_URL
+    corp_id = CORP
+    referer = "https://seven-eleven.areamarker.com/711map/"
+    fields = list(FIELDS.values())
+    search_conditions = SEARCH_CONDITIONS
+    # A nationwide query pages through all ~21K stores. Keep the page small enough
+    # that a single response stays under the API's ~6MB size cap.
+    page_size = 1000
 
-    async def start(self) -> AsyncIterator[JsonRequest]:
-        yield self.make_request()
+    def post_process_item(self, record: dict, response: TextResponse) -> Iterable[Feature]:
+        store = {label: record["fields"][column] for label, column in FIELDS.items()}
 
-    def parse(self, response) -> Iterator[Feature | JsonRequest]:
-        data = response.json()
-        hits = data["result"]["hits"]
-        for hit in hits.get("hit", []):
-            store = {label: hit["fields"][column] for label, column in FIELDS.items()}
+        item = Feature()
+        item["ref"] = store["ref"]
+        item["lat"] = store["lat"]
+        item["lon"] = store["lon"]
+        item["branch"] = store["branch"]
+        item["name"] = None
+        item["phone"] = store["phone"]
+        item["website"] = f"https://seven-eleven.areamarker.com/711map/info/{store['ref']}"
+        item["addr_full"] = store["addr"]
+        item["postcode"] = store["postcode"]
 
-            item = Feature()
-            item["ref"] = store["ref"]
-            item["lat"] = store["lat"]
-            item["lon"] = store["lon"]
-            item["branch"] = store["branch"]
-            item["name"] = None
-            item["phone"] = store["phone"]
-            item["website"] = f"https://seven-eleven.areamarker.com/711map/info/{store['ref']}"
-            item["addr_full"] = store["addr"]
-            item["postcode"] = store["postcode"]
+        apply_category(Categories.SHOP_CONVENIENCE, item)
 
-            apply_category(Categories.SHOP_CONVENIENCE, item)
+        apply_yes_no(Extras.ATM, item, store["atm"] == "1")
+        apply_yes_no(Sells.TOBACCO, item, store["tobacco"] == "1")
+        apply_yes_no(Sells.ALCOHOL, item, store["alcohol"] == "1")
+        apply_yes_no(Extras.COPYING, item, store["copier"] == "1")
+        apply_yes_no(Extras.DELIVERY, item, store["seven_now_delivery"] == "1")
+        apply_yes_no(Extras.DUTY_FREE, item, store["tax_free"] == "1")
+        apply_yes_no(Extras.SELF_CHECKOUT, item, store["self_checkout"] == "1")
+        apply_yes_no(Drink.COFFEE, item, store["seven_cafe"] == "1")
+        if store["pet_recycle"] == "1":
+            item["extras"]["recycling:pet_drink_bottles"] = "yes"
 
-            apply_yes_no(Extras.ATM, item, store["atm"] == "1")
-            apply_yes_no(Sells.TOBACCO, item, store["tobacco"] == "1")
-            apply_yes_no(Sells.ALCOHOL, item, store["alcohol"] == "1")
-            apply_yes_no(Extras.COPYING, item, store["copier"] == "1")
-            apply_yes_no(Extras.DELIVERY, item, store["seven_now_delivery"] == "1")
-            apply_yes_no(Extras.DUTY_FREE, item, store["tax_free"] == "1")
-            apply_yes_no(Extras.SELF_CHECKOUT, item, store["self_checkout"] == "1")
-            apply_yes_no(Drink.COFFEE, item, store["seven_cafe"] == "1")
-            if store["pet_recycle"] == "1":
-                item["extras"]["recycling:pet_drink_bottles"] = "yes"
+        # Skipped service flags (no established OSM tag):
+        #   store["fried_food"] 揚げ物惣菜 (fried foods)
+        #   store["seven_cafe_smoothie"] セブンカフェスムージー (Seven Cafe smoothie)
+        #   store["seven_meal"] セブンミール (Seven Meal)
+        #   store["medicine"] 薬 (medicine)
+        #   store["store_hold"] 店舗留置サービス (store hold service)
+        #   store["seven_delivery"] セブンあんしんお届け便 (mobile sales for remote areas)
+        #   store["battery_rental"] モバイルバッテリーサービス (mobile battery rental)
 
-            # Skipped service flags (no established OSM tag):
-            #   store["fried_food"] 揚げ物惣菜 (fried foods)
-            #   store["seven_cafe_smoothie"] セブンカフェスムージー (Seven Cafe smoothie)
-            #   store["seven_meal"] セブンミール (Seven Meal)
-            #   store["medicine"] 薬 (medicine)
-            #   store["store_hold"] 店舗留置サービス (store hold service)
-            #   store["seven_delivery"] セブンあんしんお届け便 (mobile sales for remote areas)
-            #   store["battery_rental"] モバイルバッテリーサービス (mobile battery rental)
-
-            yield item
-
-        # `search_after` cursor pagination requires following the cursor returned
-        # by the previous page, so the next request is issued from here.
-        search_after = hits.get("search_after")
-        if search_after:
-            yield self.make_request(search_after)
+        yield item

--- a/locations/storefinders/areamarker.py
+++ b/locations/storefinders/areamarker.py
@@ -1,0 +1,71 @@
+from typing import AsyncIterator, Iterable, Iterator
+from urllib.parse import urlsplit
+
+from scrapy import Spider
+from scrapy.http import JsonRequest, TextResponse
+
+from locations.items import Feature
+
+
+class AreamarkerSpider(Spider):
+    """
+    Store locator platform by AreaMarker (areamarker.com). POIs are served by
+    an OpenSearch-backed JSON API (ss-api.areamarker.com or a brand subdomain)
+    whose "search-by-condition" endpoint pages through results with a `search_after`
+    cursor.
+
+    The API rejects requests without the `Origin`/`Referer` headers and the
+    per-brand `X-Amss-Shopsite-Corp-ID` header, so those must be supplied.
+    `Origin` is derived from `referer` (its scheme + netloc).
+
+    To use, set `api_url`, `corp_id`, `referer`, and `fields` (the list of API
+    columns to request). `search_conditions` and `page_size` may be overridden
+    per brand. Then implement `post_process_item` to build a Feature from each
+    raw API record.
+    """
+
+    dataset_attributes = {"source": "api", "api": "areamarker.com"}
+
+    api_url: str
+    corp_id: str
+    referer: str
+    fields: list[str]
+    search_conditions: list[dict] = []
+    page_size: int = 500
+
+    def make_request(self, search_after: list | None = None) -> JsonRequest:
+        body = {
+            "search_conditions": self.search_conditions,
+            "fields": self.fields,
+            "paging_mode": "search_after",
+            "sort": "+pre_code,+city_code,+kyo_id",
+            "corp_id": self.corp_id,
+            "size": self.page_size,
+        }
+        if search_after:
+            body["search_after"] = search_after
+        split = urlsplit(self.referer)
+        headers = {
+            "X-Amss-Shopsite-Corp-ID": self.corp_id,
+            "Origin": f"{split.scheme}://{split.netloc}",
+            "Referer": self.referer,
+        }
+        return JsonRequest(self.api_url, data=body, headers=headers)
+
+    async def start(self) -> AsyncIterator[JsonRequest]:
+        yield self.make_request()
+
+    def parse(self, response: TextResponse) -> Iterator[Feature | JsonRequest]:
+        hits = response.json()["result"]["hits"]
+        for record in hits.get("hit", []):
+            yield from self.post_process_item(record, response) or []
+
+        # `search_after` cursor pagination requires following the cursor
+        # returned by the previous page, so the next request is issued from here.
+        search_after = hits.get("search_after")
+        if search_after:
+            yield self.make_request(search_after)
+
+    def post_process_item(self, record: dict, response: TextResponse) -> Iterable[Feature]:
+        """Override to build one or more Features from a raw API record."""
+        return []


### PR DESCRIPTION
This adds new convenience store Daily Yamazaki. Since it shares the same storefinder with the 7-eleven, I extracted the shared codes into a new areamarker store finder.

see also #18629 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Daily Yamazaki convenience-store locations in Japan, including addresses, opening hours, website links, and services such as alcohol, tobacco, ATMs, copiers, and self-checkout.
  - Added accurate support for 24-hour stores and normalized branch names and addresses.
- **Updates**
  - Refreshed Seven-Eleven Japan listings while preserving store metadata, operating hours, and available services.
  - Improved coverage and consistency for Japanese convenience-store location data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->